### PR TITLE
feat(ci): automate flaky issue synchronization

### DIFF
--- a/.github/workflows/ci-flaky-sync-issues.yml
+++ b/.github/workflows/ci-flaky-sync-issues.yml
@@ -1,0 +1,38 @@
+name: ci-flaky-sync-issues
+
+on:
+  schedule:
+    - cron: '37 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  flaky-sync:
+    name: Flaky Issue Sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate flaky registry
+        run: bash scripts/ci/check_flaky_registry.sh
+
+      - name: Ensure flaky label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh label list --repo "${{ github.repository }}" --search "flaky-test" | grep -q '^flaky-test'; then
+            gh label create "flaky-test" --repo "${{ github.repository }}" --color "f9d0c4" --description "Tracked flaky tests referenced by CI quarantine registry"
+          fi
+
+      - name: Sync flaky registry entries to issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/ci/sync_flaky_registry_issues.sh \
+            --repo "${{ github.repository }}"

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -60,10 +60,12 @@ Enforced by `scripts/ci/check_pr_ci_declaration.sh` in fast-gate.
 - Budget summarizer (`test_summarize_budget_artifacts.sh`)
 - PR CI declaration checker (`test_check_pr_ci_declaration.sh`)
 - Flaky report commenter (`test_post_flaky_report_comment.sh`)
+- Flaky issue syncer (`test_sync_flaky_registry_issues.sh`)
 
 ## Reporting and Burn-down
 - Weekly workflow `ci-flaky-registry` validates the quarantine registry and publishes a report artifact.
 - Weekly workflow `ci-flaky-report-comment` posts an automated report comment to issue `#70`.
+- Weekly workflow `ci-flaky-sync-issues` labels and updates tracking issues referenced in `.ci/flaky-tests.txt`.
 - Use `scripts/ci/summarize_budget_artifacts.sh` on downloaded `ci-budget-*.json` artifacts to compute p50/p95 and cache/retry trends.
 - Use `scripts/ci/download_and_summarize_budget.sh --repo <owner/repo>` to pull recent budget artifacts and produce a local trend summary.
 

--- a/scripts/ci/sync_flaky_registry_issues.sh
+++ b/scripts/ci/sync_flaky_registry_issues.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 --repo <owner/repo> [--registry <path>] [--label <name>] [--dry-run]
+
+Synchronizes flaky registry entries to GitHub issues by:
+- adding a label to each tracking issue
+- posting/updating an automated status comment
+
+Registry format:
+  owner|test-id|#issue|expires-on|notes
+USAGE
+}
+
+REPO=""
+REGISTRY=".ci/flaky-tests.txt"
+LABEL="flaky-test"
+DRY_RUN=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --registry)
+      REGISTRY="${2:-.ci/flaky-tests.txt}"
+      shift 2
+      ;;
+    --label)
+      LABEL="${2:-flaky-test}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  usage >&2
+  exit 2
+fi
+
+if [ ! -f "$REGISTRY" ]; then
+  echo "Registry file not found: $REGISTRY" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/check_flaky_registry.sh" "$REGISTRY" >/dev/null
+
+if [ "$DRY_RUN" = false ] && ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# issue_num -> lines
+# shellcheck disable=SC2034
+declare -A ISSUE_LINES=()
+
+total=0
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    ""|\#*)
+      continue
+      ;;
+  esac
+
+  IFS='|' read -r owner test_id issue expiry notes _ <<<"$line"
+  issue_num="${issue#\#}"
+
+  entry="- ${owner} | ${test_id} | expires ${expiry} | ${notes}"
+  if [ -n "${ISSUE_LINES[$issue_num]:-}" ]; then
+    ISSUE_LINES[$issue_num]="${ISSUE_LINES[$issue_num]}\n${entry}"
+  else
+    ISSUE_LINES[$issue_num]="${entry}"
+  fi
+  total=$(( total + 1 ))
+done < "$REGISTRY"
+
+if [ "$total" -eq 0 ]; then
+  echo "No flaky entries to sync."
+  exit 0
+fi
+
+now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+for issue_num in "${!ISSUE_LINES[@]}"; do
+  comment_body="$(cat <<BODY
+Flaky Registry Sync (automated) at ${now}
+
+The following flaky quarantine entries currently reference this issue:
+
+${ISSUE_LINES[$issue_num]}
+
+If an entry is no longer needed, remove it from \
+".ci/flaky-tests.txt" and keep owner/expiry updated.
+BODY
+)"
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "[dry-run] issue #${issue_num}"
+    echo "[dry-run] add label: ${LABEL}"
+    echo "[dry-run] comment body:"
+    echo "$comment_body"
+    echo
+    continue
+  fi
+
+  gh issue view "$issue_num" -R "$REPO" >/dev/null
+  gh issue edit "$issue_num" -R "$REPO" --add-label "$LABEL" >/dev/null
+
+  # Keep one rolling automated comment instead of creating weekly duplicates.
+  gh issue comment "$issue_num" -R "$REPO" --edit-last --create-if-none --body "$comment_body" >/dev/null
+  echo "Synced flaky registry to issue #${issue_num}"
+done
+
+echo "Flaky registry sync complete for ${#ISSUE_LINES[@]} issue(s)."

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -9,5 +9,6 @@ bash "$ROOT_DIR/scripts/ci/test_check_flaky_registry.sh"
 bash "$ROOT_DIR/scripts/ci/test_summarize_budget_artifacts.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_pr_ci_declaration.sh"
 bash "$ROOT_DIR/scripts/ci/test_post_flaky_report_comment.sh"
+bash "$ROOT_DIR/scripts/ci/test_sync_flaky_registry_issues.sh"
 
 echo "All CI tool regression tests passed."

--- a/scripts/ci/test_sync_flaky_registry_issues.sh
+++ b/scripts/ci/test_sync_flaky_registry_issues.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/ci/sync_flaky_registry_issues.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+future="$(date -u -d '+10 days' +%Y-%m-%d)"
+cat > "$TMP_DIR/registry.txt" <<EOF2
+owner1|crate::test_a|#70|$future|temporary quarantine
+owner2|crate::test_b|#70|$future|intermittent timeout
+owner3|crate::test_c|#69|$future|tracking bug
+EOF2
+
+out="$TMP_DIR/out.txt"
+"$SCRIPT" --repo njfio/kamn --registry "$TMP_DIR/registry.txt" --dry-run > "$out"
+
+grep -q '\[dry-run\] issue #70' "$out"
+grep -q '\[dry-run\] issue #69' "$out"
+grep -q 'owner1 | crate::test_a' "$out"
+grep -q 'owner2 | crate::test_b' "$out"
+grep -q 'owner3 | crate::test_c' "$out"
+grep -q 'Flaky registry sync complete for 2 issue(s).' "$out"
+
+echo "sync_flaky_registry_issues tests passed."


### PR DESCRIPTION
## Summary
Adds automated flaky-issue synchronization from `.ci/flaky-tests.txt` so tracked issues are kept labeled and updated with current quarantine entries. This strengthens flaky burn-down automation while CI runner availability remains constrained.

Refs #70

## Changes
- `.github/workflows/ci-flaky-sync-issues.yml`: weekly/manual workflow to sync flaky registry entries to issue tracking.
- `scripts/ci/sync_flaky_registry_issues.sh`: sync script (label + rolling comment per tracked issue).
- `scripts/ci/test_sync_flaky_registry_issues.sh`: dry-run regression tests.
- `scripts/ci/test_ci_tools.sh`: includes new sync test in CI tools suite.
- `docs/ci/strategy.md`: documents sync workflow and coverage.

## Risks & Compatibility
- No runtime app behavior changes.
- Workflow uses `issues:write` and `gh` with `GITHUB_TOKEN`.

## Validation
- [x] `bash -n scripts/ci/*.sh`
- [x] `bash scripts/ci/test_ci_tools.sh`
- [x] `bash scripts/ci/check_markdown.sh`
- [x] Manual verification: dry-run sync script output includes per-issue aggregation and completion summary.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Script-level parsing/aggregation and dry-run validation |
| Functional  | ✅     | Workflow and script wiring for issue sync behavior |
| Integration | ✅     | Combined CI tool suite includes sync script regression |
| Regression  | ✅     | Added dedicated test to protect sync behavior from drift |
