### PR TITLE
feat(core): add state namespaces and migration scaffolding

### DIFF
--- a/crates/kamn-core/src/bootstrap.rs
+++ b/crates/kamn-core/src/bootstrap.rs
@@ -1,31 +1,53 @@
 use crate::config::{ConfigError, NodeConfig};
+use crate::migrations::{MigrationPlan, MigrationRegistry};
 use crate::namespaces::StateNamespaces;
 use crate::runtime::{build_runtime_wiring, RuntimeWiring};
+use crate::state::{AppStateSchema, StateVersion, APP_STATE_VERSION};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BootstrapPlan {
     pub config: NodeConfig,
     pub namespaces: StateNamespaces,
+    pub state_schema: AppStateSchema,
+    pub migration_plan: MigrationPlan,
     pub wiring: RuntimeWiring,
 }
 
 pub fn bootstrap(config: NodeConfig) -> Result<BootstrapPlan, ConfigError> {
+    bootstrap_from_state_version(config, APP_STATE_VERSION)
+}
+
+pub fn bootstrap_from_state_version(
+    config: NodeConfig,
+    persisted_state_version: StateVersion,
+) -> Result<BootstrapPlan, ConfigError> {
     config.validate()?;
 
-    let namespaces = StateNamespaces::default();
+    let state_schema = AppStateSchema::default();
+    let target_state_version = state_schema.version;
+
+    let registry = MigrationRegistry::new();
+    let migration_plan = registry
+        .build_plan(persisted_state_version, target_state_version)
+        .map_err(|error| ConfigError::MigrationPlan(error.to_string()))?;
+
+    let namespaces = state_schema.namespaces.clone();
     let wiring = build_runtime_wiring(&config);
 
     Ok(BootstrapPlan {
         config,
         namespaces,
+        state_schema,
+        migration_plan,
         wiring,
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::bootstrap;
+    use super::{bootstrap, bootstrap_from_state_version};
     use crate::config::{ConfigError, NodeConfig, NodeRole};
+    use crate::state::{StateVersion, APP_STATE_VERSION};
 
     #[test]
     fn bootstrap_plan_builds_for_valid_config() {
@@ -40,6 +62,8 @@ mod tests {
         let plan = bootstrap(config).expect("bootstrap should succeed");
         assert!(plan.namespaces.all_unique());
         assert!(plan.wiring.all_components().contains(&"block-producer"));
+        assert_eq!(plan.state_schema.version, APP_STATE_VERSION);
+        assert!(plan.migration_plan.steps.is_empty());
     }
 
     #[test]
@@ -53,5 +77,19 @@ mod tests {
         };
 
         assert_eq!(bootstrap(config), Err(ConfigError::EmptyChainId));
+    }
+
+    #[test]
+    fn bootstrap_rejects_state_downgrade() {
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: "/tmp/kamn".to_owned(),
+            enable_gossip: true,
+        };
+
+        let result = bootstrap_from_state_version(config, StateVersion(APP_STATE_VERSION.0 + 1));
+        assert!(matches!(result, Err(ConfigError::MigrationPlan(_))));
     }
 }

--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -60,6 +60,7 @@ pub enum ConfigError {
     EmptyChainId,
     EmptyChainVersion,
     EmptyStorageDir,
+    MigrationPlan(String),
     InvalidRole(String),
     UnknownArgument(String),
     MissingArgumentValue(&'static str),
@@ -71,6 +72,7 @@ impl fmt::Display for ConfigError {
             Self::EmptyChainId => write!(f, "chain_id must not be empty"),
             Self::EmptyChainVersion => write!(f, "chain_version must not be empty"),
             Self::EmptyStorageDir => write!(f, "storage_dir must not be empty"),
+            Self::MigrationPlan(message) => write!(f, "migration planning failed: {message}"),
             Self::InvalidRole(value) => write!(f, "invalid role: {value}"),
             Self::UnknownArgument(value) => write!(f, "unknown argument: {value}"),
             Self::MissingArgumentValue(flag) => {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,9 +1,15 @@
 pub mod bootstrap;
 pub mod config;
+pub mod migrations;
 pub mod namespaces;
 pub mod runtime;
+pub mod state;
 
-pub use bootstrap::{bootstrap, BootstrapPlan};
+pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use config::{ConfigError, NodeConfig, NodeRole};
+pub use migrations::{MigrationPlan, MigrationRegistry, MigrationStep};
 pub use namespaces::StateNamespaces;
 pub use runtime::RuntimeWiring;
+pub use state::{
+    canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
+};

--- a/crates/kamn-core/src/migrations.rs
+++ b/crates/kamn-core/src/migrations.rs
@@ -1,0 +1,313 @@
+use std::fmt;
+
+use crate::state::StateVersion;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationStep {
+    pub id: &'static str,
+    pub from: StateVersion,
+    pub to: StateVersion,
+    pub description: &'static str,
+    pub namespaces: &'static [&'static str],
+}
+
+impl MigrationStep {
+    pub const fn new(
+        id: &'static str,
+        from: StateVersion,
+        to: StateVersion,
+        description: &'static str,
+        namespaces: &'static [&'static str],
+    ) -> Self {
+        Self {
+            id,
+            from,
+            to,
+            description,
+            namespaces,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationPlan {
+    pub from: StateVersion,
+    pub to: StateVersion,
+    pub steps: Vec<MigrationStep>,
+}
+
+impl MigrationPlan {
+    pub fn validate(&self) -> Result<(), MigrationError> {
+        if self.from == self.to {
+            if self.steps.is_empty() {
+                return Ok(());
+            }
+            return Err(MigrationError::UnexpectedStepsForSameVersion);
+        }
+
+        if self.steps.is_empty() {
+            return Err(MigrationError::MissingStep {
+                from: self.from,
+                to: self.to,
+            });
+        }
+
+        let mut current = self.from;
+        for step in &self.steps {
+            if step.from != current {
+                return Err(MigrationError::NonContiguousStep {
+                    expected_from: current,
+                    found_from: step.from,
+                });
+            }
+            current = step.to;
+        }
+
+        if current != self.to {
+            return Err(MigrationError::MissingStep {
+                from: current,
+                to: self.to,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MigrationRegistry {
+    steps: Vec<MigrationStep>,
+}
+
+impl MigrationRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, step: MigrationStep) -> Result<(), MigrationError> {
+        if step.from >= step.to {
+            return Err(MigrationError::InvalidStepRange {
+                id: step.id,
+                from: step.from,
+                to: step.to,
+            });
+        }
+
+        if self.steps.iter().any(|existing| existing.id == step.id) {
+            return Err(MigrationError::DuplicateStepId(step.id.to_owned()));
+        }
+
+        self.steps.push(step);
+        self.steps.sort_by_key(|item| item.from);
+        Ok(())
+    }
+
+    pub fn build_plan(
+        &self,
+        from: StateVersion,
+        to: StateVersion,
+    ) -> Result<MigrationPlan, MigrationError> {
+        if from > to {
+            return Err(MigrationError::InvalidPlanRange { from, to });
+        }
+
+        if from == to {
+            return Ok(MigrationPlan {
+                from,
+                to,
+                steps: Vec::new(),
+            });
+        }
+
+        let mut steps = Vec::new();
+        let mut current = from;
+
+        while current < to {
+            let step = self
+                .steps
+                .iter()
+                .find(|candidate| candidate.from == current)
+                .ok_or(MigrationError::MissingStep { from: current, to })?
+                .clone();
+
+            if step.to > to {
+                return Err(MigrationError::StepOvershootsTarget {
+                    id: step.id.to_owned(),
+                    target: to,
+                    step_to: step.to,
+                });
+            }
+
+            current = step.to;
+            steps.push(step);
+        }
+
+        let plan = MigrationPlan { from, to, steps };
+        plan.validate()?;
+        Ok(plan)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationError {
+    DuplicateStepId(String),
+    InvalidStepRange {
+        id: &'static str,
+        from: StateVersion,
+        to: StateVersion,
+    },
+    InvalidPlanRange {
+        from: StateVersion,
+        to: StateVersion,
+    },
+    MissingStep {
+        from: StateVersion,
+        to: StateVersion,
+    },
+    NonContiguousStep {
+        expected_from: StateVersion,
+        found_from: StateVersion,
+    },
+    StepOvershootsTarget {
+        id: String,
+        target: StateVersion,
+        step_to: StateVersion,
+    },
+    UnexpectedStepsForSameVersion,
+}
+
+impl fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateStepId(id) => write!(f, "duplicate migration step id: {id}"),
+            Self::InvalidStepRange { id, from, to } => {
+                write!(
+                    f,
+                    "invalid migration step range for {id}: {:?} -> {:?}",
+                    from, to
+                )
+            }
+            Self::InvalidPlanRange { from, to } => {
+                write!(f, "invalid migration plan range: {:?} -> {:?}", from, to)
+            }
+            Self::MissingStep { from, to } => {
+                write!(
+                    f,
+                    "missing migration step to progress from {:?} toward {:?}",
+                    from, to
+                )
+            }
+            Self::NonContiguousStep {
+                expected_from,
+                found_from,
+            } => write!(
+                f,
+                "non-contiguous migration step: expected {:?}, found {:?}",
+                expected_from, found_from
+            ),
+            Self::StepOvershootsTarget {
+                id,
+                target,
+                step_to,
+            } => write!(
+                f,
+                "migration step {id} overshoots target {:?} with {:?}",
+                target, step_to
+            ),
+            Self::UnexpectedStepsForSameVersion => {
+                write!(f, "migration plan for same version must not contain steps")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MigrationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{MigrationError, MigrationRegistry, MigrationStep};
+    use crate::state::StateVersion;
+
+    const NAMESPACES: &[&str] = &["kamn.tasks.state"];
+
+    #[test]
+    fn registry_rejects_duplicate_ids() {
+        let mut registry = MigrationRegistry::new();
+        let step = MigrationStep::new(
+            "tasks-v1-v2",
+            StateVersion(1),
+            StateVersion(2),
+            "Upgrade task schema",
+            NAMESPACES,
+        );
+
+        registry.register(step.clone()).expect("first insert works");
+        assert_eq!(
+            registry.register(step),
+            Err(MigrationError::DuplicateStepId("tasks-v1-v2".to_owned()))
+        );
+    }
+
+    #[test]
+    fn registry_builds_contiguous_plan() {
+        let mut registry = MigrationRegistry::new();
+        registry
+            .register(MigrationStep::new(
+                "tasks-v1-v2",
+                StateVersion(1),
+                StateVersion(2),
+                "Upgrade task schema",
+                NAMESPACES,
+            ))
+            .expect("register first step");
+        registry
+            .register(MigrationStep::new(
+                "tasks-v2-v3",
+                StateVersion(2),
+                StateVersion(3),
+                "Second task schema update",
+                NAMESPACES,
+            ))
+            .expect("register second step");
+
+        let plan = registry
+            .build_plan(StateVersion(1), StateVersion(3))
+            .expect("build contiguous plan");
+
+        assert_eq!(plan.steps.len(), 2);
+        assert!(plan.validate().is_ok());
+    }
+
+    #[test]
+    fn registry_rejects_missing_step() {
+        let mut registry = MigrationRegistry::new();
+        registry
+            .register(MigrationStep::new(
+                "tasks-v1-v2",
+                StateVersion(1),
+                StateVersion(2),
+                "Upgrade task schema",
+                NAMESPACES,
+            ))
+            .expect("register step");
+
+        // Regression: #17
+        assert_eq!(
+            registry.build_plan(StateVersion(1), StateVersion(3)),
+            Err(MigrationError::MissingStep {
+                from: StateVersion(2),
+                to: StateVersion(3)
+            })
+        );
+    }
+
+    #[test]
+    fn plan_for_same_version_is_empty() {
+        let registry = MigrationRegistry::new();
+        let plan = registry
+            .build_plan(StateVersion(2), StateVersion(2))
+            .expect("same version requires no steps");
+        assert!(plan.steps.is_empty());
+        assert!(plan.validate().is_ok());
+    }
+}

--- a/crates/kamn-core/src/state.rs
+++ b/crates/kamn-core/src/state.rs
@@ -1,0 +1,172 @@
+use std::fmt;
+
+use crate::namespaces::StateNamespaces;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StateVersion(pub u32);
+
+pub const APP_STATE_VERSION: StateVersion = StateVersion(1);
+pub const MAX_STATE_KEY_PART_LEN: usize = 96;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppStateSchema {
+    pub version: StateVersion,
+    pub namespaces: StateNamespaces,
+}
+
+impl Default for AppStateSchema {
+    fn default() -> Self {
+        Self {
+            version: APP_STATE_VERSION,
+            namespaces: StateNamespaces::default(),
+        }
+    }
+}
+
+pub fn canonical_state_key(
+    namespace: &str,
+    entity: &str,
+    id: &str,
+) -> Result<String, StateKeyError> {
+    validate_namespace(namespace)?;
+    validate_key_part("entity", entity)?;
+    validate_key_part("id", id)?;
+    Ok(format!("{namespace}:{entity}:{id}"))
+}
+
+fn validate_namespace(namespace: &str) -> Result<(), StateKeyError> {
+    if namespace.trim().is_empty() {
+        return Err(StateKeyError::EmptyPart("namespace"));
+    }
+    if !namespace.starts_with("kamn.") {
+        return Err(StateKeyError::NamespacePrefix(namespace.to_owned()));
+    }
+    if namespace.len() > MAX_STATE_KEY_PART_LEN {
+        return Err(StateKeyError::PartTooLong {
+            part: "namespace",
+            max: MAX_STATE_KEY_PART_LEN,
+            actual: namespace.len(),
+        });
+    }
+    if !namespace
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '.' || ch == '_')
+    {
+        return Err(StateKeyError::InvalidCharacter {
+            part: "namespace",
+            value: namespace.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_key_part(part: &'static str, value: &str) -> Result<(), StateKeyError> {
+    if value.trim().is_empty() {
+        return Err(StateKeyError::EmptyPart(part));
+    }
+    if value.len() > MAX_STATE_KEY_PART_LEN {
+        return Err(StateKeyError::PartTooLong {
+            part,
+            max: MAX_STATE_KEY_PART_LEN,
+            actual: value.len(),
+        });
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
+    {
+        return Err(StateKeyError::InvalidCharacter {
+            part,
+            value: value.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateKeyError {
+    EmptyPart(&'static str),
+    PartTooLong {
+        part: &'static str,
+        max: usize,
+        actual: usize,
+    },
+    InvalidCharacter {
+        part: &'static str,
+        value: String,
+    },
+    NamespacePrefix(String),
+}
+
+impl fmt::Display for StateKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyPart(part) => write!(f, "{part} must not be empty"),
+            Self::PartTooLong { part, max, actual } => {
+                write!(f, "{part} exceeds max length {max}: {actual}")
+            }
+            Self::InvalidCharacter { part, value } => {
+                write!(f, "invalid characters for {part}: {value}")
+            }
+            Self::NamespacePrefix(value) => {
+                write!(f, "namespace must use kamn. prefix: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StateKeyError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
+    };
+
+    #[test]
+    fn state_version_orders() {
+        assert!(StateVersion(1) < StateVersion(2));
+    }
+
+    #[test]
+    fn schema_default_matches_current_version() {
+        let schema = AppStateSchema::default();
+        assert_eq!(schema.version, APP_STATE_VERSION);
+        assert!(schema.namespaces.all_unique());
+    }
+
+    #[test]
+    fn canonical_key_is_deterministic() {
+        let key = canonical_state_key("kamn.tasks.state", "assignment", "task_123")
+            .expect("state key must be canonical");
+        assert_eq!(key, "kamn.tasks.state:assignment:task_123");
+    }
+
+    #[test]
+    fn canonical_key_rejects_invalid_namespace_prefix() {
+        let key = canonical_state_key("tasks.state", "assignment", "task_123");
+        assert_eq!(
+            key,
+            Err(StateKeyError::NamespacePrefix("tasks.state".to_owned()))
+        );
+    }
+
+    #[test]
+    fn canonical_key_rejects_invalid_characters() {
+        let key = canonical_state_key("kamn.tasks.state", "Assignment", "task_123");
+        assert_eq!(
+            key,
+            Err(StateKeyError::InvalidCharacter {
+                part: "entity",
+                value: "Assignment".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn canonical_key_rejects_empty_id() {
+        // Regression: #17
+        let key = canonical_state_key("kamn.tasks.state", "assignment", "");
+        assert_eq!(key, Err(StateKeyError::EmptyPart("id")));
+    }
+}

--- a/crates/kamn-core/tests/state_migration_bootstrap.rs
+++ b/crates/kamn-core/tests/state_migration_bootstrap.rs
@@ -1,0 +1,61 @@
+use kamn_core::{
+    bootstrap, bootstrap_from_state_version, canonical_state_key, ConfigError, MigrationRegistry,
+    MigrationStep, NodeConfig, NodeRole, StateVersion, APP_STATE_VERSION,
+};
+
+fn sample_config() -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role: NodeRole::Processor,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: true,
+    }
+}
+
+#[test]
+fn functional_bootstrap_uses_current_schema_for_fresh_state() {
+    let plan = bootstrap(sample_config()).expect("bootstrap should succeed");
+
+    assert_eq!(plan.state_schema.version, APP_STATE_VERSION);
+    assert_eq!(plan.migration_plan.from, APP_STATE_VERSION);
+    assert_eq!(plan.migration_plan.to, APP_STATE_VERSION);
+    assert!(plan.migration_plan.steps.is_empty());
+    assert_eq!(plan.namespaces, plan.state_schema.namespaces);
+}
+
+#[test]
+fn integration_registry_plan_and_key_serialization_work_together() {
+    let mut registry = MigrationRegistry::new();
+    registry
+        .register(MigrationStep::new(
+            "tasks-v0-v1",
+            StateVersion(0),
+            APP_STATE_VERSION,
+            "Initialize task namespace layout",
+            &["kamn.tasks.state"],
+        ))
+        .expect("registry step should be valid");
+
+    let plan = registry
+        .build_plan(StateVersion(0), APP_STATE_VERSION)
+        .expect("upgrade plan should build");
+
+    assert_eq!(plan.steps.len(), 1);
+    let key = canonical_state_key(plan.steps[0].namespaces[0], "migration", "tasks_v0_v1")
+        .expect("migration key should serialize");
+    assert_eq!(key, "kamn.tasks.state:migration:tasks_v0_v1");
+}
+
+#[test]
+fn regression_bootstrap_rejects_state_downgrade_attempt() {
+    // Regression: #17
+    let result =
+        bootstrap_from_state_version(sample_config(), StateVersion(APP_STATE_VERSION.0 + 1));
+    match result {
+        Err(ConfigError::MigrationPlan(message)) => {
+            assert!(message.contains("invalid migration plan range"));
+        }
+        other => panic!("expected migration planning failure, got {other:?}"),
+    }
+}

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -82,7 +82,7 @@ fn run() -> Result<(), ConfigError> {
     let plan = bootstrap(config)?;
 
     println!(
-        "KAMN node bootstrap\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  components: {}",
+        "KAMN node bootstrap\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  state_version: {}\n  pending_migrations: {}\n  components: {}",
         plan.config.role.as_str(),
         plan.config.chain_id,
         plan.config.chain_version,
@@ -92,6 +92,8 @@ fn run() -> Result<(), ConfigError> {
         } else {
             "disabled"
         },
+        plan.state_schema.version.0,
+        plan.migration_plan.steps.len(),
         plan.wiring.all_components().join(", ")
     );
 

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -13,6 +13,13 @@ This document describes the initial KAMN chain bootstrap scaffold.
   - tasks
   - reputation
   - escrows
+- App-state schema/version primitives:
+  - `APP_STATE_VERSION` for the current schema revision.
+  - `AppStateSchema` for version + namespace bundle.
+  - `canonical_state_key(namespace, entity, id)` for deterministic key serialization and strict validation.
+- Migration scaffolding:
+  - `MigrationRegistry`, `MigrationStep`, and `MigrationPlan` for deterministic, contiguous state upgrades.
+  - `bootstrap_from_state_version(...)` to compute the startup migration plan from persisted state to current schema.
 
 ## Local Validation
 Run from repository root:
@@ -31,3 +38,4 @@ cargo run -p kamn-node -- --role processor --chain-id kamn-devnet --chain-versio
 
 ## Notes
 This is intentionally minimal and dependency-light so the bootstrap path is fast and auditable.
+Migration execution is not implemented yet; this stage focuses on deterministic planning and validation hooks.


### PR DESCRIPTION
Closes #17

## Summary
Implements KAMN app-state schema/version scaffolding with deterministic state-key serialization and migration-plan hooks in bootstrap.
This establishes explicit, auditable state evolution primitives without introducing heavy dependencies.

## Changes
- `crates/kamn-core/src/state.rs`: Added `StateVersion`, `APP_STATE_VERSION`, `AppStateSchema`, canonical key serialization, and strict key validation errors.
- `crates/kamn-core/src/migrations.rs`: Added `MigrationStep`, `MigrationRegistry`, `MigrationPlan`, validation, and migration error types.
- `crates/kamn-core/src/bootstrap.rs`: Added `state_schema` and `migration_plan` to `BootstrapPlan`; introduced `bootstrap_from_state_version(...)` and migration planning in startup path.
- `crates/kamn-core/src/config.rs`: Added `ConfigError::MigrationPlan(...)` for explicit bootstrap failure mapping.
- `crates/kamn-core/src/lib.rs`: Exported state/migration APIs.
- `crates/kamn-core/tests/state_migration_bootstrap.rs`: Added functional, integration, and regression tests for #17.
- `crates/kamn-node/src/main.rs`: Extended bootstrap output to include state version and pending migrations.
- `docs/foundation/bootstrap.md`: Documented schema/version and migration scaffolding.

## Risks & Compatibility
- Breaking changes: `BootstrapPlan` now includes `state_schema` and `migration_plan` fields.
- Runtime migration execution is still out-of-scope; only deterministic planning/validation hooks are included.

## Validation
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: `kamn-node` bootstrap output now includes state version and pending migration count.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `state`, `migrations`, `bootstrap`, and config validation tests |
| Functional  | ✅     | `functional_bootstrap_uses_current_schema_for_fresh_state` |
| Integration | ✅     | `integration_registry_plan_and_key_serialization_work_together` |
| Regression  | ✅     | Missing-step regression in `migrations.rs`; downgrade rejection regression in integration tests |
