### PR TITLE
feat(core): add processor/listener/approver smoke scenarios

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod migrations;
 pub mod namespaces;
 pub mod runtime;
+pub mod smoke;
 pub mod state;
 
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
@@ -10,6 +11,7 @@ pub use config::{ConfigError, NodeConfig, NodeRole};
 pub use migrations::{MigrationPlan, MigrationRegistry, MigrationStep};
 pub use namespaces::StateNamespaces;
 pub use runtime::RuntimeWiring;
+pub use smoke::{BaselineTransaction, ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
 };

--- a/crates/kamn-core/src/smoke.rs
+++ b/crates/kamn-core/src/smoke.rs
@@ -1,0 +1,238 @@
+use std::fmt;
+
+use crate::config::NodeRole;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaselineTransaction {
+    pub id: String,
+    pub nonce: u64,
+    pub payload: String,
+}
+
+impl BaselineTransaction {
+    pub fn validate(&self) -> Result<(), SmokeError> {
+        if self.id.trim().is_empty() {
+            return Err(SmokeError::EmptyTransactionId);
+        }
+        if self.nonce == 0 {
+            return Err(SmokeError::InvalidNonce(self.nonce));
+        }
+        if self.payload.trim().is_empty() {
+            return Err(SmokeError::EmptyPayload);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProducedBlock {
+    pub height: u64,
+    pub producer: NodeRole,
+    pub transactions: Vec<BaselineTransaction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeSmokeState {
+    pub role: NodeRole,
+    mempool: Vec<BaselineTransaction>,
+    committed_tx_ids: Vec<String>,
+}
+
+impl NodeSmokeState {
+    pub fn mempool_len(&self) -> usize {
+        self.mempool.len()
+    }
+
+    pub fn committed_len(&self) -> usize {
+        self.committed_tx_ids.len()
+    }
+
+    pub fn has_seen_transaction(&self, tx_id: &str) -> bool {
+        self.mempool.iter().any(|tx| tx.id == tx_id)
+            || self.committed_tx_ids.iter().any(|seen_id| seen_id == tx_id)
+    }
+
+    fn push_mempool(&mut self, tx: BaselineTransaction) {
+        self.mempool.push(tx);
+    }
+
+    fn commit_transactions(&mut self, txs: &[BaselineTransaction]) {
+        for tx in txs {
+            self.committed_tx_ids.push(tx.id.clone());
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoleSmokeNetwork {
+    pub processor: NodeSmokeState,
+    pub listener: NodeSmokeState,
+    pub approver: NodeSmokeState,
+    pub gossip_enabled: bool,
+    next_height: u64,
+}
+
+impl RoleSmokeNetwork {
+    pub fn new(gossip_enabled: bool) -> Self {
+        Self {
+            processor: NodeSmokeState {
+                role: NodeRole::Processor,
+                mempool: Vec::new(),
+                committed_tx_ids: Vec::new(),
+            },
+            listener: NodeSmokeState {
+                role: NodeRole::Listener,
+                mempool: Vec::new(),
+                committed_tx_ids: Vec::new(),
+            },
+            approver: NodeSmokeState {
+                role: NodeRole::Approver,
+                mempool: Vec::new(),
+                committed_tx_ids: Vec::new(),
+            },
+            gossip_enabled,
+            next_height: 1,
+        }
+    }
+
+    pub fn submit_transaction(&mut self, tx: BaselineTransaction) -> Result<(), SmokeError> {
+        tx.validate()?;
+
+        if self.processor.has_seen_transaction(&tx.id)
+            || self.listener.has_seen_transaction(&tx.id)
+            || self.approver.has_seen_transaction(&tx.id)
+        {
+            return Err(SmokeError::DuplicateTransaction(tx.id));
+        }
+
+        self.processor.push_mempool(tx.clone());
+        if self.gossip_enabled {
+            self.listener.push_mempool(tx.clone());
+            self.approver.push_mempool(tx);
+        }
+
+        Ok(())
+    }
+
+    pub fn produce_block(&mut self) -> Result<ProducedBlock, SmokeError> {
+        if self.processor.mempool.is_empty() {
+            return Err(SmokeError::EmptyMempool(NodeRole::Processor));
+        }
+
+        self.processor
+            .mempool
+            .sort_by(|lhs, rhs| lhs.nonce.cmp(&rhs.nonce).then(lhs.id.cmp(&rhs.id)));
+        let transactions = std::mem::take(&mut self.processor.mempool);
+        self.processor.commit_transactions(&transactions);
+
+        if self.gossip_enabled {
+            self.listener.mempool.clear();
+            self.approver.mempool.clear();
+            self.listener.commit_transactions(&transactions);
+            self.approver.commit_transactions(&transactions);
+        }
+
+        let block = ProducedBlock {
+            height: self.next_height,
+            producer: NodeRole::Processor,
+            transactions,
+        };
+        self.next_height += 1;
+
+        Ok(block)
+    }
+
+    pub fn gossip_reached_all_roles(&self, tx_id: &str) -> bool {
+        self.listener.has_seen_transaction(tx_id) && self.approver.has_seen_transaction(tx_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmokeError {
+    DuplicateTransaction(String),
+    EmptyMempool(NodeRole),
+    EmptyPayload,
+    EmptyTransactionId,
+    InvalidNonce(u64),
+}
+
+impl fmt::Display for SmokeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateTransaction(id) => write!(f, "duplicate transaction id: {id}"),
+            Self::EmptyMempool(role) => {
+                write!(f, "no pending transactions in {} mempool", role.as_str())
+            }
+            Self::EmptyPayload => write!(f, "transaction payload must not be empty"),
+            Self::EmptyTransactionId => write!(f, "transaction id must not be empty"),
+            Self::InvalidNonce(value) => write!(f, "transaction nonce must be positive: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for SmokeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{BaselineTransaction, RoleSmokeNetwork, SmokeError};
+    use crate::config::NodeRole;
+
+    fn sample_tx(id: &str, nonce: u64) -> BaselineTransaction {
+        BaselineTransaction {
+            id: id.to_owned(),
+            nonce,
+            payload: format!("payload-{id}"),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_transaction_payload() {
+        let tx = BaselineTransaction {
+            id: "tx-1".to_owned(),
+            nonce: 1,
+            payload: String::new(),
+        };
+
+        assert_eq!(tx.validate(), Err(SmokeError::EmptyPayload));
+    }
+
+    #[test]
+    fn rejects_duplicate_transactions() {
+        let mut network = RoleSmokeNetwork::new(true);
+        network
+            .submit_transaction(sample_tx("tx-1", 1))
+            .expect("first transaction should be accepted");
+
+        assert_eq!(
+            network.submit_transaction(sample_tx("tx-1", 2)),
+            Err(SmokeError::DuplicateTransaction("tx-1".to_owned()))
+        );
+    }
+
+    #[test]
+    fn produce_block_orders_transactions_by_nonce() {
+        let mut network = RoleSmokeNetwork::new(true);
+        network
+            .submit_transaction(sample_tx("tx-2", 2))
+            .expect("first submit works");
+        network
+            .submit_transaction(sample_tx("tx-1", 1))
+            .expect("second submit works");
+
+        let block = network
+            .produce_block()
+            .expect("block production should succeed");
+        assert_eq!(block.producer, NodeRole::Processor);
+        assert_eq!(block.transactions[0].id, "tx-1");
+        assert_eq!(block.transactions[1].id, "tx-2");
+    }
+
+    #[test]
+    fn produce_block_requires_processor_transactions() {
+        let mut network = RoleSmokeNetwork::new(true);
+        assert_eq!(
+            network.produce_block(),
+            Err(SmokeError::EmptyMempool(NodeRole::Processor))
+        );
+    }
+}

--- a/crates/kamn-core/tests/role_smoke_network.rs
+++ b/crates/kamn-core/tests/role_smoke_network.rs
@@ -1,0 +1,100 @@
+use kamn_core::{
+    bootstrap, BaselineTransaction, NodeConfig, NodeRole, RoleSmokeNetwork, SmokeError,
+};
+
+fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: gossip_enabled,
+    }
+}
+
+fn sample_tx(id: &str, nonce: u64) -> BaselineTransaction {
+    BaselineTransaction {
+        id: id.to_owned(),
+        nonce,
+        payload: format!("payload-{id}"),
+    }
+}
+
+#[test]
+fn functional_roles_complete_smoke_roundtrip_with_gossip() {
+    let mut network = RoleSmokeNetwork::new(true);
+    network
+        .submit_transaction(sample_tx("tx-1", 1))
+        .expect("transaction submit should succeed");
+
+    assert!(network.gossip_reached_all_roles("tx-1"));
+
+    let block = network
+        .produce_block()
+        .expect("block production should succeed");
+    assert_eq!(block.height, 1);
+    assert_eq!(block.transactions.len(), 1);
+    assert_eq!(network.processor.committed_len(), 1);
+    assert_eq!(network.listener.committed_len(), 1);
+    assert_eq!(network.approver.committed_len(), 1);
+}
+
+#[test]
+fn integration_bootstrap_role_plans_match_smoke_network_expectations() {
+    let processor_plan =
+        bootstrap(config_for(NodeRole::Processor, true)).expect("processor bootstrap succeeds");
+    let listener_plan =
+        bootstrap(config_for(NodeRole::Listener, true)).expect("listener bootstrap succeeds");
+    let approver_plan =
+        bootstrap(config_for(NodeRole::Approver, true)).expect("approver bootstrap succeeds");
+
+    assert!(processor_plan
+        .wiring
+        .all_components()
+        .contains(&"block-producer"));
+    assert!(listener_plan
+        .wiring
+        .all_components()
+        .contains(&"external-listener"));
+    assert!(approver_plan
+        .wiring
+        .all_components()
+        .contains(&"quorum-approver"));
+
+    let mut network = RoleSmokeNetwork::new(processor_plan.config.enable_gossip);
+    network
+        .submit_transaction(sample_tx("tx-1", 1))
+        .expect("transaction submit should succeed");
+    let block = network
+        .produce_block()
+        .expect("block production should succeed");
+    assert_eq!(block.transactions[0].id, "tx-1");
+}
+
+#[test]
+fn regression_gossip_disabled_prevents_cross_role_propagation() {
+    // Regression: #18
+    let mut network = RoleSmokeNetwork::new(false);
+    network
+        .submit_transaction(sample_tx("tx-1", 1))
+        .expect("transaction submit should succeed");
+
+    assert!(!network.gossip_reached_all_roles("tx-1"));
+
+    let block = network
+        .produce_block()
+        .expect("block production should succeed");
+    assert_eq!(block.transactions.len(), 1);
+    assert_eq!(network.processor.committed_len(), 1);
+    assert_eq!(network.listener.committed_len(), 0);
+    assert_eq!(network.approver.committed_len(), 0);
+}
+
+#[test]
+fn integration_rejects_invalid_nonce_at_submit_boundary() {
+    let mut network = RoleSmokeNetwork::new(true);
+    assert_eq!(
+        network.submit_transaction(sample_tx("tx-1", 0)),
+        Err(SmokeError::InvalidNonce(0))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -39,3 +39,4 @@ cargo run -p kamn-node -- --role processor --chain-id kamn-devnet --chain-versio
 ## Notes
 This is intentionally minimal and dependency-light so the bootstrap path is fast and auditable.
 Migration execution is not implemented yet; this stage focuses on deterministic planning and validation hooks.
+For role interaction baseline coverage, see `docs/foundation/role-smoke.md`.

--- a/docs/foundation/role-smoke.md
+++ b/docs/foundation/role-smoke.md
@@ -1,0 +1,30 @@
+# Role Smoke Scenarios (Issue #18)
+
+This document describes baseline smoke scenarios for processor/listener/approver behavior.
+
+## Scope
+- Validate transaction intake at the processor boundary.
+- Validate block production from pending processor transactions.
+- Validate gossip propagation expectations to listener and approver roles.
+
+## Model
+The smoke harness is intentionally lightweight and deterministic:
+- `RoleSmokeNetwork` simulates one processor, one listener, and one approver.
+- `submit_transaction(...)` validates ID, nonce, and payload before ingest.
+- `produce_block(...)` orders transactions deterministically by nonce then ID.
+- Gossip behavior is explicit via the `gossip_enabled` toggle.
+
+## Failure Modes
+- Duplicate transaction IDs are rejected.
+- Non-positive nonces are rejected.
+- Empty payloads are rejected.
+- Producing a block with an empty processor mempool fails explicitly.
+
+## Validation Commands
+Run from repository root:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```


### PR DESCRIPTION
Closes #18

## Summary
Adds deterministic baseline smoke scenarios for processor/listener/approver interactions in `kamn-core`.
This provides low-cost, fast validation coverage for transaction intake, block production ordering, and gossip propagation behavior.

## Changes
- `crates/kamn-core/src/smoke.rs`: Added `RoleSmokeNetwork`, `BaselineTransaction`, `ProducedBlock`, and explicit `SmokeError` handling.
- `crates/kamn-core/src/lib.rs`: Exported smoke simulation types.
- `crates/kamn-core/tests/role_smoke_network.rs`: Added functional, integration, and regression smoke tests.
- `docs/foundation/role-smoke.md`: Added role-smoke model and validation runbook.
- `docs/foundation/bootstrap.md`: Linked foundation bootstrap docs to role-smoke scenarios.

## Risks & Compatibility
- No breaking API changes to existing bootstrap/config entrypoints.
- Smoke network is a deterministic validation harness, not full consensus or networking behavior.

## Validation
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: smoke scenarios cover gossip-enabled and gossip-disabled paths.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `smoke.rs` transaction validation, duplicate rejection, ordering, empty mempool checks |
| Functional  | ✅     | `functional_roles_complete_smoke_roundtrip_with_gossip` |
| Integration | ✅     | `integration_bootstrap_role_plans_match_smoke_network_expectations` + nonce boundary check |
| Regression  | ✅     | `regression_gossip_disabled_prevents_cross_role_propagation` |
