### PR TITLE
feat(core): enforce transaction guard invariants

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -5,13 +5,17 @@ pub mod namespaces;
 pub mod runtime;
 pub mod smoke;
 pub mod state;
+pub mod transaction;
 
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use config::{ConfigError, NodeConfig, NodeRole};
 pub use migrations::{MigrationPlan, MigrationRegistry, MigrationStep};
 pub use namespaces::StateNamespaces;
 pub use runtime::RuntimeWiring;
-pub use smoke::{BaselineTransaction, ProducedBlock, RoleSmokeNetwork, SmokeError};
+pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
+};
+pub use transaction::{
+    BaselineTransaction, TransactionGuardError, TransactionGuards, GENESIS_STATE_HASH,
 };

--- a/crates/kamn-core/src/smoke.rs
+++ b/crates/kamn-core/src/smoke.rs
@@ -1,28 +1,7 @@
 use std::fmt;
 
 use crate::config::NodeRole;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BaselineTransaction {
-    pub id: String,
-    pub nonce: u64,
-    pub payload: String,
-}
-
-impl BaselineTransaction {
-    pub fn validate(&self) -> Result<(), SmokeError> {
-        if self.id.trim().is_empty() {
-            return Err(SmokeError::EmptyTransactionId);
-        }
-        if self.nonce == 0 {
-            return Err(SmokeError::InvalidNonce(self.nonce));
-        }
-        if self.payload.trim().is_empty() {
-            return Err(SmokeError::EmptyPayload);
-        }
-        Ok(())
-    }
-}
+use crate::transaction::{BaselineTransaction, TransactionGuardError, TransactionGuards};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProducedBlock {
@@ -69,6 +48,7 @@ pub struct RoleSmokeNetwork {
     pub listener: NodeSmokeState,
     pub approver: NodeSmokeState,
     pub gossip_enabled: bool,
+    guards: TransactionGuards,
     next_height: u64,
 }
 
@@ -91,19 +71,17 @@ impl RoleSmokeNetwork {
                 committed_tx_ids: Vec::new(),
             },
             gossip_enabled,
+            guards: TransactionGuards::new(),
             next_height: 1,
         }
     }
 
-    pub fn submit_transaction(&mut self, tx: BaselineTransaction) -> Result<(), SmokeError> {
-        tx.validate()?;
+    pub fn expected_state_hash(&self) -> &str {
+        self.guards.expected_state_hash()
+    }
 
-        if self.processor.has_seen_transaction(&tx.id)
-            || self.listener.has_seen_transaction(&tx.id)
-            || self.approver.has_seen_transaction(&tx.id)
-        {
-            return Err(SmokeError::DuplicateTransaction(tx.id));
-        }
+    pub fn submit_transaction(&mut self, tx: BaselineTransaction) -> Result<(), SmokeError> {
+        self.guards.validate_and_record(&tx)?;
 
         self.processor.push_mempool(tx.clone());
         if self.gossip_enabled {
@@ -124,6 +102,7 @@ impl RoleSmokeNetwork {
             .sort_by(|lhs, rhs| lhs.nonce.cmp(&rhs.nonce).then(lhs.id.cmp(&rhs.id)));
         let transactions = std::mem::take(&mut self.processor.mempool);
         self.processor.commit_transactions(&transactions);
+        self.guards.commit_block(&transactions)?;
 
         if self.gossip_enabled {
             self.listener.mempool.clear();
@@ -149,23 +128,23 @@ impl RoleSmokeNetwork {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SmokeError {
-    DuplicateTransaction(String),
     EmptyMempool(NodeRole),
-    EmptyPayload,
-    EmptyTransactionId,
-    InvalidNonce(u64),
+    Guard(TransactionGuardError),
+}
+
+impl From<TransactionGuardError> for SmokeError {
+    fn from(error: TransactionGuardError) -> Self {
+        Self::Guard(error)
+    }
 }
 
 impl fmt::Display for SmokeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::DuplicateTransaction(id) => write!(f, "duplicate transaction id: {id}"),
             Self::EmptyMempool(role) => {
                 write!(f, "no pending transactions in {} mempool", role.as_str())
             }
-            Self::EmptyPayload => write!(f, "transaction payload must not be empty"),
-            Self::EmptyTransactionId => write!(f, "transaction id must not be empty"),
-            Self::InvalidNonce(value) => write!(f, "transaction nonce must be positive: {value}"),
+            Self::Guard(error) => write!(f, "{error}"),
         }
     }
 }
@@ -174,49 +153,66 @@ impl std::error::Error for SmokeError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{BaselineTransaction, RoleSmokeNetwork, SmokeError};
+    use super::{RoleSmokeNetwork, SmokeError};
     use crate::config::NodeRole;
+    use crate::transaction::{BaselineTransaction, TransactionGuardError};
 
-    fn sample_tx(id: &str, nonce: u64) -> BaselineTransaction {
-        BaselineTransaction {
-            id: id.to_owned(),
-            nonce,
-            payload: format!("payload-{id}"),
-        }
+    fn sample_tx(
+        id: &str,
+        sender: &str,
+        nonce: u64,
+        state_hash: &str,
+        payload: &str,
+    ) -> BaselineTransaction {
+        BaselineTransaction::signed(id, sender, nonce, payload, state_hash)
     }
 
     #[test]
     fn rejects_invalid_transaction_payload() {
-        let tx = BaselineTransaction {
-            id: "tx-1".to_owned(),
-            nonce: 1,
-            payload: String::new(),
-        };
+        let mut network = RoleSmokeNetwork::new(true);
+        let state_hash = network.expected_state_hash().to_owned();
+        let tx = sample_tx("tx-1", "agent-a", 1, &state_hash, "");
 
-        assert_eq!(tx.validate(), Err(SmokeError::EmptyPayload));
+        assert_eq!(
+            network.submit_transaction(tx),
+            Err(SmokeError::Guard(TransactionGuardError::EmptyField(
+                "payload"
+            )))
+        );
     }
 
     #[test]
     fn rejects_duplicate_transactions() {
         let mut network = RoleSmokeNetwork::new(true);
+        let state_hash = network.expected_state_hash().to_owned();
         network
-            .submit_transaction(sample_tx("tx-1", 1))
+            .submit_transaction(sample_tx("tx-1", "agent-a", 1, &state_hash, "payload-1"))
             .expect("first transaction should be accepted");
 
+        let second_state_hash = network.expected_state_hash().to_owned();
         assert_eq!(
-            network.submit_transaction(sample_tx("tx-1", 2)),
-            Err(SmokeError::DuplicateTransaction("tx-1".to_owned()))
+            network.submit_transaction(sample_tx(
+                "tx-1",
+                "agent-b",
+                1,
+                &second_state_hash,
+                "payload-2"
+            )),
+            Err(SmokeError::Guard(
+                TransactionGuardError::DuplicateTransactionId("tx-1".to_owned())
+            ))
         );
     }
 
     #[test]
     fn produce_block_orders_transactions_by_nonce() {
         let mut network = RoleSmokeNetwork::new(true);
+        let state_hash = network.expected_state_hash().to_owned();
         network
-            .submit_transaction(sample_tx("tx-2", 2))
+            .submit_transaction(sample_tx("tx-2", "agent-a", 1, &state_hash, "payload-2"))
             .expect("first submit works");
         network
-            .submit_transaction(sample_tx("tx-1", 1))
+            .submit_transaction(sample_tx("tx-1", "agent-b", 1, &state_hash, "payload-1"))
             .expect("second submit works");
 
         let block = network

--- a/crates/kamn-core/src/transaction.rs
+++ b/crates/kamn-core/src/transaction.rs
@@ -1,0 +1,298 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+pub const GENESIS_STATE_HASH: &str = "state:genesis";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaselineTransaction {
+    pub id: String,
+    pub sender: String,
+    pub nonce: u64,
+    pub payload: String,
+    pub state_hash: String,
+    pub signature: String,
+}
+
+impl BaselineTransaction {
+    pub fn signed(id: &str, sender: &str, nonce: u64, payload: &str, state_hash: &str) -> Self {
+        let mut tx = Self {
+            id: id.to_owned(),
+            sender: sender.to_owned(),
+            nonce,
+            payload: payload.to_owned(),
+            state_hash: state_hash.to_owned(),
+            signature: String::new(),
+        };
+        tx.signature = tx.expected_signature();
+        tx
+    }
+
+    pub fn expected_signature(&self) -> String {
+        // Lightweight deterministic placeholder for baseline integrity checks.
+        format!(
+            "sig:{}:{}:{}:{}",
+            self.sender,
+            self.nonce,
+            self.state_hash,
+            self.payload.len()
+        )
+    }
+
+    fn validate_shape(&self) -> Result<(), TransactionGuardError> {
+        if self.id.trim().is_empty() {
+            return Err(TransactionGuardError::EmptyField("id"));
+        }
+        if self.sender.trim().is_empty() {
+            return Err(TransactionGuardError::EmptyField("sender"));
+        }
+        if self.nonce == 0 {
+            return Err(TransactionGuardError::InvalidNonce(self.nonce));
+        }
+        if self.payload.trim().is_empty() {
+            return Err(TransactionGuardError::EmptyField("payload"));
+        }
+        if self.state_hash.trim().is_empty() {
+            return Err(TransactionGuardError::EmptyField("state_hash"));
+        }
+        if self.signature.trim().is_empty() {
+            return Err(TransactionGuardError::EmptyField("signature"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionGuards {
+    expected_state_hash: String,
+    seen_tx_ids: BTreeSet<String>,
+    next_nonce_by_sender: BTreeMap<String, u64>,
+}
+
+impl Default for TransactionGuards {
+    fn default() -> Self {
+        Self {
+            expected_state_hash: GENESIS_STATE_HASH.to_owned(),
+            seen_tx_ids: BTreeSet::new(),
+            next_nonce_by_sender: BTreeMap::new(),
+        }
+    }
+}
+
+impl TransactionGuards {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn expected_state_hash(&self) -> &str {
+        &self.expected_state_hash
+    }
+
+    pub fn validate_and_record(
+        &mut self,
+        tx: &BaselineTransaction,
+    ) -> Result<(), TransactionGuardError> {
+        tx.validate_shape()?;
+
+        if tx.state_hash != self.expected_state_hash {
+            return Err(TransactionGuardError::StateHashMismatch {
+                expected: self.expected_state_hash.clone(),
+                found: tx.state_hash.clone(),
+            });
+        }
+
+        if tx.signature != tx.expected_signature() {
+            return Err(TransactionGuardError::InvalidSignature {
+                tx_id: tx.id.clone(),
+                expected: tx.expected_signature(),
+                found: tx.signature.clone(),
+            });
+        }
+
+        if self.seen_tx_ids.contains(&tx.id) {
+            return Err(TransactionGuardError::DuplicateTransactionId(tx.id.clone()));
+        }
+
+        let expected_nonce = self
+            .next_nonce_by_sender
+            .get(&tx.sender)
+            .copied()
+            .unwrap_or(1);
+        if tx.nonce != expected_nonce {
+            return Err(TransactionGuardError::NonceOutOfSequence {
+                sender: tx.sender.clone(),
+                expected: expected_nonce,
+                found: tx.nonce,
+            });
+        }
+
+        self.seen_tx_ids.insert(tx.id.clone());
+        self.next_nonce_by_sender
+            .insert(tx.sender.clone(), tx.nonce + 1);
+
+        Ok(())
+    }
+
+    pub fn commit_block(
+        &mut self,
+        transactions: &[BaselineTransaction],
+    ) -> Result<(), TransactionGuardError> {
+        for tx in transactions {
+            if !self.seen_tx_ids.contains(&tx.id) {
+                return Err(TransactionGuardError::UnvalidatedCommittedTransaction(
+                    tx.id.clone(),
+                ));
+            }
+        }
+
+        if transactions.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx_digest = String::new();
+        for tx in transactions {
+            tx_digest.push('|');
+            tx_digest.push_str(&tx.id);
+            tx_digest.push(':');
+            tx_digest.push_str(&tx.nonce.to_string());
+        }
+
+        self.expected_state_hash = format!("state:{}{}", self.expected_state_hash, tx_digest);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransactionGuardError {
+    DuplicateTransactionId(String),
+    EmptyField(&'static str),
+    InvalidNonce(u64),
+    InvalidSignature {
+        tx_id: String,
+        expected: String,
+        found: String,
+    },
+    NonceOutOfSequence {
+        sender: String,
+        expected: u64,
+        found: u64,
+    },
+    StateHashMismatch {
+        expected: String,
+        found: String,
+    },
+    UnvalidatedCommittedTransaction(String),
+}
+
+impl fmt::Display for TransactionGuardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateTransactionId(tx_id) => write!(f, "duplicate transaction id: {tx_id}"),
+            Self::EmptyField(field) => write!(f, "{field} must not be empty"),
+            Self::InvalidNonce(value) => write!(f, "transaction nonce must be positive: {value}"),
+            Self::InvalidSignature {
+                tx_id,
+                expected,
+                found,
+            } => write!(
+                f,
+                "invalid signature for {tx_id}; expected {expected}, found {found}"
+            ),
+            Self::NonceOutOfSequence {
+                sender,
+                expected,
+                found,
+            } => write!(
+                f,
+                "nonce out of sequence for sender {sender}; expected {expected}, found {found}"
+            ),
+            Self::StateHashMismatch { expected, found } => {
+                write!(f, "state hash mismatch; expected {expected}, found {found}")
+            }
+            Self::UnvalidatedCommittedTransaction(tx_id) => {
+                write!(f, "committed transaction was not validated: {tx_id}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TransactionGuardError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BaselineTransaction, TransactionGuardError, TransactionGuards, GENESIS_STATE_HASH,
+    };
+
+    fn signed_tx(id: &str, sender: &str, nonce: u64, state_hash: &str) -> BaselineTransaction {
+        BaselineTransaction::signed(id, sender, nonce, &format!("payload-{id}"), state_hash)
+    }
+
+    #[test]
+    fn validates_signed_transaction() {
+        let mut guards = TransactionGuards::new();
+        let tx = signed_tx("tx-1", "agent-a", 1, guards.expected_state_hash());
+
+        assert!(guards.validate_and_record(&tx).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_signature() {
+        let mut guards = TransactionGuards::new();
+        let mut tx = signed_tx("tx-1", "agent-a", 1, guards.expected_state_hash());
+        tx.signature = "sig:tampered".to_owned();
+
+        assert!(matches!(
+            guards.validate_and_record(&tx),
+            Err(TransactionGuardError::InvalidSignature { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_nonce_out_of_sequence() {
+        let mut guards = TransactionGuards::new();
+        let tx = signed_tx("tx-1", "agent-a", 2, guards.expected_state_hash());
+
+        assert_eq!(
+            guards.validate_and_record(&tx),
+            Err(TransactionGuardError::NonceOutOfSequence {
+                sender: "agent-a".to_owned(),
+                expected: 1,
+                found: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_stale_state_hash() {
+        let mut guards = TransactionGuards::new();
+        let tx1 = signed_tx("tx-1", "agent-a", 1, guards.expected_state_hash());
+        guards
+            .validate_and_record(&tx1)
+            .expect("first transaction should validate");
+        guards
+            .commit_block(&[tx1])
+            .expect("block commit should succeed");
+
+        // Regression: #78
+        let stale = signed_tx("tx-2", "agent-a", 2, GENESIS_STATE_HASH);
+        assert!(matches!(
+            guards.validate_and_record(&stale),
+            Err(TransactionGuardError::StateHashMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn commit_advances_expected_state_hash() {
+        let mut guards = TransactionGuards::new();
+        let initial = guards.expected_state_hash().to_owned();
+        let tx = signed_tx("tx-1", "agent-a", 1, guards.expected_state_hash());
+        guards
+            .validate_and_record(&tx)
+            .expect("transaction should validate");
+
+        guards
+            .commit_block(&[tx])
+            .expect("block commit should succeed");
+        assert_ne!(guards.expected_state_hash(), initial);
+    }
+}

--- a/crates/kamn-core/tests/role_smoke_network.rs
+++ b/crates/kamn-core/tests/role_smoke_network.rs
@@ -1,5 +1,6 @@
 use kamn_core::{
     bootstrap, BaselineTransaction, NodeConfig, NodeRole, RoleSmokeNetwork, SmokeError,
+    TransactionGuardError,
 };
 
 fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
@@ -12,19 +13,26 @@ fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
     }
 }
 
-fn sample_tx(id: &str, nonce: u64) -> BaselineTransaction {
-    BaselineTransaction {
-        id: id.to_owned(),
+fn sample_tx(
+    network: &RoleSmokeNetwork,
+    id: &str,
+    sender: &str,
+    nonce: u64,
+) -> BaselineTransaction {
+    BaselineTransaction::signed(
+        id,
+        sender,
         nonce,
-        payload: format!("payload-{id}"),
-    }
+        &format!("payload-{id}"),
+        network.expected_state_hash(),
+    )
 }
 
 #[test]
 fn functional_roles_complete_smoke_roundtrip_with_gossip() {
     let mut network = RoleSmokeNetwork::new(true);
     network
-        .submit_transaction(sample_tx("tx-1", 1))
+        .submit_transaction(sample_tx(&network, "tx-1", "agent-a", 1))
         .expect("transaction submit should succeed");
 
     assert!(network.gossip_reached_all_roles("tx-1"));
@@ -63,7 +71,7 @@ fn integration_bootstrap_role_plans_match_smoke_network_expectations() {
 
     let mut network = RoleSmokeNetwork::new(processor_plan.config.enable_gossip);
     network
-        .submit_transaction(sample_tx("tx-1", 1))
+        .submit_transaction(sample_tx(&network, "tx-1", "agent-a", 1))
         .expect("transaction submit should succeed");
     let block = network
         .produce_block()
@@ -76,7 +84,7 @@ fn regression_gossip_disabled_prevents_cross_role_propagation() {
     // Regression: #18
     let mut network = RoleSmokeNetwork::new(false);
     network
-        .submit_transaction(sample_tx("tx-1", 1))
+        .submit_transaction(sample_tx(&network, "tx-1", "agent-a", 1))
         .expect("transaction submit should succeed");
 
     assert!(!network.gossip_reached_all_roles("tx-1"));
@@ -94,7 +102,7 @@ fn regression_gossip_disabled_prevents_cross_role_propagation() {
 fn integration_rejects_invalid_nonce_at_submit_boundary() {
     let mut network = RoleSmokeNetwork::new(true);
     assert_eq!(
-        network.submit_transaction(sample_tx("tx-1", 0)),
-        Err(SmokeError::InvalidNonce(0))
+        network.submit_transaction(sample_tx(&network, "tx-1", "agent-a", 0)),
+        Err(SmokeError::Guard(TransactionGuardError::InvalidNonce(0)))
     );
 }

--- a/crates/kamn-core/tests/transaction_guards.rs
+++ b/crates/kamn-core/tests/transaction_guards.rs
@@ -1,0 +1,94 @@
+use kamn_core::{
+    BaselineTransaction, RoleSmokeNetwork, SmokeError, TransactionGuardError, GENESIS_STATE_HASH,
+};
+
+fn signed_tx(
+    network: &RoleSmokeNetwork,
+    id: &str,
+    sender: &str,
+    nonce: u64,
+) -> BaselineTransaction {
+    BaselineTransaction::signed(
+        id,
+        sender,
+        nonce,
+        &format!("payload-{id}"),
+        network.expected_state_hash(),
+    )
+}
+
+#[test]
+fn functional_transaction_guards_advance_state_hash_after_commit() {
+    let mut network = RoleSmokeNetwork::new(true);
+    let initial_state_hash = network.expected_state_hash().to_owned();
+
+    network
+        .submit_transaction(signed_tx(&network, "tx-1", "agent-a", 1))
+        .expect("transaction submit should succeed");
+    network
+        .produce_block()
+        .expect("block production should succeed");
+
+    assert_ne!(network.expected_state_hash(), initial_state_hash);
+}
+
+#[test]
+fn integration_rejects_stale_state_hash_after_block_commit() {
+    let mut network = RoleSmokeNetwork::new(true);
+    let stale_state_hash = network.expected_state_hash().to_owned();
+
+    network
+        .submit_transaction(signed_tx(&network, "tx-1", "agent-a", 1))
+        .expect("first transaction submit should succeed");
+    network
+        .produce_block()
+        .expect("first block production should succeed");
+
+    let stale_tx =
+        BaselineTransaction::signed("tx-2", "agent-a", 2, "payload-tx-2", &stale_state_hash);
+    assert!(matches!(
+        network.submit_transaction(stale_tx),
+        Err(SmokeError::Guard(
+            TransactionGuardError::StateHashMismatch { .. }
+        ))
+    ));
+}
+
+#[test]
+fn integration_rejects_out_of_sequence_nonce_per_sender() {
+    let mut network = RoleSmokeNetwork::new(true);
+
+    let out_of_sequence = BaselineTransaction::signed(
+        "tx-1",
+        "agent-a",
+        2,
+        "payload-tx-1",
+        network.expected_state_hash(),
+    );
+    assert_eq!(
+        network.submit_transaction(out_of_sequence),
+        Err(SmokeError::Guard(
+            TransactionGuardError::NonceOutOfSequence {
+                sender: "agent-a".to_owned(),
+                expected: 1,
+                found: 2
+            }
+        ))
+    );
+}
+
+#[test]
+fn regression_tampered_signature_is_rejected() {
+    // Regression: #78
+    let mut network = RoleSmokeNetwork::new(true);
+    let mut tx =
+        BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-tx-1", GENESIS_STATE_HASH);
+    tx.signature = format!("{}-tampered", tx.signature);
+
+    assert!(matches!(
+        network.submit_transaction(tx),
+        Err(SmokeError::Guard(
+            TransactionGuardError::InvalidSignature { .. }
+        ))
+    ));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -40,3 +40,4 @@ cargo run -p kamn-node -- --role processor --chain-id kamn-devnet --chain-versio
 This is intentionally minimal and dependency-light so the bootstrap path is fast and auditable.
 Migration execution is not implemented yet; this stage focuses on deterministic planning and validation hooks.
 For role interaction baseline coverage, see `docs/foundation/role-smoke.md`.
+For transaction invariant guard behavior, see `docs/foundation/transaction-guards.md`.

--- a/docs/foundation/role-smoke.md
+++ b/docs/foundation/role-smoke.md
@@ -10,14 +10,16 @@ This document describes baseline smoke scenarios for processor/listener/approver
 ## Model
 The smoke harness is intentionally lightweight and deterministic:
 - `RoleSmokeNetwork` simulates one processor, one listener, and one approver.
-- `submit_transaction(...)` validates ID, nonce, and payload before ingest.
+- `submit_transaction(...)` validates ID/sender/nonce/payload/state-hash/signature before ingest.
 - `produce_block(...)` orders transactions deterministically by nonce then ID.
 - Gossip behavior is explicit via the `gossip_enabled` toggle.
+- State-hash progression and transaction guard details are documented in `docs/foundation/transaction-guards.md`.
 
 ## Failure Modes
 - Duplicate transaction IDs are rejected.
-- Non-positive nonces are rejected.
-- Empty payloads are rejected.
+- Non-positive and out-of-sequence nonces are rejected.
+- Empty/invalid envelope fields are rejected.
+- Stale state-hash and tampered signatures are rejected.
 - Producing a block with an empty processor mempool fails explicitly.
 
 ## Validation Commands

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -1,0 +1,26 @@
+# Transaction Guards (Issue #78)
+
+This document defines the baseline deterministic transaction guards implemented in `kamn-core`.
+
+## Invariants Enforced
+- Non-empty transaction envelope fields (`id`, `sender`, `payload`, `state_hash`, `signature`).
+- Positive nonce values.
+- Per-sender nonce sequencing (first nonce `1`, then increment by `1`).
+- State-hash match against the currently expected chain/app state hash.
+- Deterministic signature integrity check (baseline placeholder scheme).
+- Duplicate transaction ID rejection.
+
+## Components
+- `BaselineTransaction`: canonical envelope used by smoke/runtime scaffolding.
+- `TransactionGuards`: stateful guard evaluator that validates and records transaction invariants.
+- `TransactionGuardError`: explicit typed failures for deterministic operator/agent handling.
+- `RoleSmokeNetwork`: integrates guard checks on `submit_transaction(...)` and advances state hash on `produce_block(...)`.
+
+## Validation
+Run from repository root:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```


### PR DESCRIPTION
Closes #78

## Summary
Implements baseline transaction guard invariants for nonce sequencing, signature integrity, replay/duplicate rejection, and state-hash matching.
Wires deterministic guard enforcement into role-smoke transaction intake and block-commit state progression.

## Changes
- `crates/kamn-core/src/transaction.rs`: Added `BaselineTransaction`, `TransactionGuards`, `TransactionGuardError`, and deterministic guard logic.
- `crates/kamn-core/src/smoke.rs`: Integrated guard checks into `submit_transaction(...)` and `produce_block(...)`; added `expected_state_hash()` surface.
- `crates/kamn-core/src/lib.rs`: Exported transaction guard APIs.
- `crates/kamn-core/tests/transaction_guards.rs`: Added functional/integration/regression tests for state-hash, nonce, and signature guard behavior.
- `crates/kamn-core/tests/role_smoke_network.rs`: Updated smoke tests to use signed transactions and guard-aware error expectations.
- `docs/foundation/transaction-guards.md`: Added transaction guard runbook.
- `docs/foundation/role-smoke.md` and `docs/foundation/bootstrap.md`: Updated references and invariant behavior notes.

## Risks & Compatibility
- `BaselineTransaction` now requires sender/state-hash/signature fields; tests and callsites updated.
- Signature scheme remains a deterministic placeholder scaffold for baseline integrity checks.

## Validation
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: role-smoke flow rejects stale state hashes and tampered signatures.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `transaction.rs` guard validations and error branches |
| Functional  | ✅     | `functional_transaction_guards_advance_state_hash_after_commit` |
| Integration | ✅     | stale hash + nonce sequence checks in `transaction_guards.rs`, plus smoke-network integration |
| Regression  | ✅     | tampered signature regression in `transaction_guards.rs`; stale state-hash regression in `transaction.rs` |
