### PR TITLE
feat(core): add canonical invariant taxonomy

### DIFF
--- a/crates/kamn-core/src/invariants.rs
+++ b/crates/kamn-core/src/invariants.rs
@@ -1,0 +1,296 @@
+use std::fmt;
+
+use crate::smoke::SmokeError;
+use crate::transaction::TransactionGuardError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvariantDomain {
+    Transactions,
+    StateTransitions,
+}
+
+impl InvariantDomain {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Transactions => "transactions",
+            Self::StateTransitions => "state-transitions",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvariantFailureCode {
+    EmptyField,
+    InvalidNonce,
+    NonceOutOfSequence,
+    InvalidSignature,
+    StateHashMismatch,
+    DuplicateTransactionId,
+    UnvalidatedCommittedTransaction,
+}
+
+impl InvariantFailureCode {
+    pub fn as_code(&self) -> &'static str {
+        match self {
+            Self::EmptyField => "INV-TX-001-EMPTY-FIELD",
+            Self::InvalidNonce => "INV-TX-002-INVALID-NONCE",
+            Self::NonceOutOfSequence => "INV-TX-002-NONCE-SEQUENCE",
+            Self::InvalidSignature => "INV-TX-003-INVALID-SIGNATURE",
+            Self::StateHashMismatch => "INV-TX-004-STATE-HASH-MISMATCH",
+            Self::DuplicateTransactionId => "INV-TX-005-DUPLICATE-TX-ID",
+            Self::UnvalidatedCommittedTransaction => "INV-TX-006-UNVALIDATED-COMMIT",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvariantSpec {
+    pub id: &'static str,
+    pub domain: InvariantDomain,
+    pub description: &'static str,
+    pub prd_refs: &'static [&'static str],
+    pub owner_issue: &'static str,
+    pub failure_codes: &'static [InvariantFailureCode],
+}
+
+const FAILURES_TX_001: &[InvariantFailureCode] = &[InvariantFailureCode::EmptyField];
+const FAILURES_TX_002: &[InvariantFailureCode] = &[
+    InvariantFailureCode::InvalidNonce,
+    InvariantFailureCode::NonceOutOfSequence,
+];
+const FAILURES_TX_003: &[InvariantFailureCode] = &[InvariantFailureCode::InvalidSignature];
+const FAILURES_TX_004: &[InvariantFailureCode] = &[InvariantFailureCode::StateHashMismatch];
+const FAILURES_TX_005: &[InvariantFailureCode] = &[InvariantFailureCode::DuplicateTransactionId];
+const FAILURES_TX_006: &[InvariantFailureCode] =
+    &[InvariantFailureCode::UnvalidatedCommittedTransaction];
+
+pub const INVARIANT_CATALOG: &[InvariantSpec] = &[
+    InvariantSpec {
+        id: "INV-TX-001",
+        domain: InvariantDomain::Transactions,
+        description: "Transaction envelope fields must be present and non-empty.",
+        prd_refs: &["2.2.3", "4.1"],
+        owner_issue: "#78",
+        failure_codes: FAILURES_TX_001,
+    },
+    InvariantSpec {
+        id: "INV-TX-002",
+        domain: InvariantDomain::Transactions,
+        description: "Transaction nonce must be positive and per-sender sequential.",
+        prd_refs: &["2.2.3", "4.2"],
+        owner_issue: "#78",
+        failure_codes: FAILURES_TX_002,
+    },
+    InvariantSpec {
+        id: "INV-TX-003",
+        domain: InvariantDomain::Transactions,
+        description: "Transaction signature must match deterministic signing rules.",
+        prd_refs: &["1.3", "2.2.2", "4.1"],
+        owner_issue: "#78",
+        failure_codes: FAILURES_TX_003,
+    },
+    InvariantSpec {
+        id: "INV-TX-004",
+        domain: InvariantDomain::Transactions,
+        description: "Transaction state hash must match current expected state hash.",
+        prd_refs: &["2.2.3", "13.1"],
+        owner_issue: "#78",
+        failure_codes: FAILURES_TX_004,
+    },
+    InvariantSpec {
+        id: "INV-TX-005",
+        domain: InvariantDomain::Transactions,
+        description: "Transaction IDs must be globally unique within observed history.",
+        prd_refs: &["2.2.3", "4.2"],
+        owner_issue: "#78",
+        failure_codes: FAILURES_TX_005,
+    },
+    InvariantSpec {
+        id: "INV-TX-006",
+        domain: InvariantDomain::StateTransitions,
+        description: "Only validated transactions may participate in state commits.",
+        prd_refs: &["2.2.3", "13.1"],
+        owner_issue: "#78",
+        failure_codes: FAILURES_TX_006,
+    },
+];
+
+pub fn catalog() -> &'static [InvariantSpec] {
+    INVARIANT_CATALOG
+}
+
+pub fn invariant_by_id(id: &str) -> Option<&'static InvariantSpec> {
+    catalog().iter().find(|entry| entry.id == id)
+}
+
+pub fn validate_catalog(entries: &[InvariantSpec]) -> Result<(), InvariantCatalogError> {
+    if entries.is_empty() {
+        return Err(InvariantCatalogError::EmptyCatalog);
+    }
+
+    let mut previous_id: Option<&str> = None;
+    for entry in entries {
+        if entry.id.trim().is_empty() {
+            return Err(InvariantCatalogError::EmptyInvariantId);
+        }
+        if entry.failure_codes.is_empty() {
+            return Err(InvariantCatalogError::MissingFailureCodes(
+                entry.id.to_owned(),
+            ));
+        }
+        if let Some(previous) = previous_id {
+            if entry.id == previous {
+                return Err(InvariantCatalogError::DuplicateId(entry.id.to_owned()));
+            }
+            if entry.id < previous {
+                return Err(InvariantCatalogError::Unsorted {
+                    previous: previous.to_owned(),
+                    current: entry.id.to_owned(),
+                });
+            }
+        }
+        previous_id = Some(entry.id);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvariantViolation {
+    pub invariant_id: &'static str,
+    pub failure_code: InvariantFailureCode,
+    pub message: String,
+}
+
+pub fn classify_transaction_guard_error(error: &TransactionGuardError) -> InvariantViolation {
+    match error {
+        TransactionGuardError::EmptyField(_) => InvariantViolation {
+            invariant_id: "INV-TX-001",
+            failure_code: InvariantFailureCode::EmptyField,
+            message: error.to_string(),
+        },
+        TransactionGuardError::InvalidNonce(_) => InvariantViolation {
+            invariant_id: "INV-TX-002",
+            failure_code: InvariantFailureCode::InvalidNonce,
+            message: error.to_string(),
+        },
+        TransactionGuardError::NonceOutOfSequence { .. } => InvariantViolation {
+            invariant_id: "INV-TX-002",
+            failure_code: InvariantFailureCode::NonceOutOfSequence,
+            message: error.to_string(),
+        },
+        TransactionGuardError::InvalidSignature { .. } => InvariantViolation {
+            invariant_id: "INV-TX-003",
+            failure_code: InvariantFailureCode::InvalidSignature,
+            message: error.to_string(),
+        },
+        TransactionGuardError::StateHashMismatch { .. } => InvariantViolation {
+            invariant_id: "INV-TX-004",
+            failure_code: InvariantFailureCode::StateHashMismatch,
+            message: error.to_string(),
+        },
+        TransactionGuardError::DuplicateTransactionId(_) => InvariantViolation {
+            invariant_id: "INV-TX-005",
+            failure_code: InvariantFailureCode::DuplicateTransactionId,
+            message: error.to_string(),
+        },
+        TransactionGuardError::UnvalidatedCommittedTransaction(_) => InvariantViolation {
+            invariant_id: "INV-TX-006",
+            failure_code: InvariantFailureCode::UnvalidatedCommittedTransaction,
+            message: error.to_string(),
+        },
+    }
+}
+
+pub fn classify_smoke_error(error: &SmokeError) -> Option<InvariantViolation> {
+    match error {
+        SmokeError::Guard(guard_error) => Some(classify_transaction_guard_error(guard_error)),
+        SmokeError::EmptyMempool(_) => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvariantCatalogError {
+    DuplicateId(String),
+    EmptyCatalog,
+    EmptyInvariantId,
+    MissingFailureCodes(String),
+    Unsorted { previous: String, current: String },
+}
+
+impl fmt::Display for InvariantCatalogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateId(id) => write!(f, "duplicate invariant id: {id}"),
+            Self::EmptyCatalog => write!(f, "invariant catalog must not be empty"),
+            Self::EmptyInvariantId => write!(f, "invariant id must not be empty"),
+            Self::MissingFailureCodes(id) => {
+                write!(f, "invariant must define failure codes: {id}")
+            }
+            Self::Unsorted { previous, current } => {
+                write!(
+                    f,
+                    "invariant catalog must be sorted by id; found {current} after {previous}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for InvariantCatalogError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        catalog, classify_transaction_guard_error, validate_catalog, InvariantCatalogError,
+        InvariantFailureCode, InvariantSpec,
+    };
+    use crate::transaction::TransactionGuardError;
+
+    #[test]
+    fn default_catalog_is_valid() {
+        assert!(validate_catalog(catalog()).is_ok());
+    }
+
+    #[test]
+    fn catalog_validation_rejects_duplicates() {
+        let entry = InvariantSpec {
+            id: "INV-TX-001",
+            domain: super::InvariantDomain::Transactions,
+            description: "duplicate",
+            prd_refs: &["2.2.3"],
+            owner_issue: "#78",
+            failure_codes: &[InvariantFailureCode::EmptyField],
+        };
+
+        let entries = [entry.clone(), entry];
+        assert_eq!(
+            validate_catalog(&entries),
+            Err(InvariantCatalogError::DuplicateId("INV-TX-001".to_owned()))
+        );
+    }
+
+    #[test]
+    fn taxonomy_maps_guard_errors() {
+        let violation = classify_transaction_guard_error(&TransactionGuardError::InvalidNonce(0));
+        assert_eq!(violation.invariant_id, "INV-TX-002");
+        assert_eq!(violation.failure_code, InvariantFailureCode::InvalidNonce);
+        assert!(violation.message.contains("nonce"));
+    }
+
+    #[test]
+    fn taxonomy_maps_state_hash_to_stable_id() {
+        // Regression: #77
+        let violation =
+            classify_transaction_guard_error(&TransactionGuardError::StateHashMismatch {
+                expected: "state:1".to_owned(),
+                found: "state:0".to_owned(),
+            });
+
+        assert_eq!(violation.invariant_id, "INV-TX-004");
+        assert_eq!(
+            violation.failure_code,
+            InvariantFailureCode::StateHashMismatch
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bootstrap;
 pub mod config;
+pub mod invariants;
 pub mod migrations;
 pub mod namespaces;
 pub mod runtime;
@@ -9,6 +10,11 @@ pub mod transaction;
 
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use config::{ConfigError, NodeConfig, NodeRole};
+pub use invariants::{
+    catalog as invariant_catalog, classify_smoke_error, classify_transaction_guard_error,
+    invariant_by_id, validate_catalog, InvariantCatalogError, InvariantDomain,
+    InvariantFailureCode, InvariantSpec, InvariantViolation,
+};
 pub use migrations::{MigrationPlan, MigrationRegistry, MigrationStep};
 pub use namespaces::StateNamespaces;
 pub use runtime::RuntimeWiring;

--- a/crates/kamn-core/tests/invariant_taxonomy.rs
+++ b/crates/kamn-core/tests/invariant_taxonomy.rs
@@ -1,0 +1,73 @@
+use kamn_core::{
+    classify_smoke_error, classify_transaction_guard_error, invariant_catalog, validate_catalog,
+    BaselineTransaction, InvariantFailureCode, RoleSmokeNetwork, SmokeError, TransactionGuardError,
+};
+
+#[test]
+fn functional_nonce_violation_maps_to_canonical_taxonomy() {
+    let mut network = RoleSmokeNetwork::new(true);
+    let tx = BaselineTransaction::signed(
+        "tx-1",
+        "agent-a",
+        0,
+        "payload-tx-1",
+        network.expected_state_hash(),
+    );
+
+    let error = network
+        .submit_transaction(tx)
+        .expect_err("nonce 0 should be rejected");
+    let violation = classify_smoke_error(&error).expect("guard failures should classify");
+
+    assert_eq!(violation.invariant_id, "INV-TX-002");
+    assert_eq!(violation.failure_code, InvariantFailureCode::InvalidNonce);
+}
+
+#[test]
+fn integration_catalog_and_guard_taxonomy_are_consistent() {
+    validate_catalog(invariant_catalog()).expect("catalog must validate");
+
+    let violation = classify_transaction_guard_error(&TransactionGuardError::InvalidSignature {
+        tx_id: "tx-1".to_owned(),
+        expected: "sig:expected".to_owned(),
+        found: "sig:found".to_owned(),
+    });
+
+    assert_eq!(violation.invariant_id, "INV-TX-003");
+    assert_eq!(
+        violation.failure_code.as_code(),
+        "INV-TX-003-INVALID-SIGNATURE"
+    );
+}
+
+#[test]
+fn integration_non_guard_smoke_errors_do_not_produce_taxonomy() {
+    let empty_mempool = SmokeError::EmptyMempool(kamn_core::NodeRole::Processor);
+    assert!(classify_smoke_error(&empty_mempool).is_none());
+}
+
+#[test]
+fn regression_stale_state_hash_maps_to_expected_invariant_id() {
+    // Regression: #77
+    let mut network = RoleSmokeNetwork::new(true);
+    let stale_hash = network.expected_state_hash().to_owned();
+    let tx1 = BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-tx-1", &stale_hash);
+    network
+        .submit_transaction(tx1)
+        .expect("first transaction should be accepted");
+    network
+        .produce_block()
+        .expect("block production should succeed");
+
+    let stale_tx = BaselineTransaction::signed("tx-2", "agent-a", 2, "payload-tx-2", &stale_hash);
+    let error = network
+        .submit_transaction(stale_tx)
+        .expect_err("stale state hash must be rejected");
+    let violation = classify_smoke_error(&error).expect("guard failures should classify");
+
+    assert_eq!(violation.invariant_id, "INV-TX-004");
+    assert_eq!(
+        violation.failure_code,
+        InvariantFailureCode::StateHashMismatch
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -41,3 +41,4 @@ This is intentionally minimal and dependency-light so the bootstrap path is fast
 Migration execution is not implemented yet; this stage focuses on deterministic planning and validation hooks.
 For role interaction baseline coverage, see `docs/foundation/role-smoke.md`.
 For transaction invariant guard behavior, see `docs/foundation/transaction-guards.md`.
+For canonical invariant IDs and taxonomy mapping, see `docs/foundation/invariants.md`.

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -1,0 +1,32 @@
+# Invariant Catalog and Error Taxonomy (Issue #77)
+
+This document defines the canonical transaction invariant catalog and error taxonomy used by baseline KAMN validation scaffolding.
+
+## Catalog
+| Invariant ID | Domain | Description | Failure Codes | PRD References | Owner |
+|---|---|---|---|---|---|
+| `INV-TX-001` | transactions | Transaction envelope fields must be present and non-empty | `INV-TX-001-EMPTY-FIELD` | `2.2.3`, `4.1` | #78 |
+| `INV-TX-002` | transactions | Nonce must be positive and per-sender sequential | `INV-TX-002-INVALID-NONCE`, `INV-TX-002-NONCE-SEQUENCE` | `2.2.3`, `4.2` | #78 |
+| `INV-TX-003` | transactions | Signature must match deterministic signing rules | `INV-TX-003-INVALID-SIGNATURE` | `1.3`, `2.2.2`, `4.1` | #78 |
+| `INV-TX-004` | transactions | State hash must match the expected chain/app state hash | `INV-TX-004-STATE-HASH-MISMATCH` | `2.2.3`, `13.1` | #78 |
+| `INV-TX-005` | transactions | Transaction IDs must be globally unique in observed history | `INV-TX-005-DUPLICATE-TX-ID` | `2.2.3`, `4.2` | #78 |
+| `INV-TX-006` | state-transitions | Only validated transactions may be committed | `INV-TX-006-UNVALIDATED-COMMIT` | `2.2.3`, `13.1` | #78 |
+
+## Mapping Conventions
+- Guard-layer errors (`TransactionGuardError`) map deterministically to one invariant ID and one canonical failure code.
+- Smoke-layer errors are classified into taxonomy only when the source is a guard violation.
+- Non-guard operational errors (for example empty mempool) are intentionally out-of-taxonomy.
+
+## Current Integration Surfaces
+- `classify_transaction_guard_error(...)`
+- `classify_smoke_error(...)`
+- `validate_catalog(...)`
+
+## Validation
+Run from repository root:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -15,6 +15,7 @@ This document defines the baseline deterministic transaction guards implemented 
 - `TransactionGuards`: stateful guard evaluator that validates and records transaction invariants.
 - `TransactionGuardError`: explicit typed failures for deterministic operator/agent handling.
 - `RoleSmokeNetwork`: integrates guard checks on `submit_transaction(...)` and advances state hash on `produce_block(...)`.
+- `INVARIANT_CATALOG`: canonical invariant IDs and failure-code taxonomy mapping (`docs/foundation/invariants.md`).
 
 ## Validation
 Run from repository root:


### PR DESCRIPTION
Closes #77

## Summary
Adds a canonical invariant catalog and failure-code taxonomy for baseline transaction validation.
Introduces deterministic mapping from guard/smoke error surfaces to stable invariant IDs and error codes.

## Changes
- `crates/kamn-core/src/invariants.rs`: Added `INVARIANT_CATALOG`, taxonomy types, catalog validation, and classification helpers.
- `crates/kamn-core/src/lib.rs`: Exported invariant catalog and taxonomy APIs.
- `crates/kamn-core/tests/invariant_taxonomy.rs`: Added functional/integration/regression taxonomy tests.
- `docs/foundation/invariants.md`: Added invariant-to-PRD mapping table and taxonomy conventions.
- `docs/foundation/transaction-guards.md`: Linked guard implementation to canonical taxonomy source.
- `docs/foundation/bootstrap.md`: Linked foundation docs to invariant catalog reference.

## Risks & Compatibility
- No breaking changes to existing bootstrap/smoke interfaces.
- Catalog currently covers baseline transaction invariants; broader protocol domains are future work.

## Validation
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: guard/smoke failures classify to stable invariant IDs and canonical codes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | catalog validation + taxonomy mapping in `invariants.rs` |
| Functional  | ✅     | nonce violation classification in `tests/invariant_taxonomy.rs` |
| Integration | ✅     | catalog consistency and smoke error integration in `tests/invariant_taxonomy.rs` |
| Regression  | ✅     | stale-state-hash taxonomy regression in `tests/invariant_taxonomy.rs` |
