### PR TITLE
feat(ci): add deterministic invariant harness workflow

### DIFF
--- a/.github/workflows/ci-deep-validate.yml
+++ b/.github/workflows/ci-deep-validate.yml
@@ -66,6 +66,14 @@ jobs:
             --max-attempts 2 \
             -- cargo test --workspace --locked --all-features --no-fail-fast
 
+      - name: Invariant harness (deterministic deep lane)
+        if: steps.detect.outputs.run_rust == 'true'
+        run: |
+          bash scripts/ci/run_with_retry.sh \
+            --label invariant-harness-deep \
+            --max-attempts 1 \
+            -- bash scripts/ci/run_invariant_harness.sh --mode deep
+
       - name: No Rust project present
         if: steps.detect.outputs.run_rust != 'true'
         run: echo "No Cargo project detected; deep validation skipped."

--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -79,6 +79,14 @@ jobs:
             --max-attempts 2 \
             -- bash -lc "${{ steps.scope.outputs.test_cmd }}"
 
+      - name: Invariant harness (deterministic fast lane)
+        if: steps.scope.outputs.run_invariant_harness == 'true'
+        run: |
+          bash scripts/ci/run_with_retry.sh \
+            --label invariant-harness-fast \
+            --max-attempts 1 \
+            -- bash scripts/ci/run_invariant_harness.sh --mode fast
+
       - name: No Rust checks required
         if: steps.scope.outputs.run_rust != 'true' && steps.scope.outputs.docs_only != 'true'
         run: echo "No Rust changes detected; skipping Rust toolchain setup and tests."

--- a/crates/kamn-core/src/invariants.rs
+++ b/crates/kamn-core/src/invariants.rs
@@ -18,7 +18,7 @@ impl InvariantDomain {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InvariantFailureCode {
     EmptyField,
     InvalidNonce,

--- a/crates/kamn-core/tests/invariant_harness.rs
+++ b/crates/kamn-core/tests/invariant_harness.rs
@@ -1,0 +1,194 @@
+use std::collections::BTreeSet;
+
+use kamn_core::{
+    classify_smoke_error, BaselineTransaction, InvariantFailureCode, RoleSmokeNetwork,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scenario {
+    Valid,
+    DuplicateId,
+    NonceSequence,
+    StaleStateHash,
+    TamperedSignature,
+}
+
+fn harness_seed() -> u64 {
+    std::env::var("KAMN_INVARIANT_SEED")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(13)
+}
+
+fn next_seed(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    *state
+}
+
+fn scenario_from_seed(value: u64) -> Scenario {
+    match value % 5 {
+        0 => Scenario::Valid,
+        1 => Scenario::DuplicateId,
+        2 => Scenario::NonceSequence,
+        3 => Scenario::StaleStateHash,
+        _ => Scenario::TamperedSignature,
+    }
+}
+
+fn run_scenario(scenario: Scenario, index: usize) -> Option<InvariantFailureCode> {
+    let mut network = RoleSmokeNetwork::new(true);
+
+    match scenario {
+        Scenario::Valid => {
+            let tx = BaselineTransaction::signed(
+                &format!("tx-valid-{index}"),
+                "agent-a",
+                1,
+                "payload-valid",
+                network.expected_state_hash(),
+            );
+            network
+                .submit_transaction(tx)
+                .expect("valid scenario should submit");
+            network
+                .produce_block()
+                .expect("valid scenario should produce block");
+            None
+        }
+        Scenario::DuplicateId => {
+            let tx_id = format!("tx-dup-{index}");
+            let first = BaselineTransaction::signed(
+                &tx_id,
+                "agent-a",
+                1,
+                "payload-first",
+                network.expected_state_hash(),
+            );
+            network
+                .submit_transaction(first)
+                .expect("first duplicate scenario transaction should submit");
+
+            let duplicate = BaselineTransaction::signed(
+                &tx_id,
+                "agent-b",
+                1,
+                "payload-second",
+                network.expected_state_hash(),
+            );
+
+            classify_smoke_error(
+                &network
+                    .submit_transaction(duplicate)
+                    .expect_err("duplicate id should fail"),
+            )
+            .map(|violation| violation.failure_code)
+        }
+        Scenario::NonceSequence => {
+            let tx = BaselineTransaction::signed(
+                &format!("tx-nonce-{index}"),
+                "agent-a",
+                2,
+                "payload-nonce",
+                network.expected_state_hash(),
+            );
+
+            classify_smoke_error(
+                &network
+                    .submit_transaction(tx)
+                    .expect_err("nonce sequence violation should fail"),
+            )
+            .map(|violation| violation.failure_code)
+        }
+        Scenario::StaleStateHash => {
+            let initial_hash = network.expected_state_hash().to_owned();
+            let first = BaselineTransaction::signed(
+                &format!("tx-stale-seed-{index}"),
+                "agent-a",
+                1,
+                "payload-first",
+                &initial_hash,
+            );
+            network
+                .submit_transaction(first)
+                .expect("stale-hash setup should submit first tx");
+            network
+                .produce_block()
+                .expect("stale-hash setup should produce block");
+
+            let stale = BaselineTransaction::signed(
+                &format!("tx-stale-{index}"),
+                "agent-a",
+                2,
+                "payload-stale",
+                &initial_hash,
+            );
+
+            classify_smoke_error(
+                &network
+                    .submit_transaction(stale)
+                    .expect_err("stale state hash should fail"),
+            )
+            .map(|violation| violation.failure_code)
+        }
+        Scenario::TamperedSignature => {
+            let mut tx = BaselineTransaction::signed(
+                &format!("tx-sig-{index}"),
+                "agent-a",
+                1,
+                "payload-sig",
+                network.expected_state_hash(),
+            );
+            tx.signature.push_str("-tampered");
+
+            classify_smoke_error(
+                &network
+                    .submit_transaction(tx)
+                    .expect_err("tampered signature should fail"),
+            )
+            .map(|violation| violation.failure_code)
+        }
+    }
+}
+
+fn run_seed(seed: u64, rounds: usize) -> Vec<Option<InvariantFailureCode>> {
+    let mut state = seed;
+    let mut outcomes = Vec::with_capacity(rounds);
+
+    for index in 0..rounds {
+        let scenario = scenario_from_seed(next_seed(&mut state));
+        outcomes.push(run_scenario(scenario, index));
+    }
+
+    outcomes
+}
+
+#[test]
+fn functional_seeded_harness_is_deterministic() {
+    let seed = harness_seed();
+    let first = run_seed(seed, 16);
+    let second = run_seed(seed, 16);
+    assert_eq!(first, second);
+}
+
+#[test]
+fn integration_seeded_harness_covers_core_negative_invariants() {
+    let outcomes = run_seed(harness_seed(), 24);
+    let observed: BTreeSet<InvariantFailureCode> = outcomes.into_iter().flatten().collect();
+
+    assert!(observed.contains(&InvariantFailureCode::DuplicateTransactionId));
+    assert!(observed.contains(&InvariantFailureCode::NonceOutOfSequence));
+    assert!(observed.contains(&InvariantFailureCode::StateHashMismatch));
+    assert!(observed.contains(&InvariantFailureCode::InvalidSignature));
+}
+
+#[test]
+fn regression_seed_97_preserves_stale_hash_coverage() {
+    // Regression: #79
+    let outcomes = run_seed(97, 24);
+    assert!(outcomes
+        .into_iter()
+        .flatten()
+        .any(|code| code == InvariantFailureCode::StateHashMismatch));
+}

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -21,6 +21,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Rust changes in specific crates/manifests: run targeted clippy/tests by manifest path.
 - Core Rust metadata changes (`Cargo.toml`, `Cargo.lock`, toolchain, `.cargo`): run full workspace lane.
 - CI/workflow changes without Rust source changes: run shell syntax checks and a smoke Rust lane when a Cargo project exists.
+- Invariant-related changes (`invariants.rs`, `transaction.rs`, smoke/invariant harness tests, or harness scripts): run deterministic invariant harness in `fast` mode (single seed) after Rust tests.
 
 ## Budget Telemetry and Enforcement
 Both lanes call `scripts/ci/evaluate_budget.sh` at the end of the run to:
@@ -56,6 +57,7 @@ Enforced by `scripts/ci/check_pr_ci_declaration.sh` in fast-gate.
 `ci-fast-gate` runs `scripts/ci/test_ci_tools.sh` to locally regression-test CI helper scripts:
 - Budget evaluator (`test_evaluate_budget.sh`)
 - Retry helper (`test_run_with_retry.sh`)
+- Invariant harness runner (`test_run_invariant_harness.sh`)
 - Flaky registry validator (`test_check_flaky_registry.sh`)
 - Budget summarizer (`test_summarize_budget_artifacts.sh`)
 - PR CI declaration checker (`test_check_pr_ci_declaration.sh`)
@@ -71,6 +73,7 @@ Enforced by `scripts/ci/check_pr_ci_declaration.sh` in fast-gate.
 
 ## Deep Validation Behavior
 `ci-deep-validate` runs full formatting, linting, and test suites on a nightly schedule and manually on demand.
+It also runs deterministic invariant harness coverage in `deep` mode (bounded seed set) to keep invariant negative-path checks off the PR-critical lane while preserving repeatable coverage.
 
 ## Cost Controls
 - Concurrency cancellation enabled on both workflows.

--- a/scripts/ci/run_invariant_harness.sh
+++ b/scripts/ci/run_invariant_harness.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="fast"
+DRY_RUN="false"
+
+usage() {
+  cat <<'EOF'
+Usage: run_invariant_harness.sh [--mode fast|deep] [--dry-run]
+
+Runs deterministic invariant harness tests with bounded seed sets.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      if [ "${2:-}" = "" ]; then
+        echo "missing value for --mode" >&2
+        exit 2
+      fi
+      MODE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$MODE" in
+  fast)
+    SEEDS=(13)
+    ;;
+  deep)
+    SEEDS=(13 97 401)
+    ;;
+  *)
+    echo "unsupported mode: $MODE" >&2
+    exit 2
+    ;;
+esac
+
+COMMANDS=()
+for seed in "${SEEDS[@]}"; do
+  COMMANDS+=("KAMN_INVARIANT_SEED=$seed cargo test -p kamn-core --locked --all-features --test invariant_harness -- --nocapture")
+done
+
+for command in "${COMMANDS[@]}"; do
+  echo "$command"
+  if [ "$DRY_RUN" != "true" ]; then
+    bash -lc "$command"
+  fi
+done

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -26,6 +26,7 @@ append_summary() {
     echo "- Changed files: ${CHANGED_COUNT}"
     echo "- Docs only: ${DOCS_ONLY}"
     echo "- Run Rust checks: ${RUN_RUST}"
+    echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
     if [ -n "$CHANGED_MANIFESTS" ]; then
       echo "- Targeted manifests: ${CHANGED_MANIFESTS}"
@@ -103,6 +104,7 @@ DOCS_ONLY=true
 RUST_CHANGED=false
 CI_INFRA_CHANGED=false
 FULL_SUITE=false
+INVARIANT_RELATED_CHANGED=false
 
 # manifest -> 1
 # shellcheck disable=SC2034
@@ -130,6 +132,12 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
+    crates/kamn-core/src/invariants.rs|crates/kamn-core/src/transaction.rs|crates/kamn-core/src/smoke.rs|crates/kamn-core/tests/invariant_*|crates/kamn-core/tests/transaction_guards.rs|docs/foundation/invariants.md|docs/foundation/transaction-guards.md|scripts/ci/run_invariant_harness.sh|scripts/ci/test_run_invariant_harness.sh)
+      INVARIANT_RELATED_CHANGED=true
+      ;;
+  esac
+
+  case "$file" in
     Cargo.toml|Cargo.lock|rust-toolchain.toml|.cargo/*)
       FULL_SUITE=true
       ;;
@@ -146,6 +154,7 @@ CLIPPY_CMD=":"
 TEST_CMD=":"
 TEST_SCOPE="none"
 CHANGED_MANIFESTS=""
+RUN_INVARIANT_HARNESS=false
 
 if [ "$REPO_HAS_RUST" = true ] && { [ "$RUST_CHANGED" = true ] || [ "$CI_INFRA_CHANGED" = true ]; }; then
   RUN_RUST=true
@@ -181,8 +190,13 @@ if [ "$REPO_HAS_RUST" = true ] && { [ "$RUST_CHANGED" = true ] || [ "$CI_INFRA_C
   fi
 fi
 
+if [ "$RUN_RUST" = true ] && { [ "$INVARIANT_RELATED_CHANGED" = true ] || [ "$FULL_SUITE" = true ]; }; then
+  RUN_INVARIANT_HARNESS=true
+fi
+
 write_output "docs_only" "$DOCS_ONLY"
 write_output "run_rust" "$RUN_RUST"
+write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"
 write_output "changed_files" "$CHANGED_COUNT"
 write_output "changed_manifests" "$CHANGED_MANIFESTS"

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 bash "$ROOT_DIR/scripts/ci/test_evaluate_budget.sh"
 bash "$ROOT_DIR/scripts/ci/test_run_with_retry.sh"
+bash "$ROOT_DIR/scripts/ci/test_run_invariant_harness.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_flaky_registry.sh"
 bash "$ROOT_DIR/scripts/ci/test_summarize_budget_artifacts.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_pr_ci_declaration.sh"

--- a/scripts/ci/test_run_invariant_harness.sh
+++ b/scripts/ci/test_run_invariant_harness.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/ci/run_invariant_harness.sh"
+
+fast_output="$(bash "$SCRIPT" --mode fast --dry-run)"
+if [ "$(printf '%s\n' "$fast_output" | wc -l | tr -d ' ')" -ne 1 ]; then
+  echo "expected one command in fast mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$fast_output" | grep -q 'KAMN_INVARIANT_SEED=13'; then
+  echo "expected fast mode to use seed 13" >&2
+  exit 1
+fi
+
+deep_output="$(bash "$SCRIPT" --mode deep --dry-run)"
+if [ "$(printf '%s\n' "$deep_output" | wc -l | tr -d ' ')" -ne 3 ]; then
+  echo "expected three commands in deep mode" >&2
+  exit 1
+fi
+for seed in 13 97 401; do
+  if ! printf '%s\n' "$deep_output" | grep -q "KAMN_INVARIANT_SEED=$seed"; then
+    echo "expected deep mode to include seed $seed" >&2
+    exit 1
+  fi
+done
+
+set +e
+bash "$SCRIPT" --mode invalid --dry-run >/dev/null 2>&1
+invalid_status=$?
+set -e
+if [ "$invalid_status" -eq 0 ]; then
+  echo "expected invalid mode to fail" >&2
+  exit 1
+fi
+
+echo "run_invariant_harness tests passed."


### PR DESCRIPTION
Closes #79

## Summary
Adds a deterministic, seeded invariant harness and integrates it into CI lane strategy with low-cost fast/deep execution modes.
This provides bounded negative-path invariant coverage without adding expensive or flaky suites to the PR critical path.

## Changes
- `crates/kamn-core/tests/invariant_harness.rs`: Added deterministic seeded harness tests covering duplicate ID, nonce ordering, stale hash, and signature tampering paths.
- `scripts/ci/run_invariant_harness.sh`: Added harness runner with `fast` (seed `13`) and `deep` (seeds `13,97,401`) modes.
- `scripts/ci/test_run_invariant_harness.sh`: Added script regression tests for harness mode behavior.
- `scripts/ci/test_ci_tools.sh`: Added invariant harness script regression test.
- `scripts/ci/select_targets.sh`: Added change-aware `run_invariant_harness` output gating.
- `.github/workflows/ci-fast-gate.yml`: Added fast-lane deterministic invariant harness step gated by changed files.
- `.github/workflows/ci-deep-validate.yml`: Added deep-lane deterministic invariant harness step.
- `docs/ci/strategy.md`: Documented harness placement and cost rationale.
- `crates/kamn-core/src/invariants.rs`: Added `Ord` derive for `InvariantFailureCode` to support deterministic set-based harness assertions.

## Risks & Compatibility
- No breaking runtime API changes.
- CI runtime impact is bounded by selective fast-lane gating and a small fixed seed set.

## Validation
- [x] `bash -n scripts/ci/*.sh` — clean
- [x] `bash scripts/ci/test_ci_tools.sh` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — clean
- [x] Manual verification: harness script dry-run output and fast/deep mode seed sets verified.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | harness helper logic + CI script tests |
| Functional  | ✅     | deterministic seeded harness replay check (`functional_seeded_harness_is_deterministic`) |
| Integration | ✅     | fast/deep workflow + target selection wiring and CI script regression suite |
| Regression  | ✅     | stale-state-hash coverage guard (`regression_seed_97_preserves_stale_hash_coverage`) |
