### PR TITLE
feat(core): implement DID registry transactions slice

### DIFF
--- a/crates/kamn-core/src/did_registry.rs
+++ b/crates/kamn-core/src/did_registry.rs
@@ -1,0 +1,166 @@
+use crate::{AgentDid, DidDocument};
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DidRegistryRecord {
+    document: DidDocument,
+    revoked: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DidRegistry {
+    records: HashMap<AgentDid, DidRegistryRecord>,
+}
+
+impl DidRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(
+        &mut self,
+        did: AgentDid,
+        document: DidDocument,
+    ) -> Result<(), DidRegistryError> {
+        Self::validate_document_did(&did, &document)?;
+        let did_id = did.as_str().to_owned();
+        match self.records.get(&did) {
+            Some(record) if !record.revoked => Err(DidRegistryError::AlreadyRegistered(did_id)),
+            Some(_) => Err(DidRegistryError::Revoked(did_id)),
+            None => {
+                self.records.insert(
+                    did,
+                    DidRegistryRecord {
+                        document,
+                        revoked: false,
+                    },
+                );
+                Ok(())
+            }
+        }
+    }
+
+    pub fn resolve(&self, did: &AgentDid) -> Result<&DidDocument, DidRegistryError> {
+        match self.records.get(did) {
+            Some(record) if !record.revoked => Ok(&record.document),
+            Some(_) => Err(DidRegistryError::Revoked(did.as_str().to_owned())),
+            None => Err(DidRegistryError::NotFound(did.as_str().to_owned())),
+        }
+    }
+
+    pub fn update(&mut self, did: AgentDid, document: DidDocument) -> Result<(), DidRegistryError> {
+        Self::validate_document_did(&did, &document)?;
+        match self.records.get_mut(&did) {
+            Some(record) if record.revoked => {
+                Err(DidRegistryError::Revoked(did.as_str().to_owned()))
+            }
+            Some(record) => {
+                record.document = document;
+                Ok(())
+            }
+            None => Err(DidRegistryError::NotFound(did.as_str().to_owned())),
+        }
+    }
+
+    pub fn revoke(&mut self, did: &AgentDid) -> Result<(), DidRegistryError> {
+        match self.records.get_mut(did) {
+            Some(record) if record.revoked => {
+                Err(DidRegistryError::Revoked(did.as_str().to_owned()))
+            }
+            Some(record) => {
+                record.revoked = true;
+                Ok(())
+            }
+            None => Err(DidRegistryError::NotFound(did.as_str().to_owned())),
+        }
+    }
+
+    fn validate_document_did(
+        did: &AgentDid,
+        document: &DidDocument,
+    ) -> Result<(), DidRegistryError> {
+        if document.id != did.as_str() {
+            return Err(DidRegistryError::DocumentDidMismatch {
+                expected: did.as_str().to_owned(),
+                actual: document.id.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DidRegistryError {
+    AlreadyRegistered(String),
+    NotFound(String),
+    Revoked(String),
+    DocumentDidMismatch { expected: String, actual: String },
+}
+
+impl fmt::Display for DidRegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyRegistered(value) => write!(f, "did is already registered: {value}"),
+            Self::NotFound(value) => write!(f, "did not found: {value}"),
+            Self::Revoked(value) => write!(f, "did is revoked: {value}"),
+            Self::DocumentDidMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "did document id mismatch, expected {expected}, got {actual}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for DidRegistryError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{DidRegistry, DidRegistryError};
+    use crate::{canonical_did_document, AgentDid, AgentDidMetadata};
+
+    fn metadata() -> AgentDidMetadata {
+        AgentDidMetadata {
+            agent_type: "autonomous".to_owned(),
+            model_family: "claude-4".to_owned(),
+            capabilities: vec!["text".to_owned()],
+            operator: None,
+        }
+    }
+
+    fn document_for(did: &AgentDid) -> crate::DidDocument {
+        canonical_did_document(did, "z6Mpubkey", metadata()).expect("document should build")
+    }
+
+    #[test]
+    fn rejects_document_mismatch() {
+        let mut registry = DidRegistry::new();
+        let did = AgentDid::parse("kamn:did:agent:agent-1").expect("did should parse");
+        let other = AgentDid::parse("kamn:did:agent:agent-2").expect("did should parse");
+
+        assert_eq!(
+            registry.register(did.clone(), document_for(&other)),
+            Err(DidRegistryError::DocumentDidMismatch {
+                expected: did.as_str().to_owned(),
+                actual: other.as_str().to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn update_rejects_revoked_did() {
+        let mut registry = DidRegistry::new();
+        let did = AgentDid::parse("kamn:did:agent:agent-3").expect("did should parse");
+        registry
+            .register(did.clone(), document_for(&did))
+            .expect("register should succeed");
+        registry.revoke(&did).expect("revoke should succeed");
+
+        assert_eq!(
+            registry.update(did.clone(), document_for(&did)),
+            Err(DidRegistryError::Revoked(did.as_str().to_owned()))
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bootstrap;
 pub mod config;
 pub mod did;
+pub mod did_registry;
 pub mod escrow;
 pub mod instruction_verify;
 pub mod invariants;
@@ -20,6 +21,7 @@ pub use did::{
     canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocument,
     DidDocumentError, DidService, DidVerificationMethod,
 };
+pub use did_registry::{DidRegistry, DidRegistryError};
 pub use escrow::{EscrowLifecycle, EscrowLifecycleError, EscrowStatus};
 pub use instruction_verify::{
     InstructionClaim, InstructionRecord, InstructionVerifier, VerificationContext,

--- a/crates/kamn-core/tests/did_registry_transactions.rs
+++ b/crates/kamn-core/tests/did_registry_transactions.rs
@@ -1,0 +1,104 @@
+use kamn_core::{
+    canonical_did_document, AgentDid, AgentDidMetadata, DidDocument, DidRegistry, DidRegistryError,
+};
+
+fn metadata(model_family: &str) -> AgentDidMetadata {
+    AgentDidMetadata {
+        agent_type: "autonomous".to_owned(),
+        model_family: model_family.to_owned(),
+        capabilities: vec!["text".to_owned()],
+        operator: None,
+    }
+}
+
+fn document_for(did: &AgentDid, model_family: &str) -> DidDocument {
+    canonical_did_document(did, "z6Mpub", metadata(model_family))
+        .expect("did document should build")
+}
+
+#[test]
+fn register_and_resolve_round_trip() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:agent-1").expect("did should parse");
+    let document = document_for(&did, "claude-4");
+
+    registry
+        .register(did.clone(), document.clone())
+        .expect("register should succeed");
+    let resolved = registry.resolve(&did).expect("resolve should succeed");
+
+    assert_eq!(resolved.id, did.as_str().to_owned());
+    assert_eq!(resolved.metadata.model_family, "claude-4");
+}
+
+#[test]
+fn duplicate_register_is_rejected() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:agent-2").expect("did should parse");
+    let document = document_for(&did, "claude-4");
+
+    registry
+        .register(did.clone(), document.clone())
+        .expect("first register should succeed");
+    assert_eq!(
+        registry.register(did.clone(), document),
+        Err(DidRegistryError::AlreadyRegistered(did.as_str().to_owned()))
+    );
+}
+
+#[test]
+fn update_existing_document_succeeds() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:agent-3").expect("did should parse");
+    registry
+        .register(did.clone(), document_for(&did, "claude-4"))
+        .expect("register should succeed");
+
+    registry
+        .update(did.clone(), document_for(&did, "gpt-5"))
+        .expect("update should succeed");
+    let resolved = registry.resolve(&did).expect("resolve should succeed");
+    assert_eq!(resolved.metadata.model_family, "gpt-5");
+}
+
+#[test]
+fn update_rejects_unknown_did() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:agent-4").expect("did should parse");
+    assert_eq!(
+        registry.update(did.clone(), document_for(&did, "claude-4")),
+        Err(DidRegistryError::NotFound(did.as_str().to_owned()))
+    );
+}
+
+#[test]
+fn revoke_blocks_resolve() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:agent-5").expect("did should parse");
+    registry
+        .register(did.clone(), document_for(&did, "claude-4"))
+        .expect("register should succeed");
+    registry.revoke(&did).expect("revoke should succeed");
+
+    assert_eq!(
+        registry.resolve(&did),
+        Err(DidRegistryError::Revoked(did.as_str().to_owned()))
+    );
+}
+
+#[test]
+fn revoked_did_cannot_be_re_registered() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:agent-6").expect("did should parse");
+    let document = document_for(&did, "claude-4");
+    registry
+        .register(did.clone(), document.clone())
+        .expect("register should succeed");
+    registry.revoke(&did).expect("revoke should succeed");
+
+    // Regression: #111
+    assert_eq!(
+        registry.register(did.clone(), document),
+        Err(DidRegistryError::Revoked(did.as_str().to_owned()))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -52,3 +52,4 @@ For deterministic key lifecycle and rotation transitions, see `docs/foundation/k
 For key compromise containment and recovery workflows, see `docs/foundation/key-recovery.md`.
 For Python SDK parity slice, see `docs/foundation/python-sdk-beta.md`.
 For DID method and canonical DID document schema controls, see `docs/foundation/did-method.md`.
+For DID register/resolve/update/revoke transaction behavior, see `docs/foundation/did-registry-transactions.md`.

--- a/docs/foundation/did-registry-transactions.md
+++ b/docs/foundation/did-registry-transactions.md
@@ -1,0 +1,35 @@
+# DID Registry Transactions (Issue #110)
+
+This document defines the first implementation slice for DID
+register/resolve/update/revoke transaction behavior.
+
+## Behavior
+- `register(did, document)` stores a DID document for a new DID.
+- Registering an already active DID returns `DidRegistryError::AlreadyRegistered`.
+- Registering a revoked DID returns `DidRegistryError::Revoked`.
+- `resolve(did)` returns the active DID document.
+- Resolving a revoked DID returns `DidRegistryError::Revoked`.
+- Resolving an unknown DID returns `DidRegistryError::NotFound`.
+- `update(did, document)` replaces the active DID document for an existing DID.
+- Updating a revoked DID returns `DidRegistryError::Revoked`.
+- Updating an unknown DID returns `DidRegistryError::NotFound`.
+- `revoke(did)` transitions an active DID to revoked.
+- Re-registering a revoked DID is rejected (`DidRegistryError::Revoked`) as a regression guard.
+
+## Validation Rules
+- The DID document `id` must match the target `did`.
+- Document mismatch is rejected with `DidRegistryError::DocumentDidMismatch`.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test did_registry_transactions
+cargo test -p kamn-core
+```
+
+## Notes
+This slice is intentionally in-memory and deterministic so transaction logic can be
+validated quickly with low CI cost before introducing persistent storage.


### PR DESCRIPTION
## Summary
Implements the first DID transaction slice for register/resolve/update/revoke behavior in `kamn-core` using strict TDD flow. This adds deterministic in-memory registry semantics, regression guards for revoked DID reuse, and foundation docs for the behavior contract.

Closes #110
Closes #111

## Changes
- `crates/kamn-core/src/did_registry.rs`: added `DidRegistry` and `DidRegistryError` with register/resolve/update/revoke transaction semantics.
- `crates/kamn-core/src/lib.rs`: exported DID registry APIs.
- `crates/kamn-core/tests/did_registry_transactions.rs`: added functional/integration/regression coverage for the transaction slice.
- `docs/foundation/did-registry-transactions.md`: documented transaction behaviors, validation rules, and local validation commands.
- `docs/foundation/bootstrap.md`: linked DID registry transaction docs from foundation index.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed Red (`cargo test -p kamn-core --test did_registry_transactions` failure before implementation), then Green/regression with `cargo test -p kamn-core --test did_registry_transactions` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `did_registry::tests::{rejects_document_mismatch, update_rejects_revoked_did}` |
| Functional  | ✅     | register/resolve/update/revoke behavior in `did_registry_transactions.rs` |
| Integration | ✅     | registry exported via `kamn-core` API and exercised as external crate test |
| Regression  | ✅     | `revoked_did_cannot_be_re_registered` guard for #111 |
