### PR TITLE
feat(core): add message lifecycle state machine and index queries

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod invariants;
 pub mod key_lifecycle;
 pub mod key_recovery;
 pub mod message_envelope;
+pub mod message_lifecycle;
 pub mod migrations;
 pub mod namespaces;
 pub mod runtime;
@@ -40,6 +41,7 @@ pub use message_envelope::{
     EnvelopeProof, MessageEnvelopeError, CANONICAL_ENCRYPTION_ALGORITHM,
     CANONICAL_MESSAGE_ENVELOPE_TYPE, CANONICAL_PROOF_PURPOSE,
 };
+pub use message_lifecycle::{MessageLifecycleError, MessageLifecycleStore, MessageStatus};
 pub use migrations::{MigrationPlan, MigrationRegistry, MigrationStep};
 pub use namespaces::StateNamespaces;
 pub use runtime::RuntimeWiring;

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -1,0 +1,309 @@
+use crate::AgentDid;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum MessageStatus {
+    Created,
+    Signed,
+    Broadcast,
+    Included,
+    Delivered,
+    Validated,
+    Rejected,
+    Expired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MessageRecord {
+    sender: String,
+    recipients: Vec<String>,
+    created: String,
+    expires: String,
+    status: MessageStatus,
+    history: Vec<MessageStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MessageLifecycleStore {
+    records: BTreeMap<String, MessageRecord>,
+    ids_by_status: BTreeMap<MessageStatus, BTreeSet<String>>,
+    ids_by_sender: BTreeMap<String, BTreeSet<String>>,
+    ids_by_recipient: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl MessageLifecycleStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(
+        &mut self,
+        message_id: &str,
+        sender: &str,
+        recipients: Vec<String>,
+        created: &str,
+        expires: &str,
+    ) -> Result<(), MessageLifecycleError> {
+        if message_id.trim().is_empty() {
+            return Err(MessageLifecycleError::EmptyMessageId);
+        }
+        if self.records.contains_key(message_id) {
+            return Err(MessageLifecycleError::DuplicateMessageId(
+                message_id.to_owned(),
+            ));
+        }
+        if let Err(error) = AgentDid::parse(sender) {
+            return Err(MessageLifecycleError::InvalidSenderDid(error.to_string()));
+        }
+        if recipients.is_empty() {
+            return Err(MessageLifecycleError::EmptyRecipients);
+        }
+        for recipient in &recipients {
+            if let Err(error) = AgentDid::parse(recipient) {
+                return Err(MessageLifecycleError::InvalidRecipientDid(
+                    error.to_string(),
+                ));
+            }
+        }
+        if created.trim().is_empty() {
+            return Err(MessageLifecycleError::EmptyTimestamp("created"));
+        }
+        if expires.trim().is_empty() {
+            return Err(MessageLifecycleError::EmptyTimestamp("expires"));
+        }
+        if expires <= created {
+            return Err(MessageLifecycleError::InvalidExpiryWindow {
+                created: created.to_owned(),
+                expires: expires.to_owned(),
+            });
+        }
+
+        let id = message_id.to_owned();
+        self.records.insert(
+            id.clone(),
+            MessageRecord {
+                sender: sender.to_owned(),
+                recipients: recipients.clone(),
+                created: created.to_owned(),
+                expires: expires.to_owned(),
+                status: MessageStatus::Created,
+                history: vec![MessageStatus::Created],
+            },
+        );
+
+        self.ids_by_status
+            .entry(MessageStatus::Created)
+            .or_default()
+            .insert(id.clone());
+        self.ids_by_sender
+            .entry(sender.to_owned())
+            .or_default()
+            .insert(id.clone());
+        for recipient in recipients {
+            self.ids_by_recipient
+                .entry(recipient)
+                .or_default()
+                .insert(id.clone());
+        }
+        Ok(())
+    }
+
+    pub fn status(&self, message_id: &str) -> Result<MessageStatus, MessageLifecycleError> {
+        self.records
+            .get(message_id)
+            .map(|record| record.status)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))
+    }
+
+    pub fn transition(
+        &mut self,
+        message_id: &str,
+        to: MessageStatus,
+    ) -> Result<(), MessageLifecycleError> {
+        let record = self
+            .records
+            .get_mut(message_id)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
+        let from = record.status;
+        if !is_valid_transition(from, to) {
+            return Err(MessageLifecycleError::InvalidTransition { from, to });
+        }
+
+        record.status = to;
+        record.history.push(to);
+
+        if let Some(ids) = self.ids_by_status.get_mut(&from) {
+            ids.remove(message_id);
+        }
+        self.ids_by_status
+            .entry(to)
+            .or_default()
+            .insert(message_id.to_owned());
+        Ok(())
+    }
+
+    pub fn ids_by_status(&self, status: MessageStatus) -> Vec<String> {
+        self.ids_by_status
+            .get(&status)
+            .map(|ids| ids.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn ids_by_sender(&self, sender: &str) -> Vec<String> {
+        self.ids_by_sender
+            .get(sender)
+            .map(|ids| ids.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn ids_by_recipient(&self, recipient: &str) -> Vec<String> {
+        self.ids_by_recipient
+            .get(recipient)
+            .map(|ids| ids.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn envelope_timestamps(
+        &self,
+        message_id: &str,
+    ) -> Result<(&str, &str), MessageLifecycleError> {
+        let record = self
+            .records
+            .get(message_id)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
+        Ok((&record.created, &record.expires))
+    }
+
+    pub fn history(&self, message_id: &str) -> Result<&[MessageStatus], MessageLifecycleError> {
+        let record = self
+            .records
+            .get(message_id)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
+        Ok(&record.history)
+    }
+
+    pub fn participants(
+        &self,
+        message_id: &str,
+    ) -> Result<(&str, &[String]), MessageLifecycleError> {
+        let record = self
+            .records
+            .get(message_id)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
+        Ok((&record.sender, &record.recipients))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageLifecycleError {
+    EmptyMessageId,
+    DuplicateMessageId(String),
+    InvalidSenderDid(String),
+    EmptyRecipients,
+    InvalidRecipientDid(String),
+    EmptyTimestamp(&'static str),
+    InvalidExpiryWindow {
+        created: String,
+        expires: String,
+    },
+    NotFound(String),
+    InvalidTransition {
+        from: MessageStatus,
+        to: MessageStatus,
+    },
+}
+
+impl fmt::Display for MessageLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyMessageId => write!(f, "message_id must not be empty"),
+            Self::DuplicateMessageId(value) => write!(f, "duplicate message id: {value}"),
+            Self::InvalidSenderDid(value) => write!(f, "invalid sender did: {value}"),
+            Self::EmptyRecipients => write!(f, "recipients must not be empty"),
+            Self::InvalidRecipientDid(value) => write!(f, "invalid recipient did: {value}"),
+            Self::EmptyTimestamp(field) => write!(f, "{field} timestamp must not be empty"),
+            Self::InvalidExpiryWindow { created, expires } => write!(
+                f,
+                "invalid message expiry window, created {created}, expires {expires}"
+            ),
+            Self::NotFound(value) => write!(f, "message not found: {value}"),
+            Self::InvalidTransition { from, to } => {
+                write!(
+                    f,
+                    "invalid message lifecycle transition from {from:?} to {to:?}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for MessageLifecycleError {}
+
+fn is_valid_transition(from: MessageStatus, to: MessageStatus) -> bool {
+    matches!(
+        (from, to),
+        (MessageStatus::Created, MessageStatus::Signed)
+            | (MessageStatus::Signed, MessageStatus::Broadcast)
+            | (MessageStatus::Broadcast, MessageStatus::Included)
+            | (MessageStatus::Included, MessageStatus::Delivered)
+            | (MessageStatus::Delivered, MessageStatus::Validated)
+            | (MessageStatus::Validated, MessageStatus::Rejected)
+            | (MessageStatus::Rejected, MessageStatus::Expired)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MessageLifecycleError, MessageLifecycleStore, MessageStatus};
+
+    #[test]
+    fn register_rejects_duplicate_id() {
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg-1",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("initial register should succeed");
+
+        assert_eq!(
+            store.register(
+                "urn:uuid:msg-1",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            ),
+            Err(MessageLifecycleError::DuplicateMessageId(
+                "urn:uuid:msg-1".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn transition_updates_status_index() {
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg-2",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+
+        store
+            .transition("urn:uuid:msg-2", MessageStatus::Signed)
+            .expect("created->signed should succeed");
+        assert!(store.ids_by_status(MessageStatus::Created).is_empty());
+        assert_eq!(
+            store.ids_by_status(MessageStatus::Signed),
+            vec!["urn:uuid:msg-2".to_owned()]
+        );
+    }
+}

--- a/crates/kamn-core/tests/message_lifecycle_queries.rs
+++ b/crates/kamn-core/tests/message_lifecycle_queries.rs
@@ -1,0 +1,123 @@
+use kamn_core::{MessageLifecycleError, MessageLifecycleStore, MessageStatus};
+
+fn register_baseline(store: &mut MessageLifecycleStore, message_id: &str) {
+    store
+        .register(
+            message_id,
+            "kamn:did:agent:sender-1",
+            vec![
+                "kamn:did:agent:recipient-1".to_owned(),
+                "kamn:did:agent:recipient-2".to_owned(),
+            ],
+            "2026-02-07T20:15:30.123Z",
+            "2026-02-07T20:45:30.123Z",
+        )
+        .expect("register should succeed");
+}
+
+#[test]
+fn register_starts_message_in_created_and_indexes_participants() {
+    let mut store = MessageLifecycleStore::new();
+    register_baseline(&mut store, "urn:uuid:msg-1");
+
+    assert_eq!(
+        store.status("urn:uuid:msg-1").expect("status should exist"),
+        MessageStatus::Created
+    );
+    assert_eq!(
+        store.ids_by_sender("kamn:did:agent:sender-1"),
+        vec!["urn:uuid:msg-1".to_owned()]
+    );
+    assert_eq!(
+        store.ids_by_recipient("kamn:did:agent:recipient-1"),
+        vec!["urn:uuid:msg-1".to_owned()]
+    );
+}
+
+#[test]
+fn valid_lifecycle_transitions_are_indexed() {
+    let mut store = MessageLifecycleStore::new();
+    register_baseline(&mut store, "urn:uuid:msg-2");
+
+    store
+        .transition("urn:uuid:msg-2", MessageStatus::Signed)
+        .expect("created->signed should succeed");
+    store
+        .transition("urn:uuid:msg-2", MessageStatus::Broadcast)
+        .expect("signed->broadcast should succeed");
+    store
+        .transition("urn:uuid:msg-2", MessageStatus::Included)
+        .expect("broadcast->included should succeed");
+    store
+        .transition("urn:uuid:msg-2", MessageStatus::Delivered)
+        .expect("included->delivered should succeed");
+    store
+        .transition("urn:uuid:msg-2", MessageStatus::Validated)
+        .expect("delivered->validated should succeed");
+
+    assert_eq!(
+        store.ids_by_status(MessageStatus::Validated),
+        vec!["urn:uuid:msg-2".to_owned()]
+    );
+}
+
+#[test]
+fn invalid_transition_is_rejected() {
+    let mut store = MessageLifecycleStore::new();
+    register_baseline(&mut store, "urn:uuid:msg-3");
+
+    assert_eq!(
+        store.transition("urn:uuid:msg-3", MessageStatus::Broadcast),
+        Err(MessageLifecycleError::InvalidTransition {
+            from: MessageStatus::Created,
+            to: MessageStatus::Broadcast,
+        })
+    );
+}
+
+#[test]
+fn transition_rejects_unknown_message() {
+    let mut store = MessageLifecycleStore::new();
+    assert_eq!(
+        store.transition("urn:uuid:missing", MessageStatus::Signed),
+        Err(MessageLifecycleError::NotFound(
+            "urn:uuid:missing".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn expired_message_cannot_reenter_pipeline() {
+    let mut store = MessageLifecycleStore::new();
+    register_baseline(&mut store, "urn:uuid:msg-4");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Signed)
+        .expect("created->signed should succeed");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Broadcast)
+        .expect("signed->broadcast should succeed");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Included)
+        .expect("broadcast->included should succeed");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Delivered)
+        .expect("included->delivered should succeed");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Validated)
+        .expect("delivered->validated should succeed");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Rejected)
+        .expect("validated->rejected should succeed");
+    store
+        .transition("urn:uuid:msg-4", MessageStatus::Expired)
+        .expect("rejected->expired should succeed");
+
+    // Regression: #115
+    assert_eq!(
+        store.transition("urn:uuid:msg-4", MessageStatus::Delivered),
+        Err(MessageLifecycleError::InvalidTransition {
+            from: MessageStatus::Expired,
+            to: MessageStatus::Delivered,
+        })
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -54,3 +54,4 @@ For Python SDK parity slice, see `docs/foundation/python-sdk-beta.md`.
 For DID method and canonical DID document schema controls, see `docs/foundation/did-method.md`.
 For DID register/resolve/update/revoke transaction behavior, see `docs/foundation/did-registry-transactions.md`.
 For canonical message envelope schema and validation controls, see `docs/foundation/message-envelope-schema.md`.
+For message lifecycle state machine and index query controls, see `docs/foundation/message-lifecycle.md`.

--- a/docs/foundation/message-lifecycle.md
+++ b/docs/foundation/message-lifecycle.md
@@ -1,0 +1,44 @@
+# Message Lifecycle and Index Queries (Issue #114)
+
+This document defines the first implementation slice for message lifecycle
+state transitions and deterministic index query APIs.
+
+## Lifecycle State Machine
+- `Created -> Signed -> Broadcast -> Included -> Delivered -> Validated -> Rejected -> Expired`
+- Any transition outside the canonical chain is rejected with
+  `MessageLifecycleError::InvalidTransition`.
+
+## APIs
+- `register(message_id, sender, recipients, created, expires)`:
+  validates envelope identifiers and initializes status as `Created`.
+- `transition(message_id, status)`:
+  applies legal state transitions and updates indexes.
+- `status(message_id)`:
+  returns current lifecycle status.
+- `ids_by_status(status)`:
+  returns deterministic message IDs for a lifecycle stage.
+- `ids_by_sender(sender)`:
+  returns deterministic message IDs sent by a DID.
+- `ids_by_recipient(recipient)`:
+  returns deterministic message IDs addressed to a DID.
+
+## Validation Rules
+- `message_id` must be non-empty and unique.
+- `sender` and each recipient must be valid `kamn:did:agent:*` DIDs.
+- Recipients must be non-empty.
+- `created` and `expires` timestamps must be non-empty, with `expires > created`.
+- Unknown message IDs return `MessageLifecycleError::NotFound`.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test message_lifecycle_queries
+cargo test -p kamn-core
+```
+
+## Notes
+This slice keeps indexes in-memory and deterministic (`BTreeMap`/`BTreeSet`)
+so lifecycle audit behavior can be validated quickly at low CI cost.


### PR DESCRIPTION
## Summary
Implements the first message lifecycle slice for story #23 with a strict state machine and deterministic index query APIs. The implementation follows Red→Green TDD evidence from #115 and adds foundation docs for lifecycle behavior.

Closes #114
Closes #115

## Changes
- `crates/kamn-core/src/message_lifecycle.rs`: added lifecycle state machine, transition guards, participant/timestamp metadata, and deterministic status/sender/recipient indexes.
- `crates/kamn-core/src/lib.rs`: exported lifecycle store/status/error APIs.
- `crates/kamn-core/tests/message_lifecycle_queries.rs`: added functional/integration/regression tests for register/transition/query behavior.
- `docs/foundation/message-lifecycle.md`: documented transition graph, APIs, validation rules, and local validation commands.
- `docs/foundation/bootstrap.md`: linked lifecycle foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red with `cargo test -p kamn-core --test message_lifecycle_queries` before implementation; validated Green/regression with `cargo test -p kamn-core --test message_lifecycle_queries` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `message_lifecycle::tests::{register_rejects_duplicate_id, transition_updates_status_index}` |
| Functional  | ✅     | lifecycle transition flow in `tests/message_lifecycle_queries.rs` |
| Integration | ✅     | lifecycle APIs exercised through `kamn_core` integration test target |
| Regression  | ✅     | `expired_message_cannot_reenter_pipeline` guard for #115 |
