### PR TITLE
feat(core): enforce nonce ttl replay and failed-delivery notices

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod instruction_verify;
 pub mod invariants;
 pub mod key_lifecycle;
 pub mod key_recovery;
+pub mod message_delivery_guards;
 pub mod message_envelope;
 pub mod message_lifecycle;
 pub mod migrations;
@@ -36,6 +37,10 @@ pub use invariants::{
 };
 pub use key_lifecycle::{KeyLifecycle, KeyLifecycleError, KeyLifecycleEvent, KeyLifecycleState};
 pub use key_recovery::{KeyRecoveryManager, RecoveryError, RecoveryState};
+pub use message_delivery_guards::{
+    DeliveryFailureCode, DeliveryGuardInput, DeliveryValidationResult, FailedDeliveryNotice,
+    MessageDeliveryGuards,
+};
 pub use message_envelope::{
     AttachmentRef, CanonicalMessageEnvelope, EnvelopeEncryption, EnvelopeHeader, EnvelopeMetadata,
     EnvelopeProof, MessageEnvelopeError, CANONICAL_ENCRYPTION_ALGORITHM,

--- a/crates/kamn-core/src/message_delivery_guards.rs
+++ b/crates/kamn-core/src/message_delivery_guards.rs
@@ -1,0 +1,195 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliveryGuardInput {
+    pub message_id: String,
+    pub sender: String,
+    pub recipient: String,
+    pub nonce: u64,
+    pub created: String,
+    pub expires: String,
+    pub received_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliveryFailureCode {
+    NonceOutOfSequence { expected: u64, found: u64 },
+    Replay,
+    Expired,
+    InvalidWindow,
+}
+
+impl DeliveryFailureCode {
+    fn slug(&self) -> &'static str {
+        match self {
+            Self::NonceOutOfSequence { .. } => "nonce_out_of_sequence",
+            Self::Replay => "replay",
+            Self::Expired => "expired",
+            Self::InvalidWindow => "invalid_window",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailedDeliveryNotice {
+    pub message_id: String,
+    pub sender: String,
+    pub recipient: String,
+    pub code: DeliveryFailureCode,
+    pub detail: String,
+    pub timestamp: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliveryValidationResult {
+    Accepted,
+    Rejected(FailedDeliveryNotice),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MessageDeliveryGuards {
+    next_nonce_by_sender: BTreeMap<String, u64>,
+    seen_message_ids: BTreeSet<String>,
+}
+
+impl MessageDeliveryGuards {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn expected_nonce(&self, sender: &str) -> u64 {
+        self.next_nonce_by_sender.get(sender).copied().unwrap_or(1)
+    }
+
+    pub fn validate(&mut self, input: DeliveryGuardInput) -> DeliveryValidationResult {
+        if input.expires <= input.created {
+            return DeliveryValidationResult::Rejected(self.failed_notice(
+                &input,
+                DeliveryFailureCode::InvalidWindow,
+                "expires must be strictly greater than created".to_owned(),
+            ));
+        }
+        if input.received_at > input.expires {
+            return DeliveryValidationResult::Rejected(self.failed_notice(
+                &input,
+                DeliveryFailureCode::Expired,
+                "message expired before delivery".to_owned(),
+            ));
+        }
+        if self.seen_message_ids.contains(&input.message_id) {
+            return DeliveryValidationResult::Rejected(self.failed_notice(
+                &input,
+                DeliveryFailureCode::Replay,
+                "message replay detected".to_owned(),
+            ));
+        }
+
+        let expected = self.expected_nonce(&input.sender);
+        if input.nonce != expected {
+            return DeliveryValidationResult::Rejected(self.failed_notice(
+                &input,
+                DeliveryFailureCode::NonceOutOfSequence {
+                    expected,
+                    found: input.nonce,
+                },
+                format!(
+                    "nonce out of sequence for sender {}, expected {}, found {}",
+                    input.sender, expected, input.nonce
+                ),
+            ));
+        }
+
+        self.seen_message_ids.insert(input.message_id.clone());
+        self.next_nonce_by_sender
+            .insert(input.sender.clone(), input.nonce + 1);
+        DeliveryValidationResult::Accepted
+    }
+
+    fn failed_notice(
+        &self,
+        input: &DeliveryGuardInput,
+        code: DeliveryFailureCode,
+        detail: String,
+    ) -> FailedDeliveryNotice {
+        let code_slug = code.slug();
+        FailedDeliveryNotice {
+            message_id: input.message_id.clone(),
+            sender: input.sender.clone(),
+            recipient: input.recipient.clone(),
+            code,
+            detail,
+            timestamp: input.received_at.clone(),
+            signature: format!(
+                "notice:{}:{}:{}:{}:{}",
+                input.message_id, code_slug, input.recipient, input.received_at, input.nonce
+            ),
+        }
+    }
+}
+
+impl fmt::Display for DeliveryFailureCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonceOutOfSequence { expected, found } => {
+                write!(
+                    f,
+                    "nonce out of sequence (expected {expected}, found {found})"
+                )
+            }
+            Self::Replay => write!(f, "message replay detected"),
+            Self::Expired => write!(f, "message expired"),
+            Self::InvalidWindow => write!(f, "invalid created/expires window"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DeliveryFailureCode, DeliveryGuardInput, DeliveryValidationResult, MessageDeliveryGuards,
+    };
+
+    fn input(message_id: &str, nonce: u64, received_at: &str) -> DeliveryGuardInput {
+        DeliveryGuardInput {
+            message_id: message_id.to_owned(),
+            sender: "kamn:did:agent:sender-1".to_owned(),
+            recipient: "kamn:did:agent:recipient-1".to_owned(),
+            nonce,
+            created: "2026-02-07T20:15:30.123Z".to_owned(),
+            expires: "2026-02-07T20:45:30.123Z".to_owned(),
+            received_at: received_at.to_owned(),
+        }
+    }
+
+    #[test]
+    fn invalid_window_is_rejected() {
+        let mut guards = MessageDeliveryGuards::new();
+        let mut candidate = input("urn:uuid:msg-1", 1, "2026-02-07T20:20:30.123Z");
+        candidate.expires = candidate.created.clone();
+
+        match guards.validate(candidate) {
+            DeliveryValidationResult::Rejected(notice) => {
+                assert_eq!(notice.code, DeliveryFailureCode::InvalidWindow);
+            }
+            DeliveryValidationResult::Accepted => panic!("expected invalid window rejection"),
+        }
+    }
+
+    #[test]
+    fn replay_rejected_after_accept() {
+        let mut guards = MessageDeliveryGuards::new();
+        assert_eq!(
+            guards.validate(input("urn:uuid:msg-2", 1, "2026-02-07T20:20:30.123Z")),
+            DeliveryValidationResult::Accepted
+        );
+
+        match guards.validate(input("urn:uuid:msg-2", 2, "2026-02-07T20:21:30.123Z")) {
+            DeliveryValidationResult::Rejected(notice) => {
+                assert_eq!(notice.code, DeliveryFailureCode::Replay);
+            }
+            DeliveryValidationResult::Accepted => panic!("expected replay rejection"),
+        }
+    }
+}

--- a/crates/kamn-core/tests/message_delivery_guards.rs
+++ b/crates/kamn-core/tests/message_delivery_guards.rs
@@ -1,0 +1,93 @@
+use kamn_core::{
+    DeliveryFailureCode, DeliveryGuardInput, DeliveryValidationResult, MessageDeliveryGuards,
+};
+
+fn input(message_id: &str, nonce: u64, received_at: &str) -> DeliveryGuardInput {
+    DeliveryGuardInput {
+        message_id: message_id.to_owned(),
+        sender: "kamn:did:agent:sender-1".to_owned(),
+        recipient: "kamn:did:agent:recipient-1".to_owned(),
+        nonce,
+        created: "2026-02-07T20:15:30.123Z".to_owned(),
+        expires: "2026-02-07T20:45:30.123Z".to_owned(),
+        received_at: received_at.to_owned(),
+    }
+}
+
+#[test]
+fn accepts_valid_delivery_and_advances_nonce() {
+    let mut guards = MessageDeliveryGuards::new();
+
+    assert_eq!(
+        guards.validate(input("urn:uuid:msg-1", 1, "2026-02-07T20:20:30.123Z")),
+        DeliveryValidationResult::Accepted
+    );
+    assert_eq!(guards.expected_nonce("kamn:did:agent:sender-1"), 2);
+}
+
+#[test]
+fn rejects_nonce_out_of_sequence_with_failed_delivery_notice() {
+    let mut guards = MessageDeliveryGuards::new();
+
+    let result = guards.validate(input("urn:uuid:msg-2", 2, "2026-02-07T20:20:30.123Z"));
+    match result {
+        DeliveryValidationResult::Rejected(notice) => {
+            assert_eq!(
+                notice.code,
+                DeliveryFailureCode::NonceOutOfSequence {
+                    expected: 1,
+                    found: 2,
+                }
+            );
+            assert!(
+                notice
+                    .signature
+                    .starts_with("notice:urn:uuid:msg-2:nonce_out_of_sequence"),
+                "signature should include deterministic notice prefix"
+            );
+        }
+        DeliveryValidationResult::Accepted => panic!("expected rejection"),
+    }
+}
+
+#[test]
+fn rejects_replay_message_id() {
+    let mut guards = MessageDeliveryGuards::new();
+    assert_eq!(
+        guards.validate(input("urn:uuid:msg-3", 1, "2026-02-07T20:20:30.123Z")),
+        DeliveryValidationResult::Accepted
+    );
+
+    let result = guards.validate(input("urn:uuid:msg-3", 2, "2026-02-07T20:25:30.123Z"));
+    match result {
+        DeliveryValidationResult::Rejected(notice) => {
+            assert_eq!(notice.code, DeliveryFailureCode::Replay);
+        }
+        DeliveryValidationResult::Accepted => panic!("expected replay rejection"),
+    }
+}
+
+#[test]
+fn rejects_expired_message() {
+    let mut guards = MessageDeliveryGuards::new();
+    let result = guards.validate(input("urn:uuid:msg-4", 1, "2026-02-07T20:50:30.123Z"));
+    match result {
+        DeliveryValidationResult::Rejected(notice) => {
+            assert_eq!(notice.code, DeliveryFailureCode::Expired);
+        }
+        DeliveryValidationResult::Accepted => panic!("expected expiry rejection"),
+    }
+}
+
+#[test]
+fn rejected_delivery_does_not_advance_nonce() {
+    let mut guards = MessageDeliveryGuards::new();
+    let _ = guards.validate(input("urn:uuid:msg-5", 2, "2026-02-07T20:20:30.123Z"));
+
+    // Regression: #117
+    assert_eq!(
+        guards.validate(input("urn:uuid:msg-6", 1, "2026-02-07T20:21:30.123Z")),
+        DeliveryValidationResult::Accepted
+    );
+    assert_eq!(guards.expected_nonce("kamn:did:agent:sender-1"), 2);
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -55,3 +55,4 @@ For DID method and canonical DID document schema controls, see `docs/foundation/
 For DID register/resolve/update/revoke transaction behavior, see `docs/foundation/did-registry-transactions.md`.
 For canonical message envelope schema and validation controls, see `docs/foundation/message-envelope-schema.md`.
 For message lifecycle state machine and index query controls, see `docs/foundation/message-lifecycle.md`.
+For nonce/TTL/replay enforcement and failed-delivery notice controls, see `docs/foundation/message-delivery-guards.md`.

--- a/docs/foundation/message-delivery-guards.md
+++ b/docs/foundation/message-delivery-guards.md
@@ -1,0 +1,43 @@
+# Message Delivery Guards (Issue #116)
+
+This document defines the first implementation slice for nonce, TTL, replay,
+and failed-delivery notification controls.
+
+## Core Types
+- `DeliveryGuardInput`: delivery metadata (`message_id`, sender/recipient, nonce, created/expires, received_at).
+- `MessageDeliveryGuards`: in-memory nonce + replay guard state.
+- `DeliveryValidationResult`: `Accepted` or `Rejected(FailedDeliveryNotice)`.
+- `DeliveryFailureCode`:
+  - `NonceOutOfSequence { expected, found }`
+  - `Replay`
+  - `Expired`
+  - `InvalidWindow`
+- `FailedDeliveryNotice`: deterministic signed failure artifact for rejected deliveries.
+
+## Validation Rules
+- Reject if `expires <= created` with `InvalidWindow`.
+- Reject if `received_at > expires` with `Expired`.
+- Reject if `message_id` was already accepted with `Replay`.
+- Reject if `nonce` does not match sender expected nonce with `NonceOutOfSequence`.
+- Accept only when all checks pass; accepted deliveries:
+  - record `message_id` in replay set
+  - advance sender nonce (`expected_nonce = nonce + 1`)
+
+## Failure Notifications
+- Rejections emit `FailedDeliveryNotice` with deterministic signature format:
+  `notice:<message_id>:<code>:<recipient>:<received_at>:<nonce>`
+- Rejected deliveries do not mutate nonce progression state.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test message_delivery_guards
+cargo test -p kamn-core
+```
+
+## Notes
+This slice intentionally uses deterministic in-memory structures so CI remains
+fast and low-cost while safety controls are established.


### PR DESCRIPTION
## Summary
Implements the first delivery-guard slice for story #24 by enforcing nonce ordering, TTL expiry checks, replay protection, and deterministic failed-delivery notice emission. This follows strict Red→Green evidence from #117 and updates foundation documentation.

Closes #116
Closes #117

## Changes
- `crates/kamn-core/src/message_delivery_guards.rs`: added delivery guard input/result models, failure codes, deterministic failed-delivery notices, and guard logic for nonce/TTL/replay enforcement.
- `crates/kamn-core/src/lib.rs`: exported delivery guard APIs.
- `crates/kamn-core/tests/message_delivery_guards.rs`: added functional/integration/regression coverage for accepted/rejected delivery paths.
- `docs/foundation/message-delivery-guards.md`: documented controls, failure notices, and validation commands.
- `docs/foundation/bootstrap.md`: linked delivery guard foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red via `cargo test -p kamn-core --test message_delivery_guards` before implementation; validated Green/regression with `cargo test -p kamn-core --test message_delivery_guards` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `message_delivery_guards::tests::{invalid_window_is_rejected, replay_rejected_after_accept}` |
| Functional  | ✅     | delivery acceptance/rejection flows in `tests/message_delivery_guards.rs` |
| Integration | ✅     | `kamn_core` exported guard APIs exercised in integration test target |
| Regression  | ✅     | `rejected_delivery_does_not_advance_nonce` guard for #117 |
