### PR TITLE
feat(core): implement direct and group channel models

### DIFF
--- a/crates/kamn-core/src/channel_models.rs
+++ b/crates/kamn-core/src/channel_models.rs
@@ -1,0 +1,402 @@
+use crate::AgentDid;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelType {
+    Direct,
+    Group,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChannelRecord {
+    channel_type: ChannelType,
+    members: BTreeSet<String>,
+    admins: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ChannelStore {
+    channels: BTreeMap<String, ChannelRecord>,
+    channels_by_member: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl ChannelStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn create_direct(
+        &mut self,
+        channel_id: &str,
+        participant_a: &str,
+        participant_b: &str,
+    ) -> Result<(), ChannelModelError> {
+        validate_channel_id(channel_id)?;
+        self.ensure_channel_not_exists(channel_id)?;
+        validate_did(participant_a)?;
+        validate_did(participant_b)?;
+        if participant_a == participant_b {
+            return Err(ChannelModelError::InvalidDirectParticipants);
+        }
+
+        let members = BTreeSet::from([participant_a.to_owned(), participant_b.to_owned()]);
+        let admins = members.clone();
+        self.insert_channel(channel_id, ChannelType::Direct, members, admins);
+        Ok(())
+    }
+
+    pub fn create_group(
+        &mut self,
+        channel_id: &str,
+        creator: &str,
+        members: Vec<String>,
+        admins: Vec<String>,
+    ) -> Result<(), ChannelModelError> {
+        validate_channel_id(channel_id)?;
+        self.ensure_channel_not_exists(channel_id)?;
+        validate_did(creator)?;
+        if members.is_empty() {
+            return Err(ChannelModelError::EmptyMembers);
+        }
+        if admins.is_empty() {
+            return Err(ChannelModelError::EmptyAdmins);
+        }
+
+        let mut member_set = BTreeSet::new();
+        for member in members {
+            validate_did(&member)?;
+            member_set.insert(member);
+        }
+        if !member_set.contains(creator) {
+            return Err(ChannelModelError::CreatorNotMember(creator.to_owned()));
+        }
+
+        let mut admin_set = BTreeSet::new();
+        for admin in admins {
+            validate_did(&admin)?;
+            if !member_set.contains(&admin) {
+                return Err(ChannelModelError::AdminNotMember(admin));
+            }
+            admin_set.insert(admin);
+        }
+        if !admin_set.contains(creator) {
+            return Err(ChannelModelError::UnauthorizedActor {
+                actor: creator.to_owned(),
+                required: "admin",
+            });
+        }
+
+        self.insert_channel(channel_id, ChannelType::Group, member_set, admin_set);
+        Ok(())
+    }
+
+    pub fn channel_type(&self, channel_id: &str) -> Result<ChannelType, ChannelModelError> {
+        self.channels
+            .get(channel_id)
+            .map(|record| record.channel_type)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))
+    }
+
+    pub fn members(&self, channel_id: &str) -> Result<Vec<String>, ChannelModelError> {
+        let record = self
+            .channels
+            .get(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        Ok(record.members.iter().cloned().collect())
+    }
+
+    pub fn admins(&self, channel_id: &str) -> Result<Vec<String>, ChannelModelError> {
+        let record = self
+            .channels
+            .get(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        Ok(record.admins.iter().cloned().collect())
+    }
+
+    pub fn channels_for_member(&self, member: &str) -> Vec<String> {
+        self.channels_by_member
+            .get(member)
+            .map(|values| values.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn is_member(&self, channel_id: &str, member: &str) -> Result<bool, ChannelModelError> {
+        let record = self
+            .channels
+            .get(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        Ok(record.members.contains(member))
+    }
+
+    pub fn invite_member(
+        &mut self,
+        channel_id: &str,
+        actor: &str,
+        new_member: &str,
+    ) -> Result<(), ChannelModelError> {
+        validate_did(new_member)?;
+        let record = self
+            .channels
+            .get_mut(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        if record.channel_type == ChannelType::Direct {
+            return Err(ChannelModelError::UnsupportedOperation {
+                channel_type: ChannelType::Direct,
+                action: "invite_member",
+            });
+        }
+        if !record.admins.contains(actor) {
+            return Err(ChannelModelError::UnauthorizedActor {
+                actor: actor.to_owned(),
+                required: "admin",
+            });
+        }
+        if !record.members.insert(new_member.to_owned()) {
+            return Err(ChannelModelError::MemberAlreadyPresent(
+                new_member.to_owned(),
+            ));
+        }
+
+        self.channels_by_member
+            .entry(new_member.to_owned())
+            .or_default()
+            .insert(channel_id.to_owned());
+        Ok(())
+    }
+
+    pub fn remove_member(
+        &mut self,
+        channel_id: &str,
+        actor: &str,
+        member: &str,
+    ) -> Result<(), ChannelModelError> {
+        let record = self
+            .channels
+            .get_mut(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        if record.channel_type == ChannelType::Direct {
+            return Err(ChannelModelError::UnsupportedOperation {
+                channel_type: ChannelType::Direct,
+                action: "remove_member",
+            });
+        }
+        if !record.admins.contains(actor) {
+            return Err(ChannelModelError::UnauthorizedActor {
+                actor: actor.to_owned(),
+                required: "admin",
+            });
+        }
+        if !record.members.contains(member) {
+            return Err(ChannelModelError::MemberNotFound(member.to_owned()));
+        }
+        if record.admins.contains(member) && record.admins.len() == 1 {
+            return Err(ChannelModelError::LastAdminRemoval(channel_id.to_owned()));
+        }
+
+        record.members.remove(member);
+        record.admins.remove(member);
+        if let Some(channels) = self.channels_by_member.get_mut(member) {
+            channels.remove(channel_id);
+        }
+        Ok(())
+    }
+
+    pub fn add_admin(
+        &mut self,
+        channel_id: &str,
+        actor: &str,
+        member: &str,
+    ) -> Result<(), ChannelModelError> {
+        let record = self
+            .channels
+            .get_mut(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        if record.channel_type == ChannelType::Direct {
+            return Err(ChannelModelError::UnsupportedOperation {
+                channel_type: ChannelType::Direct,
+                action: "add_admin",
+            });
+        }
+        if !record.admins.contains(actor) {
+            return Err(ChannelModelError::UnauthorizedActor {
+                actor: actor.to_owned(),
+                required: "admin",
+            });
+        }
+        if !record.members.contains(member) {
+            return Err(ChannelModelError::MemberNotFound(member.to_owned()));
+        }
+
+        record.admins.insert(member.to_owned());
+        Ok(())
+    }
+
+    pub fn remove_admin(
+        &mut self,
+        channel_id: &str,
+        actor: &str,
+        member: &str,
+    ) -> Result<(), ChannelModelError> {
+        let record = self
+            .channels
+            .get_mut(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        if record.channel_type == ChannelType::Direct {
+            return Err(ChannelModelError::UnsupportedOperation {
+                channel_type: ChannelType::Direct,
+                action: "remove_admin",
+            });
+        }
+        if !record.admins.contains(actor) {
+            return Err(ChannelModelError::UnauthorizedActor {
+                actor: actor.to_owned(),
+                required: "admin",
+            });
+        }
+        if !record.admins.contains(member) {
+            return Err(ChannelModelError::AdminNotFound(member.to_owned()));
+        }
+        if record.admins.len() == 1 {
+            return Err(ChannelModelError::LastAdminRemoval(channel_id.to_owned()));
+        }
+
+        record.admins.remove(member);
+        Ok(())
+    }
+
+    fn ensure_channel_not_exists(&self, channel_id: &str) -> Result<(), ChannelModelError> {
+        if self.channels.contains_key(channel_id) {
+            return Err(ChannelModelError::DuplicateChannelId(channel_id.to_owned()));
+        }
+        Ok(())
+    }
+
+    fn insert_channel(
+        &mut self,
+        channel_id: &str,
+        channel_type: ChannelType,
+        members: BTreeSet<String>,
+        admins: BTreeSet<String>,
+    ) {
+        self.channels.insert(
+            channel_id.to_owned(),
+            ChannelRecord {
+                channel_type,
+                members: members.clone(),
+                admins,
+            },
+        );
+        for member in members {
+            self.channels_by_member
+                .entry(member)
+                .or_default()
+                .insert(channel_id.to_owned());
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelModelError {
+    EmptyChannelId,
+    InvalidDid(String),
+    DuplicateChannelId(String),
+    InvalidDirectParticipants,
+    EmptyMembers,
+    EmptyAdmins,
+    CreatorNotMember(String),
+    AdminNotMember(String),
+    UnauthorizedActor {
+        actor: String,
+        required: &'static str,
+    },
+    NotFound(String),
+    MemberAlreadyPresent(String),
+    MemberNotFound(String),
+    AdminNotFound(String),
+    LastAdminRemoval(String),
+    UnsupportedOperation {
+        channel_type: ChannelType,
+        action: &'static str,
+    },
+}
+
+impl fmt::Display for ChannelModelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyChannelId => write!(f, "channel_id must not be empty"),
+            Self::InvalidDid(value) => write!(f, "invalid channel DID: {value}"),
+            Self::DuplicateChannelId(value) => write!(f, "duplicate channel id: {value}"),
+            Self::InvalidDirectParticipants => {
+                write!(f, "direct channels require two distinct participants")
+            }
+            Self::EmptyMembers => write!(f, "group channel members must not be empty"),
+            Self::EmptyAdmins => write!(f, "group channel admins must not be empty"),
+            Self::CreatorNotMember(value) => write!(f, "creator must be a member: {value}"),
+            Self::AdminNotMember(value) => write!(f, "admin must be a member: {value}"),
+            Self::UnauthorizedActor { actor, required } => {
+                write!(f, "unauthorized actor {actor}, requires {required}")
+            }
+            Self::NotFound(value) => write!(f, "channel not found: {value}"),
+            Self::MemberAlreadyPresent(value) => write!(f, "member already present: {value}"),
+            Self::MemberNotFound(value) => write!(f, "member not found: {value}"),
+            Self::AdminNotFound(value) => write!(f, "admin not found: {value}"),
+            Self::LastAdminRemoval(value) => write!(f, "cannot remove last admin from {value}"),
+            Self::UnsupportedOperation {
+                channel_type,
+                action,
+            } => write!(
+                f,
+                "unsupported operation {action} for channel type {channel_type:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChannelModelError {}
+
+fn validate_channel_id(channel_id: &str) -> Result<(), ChannelModelError> {
+    if channel_id.trim().is_empty() {
+        return Err(ChannelModelError::EmptyChannelId);
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), ChannelModelError> {
+    AgentDid::parse(value).map_err(|error| ChannelModelError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChannelModelError, ChannelStore};
+
+    #[test]
+    fn group_creator_must_be_member() {
+        let mut store = ChannelStore::new();
+        assert_eq!(
+            store.create_group(
+                "channel:group:1",
+                "kamn:did:agent:owner",
+                vec!["kamn:did:agent:member-1".to_owned()],
+                vec!["kamn:did:agent:member-1".to_owned()],
+            ),
+            Err(ChannelModelError::CreatorNotMember(
+                "kamn:did:agent:owner".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn direct_channels_require_distinct_participants() {
+        let mut store = ChannelStore::new();
+        assert_eq!(
+            store.create_direct(
+                "channel:direct:1",
+                "kamn:did:agent:alice",
+                "kamn:did:agent:alice",
+            ),
+            Err(ChannelModelError::InvalidDirectParticipants)
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bootstrap;
+pub mod channel_models;
 pub mod config;
 pub mod did;
 pub mod did_registry;
@@ -19,6 +20,7 @@ pub mod token;
 pub mod transaction;
 
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
+pub use channel_models::{ChannelModelError, ChannelStore, ChannelType};
 pub use config::{ConfigError, NodeConfig, NodeRole};
 pub use did::{
     canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocument,

--- a/crates/kamn-core/tests/channel_models.rs
+++ b/crates/kamn-core/tests/channel_models.rs
@@ -1,0 +1,157 @@
+use kamn_core::{ChannelModelError, ChannelStore, ChannelType};
+
+#[test]
+fn direct_channel_registers_membership_and_admins() {
+    let mut store = ChannelStore::new();
+    store
+        .create_direct(
+            "channel:direct:1",
+            "kamn:did:agent:alice",
+            "kamn:did:agent:bob",
+        )
+        .expect("direct channel should be created");
+
+    assert_eq!(
+        store
+            .channel_type("channel:direct:1")
+            .expect("type should exist"),
+        ChannelType::Direct
+    );
+    assert_eq!(
+        store
+            .members("channel:direct:1")
+            .expect("members should exist"),
+        vec![
+            "kamn:did:agent:alice".to_owned(),
+            "kamn:did:agent:bob".to_owned()
+        ]
+    );
+    assert_eq!(
+        store
+            .admins("channel:direct:1")
+            .expect("admins should exist"),
+        vec![
+            "kamn:did:agent:alice".to_owned(),
+            "kamn:did:agent:bob".to_owned()
+        ]
+    );
+    assert_eq!(
+        store.channels_for_member("kamn:did:agent:alice"),
+        vec!["channel:direct:1".to_owned()]
+    );
+}
+
+#[test]
+fn group_channel_admin_can_invite_and_remove_members() {
+    let mut store = ChannelStore::new();
+    store
+        .create_group(
+            "channel:group:1",
+            "kamn:did:agent:owner",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("group channel should be created");
+
+    store
+        .invite_member(
+            "channel:group:1",
+            "kamn:did:agent:owner",
+            "kamn:did:agent:member-2",
+        )
+        .expect("admin should invite member");
+    assert!(store
+        .is_member("channel:group:1", "kamn:did:agent:member-2")
+        .expect("membership query should succeed"));
+
+    store
+        .remove_member(
+            "channel:group:1",
+            "kamn:did:agent:owner",
+            "kamn:did:agent:member-2",
+        )
+        .expect("admin should remove member");
+    assert!(!store
+        .is_member("channel:group:1", "kamn:did:agent:member-2")
+        .expect("membership query should succeed"));
+}
+
+#[test]
+fn non_admin_cannot_invite_member() {
+    let mut store = ChannelStore::new();
+    store
+        .create_group(
+            "channel:group:2",
+            "kamn:did:agent:owner",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("group channel should be created");
+
+    assert_eq!(
+        store.invite_member(
+            "channel:group:2",
+            "kamn:did:agent:member-1",
+            "kamn:did:agent:member-2",
+        ),
+        Err(ChannelModelError::UnauthorizedActor {
+            actor: "kamn:did:agent:member-1".to_owned(),
+            required: "admin",
+        })
+    );
+}
+
+#[test]
+fn direct_channel_member_removal_is_rejected() {
+    let mut store = ChannelStore::new();
+    store
+        .create_direct(
+            "channel:direct:2",
+            "kamn:did:agent:alice",
+            "kamn:did:agent:bob",
+        )
+        .expect("direct channel should be created");
+
+    assert_eq!(
+        store.remove_member(
+            "channel:direct:2",
+            "kamn:did:agent:alice",
+            "kamn:did:agent:bob",
+        ),
+        Err(ChannelModelError::UnsupportedOperation {
+            channel_type: ChannelType::Direct,
+            action: "remove_member",
+        })
+    );
+}
+
+#[test]
+fn removing_last_admin_is_rejected() {
+    let mut store = ChannelStore::new();
+    store
+        .create_group(
+            "channel:group:3",
+            "kamn:did:agent:owner",
+            vec!["kamn:did:agent:owner".to_owned()],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("group channel should be created");
+
+    // Regression: #119
+    assert_eq!(
+        store.remove_admin(
+            "channel:group:3",
+            "kamn:did:agent:owner",
+            "kamn:did:agent:owner",
+        ),
+        Err(ChannelModelError::LastAdminRemoval(
+            "channel:group:3".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -56,3 +56,4 @@ For DID register/resolve/update/revoke transaction behavior, see `docs/foundatio
 For canonical message envelope schema and validation controls, see `docs/foundation/message-envelope-schema.md`.
 For message lifecycle state machine and index query controls, see `docs/foundation/message-lifecycle.md`.
 For nonce/TTL/replay enforcement and failed-delivery notice controls, see `docs/foundation/message-delivery-guards.md`.
+For direct/group channel models with membership/admin operations, see `docs/foundation/channel-models.md`.

--- a/docs/foundation/channel-models.md
+++ b/docs/foundation/channel-models.md
@@ -1,0 +1,53 @@
+# Direct and Group Channel Models (Issue #118)
+
+This document defines the first implementation slice for direct/group channel
+models with membership and admin operations.
+
+## Core Models
+- `ChannelType`:
+  - `Direct`
+  - `Group`
+- `ChannelStore`: in-memory channel registry with deterministic member-to-channel indexing.
+
+## Supported Operations
+- `create_direct(channel_id, participant_a, participant_b)`
+  - requires two distinct valid `kamn:did:agent:*` participants.
+  - both participants become members and admins.
+- `create_group(channel_id, creator, members, admins)`
+  - requires non-empty members/admins.
+  - creator must be both member and admin.
+  - admins must be a subset of members.
+- `invite_member(channel_id, actor, new_member)`
+  - actor must be admin (group channel only).
+- `remove_member(channel_id, actor, member)`
+  - actor must be admin (group channel only).
+  - removing the last admin is blocked.
+- `add_admin(channel_id, actor, member)` / `remove_admin(channel_id, actor, member)`
+  - actor must be admin (group channel only).
+  - removing the last admin is blocked.
+- Query APIs:
+  - `channel_type(channel_id)`
+  - `members(channel_id)`
+  - `admins(channel_id)`
+  - `is_member(channel_id, did)`
+  - `channels_for_member(did)`
+
+## Validation and Safety Rules
+- Channel IDs must be non-empty and unique.
+- DIDs must parse as `kamn:did:agent:*`.
+- Non-admin actors cannot mutate group membership/admin state.
+- Direct channels reject unsupported group-style mutations.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test channel_models
+cargo test -p kamn-core
+```
+
+## Notes
+This slice is deterministic and dependency-light (`BTreeMap`/`BTreeSet`) to keep
+CI fast and low-cost while establishing channel authorization semantics.


### PR DESCRIPTION
## Summary
Implements the first channel-model slice for story #25 with direct/group channel creation, admin-gated membership/admin operations, and deterministic membership index queries. This follows strict Red→Green evidence from #119 and updates foundation documentation.

Closes #118
Closes #119

## Changes
- `crates/kamn-core/src/channel_models.rs`: added `ChannelStore`, `ChannelType`, and explicit channel membership/admin operation rules with deterministic indexes.
- `crates/kamn-core/src/lib.rs`: exported channel model APIs.
- `crates/kamn-core/tests/channel_models.rs`: added functional/integration/regression tests for direct/group channel behavior.
- `docs/foundation/channel-models.md`: documented channel model contracts and local validation commands.
- `docs/foundation/bootstrap.md`: linked channel model foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red via `cargo test -p kamn-core --test channel_models` before implementation; validated Green/regression with `cargo test -p kamn-core --test channel_models` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `channel_models::tests::{group_creator_must_be_member, direct_channels_require_distinct_participants}` |
| Functional  | ✅     | direct/group CRUD and membership/admin mutation behavior in `tests/channel_models.rs` |
| Integration | ✅     | `kamn_core` exported channel APIs exercised in integration test target |
| Regression  | ✅     | `removing_last_admin_is_rejected` guard for #119 |
