### PR TITLE
feat(core): implement channel permissions and retention policies

### DIFF
--- a/crates/kamn-core/src/channel_policies.rs
+++ b/crates/kamn-core/src/channel_policies.rs
@@ -1,0 +1,348 @@
+use crate::AgentDid;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelAction {
+    Send,
+    Read,
+    Invite,
+    Remove,
+    Configure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionRule {
+    All,
+    Members,
+    Admins,
+    Allowlist(BTreeSet<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetentionPolicy {
+    Forever,
+    MaxAgeSeconds(u64),
+    MaxMessageCount(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelPermissions {
+    pub send: PermissionRule,
+    pub read: PermissionRule,
+    pub invite: PermissionRule,
+    pub remove: PermissionRule,
+    pub configure: PermissionRule,
+    pub retention: RetentionPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionMessage {
+    pub id: String,
+    pub created_at_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChannelPolicyRecord {
+    members: BTreeSet<String>,
+    admins: BTreeSet<String>,
+    permissions: ChannelPermissions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ChannelPermissionEngine {
+    channels: BTreeMap<String, ChannelPolicyRecord>,
+}
+
+impl ChannelPermissionEngine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_channel(
+        &mut self,
+        channel_id: &str,
+        members: Vec<String>,
+        admins: Vec<String>,
+        permissions: ChannelPermissions,
+    ) -> Result<(), ChannelPolicyError> {
+        if channel_id.trim().is_empty() {
+            return Err(ChannelPolicyError::EmptyChannelId);
+        }
+        if self.channels.contains_key(channel_id) {
+            return Err(ChannelPolicyError::DuplicateChannelId(
+                channel_id.to_owned(),
+            ));
+        }
+        if members.is_empty() {
+            return Err(ChannelPolicyError::EmptyMembers);
+        }
+        if admins.is_empty() {
+            return Err(ChannelPolicyError::EmptyAdmins);
+        }
+
+        validate_retention_policy(&permissions.retention)?;
+
+        let mut member_set = BTreeSet::new();
+        for member in members {
+            validate_did(&member)?;
+            member_set.insert(member);
+        }
+
+        let mut admin_set = BTreeSet::new();
+        for admin in admins {
+            validate_did(&admin)?;
+            if !member_set.contains(&admin) {
+                return Err(ChannelPolicyError::AdminNotMember(admin));
+            }
+            admin_set.insert(admin);
+        }
+
+        self.channels.insert(
+            channel_id.to_owned(),
+            ChannelPolicyRecord {
+                members: member_set,
+                admins: admin_set,
+                permissions,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn authorize(
+        &self,
+        channel_id: &str,
+        actor: &str,
+        action: ChannelAction,
+    ) -> Result<(), ChannelPolicyError> {
+        validate_did(actor)?;
+        let record = self
+            .channels
+            .get(channel_id)
+            .ok_or_else(|| ChannelPolicyError::NotFound(channel_id.to_owned()))?;
+        let rule = match action {
+            ChannelAction::Send => &record.permissions.send,
+            ChannelAction::Read => &record.permissions.read,
+            ChannelAction::Invite => &record.permissions.invite,
+            ChannelAction::Remove => &record.permissions.remove,
+            ChannelAction::Configure => &record.permissions.configure,
+        };
+
+        if is_authorized(rule, actor, &record.members, &record.admins) {
+            Ok(())
+        } else {
+            Err(ChannelPolicyError::Unauthorized {
+                actor: actor.to_owned(),
+                action,
+                rule: rule.clone(),
+            })
+        }
+    }
+
+    pub fn retention_candidates(
+        &self,
+        channel_id: &str,
+        now_secs: u64,
+        mut messages: Vec<RetentionMessage>,
+    ) -> Result<Vec<String>, ChannelPolicyError> {
+        let record = self
+            .channels
+            .get(channel_id)
+            .ok_or_else(|| ChannelPolicyError::NotFound(channel_id.to_owned()))?;
+        match record.permissions.retention {
+            RetentionPolicy::Forever => Ok(Vec::new()),
+            RetentionPolicy::MaxAgeSeconds(max_age) => {
+                let mut candidates: Vec<String> = messages
+                    .into_iter()
+                    .filter(|message| now_secs.saturating_sub(message.created_at_secs) > max_age)
+                    .map(|message| message.id)
+                    .collect();
+                candidates.sort();
+                Ok(candidates)
+            }
+            RetentionPolicy::MaxMessageCount(limit) => {
+                if messages.len() <= limit {
+                    return Ok(Vec::new());
+                }
+                messages.sort_by(|left, right| {
+                    left.created_at_secs
+                        .cmp(&right.created_at_secs)
+                        .then_with(|| left.id.cmp(&right.id))
+                });
+                let prune_count = messages.len() - limit;
+                Ok(messages
+                    .into_iter()
+                    .take(prune_count)
+                    .map(|message| message.id)
+                    .collect())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelPolicyError {
+    EmptyChannelId,
+    DuplicateChannelId(String),
+    EmptyMembers,
+    EmptyAdmins,
+    InvalidDid(String),
+    AdminNotMember(String),
+    NotFound(String),
+    Unauthorized {
+        actor: String,
+        action: ChannelAction,
+        rule: PermissionRule,
+    },
+    InvalidRetentionPolicy(String),
+}
+
+impl fmt::Display for ChannelPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyChannelId => write!(f, "channel_id must not be empty"),
+            Self::DuplicateChannelId(value) => write!(f, "duplicate channel id: {value}"),
+            Self::EmptyMembers => write!(f, "members must not be empty"),
+            Self::EmptyAdmins => write!(f, "admins must not be empty"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::AdminNotMember(value) => write!(f, "admin must be a member: {value}"),
+            Self::NotFound(value) => write!(f, "channel not found: {value}"),
+            Self::Unauthorized {
+                actor,
+                action,
+                rule,
+            } => write!(
+                f,
+                "actor {actor} is unauthorized for action {action:?} under rule {rule:?}"
+            ),
+            Self::InvalidRetentionPolicy(value) => write!(f, "invalid retention policy: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for ChannelPolicyError {}
+
+fn validate_did(value: &str) -> Result<(), ChannelPolicyError> {
+    AgentDid::parse(value).map_err(|error| ChannelPolicyError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn validate_retention_policy(policy: &RetentionPolicy) -> Result<(), ChannelPolicyError> {
+    match policy {
+        RetentionPolicy::MaxMessageCount(0) => Err(ChannelPolicyError::InvalidRetentionPolicy(
+            "max message count must be greater than zero".to_owned(),
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn is_authorized(
+    rule: &PermissionRule,
+    actor: &str,
+    members: &BTreeSet<String>,
+    admins: &BTreeSet<String>,
+) -> bool {
+    match rule {
+        PermissionRule::All => true,
+        PermissionRule::Members => members.contains(actor),
+        PermissionRule::Admins => admins.contains(actor),
+        PermissionRule::Allowlist(values) => values.contains(actor),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError,
+        PermissionRule, RetentionMessage, RetentionPolicy,
+    };
+
+    fn permissions(retention: RetentionPolicy) -> ChannelPermissions {
+        ChannelPermissions {
+            send: PermissionRule::Members,
+            read: PermissionRule::Members,
+            invite: PermissionRule::Admins,
+            remove: PermissionRule::Admins,
+            configure: PermissionRule::Admins,
+            retention,
+        }
+    }
+
+    #[test]
+    fn registration_rejects_admin_outside_members() {
+        let mut engine = ChannelPermissionEngine::new();
+        assert_eq!(
+            engine.register_channel(
+                "channel:group:1",
+                vec!["kamn:did:agent:member-1".to_owned()],
+                vec!["kamn:did:agent:admin-1".to_owned()],
+                permissions(RetentionPolicy::Forever),
+            ),
+            Err(ChannelPolicyError::AdminNotMember(
+                "kamn:did:agent:admin-1".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn max_count_retention_prunes_oldest_first() {
+        let mut engine = ChannelPermissionEngine::new();
+        engine
+            .register_channel(
+                "channel:group:2",
+                vec!["kamn:did:agent:member-1".to_owned()],
+                vec!["kamn:did:agent:member-1".to_owned()],
+                permissions(RetentionPolicy::MaxMessageCount(2)),
+            )
+            .expect("registration should succeed");
+
+        let candidates = engine
+            .retention_candidates(
+                "channel:group:2",
+                500,
+                vec![
+                    RetentionMessage {
+                        id: "msg-c".to_owned(),
+                        created_at_secs: 200,
+                    },
+                    RetentionMessage {
+                        id: "msg-a".to_owned(),
+                        created_at_secs: 100,
+                    },
+                    RetentionMessage {
+                        id: "msg-b".to_owned(),
+                        created_at_secs: 200,
+                    },
+                ],
+            )
+            .expect("retention candidates should compute");
+
+        assert_eq!(candidates, vec!["msg-a".to_owned()]);
+    }
+
+    #[test]
+    fn authorize_members_rule_requires_membership() {
+        let mut engine = ChannelPermissionEngine::new();
+        engine
+            .register_channel(
+                "channel:group:3",
+                vec!["kamn:did:agent:member-1".to_owned()],
+                vec!["kamn:did:agent:member-1".to_owned()],
+                permissions(RetentionPolicy::Forever),
+            )
+            .expect("registration should succeed");
+
+        assert_eq!(
+            engine.authorize(
+                "channel:group:3",
+                "kamn:did:agent:member-2",
+                ChannelAction::Send,
+            ),
+            Err(ChannelPolicyError::Unauthorized {
+                actor: "kamn:did:agent:member-2".to_owned(),
+                action: ChannelAction::Send,
+                rule: PermissionRule::Members,
+            })
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bootstrap;
 pub mod channel_models;
+pub mod channel_policies;
 pub mod config;
 pub mod did;
 pub mod did_registry;
@@ -21,6 +22,10 @@ pub mod transaction;
 
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use channel_models::{ChannelModelError, ChannelStore, ChannelType};
+pub use channel_policies::{
+    ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError, PermissionRule,
+    RetentionMessage, RetentionPolicy,
+};
 pub use config::{ConfigError, NodeConfig, NodeRole};
 pub use did::{
     canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocument,

--- a/crates/kamn-core/tests/channel_permissions_retention.rs
+++ b/crates/kamn-core/tests/channel_permissions_retention.rs
@@ -1,0 +1,206 @@
+use kamn_core::{
+    ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError, PermissionRule,
+    RetentionMessage, RetentionPolicy,
+};
+
+fn base_permissions() -> ChannelPermissions {
+    ChannelPermissions {
+        send: PermissionRule::Members,
+        read: PermissionRule::Members,
+        invite: PermissionRule::Admins,
+        remove: PermissionRule::Admins,
+        configure: PermissionRule::Admins,
+        retention: RetentionPolicy::Forever,
+    }
+}
+
+fn register_group(engine: &mut ChannelPermissionEngine, channel_id: &str) {
+    engine
+        .register_channel(
+            channel_id,
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+                "kamn:did:agent:member-2".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            base_permissions(),
+        )
+        .expect("channel should register");
+}
+
+#[test]
+fn admin_and_member_permissions_are_enforced() {
+    let mut engine = ChannelPermissionEngine::new();
+    register_group(&mut engine, "channel:group:perm-1");
+
+    assert!(engine
+        .authorize(
+            "channel:group:perm-1",
+            "kamn:did:agent:member-1",
+            ChannelAction::Send,
+        )
+        .is_ok());
+    assert_eq!(
+        engine.authorize(
+            "channel:group:perm-1",
+            "kamn:did:agent:member-1",
+            ChannelAction::Invite,
+        ),
+        Err(ChannelPolicyError::Unauthorized {
+            actor: "kamn:did:agent:member-1".to_owned(),
+            action: ChannelAction::Invite,
+            rule: PermissionRule::Admins,
+        })
+    );
+    assert!(engine
+        .authorize(
+            "channel:group:perm-1",
+            "kamn:did:agent:owner",
+            ChannelAction::Invite,
+        )
+        .is_ok());
+}
+
+#[test]
+fn allowlist_rules_restrict_actions() {
+    let mut engine = ChannelPermissionEngine::new();
+    let mut permissions = base_permissions();
+    permissions.send =
+        PermissionRule::Allowlist(["kamn:did:agent:member-1".to_owned()].into_iter().collect());
+    engine
+        .register_channel(
+            "channel:group:perm-2",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+                "kamn:did:agent:member-2".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            permissions,
+        )
+        .expect("channel should register");
+
+    assert!(engine
+        .authorize(
+            "channel:group:perm-2",
+            "kamn:did:agent:member-1",
+            ChannelAction::Send,
+        )
+        .is_ok());
+    assert_eq!(
+        engine.authorize(
+            "channel:group:perm-2",
+            "kamn:did:agent:member-2",
+            ChannelAction::Send,
+        ),
+        Err(ChannelPolicyError::Unauthorized {
+            actor: "kamn:did:agent:member-2".to_owned(),
+            action: ChannelAction::Send,
+            rule: PermissionRule::Allowlist(
+                ["kamn:did:agent:member-1".to_owned()].into_iter().collect(),
+            ),
+        })
+    );
+}
+
+#[test]
+fn retention_message_count_prunes_oldest_deterministically() {
+    let mut engine = ChannelPermissionEngine::new();
+    let mut permissions = base_permissions();
+    permissions.retention = RetentionPolicy::MaxMessageCount(2);
+    engine
+        .register_channel(
+            "channel:group:perm-3",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            permissions,
+        )
+        .expect("channel should register");
+
+    let candidates = engine
+        .retention_candidates(
+            "channel:group:perm-3",
+            1000,
+            vec![
+                RetentionMessage {
+                    id: "msg-a".to_owned(),
+                    created_at_secs: 100,
+                },
+                RetentionMessage {
+                    id: "msg-b".to_owned(),
+                    created_at_secs: 200,
+                },
+                RetentionMessage {
+                    id: "msg-c".to_owned(),
+                    created_at_secs: 200,
+                },
+            ],
+        )
+        .expect("retention candidates should compute");
+
+    assert_eq!(candidates, vec!["msg-a".to_owned()]);
+}
+
+#[test]
+fn retention_max_age_prunes_expired_messages() {
+    let mut engine = ChannelPermissionEngine::new();
+    let mut permissions = base_permissions();
+    permissions.retention = RetentionPolicy::MaxAgeSeconds(300);
+    engine
+        .register_channel(
+            "channel:group:perm-4",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            permissions,
+        )
+        .expect("channel should register");
+
+    let candidates = engine
+        .retention_candidates(
+            "channel:group:perm-4",
+            1000,
+            vec![
+                RetentionMessage {
+                    id: "msg-old".to_owned(),
+                    created_at_secs: 500,
+                },
+                RetentionMessage {
+                    id: "msg-fresh".to_owned(),
+                    created_at_secs: 800,
+                },
+            ],
+        )
+        .expect("retention candidates should compute");
+
+    assert_eq!(candidates, vec!["msg-old".to_owned()]);
+}
+
+#[test]
+fn zero_message_count_retention_is_rejected() {
+    let mut engine = ChannelPermissionEngine::new();
+    let mut permissions = base_permissions();
+    permissions.retention = RetentionPolicy::MaxMessageCount(0);
+
+    // Regression: #121
+    assert_eq!(
+        engine.register_channel(
+            "channel:group:perm-5",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            permissions,
+        ),
+        Err(ChannelPolicyError::InvalidRetentionPolicy(
+            "max message count must be greater than zero".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -57,3 +57,4 @@ For canonical message envelope schema and validation controls, see `docs/foundat
 For message lifecycle state machine and index query controls, see `docs/foundation/message-lifecycle.md`.
 For nonce/TTL/replay enforcement and failed-delivery notice controls, see `docs/foundation/message-delivery-guards.md`.
 For direct/group channel models with membership/admin operations, see `docs/foundation/channel-models.md`.
+For channel permission and retention policy controls, see `docs/foundation/channel-permissions-retention.md`.

--- a/docs/foundation/channel-permissions-retention.md
+++ b/docs/foundation/channel-permissions-retention.md
@@ -1,0 +1,56 @@
+# Channel Permissions and Retention Policies (Issue #120)
+
+This document defines the first implementation slice for channel permission
+evaluation and retention policy behavior.
+
+## Core Types
+- `ChannelPermissionEngine`: deterministic in-memory permission/retention engine.
+- `ChannelPermissions`: per-channel rules for:
+  - `send`
+  - `read`
+  - `invite`
+  - `remove`
+  - `configure`
+  - `retention`
+- `PermissionRule`:
+  - `All`
+  - `Members`
+  - `Admins`
+  - `Allowlist(BTreeSet<String>)`
+- `RetentionPolicy`:
+  - `Forever`
+  - `MaxAgeSeconds(u64)`
+  - `MaxMessageCount(usize)`
+- `RetentionMessage`: message metadata for retention candidate evaluation.
+
+## Permission Evaluation
+- `authorize(channel_id, actor, action)` validates actor DID and applies rule for action.
+- Unauthorized access returns `ChannelPolicyError::Unauthorized` with actor/action/rule context.
+- Channel registration enforces:
+  - non-empty channel ID
+  - non-empty members/admins
+  - valid `kamn:did:agent:*` identifiers
+  - admins must be members
+
+## Retention Evaluation
+- `retention_candidates(channel_id, now_secs, messages)` returns message IDs eligible for pruning.
+- `Forever` returns no candidates.
+- `MaxAgeSeconds` prunes messages where `now_secs - created_at_secs > max_age`.
+- `MaxMessageCount` keeps newest `N` messages and prunes oldest deterministically
+  (sort by `created_at_secs`, then message ID).
+- Invalid policy guard:
+  - `MaxMessageCount(0)` is rejected at registration.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test channel_permissions_retention
+cargo test -p kamn-core
+```
+
+## Notes
+This slice is intentionally dependency-free and deterministic to keep CI fast
+and low-cost while establishing channel safety controls.


### PR DESCRIPTION
## Summary
Implements the first channel permission and retention slice for story #27 with deterministic permission evaluation (`All/Members/Admins/Allowlist`) and retention candidate computation (`Forever/MaxAgeSeconds/MaxMessageCount`). The work follows strict Red→Green TDD evidence from #121 and updates foundation documentation.

Closes #120
Closes #121

## Changes
- `crates/kamn-core/src/channel_policies.rs`: added permission engine, rules, actions, retention policy model, and typed error surface.
- `crates/kamn-core/src/lib.rs`: exported channel permission/retention APIs.
- `crates/kamn-core/tests/channel_permissions_retention.rs`: added functional/integration/regression tests for authorization and deterministic retention behavior.
- `docs/foundation/channel-permissions-retention.md`: documented API contract, validation rules, and local validation commands.
- `docs/foundation/bootstrap.md`: linked permission/retention foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red via `cargo test -p kamn-core --test channel_permissions_retention` before implementation; validated Green/regression with `cargo test -p kamn-core --test channel_permissions_retention` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `channel_policies::tests::{registration_rejects_admin_outside_members, max_count_retention_prunes_oldest_first}` |
| Functional  | ✅     | permission + retention scenarios in `tests/channel_permissions_retention.rs` |
| Integration | ✅     | `kamn_core` exported permission APIs exercised in integration test target |
| Regression  | ✅     | `zero_message_count_retention_is_rejected` guard for #121 |
