### PR TITLE
feat(core): implement agent key hierarchy roles

### DIFF
--- a/crates/kamn-core/src/agent_key_hierarchy.rs
+++ b/crates/kamn-core/src/agent_key_hierarchy.rs
@@ -1,0 +1,192 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyRole {
+    Identity,
+    Signing,
+    Agreement,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EphemeralSessionKey {
+    pub key_id: String,
+    pub expires_at_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentKeyHierarchy {
+    identity_key_id: String,
+    signing_key_id: String,
+    agreement_key_id: String,
+    ephemeral_by_session: BTreeMap<String, EphemeralSessionKey>,
+}
+
+impl AgentKeyHierarchy {
+    pub fn new(
+        identity_key_id: &str,
+        signing_key_id: &str,
+        agreement_key_id: &str,
+    ) -> Result<Self, AgentKeyHierarchyError> {
+        ensure_non_empty("identity", identity_key_id)?;
+        ensure_non_empty("signing", signing_key_id)?;
+        ensure_non_empty("agreement", agreement_key_id)?;
+        ensure_distinct(identity_key_id, signing_key_id, agreement_key_id)?;
+
+        Ok(Self {
+            identity_key_id: identity_key_id.to_owned(),
+            signing_key_id: signing_key_id.to_owned(),
+            agreement_key_id: agreement_key_id.to_owned(),
+            ephemeral_by_session: BTreeMap::new(),
+        })
+    }
+
+    pub fn current_key(&self, role: KeyRole) -> Result<&str, AgentKeyHierarchyError> {
+        Ok(match role {
+            KeyRole::Identity => &self.identity_key_id,
+            KeyRole::Signing => &self.signing_key_id,
+            KeyRole::Agreement => &self.agreement_key_id,
+        })
+    }
+
+    pub fn rotate_signing_key(&mut self, key_id: &str) -> Result<(), AgentKeyHierarchyError> {
+        ensure_non_empty("signing", key_id)?;
+        if key_id == self.identity_key_id || key_id == self.agreement_key_id {
+            return Err(AgentKeyHierarchyError::DuplicateRoleKey(key_id.to_owned()));
+        }
+        self.signing_key_id = key_id.to_owned();
+        Ok(())
+    }
+
+    pub fn rotate_agreement_key(&mut self, key_id: &str) -> Result<(), AgentKeyHierarchyError> {
+        ensure_non_empty("agreement", key_id)?;
+        if key_id == self.identity_key_id || key_id == self.signing_key_id {
+            return Err(AgentKeyHierarchyError::DuplicateRoleKey(key_id.to_owned()));
+        }
+        self.agreement_key_id = key_id.to_owned();
+        Ok(())
+    }
+
+    pub fn register_ephemeral(
+        &mut self,
+        session_id: &str,
+        key_id: &str,
+        expires_at_secs: u64,
+    ) -> Result<(), AgentKeyHierarchyError> {
+        if session_id.trim().is_empty() {
+            return Err(AgentKeyHierarchyError::EmptySessionId);
+        }
+        ensure_non_empty("ephemeral", key_id)?;
+        if expires_at_secs == 0 {
+            return Err(AgentKeyHierarchyError::InvalidExpiry(expires_at_secs));
+        }
+        if self.ephemeral_by_session.contains_key(session_id) {
+            return Err(AgentKeyHierarchyError::DuplicateSession(
+                session_id.to_owned(),
+            ));
+        }
+
+        self.ephemeral_by_session.insert(
+            session_id.to_owned(),
+            EphemeralSessionKey {
+                key_id: key_id.to_owned(),
+                expires_at_secs,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn ephemeral_key(
+        &self,
+        session_id: &str,
+    ) -> Result<&EphemeralSessionKey, AgentKeyHierarchyError> {
+        self.ephemeral_by_session
+            .get(session_id)
+            .ok_or_else(|| AgentKeyHierarchyError::SessionNotFound(session_id.to_owned()))
+    }
+
+    pub fn retire_ephemeral(&mut self, session_id: &str) -> Result<(), AgentKeyHierarchyError> {
+        if self.ephemeral_by_session.remove(session_id).is_none() {
+            return Err(AgentKeyHierarchyError::SessionNotFound(
+                session_id.to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentKeyHierarchyError {
+    EmptyKeyId(&'static str),
+    DuplicateRoleKey(String),
+    EmptySessionId,
+    DuplicateSession(String),
+    SessionNotFound(String),
+    InvalidExpiry(u64),
+}
+
+impl fmt::Display for AgentKeyHierarchyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyKeyId(role) => write!(f, "{role} key id must not be empty"),
+            Self::DuplicateRoleKey(value) => write!(f, "key id reused across roles: {value}"),
+            Self::EmptySessionId => write!(f, "session id must not be empty"),
+            Self::DuplicateSession(value) => write!(f, "ephemeral session already exists: {value}"),
+            Self::SessionNotFound(value) => write!(f, "ephemeral session not found: {value}"),
+            Self::InvalidExpiry(value) => write!(f, "invalid ephemeral expiry: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentKeyHierarchyError {}
+
+fn ensure_non_empty(role: &'static str, key_id: &str) -> Result<(), AgentKeyHierarchyError> {
+    if key_id.trim().is_empty() {
+        return Err(AgentKeyHierarchyError::EmptyKeyId(role));
+    }
+    Ok(())
+}
+
+fn ensure_distinct(
+    identity_key_id: &str,
+    signing_key_id: &str,
+    agreement_key_id: &str,
+) -> Result<(), AgentKeyHierarchyError> {
+    if identity_key_id == signing_key_id
+        || identity_key_id == agreement_key_id
+        || signing_key_id == agreement_key_id
+    {
+        return Err(AgentKeyHierarchyError::DuplicateRoleKey(
+            identity_key_id.to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentKeyHierarchy, AgentKeyHierarchyError};
+
+    #[test]
+    fn constructor_rejects_duplicate_role_keys() {
+        assert_eq!(
+            AgentKeyHierarchy::new("id:key:v1", "id:key:v1", "agr:key:v1"),
+            Err(AgentKeyHierarchyError::DuplicateRoleKey(
+                "id:key:v1".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rotate_signing_rejects_duplicate_role_binding() {
+        let mut hierarchy = AgentKeyHierarchy::new("id:key:v1", "sig:key:v1", "agr:key:v1")
+            .expect("hierarchy should initialize");
+
+        assert_eq!(
+            hierarchy.rotate_signing_key("agr:key:v1"),
+            Err(AgentKeyHierarchyError::DuplicateRoleKey(
+                "agr:key:v1".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_key_hierarchy;
 pub mod bootstrap;
 pub mod channel_models;
 pub mod channel_policies;
@@ -20,6 +21,9 @@ pub mod state;
 pub mod token;
 pub mod transaction;
 
+pub use agent_key_hierarchy::{
+    AgentKeyHierarchy, AgentKeyHierarchyError, EphemeralSessionKey, KeyRole,
+};
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use channel_models::{ChannelModelError, ChannelStore, ChannelType};
 pub use channel_policies::{

--- a/crates/kamn-core/tests/agent_key_hierarchy.rs
+++ b/crates/kamn-core/tests/agent_key_hierarchy.rs
@@ -1,0 +1,103 @@
+use kamn_core::{AgentKeyHierarchy, AgentKeyHierarchyError, KeyRole};
+
+#[test]
+fn hierarchy_tracks_identity_signing_and_agreement_keys() {
+    let hierarchy = AgentKeyHierarchy::new("id:key:v1", "sig:key:v1", "agr:key:v1")
+        .expect("hierarchy should initialize");
+
+    assert_eq!(
+        hierarchy
+            .current_key(KeyRole::Identity)
+            .expect("identity key"),
+        "id:key:v1"
+    );
+    assert_eq!(
+        hierarchy
+            .current_key(KeyRole::Signing)
+            .expect("signing key"),
+        "sig:key:v1"
+    );
+    assert_eq!(
+        hierarchy
+            .current_key(KeyRole::Agreement)
+            .expect("agreement key"),
+        "agr:key:v1"
+    );
+}
+
+#[test]
+fn signing_and_agreement_rotation_update_role_bindings() {
+    let mut hierarchy = AgentKeyHierarchy::new("id:key:v1", "sig:key:v1", "agr:key:v1")
+        .expect("hierarchy should initialize");
+
+    hierarchy
+        .rotate_signing_key("sig:key:v2")
+        .expect("signing rotation should succeed");
+    hierarchy
+        .rotate_agreement_key("agr:key:v2")
+        .expect("agreement rotation should succeed");
+
+    assert_eq!(
+        hierarchy
+            .current_key(KeyRole::Signing)
+            .expect("signing key"),
+        "sig:key:v2"
+    );
+    assert_eq!(
+        hierarchy
+            .current_key(KeyRole::Agreement)
+            .expect("agreement key"),
+        "agr:key:v2"
+    );
+}
+
+#[test]
+fn ephemeral_session_keys_are_registered_and_queryable() {
+    let mut hierarchy = AgentKeyHierarchy::new("id:key:v1", "sig:key:v1", "agr:key:v1")
+        .expect("hierarchy should initialize");
+
+    hierarchy
+        .register_ephemeral("session-a", "eph:key:1", 1_000)
+        .expect("ephemeral registration should succeed");
+    let session_key = hierarchy
+        .ephemeral_key("session-a")
+        .expect("session key should exist");
+    assert_eq!(session_key.key_id, "eph:key:1");
+    assert_eq!(session_key.expires_at_secs, 1_000);
+}
+
+#[test]
+fn duplicate_ephemeral_session_is_rejected() {
+    let mut hierarchy = AgentKeyHierarchy::new("id:key:v1", "sig:key:v1", "agr:key:v1")
+        .expect("hierarchy should initialize");
+    hierarchy
+        .register_ephemeral("session-a", "eph:key:1", 1_000)
+        .expect("ephemeral registration should succeed");
+
+    assert_eq!(
+        hierarchy.register_ephemeral("session-a", "eph:key:2", 2_000),
+        Err(AgentKeyHierarchyError::DuplicateSession(
+            "session-a".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn retired_ephemeral_keys_are_not_retrievable() {
+    let mut hierarchy = AgentKeyHierarchy::new("id:key:v1", "sig:key:v1", "agr:key:v1")
+        .expect("hierarchy should initialize");
+    hierarchy
+        .register_ephemeral("session-z", "eph:key:z", 1_000)
+        .expect("ephemeral registration should succeed");
+    hierarchy
+        .retire_ephemeral("session-z")
+        .expect("retire should succeed");
+
+    // Regression: #123
+    assert_eq!(
+        hierarchy.ephemeral_key("session-z"),
+        Err(AgentKeyHierarchyError::SessionNotFound(
+            "session-z".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/agent-key-hierarchy.md
+++ b/docs/foundation/agent-key-hierarchy.md
@@ -1,0 +1,52 @@
+# Agent Key Hierarchy (Issue #122)
+
+This document defines the first implementation slice for agent key hierarchy
+interfaces across identity, signing, agreement, and ephemeral session keys.
+
+## Core Types
+- `KeyRole`:
+  - `Identity`
+  - `Signing`
+  - `Agreement`
+- `AgentKeyHierarchy`:
+  - current role-bound key IDs
+  - ephemeral session key registry
+- `EphemeralSessionKey`:
+  - `key_id`
+  - `expires_at_secs`
+
+## Supported Operations
+- `new(identity, signing, agreement)`
+  - validates non-empty key IDs
+  - enforces distinct long-term role keys
+- `current_key(role)`
+  - returns current key ID for identity/signing/agreement role
+- `rotate_signing_key(key_id)` / `rotate_agreement_key(key_id)`
+  - updates role binding while preserving long-term key separation
+- `register_ephemeral(session_id, key_id, expires_at_secs)`
+  - registers session-scoped ephemeral key material
+- `ephemeral_key(session_id)`
+  - retrieves session key details
+- `retire_ephemeral(session_id)`
+  - removes ephemeral key binding for a session
+
+## Validation Rules
+- Empty key IDs and empty session IDs are rejected.
+- Long-term key IDs cannot be reused across identity/signing/agreement roles.
+- Ephemeral expiry must be positive (`> 0`).
+- Duplicate ephemeral session registration is rejected.
+- Retired/missing session lookups return `SessionNotFound`.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test agent_key_hierarchy
+cargo test -p kamn-core
+```
+
+## Notes
+This initial slice provides deterministic, dependency-free key hierarchy
+interfaces suitable for later wiring into cryptographic material management.

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -58,3 +58,4 @@ For message lifecycle state machine and index query controls, see `docs/foundati
 For nonce/TTL/replay enforcement and failed-delivery notice controls, see `docs/foundation/message-delivery-guards.md`.
 For direct/group channel models with membership/admin operations, see `docs/foundation/channel-models.md`.
 For channel permission and retention policy controls, see `docs/foundation/channel-permissions-retention.md`.
+For agent key hierarchy role bindings and ephemeral session key controls, see `docs/foundation/agent-key-hierarchy.md`.


### PR DESCRIPTION
## Summary
Implements the first agent key hierarchy slice for story #28 with explicit identity/signing/agreement key-role bindings, signing/agreement rotation, and ephemeral session key lifecycle operations. This follows strict Red→Green evidence from #123 and updates foundation docs.

Closes #122
Closes #123

## Changes
- `crates/kamn-core/src/agent_key_hierarchy.rs`: added role model, hierarchy structure, rotation APIs, ephemeral key register/query/retire paths, and typed errors.
- `crates/kamn-core/src/lib.rs`: exported key hierarchy APIs.
- `crates/kamn-core/tests/agent_key_hierarchy.rs`: added functional/integration/regression coverage.
- `docs/foundation/agent-key-hierarchy.md`: documented hierarchy contracts and validation commands.
- `docs/foundation/bootstrap.md`: linked key hierarchy foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red via `cargo test -p kamn-core --test agent_key_hierarchy` before implementation; validated Green/regression with `cargo test -p kamn-core --test agent_key_hierarchy` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `agent_key_hierarchy::tests::{constructor_rejects_duplicate_role_keys, rotate_signing_rejects_duplicate_role_binding}` |
| Functional  | ✅     | role binding + ephemeral lifecycle paths in `tests/agent_key_hierarchy.rs` |
| Integration | ✅     | exported hierarchy APIs exercised through `kamn_core` integration test target |
| Regression  | ✅     | `retired_ephemeral_keys_are_not_retrievable` guard for #123 |
