### PR TITLE
feat(core): implement task state machine and transition validator

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod namespaces;
 pub mod runtime;
 pub mod smoke;
 pub mod state;
+pub mod task_lifecycle;
 pub mod token;
 pub mod transaction;
 
@@ -70,6 +71,7 @@ pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
 };
+pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 pub use token::{
     default_token_config, AllocationBucket, GenesisAllocation, TokenConfig, TokenConfigError,
     DEFAULT_DECIMALS, DEFAULT_TOKEN_SYMBOL, DEFAULT_TOTAL_SUPPLY,

--- a/crates/kamn-core/src/task_lifecycle.rs
+++ b/crates/kamn-core/src/task_lifecycle.rs
@@ -1,0 +1,152 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskState {
+    Submitted,
+    Accepted,
+    Delegated,
+    InProgress,
+    Blocked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskTransition {
+    Accept,
+    Delegate,
+    StartWork,
+    Block,
+    Complete,
+    Fail,
+    Cancel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskLifecycle {
+    task_id: String,
+    state: TaskState,
+    history: Vec<TaskState>,
+}
+
+impl TaskLifecycle {
+    pub fn new(task_id: &str) -> Result<Self, TaskLifecycleError> {
+        if task_id.trim().is_empty() {
+            return Err(TaskLifecycleError::EmptyTaskId);
+        }
+        Ok(Self {
+            task_id: task_id.to_owned(),
+            state: TaskState::Submitted,
+            history: vec![TaskState::Submitted],
+        })
+    }
+
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
+
+    pub fn state(&self) -> TaskState {
+        self.state
+    }
+
+    pub fn history(&self) -> Vec<TaskState> {
+        self.history.clone()
+    }
+
+    pub fn transition(&mut self, transition: TaskTransition) -> Result<(), TaskLifecycleError> {
+        if is_terminal(self.state) {
+            return Err(TaskLifecycleError::TerminalState(self.state));
+        }
+
+        let next = match (self.state, transition) {
+            (TaskState::Submitted, TaskTransition::Accept) => TaskState::Accepted,
+            (TaskState::Submitted, TaskTransition::Cancel) => TaskState::Cancelled,
+
+            (TaskState::Accepted, TaskTransition::Delegate) => TaskState::Delegated,
+            (TaskState::Accepted, TaskTransition::StartWork) => TaskState::InProgress,
+            (TaskState::Accepted, TaskTransition::Cancel) => TaskState::Cancelled,
+
+            (TaskState::Delegated, TaskTransition::StartWork) => TaskState::InProgress,
+            (TaskState::Delegated, TaskTransition::Cancel) => TaskState::Cancelled,
+
+            (TaskState::InProgress, TaskTransition::Block) => TaskState::Blocked,
+            (TaskState::InProgress, TaskTransition::Complete) => TaskState::Completed,
+            (TaskState::InProgress, TaskTransition::Fail) => TaskState::Failed,
+            (TaskState::InProgress, TaskTransition::Cancel) => TaskState::Cancelled,
+
+            (TaskState::Blocked, TaskTransition::StartWork) => TaskState::InProgress,
+            (TaskState::Blocked, TaskTransition::Fail) => TaskState::Failed,
+            (TaskState::Blocked, TaskTransition::Cancel) => TaskState::Cancelled,
+
+            _ => {
+                return Err(TaskLifecycleError::InvalidTransition {
+                    from: self.state,
+                    transition,
+                });
+            }
+        };
+
+        self.state = next;
+        self.history.push(next);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskLifecycleError {
+    EmptyTaskId,
+    InvalidTransition {
+        from: TaskState,
+        transition: TaskTransition,
+    },
+    TerminalState(TaskState),
+}
+
+impl fmt::Display for TaskLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyTaskId => write!(f, "task_id must not be empty"),
+            Self::InvalidTransition { from, transition } => {
+                write!(
+                    f,
+                    "invalid task transition from {:?} via {:?}",
+                    from, transition
+                )
+            }
+            Self::TerminalState(state) => write!(f, "task is in terminal state: {state:?}"),
+        }
+    }
+}
+
+impl std::error::Error for TaskLifecycleError {}
+
+fn is_terminal(state: TaskState) -> bool {
+    matches!(
+        state,
+        TaskState::Completed | TaskState::Failed | TaskState::Cancelled
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
+
+    #[test]
+    fn new_rejects_empty_task_id() {
+        assert_eq!(TaskLifecycle::new(""), Err(TaskLifecycleError::EmptyTaskId));
+    }
+
+    #[test]
+    fn blocked_can_return_to_in_progress() {
+        let mut lifecycle = match TaskLifecycle::new("task-1") {
+            Ok(value) => value,
+            Err(error) => panic!("init failed: {error}"),
+        };
+        assert!(lifecycle.transition(TaskTransition::Accept).is_ok());
+        assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
+        assert!(lifecycle.transition(TaskTransition::Block).is_ok());
+        assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
+        assert_eq!(lifecycle.state(), TaskState::InProgress);
+    }
+}

--- a/crates/kamn-core/tests/task_state_machine.rs
+++ b/crates/kamn-core/tests/task_state_machine.rs
@@ -1,0 +1,90 @@
+use kamn_core::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
+
+#[test]
+fn new_task_starts_submitted_with_history() {
+    let lifecycle = TaskLifecycle::new("task-1").expect("task lifecycle should initialize");
+    assert_eq!(lifecycle.state(), TaskState::Submitted);
+    assert_eq!(lifecycle.history(), vec![TaskState::Submitted]);
+}
+
+#[test]
+fn legal_transition_flow_reaches_completed() {
+    let mut lifecycle = TaskLifecycle::new("task-2").expect("task lifecycle should initialize");
+
+    lifecycle
+        .transition(TaskTransition::Accept)
+        .expect("submit->accept should succeed");
+    lifecycle
+        .transition(TaskTransition::Delegate)
+        .expect("accept->delegate should succeed");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("delegate->in_progress should succeed");
+    lifecycle
+        .transition(TaskTransition::Block)
+        .expect("in_progress->blocked should succeed");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("blocked->in_progress should succeed");
+    lifecycle
+        .transition(TaskTransition::Complete)
+        .expect("in_progress->completed should succeed");
+
+    assert_eq!(lifecycle.state(), TaskState::Completed);
+    assert_eq!(
+        lifecycle.history(),
+        vec![
+            TaskState::Submitted,
+            TaskState::Accepted,
+            TaskState::Delegated,
+            TaskState::InProgress,
+            TaskState::Blocked,
+            TaskState::InProgress,
+            TaskState::Completed,
+        ]
+    );
+}
+
+#[test]
+fn invalid_transition_is_rejected() {
+    let mut lifecycle = TaskLifecycle::new("task-3").expect("task lifecycle should initialize");
+    assert_eq!(
+        lifecycle.transition(TaskTransition::Complete),
+        Err(TaskLifecycleError::InvalidTransition {
+            from: TaskState::Submitted,
+            transition: TaskTransition::Complete,
+        })
+    );
+}
+
+#[test]
+fn terminal_states_reject_follow_up_transitions() {
+    let mut completed = TaskLifecycle::new("task-4").expect("task lifecycle should initialize");
+    completed
+        .transition(TaskTransition::Accept)
+        .expect("accept should succeed");
+    completed
+        .transition(TaskTransition::StartWork)
+        .expect("start should succeed");
+    completed
+        .transition(TaskTransition::Complete)
+        .expect("complete should succeed");
+    assert_eq!(
+        completed.transition(TaskTransition::Fail),
+        Err(TaskLifecycleError::TerminalState(TaskState::Completed))
+    );
+}
+
+#[test]
+fn cancelled_task_cannot_be_completed() {
+    let mut lifecycle = TaskLifecycle::new("task-5").expect("task lifecycle should initialize");
+    lifecycle
+        .transition(TaskTransition::Cancel)
+        .expect("submit->cancel should succeed");
+
+    // Regression: #127
+    assert_eq!(
+        lifecycle.transition(TaskTransition::Complete),
+        Err(TaskLifecycleError::TerminalState(TaskState::Cancelled))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -60,3 +60,4 @@ For direct/group channel models with membership/admin operations, see `docs/foun
 For channel permission and retention policy controls, see `docs/foundation/channel-permissions-retention.md`.
 For agent key hierarchy role bindings and ephemeral session key controls, see `docs/foundation/agent-key-hierarchy.md`.
 For direct-message encryption path controls, see `docs/foundation/direct-message-encryption.md`.
+For task state machine and legal transition validation controls, see `docs/foundation/task-state-machine.md`.

--- a/docs/foundation/task-state-machine.md
+++ b/docs/foundation/task-state-machine.md
@@ -1,0 +1,48 @@
+# Task State Machine and Transition Validator (Issue #126)
+
+This document defines the first implementation slice for deterministic task
+state transitions and legal transition validation.
+
+## Task States
+- `Submitted`
+- `Accepted`
+- `Delegated`
+- `InProgress`
+- `Blocked`
+- `Completed` (terminal)
+- `Failed` (terminal)
+- `Cancelled` (terminal)
+
+## Supported Transitions
+- `Submitted -> Accepted | Cancelled`
+- `Accepted -> Delegated | InProgress | Cancelled`
+- `Delegated -> InProgress | Cancelled`
+- `InProgress -> Blocked | Completed | Failed | Cancelled`
+- `Blocked -> InProgress | Failed | Cancelled`
+
+Any transition outside this map is rejected.
+
+## APIs
+- `TaskLifecycle::new(task_id)` initializes task in `Submitted`.
+- `transition(TaskTransition)` validates and applies a transition.
+- `state()` returns current state.
+- `history()` returns immutable state history sequence.
+
+## Validation Rules
+- Empty task IDs are rejected.
+- Terminal states reject follow-up transitions (`TerminalState`).
+- Illegal transitions return `InvalidTransition { from, transition }`.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test task_state_machine
+cargo test -p kamn-core
+```
+
+## Notes
+This slice uses deterministic in-memory validation with explicit typed errors
+for low-cost, high-signal CI coverage.


### PR DESCRIPTION
## Summary
Implements the first task lifecycle slice for story #31 with deterministic state transitions, explicit legal transition validation, terminal-state protection, and immutable history tracking. This follows strict Red→Green evidence from #127 and updates foundation docs.

Closes #126
Closes #127

## Changes
- `crates/kamn-core/src/task_lifecycle.rs`: added task states, transitions, lifecycle state machine, history tracking, and typed error model.
- `crates/kamn-core/src/lib.rs`: exported task lifecycle APIs.
- `crates/kamn-core/tests/task_state_machine.rs`: added functional/integration/regression tests for lifecycle behavior.
- `docs/foundation/task-state-machine.md`: documented state map, transition rules, and local validation commands.
- `docs/foundation/bootstrap.md`: linked task-state-machine foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red via `cargo test -p kamn-core --test task_state_machine` before implementation; validated Green/regression with `cargo test -p kamn-core --test task_state_machine` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `task_lifecycle::tests::{new_rejects_empty_task_id, blocked_can_return_to_in_progress}` |
| Functional  | ✅     | legal/illegal lifecycle behavior in `tests/task_state_machine.rs` |
| Integration | ✅     | exported task lifecycle APIs exercised via `kamn_core` integration test target |
| Regression  | ✅     | `cancelled_task_cannot_be_completed` guard for #127 |
