### PR TITLE
feat(core): implement task operation command handlers

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod runtime;
 pub mod smoke;
 pub mod state;
 pub mod task_lifecycle;
+pub mod task_operations;
 pub mod token;
 pub mod transaction;
 
@@ -72,6 +73,9 @@ pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
 };
 pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
+pub use task_operations::{
+    TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskOperationRecord,
+};
 pub use token::{
     default_token_config, AllocationBucket, GenesisAllocation, TokenConfig, TokenConfigError,
     DEFAULT_DECIMALS, DEFAULT_TOKEN_SYMBOL, DEFAULT_TOTAL_SUPPLY,

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -1,0 +1,305 @@
+use crate::{AgentDid, TaskLifecycle, TaskLifecycleError, TaskTransition};
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskOperationNoticeKind {
+    Submitted,
+    Accepted,
+    Delegated,
+    Started,
+    Blocked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskOperationRecord {
+    pub task_id: String,
+    pub requester: String,
+    pub assignee: Option<String>,
+    pub description: String,
+    pub lifecycle: TaskLifecycle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TaskOperationEngine {
+    tasks: BTreeMap<String, TaskOperationRecord>,
+    notices_by_task: BTreeMap<String, Vec<TaskOperationNoticeKind>>,
+}
+
+impl TaskOperationEngine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn submit(
+        &mut self,
+        task_id: &str,
+        requester: &str,
+        description: &str,
+    ) -> Result<(), TaskOperationError> {
+        if self.tasks.contains_key(task_id) {
+            return Err(TaskOperationError::DuplicateTaskId(task_id.to_owned()));
+        }
+        validate_did(requester)?;
+        if description.trim().is_empty() {
+            return Err(TaskOperationError::EmptyDescription);
+        }
+
+        let lifecycle = TaskLifecycle::new(task_id)
+            .map_err(|error| TaskOperationError::Lifecycle(error.to_string()))?;
+        self.tasks.insert(
+            task_id.to_owned(),
+            TaskOperationRecord {
+                task_id: task_id.to_owned(),
+                requester: requester.to_owned(),
+                assignee: None,
+                description: description.to_owned(),
+                lifecycle,
+            },
+        );
+        self.push_notice(task_id, TaskOperationNoticeKind::Submitted);
+        Ok(())
+    }
+
+    pub fn accept(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        let record = self.task_mut(task_id)?;
+
+        if let Some(current) = record.assignee.as_deref() {
+            if current != actor {
+                return Err(TaskOperationError::UnauthorizedActor {
+                    actor: actor.to_owned(),
+                    required: "unassigned_or_current_assignee",
+                });
+            }
+        }
+
+        record
+            .lifecycle
+            .transition(TaskTransition::Accept)
+            .map_err(lifecycle_error)?;
+        record.assignee = Some(actor.to_owned());
+        self.push_notice(task_id, TaskOperationNoticeKind::Accepted);
+        Ok(())
+    }
+
+    pub fn delegate(
+        &mut self,
+        task_id: &str,
+        actor: &str,
+        delegatee: &str,
+    ) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        validate_did(delegatee)?;
+        let record = self.task_mut(task_id)?;
+        Self::require_assignee(record, actor)?;
+
+        record
+            .lifecycle
+            .transition(TaskTransition::Delegate)
+            .map_err(lifecycle_error)?;
+        record.assignee = Some(delegatee.to_owned());
+        self.push_notice(task_id, TaskOperationNoticeKind::Delegated);
+        Ok(())
+    }
+
+    pub fn start_work(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        let record = self.task_mut(task_id)?;
+        Self::require_assignee(record, actor)?;
+        record
+            .lifecycle
+            .transition(TaskTransition::StartWork)
+            .map_err(lifecycle_error)?;
+        self.push_notice(task_id, TaskOperationNoticeKind::Started);
+        Ok(())
+    }
+
+    pub fn block(
+        &mut self,
+        task_id: &str,
+        actor: &str,
+        reason: &str,
+    ) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        if reason.trim().is_empty() {
+            return Err(TaskOperationError::EmptyReason("block"));
+        }
+        let record = self.task_mut(task_id)?;
+        Self::require_assignee(record, actor)?;
+        record
+            .lifecycle
+            .transition(TaskTransition::Block)
+            .map_err(lifecycle_error)?;
+        self.push_notice(task_id, TaskOperationNoticeKind::Blocked);
+        Ok(())
+    }
+
+    pub fn complete(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        let record = self.task_mut(task_id)?;
+        Self::require_assignee(record, actor)?;
+        record
+            .lifecycle
+            .transition(TaskTransition::Complete)
+            .map_err(lifecycle_error)?;
+        self.push_notice(task_id, TaskOperationNoticeKind::Completed);
+        Ok(())
+    }
+
+    pub fn fail(
+        &mut self,
+        task_id: &str,
+        actor: &str,
+        reason: &str,
+    ) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        if reason.trim().is_empty() {
+            return Err(TaskOperationError::EmptyReason("fail"));
+        }
+        let record = self.task_mut(task_id)?;
+        Self::require_assignee(record, actor)?;
+        record
+            .lifecycle
+            .transition(TaskTransition::Fail)
+            .map_err(lifecycle_error)?;
+        self.push_notice(task_id, TaskOperationNoticeKind::Failed);
+        Ok(())
+    }
+
+    pub fn cancel(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        let record = self.task_mut(task_id)?;
+        let is_requester = record.requester == actor;
+        let is_assignee = record.assignee.as_deref() == Some(actor);
+        if !is_requester && !is_assignee {
+            return Err(TaskOperationError::UnauthorizedActor {
+                actor: actor.to_owned(),
+                required: "requester_or_assignee",
+            });
+        }
+
+        record
+            .lifecycle
+            .transition(TaskTransition::Cancel)
+            .map_err(lifecycle_error)?;
+        self.push_notice(task_id, TaskOperationNoticeKind::Cancelled);
+        Ok(())
+    }
+
+    pub fn task(&self, task_id: &str) -> Result<&TaskOperationRecord, TaskOperationError> {
+        self.tasks
+            .get(task_id)
+            .ok_or_else(|| TaskOperationError::NotFound(task_id.to_owned()))
+    }
+
+    pub fn notices(&self, task_id: &str) -> Vec<TaskOperationNoticeKind> {
+        self.notices_by_task
+            .get(task_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn task_mut(&mut self, task_id: &str) -> Result<&mut TaskOperationRecord, TaskOperationError> {
+        self.tasks
+            .get_mut(task_id)
+            .ok_or_else(|| TaskOperationError::NotFound(task_id.to_owned()))
+    }
+
+    fn require_assignee(
+        record: &TaskOperationRecord,
+        actor: &str,
+    ) -> Result<(), TaskOperationError> {
+        if record.assignee.as_deref() != Some(actor) {
+            return Err(TaskOperationError::UnauthorizedActor {
+                actor: actor.to_owned(),
+                required: "assignee",
+            });
+        }
+        Ok(())
+    }
+
+    fn push_notice(&mut self, task_id: &str, notice: TaskOperationNoticeKind) {
+        self.notices_by_task
+            .entry(task_id.to_owned())
+            .or_default()
+            .push(notice);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskOperationError {
+    NotFound(String),
+    DuplicateTaskId(String),
+    InvalidDid(String),
+    EmptyDescription,
+    EmptyReason(&'static str),
+    UnauthorizedActor {
+        actor: String,
+        required: &'static str,
+    },
+    Lifecycle(String),
+}
+
+impl fmt::Display for TaskOperationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(value) => write!(f, "task not found: {value}"),
+            Self::DuplicateTaskId(value) => write!(f, "duplicate task id: {value}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::EmptyDescription => write!(f, "task description must not be empty"),
+            Self::EmptyReason(action) => write!(f, "reason must not be empty for {action}"),
+            Self::UnauthorizedActor { actor, required } => {
+                write!(f, "unauthorized actor {actor}, requires {required}")
+            }
+            Self::Lifecycle(value) => write!(f, "task lifecycle error: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for TaskOperationError {}
+
+fn validate_did(value: &str) -> Result<(), TaskOperationError> {
+    AgentDid::parse(value).map_err(|error| TaskOperationError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn lifecycle_error(error: TaskLifecycleError) -> TaskOperationError {
+    TaskOperationError::Lifecycle(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TaskOperationEngine, TaskOperationError};
+    use crate::TaskState;
+
+    #[test]
+    fn submit_rejects_duplicate_task_id() {
+        let mut engine = TaskOperationEngine::new();
+        assert!(engine
+            .submit("task-1", "kamn:did:agent:req-1", "desc")
+            .is_ok());
+        assert_eq!(
+            engine.submit("task-1", "kamn:did:agent:req-1", "desc"),
+            Err(TaskOperationError::DuplicateTaskId("task-1".to_owned()))
+        );
+    }
+
+    #[test]
+    fn cancel_allowed_for_assignee() {
+        let mut engine = TaskOperationEngine::new();
+        assert!(engine
+            .submit("task-2", "kamn:did:agent:req-1", "desc")
+            .is_ok());
+        assert!(engine.accept("task-2", "kamn:did:agent:worker-1").is_ok());
+        assert!(engine.cancel("task-2", "kamn:did:agent:worker-1").is_ok());
+        let state = match engine.task("task-2") {
+            Ok(task) => task.lifecycle.state(),
+            Err(error) => panic!("task lookup failed: {error}"),
+        };
+        assert_eq!(state, TaskState::Cancelled);
+    }
+}

--- a/crates/kamn-core/tests/task_operations.rs
+++ b/crates/kamn-core/tests/task_operations.rs
@@ -1,0 +1,115 @@
+use kamn_core::{TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskState};
+
+#[test]
+fn submit_creates_task_and_emits_notice() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit(
+            "task-op-1",
+            "kamn:did:agent:requester-1",
+            "Collect requirements",
+        )
+        .expect("submit should succeed");
+
+    let task = engine.task("task-op-1").expect("task should exist");
+    assert_eq!(task.lifecycle.state(), TaskState::Submitted);
+    assert_eq!(task.requester, "kamn:did:agent:requester-1");
+    assert_eq!(
+        engine.notices("task-op-1"),
+        vec![TaskOperationNoticeKind::Submitted]
+    );
+}
+
+#[test]
+fn accept_then_delegate_updates_assignee_and_state() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit(
+            "task-op-2",
+            "kamn:did:agent:requester-1",
+            "Draft architecture",
+        )
+        .expect("submit should succeed");
+    engine
+        .accept("task-op-2", "kamn:did:agent:worker-1")
+        .expect("accept should succeed");
+    engine
+        .delegate(
+            "task-op-2",
+            "kamn:did:agent:worker-1",
+            "kamn:did:agent:worker-2",
+        )
+        .expect("delegate should succeed");
+
+    let task = engine.task("task-op-2").expect("task should exist");
+    assert_eq!(task.lifecycle.state(), TaskState::Delegated);
+    assert_eq!(task.assignee.as_deref(), Some("kamn:did:agent:worker-2"));
+}
+
+#[test]
+fn block_and_complete_flow_is_legal_for_assignee() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit("task-op-3", "kamn:did:agent:requester-1", "Compile report")
+        .expect("submit should succeed");
+    engine
+        .accept("task-op-3", "kamn:did:agent:worker-1")
+        .expect("accept should succeed");
+    engine
+        .start_work("task-op-3", "kamn:did:agent:worker-1")
+        .expect("start should succeed");
+    engine
+        .block("task-op-3", "kamn:did:agent:worker-1", "Need access token")
+        .expect("block should succeed");
+    engine
+        .start_work("task-op-3", "kamn:did:agent:worker-1")
+        .expect("restart should succeed");
+    engine
+        .complete("task-op-3", "kamn:did:agent:worker-1")
+        .expect("complete should succeed");
+
+    let task = engine.task("task-op-3").expect("task should exist");
+    assert_eq!(task.lifecycle.state(), TaskState::Completed);
+}
+
+#[test]
+fn unauthorized_actor_cannot_delegate_task() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit("task-op-4", "kamn:did:agent:requester-1", "Run tests")
+        .expect("submit should succeed");
+    engine
+        .accept("task-op-4", "kamn:did:agent:worker-1")
+        .expect("accept should succeed");
+
+    assert_eq!(
+        engine.delegate(
+            "task-op-4",
+            "kamn:did:agent:worker-x",
+            "kamn:did:agent:worker-2",
+        ),
+        Err(TaskOperationError::UnauthorizedActor {
+            actor: "kamn:did:agent:worker-x".to_owned(),
+            required: "assignee",
+        })
+    );
+}
+
+#[test]
+fn cancelled_task_cannot_be_accepted_again() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit("task-op-5", "kamn:did:agent:requester-1", "Write changelog")
+        .expect("submit should succeed");
+    engine
+        .cancel("task-op-5", "kamn:did:agent:requester-1")
+        .expect("cancel should succeed");
+
+    // Regression: #129
+    assert_eq!(
+        engine.accept("task-op-5", "kamn:did:agent:worker-1"),
+        Err(TaskOperationError::Lifecycle(
+            "task is in terminal state: Cancelled".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -61,3 +61,4 @@ For channel permission and retention policy controls, see `docs/foundation/chann
 For agent key hierarchy role bindings and ephemeral session key controls, see `docs/foundation/agent-key-hierarchy.md`.
 For direct-message encryption path controls, see `docs/foundation/direct-message-encryption.md`.
 For task state machine and legal transition validation controls, see `docs/foundation/task-state-machine.md`.
+For task operation command handling controls, see `docs/foundation/task-operations.md`.

--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -1,0 +1,77 @@
+# Task Operations Command Surface (Issue #128)
+
+This document defines the first implementation slice for task operation command
+handling across `submit`, `accept`, `delegate`, `block`, `complete`, `fail`,
+and `cancel`.
+
+## Core Types
+- `TaskOperationEngine`: deterministic in-memory task operations handler.
+- `TaskOperationRecord`: task-level operation context:
+  - `task_id`
+  - `requester`
+  - `assignee`
+  - `description`
+  - `lifecycle` (`TaskLifecycle`)
+- `TaskOperationNoticeKind`:
+  - `Submitted`
+  - `Accepted`
+  - `Delegated`
+  - `Started`
+  - `Blocked`
+  - `Completed`
+  - `Failed`
+  - `Cancelled`
+
+## Command Behavior
+- `submit(task_id, requester, description)`:
+  - creates a new task record in `Submitted`.
+  - emits `Submitted` notice.
+- `accept(task_id, actor)`:
+  - transitions lifecycle using `Accept`.
+  - binds `assignee = actor`.
+  - emits `Accepted` notice.
+- `delegate(task_id, actor, delegatee)`:
+  - requires current assignee actor.
+  - transitions via `Delegate`.
+  - updates assignee to delegatee.
+  - emits `Delegated` notice.
+- `start_work(task_id, actor)`:
+  - assignee-only.
+  - transitions via `StartWork`.
+  - emits `Started` notice.
+- `block(task_id, actor, reason)`:
+  - assignee-only with non-empty reason.
+  - transitions via `Block`.
+  - emits `Blocked` notice.
+- `complete(task_id, actor)`:
+  - assignee-only.
+  - transitions via `Complete`.
+  - emits `Completed` notice.
+- `fail(task_id, actor, reason)`:
+  - assignee-only with non-empty reason.
+  - transitions via `Fail`.
+  - emits `Failed` notice.
+- `cancel(task_id, actor)`:
+  - requester or current assignee.
+  - transitions via `Cancel`.
+  - emits `Cancelled` notice.
+
+## Validation and Safety Rules
+- Task IDs must be unique.
+- DIDs must parse as `kamn:did:agent:*`.
+- Unauthorized actors are rejected with explicit required-role context.
+- Underlying illegal or terminal lifecycle transitions bubble as typed lifecycle errors.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test task_operations
+cargo test -p kamn-core
+```
+
+## Notes
+This slice wires operation commands directly to the deterministic task lifecycle
+validator to keep CI fast and behavior auditable.


### PR DESCRIPTION
## Summary
Implements the first task-operations slice for story #32 with deterministic command handling for submit/accept/delegate/start/block/complete/fail/cancel operations, role checks, and operation notice tracking. This follows strict Red→Green evidence from #129 and updates foundation docs.

Closes #128
Closes #129

## Changes
- `crates/kamn-core/src/task_operations.rs`: added task operation engine, task records, operation notice model, actor authorization checks, and typed error surface.
- `crates/kamn-core/src/lib.rs`: exported task operations APIs.
- `crates/kamn-core/tests/task_operations.rs`: added functional/integration/regression coverage for command flow and authorization behavior.
- `docs/foundation/task-operations.md`: documented operation contracts and local validation commands.
- `docs/foundation/bootstrap.md`: linked task operations foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: captured Red via `cargo test -p kamn-core --test task_operations` before implementation; validated Green/regression with `cargo test -p kamn-core --test task_operations` and `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `task_operations::tests::{submit_rejects_duplicate_task_id, cancel_allowed_for_assignee}` |
| Functional  | ✅     | command flow and role checks in `tests/task_operations.rs` |
| Integration | ✅     | exported task operation APIs exercised via `kamn_core` integration target |
| Regression  | ✅     | `cancelled_task_cannot_be_accepted_again` guard for #129 |
