### PR TITLE
feat(core): implement redaction and tombstone compliance slice (#150 #151)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod message_envelope;
 pub mod message_lifecycle;
 pub mod migrations;
 pub mod namespaces;
+pub mod redaction_compliance;
 pub mod runtime;
 pub mod smoke;
 pub mod state;
@@ -73,6 +74,10 @@ pub use message_envelope::{
 pub use message_lifecycle::{MessageLifecycleError, MessageLifecycleStore, MessageStatus};
 pub use migrations::{MigrationPlan, MigrationRegistry, MigrationStep};
 pub use namespaces::StateNamespaces;
+pub use redaction_compliance::{
+    RedactionAction, RedactionAuditEvent, RedactionAuditEventKind, RedactionComplianceEngine,
+    RedactionComplianceError, RedactionRequestStatus, RedactionVisibility,
+};
 pub use runtime::RuntimeWiring;
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{

--- a/crates/kamn-core/src/redaction_compliance.rs
+++ b/crates/kamn-core/src/redaction_compliance.rs
@@ -1,0 +1,476 @@
+use crate::{canonical_state_key, AgentDid};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RedactionAction {
+    Redact,
+    Tombstone,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedactionRequestStatus {
+    PendingApproval {
+        approvals_collected: usize,
+        approvals_required: usize,
+    },
+    Rejected,
+    Applied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedactionVisibility {
+    Available,
+    Redacted { request_id: String },
+    Tombstoned { request_id: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RedactionAuditEventKind {
+    Requested,
+    Approved,
+    Rejected,
+    Applied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedactionAuditEvent {
+    pub request_id: String,
+    pub actor: String,
+    pub kind: RedactionAuditEventKind,
+    pub at: String,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RedactionRequestRecord {
+    id: String,
+    target_namespace: String,
+    target_entity_id: String,
+    requester: String,
+    action: RedactionAction,
+    status: InternalStatus,
+    approvals: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InternalStatus {
+    PendingApproval,
+    Rejected,
+    Applied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedactionComplianceEngine {
+    approvals_required: usize,
+    requests: BTreeMap<String, RedactionRequestRecord>,
+    visibility_by_target: BTreeMap<String, RedactionVisibility>,
+    protected_targets: BTreeSet<String>,
+    audit_events_by_request: BTreeMap<String, Vec<RedactionAuditEvent>>,
+}
+
+impl RedactionComplianceEngine {
+    pub fn new(approvals_required: usize) -> Result<Self, RedactionComplianceError> {
+        if approvals_required == 0 {
+            return Err(RedactionComplianceError::InvalidApprovalsRequired(
+                approvals_required,
+            ));
+        }
+
+        Ok(Self {
+            approvals_required,
+            requests: BTreeMap::new(),
+            visibility_by_target: BTreeMap::new(),
+            protected_targets: BTreeSet::new(),
+            audit_events_by_request: BTreeMap::new(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn submit_request(
+        &mut self,
+        request_id: &str,
+        target_namespace: &str,
+        target_entity_id: &str,
+        requester: &str,
+        action: RedactionAction,
+        reason: &str,
+        requested_at: &str,
+    ) -> Result<(), RedactionComplianceError> {
+        validate_non_empty("request_id", request_id)?;
+        validate_non_empty("target_namespace", target_namespace)?;
+        validate_non_empty("target_entity_id", target_entity_id)?;
+        validate_did(requester)?;
+        validate_non_empty("reason", reason)?;
+        validate_non_empty("requested_at", requested_at)?;
+
+        if self.requests.contains_key(request_id) {
+            return Err(RedactionComplianceError::DuplicateRequestId(
+                request_id.to_owned(),
+            ));
+        }
+
+        let key = self.target_storage_key(target_namespace, target_entity_id)?;
+        if self.protected_targets.contains(&key) {
+            return Err(RedactionComplianceError::TargetAlreadyProtected {
+                namespace: target_namespace.to_owned(),
+                entity_id: target_entity_id.to_owned(),
+            });
+        }
+
+        self.requests.insert(
+            request_id.to_owned(),
+            RedactionRequestRecord {
+                id: request_id.to_owned(),
+                target_namespace: target_namespace.to_owned(),
+                target_entity_id: target_entity_id.to_owned(),
+                requester: requester.to_owned(),
+                action,
+                status: InternalStatus::PendingApproval,
+                approvals: BTreeSet::new(),
+            },
+        );
+
+        self.push_audit_event(RedactionAuditEvent {
+            request_id: request_id.to_owned(),
+            actor: requester.to_owned(),
+            kind: RedactionAuditEventKind::Requested,
+            at: requested_at.to_owned(),
+            note: reason.to_owned(),
+        });
+
+        Ok(())
+    }
+
+    pub fn approve(
+        &mut self,
+        request_id: &str,
+        approver: &str,
+        approved_at: &str,
+        note: &str,
+    ) -> Result<(), RedactionComplianceError> {
+        validate_non_empty("request_id", request_id)?;
+        validate_did(approver)?;
+        validate_non_empty("approved_at", approved_at)?;
+        validate_non_empty("note", note)?;
+
+        let approvals_required = self.approvals_required;
+        let mut apply_snapshot: Option<(String, String, RedactionAction)> = None;
+
+        {
+            let record = self.request_mut(request_id)?;
+            if record.status != InternalStatus::PendingApproval {
+                return Err(RedactionComplianceError::RequestNotPendingApproval(
+                    request_id.to_owned(),
+                ));
+            }
+
+            if !record.approvals.insert(approver.to_owned()) {
+                return Err(RedactionComplianceError::DuplicateApproval {
+                    request_id: request_id.to_owned(),
+                    approver: approver.to_owned(),
+                });
+            }
+
+            if record.approvals.len() >= approvals_required {
+                apply_snapshot = Some((
+                    record.target_namespace.clone(),
+                    record.target_entity_id.clone(),
+                    record.action,
+                ));
+                record.status = InternalStatus::Applied;
+            }
+        }
+
+        self.push_audit_event(RedactionAuditEvent {
+            request_id: request_id.to_owned(),
+            actor: approver.to_owned(),
+            kind: RedactionAuditEventKind::Approved,
+            at: approved_at.to_owned(),
+            note: note.to_owned(),
+        });
+
+        if let Some((target_namespace, target_entity_id, action)) = apply_snapshot {
+            let target_key = self.target_storage_key(&target_namespace, &target_entity_id)?;
+            let visibility = match action {
+                RedactionAction::Redact => RedactionVisibility::Redacted {
+                    request_id: request_id.to_owned(),
+                },
+                RedactionAction::Tombstone => RedactionVisibility::Tombstoned {
+                    request_id: request_id.to_owned(),
+                },
+            };
+            self.visibility_by_target
+                .insert(target_key.clone(), visibility);
+            self.protected_targets.insert(target_key);
+
+            self.push_audit_event(RedactionAuditEvent {
+                request_id: request_id.to_owned(),
+                actor: approver.to_owned(),
+                kind: RedactionAuditEventKind::Applied,
+                at: approved_at.to_owned(),
+                note: "quorum reached; protection applied".to_owned(),
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn reject(
+        &mut self,
+        request_id: &str,
+        actor: &str,
+        rejected_at: &str,
+        reason: &str,
+    ) -> Result<(), RedactionComplianceError> {
+        validate_non_empty("request_id", request_id)?;
+        validate_did(actor)?;
+        validate_non_empty("rejected_at", rejected_at)?;
+        validate_non_empty("reason", reason)?;
+
+        let record = self.request_mut(request_id)?;
+        if record.status != InternalStatus::PendingApproval {
+            return Err(RedactionComplianceError::RequestNotPendingApproval(
+                request_id.to_owned(),
+            ));
+        }
+        record.status = InternalStatus::Rejected;
+
+        self.push_audit_event(RedactionAuditEvent {
+            request_id: request_id.to_owned(),
+            actor: actor.to_owned(),
+            kind: RedactionAuditEventKind::Rejected,
+            at: rejected_at.to_owned(),
+            note: reason.to_owned(),
+        });
+
+        Ok(())
+    }
+
+    pub fn request_status(
+        &self,
+        request_id: &str,
+    ) -> Result<RedactionRequestStatus, RedactionComplianceError> {
+        let record = self
+            .requests
+            .get(request_id)
+            .ok_or_else(|| RedactionComplianceError::NotFound(request_id.to_owned()))?;
+
+        Ok(match record.status {
+            InternalStatus::PendingApproval => RedactionRequestStatus::PendingApproval {
+                approvals_collected: record.approvals.len(),
+                approvals_required: self.approvals_required,
+            },
+            InternalStatus::Rejected => RedactionRequestStatus::Rejected,
+            InternalStatus::Applied => RedactionRequestStatus::Applied,
+        })
+    }
+
+    pub fn retrieve_visibility(
+        &self,
+        target_namespace: &str,
+        target_entity_id: &str,
+    ) -> Result<RedactionVisibility, RedactionComplianceError> {
+        let key = self.target_storage_key(target_namespace, target_entity_id)?;
+        Ok(self
+            .visibility_by_target
+            .get(&key)
+            .cloned()
+            .unwrap_or(RedactionVisibility::Available))
+    }
+
+    pub fn target_storage_key(
+        &self,
+        target_namespace: &str,
+        target_entity_id: &str,
+    ) -> Result<String, RedactionComplianceError> {
+        canonical_state_key(target_namespace, "record", target_entity_id)
+            .map_err(|error| RedactionComplianceError::InvalidTarget(error.to_string()))
+    }
+
+    pub fn audit_events(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<RedactionAuditEvent>, RedactionComplianceError> {
+        if !self.requests.contains_key(request_id) {
+            return Err(RedactionComplianceError::NotFound(request_id.to_owned()));
+        }
+
+        Ok(self
+            .audit_events_by_request
+            .get(request_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn request_mut(
+        &mut self,
+        request_id: &str,
+    ) -> Result<&mut RedactionRequestRecord, RedactionComplianceError> {
+        self.requests
+            .get_mut(request_id)
+            .ok_or_else(|| RedactionComplianceError::NotFound(request_id.to_owned()))
+    }
+
+    fn push_audit_event(&mut self, event: RedactionAuditEvent) {
+        self.audit_events_by_request
+            .entry(event.request_id.clone())
+            .or_default()
+            .push(event);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedactionComplianceError {
+    InvalidApprovalsRequired(usize),
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidTarget(String),
+    DuplicateRequestId(String),
+    TargetAlreadyProtected {
+        namespace: String,
+        entity_id: String,
+    },
+    NotFound(String),
+    RequestNotPendingApproval(String),
+    DuplicateApproval {
+        request_id: String,
+        approver: String,
+    },
+}
+
+impl fmt::Display for RedactionComplianceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidApprovalsRequired(value) => {
+                write!(f, "approvals_required must be greater than zero: {value}")
+            }
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidTarget(value) => write!(f, "invalid target reference: {value}"),
+            Self::DuplicateRequestId(value) => write!(f, "duplicate request id: {value}"),
+            Self::TargetAlreadyProtected {
+                namespace,
+                entity_id,
+            } => {
+                write!(f, "target already protected: {namespace}/{entity_id}")
+            }
+            Self::NotFound(value) => write!(f, "redaction request not found: {value}"),
+            Self::RequestNotPendingApproval(value) => {
+                write!(f, "redaction request is not pending approval: {value}")
+            }
+            Self::DuplicateApproval {
+                request_id,
+                approver,
+            } => write!(
+                f,
+                "duplicate approval for request {request_id} from approver {approver}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RedactionComplianceError {}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), RedactionComplianceError> {
+    if value.trim().is_empty() {
+        return Err(RedactionComplianceError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), RedactionComplianceError> {
+    AgentDid::parse(value)
+        .map_err(|error| RedactionComplianceError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RedactionAction, RedactionComplianceEngine, RedactionComplianceError,
+        RedactionRequestStatus, RedactionVisibility,
+    };
+
+    #[test]
+    fn constructor_rejects_zero_approvals() {
+        assert_eq!(
+            RedactionComplianceEngine::new(0),
+            Err(RedactionComplianceError::InvalidApprovalsRequired(0))
+        );
+    }
+
+    #[test]
+    fn duplicate_approval_is_rejected() {
+        let mut engine = RedactionComplianceEngine::new(2).expect("engine should construct");
+        engine
+            .submit_request(
+                "req-dup-1",
+                "kamn.messages",
+                "msg-1",
+                "kamn:did:agent:owner-1",
+                RedactionAction::Redact,
+                "request",
+                "2026-02-08T10:00:00Z",
+            )
+            .expect("request should be accepted");
+        engine
+            .approve(
+                "req-dup-1",
+                "kamn:did:agent:approver-1",
+                "2026-02-08T10:01:00Z",
+                "first",
+            )
+            .expect("first approval should succeed");
+
+        assert_eq!(
+            engine.approve(
+                "req-dup-1",
+                "kamn:did:agent:approver-1",
+                "2026-02-08T10:02:00Z",
+                "duplicate",
+            ),
+            Err(RedactionComplianceError::DuplicateApproval {
+                request_id: "req-dup-1".to_owned(),
+                approver: "kamn:did:agent:approver-1".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejected_request_stays_available() {
+        let mut engine = RedactionComplianceEngine::new(1).expect("engine should construct");
+        engine
+            .submit_request(
+                "req-reject-1",
+                "kamn.tasks",
+                "task-1",
+                "kamn:did:agent:owner-1",
+                RedactionAction::Tombstone,
+                "request",
+                "2026-02-08T10:00:00Z",
+            )
+            .expect("request should be accepted");
+        engine
+            .reject(
+                "req-reject-1",
+                "kamn:did:agent:approver-9",
+                "2026-02-08T10:01:00Z",
+                "insufficient grounds",
+            )
+            .expect("reject should succeed");
+
+        assert_eq!(
+            engine
+                .request_status("req-reject-1")
+                .expect("status should resolve"),
+            RedactionRequestStatus::Rejected
+        );
+        assert_eq!(
+            engine
+                .retrieve_visibility("kamn.tasks", "task-1")
+                .expect("visibility should resolve"),
+            RedactionVisibility::Available
+        );
+    }
+}

--- a/crates/kamn-core/tests/redaction_tombstones.rs
+++ b/crates/kamn-core/tests/redaction_tombstones.rs
@@ -1,0 +1,181 @@
+use kamn_core::{
+    canonical_state_key, RedactionAction, RedactionComplianceEngine, RedactionComplianceError,
+    RedactionRequestStatus, RedactionVisibility,
+};
+
+fn requester() -> &'static str {
+    "kamn:did:agent:operator-1"
+}
+
+#[test]
+fn redaction_requires_quorum_before_application() {
+    let mut engine = RedactionComplianceEngine::new(2).expect("engine should construct");
+
+    engine
+        .submit_request(
+            "redact-1",
+            "kamn.messages",
+            "msg-42",
+            requester(),
+            RedactionAction::Redact,
+            "contains regulated data",
+            "2026-02-08T12:00:00Z",
+        )
+        .expect("request should be accepted");
+
+    engine
+        .approve(
+            "redact-1",
+            "kamn:did:agent:approver-1",
+            "2026-02-08T12:01:00Z",
+            "first approval",
+        )
+        .expect("first approval should succeed");
+
+    assert_eq!(
+        engine
+            .request_status("redact-1")
+            .expect("status should resolve"),
+        RedactionRequestStatus::PendingApproval {
+            approvals_collected: 1,
+            approvals_required: 2,
+        }
+    );
+    assert_eq!(
+        engine
+            .retrieve_visibility("kamn.messages", "msg-42")
+            .expect("visibility should resolve"),
+        RedactionVisibility::Available
+    );
+
+    engine
+        .approve(
+            "redact-1",
+            "kamn:did:agent:approver-2",
+            "2026-02-08T12:02:00Z",
+            "second approval",
+        )
+        .expect("second approval should apply redaction");
+
+    assert_eq!(
+        engine
+            .request_status("redact-1")
+            .expect("status should resolve"),
+        RedactionRequestStatus::Applied
+    );
+    assert_eq!(
+        engine
+            .retrieve_visibility("kamn.messages", "msg-42")
+            .expect("visibility should resolve"),
+        RedactionVisibility::Redacted {
+            request_id: "redact-1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn tombstone_returns_explicit_retrieval_notice() {
+    let mut engine = RedactionComplianceEngine::new(1).expect("engine should construct");
+
+    engine
+        .submit_request(
+            "tombstone-1",
+            "kamn.tasks",
+            "task-9",
+            requester(),
+            RedactionAction::Tombstone,
+            "legal erasure request",
+            "2026-02-08T12:10:00Z",
+        )
+        .expect("request should be accepted");
+    engine
+        .approve(
+            "tombstone-1",
+            "kamn:did:agent:approver-1",
+            "2026-02-08T12:11:00Z",
+            "approved",
+        )
+        .expect("approval should apply tombstone");
+
+    assert_eq!(
+        engine
+            .retrieve_visibility("kamn.tasks", "task-9")
+            .expect("visibility should resolve"),
+        RedactionVisibility::Tombstoned {
+            request_id: "tombstone-1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn integration_uses_canonical_state_key_for_target_index() {
+    let mut engine = RedactionComplianceEngine::new(1).expect("engine should construct");
+    engine
+        .submit_request(
+            "redact-2",
+            "kamn.messages",
+            "msg-77",
+            requester(),
+            RedactionAction::Redact,
+            "compliance action",
+            "2026-02-08T12:20:00Z",
+        )
+        .expect("request should be accepted");
+    engine
+        .approve(
+            "redact-2",
+            "kamn:did:agent:approver-3",
+            "2026-02-08T12:21:00Z",
+            "approved",
+        )
+        .expect("approval should apply redaction");
+
+    assert_eq!(
+        engine
+            .target_storage_key("kamn.messages", "msg-77")
+            .expect("key should resolve"),
+        canonical_state_key("kamn.messages", "record", "msg-77")
+            .expect("canonical key should compute")
+    );
+}
+
+#[test]
+fn regression_prevents_silent_restore_after_tombstone() {
+    let mut engine = RedactionComplianceEngine::new(1).expect("engine should construct");
+    engine
+        .submit_request(
+            "tombstone-2",
+            "kamn.messages",
+            "msg-99",
+            requester(),
+            RedactionAction::Tombstone,
+            "high-severity compliance event",
+            "2026-02-08T12:30:00Z",
+        )
+        .expect("request should be accepted");
+    engine
+        .approve(
+            "tombstone-2",
+            "kamn:did:agent:approver-5",
+            "2026-02-08T12:31:00Z",
+            "approved",
+        )
+        .expect("approval should apply tombstone");
+
+    // Regression: #151
+    assert_eq!(
+        engine.submit_request(
+            "restore-attempt",
+            "kamn.messages",
+            "msg-99",
+            requester(),
+            RedactionAction::Redact,
+            "attempt to override tombstone",
+            "2026-02-08T12:32:00Z",
+        ),
+        Err(RedactionComplianceError::TargetAlreadyProtected {
+            namespace: "kamn.messages".to_owned(),
+            entity_id: "msg-99".to_owned(),
+        })
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -65,3 +65,4 @@ For task operation command handling controls, see `docs/foundation/task-operatio
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-caching-parallelism.md`.
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
+For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.

--- a/docs/foundation/redaction-tombstones.md
+++ b/docs/foundation/redaction-tombstones.md
@@ -1,0 +1,31 @@
+# Redaction and Tombstone Compliance Slice (Issues #150, #151)
+
+This document describes the first implementation slice for PRD-aligned redaction and tombstone compliance workflows.
+
+## Scope Delivered
+- Added `RedactionComplianceEngine` in `kamn-core` for controlled redaction/tombstone workflows.
+- Implemented quorum-based approval flow:
+  - Requests remain pending until required approvals are collected.
+  - Quorum automatically applies protection (redacted or tombstoned visibility).
+- Implemented deterministic retrieval behavior:
+  - `Available`
+  - `Redacted { request_id }`
+  - `Tombstoned { request_id }`
+- Added immutable audit evidence stream per request:
+  - `Requested`, `Approved`, `Rejected`, `Applied`
+- Added target protection guard preventing silent restore/override for already protected targets.
+- Integrated canonical state-key usage for target indexing.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test redaction_tombstones
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```
+
+## Follow-up
+- Add explicit requester/approver role policy checks and configurable authorization chains.
+- Extend integration with storage and query APIs for operator-facing redaction history views.


### PR DESCRIPTION
## Summary
Implements the first redaction/tombstone compliance slice by adding a quorum-based redaction workflow engine, deterministic retrieval visibility semantics, and immutable audit evidence in `kamn-core`. This delivers the first executable contract for compliance-safe content protection without silent restoration.

Closes #150
Closes #151

## Changes
- `crates/kamn-core/src/redaction_compliance.rs`: added redaction compliance engine, request lifecycle, approval quorum handling, deterministic visibility states, target protection guard, audit events, and unit tests.
- `crates/kamn-core/tests/redaction_tombstones.rs`: added functional/integration/regression coverage for quorum gating, tombstone retrieval behavior, canonical key indexing, and restore-prevention guard.
- `crates/kamn-core/src/lib.rs`: exported redaction compliance API types.
- `docs/foundation/redaction-tombstones.md`: documented delivered workflow behavior, validation commands, and follow-up scope.
- `docs/foundation/bootstrap.md`: linked new foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed `cargo test -p kamn-core --test redaction_tombstones` and full `cargo test -p kamn-core`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Module tests cover constructor guard, duplicate approvals, and rejected-request visibility semantics. |
| Functional  | ✅     | Integration tests validate quorum-gated application and deterministic redacted/tombstoned retrieval states. |
| Integration | ✅     | Canonical target key integration validated via `canonical_state_key` parity test. |
| Regression  | ✅     | Regression test enforces no silent restore by rejecting new protection requests on already protected targets. |
