### PR TITLE
feat(core): implement compliance audit export interface slice (#152 #153)

### DIFF
--- a/crates/kamn-core/src/audit_exports.rs
+++ b/crates/kamn-core/src/audit_exports.rs
@@ -1,0 +1,297 @@
+use crate::AgentDid;
+use std::collections::BTreeSet;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuditDomain {
+    Messages,
+    Tasks,
+    Escrows,
+    Reputation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditEventRecord {
+    pub domain: AuditDomain,
+    pub event_id: String,
+    pub occurred_at: String,
+    pub actor: String,
+    pub action: String,
+    pub payload_digest: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuditExportFormat {
+    Json,
+    JsonLines,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AuditExportFilter {
+    pub domains: BTreeSet<AuditDomain>,
+    pub actor_allowlist: BTreeSet<String>,
+    pub from_inclusive: Option<String>,
+    pub to_inclusive: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditExportRequest {
+    pub request_id: String,
+    pub requested_by: String,
+    pub requested_at: String,
+    pub format: AuditExportFormat,
+    pub filter: AuditExportFilter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditExportManifest {
+    pub request_id: String,
+    pub requested_by: String,
+    pub exported_at: String,
+    pub format: AuditExportFormat,
+    pub record_count: usize,
+    pub integrity_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditExportBundle {
+    pub records: Vec<AuditEventRecord>,
+    pub manifest: AuditExportManifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditExportEngine {
+    authorized_exporters: BTreeSet<String>,
+    events: Vec<AuditEventRecord>,
+}
+
+impl AuditExportEngine {
+    pub fn new(authorized_exporters: Vec<String>) -> Result<Self, AuditExportError> {
+        if authorized_exporters.is_empty() {
+            return Err(AuditExportError::EmptyAuthorizedExporters);
+        }
+
+        let mut exporters = BTreeSet::new();
+        for exporter in authorized_exporters {
+            validate_did(&exporter)?;
+            exporters.insert(exporter);
+        }
+
+        Ok(Self {
+            authorized_exporters: exporters,
+            events: Vec::new(),
+        })
+    }
+
+    pub fn ingest_event(&mut self, event: AuditEventRecord) -> Result<(), AuditExportError> {
+        validate_non_empty("event_id", &event.event_id)?;
+        validate_non_empty("occurred_at", &event.occurred_at)?;
+        validate_did(&event.actor)?;
+        validate_non_empty("action", &event.action)?;
+        validate_non_empty("payload_digest", &event.payload_digest)?;
+        self.events.push(event);
+        Ok(())
+    }
+
+    pub fn export(
+        &self,
+        request: &AuditExportRequest,
+    ) -> Result<AuditExportBundle, AuditExportError> {
+        validate_non_empty("request_id", &request.request_id)?;
+        validate_did(&request.requested_by)?;
+        validate_non_empty("requested_at", &request.requested_at)?;
+
+        if !self.authorized_exporters.contains(&request.requested_by) {
+            return Err(AuditExportError::UnauthorizedExporter(
+                request.requested_by.clone(),
+            ));
+        }
+
+        if let (Some(from), Some(to)) = (
+            request.filter.from_inclusive.as_deref(),
+            request.filter.to_inclusive.as_deref(),
+        ) {
+            if from > to {
+                return Err(AuditExportError::InvalidTimeWindow {
+                    from: from.to_owned(),
+                    to: to.to_owned(),
+                });
+            }
+        }
+
+        let mut records: Vec<AuditEventRecord> = self
+            .events
+            .iter()
+            .filter(|event| matches_filter(event, &request.filter))
+            .cloned()
+            .collect();
+
+        records.sort_by(|left, right| {
+            left.occurred_at
+                .cmp(&right.occurred_at)
+                .then_with(|| left.domain.cmp(&right.domain))
+                .then_with(|| left.event_id.cmp(&right.event_id))
+                .then_with(|| left.actor.cmp(&right.actor))
+                .then_with(|| left.action.cmp(&right.action))
+        });
+
+        let canonical = canonical_export_payload(&records);
+        let integrity_hash = fnv1a_hex(&canonical);
+
+        Ok(AuditExportBundle {
+            manifest: AuditExportManifest {
+                request_id: request.request_id.clone(),
+                requested_by: request.requested_by.clone(),
+                exported_at: request.requested_at.clone(),
+                format: request.format,
+                record_count: records.len(),
+                integrity_hash,
+            },
+            records,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuditExportError {
+    EmptyAuthorizedExporters,
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidTimeWindow { from: String, to: String },
+    UnauthorizedExporter(String),
+}
+
+impl fmt::Display for AuditExportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyAuthorizedExporters => write!(f, "authorized_exporters must not be empty"),
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidTimeWindow { from, to } => {
+                write!(f, "invalid time window: from {from} is after to {to}")
+            }
+            Self::UnauthorizedExporter(value) => write!(f, "unauthorized exporter: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for AuditExportError {}
+
+fn matches_filter(event: &AuditEventRecord, filter: &AuditExportFilter) -> bool {
+    if !filter.domains.is_empty() && !filter.domains.contains(&event.domain) {
+        return false;
+    }
+    if !filter.actor_allowlist.is_empty() && !filter.actor_allowlist.contains(&event.actor) {
+        return false;
+    }
+    if let Some(from) = filter.from_inclusive.as_deref() {
+        if event.occurred_at.as_str() < from {
+            return false;
+        }
+    }
+    if let Some(to) = filter.to_inclusive.as_deref() {
+        if event.occurred_at.as_str() > to {
+            return false;
+        }
+    }
+    true
+}
+
+fn canonical_export_payload(records: &[AuditEventRecord]) -> String {
+    let mut output = String::new();
+    for record in records {
+        output.push_str(match record.domain {
+            AuditDomain::Messages => "messages",
+            AuditDomain::Tasks => "tasks",
+            AuditDomain::Escrows => "escrows",
+            AuditDomain::Reputation => "reputation",
+        });
+        output.push('|');
+        output.push_str(&record.event_id);
+        output.push('|');
+        output.push_str(&record.occurred_at);
+        output.push('|');
+        output.push_str(&record.actor);
+        output.push('|');
+        output.push_str(&record.action);
+        output.push('|');
+        output.push_str(&record.payload_digest);
+        output.push('\n');
+    }
+    output
+}
+
+fn fnv1a_hex(value: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), AuditExportError> {
+    if value.trim().is_empty() {
+        return Err(AuditExportError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), AuditExportError> {
+    AgentDid::parse(value).map_err(|error| AuditExportError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AuditDomain, AuditEventRecord, AuditExportEngine, AuditExportError, AuditExportFilter,
+        AuditExportFormat, AuditExportRequest,
+    };
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn constructor_requires_authorized_exporter() {
+        assert_eq!(
+            AuditExportEngine::new(Vec::new()),
+            Err(AuditExportError::EmptyAuthorizedExporters)
+        );
+    }
+
+    #[test]
+    fn invalid_time_window_is_rejected() {
+        let mut engine = AuditExportEngine::new(vec!["kamn:did:agent:audit-operator".to_owned()])
+            .expect("engine should construct");
+        engine
+            .ingest_event(AuditEventRecord {
+                domain: AuditDomain::Messages,
+                event_id: "event-1".to_owned(),
+                occurred_at: "2026-02-08T10:00:00Z".to_owned(),
+                actor: "kamn:did:agent:operator-1".to_owned(),
+                action: "MessageSent".to_owned(),
+                payload_digest: "sha256:1".to_owned(),
+            })
+            .expect("event should ingest");
+
+        let request = AuditExportRequest {
+            request_id: "req-1".to_owned(),
+            requested_by: "kamn:did:agent:audit-operator".to_owned(),
+            requested_at: "2026-02-08T10:10:00Z".to_owned(),
+            format: AuditExportFormat::Json,
+            filter: AuditExportFilter {
+                domains: [AuditDomain::Messages].into_iter().collect(),
+                actor_allowlist: BTreeSet::new(),
+                from_inclusive: Some("2026-02-08T11:00:00Z".to_owned()),
+                to_inclusive: Some("2026-02-08T10:00:00Z".to_owned()),
+            },
+        };
+
+        assert_eq!(
+            engine.export(&request),
+            Err(AuditExportError::InvalidTimeWindow {
+                from: "2026-02-08T11:00:00Z".to_owned(),
+                to: "2026-02-08T10:00:00Z".to_owned(),
+            })
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_key_hierarchy;
+pub mod audit_exports;
 pub mod bootstrap;
 pub mod bridge_adapter;
 pub mod channel_models;
@@ -28,6 +29,10 @@ pub mod transaction;
 
 pub use agent_key_hierarchy::{
     AgentKeyHierarchy, AgentKeyHierarchyError, EphemeralSessionKey, KeyRole,
+};
+pub use audit_exports::{
+    AuditDomain, AuditEventRecord, AuditExportBundle, AuditExportEngine, AuditExportError,
+    AuditExportFilter, AuditExportFormat, AuditExportManifest, AuditExportRequest,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/audit_export_interfaces.rs
+++ b/crates/kamn-core/tests/audit_export_interfaces.rs
@@ -1,0 +1,195 @@
+use kamn_core::{
+    AuditDomain, AuditEventRecord, AuditExportEngine, AuditExportError, AuditExportFilter,
+    AuditExportFormat, AuditExportRequest,
+};
+use std::collections::BTreeSet;
+
+fn authorized_exporter() -> &'static str {
+    "kamn:did:agent:compliance-operator-1"
+}
+
+fn event(
+    domain: AuditDomain,
+    event_id: &str,
+    occurred_at: &str,
+    actor: &str,
+    action: &str,
+    payload_digest: &str,
+) -> AuditEventRecord {
+    AuditEventRecord {
+        domain,
+        event_id: event_id.to_owned(),
+        occurred_at: occurred_at.to_owned(),
+        actor: actor.to_owned(),
+        action: action.to_owned(),
+        payload_digest: payload_digest.to_owned(),
+    }
+}
+
+#[test]
+fn export_is_deterministic_and_integrity_stable() {
+    let mut engine =
+        AuditExportEngine::new(vec![authorized_exporter().to_owned()]).expect("engine constructs");
+
+    engine
+        .ingest_event(event(
+            AuditDomain::Tasks,
+            "task-event-2",
+            "2026-02-08T14:02:00Z",
+            "kamn:did:agent:task-worker-1",
+            "TaskCompleted",
+            "sha256:task-2",
+        ))
+        .expect("event ingests");
+    engine
+        .ingest_event(event(
+            AuditDomain::Messages,
+            "msg-event-1",
+            "2026-02-08T14:01:00Z",
+            "kamn:did:agent:messenger-1",
+            "MessageSent",
+            "sha256:msg-1",
+        ))
+        .expect("event ingests");
+
+    let request = AuditExportRequest {
+        request_id: "export-1".to_owned(),
+        requested_by: authorized_exporter().to_owned(),
+        requested_at: "2026-02-08T14:03:00Z".to_owned(),
+        format: AuditExportFormat::JsonLines,
+        filter: AuditExportFilter::default(),
+    };
+
+    let first = engine.export(&request).expect("export should succeed");
+    let second = engine.export(&request).expect("export should succeed");
+
+    assert_eq!(first.records.len(), 2);
+    assert_eq!(first.records[0].event_id, "msg-event-1");
+    assert_eq!(first.records[1].event_id, "task-event-2");
+    assert_eq!(
+        first.manifest.integrity_hash,
+        second.manifest.integrity_hash
+    );
+}
+
+#[test]
+fn export_filter_is_respected_across_domains_and_actor_allowlist() {
+    let mut engine =
+        AuditExportEngine::new(vec![authorized_exporter().to_owned()]).expect("engine constructs");
+
+    engine
+        .ingest_event(event(
+            AuditDomain::Messages,
+            "msg-keep",
+            "2026-02-08T15:01:00Z",
+            "kamn:did:agent:operator-a",
+            "MessageRedacted",
+            "sha256:keep",
+        ))
+        .expect("event ingests");
+    engine
+        .ingest_event(event(
+            AuditDomain::Escrows,
+            "escrow-drop",
+            "2026-02-08T15:02:00Z",
+            "kamn:did:agent:operator-b",
+            "EscrowReleased",
+            "sha256:drop",
+        ))
+        .expect("event ingests");
+
+    let request = AuditExportRequest {
+        request_id: "export-2".to_owned(),
+        requested_by: authorized_exporter().to_owned(),
+        requested_at: "2026-02-08T15:03:00Z".to_owned(),
+        format: AuditExportFormat::Json,
+        filter: AuditExportFilter {
+            domains: [AuditDomain::Messages].into_iter().collect(),
+            actor_allowlist: ["kamn:did:agent:operator-a".to_owned()]
+                .into_iter()
+                .collect(),
+            from_inclusive: Some("2026-02-08T15:00:00Z".to_owned()),
+            to_inclusive: Some("2026-02-08T15:10:00Z".to_owned()),
+        },
+    };
+
+    let exported = engine.export(&request).expect("export should succeed");
+    assert_eq!(exported.records.len(), 1);
+    assert_eq!(exported.records[0].event_id, "msg-keep");
+}
+
+#[test]
+fn integration_multi_domain_pipeline_exports_all_domains() {
+    let mut engine =
+        AuditExportEngine::new(vec![authorized_exporter().to_owned()]).expect("engine constructs");
+
+    let domains = [
+        AuditDomain::Messages,
+        AuditDomain::Tasks,
+        AuditDomain::Escrows,
+        AuditDomain::Reputation,
+    ];
+
+    for (index, domain) in domains.iter().enumerate() {
+        engine
+            .ingest_event(event(
+                domain.clone(),
+                &format!("event-{index}"),
+                &format!("2026-02-08T16:0{}:00Z", index + 1),
+                "kamn:did:agent:operator-a",
+                "DomainEvent",
+                &format!("sha256:{index}"),
+            ))
+            .expect("event ingests");
+    }
+
+    let mut domain_filter = BTreeSet::new();
+    domain_filter.extend(domains);
+
+    let request = AuditExportRequest {
+        request_id: "export-3".to_owned(),
+        requested_by: authorized_exporter().to_owned(),
+        requested_at: "2026-02-08T16:10:00Z".to_owned(),
+        format: AuditExportFormat::JsonLines,
+        filter: AuditExportFilter {
+            domains: domain_filter,
+            actor_allowlist: BTreeSet::new(),
+            from_inclusive: None,
+            to_inclusive: None,
+        },
+    };
+
+    let exported = engine.export(&request).expect("export should succeed");
+    assert_eq!(exported.records.len(), 4);
+    assert_eq!(exported.manifest.record_count, 4);
+}
+
+#[test]
+fn regression_blocks_unauthorized_export_request() {
+    let mut engine =
+        AuditExportEngine::new(vec![authorized_exporter().to_owned()]).expect("engine constructs");
+    engine
+        .ingest_event(event(
+            AuditDomain::Messages,
+            "msg-unauth",
+            "2026-02-08T17:00:00Z",
+            "kamn:did:agent:operator-a",
+            "MessageSent",
+            "sha256:unauth",
+        ))
+        .expect("event ingests");
+
+    // Regression: #153
+    assert_eq!(
+        engine.export(&AuditExportRequest {
+            request_id: "export-4".to_owned(),
+            requested_by: "kamn:did:agent:unauthorized-1".to_owned(),
+            requested_at: "2026-02-08T17:01:00Z".to_owned(),
+            format: AuditExportFormat::Json,
+            filter: AuditExportFilter::default(),
+        }),
+        Err(AuditExportError::UnauthorizedExporter(
+            "kamn:did:agent:unauthorized-1".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/audit-export-interfaces.md
+++ b/docs/foundation/audit-export-interfaces.md
@@ -1,0 +1,39 @@
+# Compliance Audit Export Interfaces Slice (Issues #152, #153)
+
+This document describes the first implementation slice for multi-domain compliance audit exports.
+
+## Scope Delivered
+- Added `AuditExportEngine` in `kamn-core` with deterministic export behavior across domains:
+  - `messages`
+  - `tasks`
+  - `escrows`
+  - `reputation`
+- Added structured export contract:
+  - `AuditEventRecord`
+  - `AuditExportRequest`
+  - `AuditExportFilter`
+  - `AuditExportBundle`
+  - `AuditExportManifest`
+- Enforced export access controls:
+  - Only authorized exporter DIDs can generate exports.
+- Implemented deterministic filtering and ordering:
+  - Domain filter
+  - Actor allowlist filter
+  - Inclusive time window filter
+- Added integrity metadata:
+  - Canonical export payload serialization
+  - Deterministic `fnv1a64` hash in manifest
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test audit_export_interfaces
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```
+
+## Follow-up
+- Add explicit export scope permissions mapped to operator roles and tenant boundaries.
+- Add stream-oriented export interfaces for large historical datasets.

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -66,3 +66,4 @@ For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/b
 For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-caching-parallelism.md`.
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.
+For compliance audit export interface controls, see `docs/foundation/audit-export-interfaces.md`.


### PR DESCRIPTION
## Summary
Implements the first compliance audit export interface slice by adding deterministic, filterable, integrity-tagged multi-domain exports in `kamn-core`, with explicit exporter authorization controls.

Closes #152
Closes #153

## Changes
- `crates/kamn-core/src/audit_exports.rs`: added multi-domain audit export engine, schema types, deterministic filtering/sorting, integrity manifest generation, and unit tests.
- `crates/kamn-core/tests/audit_export_interfaces.rs`: added functional/integration/regression tests for deterministic exports, multi-domain coverage, and unauthorized access blocking.
- `crates/kamn-core/src/lib.rs`: exported audit export API types.
- `docs/foundation/audit-export-interfaces.md`: documented export contract, validation path, and follow-up scope.
- `docs/foundation/bootstrap.md`: linked new foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `cargo test -p kamn-core --test audit_export_interfaces` and full `cargo test -p kamn-core`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Engine-level tests cover constructor and invalid filter-window guards. |
| Functional  | ✅     | Deterministic export behavior and filter semantics verified in integration tests. |
| Integration | ✅     | Multi-domain export pipeline validated across messages/tasks/escrows/reputation records. |
| Regression  | ✅     | Unauthorized export request remains blocked by explicit authorization check. |
