### PR TITLE
feat(core): implement configurable retention policy engine slice (#154 #155)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod message_lifecycle;
 pub mod migrations;
 pub mod namespaces;
 pub mod redaction_compliance;
+pub mod retention_engine;
 pub mod runtime;
 pub mod smoke;
 pub mod state;
@@ -82,6 +83,10 @@ pub use namespaces::StateNamespaces;
 pub use redaction_compliance::{
     RedactionAction, RedactionAuditEvent, RedactionAuditEventKind, RedactionComplianceEngine,
     RedactionComplianceError, RedactionRequestStatus, RedactionVisibility,
+};
+pub use retention_engine::{
+    RetentionClass, RetentionDomain, RetentionEnginePolicy, RetentionEvaluation,
+    RetentionPolicyEngine, RetentionPolicyError, RetentionRecord, RetentionStatus,
 };
 pub use runtime::RuntimeWiring;
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};

--- a/crates/kamn-core/src/retention_engine.rs
+++ b/crates/kamn-core/src/retention_engine.rs
@@ -1,0 +1,235 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RetentionDomain {
+    Messages,
+    Tasks,
+    Escrows,
+    Reputation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RetentionClass {
+    MaxAgeSeconds(u64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionEnginePolicy {
+    pub default_class: RetentionClass,
+    pub overrides: BTreeMap<RetentionDomain, RetentionClass>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionRecord {
+    pub domain: RetentionDomain,
+    pub record_id: String,
+    pub created_at_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionStatus {
+    pub domain: RetentionDomain,
+    pub record_id: String,
+    pub class: RetentionClass,
+    pub expires_at_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionEvaluation {
+    pub expired_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionPolicyEngine {
+    policy: RetentionEnginePolicy,
+    blocked_ids: BTreeSet<String>,
+}
+
+impl RetentionPolicyEngine {
+    pub fn new(policy: RetentionEnginePolicy) -> Result<Self, RetentionPolicyError> {
+        validate_class(policy.default_class)?;
+        for class in policy.overrides.values() {
+            validate_class(*class)?;
+        }
+
+        Ok(Self {
+            policy,
+            blocked_ids: BTreeSet::new(),
+        })
+    }
+
+    pub fn evaluate(
+        &mut self,
+        now_secs: u64,
+        mut records: Vec<RetentionRecord>,
+    ) -> Result<RetentionEvaluation, RetentionPolicyError> {
+        records.sort_by(|left, right| {
+            left.domain
+                .cmp(&right.domain)
+                .then_with(|| left.record_id.cmp(&right.record_id))
+                .then_with(|| left.created_at_secs.cmp(&right.created_at_secs))
+        });
+
+        let mut expired_ids = Vec::new();
+
+        for record in records {
+            if self.blocked_ids.contains(&record.record_id) {
+                return Err(RetentionPolicyError::ResurfacedExpiredRecord(
+                    record.record_id,
+                ));
+            }
+
+            let status = self.status_for(&record)?;
+            if now_secs > status.expires_at_secs {
+                self.blocked_ids.insert(record.record_id.clone());
+                expired_ids.push(record.record_id);
+            }
+        }
+
+        Ok(RetentionEvaluation { expired_ids })
+    }
+
+    pub fn status_for(
+        &self,
+        record: &RetentionRecord,
+    ) -> Result<RetentionStatus, RetentionPolicyError> {
+        validate_non_empty("record_id", &record.record_id)?;
+
+        let class = self
+            .policy
+            .overrides
+            .get(&record.domain)
+            .copied()
+            .unwrap_or(self.policy.default_class);
+        let max_age = class_max_age_secs(class)?;
+
+        Ok(RetentionStatus {
+            domain: record.domain,
+            record_id: record.record_id.clone(),
+            class,
+            expires_at_secs: record.created_at_secs.saturating_add(max_age),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetentionPolicyError {
+    InvalidRetentionClass(u64),
+    EmptyField(&'static str),
+    ResurfacedExpiredRecord(String),
+}
+
+impl fmt::Display for RetentionPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRetentionClass(value) => {
+                write!(f, "retention max age must be greater than zero: {value}")
+            }
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::ResurfacedExpiredRecord(value) => {
+                write!(f, "expired record attempted to resurface: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RetentionPolicyError {}
+
+fn validate_class(class: RetentionClass) -> Result<(), RetentionPolicyError> {
+    let max_age = class_max_age_secs(class)?;
+    if max_age == 0 {
+        return Err(RetentionPolicyError::InvalidRetentionClass(max_age));
+    }
+    Ok(())
+}
+
+fn class_max_age_secs(class: RetentionClass) -> Result<u64, RetentionPolicyError> {
+    match class {
+        RetentionClass::MaxAgeSeconds(value) => {
+            if value == 0 {
+                return Err(RetentionPolicyError::InvalidRetentionClass(value));
+            }
+            Ok(value)
+        }
+    }
+}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), RetentionPolicyError> {
+    if value.trim().is_empty() {
+        return Err(RetentionPolicyError::EmptyField(field));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RetentionClass, RetentionDomain, RetentionEnginePolicy, RetentionPolicyEngine,
+        RetentionPolicyError, RetentionRecord,
+    };
+    use std::collections::BTreeMap;
+
+    fn base_policy() -> RetentionEnginePolicy {
+        RetentionEnginePolicy {
+            default_class: RetentionClass::MaxAgeSeconds(300),
+            overrides: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn rejects_zero_age_class() {
+        assert_eq!(
+            RetentionPolicyEngine::new(RetentionEnginePolicy {
+                default_class: RetentionClass::MaxAgeSeconds(0),
+                overrides: BTreeMap::new(),
+            }),
+            Err(RetentionPolicyError::InvalidRetentionClass(0))
+        );
+    }
+
+    #[test]
+    fn empty_record_id_is_rejected() {
+        let engine = RetentionPolicyEngine::new(base_policy()).expect("engine should construct");
+        assert_eq!(
+            engine.status_for(&RetentionRecord {
+                domain: RetentionDomain::Tasks,
+                record_id: "".to_owned(),
+                created_at_secs: 1,
+            }),
+            Err(RetentionPolicyError::EmptyField("record_id"))
+        );
+    }
+
+    #[test]
+    fn expired_record_is_blocked_on_resurface() {
+        let mut engine =
+            RetentionPolicyEngine::new(base_policy()).expect("engine should construct");
+
+        let first = engine
+            .evaluate(
+                1_000,
+                vec![RetentionRecord {
+                    domain: RetentionDomain::Tasks,
+                    record_id: "task-1".to_owned(),
+                    created_at_secs: 1,
+                }],
+            )
+            .expect("first evaluation should succeed");
+        assert_eq!(first.expired_ids, vec!["task-1".to_owned()]);
+
+        assert_eq!(
+            engine.evaluate(
+                1_001,
+                vec![RetentionRecord {
+                    domain: RetentionDomain::Tasks,
+                    record_id: "task-1".to_owned(),
+                    created_at_secs: 999,
+                }],
+            ),
+            Err(RetentionPolicyError::ResurfacedExpiredRecord(
+                "task-1".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/kamn-core/tests/retention_policy_engine.rs
+++ b/crates/kamn-core/tests/retention_policy_engine.rs
@@ -1,0 +1,134 @@
+use kamn_core::{
+    RetentionClass, RetentionDomain, RetentionEnginePolicy, RetentionPolicyEngine,
+    RetentionPolicyError, RetentionRecord, RetentionStatus,
+};
+use std::collections::BTreeMap;
+
+fn policy() -> RetentionEnginePolicy {
+    let mut overrides = BTreeMap::new();
+    overrides.insert(
+        RetentionDomain::Messages,
+        RetentionClass::MaxAgeSeconds(300),
+    );
+    overrides.insert(
+        RetentionDomain::Escrows,
+        RetentionClass::MaxAgeSeconds(1200),
+    );
+    RetentionEnginePolicy {
+        default_class: RetentionClass::MaxAgeSeconds(600),
+        overrides,
+    }
+}
+
+#[test]
+fn domain_override_controls_expiration_window() {
+    let mut engine = RetentionPolicyEngine::new(policy()).expect("engine should construct");
+
+    let expired = engine
+        .evaluate(
+            1_000,
+            vec![
+                RetentionRecord {
+                    domain: RetentionDomain::Messages,
+                    record_id: "msg-old".to_owned(),
+                    created_at_secs: 200,
+                },
+                RetentionRecord {
+                    domain: RetentionDomain::Tasks,
+                    record_id: "task-fresh".to_owned(),
+                    created_at_secs: 600,
+                },
+            ],
+        )
+        .expect("evaluation should succeed");
+
+    assert_eq!(expired.expired_ids, vec!["msg-old".to_owned()]);
+}
+
+#[test]
+fn expiration_order_is_deterministic() {
+    let mut engine = RetentionPolicyEngine::new(policy()).expect("engine should construct");
+
+    let expired = engine
+        .evaluate(
+            10_000,
+            vec![
+                RetentionRecord {
+                    domain: RetentionDomain::Tasks,
+                    record_id: "task-b".to_owned(),
+                    created_at_secs: 100,
+                },
+                RetentionRecord {
+                    domain: RetentionDomain::Tasks,
+                    record_id: "task-a".to_owned(),
+                    created_at_secs: 100,
+                },
+                RetentionRecord {
+                    domain: RetentionDomain::Messages,
+                    record_id: "msg-a".to_owned(),
+                    created_at_secs: 100,
+                },
+            ],
+        )
+        .expect("evaluation should succeed");
+
+    assert_eq!(
+        expired.expired_ids,
+        vec!["msg-a".to_owned(), "task-a".to_owned(), "task-b".to_owned(),]
+    );
+}
+
+#[test]
+fn integration_status_surface_reports_domain_class_and_expiry() {
+    let engine = RetentionPolicyEngine::new(policy()).expect("engine should construct");
+
+    let status = engine
+        .status_for(&RetentionRecord {
+            domain: RetentionDomain::Escrows,
+            record_id: "escrow-1".to_owned(),
+            created_at_secs: 100,
+        })
+        .expect("status should resolve");
+
+    assert_eq!(
+        status,
+        RetentionStatus {
+            domain: RetentionDomain::Escrows,
+            record_id: "escrow-1".to_owned(),
+            class: RetentionClass::MaxAgeSeconds(1200),
+            expires_at_secs: 1300,
+        }
+    );
+}
+
+#[test]
+fn regression_expired_record_cannot_resurface() {
+    let mut engine = RetentionPolicyEngine::new(policy()).expect("engine should construct");
+
+    let first = engine
+        .evaluate(
+            2_000,
+            vec![RetentionRecord {
+                domain: RetentionDomain::Messages,
+                record_id: "msg-resurface".to_owned(),
+                created_at_secs: 100,
+            }],
+        )
+        .expect("evaluation should succeed");
+    assert_eq!(first.expired_ids, vec!["msg-resurface".to_owned()]);
+
+    // Regression: #155
+    assert_eq!(
+        engine.evaluate(
+            2_100,
+            vec![RetentionRecord {
+                domain: RetentionDomain::Messages,
+                record_id: "msg-resurface".to_owned(),
+                created_at_secs: 2_050,
+            }],
+        ),
+        Err(RetentionPolicyError::ResurfacedExpiredRecord(
+            "msg-resurface".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -67,3 +67,4 @@ For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.
 For compliance audit export interface controls, see `docs/foundation/audit-export-interfaces.md`.
+For configurable retention policy enforcement controls, see `docs/foundation/retention-policy-engine.md`.

--- a/docs/foundation/retention-policy-engine.md
+++ b/docs/foundation/retention-policy-engine.md
@@ -1,0 +1,27 @@
+# Retention Policy Engine Slice (Issues #154, #155)
+
+This document describes the first implementation slice for configurable retention policy enforcement.
+
+## Scope Delivered
+- Added `RetentionPolicyEngine` with configurable default retention class plus domain overrides.
+- Added deterministic expiration evaluation across domains:
+  - Stable sort order for evaluation and expiration output.
+  - Domain override precedence over default policy class.
+- Added operator status surface:
+  - `status_for(...)` returns class + deterministic expiry timestamp per record.
+- Added resurfacing regression guard:
+  - Expired record IDs are blocked from reappearing in later evaluations.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test retention_policy_engine
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```
+
+## Follow-up
+- Add richer retention classes (class tiers + legal hold semantics).
+- Integrate retention evaluation output with audit export and redaction workflows.


### PR DESCRIPTION
## Summary
Implements the first configurable retention policy slice with deterministic enforcement, domain overrides, operator status visibility, and resurfacing regression guards in `kamn-core`.

Closes #154
Closes #155

## Changes
- `crates/kamn-core/src/retention_engine.rs`: added retention domain/class model, policy engine, deterministic evaluation, status surface, resurfacing guard, and unit tests.
- `crates/kamn-core/tests/retention_policy_engine.rs`: added functional/integration/regression coverage for overrides, deterministic expiration ordering, status output, and resurfacing block behavior.
- `crates/kamn-core/src/lib.rs`: exported retention engine API types.
- `docs/foundation/retention-policy-engine.md`: documented delivered behavior and validation path.
- `docs/foundation/bootstrap.md`: linked new foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `cargo test -p kamn-core --test retention_policy_engine` and full `cargo test -p kamn-core`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Engine module tests cover invalid class config, empty record guard, and resurfacing block behavior. |
| Functional  | ✅     | Override-specific expiration behavior and deterministic ordering are validated in integration tests. |
| Integration | ✅     | Cross-domain status surface validated with explicit class/expiry assertions. |
| Regression  | ✅     | Expired record resurfacing is blocked and enforced by dedicated regression test. |
