### PR TITLE
feat(core): implement data classification tagging slice (#156 #157)

### DIFF
--- a/crates/kamn-core/src/data_classification.rs
+++ b/crates/kamn-core/src/data_classification.rs
@@ -1,0 +1,317 @@
+use crate::{canonical_state_key, AgentDid};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DataClassificationLevel {
+    Public,
+    Internal,
+    Sensitive,
+    Restricted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum WriteDomain {
+    Messages,
+    Tasks,
+    Escrows,
+    Reputation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassificationPolicy {
+    pub minimum_by_domain: BTreeMap<WriteDomain, DataClassificationLevel>,
+    pub required_tags_by_level: BTreeMap<DataClassificationLevel, BTreeSet<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteTag {
+    pub level: DataClassificationLevel,
+    pub tags: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteRequestContext {
+    pub domain: WriteDomain,
+    pub record_id: String,
+    pub actor: String,
+    pub tag: WriteTag,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassificationStatus {
+    pub domain: WriteDomain,
+    pub record_id: String,
+    pub minimum_level: DataClassificationLevel,
+    pub provided_level: DataClassificationLevel,
+    pub missing_tags: Vec<String>,
+    pub authorized: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataClassificationEngine {
+    policy: ClassificationPolicy,
+}
+
+impl DataClassificationEngine {
+    pub fn new(policy: ClassificationPolicy) -> Result<Self, DataClassificationError> {
+        for domain in [
+            WriteDomain::Messages,
+            WriteDomain::Tasks,
+            WriteDomain::Escrows,
+            WriteDomain::Reputation,
+        ] {
+            if !policy.minimum_by_domain.contains_key(&domain) {
+                return Err(DataClassificationError::InvalidPolicy(format!(
+                    "missing minimum classification for domain {domain:?}"
+                )));
+            }
+        }
+
+        for tags in policy.required_tags_by_level.values() {
+            for tag in tags {
+                validate_tag(tag)?;
+            }
+        }
+
+        Ok(Self { policy })
+    }
+
+    pub fn authorize_write(
+        &mut self,
+        context: &WriteRequestContext,
+    ) -> Result<String, DataClassificationError> {
+        validate_non_empty("record_id", &context.record_id)?;
+        validate_did(&context.actor)?;
+        self.validate_write_tag(&context.record_id, &context.tag)?;
+
+        let minimum = self.minimum_for(context.domain);
+        if context.tag.level < minimum {
+            return Err(DataClassificationError::ClassificationBelowDomainMinimum {
+                domain: context.domain,
+                required: minimum,
+                provided: context.tag.level,
+            });
+        }
+
+        let missing = self.missing_required_tags(&context.tag);
+        if !missing.is_empty() {
+            return Err(DataClassificationError::MissingRequiredTags {
+                level: context.tag.level,
+                missing,
+            });
+        }
+
+        canonical_state_key(
+            namespace_for_domain(context.domain),
+            "record",
+            &context.record_id,
+        )
+        .map_err(|error| DataClassificationError::InvalidPolicy(error.to_string()))
+    }
+
+    pub fn status_for(
+        &self,
+        domain: WriteDomain,
+        record_id: &str,
+        tag: WriteTag,
+    ) -> Result<ClassificationStatus, DataClassificationError> {
+        validate_non_empty("record_id", record_id)?;
+        self.validate_write_tag(record_id, &tag)?;
+
+        let minimum = self.minimum_for(domain);
+        let missing: Vec<String> = self.missing_required_tags(&tag).into_iter().collect();
+        let authorized = tag.level >= minimum
+            && !(tag.level >= DataClassificationLevel::Sensitive && tag.tags.is_empty())
+            && missing.is_empty();
+
+        Ok(ClassificationStatus {
+            domain,
+            record_id: record_id.to_owned(),
+            minimum_level: minimum,
+            provided_level: tag.level,
+            missing_tags: missing,
+            authorized,
+        })
+    }
+
+    fn minimum_for(&self, domain: WriteDomain) -> DataClassificationLevel {
+        self.policy
+            .minimum_by_domain
+            .get(&domain)
+            .copied()
+            .unwrap_or(DataClassificationLevel::Public)
+    }
+
+    fn validate_write_tag(
+        &self,
+        record_id: &str,
+        tag: &WriteTag,
+    ) -> Result<(), DataClassificationError> {
+        for value in &tag.tags {
+            validate_tag(value)?;
+        }
+
+        if tag.level >= DataClassificationLevel::Sensitive && tag.tags.is_empty() {
+            return Err(DataClassificationError::UntaggedSensitiveWrite(
+                record_id.to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn missing_required_tags(&self, tag: &WriteTag) -> BTreeSet<String> {
+        match self.policy.required_tags_by_level.get(&tag.level) {
+            Some(required) => required.difference(&tag.tags).cloned().collect(),
+            None => BTreeSet::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataClassificationError {
+    InvalidPolicy(String),
+    EmptyField(&'static str),
+    InvalidTag(String),
+    InvalidDid(String),
+    MissingRequiredTags {
+        level: DataClassificationLevel,
+        missing: BTreeSet<String>,
+    },
+    ClassificationBelowDomainMinimum {
+        domain: WriteDomain,
+        required: DataClassificationLevel,
+        provided: DataClassificationLevel,
+    },
+    UntaggedSensitiveWrite(String),
+}
+
+impl fmt::Display for DataClassificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPolicy(value) => write!(f, "invalid classification policy: {value}"),
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidTag(value) => write!(f, "invalid tag: {value}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::MissingRequiredTags { level, missing } => write!(
+                f,
+                "missing required tags for level {level:?}: {}",
+                missing.iter().cloned().collect::<Vec<_>>().join(", ")
+            ),
+            Self::ClassificationBelowDomainMinimum {
+                domain,
+                required,
+                provided,
+            } => write!(
+                f,
+                "classification level {provided:?} is below minimum {required:?} for domain {domain:?}"
+            ),
+            Self::UntaggedSensitiveWrite(value) => {
+                write!(f, "sensitive/restricted write is missing tags: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DataClassificationError {}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), DataClassificationError> {
+    if value.trim().is_empty() {
+        return Err(DataClassificationError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_tag(value: &str) -> Result<(), DataClassificationError> {
+    if value.trim().is_empty() {
+        return Err(DataClassificationError::InvalidTag(value.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), DataClassificationError> {
+    AgentDid::parse(value)
+        .map_err(|error| DataClassificationError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn namespace_for_domain(domain: WriteDomain) -> &'static str {
+    match domain {
+        WriteDomain::Messages => "kamn.messages",
+        WriteDomain::Tasks => "kamn.tasks",
+        WriteDomain::Escrows => "kamn.escrows",
+        WriteDomain::Reputation => "kamn.reputation",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ClassificationPolicy, DataClassificationEngine, DataClassificationError,
+        DataClassificationLevel, WriteDomain, WriteRequestContext, WriteTag,
+    };
+    use std::collections::BTreeMap;
+
+    fn policy() -> ClassificationPolicy {
+        let mut minimum_by_domain = BTreeMap::new();
+        minimum_by_domain.insert(WriteDomain::Messages, DataClassificationLevel::Internal);
+        minimum_by_domain.insert(WriteDomain::Tasks, DataClassificationLevel::Internal);
+        minimum_by_domain.insert(WriteDomain::Escrows, DataClassificationLevel::Sensitive);
+        minimum_by_domain.insert(WriteDomain::Reputation, DataClassificationLevel::Public);
+
+        ClassificationPolicy {
+            minimum_by_domain,
+            required_tags_by_level: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn constructor_requires_domain_minimums() {
+        assert_eq!(
+            DataClassificationEngine::new(ClassificationPolicy {
+                minimum_by_domain: BTreeMap::new(),
+                required_tags_by_level: BTreeMap::new(),
+            }),
+            Err(DataClassificationError::InvalidPolicy(
+                "missing minimum classification for domain Messages".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn authorize_rejects_invalid_did() {
+        let mut engine = DataClassificationEngine::new(policy()).expect("engine should construct");
+
+        assert_eq!(
+            engine.authorize_write(&WriteRequestContext {
+                domain: WriteDomain::Messages,
+                record_id: "msg-1".to_owned(),
+                actor: "bad-did".to_owned(),
+                tag: WriteTag {
+                    level: DataClassificationLevel::Internal,
+                    tags: Default::default(),
+                },
+            }),
+            Err(DataClassificationError::InvalidDid(
+                "invalid agent did prefix: bad-did".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn status_marks_authorized_when_all_controls_pass() {
+        let engine = DataClassificationEngine::new(policy()).expect("engine should construct");
+        let status = engine
+            .status_for(
+                WriteDomain::Tasks,
+                "task-1",
+                WriteTag {
+                    level: DataClassificationLevel::Internal,
+                    tags: Default::default(),
+                },
+            )
+            .expect("status should resolve");
+        assert!(status.authorized);
+        assert!(status.missing_tags.is_empty());
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bridge_adapter;
 pub mod channel_models;
 pub mod channel_policies;
 pub mod config;
+pub mod data_classification;
 pub mod did;
 pub mod did_registry;
 pub mod direct_message_crypto;
@@ -47,6 +48,10 @@ pub use channel_policies::{
     RetentionMessage, RetentionPolicy,
 };
 pub use config::{ConfigError, NodeConfig, NodeRole};
+pub use data_classification::{
+    ClassificationPolicy, ClassificationStatus, DataClassificationEngine, DataClassificationError,
+    DataClassificationLevel, WriteDomain, WriteRequestContext, WriteTag,
+};
 pub use did::{
     canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocument,
     DidDocumentError, DidService, DidVerificationMethod,

--- a/crates/kamn-core/tests/data_classification_tagging.rs
+++ b/crates/kamn-core/tests/data_classification_tagging.rs
@@ -1,0 +1,140 @@
+use kamn_core::{
+    canonical_state_key, ClassificationPolicy, ClassificationStatus, DataClassificationEngine,
+    DataClassificationError, DataClassificationLevel, WriteDomain, WriteRequestContext, WriteTag,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn policy() -> ClassificationPolicy {
+    let mut minimum_by_domain = BTreeMap::new();
+    minimum_by_domain.insert(WriteDomain::Messages, DataClassificationLevel::Internal);
+    minimum_by_domain.insert(WriteDomain::Tasks, DataClassificationLevel::Internal);
+    minimum_by_domain.insert(WriteDomain::Escrows, DataClassificationLevel::Sensitive);
+    minimum_by_domain.insert(WriteDomain::Reputation, DataClassificationLevel::Public);
+
+    let mut required_tags_by_level = BTreeMap::new();
+    required_tags_by_level.insert(
+        DataClassificationLevel::Sensitive,
+        ["contains-sensitive".to_owned()].into_iter().collect(),
+    );
+    required_tags_by_level.insert(
+        DataClassificationLevel::Restricted,
+        [
+            "contains-sensitive".to_owned(),
+            "contains-restricted".to_owned(),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    ClassificationPolicy {
+        minimum_by_domain,
+        required_tags_by_level,
+    }
+}
+
+#[test]
+fn sensitive_write_with_required_tag_is_authorized() {
+    let mut engine = DataClassificationEngine::new(policy()).expect("engine should construct");
+    let key = engine
+        .authorize_write(&WriteRequestContext {
+            domain: WriteDomain::Messages,
+            record_id: "msg-42".to_owned(),
+            actor: "kamn:did:agent:writer-1".to_owned(),
+            tag: WriteTag {
+                level: DataClassificationLevel::Sensitive,
+                tags: ["contains-sensitive".to_owned()].into_iter().collect(),
+            },
+        })
+        .expect("write should be authorized");
+
+    assert_eq!(
+        key,
+        canonical_state_key("kamn.messages", "record", "msg-42")
+            .expect("canonical key should compute")
+    );
+}
+
+#[test]
+fn missing_required_tags_is_rejected_with_typed_error() {
+    let mut engine = DataClassificationEngine::new(policy()).expect("engine should construct");
+
+    assert_eq!(
+        engine.authorize_write(&WriteRequestContext {
+            domain: WriteDomain::Messages,
+            record_id: "msg-43".to_owned(),
+            actor: "kamn:did:agent:writer-2".to_owned(),
+            tag: WriteTag {
+                level: DataClassificationLevel::Restricted,
+                tags: ["contains-sensitive".to_owned()].into_iter().collect(),
+            },
+        }),
+        Err(DataClassificationError::MissingRequiredTags {
+            level: DataClassificationLevel::Restricted,
+            missing: ["contains-restricted".to_owned()].into_iter().collect(),
+        })
+    );
+}
+
+#[test]
+fn integration_domain_minimum_and_status_surface_are_enforced() {
+    let mut engine = DataClassificationEngine::new(policy()).expect("engine should construct");
+
+    assert_eq!(
+        engine.authorize_write(&WriteRequestContext {
+            domain: WriteDomain::Escrows,
+            record_id: "escrow-1".to_owned(),
+            actor: "kamn:did:agent:writer-3".to_owned(),
+            tag: WriteTag {
+                level: DataClassificationLevel::Internal,
+                tags: BTreeSet::new(),
+            },
+        }),
+        Err(DataClassificationError::ClassificationBelowDomainMinimum {
+            domain: WriteDomain::Escrows,
+            required: DataClassificationLevel::Sensitive,
+            provided: DataClassificationLevel::Internal,
+        })
+    );
+
+    assert_eq!(
+        engine
+            .status_for(
+                WriteDomain::Escrows,
+                "escrow-1",
+                WriteTag {
+                    level: DataClassificationLevel::Internal,
+                    tags: BTreeSet::new(),
+                },
+            )
+            .expect("status should resolve"),
+        ClassificationStatus {
+            domain: WriteDomain::Escrows,
+            record_id: "escrow-1".to_owned(),
+            minimum_level: DataClassificationLevel::Sensitive,
+            provided_level: DataClassificationLevel::Internal,
+            missing_tags: Vec::new(),
+            authorized: false,
+        }
+    );
+}
+
+#[test]
+fn regression_untagged_sensitive_write_is_blocked() {
+    let mut engine = DataClassificationEngine::new(policy()).expect("engine should construct");
+
+    // Regression: #157
+    assert_eq!(
+        engine.authorize_write(&WriteRequestContext {
+            domain: WriteDomain::Messages,
+            record_id: "msg-99".to_owned(),
+            actor: "kamn:did:agent:writer-4".to_owned(),
+            tag: WriteTag {
+                level: DataClassificationLevel::Sensitive,
+                tags: BTreeSet::new(),
+            },
+        }),
+        Err(DataClassificationError::UntaggedSensitiveWrite(
+            "msg-99".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -68,3 +68,4 @@ For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-fl
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.
 For compliance audit export interface controls, see `docs/foundation/audit-export-interfaces.md`.
 For configurable retention policy enforcement controls, see `docs/foundation/retention-policy-engine.md`.
+For data classification tiers and write-path tagging enforcement controls, see `docs/foundation/data-classification-tagging.md`.

--- a/docs/foundation/data-classification-tagging.md
+++ b/docs/foundation/data-classification-tagging.md
@@ -1,0 +1,35 @@
+# Data Classification and Write-Tagging Slice (Issues #156, #157)
+
+This document describes the first implementation slice for classification tiers and write-path tagging enforcement.
+
+## Scope Delivered
+- Added `DataClassificationEngine` to enforce write-path classification controls.
+- Added versionable classification model:
+  - `Public`
+  - `Internal`
+  - `Sensitive`
+  - `Restricted`
+- Added domain-level minimum classification policy:
+  - `messages`, `tasks`, `escrows`, `reputation`
+- Added required-tag enforcement by classification level.
+- Enforced typed write-path failures for:
+  - Missing required tags
+  - Classification below domain minimum
+  - Sensitive/restricted writes without tags
+  - Invalid actor DIDs and malformed policy/tag definitions
+- Added operator-facing status surface (`ClassificationStatus`) for deterministic control visibility.
+- Integrated canonical write-key output through existing state key normalization.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test data_classification_tagging
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```
+
+## Follow-up
+- Add classification inheritance for nested write contexts.
+- Add policy-version tracking and migration rules for classification updates.


### PR DESCRIPTION
## Summary
Implements the first data-classification/write-tagging slice by introducing a typed classification model, domain-level minimum enforcement, required-tag controls, and deterministic write-path validation in `kamn-core`.

Closes #156
Closes #157

## Changes
- `crates/kamn-core/src/data_classification.rs`: added classification levels, write domains, policy model, write authorization engine, status surface, typed errors, canonical key integration, and unit tests.
- `crates/kamn-core/tests/data_classification_tagging.rs`: added functional/integration/regression tests for required tags, domain minimum enforcement, status behavior, and untagged sensitive write blocking.
- `crates/kamn-core/src/lib.rs`: exported classification/tagging API.
- `docs/foundation/data-classification-tagging.md`: documented model, controls, and validation path.
- `docs/foundation/bootstrap.md`: linked new foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `cargo test -p kamn-core --test data_classification_tagging` and full `cargo test -p kamn-core`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Engine module tests cover policy guardrails, invalid DID handling, and authorization baseline status behavior. |
| Functional  | ✅     | Sensitive/restricted tag controls and typed missing-tag errors validated in integration tests. |
| Integration | ✅     | Canonical write-key integration and domain-minimum enforcement validated through end-to-end write contexts. |
| Regression  | ✅     | Untagged sensitive write path remains blocked via dedicated regression test (`#157`). |
