### PR TITLE
feat(config): implement sync-mode profile slice (#208 #209)

### DIFF
--- a/crates/kamn-core/src/bootstrap.rs
+++ b/crates/kamn-core/src/bootstrap.rs
@@ -53,7 +53,7 @@ pub fn bootstrap_from_state_version(
 #[cfg(test)]
 mod tests {
     use super::{bootstrap, bootstrap_from_state_version};
-    use crate::config::{ConfigError, NodeConfig, NodeRole};
+    use crate::config::{ConfigError, NodeConfig, NodeRole, SyncMode};
     use crate::state::{StateVersion, APP_STATE_VERSION};
     use crate::token::DEFAULT_TOKEN_SYMBOL;
 
@@ -65,6 +65,7 @@ mod tests {
             role: NodeRole::Processor,
             storage_dir: "/tmp/kamn".to_owned(),
             enable_gossip: true,
+            sync_mode: SyncMode::Fast,
         };
 
         let plan = bootstrap(config).expect("bootstrap should succeed");
@@ -84,6 +85,7 @@ mod tests {
             role: NodeRole::Processor,
             storage_dir: "/tmp/kamn".to_owned(),
             enable_gossip: true,
+            sync_mode: SyncMode::Fast,
         };
 
         assert_eq!(bootstrap(config), Err(ConfigError::EmptyChainId));
@@ -97,6 +99,7 @@ mod tests {
             role: NodeRole::Processor,
             storage_dir: "/tmp/kamn".to_owned(),
             enable_gossip: true,
+            sync_mode: SyncMode::Fast,
         };
 
         let result = bootstrap_from_state_version(config, StateVersion(APP_STATE_VERSION.0 + 1));

--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -31,6 +31,85 @@ impl FromStr for NodeRole {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncMode {
+    Fast,
+    Slow,
+    Archive,
+}
+
+impl SyncMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fast => "fast",
+            Self::Slow => "slow",
+            Self::Archive => "archive",
+        }
+    }
+
+    pub fn profile(self) -> SyncOperationalProfile {
+        match self {
+            Self::Fast => SyncOperationalProfile {
+                mode: self,
+                startup_strategy: SyncStartupStrategy::StateSyncToLatest,
+                recovery_strategy: SyncRecoveryStrategy::ResumeRecentState,
+                requires_chain_version_match: false,
+                maintain_full_history: false,
+            },
+            Self::Slow => SyncOperationalProfile {
+                mode: self,
+                startup_strategy: SyncStartupStrategy::BlockReplayFromGenesis,
+                recovery_strategy: SyncRecoveryStrategy::ReplayMissingBlocks,
+                requires_chain_version_match: true,
+                maintain_full_history: false,
+            },
+            Self::Archive => SyncOperationalProfile {
+                mode: self,
+                startup_strategy: SyncStartupStrategy::ArchiveStateSyncFromGenesis,
+                recovery_strategy: SyncRecoveryStrategy::ReplayArchivedHistory,
+                requires_chain_version_match: false,
+                maintain_full_history: true,
+            },
+        }
+    }
+}
+
+impl FromStr for SyncMode {
+    type Err = ConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "fast" => Ok(Self::Fast),
+            "slow" => Ok(Self::Slow),
+            "archive" => Ok(Self::Archive),
+            other => Err(ConfigError::InvalidSyncMode(other.to_owned())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncStartupStrategy {
+    StateSyncToLatest,
+    BlockReplayFromGenesis,
+    ArchiveStateSyncFromGenesis,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncRecoveryStrategy {
+    ResumeRecentState,
+    ReplayMissingBlocks,
+    ReplayArchivedHistory,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncOperationalProfile {
+    pub mode: SyncMode,
+    pub startup_strategy: SyncStartupStrategy,
+    pub recovery_strategy: SyncRecoveryStrategy,
+    pub requires_chain_version_match: bool,
+    pub maintain_full_history: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeConfig {
     pub chain_id: String,
@@ -38,6 +117,7 @@ pub struct NodeConfig {
     pub role: NodeRole,
     pub storage_dir: String,
     pub enable_gossip: bool,
+    pub sync_mode: SyncMode,
 }
 
 impl NodeConfig {
@@ -53,6 +133,10 @@ impl NodeConfig {
         }
         Ok(())
     }
+
+    pub fn operational_profile(&self) -> SyncOperationalProfile {
+        self.sync_mode.profile()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,6 +147,7 @@ pub enum ConfigError {
     MigrationPlan(String),
     TokenModel(String),
     InvalidRole(String),
+    InvalidSyncMode(String),
     UnknownArgument(String),
     MissingArgumentValue(&'static str),
 }
@@ -76,6 +161,7 @@ impl fmt::Display for ConfigError {
             Self::MigrationPlan(message) => write!(f, "migration planning failed: {message}"),
             Self::TokenModel(message) => write!(f, "token model validation failed: {message}"),
             Self::InvalidRole(value) => write!(f, "invalid role: {value}"),
+            Self::InvalidSyncMode(value) => write!(f, "invalid sync mode: {value}"),
             Self::UnknownArgument(value) => write!(f, "unknown argument: {value}"),
             Self::MissingArgumentValue(flag) => {
                 write!(f, "missing value for argument: {flag}")
@@ -88,13 +174,22 @@ impl std::error::Error for ConfigError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{ConfigError, NodeConfig, NodeRole};
+    use super::{
+        ConfigError, NodeConfig, NodeRole, SyncMode, SyncRecoveryStrategy, SyncStartupStrategy,
+    };
 
     #[test]
     fn parses_node_roles() {
         assert_eq!("processor".parse::<NodeRole>(), Ok(NodeRole::Processor));
         assert_eq!("listener".parse::<NodeRole>(), Ok(NodeRole::Listener));
         assert_eq!("approver".parse::<NodeRole>(), Ok(NodeRole::Approver));
+    }
+
+    #[test]
+    fn parses_sync_modes() {
+        assert_eq!("fast".parse::<SyncMode>(), Ok(SyncMode::Fast));
+        assert_eq!("slow".parse::<SyncMode>(), Ok(SyncMode::Slow));
+        assert_eq!("archive".parse::<SyncMode>(), Ok(SyncMode::Archive));
     }
 
     #[test]
@@ -106,6 +201,14 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_sync_mode() {
+        assert_eq!(
+            "turbo".parse::<SyncMode>(),
+            Err(ConfigError::InvalidSyncMode("turbo".to_owned()))
+        );
+    }
+
+    #[test]
     fn validates_config_fields() {
         let config = NodeConfig {
             chain_id: "kamn-devnet".to_owned(),
@@ -113,9 +216,34 @@ mod tests {
             role: NodeRole::Processor,
             storage_dir: "/tmp/kamn".to_owned(),
             enable_gossip: true,
+            sync_mode: SyncMode::Fast,
         };
 
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn operational_profile_maps_archive_recovery() {
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: "/tmp/kamn".to_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Archive,
+        };
+
+        let profile = config.operational_profile();
+        assert_eq!(profile.mode, SyncMode::Archive);
+        assert_eq!(
+            profile.startup_strategy,
+            SyncStartupStrategy::ArchiveStateSyncFromGenesis
+        );
+        assert_eq!(
+            profile.recovery_strategy,
+            SyncRecoveryStrategy::ReplayArchivedHistory
+        );
+        assert!(profile.maintain_full_history);
     }
 
     #[test]
@@ -126,6 +254,7 @@ mod tests {
             role: NodeRole::Processor,
             storage_dir: "/tmp/kamn".to_owned(),
             enable_gossip: true,
+            sync_mode: SyncMode::Fast,
         };
 
         assert_eq!(config.validate(), Err(ConfigError::EmptyChainId));

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -48,7 +48,10 @@ pub use channel_policies::{
     ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError, PermissionRule,
     RetentionMessage, RetentionPolicy,
 };
-pub use config::{ConfigError, NodeConfig, NodeRole};
+pub use config::{
+    ConfigError, NodeConfig, NodeRole, SyncMode, SyncOperationalProfile, SyncRecoveryStrategy,
+    SyncStartupStrategy,
+};
 pub use data_classification::{
     ClassificationPolicy, ClassificationStatus, DataClassificationEngine, DataClassificationError,
     DataClassificationLevel, WriteDomain, WriteRequestContext, WriteTag,

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -32,7 +32,7 @@ pub fn build_runtime_wiring(config: &NodeConfig) -> RuntimeWiring {
 #[cfg(test)]
 mod tests {
     use super::build_runtime_wiring;
-    use crate::config::{NodeConfig, NodeRole};
+    use crate::config::{NodeConfig, NodeRole, SyncMode};
 
     fn sample_config(role: NodeRole) -> NodeConfig {
         NodeConfig {
@@ -41,6 +41,7 @@ mod tests {
             role,
             storage_dir: "/tmp/kamn".to_owned(),
             enable_gossip: true,
+            sync_mode: SyncMode::Fast,
         }
     }
 

--- a/crates/kamn-core/tests/role_smoke_network.rs
+++ b/crates/kamn-core/tests/role_smoke_network.rs
@@ -1,5 +1,5 @@
 use kamn_core::{
-    bootstrap, BaselineTransaction, NodeConfig, NodeRole, RoleSmokeNetwork, SmokeError,
+    bootstrap, BaselineTransaction, NodeConfig, NodeRole, RoleSmokeNetwork, SmokeError, SyncMode,
     TransactionGuardError,
 };
 
@@ -10,6 +10,7 @@ fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
         role,
         storage_dir: "/tmp/kamn".to_owned(),
         enable_gossip: gossip_enabled,
+        sync_mode: SyncMode::Fast,
     }
 }
 

--- a/crates/kamn-core/tests/state_migration_bootstrap.rs
+++ b/crates/kamn-core/tests/state_migration_bootstrap.rs
@@ -1,6 +1,6 @@
 use kamn_core::{
     bootstrap, bootstrap_from_state_version, canonical_state_key, ConfigError, MigrationRegistry,
-    MigrationStep, NodeConfig, NodeRole, StateVersion, APP_STATE_VERSION,
+    MigrationStep, NodeConfig, NodeRole, StateVersion, SyncMode, APP_STATE_VERSION,
 };
 
 fn sample_config() -> NodeConfig {
@@ -10,6 +10,7 @@ fn sample_config() -> NodeConfig {
         role: NodeRole::Processor,
         storage_dir: "/tmp/kamn".to_owned(),
         enable_gossip: true,
+        sync_mode: SyncMode::Fast,
     }
 }
 

--- a/crates/kamn-core/tests/sync_mode_profiles.rs
+++ b/crates/kamn-core/tests/sync_mode_profiles.rs
@@ -1,0 +1,65 @@
+use kamn_core::{
+    ConfigError, NodeConfig, NodeRole, SyncMode, SyncOperationalProfile, SyncRecoveryStrategy,
+    SyncStartupStrategy,
+};
+
+#[test]
+fn fast_mode_uses_state_sync_then_block_follow() {
+    let profile = SyncMode::Fast.profile();
+    assert_eq!(
+        profile,
+        SyncOperationalProfile {
+            mode: SyncMode::Fast,
+            startup_strategy: SyncStartupStrategy::StateSyncToLatest,
+            recovery_strategy: SyncRecoveryStrategy::ResumeRecentState,
+            requires_chain_version_match: false,
+            maintain_full_history: false,
+        }
+    );
+}
+
+#[test]
+fn slow_mode_prefers_block_replay_with_version_guard() {
+    let profile = SyncMode::Slow.profile();
+    assert_eq!(
+        profile.startup_strategy,
+        SyncStartupStrategy::BlockReplayFromGenesis
+    );
+    assert_eq!(
+        profile.recovery_strategy,
+        SyncRecoveryStrategy::ReplayMissingBlocks
+    );
+    assert!(profile.requires_chain_version_match);
+    assert!(!profile.maintain_full_history);
+}
+
+#[test]
+fn integration_node_config_exposes_archive_sync_profile() {
+    let config = NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role: NodeRole::Processor,
+        storage_dir: "./data".to_owned(),
+        enable_gossip: true,
+        sync_mode: SyncMode::Archive,
+    };
+
+    config.validate().expect("config should validate");
+
+    let profile = config.operational_profile();
+    assert_eq!(profile.mode, SyncMode::Archive);
+    assert_eq!(
+        profile.recovery_strategy,
+        SyncRecoveryStrategy::ReplayArchivedHistory
+    );
+    assert!(profile.maintain_full_history);
+}
+
+#[test]
+fn regression_invalid_sync_mode_string_is_rejected() {
+    // Regression: #209
+    assert_eq!(
+        "turbo".parse::<SyncMode>(),
+        Err(ConfigError::InvalidSyncMode("turbo".to_owned()))
+    );
+}

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process::ExitCode;
 
-use kamn_core::{bootstrap, ConfigError, NodeConfig, NodeRole};
+use kamn_core::{bootstrap, ConfigError, NodeConfig, NodeRole, SyncMode};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NodeCli {
@@ -10,6 +10,7 @@ struct NodeCli {
     chain_version: String,
     storage_dir: String,
     enable_gossip: bool,
+    sync_mode: SyncMode,
 }
 
 fn parse_args<I>(args: I) -> Result<NodeCli, ConfigError>
@@ -21,6 +22,7 @@ where
     let mut chain_version = String::from("v0.1.0");
     let mut storage_dir = String::from("./data");
     let mut enable_gossip = true;
+    let mut sync_mode = SyncMode::Fast;
 
     let mut iter = args.into_iter();
     let _bin = iter.next();
@@ -51,6 +53,12 @@ where
             "--disable-gossip" => {
                 enable_gossip = false;
             }
+            "--sync-mode" => {
+                let value = iter
+                    .next()
+                    .ok_or(ConfigError::MissingArgumentValue("--sync-mode"))?;
+                sync_mode = value.parse::<SyncMode>()?;
+            }
             unknown => {
                 return Err(ConfigError::UnknownArgument(unknown.to_owned()));
             }
@@ -65,6 +73,7 @@ where
         chain_version,
         storage_dir,
         enable_gossip,
+        sync_mode,
     })
 }
 
@@ -77,12 +86,14 @@ fn run() -> Result<(), ConfigError> {
         role: cli.role,
         storage_dir: cli.storage_dir,
         enable_gossip: cli.enable_gossip,
+        sync_mode: cli.sync_mode,
     };
 
     let plan = bootstrap(config)?;
+    let profile = plan.config.operational_profile();
 
     println!(
-        "KAMN node bootstrap\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  state_version: {}\n  pending_migrations: {}\n  components: {}",
+        "KAMN node bootstrap\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  sync_mode: {}\n  sync_startup: {:?}\n  sync_recovery: {:?}\n  state_version: {}\n  pending_migrations: {}\n  components: {}",
         plan.config.role.as_str(),
         plan.config.chain_id,
         plan.config.chain_version,
@@ -92,6 +103,9 @@ fn run() -> Result<(), ConfigError> {
         } else {
             "disabled"
         },
+        plan.config.sync_mode.as_str(),
+        profile.startup_strategy,
+        profile.recovery_strategy,
         plan.state_schema.version.0,
         plan.migration_plan.steps.len(),
         plan.wiring.all_components().join(", ")
@@ -113,7 +127,7 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::parse_args;
-    use kamn_core::{ConfigError, NodeRole};
+    use kamn_core::{ConfigError, NodeRole, SyncMode};
 
     #[test]
     fn parses_required_role_and_defaults() {
@@ -129,6 +143,7 @@ mod tests {
         assert_eq!(parsed.chain_version, "v0.1.0");
         assert_eq!(parsed.storage_dir, "./data");
         assert!(parsed.enable_gossip);
+        assert_eq!(parsed.sync_mode, SyncMode::Fast);
     }
 
     #[test]
@@ -143,6 +158,21 @@ mod tests {
         let parsed = parse_args(args).expect("args should parse");
         assert_eq!(parsed.role, NodeRole::Listener);
         assert!(!parsed.enable_gossip);
+        assert_eq!(parsed.sync_mode, SyncMode::Fast);
+    }
+
+    #[test]
+    fn parses_sync_mode_flag() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--sync-mode".to_owned(),
+            "archive".to_owned(),
+        ];
+
+        let parsed = parse_args(args).expect("args should parse");
+        assert_eq!(parsed.sync_mode, SyncMode::Archive);
     }
 
     #[test]

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -70,3 +70,4 @@ For compliance audit export interface controls, see `docs/foundation/audit-expor
 For configurable retention policy enforcement controls, see `docs/foundation/retention-policy-engine.md`.
 For data classification tiers and write-path tagging enforcement controls, see `docs/foundation/data-classification-tagging.md`.
 For optional operator binding proof validation and configure/revoke/read-history permission controls, see `docs/foundation/operator-binding-permissions.md`.
+For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.

--- a/docs/foundation/sync-mode-profiles.md
+++ b/docs/foundation/sync-mode-profiles.md
@@ -1,0 +1,50 @@
+# Sync-Mode Operational Profiles (Issues #208, #209)
+
+This document captures the first implementation slice for startup sync profiles and recovery behavior selection.
+
+## Scope Delivered
+- Added sync profile primitives in `crates/kamn-core/src/config.rs`:
+  - `SyncMode`: `fast`, `slow`, `archive`
+  - `SyncStartupStrategy` and `SyncRecoveryStrategy`
+  - `SyncOperationalProfile` mapping from `SyncMode::profile()`
+- Extended `NodeConfig` with `sync_mode` and `operational_profile()`.
+- Added CLI wiring in `crates/kamn-node/src/main.rs`:
+  - new flag: `--sync-mode <fast|slow|archive>`
+  - default: `fast`
+- Added integration tests in `crates/kamn-core/tests/sync_mode_profiles.rs`.
+
+## Profile Semantics
+- `fast`:
+  - Startup: state-sync to latest known state.
+  - Recovery: resume from recent state and continue.
+  - Version guard: relaxed.
+  - History: does not require full chain history.
+- `slow`:
+  - Startup: block replay from genesis.
+  - Recovery: replay missing blocks.
+  - Version guard: strict chain/code version alignment required.
+  - History: no archive guarantee.
+- `archive`:
+  - Startup: archive-oriented state sync from genesis horizon.
+  - Recovery: replay archived history.
+  - Version guard: relaxed.
+  - History: full history retention expected.
+
+## Kolme Alignment Reference
+The profile split follows Kolme sync-manager concepts:
+- block sync mode
+- state sync mode
+- archive mode
+
+KAMN names this first slice as `slow`, `fast`, and `archive` to keep operator-facing semantics direct.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test sync_mode_profiles
+cargo test -p kamn-node
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first sync-mode operational profile slice by adding explicit `fast`, `slow`, and `archive` configuration semantics and wiring them into core config and node CLI startup options. This delivers deterministic profile/recovery behavior and docs with strict Red→Green evidence.

Closes #208
Closes #209

## Changes
- `crates/kamn-core/src/config.rs`: added `SyncMode`, `SyncStartupStrategy`, `SyncRecoveryStrategy`, `SyncOperationalProfile`, `NodeConfig.sync_mode`, `NodeConfig::operational_profile()`, and `ConfigError::InvalidSyncMode`.
- `crates/kamn-core/tests/sync_mode_profiles.rs`: added functional/integration/regression tests for sync profile mapping and invalid sync mode guard.
- `crates/kamn-node/src/main.rs`: added `--sync-mode <fast|slow|archive>` parsing and default `fast` wiring to `NodeConfig`.
- `crates/kamn-core/src/bootstrap.rs`, `crates/kamn-core/src/runtime.rs`, `crates/kamn-core/tests/role_smoke_network.rs`, `crates/kamn-core/tests/state_migration_bootstrap.rs`: updated `NodeConfig` fixtures to include `sync_mode`.
- `docs/foundation/sync-mode-profiles.md`: documented profile semantics and Kolme alignment.
- `docs/foundation/bootstrap.md`: linked sync profile doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ cargo test -p kamn-core --test sync_mode_profiles
error[E0432]: unresolved imports `SyncMode`, `SyncOperationalProfile`, `SyncRecoveryStrategy`, `SyncStartupStrategy`
error[E0560]: struct `NodeConfig` has no field named `sync_mode`
error[E0599]: no method named `operational_profile` found for struct `NodeConfig`
error[E0599]: no variant `ConfigError::InvalidSyncMode`
```

### 🟢 Green Phase
```bash
$ cargo test -p kamn-core --test sync_mode_profiles
running 4 tests
... all passed ...
test result: ok. 4 passed; 0 failed

$ cargo test -p kamn-node
running 5 tests
... all passed ...
test result: ok. 5 passed; 0 failed
```

### 🔁 Regression
```bash
$ cargo fmt --check
$ cargo clippy -- -D warnings
$ cargo test -p kamn-core
$ cargo test -p kamn-node
```
All commands passed locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `config` module tests for sync mode parsing + profile mapping | |
| Functional   | ✅     | `fast_mode_uses_state_sync_then_block_follow`, `slow_mode_prefers_block_replay_with_version_guard` | |
| Integration  | ✅     | `integration_node_config_exposes_archive_sync_profile`, `kamn-node` CLI `parses_sync_mode_flag` | |
| Regression   | ✅     | `regression_invalid_sync_mode_string_is_rejected` (`// Regression: #209`) | |
| Performance  | N/A    | None | No throughput-sensitive execution path introduced in this slice. |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to remove sync-mode fields/CLI/docs in one change.

## Documentation Updates
- `docs/foundation/sync-mode-profiles.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
