### PR TITLE
feat(channels): implement specialized channel type slice (#228 #229)

### DIFF
--- a/crates/kamn-core/src/channel_models.rs
+++ b/crates/kamn-core/src/channel_models.rs
@@ -6,11 +6,26 @@ use std::fmt;
 pub enum ChannelType {
     Direct,
     Group,
+    Broadcast,
+    Task,
+    Marketplace,
+    Governance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelMetadata {
+    Direct,
+    Group,
+    Broadcast { topic: String },
+    Task { task_id: String },
+    Marketplace { market_scope: String },
+    Governance { proposal_scope: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ChannelRecord {
     channel_type: ChannelType,
+    metadata: ChannelMetadata,
     members: BTreeSet<String>,
     admins: BTreeSet<String>,
 }
@@ -42,7 +57,13 @@ impl ChannelStore {
 
         let members = BTreeSet::from([participant_a.to_owned(), participant_b.to_owned()]);
         let admins = members.clone();
-        self.insert_channel(channel_id, ChannelType::Direct, members, admins);
+        self.insert_channel(
+            channel_id,
+            ChannelType::Direct,
+            ChannelMetadata::Direct,
+            members,
+            admins,
+        );
         Ok(())
     }
 
@@ -87,7 +108,119 @@ impl ChannelStore {
             });
         }
 
-        self.insert_channel(channel_id, ChannelType::Group, member_set, admin_set);
+        self.insert_channel(
+            channel_id,
+            ChannelType::Group,
+            ChannelMetadata::Group,
+            member_set,
+            admin_set,
+        );
+        Ok(())
+    }
+
+    pub fn create_broadcast(
+        &mut self,
+        channel_id: &str,
+        creator: &str,
+        topic: &str,
+        members: Vec<String>,
+        admins: Vec<String>,
+    ) -> Result<(), ChannelModelError> {
+        self.create_specialized_channel(
+            channel_id,
+            creator,
+            ChannelType::Broadcast,
+            ChannelMetadata::Broadcast {
+                topic: topic.to_owned(),
+            },
+            members,
+            admins,
+        )
+    }
+
+    pub fn create_task_channel(
+        &mut self,
+        channel_id: &str,
+        creator: &str,
+        task_id: &str,
+        members: Vec<String>,
+        admins: Vec<String>,
+    ) -> Result<(), ChannelModelError> {
+        self.create_specialized_channel(
+            channel_id,
+            creator,
+            ChannelType::Task,
+            ChannelMetadata::Task {
+                task_id: task_id.to_owned(),
+            },
+            members,
+            admins,
+        )
+    }
+
+    pub fn create_marketplace_channel(
+        &mut self,
+        channel_id: &str,
+        creator: &str,
+        market_scope: &str,
+        members: Vec<String>,
+        admins: Vec<String>,
+    ) -> Result<(), ChannelModelError> {
+        self.create_specialized_channel(
+            channel_id,
+            creator,
+            ChannelType::Marketplace,
+            ChannelMetadata::Marketplace {
+                market_scope: market_scope.to_owned(),
+            },
+            members,
+            admins,
+        )
+    }
+
+    pub fn create_governance_channel(
+        &mut self,
+        channel_id: &str,
+        creator: &str,
+        proposal_scope: &str,
+        members: Vec<String>,
+        admins: Vec<String>,
+    ) -> Result<(), ChannelModelError> {
+        self.create_specialized_channel(
+            channel_id,
+            creator,
+            ChannelType::Governance,
+            ChannelMetadata::Governance {
+                proposal_scope: proposal_scope.to_owned(),
+            },
+            members,
+            admins,
+        )
+    }
+
+    fn create_specialized_channel(
+        &mut self,
+        channel_id: &str,
+        creator: &str,
+        channel_type: ChannelType,
+        metadata: ChannelMetadata,
+        members: Vec<String>,
+        admins: Vec<String>,
+    ) -> Result<(), ChannelModelError> {
+        validate_metadata(&metadata)?;
+        self.create_group(channel_id, creator, members, admins)?;
+        let member_count = self
+            .channels
+            .get(channel_id)
+            .map(|record| record.members.len())
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        enforce_specialized_member_requirements(channel_type, member_count)?;
+        let record = self
+            .channels
+            .get_mut(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        record.channel_type = channel_type;
+        record.metadata = metadata;
         Ok(())
     }
 
@@ -127,6 +260,14 @@ impl ChannelStore {
             .get(channel_id)
             .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
         Ok(record.members.contains(member))
+    }
+
+    pub fn metadata(&self, channel_id: &str) -> Result<ChannelMetadata, ChannelModelError> {
+        let record = self
+            .channels
+            .get(channel_id)
+            .ok_or_else(|| ChannelModelError::NotFound(channel_id.to_owned()))?;
+        Ok(record.metadata.clone())
     }
 
     pub fn invite_member(
@@ -276,6 +417,7 @@ impl ChannelStore {
         &mut self,
         channel_id: &str,
         channel_type: ChannelType,
+        metadata: ChannelMetadata,
         members: BTreeSet<String>,
         admins: BTreeSet<String>,
     ) {
@@ -283,6 +425,7 @@ impl ChannelStore {
             channel_id.to_owned(),
             ChannelRecord {
                 channel_type,
+                metadata,
                 members: members.clone(),
                 admins,
             },
@@ -304,6 +447,12 @@ pub enum ChannelModelError {
     InvalidDirectParticipants,
     EmptyMembers,
     EmptyAdmins,
+    InvalidMetadata(String),
+    InsufficientMembers {
+        channel_type: ChannelType,
+        minimum: usize,
+        actual: usize,
+    },
     CreatorNotMember(String),
     AdminNotMember(String),
     UnauthorizedActor {
@@ -332,6 +481,15 @@ impl fmt::Display for ChannelModelError {
             }
             Self::EmptyMembers => write!(f, "group channel members must not be empty"),
             Self::EmptyAdmins => write!(f, "group channel admins must not be empty"),
+            Self::InvalidMetadata(value) => write!(f, "invalid channel metadata: {value}"),
+            Self::InsufficientMembers {
+                channel_type,
+                minimum,
+                actual,
+            } => write!(
+                f,
+                "channel type {channel_type:?} requires at least {minimum} members, found {actual}"
+            ),
             Self::CreatorNotMember(value) => write!(f, "creator must be a member: {value}"),
             Self::AdminNotMember(value) => write!(f, "admin must be a member: {value}"),
             Self::UnauthorizedActor { actor, required } => {
@@ -367,9 +525,50 @@ fn validate_did(value: &str) -> Result<(), ChannelModelError> {
     Ok(())
 }
 
+fn validate_metadata(metadata: &ChannelMetadata) -> Result<(), ChannelModelError> {
+    let invalid = match metadata {
+        ChannelMetadata::Broadcast { topic } if topic.trim().is_empty() => Some("topic"),
+        ChannelMetadata::Task { task_id } if task_id.trim().is_empty() => Some("task_id"),
+        ChannelMetadata::Marketplace { market_scope } if market_scope.trim().is_empty() => {
+            Some("market_scope")
+        }
+        ChannelMetadata::Governance { proposal_scope } if proposal_scope.trim().is_empty() => {
+            Some("proposal_scope")
+        }
+        _ => None,
+    };
+
+    if let Some(field) = invalid {
+        return Err(ChannelModelError::InvalidMetadata(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn enforce_specialized_member_requirements(
+    channel_type: ChannelType,
+    actual: usize,
+) -> Result<(), ChannelModelError> {
+    let minimum = match channel_type {
+        ChannelType::Task | ChannelType::Marketplace => 2,
+        ChannelType::Governance => 3,
+        _ => 1,
+    };
+
+    if actual < minimum {
+        return Err(ChannelModelError::InsufficientMembers {
+            channel_type,
+            minimum,
+            actual,
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ChannelModelError, ChannelStore};
+    use super::{ChannelMetadata, ChannelModelError, ChannelStore, ChannelType};
 
     #[test]
     fn group_creator_must_be_member() {
@@ -397,6 +596,64 @@ mod tests {
                 "kamn:did:agent:alice",
             ),
             Err(ChannelModelError::InvalidDirectParticipants)
+        );
+    }
+
+    #[test]
+    fn governance_channels_require_three_members() {
+        let mut store = ChannelStore::new();
+        assert_eq!(
+            store.create_governance_channel(
+                "channel:gov:1",
+                "kamn:did:agent:owner",
+                "core-protocol",
+                vec![
+                    "kamn:did:agent:owner".to_owned(),
+                    "kamn:did:agent:validator-1".to_owned(),
+                ],
+                vec!["kamn:did:agent:owner".to_owned()],
+            ),
+            Err(ChannelModelError::InsufficientMembers {
+                channel_type: ChannelType::Governance,
+                minimum: 3,
+                actual: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn broadcast_metadata_requires_non_empty_topic() {
+        let mut store = ChannelStore::new();
+        assert_eq!(
+            store.create_broadcast(
+                "channel:broadcast:1",
+                "kamn:did:agent:owner",
+                "",
+                vec!["kamn:did:agent:owner".to_owned()],
+                vec!["kamn:did:agent:owner".to_owned()],
+            ),
+            Err(ChannelModelError::InvalidMetadata(
+                "topic must not be empty".to_owned()
+            ))
+        );
+
+        store
+            .create_broadcast(
+                "channel:broadcast:2",
+                "kamn:did:agent:owner",
+                "announcements",
+                vec!["kamn:did:agent:owner".to_owned()],
+                vec!["kamn:did:agent:owner".to_owned()],
+            )
+            .expect("broadcast should be created");
+
+        assert_eq!(
+            store
+                .metadata("channel:broadcast:2")
+                .expect("metadata should resolve"),
+            ChannelMetadata::Broadcast {
+                topic: "announcements".to_owned(),
+            }
         );
     }
 }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -43,7 +43,7 @@ pub use bridge_adapter::{
     BridgeInboundEnvelope, BridgeOutboundEnvelope, BridgeOutboundRequest, BridgePlatform,
     BridgePolicyHook, NormalizedInboundMessage, PassThroughBridgeAdapter,
 };
-pub use channel_models::{ChannelModelError, ChannelStore, ChannelType};
+pub use channel_models::{ChannelMetadata, ChannelModelError, ChannelStore, ChannelType};
 pub use channel_policies::{
     ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError, PermissionRule,
     RetentionMessage, RetentionPolicy,

--- a/crates/kamn-core/tests/channel_models.rs
+++ b/crates/kamn-core/tests/channel_models.rs
@@ -1,4 +1,4 @@
-use kamn_core::{ChannelModelError, ChannelStore, ChannelType};
+use kamn_core::{ChannelMetadata, ChannelModelError, ChannelStore, ChannelType};
 
 #[test]
 fn direct_channel_registers_membership_and_admins() {
@@ -153,5 +153,139 @@ fn removing_last_admin_is_rejected() {
         Err(ChannelModelError::LastAdminRemoval(
             "channel:group:3".to_owned()
         ))
+    );
+}
+
+#[test]
+fn broadcast_channel_exposes_topic_metadata() {
+    let mut store = ChannelStore::new();
+    store
+        .create_broadcast(
+            "channel:broadcast:1",
+            "kamn:did:agent:owner",
+            "protocol-updates",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("broadcast channel should be created");
+
+    assert_eq!(
+        store
+            .channel_type("channel:broadcast:1")
+            .expect("type should exist"),
+        ChannelType::Broadcast
+    );
+    assert_eq!(
+        store
+            .metadata("channel:broadcast:1")
+            .expect("metadata should exist"),
+        ChannelMetadata::Broadcast {
+            topic: "protocol-updates".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn specialized_task_and_marketplace_channels_preserve_metadata() {
+    let mut store = ChannelStore::new();
+    store
+        .create_task_channel(
+            "channel:task:1",
+            "kamn:did:agent:owner",
+            "task-42",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:assignee-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("task channel should be created");
+    store
+        .create_marketplace_channel(
+            "channel:market:1",
+            "kamn:did:agent:owner",
+            "service-market-v1",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:buyer-1".to_owned(),
+                "kamn:did:agent:seller-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("marketplace channel should be created");
+
+    assert_eq!(
+        store
+            .metadata("channel:task:1")
+            .expect("metadata should exist"),
+        ChannelMetadata::Task {
+            task_id: "task-42".to_owned(),
+        }
+    );
+    assert_eq!(
+        store
+            .metadata("channel:market:1")
+            .expect("metadata should exist"),
+        ChannelMetadata::Marketplace {
+            market_scope: "service-market-v1".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn integration_governance_channel_requires_quorum_ready_membership() {
+    let mut store = ChannelStore::new();
+    store
+        .create_governance_channel(
+            "channel:gov:1",
+            "kamn:did:agent:owner",
+            "core-protocol",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:validator-1".to_owned(),
+                "kamn:did:agent:validator-2".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        )
+        .expect("governance channel should be created");
+
+    assert_eq!(
+        store
+            .metadata("channel:gov:1")
+            .expect("metadata should exist"),
+        ChannelMetadata::Governance {
+            proposal_scope: "core-protocol".to_owned(),
+        }
+    );
+    assert_eq!(
+        store.channels_for_member("kamn:did:agent:validator-1"),
+        vec!["channel:gov:1".to_owned()]
+    );
+}
+
+#[test]
+fn regression_governance_channel_rejects_under_quorum_membership() {
+    let mut store = ChannelStore::new();
+
+    // Regression: #229
+    assert_eq!(
+        store.create_governance_channel(
+            "channel:gov:2",
+            "kamn:did:agent:owner",
+            "core-protocol",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:validator-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+        ),
+        Err(ChannelModelError::InsufficientMembers {
+            channel_type: ChannelType::Governance,
+            minimum: 3,
+            actual: 2,
+        })
     );
 }

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -56,7 +56,7 @@ For DID register/resolve/update/revoke transaction behavior, see `docs/foundatio
 For canonical message envelope schema and validation controls, see `docs/foundation/message-envelope-schema.md`.
 For message lifecycle state machine and index query controls, see `docs/foundation/message-lifecycle.md`.
 For nonce/TTL/replay enforcement and failed-delivery notice controls, see `docs/foundation/message-delivery-guards.md`.
-For direct/group channel models with membership/admin operations, see `docs/foundation/channel-models.md`.
+For direct/group plus specialized broadcast/task/marketplace/governance channel models, see `docs/foundation/channel-models.md`.
 For channel permission and retention policy controls, see `docs/foundation/channel-permissions-retention.md`.
 For agent key hierarchy role bindings and ephemeral session key controls, see `docs/foundation/agent-key-hierarchy.md`.
 For direct-message encryption path controls, see `docs/foundation/direct-message-encryption.md`.

--- a/docs/foundation/channel-models.md
+++ b/docs/foundation/channel-models.md
@@ -1,12 +1,23 @@
-# Direct and Group Channel Models (Issue #118)
+# Channel Models (Issues #118, #228, #229)
 
-This document defines the first implementation slice for direct/group channel
-models with membership and admin operations.
+This document defines the implemented channel model slices for direct/group
+channels and specialized broadcast/task/marketplace/governance channels.
 
 ## Core Models
 - `ChannelType`:
   - `Direct`
   - `Group`
+  - `Broadcast`
+  - `Task`
+  - `Marketplace`
+  - `Governance`
+- `ChannelMetadata`:
+  - `Direct`
+  - `Group`
+  - `Broadcast { topic }`
+  - `Task { task_id }`
+  - `Marketplace { market_scope }`
+  - `Governance { proposal_scope }`
 - `ChannelStore`: in-memory channel registry with deterministic member-to-channel indexing.
 
 ## Supported Operations
@@ -17,6 +28,17 @@ models with membership and admin operations.
   - requires non-empty members/admins.
   - creator must be both member and admin.
   - admins must be a subset of members.
+- `create_broadcast(channel_id, creator, topic, members, admins)`
+  - validates non-empty `topic`.
+- `create_task_channel(channel_id, creator, task_id, members, admins)`
+  - validates non-empty `task_id`.
+  - requires at least 2 members.
+- `create_marketplace_channel(channel_id, creator, market_scope, members, admins)`
+  - validates non-empty `market_scope`.
+  - requires at least 2 members.
+- `create_governance_channel(channel_id, creator, proposal_scope, members, admins)`
+  - validates non-empty `proposal_scope`.
+  - requires at least 3 members.
 - `invite_member(channel_id, actor, new_member)`
   - actor must be admin (group channel only).
 - `remove_member(channel_id, actor, member)`
@@ -27,6 +49,7 @@ models with membership and admin operations.
   - removing the last admin is blocked.
 - Query APIs:
   - `channel_type(channel_id)`
+  - `metadata(channel_id)`
   - `members(channel_id)`
   - `admins(channel_id)`
   - `is_member(channel_id, did)`
@@ -37,6 +60,7 @@ models with membership and admin operations.
 - DIDs must parse as `kamn:did:agent:*`.
 - Non-admin actors cannot mutate group membership/admin state.
 - Direct channels reject unsupported group-style mutations.
+- Specialized channels enforce typed metadata and per-type minimum member thresholds.
 
 ## Local Validation
 Run from repository root:


### PR DESCRIPTION
## Summary
Implements the first specialized-channel slice by extending channel models with `broadcast`, `task`, `marketplace`, and `governance` types, typed metadata, and deterministic per-type member requirements. This lands a focused API/data-model increment with strict Red→Green evidence and updated docs.

Closes #228
Closes #229

## Changes
- `crates/kamn-core/src/channel_models.rs`:
  - Added `ChannelType` variants: `Broadcast`, `Task`, `Marketplace`, `Governance`.
  - Added `ChannelMetadata` and metadata retrieval API (`metadata(channel_id)`).
  - Added specialized creation APIs:
    - `create_broadcast(...)`
    - `create_task_channel(...)`
    - `create_marketplace_channel(...)`
    - `create_governance_channel(...)`
  - Added typed validation errors for metadata and minimum members.
  - Added unit tests for governance minimum-members and broadcast metadata validation.
- `crates/kamn-core/tests/channel_models.rs`:
  - Added functional/integration/regression coverage for specialized channels and governance quorum guard.
- `crates/kamn-core/src/lib.rs`: exported `ChannelMetadata`.
- `docs/foundation/channel-models.md`: documented specialized channel models and constraints.
- `docs/foundation/bootstrap.md`: updated foundation index wording for channel model scope.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ cargo test -p kamn-core --test channel_models
error[E0432]: unresolved import `kamn_core::ChannelMetadata`
error[E0599]: no method named `create_broadcast` found for `ChannelStore`
error[E0599]: no variant `ChannelType::Broadcast`
error[E0599]: no method named `metadata` found for `ChannelStore`
error[E0599]: no method named `create_task_channel` found for `ChannelStore`
error[E0599]: no method named `create_marketplace_channel` found for `ChannelStore`
error[E0599]: no method named `create_governance_channel` found for `ChannelStore`
error[E0599]: no variant `ChannelModelError::InsufficientMembers`
```

### 🟢 Green Phase
```bash
$ cargo test -p kamn-core --test channel_models
running 9 tests
... all passed ...
test result: ok. 9 passed; 0 failed
```

### 🔁 Regression
```bash
$ cargo fmt --check
$ cargo clippy -- -D warnings
$ cargo test -p kamn-core --test channel_models
$ cargo test -p kamn-core
```
All commands passed locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `channel_models` module tests: governance minimum-member rule and broadcast metadata validation | |
| Functional   | ✅     | `broadcast_channel_exposes_topic_metadata`, `specialized_task_and_marketplace_channels_preserve_metadata` | |
| Integration  | ✅     | `integration_governance_channel_requires_quorum_ready_membership` | |
| Regression   | ✅     | `regression_governance_channel_rejects_under_quorum_membership` (`// Regression: #229`) | |
| Performance  | N/A    | None | No new throughput-sensitive path introduced in this slice. |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to return to direct/group-only channel model behavior.

## Documentation Updates
- `docs/foundation/channel-models.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
