### PR TITLE
feat(tasks): implement artifact provenance slice (#224 #225)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod retention_engine;
 pub mod runtime;
 pub mod smoke;
 pub mod state;
+pub mod task_artifacts;
 pub mod task_lifecycle;
 pub mod task_operations;
 pub mod token;
@@ -111,6 +112,9 @@ pub use runtime::RuntimeWiring;
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
+};
+pub use task_artifacts::{
+    TaskArtifactError, TaskArtifactRecord, TaskArtifactRegistry, TaskArtifactSubmission,
 };
 pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 pub use task_operations::{

--- a/crates/kamn-core/src/task_artifacts.rs
+++ b/crates/kamn-core/src/task_artifacts.rs
@@ -1,0 +1,230 @@
+use crate::AgentDid;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskArtifactRecord {
+    pub artifact_id: String,
+    pub task_id: String,
+    pub creator: String,
+    pub created_at_unix: u64,
+    pub on_chain_hash: String,
+    pub off_chain_uri: String,
+    pub content_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskArtifactSubmission {
+    pub artifact_id: String,
+    pub task_id: String,
+    pub creator: String,
+    pub created_at_unix: u64,
+    pub on_chain_hash: String,
+    pub off_chain_uri: String,
+    pub content_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TaskArtifactRegistry {
+    artifacts: BTreeMap<String, TaskArtifactRecord>,
+    artifacts_by_task: BTreeMap<String, BTreeSet<String>>,
+    artifacts_by_creator: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl TaskArtifactRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn integrity_fingerprint(task_id: &str, creator: &str, off_chain_uri: &str) -> String {
+        let canonical = format!("{task_id}|{creator}|{off_chain_uri}");
+        fnv1a_hex(&canonical)
+    }
+
+    pub fn register(
+        &mut self,
+        submission: TaskArtifactSubmission,
+    ) -> Result<(), TaskArtifactError> {
+        validate_non_empty("artifact_id", &submission.artifact_id)?;
+        validate_non_empty("task_id", &submission.task_id)?;
+        validate_did(&submission.creator)?;
+        if submission.created_at_unix == 0 {
+            return Err(TaskArtifactError::EmptyField("created_at_unix"));
+        }
+        validate_non_empty("on_chain_hash", &submission.on_chain_hash)?;
+        validate_non_empty("off_chain_uri", &submission.off_chain_uri)?;
+        validate_non_empty("content_type", &submission.content_type)?;
+
+        if self.artifacts.contains_key(&submission.artifact_id) {
+            return Err(TaskArtifactError::DuplicateArtifactId(
+                submission.artifact_id.clone(),
+            ));
+        }
+
+        let expected = Self::integrity_fingerprint(
+            &submission.task_id,
+            &submission.creator,
+            &submission.off_chain_uri,
+        );
+        if submission.on_chain_hash != expected {
+            return Err(TaskArtifactError::IntegrityMismatch {
+                expected,
+                provided: submission.on_chain_hash.clone(),
+            });
+        }
+
+        let record = TaskArtifactRecord {
+            artifact_id: submission.artifact_id.clone(),
+            task_id: submission.task_id.clone(),
+            creator: submission.creator.clone(),
+            created_at_unix: submission.created_at_unix,
+            on_chain_hash: submission.on_chain_hash.clone(),
+            off_chain_uri: submission.off_chain_uri.clone(),
+            content_type: submission.content_type.clone(),
+        };
+
+        self.artifacts
+            .insert(submission.artifact_id.clone(), record);
+        self.artifacts_by_task
+            .entry(submission.task_id)
+            .or_default()
+            .insert(submission.artifact_id.clone());
+        self.artifacts_by_creator
+            .entry(submission.creator)
+            .or_default()
+            .insert(submission.artifact_id);
+        Ok(())
+    }
+
+    pub fn artifact(&self, artifact_id: &str) -> Result<&TaskArtifactRecord, TaskArtifactError> {
+        self.artifacts
+            .get(artifact_id)
+            .ok_or_else(|| TaskArtifactError::NotFound(artifact_id.to_owned()))
+    }
+
+    pub fn artifacts_for_task(&self, task_id: &str) -> Vec<String> {
+        self.artifacts_by_task
+            .get(task_id)
+            .map(|values| values.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn artifacts_for_creator(&self, creator: &str) -> Vec<String> {
+        self.artifacts_by_creator
+            .get(creator)
+            .map(|values| values.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskArtifactError {
+    EmptyField(&'static str),
+    InvalidDid(String),
+    DuplicateArtifactId(String),
+    IntegrityMismatch { expected: String, provided: String },
+    NotFound(String),
+}
+
+impl fmt::Display for TaskArtifactError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::DuplicateArtifactId(value) => write!(f, "duplicate artifact id: {value}"),
+            Self::IntegrityMismatch { expected, provided } => {
+                write!(
+                    f,
+                    "artifact integrity mismatch, expected {expected}, got {provided}"
+                )
+            }
+            Self::NotFound(value) => write!(f, "artifact not found: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for TaskArtifactError {}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), TaskArtifactError> {
+    if value.trim().is_empty() {
+        return Err(TaskArtifactError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), TaskArtifactError> {
+    AgentDid::parse(value).map_err(|error| TaskArtifactError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn fnv1a_hex(value: &str) -> String {
+    let mut acc: u64 = 0xcbf29ce484222325;
+    for byte in value.bytes() {
+        acc = acc.wrapping_mul(0x00000100000001B3);
+        acc ^= u64::from(byte);
+    }
+    format!("{acc:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TaskArtifactError, TaskArtifactRegistry, TaskArtifactSubmission};
+
+    #[test]
+    fn integrity_fingerprint_is_deterministic() {
+        let first = TaskArtifactRegistry::integrity_fingerprint(
+            "task-1",
+            "kamn:did:agent:builder-1",
+            "ipfs://artifact",
+        );
+        let second = TaskArtifactRegistry::integrity_fingerprint(
+            "task-1",
+            "kamn:did:agent:builder-1",
+            "ipfs://artifact",
+        );
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn register_rejects_invalid_did() {
+        let mut registry = TaskArtifactRegistry::new();
+        let hash = TaskArtifactRegistry::integrity_fingerprint("task-1", "bad-did", "uri");
+        assert_eq!(
+            registry.register(TaskArtifactSubmission {
+                artifact_id: "artifact-1".to_owned(),
+                task_id: "task-1".to_owned(),
+                creator: "bad-did".to_owned(),
+                created_at_unix: 1,
+                on_chain_hash: hash,
+                off_chain_uri: "uri".to_owned(),
+                content_type: "application/json".to_owned(),
+            }),
+            Err(TaskArtifactError::InvalidDid(
+                "invalid agent did prefix: bad-did".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn register_rejects_zero_timestamp() {
+        let mut registry = TaskArtifactRegistry::new();
+        let hash = TaskArtifactRegistry::integrity_fingerprint(
+            "task-1",
+            "kamn:did:agent:builder-1",
+            "uri",
+        );
+        assert_eq!(
+            registry.register(TaskArtifactSubmission {
+                artifact_id: "artifact-1".to_owned(),
+                task_id: "task-1".to_owned(),
+                creator: "kamn:did:agent:builder-1".to_owned(),
+                created_at_unix: 0,
+                on_chain_hash: hash,
+                off_chain_uri: "uri".to_owned(),
+                content_type: "application/json".to_owned(),
+            }),
+            Err(TaskArtifactError::EmptyField("created_at_unix"))
+        );
+    }
+}

--- a/crates/kamn-core/tests/task_artifacts.rs
+++ b/crates/kamn-core/tests/task_artifacts.rs
@@ -1,0 +1,152 @@
+use kamn_core::{
+    TaskArtifactError, TaskArtifactRecord, TaskArtifactRegistry, TaskArtifactSubmission,
+};
+
+#[test]
+fn register_artifact_persists_integrity_and_provenance() {
+    let mut registry = TaskArtifactRegistry::new();
+    let hash = TaskArtifactRegistry::integrity_fingerprint(
+        "task-1",
+        "kamn:did:agent:builder-1",
+        "ipfs://bafy-artifact-1",
+    );
+
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-1".to_owned(),
+            task_id: "task-1".to_owned(),
+            creator: "kamn:did:agent:builder-1".to_owned(),
+            created_at_unix: 1_738_000_000,
+            on_chain_hash: hash.clone(),
+            off_chain_uri: "ipfs://bafy-artifact-1".to_owned(),
+            content_type: "application/json".to_owned(),
+        })
+        .expect("artifact should register");
+
+    assert_eq!(
+        registry
+            .artifact("artifact-1")
+            .expect("artifact should exist"),
+        &TaskArtifactRecord {
+            artifact_id: "artifact-1".to_owned(),
+            task_id: "task-1".to_owned(),
+            creator: "kamn:did:agent:builder-1".to_owned(),
+            created_at_unix: 1_738_000_000,
+            on_chain_hash: hash,
+            off_chain_uri: "ipfs://bafy-artifact-1".to_owned(),
+            content_type: "application/json".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn duplicate_artifact_id_is_rejected() {
+    let mut registry = TaskArtifactRegistry::new();
+    let hash = TaskArtifactRegistry::integrity_fingerprint(
+        "task-2",
+        "kamn:did:agent:builder-2",
+        "https://example.com/artifacts/2",
+    );
+
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-2".to_owned(),
+            task_id: "task-2".to_owned(),
+            creator: "kamn:did:agent:builder-2".to_owned(),
+            created_at_unix: 1_738_000_010,
+            on_chain_hash: hash.clone(),
+            off_chain_uri: "https://example.com/artifacts/2".to_owned(),
+            content_type: "text/plain".to_owned(),
+        })
+        .expect("artifact should register");
+
+    assert_eq!(
+        registry.register(TaskArtifactSubmission {
+            artifact_id: "artifact-2".to_owned(),
+            task_id: "task-2".to_owned(),
+            creator: "kamn:did:agent:builder-2".to_owned(),
+            created_at_unix: 1_738_000_011,
+            on_chain_hash: hash,
+            off_chain_uri: "https://example.com/artifacts/2".to_owned(),
+            content_type: "text/plain".to_owned(),
+        }),
+        Err(TaskArtifactError::DuplicateArtifactId(
+            "artifact-2".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn integration_indexes_by_task_and_creator() {
+    let mut registry = TaskArtifactRegistry::new();
+
+    let hash_a = TaskArtifactRegistry::integrity_fingerprint(
+        "task-3",
+        "kamn:did:agent:creator-a",
+        "https://example.com/a",
+    );
+    let hash_b = TaskArtifactRegistry::integrity_fingerprint(
+        "task-3",
+        "kamn:did:agent:creator-b",
+        "https://example.com/b",
+    );
+
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-a".to_owned(),
+            task_id: "task-3".to_owned(),
+            creator: "kamn:did:agent:creator-a".to_owned(),
+            created_at_unix: 1_738_000_020,
+            on_chain_hash: hash_a,
+            off_chain_uri: "https://example.com/a".to_owned(),
+            content_type: "application/pdf".to_owned(),
+        })
+        .expect("artifact a should register");
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-b".to_owned(),
+            task_id: "task-3".to_owned(),
+            creator: "kamn:did:agent:creator-b".to_owned(),
+            created_at_unix: 1_738_000_021,
+            on_chain_hash: hash_b,
+            off_chain_uri: "https://example.com/b".to_owned(),
+            content_type: "application/pdf".to_owned(),
+        })
+        .expect("artifact b should register");
+
+    assert_eq!(
+        registry.artifacts_for_task("task-3"),
+        vec!["artifact-a".to_owned(), "artifact-b".to_owned()]
+    );
+    assert_eq!(
+        registry.artifacts_for_creator("kamn:did:agent:creator-b"),
+        vec!["artifact-b".to_owned()]
+    );
+}
+
+#[test]
+fn regression_tampered_integrity_hash_is_rejected() {
+    let mut registry = TaskArtifactRegistry::new();
+    let expected = TaskArtifactRegistry::integrity_fingerprint(
+        "task-4",
+        "kamn:did:agent:builder-4",
+        "ipfs://bafy-artifact-4",
+    );
+
+    // Regression: #225
+    assert_eq!(
+        registry.register(TaskArtifactSubmission {
+            artifact_id: "artifact-4".to_owned(),
+            task_id: "task-4".to_owned(),
+            creator: "kamn:did:agent:builder-4".to_owned(),
+            created_at_unix: 1_738_000_030,
+            on_chain_hash: "deadbeef".to_owned(),
+            off_chain_uri: "ipfs://bafy-artifact-4".to_owned(),
+            content_type: "application/octet-stream".to_owned(),
+        }),
+        Err(TaskArtifactError::IntegrityMismatch {
+            expected,
+            provided: "deadbeef".to_owned(),
+        })
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -63,6 +63,7 @@ For direct-message encryption path controls, see `docs/foundation/direct-message
 For group sender-key distribution and rotation controls, see `docs/foundation/group-sender-key-rotation.md`.
 For task state machine and legal transition validation controls, see `docs/foundation/task-state-machine.md`.
 For task operation command handling controls, see `docs/foundation/task-operations.md`.
+For task artifact integrity references and provenance metadata controls, see `docs/foundation/task-artifacts-provenance.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-caching-parallelism.md`.
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.

--- a/docs/foundation/task-artifacts-provenance.md
+++ b/docs/foundation/task-artifacts-provenance.md
@@ -1,0 +1,33 @@
+# Task Artifacts Integrity and Provenance (Issues #224, #225)
+
+This document captures the first implementation slice for task artifact provenance with integrity references.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/task_artifacts.rs` with:
+  - `TaskArtifactRegistry` for deterministic artifact registration and lookup.
+  - `TaskArtifactRecord` fields for artifact/task linkage, creator, timestamp, on-chain hash, off-chain URI, and content type.
+  - `integrity_fingerprint(task_id, creator, off_chain_uri)` helper.
+  - typed errors via `TaskArtifactError` for validation, duplicates, missing records, and integrity mismatch.
+- Added integration tests in `crates/kamn-core/tests/task_artifacts.rs`.
+
+## Validation Rules
+- `artifact_id`, `task_id`, `on_chain_hash`, `off_chain_uri`, and `content_type` must be non-empty.
+- `creator` must parse as `kamn:did:agent:*`.
+- `created_at_unix` must be non-zero.
+- `on_chain_hash` must match deterministic integrity fingerprint:
+  - `fnv1a_hex(\"<task_id>|<creator>|<off_chain_uri>\")`
+
+## Query Surfaces
+- `artifact(artifact_id)` for direct lookup.
+- `artifacts_for_task(task_id)` for task-linked listing.
+- `artifacts_for_creator(creator)` for creator-linked listing.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test task_artifacts
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first task-artifact provenance slice with deterministic integrity references and queryable provenance metadata. The new registry supports artifact/task/creator linkage, integrity hash validation, and indexed retrieval surfaces with typed errors.

Closes #224
Closes #225

## Changes
- `crates/kamn-core/src/task_artifacts.rs`:
  - Added `TaskArtifactRegistry` with deterministic registration and lookup.
  - Added `TaskArtifactSubmission` and `TaskArtifactRecord`.
  - Added integrity helper: `integrity_fingerprint(task_id, creator, off_chain_uri)`.
  - Added typed errors: `TaskArtifactError`.
- `crates/kamn-core/tests/task_artifacts.rs`:
  - Added functional/integration/regression tests for provenance and integrity behavior.
- `crates/kamn-core/src/lib.rs`:
  - Exported task-artifact APIs/types.
- `docs/foundation/task-artifacts-provenance.md`:
  - Documented artifact integrity/provenance semantics.
- `docs/foundation/bootstrap.md`:
  - Added foundation index link.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ cargo test -p kamn-core --test task_artifacts
error[E0432]: unresolved imports `TaskArtifactError`, `TaskArtifactRecord`, `TaskArtifactRegistry`
```

### 🟢 Green Phase
```bash
$ cargo test -p kamn-core --test task_artifacts
running 4 tests
... all passed ...
test result: ok. 4 passed; 0 failed
```

### 🔁 Regression
```bash
$ cargo fmt --check
$ cargo clippy -- -D warnings
$ cargo test -p kamn-core --test task_artifacts
$ cargo test -p kamn-core
```
All commands passed locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `task_artifacts` module tests (`integrity_fingerprint_is_deterministic`, invalid did, zero timestamp) | |
| Functional   | ✅     | `register_artifact_persists_integrity_and_provenance`, `duplicate_artifact_id_is_rejected` | |
| Integration  | ✅     | `integration_indexes_by_task_and_creator` | |
| Regression   | ✅     | `regression_tampered_integrity_hash_is_rejected` (`// Regression: #225`) | |
| Performance  | N/A    | None | No performance-sensitive path introduced in this first slice. |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to remove task-artifact registry/docs/tests.

## Documentation Updates
- `docs/foundation/task-artifacts-provenance.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
