### PR TITLE
feat(bridge): implement telegram listener-validated inbound slice (#222 #223)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod state;
 pub mod task_artifacts;
 pub mod task_lifecycle;
 pub mod task_operations;
+pub mod telegram_bridge;
 pub mod token;
 pub mod transaction;
 
@@ -119,6 +120,9 @@ pub use task_artifacts::{
 pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 pub use task_operations::{
     TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskOperationRecord,
+};
+pub use telegram_bridge::{
+    TelegramBridgeConfig, TelegramBridgeEngine, TelegramBridgeError, TelegramInboundRequest,
 };
 pub use token::{
     default_token_config, AllocationBucket, GenesisAllocation, TokenConfig, TokenConfigError,

--- a/crates/kamn-core/src/telegram_bridge.rs
+++ b/crates/kamn-core/src/telegram_bridge.rs
@@ -1,0 +1,194 @@
+use crate::{
+    AgentDid, AllowAllBridgePolicy, BridgeAdapterEngine, BridgeInboundEnvelope, BridgePlatform,
+    CanonicalMessageEnvelope, NormalizedInboundMessage, PassThroughBridgeAdapter,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelegramBridgeConfig {
+    pub bridge_agent_did: String,
+    pub authorized_listener_dids: BTreeSet<String>,
+    pub channel_routes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelegramInboundRequest {
+    pub listener_did: String,
+    pub inbound: BridgeInboundEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelegramBridgeEngine {
+    config: TelegramBridgeConfig,
+    bridge: BridgeAdapterEngine<PassThroughBridgeAdapter, AllowAllBridgePolicy>,
+}
+
+impl TelegramBridgeEngine {
+    pub fn new(config: TelegramBridgeConfig) -> Result<Self, TelegramBridgeError> {
+        validate_did(&config.bridge_agent_did)?;
+        if config.authorized_listener_dids.is_empty() {
+            return Err(TelegramBridgeError::EmptyField("authorized_listener_dids"));
+        }
+        for listener_did in &config.authorized_listener_dids {
+            validate_did(listener_did)?;
+        }
+        if config.channel_routes.is_empty() {
+            return Err(TelegramBridgeError::EmptyField("channel_routes"));
+        }
+        for (external_channel_id, target_did) in &config.channel_routes {
+            validate_non_empty("channel_routes.external_channel_id", external_channel_id)?;
+            validate_did(target_did)?;
+        }
+
+        let adapter =
+            PassThroughBridgeAdapter::new(BridgePlatform::Telegram, &config.bridge_agent_did)
+                .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))?;
+        let bridge = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
+
+        Ok(Self { config, bridge })
+    }
+
+    pub fn process_inbound(
+        &self,
+        request: &TelegramInboundRequest,
+    ) -> Result<NormalizedInboundMessage, TelegramBridgeError> {
+        validate_did(&request.listener_did)?;
+        if !self
+            .config
+            .authorized_listener_dids
+            .contains(&request.listener_did)
+        {
+            return Err(TelegramBridgeError::UnauthorizedListener(
+                request.listener_did.clone(),
+            ));
+        }
+
+        let external_channel_id = request.inbound.external_channel_id.clone();
+        let expected_target_did = self
+            .config
+            .channel_routes
+            .get(&external_channel_id)
+            .ok_or_else(|| TelegramBridgeError::UnknownRouteChannel(external_channel_id.clone()))?;
+
+        if expected_target_did != &request.inbound.target_agent_did {
+            return Err(TelegramBridgeError::RouteTargetMismatch {
+                external_channel_id,
+                expected_target_did: expected_target_did.clone(),
+                provided_target_did: request.inbound.target_agent_did.clone(),
+            });
+        }
+
+        self.bridge
+            .process_inbound(&request.inbound)
+            .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_inbound_to_envelope(
+        &self,
+        request: &TelegramInboundRequest,
+        recipient_keys: Vec<String>,
+        expires: &str,
+        nonce: u64,
+    ) -> Result<CanonicalMessageEnvelope, TelegramBridgeError> {
+        self.process_inbound(request)?;
+        self.bridge
+            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TelegramBridgeError {
+    EmptyField(&'static str),
+    InvalidDid(String),
+    UnauthorizedListener(String),
+    UnknownRouteChannel(String),
+    RouteTargetMismatch {
+        external_channel_id: String,
+        expected_target_did: String,
+        provided_target_did: String,
+    },
+    Bridge(String),
+}
+
+impl fmt::Display for TelegramBridgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::UnauthorizedListener(value) => write!(f, "unauthorized listener did: {value}"),
+            Self::UnknownRouteChannel(value) => {
+                write!(f, "telegram channel route not found: {value}")
+            }
+            Self::RouteTargetMismatch {
+                external_channel_id,
+                expected_target_did,
+                provided_target_did,
+            } => write!(
+                f,
+                "telegram channel route target mismatch for {external_channel_id}, expected {expected_target_did}, got {provided_target_did}"
+            ),
+            Self::Bridge(value) => write!(f, "telegram bridge error: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for TelegramBridgeError {}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), TelegramBridgeError> {
+    if value.trim().is_empty() {
+        return Err(TelegramBridgeError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), TelegramBridgeError> {
+    AgentDid::parse(value).map_err(|error| TelegramBridgeError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TelegramBridgeConfig, TelegramBridgeEngine, TelegramBridgeError};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn config() -> TelegramBridgeConfig {
+        let mut channel_routes = BTreeMap::new();
+        channel_routes.insert(
+            "telegram:channel:ops".to_owned(),
+            "kamn:did:agent:target-1".to_owned(),
+        );
+        TelegramBridgeConfig {
+            bridge_agent_did: "kamn:did:agent:bridge-telegram-1".to_owned(),
+            authorized_listener_dids: ["kamn:did:agent:listener-1".to_owned()]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            channel_routes,
+        }
+    }
+
+    #[test]
+    fn constructor_rejects_empty_listener_allowlist() {
+        let mut config = config();
+        config.authorized_listener_dids.clear();
+        assert_eq!(
+            TelegramBridgeEngine::new(config),
+            Err(TelegramBridgeError::EmptyField("authorized_listener_dids"))
+        );
+    }
+
+    #[test]
+    fn constructor_rejects_invalid_target_did_in_route_map() {
+        let mut config = config();
+        config
+            .channel_routes
+            .insert("telegram:channel:ops".to_owned(), "bad-did".to_owned());
+        assert_eq!(
+            TelegramBridgeEngine::new(config),
+            Err(TelegramBridgeError::InvalidDid(
+                "invalid agent did prefix: bad-did".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/kamn-core/tests/telegram_bridge.rs
+++ b/crates/kamn-core/tests/telegram_bridge.rs
@@ -1,0 +1,109 @@
+use kamn_core::{
+    BridgeInboundEnvelope, TelegramBridgeConfig, TelegramBridgeEngine, TelegramBridgeError,
+    TelegramInboundRequest,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn config() -> TelegramBridgeConfig {
+    let mut channel_routes = BTreeMap::new();
+    channel_routes.insert(
+        "telegram:channel:ops".to_owned(),
+        "kamn:did:agent:listener-target-1".to_owned(),
+    );
+
+    TelegramBridgeConfig {
+        bridge_agent_did: "kamn:did:agent:bridge-telegram-1".to_owned(),
+        authorized_listener_dids: ["kamn:did:agent:listener-1".to_owned()]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        channel_routes,
+    }
+}
+
+fn inbound(target: &str) -> BridgeInboundEnvelope {
+    BridgeInboundEnvelope {
+        external_message_id: "tg-msg-1".to_owned(),
+        external_sender_id: "tg-user-9".to_owned(),
+        external_channel_id: "telegram:channel:ops".to_owned(),
+        target_agent_did: target.to_owned(),
+        body: "run diagnostics".to_owned(),
+        received_at: "2026-02-07T21:00:00Z".to_owned(),
+    }
+}
+
+#[test]
+fn authorized_listener_can_process_inbound() {
+    let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
+
+    let normalized = engine
+        .process_inbound(&TelegramInboundRequest {
+            listener_did: "kamn:did:agent:listener-1".to_owned(),
+            inbound: inbound("kamn:did:agent:listener-target-1"),
+        })
+        .expect("inbound should process");
+
+    assert_eq!(normalized.sender_handle, "tg-user-9");
+    assert_eq!(
+        normalized.target_agent_did,
+        "kamn:did:agent:listener-target-1"
+    );
+}
+
+#[test]
+fn integration_processes_inbound_to_canonical_envelope() {
+    let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
+
+    let envelope = engine
+        .process_inbound_to_envelope(
+            &TelegramInboundRequest {
+                listener_did: "kamn:did:agent:listener-1".to_owned(),
+                inbound: inbound("kamn:did:agent:listener-target-1"),
+            },
+            vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
+            "2026-02-07T21:15:00Z",
+            41,
+        )
+        .expect("envelope conversion should succeed");
+
+    assert_eq!(
+        envelope.envelope.from,
+        "kamn:did:agent:bridge-telegram-1".to_owned()
+    );
+    assert_eq!(
+        envelope.envelope.to,
+        vec!["kamn:did:agent:listener-target-1".to_owned()]
+    );
+}
+
+#[test]
+fn route_target_mismatch_is_rejected() {
+    let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
+
+    assert_eq!(
+        engine.process_inbound(&TelegramInboundRequest {
+            listener_did: "kamn:did:agent:listener-1".to_owned(),
+            inbound: inbound("kamn:did:agent:different-target"),
+        }),
+        Err(TelegramBridgeError::RouteTargetMismatch {
+            external_channel_id: "telegram:channel:ops".to_owned(),
+            expected_target_did: "kamn:did:agent:listener-target-1".to_owned(),
+            provided_target_did: "kamn:did:agent:different-target".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_unauthorized_listener_is_rejected() {
+    let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
+
+    // Regression: #223
+    assert_eq!(
+        engine.process_inbound(&TelegramInboundRequest {
+            listener_did: "kamn:did:agent:listener-x".to_owned(),
+            inbound: inbound("kamn:did:agent:listener-target-1"),
+        }),
+        Err(TelegramBridgeError::UnauthorizedListener(
+            "kamn:did:agent:listener-x".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -65,6 +65,7 @@ For task state machine and legal transition validation controls, see `docs/found
 For task operation command handling controls, see `docs/foundation/task-operations.md`.
 For task artifact integrity references and provenance metadata controls, see `docs/foundation/task-artifacts-provenance.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
+For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
 For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-caching-parallelism.md`.
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.

--- a/docs/foundation/telegram-bridge-listener-validation.md
+++ b/docs/foundation/telegram-bridge-listener-validation.md
@@ -1,0 +1,39 @@
+# Telegram Bridge Listener-Validated Inbound Flow (Issues #222, #223)
+
+This document captures the first implementation slice for Telegram bridge inbound processing with listener validation.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/telegram_bridge.rs` with:
+  - `TelegramBridgeConfig` for bridge agent DID, authorized listener DIDs, and channel route map.
+  - `TelegramInboundRequest` as inbound request envelope with listener DID context.
+  - `TelegramBridgeEngine` wrapper over generic bridge adapter flow.
+  - typed errors via `TelegramBridgeError`.
+- Added integration tests in `crates/kamn-core/tests/telegram_bridge.rs`.
+
+## Validation Rules
+- Bridge agent DID and listener DIDs must parse as `kamn:did:agent:*`.
+- At least one authorized listener DID is required.
+- At least one Telegram channel route is required.
+- Each route target DID must be valid.
+- Inbound processing requires:
+  - listener DID must be authorized.
+  - inbound `external_channel_id` must exist in route map.
+  - inbound `target_agent_did` must match mapped route target.
+
+## Processing Flow
+- `process_inbound(...)`:
+  - validates listener + route constraints.
+  - delegates canonical normalization to `BridgeAdapterEngine` with Telegram platform adapter.
+- `process_inbound_to_envelope(...)`:
+  - runs listener/route validation.
+  - converts inbound message into canonical KAMN envelope.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test telegram_bridge
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first Telegram bridge MVP slice with listener-validated inbound flow. The new Telegram-specific bridge engine enforces authorized listener DIDs and route-to-target checks before canonical inbound normalization and envelope conversion.

Closes #222
Closes #223

## Changes
- `crates/kamn-core/src/telegram_bridge.rs`:
  - Added `TelegramBridgeConfig`, `TelegramInboundRequest`, and `TelegramBridgeEngine`.
  - Added listener allowlist validation and channel-route target matching.
  - Integrated with existing bridge adapter engine for canonical inbound processing and envelope conversion.
  - Added typed errors via `TelegramBridgeError`.
  - Added unit tests for constructor validation paths.
- `crates/kamn-core/tests/telegram_bridge.rs`:
  - Added functional/integration/regression tests for authorized inbound flow, canonical envelope conversion, route mismatch handling, and unauthorized listener rejection.
- `crates/kamn-core/src/lib.rs`:
  - Exported Telegram bridge APIs.
- `docs/foundation/telegram-bridge-listener-validation.md`:
  - Documented listener-validated Telegram inbound behavior.
- `docs/foundation/bootstrap.md`:
  - Added foundation index link.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ cargo test -p kamn-core --test telegram_bridge
error[E0432]: unresolved imports `TelegramBridgeConfig`, `TelegramBridgeEngine`, `TelegramBridgeError`, `TelegramInboundRequest`
```

### 🟢 Green Phase
```bash
$ cargo test -p kamn-core --test telegram_bridge
running 4 tests
... all passed ...
test result: ok. 4 passed; 0 failed
```

### 🔁 Regression
```bash
$ cargo fmt --check
$ cargo clippy -- -D warnings
$ cargo test -p kamn-core --test telegram_bridge
$ cargo test -p kamn-core
```
All commands passed locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `telegram_bridge` module tests (`constructor_rejects_empty_listener_allowlist`, invalid route target DID) | |
| Functional   | ✅     | `authorized_listener_can_process_inbound`, `route_target_mismatch_is_rejected` | |
| Integration  | ✅     | `integration_processes_inbound_to_canonical_envelope` | |
| Regression   | ✅     | `regression_unauthorized_listener_is_rejected` (`// Regression: #223`) | |
| Performance  | N/A    | None | No throughput benchmarking path introduced in this slice. |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to remove Telegram-specific bridge wrapper/docs/tests.

## Documentation Updates
- `docs/foundation/telegram-bridge-listener-validation.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
