### PR TITLE
feat: Discord bridge approver-gated outbound flow

### DIFF
--- a/crates/kamn-core/src/discord_bridge.rs
+++ b/crates/kamn-core/src/discord_bridge.rs
@@ -1,0 +1,319 @@
+use crate::{
+    AgentDid, AllowAllBridgePolicy, BridgeAdapterEngine, BridgeInboundEnvelope,
+    BridgeOutboundEnvelope, BridgeOutboundRequest, BridgePlatform, CanonicalMessageEnvelope,
+    NormalizedInboundMessage, PassThroughBridgeAdapter,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordBridgeConfig {
+    pub bridge_agent_did: String,
+    pub authorized_listener_dids: BTreeSet<String>,
+    pub authorized_approver_dids: BTreeSet<String>,
+    pub required_approvals: usize,
+    pub channel_routes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordInboundRequest {
+    pub listener_did: String,
+    pub inbound: BridgeInboundEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordOutboundApproval {
+    pub request_id: String,
+    pub required_approvals: usize,
+    pub approved_by: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordOutboundDispatch {
+    pub envelope: BridgeOutboundEnvelope,
+    pub approval: DiscordOutboundApproval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordBridgeEngine {
+    config: DiscordBridgeConfig,
+    bridge: BridgeAdapterEngine<PassThroughBridgeAdapter, AllowAllBridgePolicy>,
+}
+
+impl DiscordBridgeEngine {
+    pub fn new(config: DiscordBridgeConfig) -> Result<Self, DiscordBridgeError> {
+        validate_did(&config.bridge_agent_did)?;
+        if config.authorized_listener_dids.is_empty() {
+            return Err(DiscordBridgeError::EmptyField("authorized_listener_dids"));
+        }
+        for listener_did in &config.authorized_listener_dids {
+            validate_did(listener_did)?;
+        }
+
+        if config.authorized_approver_dids.is_empty() {
+            return Err(DiscordBridgeError::EmptyField("authorized_approver_dids"));
+        }
+        for approver_did in &config.authorized_approver_dids {
+            validate_did(approver_did)?;
+        }
+        if config.required_approvals == 0
+            || config.required_approvals > config.authorized_approver_dids.len()
+        {
+            return Err(DiscordBridgeError::InvalidRequiredApprovals {
+                required: config.required_approvals,
+                approver_count: config.authorized_approver_dids.len(),
+            });
+        }
+
+        if config.channel_routes.is_empty() {
+            return Err(DiscordBridgeError::EmptyField("channel_routes"));
+        }
+        for (external_channel_id, target_did) in &config.channel_routes {
+            validate_non_empty("channel_routes.external_channel_id", external_channel_id)?;
+            validate_did(target_did)?;
+        }
+
+        let adapter =
+            PassThroughBridgeAdapter::new(BridgePlatform::Discord, &config.bridge_agent_did)
+                .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))?;
+        let bridge = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
+        Ok(Self { config, bridge })
+    }
+
+    pub fn process_inbound(
+        &self,
+        request: &DiscordInboundRequest,
+    ) -> Result<NormalizedInboundMessage, DiscordBridgeError> {
+        validate_did(&request.listener_did)?;
+        if !self
+            .config
+            .authorized_listener_dids
+            .contains(&request.listener_did)
+        {
+            return Err(DiscordBridgeError::UnauthorizedListener(
+                request.listener_did.clone(),
+            ));
+        }
+
+        let external_channel_id = request.inbound.external_channel_id.clone();
+        let expected_target_did = self
+            .config
+            .channel_routes
+            .get(&external_channel_id)
+            .ok_or_else(|| DiscordBridgeError::UnknownRouteChannel(external_channel_id.clone()))?;
+
+        if expected_target_did != &request.inbound.target_agent_did {
+            return Err(DiscordBridgeError::RouteTargetMismatch {
+                external_channel_id,
+                expected_target_did: expected_target_did.clone(),
+                provided_target_did: request.inbound.target_agent_did.clone(),
+            });
+        }
+
+        self.bridge
+            .process_inbound(&request.inbound)
+            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_inbound_to_envelope(
+        &self,
+        request: &DiscordInboundRequest,
+        recipient_keys: Vec<String>,
+        expires: &str,
+        nonce: u64,
+    ) -> Result<CanonicalMessageEnvelope, DiscordBridgeError> {
+        self.process_inbound(request)?;
+        self.bridge
+            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_outbound_with_approvals(
+        &self,
+        request: &BridgeOutboundRequest,
+        approver_dids: Vec<String>,
+    ) -> Result<DiscordOutboundDispatch, DiscordBridgeError> {
+        self.validate_outbound_channel(&request.destination_channel_id)?;
+        let approved_by = self.validate_approvals(approver_dids)?;
+        let envelope = self
+            .bridge
+            .process_outbound(request)
+            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))?;
+
+        Ok(DiscordOutboundDispatch {
+            envelope,
+            approval: DiscordOutboundApproval {
+                request_id: request.request_id.clone(),
+                required_approvals: self.config.required_approvals,
+                approved_by,
+            },
+        })
+    }
+
+    fn validate_outbound_channel(
+        &self,
+        destination_channel_id: &str,
+    ) -> Result<(), DiscordBridgeError> {
+        validate_non_empty(
+            "bridge_outbound_request.destination_channel_id",
+            destination_channel_id,
+        )?;
+        if !self
+            .config
+            .channel_routes
+            .contains_key(destination_channel_id)
+        {
+            return Err(DiscordBridgeError::UnknownRouteChannel(
+                destination_channel_id.to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_approvals(
+        &self,
+        approver_dids: Vec<String>,
+    ) -> Result<BTreeSet<String>, DiscordBridgeError> {
+        let mut approved_by = BTreeSet::new();
+        for approver_did in approver_dids {
+            validate_did(&approver_did)?;
+            if !self.config.authorized_approver_dids.contains(&approver_did) {
+                return Err(DiscordBridgeError::UnauthorizedApprover(approver_did));
+            }
+            if !approved_by.insert(approver_did.clone()) {
+                return Err(DiscordBridgeError::DuplicateApproval(approver_did));
+            }
+        }
+        if approved_by.len() < self.config.required_approvals {
+            return Err(DiscordBridgeError::InsufficientApprovals {
+                required: self.config.required_approvals,
+                provided: approved_by.len(),
+            });
+        }
+        Ok(approved_by)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscordBridgeError {
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidRequiredApprovals {
+        required: usize,
+        approver_count: usize,
+    },
+    UnauthorizedListener(String),
+    UnauthorizedApprover(String),
+    DuplicateApproval(String),
+    InsufficientApprovals {
+        required: usize,
+        provided: usize,
+    },
+    UnknownRouteChannel(String),
+    RouteTargetMismatch {
+        external_channel_id: String,
+        expected_target_did: String,
+        provided_target_did: String,
+    },
+    Bridge(String),
+}
+
+impl fmt::Display for DiscordBridgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidRequiredApprovals {
+                required,
+                approver_count,
+            } => write!(
+                f,
+                "invalid required approvals {required}, approver count {approver_count}"
+            ),
+            Self::UnauthorizedListener(value) => write!(f, "unauthorized listener did: {value}"),
+            Self::UnauthorizedApprover(value) => write!(f, "unauthorized approver did: {value}"),
+            Self::DuplicateApproval(value) => write!(f, "duplicate approval from: {value}"),
+            Self::InsufficientApprovals { required, provided } => write!(
+                f,
+                "insufficient approvals: required {required}, provided {provided}"
+            ),
+            Self::UnknownRouteChannel(value) => {
+                write!(f, "discord channel route not found: {value}")
+            }
+            Self::RouteTargetMismatch {
+                external_channel_id,
+                expected_target_did,
+                provided_target_did,
+            } => write!(
+                f,
+                "discord channel route target mismatch for {external_channel_id}, expected {expected_target_did}, got {provided_target_did}"
+            ),
+            Self::Bridge(value) => write!(f, "discord bridge error: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for DiscordBridgeError {}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), DiscordBridgeError> {
+    if value.trim().is_empty() {
+        return Err(DiscordBridgeError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), DiscordBridgeError> {
+    AgentDid::parse(value).map_err(|error| DiscordBridgeError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DiscordBridgeConfig, DiscordBridgeEngine, DiscordBridgeError};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn config() -> DiscordBridgeConfig {
+        let mut channel_routes = BTreeMap::new();
+        channel_routes.insert(
+            "discord:channel:ops".to_owned(),
+            "kamn:did:agent:target-1".to_owned(),
+        );
+        DiscordBridgeConfig {
+            bridge_agent_did: "kamn:did:agent:bridge-discord-1".to_owned(),
+            authorized_listener_dids: ["kamn:did:agent:listener-1".to_owned()]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            authorized_approver_dids: [
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-2".to_owned(),
+            ]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+            required_approvals: 2,
+            channel_routes,
+        }
+    }
+
+    #[test]
+    fn constructor_rejects_empty_approver_allowlist() {
+        let mut config = config();
+        config.authorized_approver_dids.clear();
+        assert_eq!(
+            DiscordBridgeEngine::new(config),
+            Err(DiscordBridgeError::EmptyField("authorized_approver_dids"))
+        );
+    }
+
+    #[test]
+    fn constructor_rejects_invalid_required_approvals_threshold() {
+        let mut config = config();
+        config.required_approvals = 3;
+        assert_eq!(
+            DiscordBridgeEngine::new(config),
+            Err(DiscordBridgeError::InvalidRequiredApprovals {
+                required: 3,
+                approver_count: 2,
+            })
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod data_classification;
 pub mod did;
 pub mod did_registry;
 pub mod direct_message_crypto;
+pub mod discord_bridge;
 pub mod escrow;
 pub mod group_channel_crypto;
 pub mod instruction_verify;
@@ -67,6 +68,10 @@ pub use did_registry::{DidRegistry, DidRegistryError};
 pub use direct_message_crypto::{
     DirectMessageCiphertext, DirectMessageCryptoEngine, DirectMessageCryptoError,
     DIRECT_MESSAGE_CIPHER_ALGORITHM, DIRECT_MESSAGE_KEY_AGREEMENT_ALGORITHM,
+};
+pub use discord_bridge::{
+    DiscordBridgeConfig, DiscordBridgeEngine, DiscordBridgeError, DiscordInboundRequest,
+    DiscordOutboundApproval, DiscordOutboundDispatch,
 };
 pub use escrow::{EscrowLifecycle, EscrowLifecycleError, EscrowStatus};
 pub use group_channel_crypto::{

--- a/crates/kamn-core/tests/discord_bridge.rs
+++ b/crates/kamn-core/tests/discord_bridge.rs
@@ -1,0 +1,149 @@
+use kamn_core::{
+    BridgeInboundEnvelope, BridgeOutboundRequest, BridgePlatform, DiscordBridgeConfig,
+    DiscordBridgeEngine, DiscordBridgeError, DiscordInboundRequest,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn config() -> DiscordBridgeConfig {
+    let mut channel_routes = BTreeMap::new();
+    channel_routes.insert(
+        "discord:channel:ops".to_owned(),
+        "kamn:did:agent:listener-target-1".to_owned(),
+    );
+
+    DiscordBridgeConfig {
+        bridge_agent_did: "kamn:did:agent:bridge-discord-1".to_owned(),
+        authorized_listener_dids: ["kamn:did:agent:listener-1".to_owned()]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        authorized_approver_dids: [
+            "kamn:did:agent:approver-1".to_owned(),
+            "kamn:did:agent:approver-2".to_owned(),
+            "kamn:did:agent:approver-3".to_owned(),
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>(),
+        required_approvals: 2,
+        channel_routes,
+    }
+}
+
+fn inbound(target: &str) -> BridgeInboundEnvelope {
+    BridgeInboundEnvelope {
+        external_message_id: "discord-msg-1".to_owned(),
+        external_sender_id: "discord:user-9".to_owned(),
+        external_channel_id: "discord:channel:ops".to_owned(),
+        target_agent_did: target.to_owned(),
+        body: "run diagnostics".to_owned(),
+        received_at: "2026-02-08T04:00:00Z".to_owned(),
+    }
+}
+
+fn outbound() -> BridgeOutboundRequest {
+    BridgeOutboundRequest {
+        request_id: "discord-outbound-1".to_owned(),
+        from_agent_did: "kamn:did:agent:processor-1".to_owned(),
+        destination_channel_id: "discord:channel:ops".to_owned(),
+        body: "status: green".to_owned(),
+        created_at: "2026-02-08T04:10:00Z".to_owned(),
+    }
+}
+
+#[test]
+fn approver_quorum_dispatches_outbound() {
+    let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
+
+    let dispatch = engine
+        .process_outbound_with_approvals(
+            &outbound(),
+            vec![
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-2".to_owned(),
+            ],
+        )
+        .expect("quorum approvals should dispatch outbound");
+
+    assert_eq!(dispatch.envelope.request_id, "discord-outbound-1");
+    assert_eq!(dispatch.envelope.platform, BridgePlatform::Discord);
+    assert_eq!(dispatch.approval.required_approvals, 2);
+    assert_eq!(dispatch.approval.approved_by.len(), 2);
+}
+
+#[test]
+fn outbound_rejects_insufficient_approvals() {
+    let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
+
+    assert_eq!(
+        engine.process_outbound_with_approvals(
+            &outbound(),
+            vec!["kamn:did:agent:approver-1".to_owned()],
+        ),
+        Err(DiscordBridgeError::InsufficientApprovals {
+            required: 2,
+            provided: 1,
+        })
+    );
+}
+
+#[test]
+fn outbound_rejects_unauthorized_approver() {
+    let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
+
+    assert_eq!(
+        engine.process_outbound_with_approvals(
+            &outbound(),
+            vec![
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-x".to_owned(),
+            ],
+        ),
+        Err(DiscordBridgeError::UnauthorizedApprover(
+            "kamn:did:agent:approver-x".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn integration_processes_discord_inbound_to_envelope() {
+    let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
+
+    let envelope = engine
+        .process_inbound_to_envelope(
+            &DiscordInboundRequest {
+                listener_did: "kamn:did:agent:listener-1".to_owned(),
+                inbound: inbound("kamn:did:agent:listener-target-1"),
+            },
+            vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
+            "2026-02-08T04:30:00Z",
+            81,
+        )
+        .expect("envelope conversion should succeed");
+
+    assert_eq!(
+        envelope.envelope.from,
+        "kamn:did:agent:bridge-discord-1".to_owned()
+    );
+    assert_eq!(
+        envelope.envelope.to,
+        vec!["kamn:did:agent:listener-target-1".to_owned()]
+    );
+}
+
+#[test]
+fn regression_duplicate_approval_is_rejected() {
+    let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
+
+    // Regression: #221
+    assert_eq!(
+        engine.process_outbound_with_approvals(
+            &outbound(),
+            vec![
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-1".to_owned(),
+            ],
+        ),
+        Err(DiscordBridgeError::DuplicateApproval(
+            "kamn:did:agent:approver-1".to_owned()
+        ))
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -66,6 +66,7 @@ For task operation command handling controls, see `docs/foundation/task-operatio
 For task artifact integrity references and provenance metadata controls, see `docs/foundation/task-artifacts-provenance.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
+For Discord bridge approver-gated outbound flow controls, see `docs/foundation/discord-bridge-approver-gating.md`.
 For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-caching-parallelism.md`.
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.

--- a/docs/foundation/discord-bridge-approver-gating.md
+++ b/docs/foundation/discord-bridge-approver-gating.md
@@ -1,0 +1,45 @@
+# Discord Bridge Approver-Gated Outbound Flow (Issues #220, #221)
+
+This document captures the first implementation slice for Discord bridge processing with approver quorum gating on outbound actions.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/discord_bridge.rs` with:
+  - `DiscordBridgeConfig` for bridge DID, listener allowlist, approver allowlist, required approval threshold, and route map.
+  - `DiscordInboundRequest` and `DiscordBridgeEngine` for listener-validated inbound normalization.
+  - `process_outbound_with_approvals(...)` for approver-gated outbound dispatch.
+  - `DiscordOutboundApproval` and `DiscordOutboundDispatch` to preserve deterministic approval metadata for auditing.
+  - typed error handling via `DiscordBridgeError`.
+- Added integration tests in `crates/kamn-core/tests/discord_bridge.rs`.
+
+## Validation Rules
+- Bridge/listener/approver DIDs must parse as `kamn:did:agent:*`.
+- At least one authorized listener and approver DID is required.
+- `required_approvals` must be between `1` and approver allowlist size.
+- At least one route entry is required and route target DIDs must be valid.
+- Outbound processing requires:
+  - destination channel mapped in route map.
+  - approver set contains no duplicates.
+  - all approvers are authorized.
+  - provided approvals satisfy quorum threshold.
+
+## Processing Flow
+- `process_inbound(...)`:
+  - validates listener identity and route target mapping.
+  - normalizes inbound payload through `BridgeAdapterEngine` with Discord platform adapter.
+- `process_inbound_to_envelope(...)`:
+  - preserves listener/route checks.
+  - projects to canonical KAMN message envelope.
+- `process_outbound_with_approvals(...)`:
+  - enforces channel routing + approver quorum checks.
+  - delegates outbound translation to `BridgeAdapterEngine`.
+  - returns translated payload plus approval metadata for audit trails.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test discord_bridge
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first Discord bridge MVP slice for story #36 by adding listener-validated inbound processing and approver-quorum-gated outbound dispatch. The outbound path now enforces authorized approvers, duplicate approval rejection, and deterministic approval metadata for auditing.

Closes #220
Closes #221

## Changes
- `crates/kamn-core/src/discord_bridge.rs`: added Discord bridge config, engine, inbound/outbound flows, typed errors, and unit tests for constructor guards.
- `crates/kamn-core/tests/discord_bridge.rs`: added functional/integration/regression coverage for quorum-gated outbound behavior and inbound envelope projection.
- `crates/kamn-core/src/lib.rs`: exported Discord bridge types.
- `docs/foundation/discord-bridge-approver-gating.md`: documented behavior, validation rules, and local verification commands.
- `docs/foundation/bootstrap.md`: linked new Discord bridge foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test discord_bridge
```
Failure before implementation:
```text
error[E0432]: unresolved imports `kamn_core::DiscordBridgeConfig`, `kamn_core::DiscordBridgeEngine`, `kamn_core::DiscordBridgeError`, `kamn_core::DiscordInboundRequest`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test discord_bridge
```
Passing output summary:
```text
running 5 tests
... all passed ...
test result: ok. 5 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Passing output summary:
```text
fmt: clean
clippy: finished with no warnings
cargo test -p kamn-core: 103 unit tests + integration suites passed; 0 failed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `discord_bridge::tests::constructor_rejects_empty_approver_allowlist`; `discord_bridge::tests::constructor_rejects_invalid_required_approvals_threshold` | |
| Functional   | ✅     | `approver_quorum_dispatches_outbound`; `outbound_rejects_insufficient_approvals`; `outbound_rejects_unauthorized_approver` | |
| Integration  | ✅     | `integration_processes_discord_inbound_to_envelope` | |
| Regression   | ✅     | `regression_duplicate_approval_is_rejected` (`// Regression: #221`) | |
| Performance  | N/A    | None | No throughput-critical runtime path introduced in this MVP slice |

## Risks & Rollback
- None expected for existing behavior; this adds a new module and exports.
- Rollback: revert this PR to remove Discord bridge module and exports.

## Documentation Updates
- `docs/foundation/discord-bridge-approver-gating.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
