### PR TITLE
feat: add Ethereum/Solana cross-chain bridge adapter slice

### DIFF
--- a/crates/kamn-core/src/cross_chain_bridge.rs
+++ b/crates/kamn-core/src/cross_chain_bridge.rs
@@ -1,0 +1,401 @@
+use crate::{
+    AgentDid, AllowAllBridgePolicy, BridgeAdapterEngine, BridgeInboundEnvelope,
+    BridgeOutboundEnvelope, BridgeOutboundRequest, BridgePlatform, CanonicalMessageEnvelope,
+    NormalizedInboundMessage, PassThroughBridgeAdapter,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CrossChainNetwork {
+    Ethereum,
+    Solana,
+}
+
+impl CrossChainNetwork {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ethereum => "ethereum",
+            Self::Solana => "solana",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossChainBridgeConfig {
+    pub bridge_agent_did: String,
+    pub authorized_listener_dids: BTreeSet<String>,
+    pub authorized_approver_dids: BTreeSet<String>,
+    pub required_approvals: usize,
+    pub ethereum_routes: BTreeMap<String, String>,
+    pub solana_routes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossChainInboundRequest {
+    pub listener_did: String,
+    pub chain: CrossChainNetwork,
+    pub inbound: BridgeInboundEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossChainOutboundApproval {
+    pub chain: CrossChainNetwork,
+    pub request_id: String,
+    pub required_approvals: usize,
+    pub approved_by: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossChainOutboundDispatch {
+    pub envelope: BridgeOutboundEnvelope,
+    pub approval: CrossChainOutboundApproval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossChainBridgeEngine {
+    config: CrossChainBridgeConfig,
+    ethereum_bridge: BridgeAdapterEngine<PassThroughBridgeAdapter, AllowAllBridgePolicy>,
+    solana_bridge: BridgeAdapterEngine<PassThroughBridgeAdapter, AllowAllBridgePolicy>,
+}
+
+impl CrossChainBridgeEngine {
+    pub fn new(config: CrossChainBridgeConfig) -> Result<Self, CrossChainBridgeError> {
+        validate_did(&config.bridge_agent_did)?;
+
+        if config.authorized_listener_dids.is_empty() {
+            return Err(CrossChainBridgeError::EmptyField(
+                "authorized_listener_dids",
+            ));
+        }
+        for listener_did in &config.authorized_listener_dids {
+            validate_did(listener_did)?;
+        }
+
+        if config.authorized_approver_dids.is_empty() {
+            return Err(CrossChainBridgeError::EmptyField(
+                "authorized_approver_dids",
+            ));
+        }
+        for approver_did in &config.authorized_approver_dids {
+            validate_did(approver_did)?;
+        }
+        if config.required_approvals == 0
+            || config.required_approvals > config.authorized_approver_dids.len()
+        {
+            return Err(CrossChainBridgeError::InvalidRequiredApprovals {
+                required: config.required_approvals,
+                approver_count: config.authorized_approver_dids.len(),
+            });
+        }
+
+        if config.ethereum_routes.is_empty() {
+            return Err(CrossChainBridgeError::EmptyField("ethereum_routes"));
+        }
+        for (channel_id, target_did) in &config.ethereum_routes {
+            validate_non_empty("ethereum_routes.channel_id", channel_id)?;
+            validate_did(target_did)?;
+        }
+
+        if config.solana_routes.is_empty() {
+            return Err(CrossChainBridgeError::EmptyField("solana_routes"));
+        }
+        for (channel_id, target_did) in &config.solana_routes {
+            validate_non_empty("solana_routes.channel_id", channel_id)?;
+            validate_did(target_did)?;
+        }
+
+        let ethereum_adapter = PassThroughBridgeAdapter::new(
+            BridgePlatform::Custom(CrossChainNetwork::Ethereum.label().to_owned()),
+            &config.bridge_agent_did,
+        )
+        .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))?;
+
+        let solana_adapter = PassThroughBridgeAdapter::new(
+            BridgePlatform::Custom(CrossChainNetwork::Solana.label().to_owned()),
+            &config.bridge_agent_did,
+        )
+        .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))?;
+
+        Ok(Self {
+            config,
+            ethereum_bridge: BridgeAdapterEngine::new(
+                ethereum_adapter,
+                AllowAllBridgePolicy::new(),
+            ),
+            solana_bridge: BridgeAdapterEngine::new(solana_adapter, AllowAllBridgePolicy::new()),
+        })
+    }
+
+    pub fn process_inbound(
+        &self,
+        request: &CrossChainInboundRequest,
+    ) -> Result<NormalizedInboundMessage, CrossChainBridgeError> {
+        validate_did(&request.listener_did)?;
+        if !self
+            .config
+            .authorized_listener_dids
+            .contains(&request.listener_did)
+        {
+            return Err(CrossChainBridgeError::UnauthorizedListener(
+                request.listener_did.clone(),
+            ));
+        }
+
+        let routes = self.route_map(request.chain);
+        let channel_id = request.inbound.external_channel_id.clone();
+        let expected_target_did =
+            routes
+                .get(&channel_id)
+                .ok_or_else(|| CrossChainBridgeError::UnknownRouteChannel {
+                    chain: request.chain,
+                    channel_id: channel_id.clone(),
+                })?;
+
+        if expected_target_did != &request.inbound.target_agent_did {
+            return Err(CrossChainBridgeError::RouteTargetMismatch {
+                chain: request.chain,
+                external_channel_id: channel_id,
+                expected_target_did: expected_target_did.clone(),
+                provided_target_did: request.inbound.target_agent_did.clone(),
+            });
+        }
+
+        self.bridge_engine(request.chain)
+            .process_inbound(&request.inbound)
+            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_inbound_to_envelope(
+        &self,
+        request: &CrossChainInboundRequest,
+        recipient_keys: Vec<String>,
+        expires: &str,
+        nonce: u64,
+    ) -> Result<CanonicalMessageEnvelope, CrossChainBridgeError> {
+        self.process_inbound(request)?;
+        self.bridge_engine(request.chain)
+            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_outbound_with_approvals(
+        &self,
+        chain: CrossChainNetwork,
+        request: &BridgeOutboundRequest,
+        approver_dids: Vec<String>,
+    ) -> Result<CrossChainOutboundDispatch, CrossChainBridgeError> {
+        self.validate_outbound_channel(chain, &request.destination_channel_id)?;
+        let approved_by = self.validate_approvals(approver_dids)?;
+        let envelope = self
+            .bridge_engine(chain)
+            .process_outbound(request)
+            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))?;
+
+        Ok(CrossChainOutboundDispatch {
+            envelope,
+            approval: CrossChainOutboundApproval {
+                chain,
+                request_id: request.request_id.clone(),
+                required_approvals: self.config.required_approvals,
+                approved_by,
+            },
+        })
+    }
+
+    fn route_map(&self, chain: CrossChainNetwork) -> &BTreeMap<String, String> {
+        match chain {
+            CrossChainNetwork::Ethereum => &self.config.ethereum_routes,
+            CrossChainNetwork::Solana => &self.config.solana_routes,
+        }
+    }
+
+    fn bridge_engine(
+        &self,
+        chain: CrossChainNetwork,
+    ) -> &BridgeAdapterEngine<PassThroughBridgeAdapter, AllowAllBridgePolicy> {
+        match chain {
+            CrossChainNetwork::Ethereum => &self.ethereum_bridge,
+            CrossChainNetwork::Solana => &self.solana_bridge,
+        }
+    }
+
+    fn validate_outbound_channel(
+        &self,
+        chain: CrossChainNetwork,
+        destination_channel_id: &str,
+    ) -> Result<(), CrossChainBridgeError> {
+        validate_non_empty(
+            "bridge_outbound_request.destination_channel_id",
+            destination_channel_id,
+        )?;
+        if !self.route_map(chain).contains_key(destination_channel_id) {
+            return Err(CrossChainBridgeError::UnknownRouteChannel {
+                chain,
+                channel_id: destination_channel_id.to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_approvals(
+        &self,
+        approver_dids: Vec<String>,
+    ) -> Result<BTreeSet<String>, CrossChainBridgeError> {
+        let mut approved_by = BTreeSet::new();
+        for approver_did in approver_dids {
+            validate_did(&approver_did)?;
+            if !self.config.authorized_approver_dids.contains(&approver_did) {
+                return Err(CrossChainBridgeError::UnauthorizedApprover(approver_did));
+            }
+            if !approved_by.insert(approver_did.clone()) {
+                return Err(CrossChainBridgeError::DuplicateApproval(approver_did));
+            }
+        }
+        if approved_by.len() < self.config.required_approvals {
+            return Err(CrossChainBridgeError::InsufficientApprovals {
+                required: self.config.required_approvals,
+                provided: approved_by.len(),
+            });
+        }
+        Ok(approved_by)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrossChainBridgeError {
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidRequiredApprovals {
+        required: usize,
+        approver_count: usize,
+    },
+    UnauthorizedListener(String),
+    UnauthorizedApprover(String),
+    DuplicateApproval(String),
+    InsufficientApprovals {
+        required: usize,
+        provided: usize,
+    },
+    UnknownRouteChannel {
+        chain: CrossChainNetwork,
+        channel_id: String,
+    },
+    RouteTargetMismatch {
+        chain: CrossChainNetwork,
+        external_channel_id: String,
+        expected_target_did: String,
+        provided_target_did: String,
+    },
+    Bridge(String),
+}
+
+impl fmt::Display for CrossChainBridgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidRequiredApprovals {
+                required,
+                approver_count,
+            } => write!(
+                f,
+                "invalid required approvals {required}, approver count {approver_count}"
+            ),
+            Self::UnauthorizedListener(value) => write!(f, "unauthorized listener did: {value}"),
+            Self::UnauthorizedApprover(value) => write!(f, "unauthorized approver did: {value}"),
+            Self::DuplicateApproval(value) => write!(f, "duplicate approval from: {value}"),
+            Self::InsufficientApprovals { required, provided } => write!(
+                f,
+                "insufficient approvals: required {required}, provided {provided}"
+            ),
+            Self::UnknownRouteChannel { chain, channel_id } => {
+                write!(f, "{} route not found: {channel_id}", chain.label())
+            }
+            Self::RouteTargetMismatch {
+                chain,
+                external_channel_id,
+                expected_target_did,
+                provided_target_did,
+            } => write!(
+                f,
+                "{} route target mismatch for {external_channel_id}, expected {expected_target_did}, got {provided_target_did}",
+                chain.label()
+            ),
+            Self::Bridge(value) => write!(f, "cross-chain bridge error: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for CrossChainBridgeError {}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), CrossChainBridgeError> {
+    if value.trim().is_empty() {
+        return Err(CrossChainBridgeError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), CrossChainBridgeError> {
+    AgentDid::parse(value).map_err(|error| CrossChainBridgeError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CrossChainBridgeConfig, CrossChainBridgeEngine, CrossChainBridgeError};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn config() -> CrossChainBridgeConfig {
+        let mut ethereum_routes = BTreeMap::new();
+        ethereum_routes.insert(
+            "ethereum:sepolia:contract:escrow-v1".to_owned(),
+            "kamn:did:agent:target-eth".to_owned(),
+        );
+
+        let mut solana_routes = BTreeMap::new();
+        solana_routes.insert(
+            "solana:devnet:program:task-v1".to_owned(),
+            "kamn:did:agent:target-sol".to_owned(),
+        );
+
+        CrossChainBridgeConfig {
+            bridge_agent_did: "kamn:did:agent:bridge-crosschain-1".to_owned(),
+            authorized_listener_dids: ["kamn:did:agent:listener-1".to_owned()]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            authorized_approver_dids: [
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-2".to_owned(),
+            ]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+            required_approvals: 2,
+            ethereum_routes,
+            solana_routes,
+        }
+    }
+
+    #[test]
+    fn constructor_rejects_empty_ethereum_routes() {
+        let mut config = config();
+        config.ethereum_routes.clear();
+        assert_eq!(
+            CrossChainBridgeEngine::new(config),
+            Err(CrossChainBridgeError::EmptyField("ethereum_routes"))
+        );
+    }
+
+    #[test]
+    fn constructor_rejects_invalid_required_approvals_threshold() {
+        let mut config = config();
+        config.required_approvals = 3;
+        assert_eq!(
+            CrossChainBridgeEngine::new(config),
+            Err(CrossChainBridgeError::InvalidRequiredApprovals {
+                required: 3,
+                approver_count: 2,
+            })
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bridge_adapter;
 pub mod channel_models;
 pub mod channel_policies;
 pub mod config;
+pub mod cross_chain_bridge;
 pub mod data_classification;
 pub mod did;
 pub mod did_registry;
@@ -55,6 +56,11 @@ pub use channel_policies::{
 pub use config::{
     ConfigError, NodeConfig, NodeRole, SyncMode, SyncOperationalProfile, SyncRecoveryStrategy,
     SyncStartupStrategy,
+};
+pub use cross_chain_bridge::{
+    CrossChainBridgeConfig, CrossChainBridgeEngine, CrossChainBridgeError,
+    CrossChainInboundRequest, CrossChainNetwork, CrossChainOutboundApproval,
+    CrossChainOutboundDispatch,
 };
 pub use data_classification::{
     ClassificationPolicy, ClassificationStatus, DataClassificationEngine, DataClassificationError,

--- a/crates/kamn-core/tests/cross_chain_bridge.rs
+++ b/crates/kamn-core/tests/cross_chain_bridge.rs
@@ -1,0 +1,178 @@
+use kamn_core::{
+    BridgeInboundEnvelope, BridgeOutboundRequest, BridgePlatform, CrossChainBridgeConfig,
+    CrossChainBridgeEngine, CrossChainBridgeError, CrossChainInboundRequest, CrossChainNetwork,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn config() -> CrossChainBridgeConfig {
+    let mut ethereum_routes = BTreeMap::new();
+    ethereum_routes.insert(
+        "ethereum:sepolia:contract:escrow-v1".to_owned(),
+        "kamn:did:agent:listener-target-eth".to_owned(),
+    );
+
+    let mut solana_routes = BTreeMap::new();
+    solana_routes.insert(
+        "solana:devnet:program:task-v1".to_owned(),
+        "kamn:did:agent:listener-target-sol".to_owned(),
+    );
+
+    CrossChainBridgeConfig {
+        bridge_agent_did: "kamn:did:agent:bridge-crosschain-1".to_owned(),
+        authorized_listener_dids: ["kamn:did:agent:listener-1".to_owned()]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        authorized_approver_dids: [
+            "kamn:did:agent:approver-1".to_owned(),
+            "kamn:did:agent:approver-2".to_owned(),
+            "kamn:did:agent:approver-3".to_owned(),
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>(),
+        required_approvals: 2,
+        ethereum_routes,
+        solana_routes,
+    }
+}
+
+fn eth_inbound(target: &str) -> BridgeInboundEnvelope {
+    BridgeInboundEnvelope {
+        external_message_id: "0xabc123:7".to_owned(),
+        external_sender_id: "0xContractEscrow".to_owned(),
+        external_channel_id: "ethereum:sepolia:contract:escrow-v1".to_owned(),
+        target_agent_did: target.to_owned(),
+        body: "event:PaymentOffer".to_owned(),
+        received_at: "2026-02-08T09:00:00Z".to_owned(),
+    }
+}
+
+fn solana_inbound(target: &str) -> BridgeInboundEnvelope {
+    BridgeInboundEnvelope {
+        external_message_id: "slot-881991:ix-2".to_owned(),
+        external_sender_id: "So11111111111111111111111111111111111111112".to_owned(),
+        external_channel_id: "solana:devnet:program:task-v1".to_owned(),
+        target_agent_did: target.to_owned(),
+        body: "event:TaskStateChanged".to_owned(),
+        received_at: "2026-02-08T09:05:00Z".to_owned(),
+    }
+}
+
+fn solana_outbound() -> BridgeOutboundRequest {
+    BridgeOutboundRequest {
+        request_id: "solana-outbound-1".to_owned(),
+        from_agent_did: "kamn:did:agent:processor-1".to_owned(),
+        destination_channel_id: "solana:devnet:program:task-v1".to_owned(),
+        body: "instruction:acknowledge".to_owned(),
+        created_at: "2026-02-08T09:10:00Z".to_owned(),
+    }
+}
+
+#[test]
+fn ethereum_listener_can_process_inbound() {
+    let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
+
+    let normalized = engine
+        .process_inbound(&CrossChainInboundRequest {
+            listener_did: "kamn:did:agent:listener-1".to_owned(),
+            chain: CrossChainNetwork::Ethereum,
+            inbound: eth_inbound("kamn:did:agent:listener-target-eth"),
+        })
+        .expect("ethereum inbound should process");
+
+    assert_eq!(normalized.sender_handle, "0xContractEscrow");
+    assert_eq!(normalized.bridge_message_id, "ethereum:0xabc123:7");
+}
+
+#[test]
+fn solana_quorum_dispatches_outbound() {
+    let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
+
+    let dispatch = engine
+        .process_outbound_with_approvals(
+            CrossChainNetwork::Solana,
+            &solana_outbound(),
+            vec![
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-2".to_owned(),
+            ],
+        )
+        .expect("solana outbound should dispatch with quorum");
+
+    assert_eq!(dispatch.envelope.request_id, "solana-outbound-1");
+    assert_eq!(
+        dispatch.envelope.platform,
+        BridgePlatform::Custom("solana".to_owned())
+    );
+    assert_eq!(dispatch.approval.required_approvals, 2);
+    assert_eq!(dispatch.approval.approved_by.len(), 2);
+}
+
+#[test]
+fn outbound_rejects_unauthorized_approver() {
+    let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
+
+    assert_eq!(
+        engine.process_outbound_with_approvals(
+            CrossChainNetwork::Ethereum,
+            &BridgeOutboundRequest {
+                destination_channel_id: "ethereum:sepolia:contract:escrow-v1".to_owned(),
+                ..solana_outbound()
+            },
+            vec![
+                "kamn:did:agent:approver-1".to_owned(),
+                "kamn:did:agent:approver-x".to_owned(),
+            ],
+        ),
+        Err(CrossChainBridgeError::UnauthorizedApprover(
+            "kamn:did:agent:approver-x".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn integration_projects_solana_inbound_to_envelope() {
+    let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
+
+    let envelope = engine
+        .process_inbound_to_envelope(
+            &CrossChainInboundRequest {
+                listener_did: "kamn:did:agent:listener-1".to_owned(),
+                chain: CrossChainNetwork::Solana,
+                inbound: solana_inbound("kamn:did:agent:listener-target-sol"),
+            },
+            vec!["kamn:did:agent:listener-target-sol#key-agreement-1".to_owned()],
+            "2026-02-08T09:30:00Z",
+            13,
+        )
+        .expect("solana inbound projection should succeed");
+
+    assert_eq!(
+        envelope.envelope.from,
+        "kamn:did:agent:bridge-crosschain-1".to_owned()
+    );
+    assert_eq!(
+        envelope.envelope.to,
+        vec!["kamn:did:agent:listener-target-sol".to_owned()]
+    );
+}
+
+#[test]
+fn regression_unknown_ethereum_route_is_rejected() {
+    let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
+
+    // Regression: #233
+    assert_eq!(
+        engine.process_inbound(&CrossChainInboundRequest {
+            listener_did: "kamn:did:agent:listener-1".to_owned(),
+            chain: CrossChainNetwork::Ethereum,
+            inbound: BridgeInboundEnvelope {
+                external_channel_id: "ethereum:sepolia:contract:unknown".to_owned(),
+                ..eth_inbound("kamn:did:agent:listener-target-eth")
+            },
+        }),
+        Err(CrossChainBridgeError::UnknownRouteChannel {
+            chain: CrossChainNetwork::Ethereum,
+            channel_id: "ethereum:sepolia:contract:unknown".to_owned(),
+        })
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -67,6 +67,7 @@ For task artifact integrity references and provenance metadata controls, see `do
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
 For Discord bridge approver-gated outbound flow controls, see `docs/foundation/discord-bridge-approver-gating.md`.
+For Ethereum/Solana cross-chain adapter foundation controls, see `docs/foundation/cross-chain-bridge-adapters.md`.
 For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-caching-parallelism.md`.
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.

--- a/docs/foundation/cross-chain-bridge-adapters.md
+++ b/docs/foundation/cross-chain-bridge-adapters.md
@@ -1,0 +1,49 @@
+# Cross-Chain Bridge Adapters (Ethereum and Solana) (Issues #232, #233)
+
+This document captures the first implementation slice for cross-chain bridge adapters covering Ethereum and Solana inbound/outbound pathways.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/cross_chain_bridge.rs` with:
+  - `CrossChainNetwork` enum (`Ethereum`, `Solana`).
+  - `CrossChainBridgeConfig` for listener and approver allowlists, approval threshold, and chain route maps.
+  - `CrossChainBridgeEngine` that wires chain-specific adapter engines.
+  - `process_inbound(...)` and `process_inbound_to_envelope(...)` with listener and route validation.
+  - `process_outbound_with_approvals(...)` with approver quorum enforcement and deterministic approval metadata.
+  - typed error handling via `CrossChainBridgeError`.
+- Added integration tests in `crates/kamn-core/tests/cross_chain_bridge.rs`.
+
+## Validation Rules
+- Bridge/listener/approver DIDs must parse as `kamn:did:agent:*`.
+- Listener and approver allowlists must be non-empty.
+- `required_approvals` must be between `1` and approver allowlist size.
+- Ethereum and Solana route maps must both be present and non-empty.
+- Inbound processing requires:
+  - authorized listener DID.
+  - route lookup hit for chain-specific `external_channel_id`.
+  - `target_agent_did` equal to mapped route target DID.
+- Outbound processing requires:
+  - destination channel present in chain-specific route map.
+  - authorized approver set with no duplicates.
+  - provided approvals satisfy quorum threshold.
+
+## Processing Flow
+- `process_inbound(...)`:
+  - validates listener and chain route mapping.
+  - normalizes payload through chain-specific bridge adapter engine.
+- `process_inbound_to_envelope(...)`:
+  - reuses inbound validation path.
+  - projects inbound message to canonical KAMN envelope.
+- `process_outbound_with_approvals(...)`:
+  - validates route + approver quorum.
+  - translates outbound payload via selected chain adapter engine.
+  - returns translated payload and approval metadata for audit trails.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test cross_chain_bridge
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first cross-chain bridge adapter slice for story #60 by adding Ethereum and Solana adapter foundations with deterministic inbound routing and approver-gated outbound dispatch. The implementation reuses existing bridge adapter contracts while adding chain-aware validation and typed errors.

Closes #232
Closes #233

## Changes
- `crates/kamn-core/src/cross_chain_bridge.rs`: added cross-chain engine, chain enum, config, inbound/outbound processing paths, approval metadata, and typed errors.
- `crates/kamn-core/tests/cross_chain_bridge.rs`: added functional/integration/regression coverage for Ethereum and Solana flows.
- `crates/kamn-core/src/lib.rs`: exported cross-chain bridge types.
- `docs/foundation/cross-chain-bridge-adapters.md`: documented behavior and validation rules.
- `docs/foundation/bootstrap.md`: linked cross-chain adapter foundation docs.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test cross_chain_bridge
```
Failure before implementation:
```text
error[E0432]: unresolved imports `kamn_core::CrossChainBridgeConfig`, `kamn_core::CrossChainBridgeEngine`, `kamn_core::CrossChainBridgeError`, `kamn_core::CrossChainInboundRequest`, `kamn_core::CrossChainNetwork`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test cross_chain_bridge
```
Passing output summary:
```text
running 5 tests
... all passed ...
test result: ok. 5 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Passing output summary:
```text
fmt: clean
clippy: finished with no warnings
cargo test -p kamn-core: 105 unit tests + integration suites passed; 0 failed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `constructor_rejects_empty_ethereum_routes`; `constructor_rejects_invalid_required_approvals_threshold` | |
| Functional   | ✅     | `ethereum_listener_can_process_inbound`; `solana_quorum_dispatches_outbound`; `outbound_rejects_unauthorized_approver` | |
| Integration  | ✅     | `integration_projects_solana_inbound_to_envelope` | |
| Regression   | ✅     | `regression_unknown_ethereum_route_is_rejected` (`// Regression: #233`) | |
| Performance  | N/A    | None | MVP control-plane validation path only; no throughput benchmark scope in this slice |

## Risks & Rollback
- None expected for existing behavior; this adds new module exports and tests.
- Rollback: revert this PR to remove cross-chain adapter slice.

## Documentation Updates
- `docs/foundation/cross-chain-bridge-adapters.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
