### PR TITLE
docs: add semantic versioning policy and compatibility matrix

### DIFF
--- a/crates/kamn-core/tests/versioning_compatibility_docs.rs
+++ b/crates/kamn-core/tests/versioning_compatibility_docs.rs
@@ -1,0 +1,39 @@
+const POLICY: &str = include_str!("../../../docs/foundation/versioning-compatibility-matrix.md");
+
+#[test]
+fn policy_defines_semantic_versions_for_chain_app_and_sdks() {
+    assert!(POLICY.contains("## Semantic Versioning Policy"));
+    assert!(POLICY.contains("Chain protocol version follows MAJOR.MINOR.PATCH."));
+    assert!(POLICY.contains("App-state schema version follows MAJOR.MINOR.PATCH."));
+    assert!(POLICY.contains("SDK versions (Rust, Python, TypeScript) follow MAJOR.MINOR.PATCH."));
+}
+
+#[test]
+fn policy_contains_compatibility_matrix_with_upgrade_and_downgrade_expectations() {
+    assert!(POLICY.contains("## Compatibility Matrix"));
+    assert!(POLICY.contains("| Chain Protocol | App-State Schema | Node Binary | SDK Family | Upgrade Expectation | Downgrade Expectation |"));
+    assert!(POLICY.contains("Same major version upgrade: supported with migration plan."));
+    assert!(
+        POLICY.contains("Cross-major upgrade: requires governance approval and staged rollout.")
+    );
+    assert!(POLICY.contains("Downgrade across major versions: blocked."));
+}
+
+#[test]
+fn policy_defines_support_and_deprecation_windows() {
+    assert!(POLICY.contains("## Support and Deprecation Windows"));
+    assert!(POLICY.contains("Current minor (N) and previous minor (N-1) are supported."));
+    assert!(POLICY.contains("Anything older than N-1 is deprecated and no-go for new rollouts."));
+}
+
+#[test]
+fn regression_requires_incompatible_downgrade_no_go_rule() {
+    // Regression: #175
+    assert!(POLICY.contains("Incompatible downgrade decision: NO-GO."));
+    assert!(POLICY.contains(
+        "Referenced by governance workflow: docs/foundation/release-gonogo-checklist.md"
+    ));
+    assert!(POLICY.contains(
+        "Referenced by migration/rollback workflow: docs/foundation/upgrade-rollback-runbook.md"
+    ));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -72,6 +72,7 @@ For CI cache strategy and bounded parallelism controls, see `docs/foundation/ci-
 For flaky-test quarantine and bounded retry controls, see `docs/foundation/ci-flaky-quarantine.md`.
 For release rollback triggers and post-upgrade verification controls, see `docs/foundation/upgrade-rollback-runbook.md`.
 For release go/no-go checklist and dry-run evidence controls, see `docs/foundation/release-gonogo-checklist.md`.
+For semantic version policy and compatibility matrix controls, see `docs/foundation/versioning-compatibility-matrix.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.
 For compliance audit export interface controls, see `docs/foundation/audit-export-interfaces.md`.
 For configurable retention policy enforcement controls, see `docs/foundation/retention-policy-engine.md`.

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -1,6 +1,7 @@
 # Release Go/No-Go Checklist and Dry-Run Workflow (Issues #172, #173)
 
 This checklist defines deterministic release gates and auditable evidence requirements before approving a protocol or runtime upgrade.
+For semantic versioning policy and compatibility rules, see `docs/foundation/versioning-compatibility-matrix.md`.
 
 ## Preflight Gates
 - Migration plan reviewed and signed.

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -1,6 +1,7 @@
 # Upgrade Rollback and Post-Upgrade Verification Runbook (Issues #170, #171)
 
 This runbook defines deterministic rollback triggers, rollback execution steps, and post-upgrade verification checks for KAMN operators.
+For semantic versioning policy and compatibility rules, see `docs/foundation/versioning-compatibility-matrix.md`.
 
 ## Rollback Triggers
 - State migration checksum mismatch.

--- a/docs/foundation/versioning-compatibility-matrix.md
+++ b/docs/foundation/versioning-compatibility-matrix.md
@@ -1,0 +1,42 @@
+# Semantic Versioning and Compatibility Matrix (Issues #174, #175)
+
+This document defines the first versioning policy slice for chain protocol, app-state schema, and SDK families, including compatibility expectations for upgrades and downgrades.
+
+## Semantic Versioning Policy
+- Chain protocol version follows MAJOR.MINOR.PATCH.
+- App-state schema version follows MAJOR.MINOR.PATCH.
+- SDK versions (Rust, Python, TypeScript) follow MAJOR.MINOR.PATCH.
+- MAJOR increments indicate breaking protocol or schema changes.
+- MINOR increments indicate backward-compatible feature additions.
+- PATCH increments indicate backward-compatible fixes and hardening.
+
+## Compatibility Matrix
+| Chain Protocol | App-State Schema | Node Binary | SDK Family | Upgrade Expectation | Downgrade Expectation |
+|---|---|---|---|---|---|
+| Same major version | Same major version | Same major version | Same or previous minor | Same major version upgrade: supported with migration plan. | Downgrade within same major may be allowed only with rollback checklist evidence. |
+| Next major version | Next major version | Next major version | Mixed major not allowed | Cross-major upgrade: requires governance approval and staged rollout. | Downgrade across major versions: blocked. |
+
+## Support and Deprecation Windows
+- Current minor (N) and previous minor (N-1) are supported.
+- Anything older than N-1 is deprecated and no-go for new rollouts.
+- Security fixes are backported only for supported minors.
+- Deprecated minors require explicit governance waiver for continued operation.
+
+## Decision Rules
+- Incompatible downgrade decision: NO-GO.
+- Any cross-major schema shift requires dry-run evidence before GO.
+- Mixed-major node binaries are never GO in production rollout windows.
+
+## Workflow References
+- Referenced by governance workflow: docs/foundation/release-gonogo-checklist.md
+- Referenced by migration/rollback workflow: docs/foundation/upgrade-rollback-runbook.md
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test versioning_compatibility_docs
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first semantic versioning policy slice for story #85 by adding a formal chain/app/SDK versioning policy, compatibility matrix, support windows, and explicit decision rules. The policy is now referenced by both governance go/no-go and migration/rollback workflows.

Closes #174
Closes #175

## Changes
- `docs/foundation/versioning-compatibility-matrix.md`: added semantic version policy, compatibility matrix, support/deprecation windows, decision rules, and workflow references.
- `crates/kamn-core/tests/versioning_compatibility_docs.rs`: added docs assertions for required policy/matrix sections and downgrade regression guard.
- `docs/foundation/release-gonogo-checklist.md`: linked semantic versioning policy.
- `docs/foundation/upgrade-rollback-runbook.md`: linked semantic versioning policy.
- `docs/foundation/bootstrap.md`: linked semantic versioning policy doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test versioning_compatibility_docs
```
Failure before implementation:
```text
error: couldn't read docs/foundation/versioning-compatibility-matrix.md: No such file or directory
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test versioning_compatibility_docs
```
Passing output summary:
```text
running 4 tests
... all passed ...
test result: ok. 4 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Passing output summary:
```text
fmt: clean
clippy: finished with no warnings
cargo test -p kamn-core: all tests passed (including new versioning docs test)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `policy_defines_semantic_versions_for_chain_app_and_sdks` | |
| Functional   | ✅     | `policy_contains_compatibility_matrix_with_upgrade_and_downgrade_expectations` | |
| Integration  | ✅     | `policy_defines_support_and_deprecation_windows` | |
| Regression   | ✅     | `regression_requires_incompatible_downgrade_no_go_rule` (`// Regression: #175`) | |
| Performance  | N/A    | None | Documentation and static assertion slice only |

## Risks & Rollback
- None expected; documentation and docs tests only.
- Rollback: revert this PR.

## Documentation Updates
- `docs/foundation/versioning-compatibility-matrix.md`
- `docs/foundation/release-gonogo-checklist.md`
- `docs/foundation/upgrade-rollback-runbook.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
