### PR TITLE
docs(interop): map kamn:did DID Core 1.1 conformance (#81)

### DIFF
--- a/crates/kamn-core/tests/did_core_conformance_docs.rs
+++ b/crates/kamn-core/tests/did_core_conformance_docs.rs
@@ -1,0 +1,42 @@
+const PROFILE: &str = include_str!("../../../docs/foundation/did-core-conformance-kamn-method.md");
+
+#[test]
+fn profile_contains_did_core_requirement_mapping() {
+    assert!(PROFILE.contains("## DID Core Requirement Mapping"));
+    assert!(PROFILE.contains("| DID Core Element | Requirement Level | kamn:did Status | Notes |"));
+    assert!(PROFILE.contains("| id | REQUIRED | covered | DID subject identifier is mandatory. |"));
+    assert!(PROFILE.contains("| verificationMethod | REQUIRED | covered | At least one verification method is required. |"));
+    assert!(PROFILE.contains(
+        "| authentication | REQUIRED | covered | Authentication relationship must be present. |"
+    ));
+    assert!(PROFILE
+        .contains("| service | OPTIONAL | partial | Service rules remain profile-constrained. |"));
+}
+
+#[test]
+fn profile_contains_conformance_decisions_and_open_questions() {
+    assert!(PROFILE.contains("## Conformance Decisions and Open Questions"));
+    assert!(PROFILE.contains("Decision: require verificationMethod and capabilityInvocation."));
+    assert!(PROFILE.contains("Decision: reject unsupported DID method prefixes."));
+    assert!(PROFILE.contains("Open question: service endpoint canonicalization strategy."));
+}
+
+#[test]
+fn profile_contains_candidate_test_vectors_and_downstream_categories() {
+    assert!(PROFILE.contains("## Candidate Test Vectors"));
+    assert!(PROFILE.contains("Vector-C1: valid kamn:did document with required relationships."));
+    assert!(PROFILE.contains("Vector-C2: valid update preserving DID subject continuity."));
+    assert!(PROFILE.contains("Vector-N1: document missing id is rejected."));
+    assert!(PROFILE.contains("Vector-N2: unsupported verification method algorithm is rejected."));
+    assert!(PROFILE.contains("## Downstream Test Category Mapping"));
+    assert!(PROFILE.contains("Unit: schema-field validator mappings."));
+    assert!(PROFILE.contains("Functional: DID document acceptance and rejection examples."));
+    assert!(PROFILE.contains("Integration: DID registry interaction expectations."));
+    assert!(PROFILE.contains("Regression: previously non-conformant examples remain rejected."));
+}
+
+#[test]
+fn regression_requires_missing_id_rejection_rule() {
+    // Regression: #81
+    assert!(PROFILE.contains("Previously non-conformant document (missing id) must be rejected."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -75,6 +75,7 @@ For release go/no-go checklist and dry-run evidence controls, see `docs/foundati
 For semantic version policy and compatibility matrix controls, see `docs/foundation/versioning-compatibility-matrix.md`.
 For A2A and MCP interoperability mapping controls, see `docs/foundation/a2a-mcp-interoperability.md`.
 For KAMN to DIDComm v2 compatibility profile controls, see `docs/foundation/didcomm-v2-compatibility-profile.md`.
+For `kamn:did` to DID Core 1.1 conformance controls, see `docs/foundation/did-core-conformance-kamn-method.md`.
 For redaction and tombstone compliance workflow controls, see `docs/foundation/redaction-tombstones.md`.
 For compliance audit export interface controls, see `docs/foundation/audit-export-interfaces.md`.
 For configurable retention policy enforcement controls, see `docs/foundation/retention-policy-engine.md`.

--- a/docs/foundation/did-core-conformance-kamn-method.md
+++ b/docs/foundation/did-core-conformance-kamn-method.md
@@ -1,0 +1,43 @@
+# DID Core 1.1 Conformance Profile for `kamn:did` (Issue #81)
+
+This profile maps the `kamn:did` method schema to DID Core 1.1 conformance requirements and captures explicit decisions, known gaps, and future test vectors.
+
+## DID Core Requirement Mapping
+| DID Core Element | Requirement Level | kamn:did Status | Notes |
+|---|---|---|---|
+| id | REQUIRED | covered | DID subject identifier is mandatory. |
+| verificationMethod | REQUIRED | covered | At least one verification method is required. |
+| authentication | REQUIRED | covered | Authentication relationship must be present. |
+| assertionMethod | RECOMMENDED | covered | Included for signed claim validation surfaces. |
+| capabilityInvocation | RECOMMENDED | covered | Required by profile for operator-bound actions. |
+| service | OPTIONAL | partial | Service rules remain profile-constrained. |
+
+## Conformance Decisions and Open Questions
+- Decision: require verificationMethod and capabilityInvocation.
+- Decision: reject unsupported DID method prefixes.
+- Decision: treat empty capability relationship arrays as invalid.
+- Open question: service endpoint canonicalization strategy.
+- Open question: multi-key algorithm mixing policy for future revisions.
+
+## Candidate Test Vectors
+- Vector-C1: valid kamn:did document with required relationships.
+- Vector-C2: valid update preserving DID subject continuity.
+- Vector-N1: document missing id is rejected.
+- Vector-N2: unsupported verification method algorithm is rejected.
+- Previously non-conformant document (missing id) must be rejected.
+
+## Downstream Test Category Mapping
+- Unit: schema-field validator mappings.
+- Functional: DID document acceptance and rejection examples.
+- Integration: DID registry interaction expectations.
+- Regression: previously non-conformant examples remain rejected.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test did_core_conformance_docs
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```

--- a/docs/foundation/did-method.md
+++ b/docs/foundation/did-method.md
@@ -1,6 +1,7 @@
 # DID Method and Canonical DID Document Schema (Issues #108, #109)
 
 This document captures the first implementation slice for KAMN DID method handling and canonical DID document construction.
+For DID Core 1.1 conformance mapping of `kamn:did`, see `docs/foundation/did-core-conformance-kamn-method.md`.
 
 ## Scope Delivered
 - Added `crates/kamn-core/src/did.rs` with:


### PR DESCRIPTION
## Summary
Adds the DID Core 1.1 conformance mapping profile for `kamn:did` and links it into the existing DID/foundation docs. Includes a TDD-backed docs regression test to lock required mapping and rejection rules.

## Changes
- `docs/foundation/did-core-conformance-kamn-method.md`: New conformance profile (requirements mapping, decisions, open questions, vectors, downstream tests).
- `crates/kamn-core/tests/did_core_conformance_docs.rs`: New docs contract test and regression check for missing `id` rejection rule.
- `docs/foundation/did-method.md`: Added forward link to the conformance profile.
- `docs/foundation/bootstrap.md`: Added catalog reference to the new profile.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed profile mapping table, decisions, vectors, and bootstrap/did cross-links.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test did_core_conformance_docs` |
| Functional  | ✅     | Profile vectors include valid/invalid acceptance criteria |
| Integration | ✅     | `cargo test -p kamn-core` clean across existing integration suite |
| Regression  | ✅     | `regression_requires_missing_id_rejection_rule` locks prior gap |

Closes #81
