### PR TITLE
feat(keys): add tamper-evident lifecycle audit verification (#158)

### DIFF
--- a/crates/kamn-core/src/key_lifecycle.rs
+++ b/crates/kamn-core/src/key_lifecycle.rs
@@ -23,6 +23,77 @@ pub enum KeyLifecycleEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyLifecycleAuditRecord {
+    pub sequence: u64,
+    pub event_kind: String,
+    pub event_payload: String,
+    pub previous_hash: String,
+    pub record_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyLifecycleAuditError {
+    EmptyAuditTrail,
+    SequenceGap { expected: u64, found: u64 },
+    BrokenHashChain { sequence: u64 },
+    HashMismatch { sequence: u64 },
+}
+
+impl std::fmt::Display for KeyLifecycleAuditError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyAuditTrail => write!(f, "audit trail must not be empty"),
+            Self::SequenceGap { expected, found } => write!(
+                f,
+                "audit sequence gap detected: expected {expected}, found {found}"
+            ),
+            Self::BrokenHashChain { sequence } => {
+                write!(f, "audit hash chain link mismatch at sequence {sequence}")
+            }
+            Self::HashMismatch { sequence } => {
+                write!(f, "audit hash mismatch at sequence {sequence}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KeyLifecycleAuditError {}
+
+impl KeyLifecycleEvent {
+    fn sequence(&self) -> u64 {
+        match self {
+            Self::RotationInitiated { sequence, .. }
+            | Self::RotationActivated { sequence, .. }
+            | Self::KeyRevoked { sequence, .. } => *sequence,
+        }
+    }
+
+    fn canonical_kind(&self) -> &'static str {
+        match self {
+            Self::RotationInitiated { .. } => "rotation_initiated",
+            Self::RotationActivated { .. } => "rotation_activated",
+            Self::KeyRevoked { .. } => "key_revoked",
+        }
+    }
+
+    fn canonical_payload(&self) -> String {
+        match self {
+            Self::RotationInitiated {
+                from_key, to_key, ..
+            } => {
+                format!("from_key={from_key};to_key={to_key}")
+            }
+            Self::RotationActivated { active_key, .. } => {
+                format!("active_key={active_key}")
+            }
+            Self::KeyRevoked { key_id, .. } => {
+                format!("key_id={key_id}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyLifecycle {
     state: KeyLifecycleState,
     active_key_id: String,
@@ -59,6 +130,78 @@ impl KeyLifecycle {
 
     pub fn events(&self) -> &[KeyLifecycleEvent] {
         &self.events
+    }
+
+    pub fn audit_records(&self) -> Vec<KeyLifecycleAuditRecord> {
+        let mut records = Vec::with_capacity(self.events.len());
+        let mut previous_hash = AUDIT_CHAIN_GENESIS.to_owned();
+
+        for event in &self.events {
+            let sequence = event.sequence();
+            let event_kind = event.canonical_kind().to_owned();
+            let event_payload = event.canonical_payload();
+            let record_hash =
+                compute_audit_hash(sequence, &event_kind, &event_payload, &previous_hash);
+
+            records.push(KeyLifecycleAuditRecord {
+                sequence,
+                event_kind,
+                event_payload,
+                previous_hash: previous_hash.clone(),
+                record_hash: record_hash.clone(),
+            });
+
+            previous_hash = record_hash;
+        }
+
+        records
+    }
+
+    pub fn verify_audit_trail(&self) -> Result<(), KeyLifecycleAuditError> {
+        Self::verify_audit_records(&self.audit_records())
+    }
+
+    pub fn verify_audit_records(
+        records: &[KeyLifecycleAuditRecord],
+    ) -> Result<(), KeyLifecycleAuditError> {
+        if records.is_empty() {
+            return Err(KeyLifecycleAuditError::EmptyAuditTrail);
+        }
+
+        let mut expected_sequence = 1;
+        let mut previous_hash = AUDIT_CHAIN_GENESIS.to_owned();
+
+        for record in records {
+            if record.sequence != expected_sequence {
+                return Err(KeyLifecycleAuditError::SequenceGap {
+                    expected: expected_sequence,
+                    found: record.sequence,
+                });
+            }
+
+            if record.previous_hash != previous_hash {
+                return Err(KeyLifecycleAuditError::BrokenHashChain {
+                    sequence: record.sequence,
+                });
+            }
+
+            let expected_hash = compute_audit_hash(
+                record.sequence,
+                &record.event_kind,
+                &record.event_payload,
+                &record.previous_hash,
+            );
+            if record.record_hash != expected_hash {
+                return Err(KeyLifecycleAuditError::HashMismatch {
+                    sequence: record.sequence,
+                });
+            }
+
+            previous_hash = record.record_hash.clone();
+            expected_sequence += 1;
+        }
+
+        Ok(())
     }
 
     pub fn initiate_rotation(&mut self, next_key_id: &str) -> Result<(), KeyLifecycleError> {
@@ -133,6 +276,26 @@ impl KeyLifecycle {
         });
         Ok(())
     }
+}
+
+const AUDIT_CHAIN_GENESIS: &str = "GENESIS";
+
+fn compute_audit_hash(
+    sequence: u64,
+    event_kind: &str,
+    event_payload: &str,
+    previous_hash: &str,
+) -> String {
+    let canonical_payload = format!("{sequence}|{event_kind}|{event_payload}|{previous_hash}");
+
+    // First slice uses a deterministic non-cryptographic hash; this can be replaced by SHA-256 later.
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in canonical_payload.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3_u64);
+    }
+
+    format!("{hash:016x}")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -94,7 +94,10 @@ pub use invariants::{
     invariant_by_id, validate_catalog, InvariantCatalogError, InvariantDomain,
     InvariantFailureCode, InvariantSpec, InvariantViolation,
 };
-pub use key_lifecycle::{KeyLifecycle, KeyLifecycleError, KeyLifecycleEvent, KeyLifecycleState};
+pub use key_lifecycle::{
+    KeyLifecycle, KeyLifecycleAuditError, KeyLifecycleAuditRecord, KeyLifecycleError,
+    KeyLifecycleEvent, KeyLifecycleState,
+};
 pub use key_recovery::{KeyRecoveryManager, RecoveryError, RecoveryState};
 pub use message_delivery_guards::{
     DeliveryFailureCode, DeliveryGuardInput, DeliveryValidationResult, FailedDeliveryNotice,

--- a/crates/kamn-core/tests/key_lifecycle.rs
+++ b/crates/kamn-core/tests/key_lifecycle.rs
@@ -1,4 +1,6 @@
-use kamn_core::{KeyLifecycle, KeyLifecycleError, KeyLifecycleEvent, KeyLifecycleState};
+use kamn_core::{
+    KeyLifecycle, KeyLifecycleAuditError, KeyLifecycleError, KeyLifecycleEvent, KeyLifecycleState,
+};
 
 #[test]
 fn active_to_rotating_to_active_emits_audit_events() {
@@ -73,5 +75,70 @@ fn rotation_rejects_same_key_or_empty_key() {
     assert_eq!(
         lifecycle.initiate_rotation("key_v1"),
         Err(KeyLifecycleError::RotationKeyUnchanged)
+    );
+}
+
+#[test]
+fn audit_records_form_tamper_evident_chain() {
+    let mut lifecycle = KeyLifecycle::new("key_v1").expect("lifecycle should initialize");
+    lifecycle
+        .initiate_rotation("key_v2")
+        .expect("rotation init should succeed");
+    lifecycle
+        .activate_rotation()
+        .expect("rotation activation should succeed");
+    lifecycle.revoke().expect("revoke should succeed");
+
+    let records = lifecycle.audit_records();
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[0].previous_hash, "GENESIS");
+    assert_eq!(records[0].sequence, 1);
+    assert_eq!(records[1].sequence, 2);
+    assert_eq!(records[2].sequence, 3);
+    assert_ne!(records[0].record_hash, records[1].record_hash);
+
+    lifecycle
+        .verify_audit_trail()
+        .expect("audit trail should verify");
+}
+
+#[test]
+fn verify_rejects_tampered_hash_chain() {
+    let mut lifecycle = KeyLifecycle::new("key_v1").expect("lifecycle should initialize");
+    lifecycle
+        .initiate_rotation("key_v2")
+        .expect("rotation init should succeed");
+    lifecycle
+        .activate_rotation()
+        .expect("rotation activation should succeed");
+
+    let mut records = lifecycle.audit_records();
+    records[1].previous_hash = "tampered-link".to_owned();
+
+    assert_eq!(
+        KeyLifecycle::verify_audit_records(&records),
+        Err(KeyLifecycleAuditError::BrokenHashChain { sequence: 2 })
+    );
+}
+
+#[test]
+fn regression_detects_sequence_gap_in_audit_records() {
+    let mut lifecycle = KeyLifecycle::new("key_v1").expect("lifecycle should initialize");
+    lifecycle
+        .initiate_rotation("key_v2")
+        .expect("rotation init should succeed");
+    lifecycle
+        .activate_rotation()
+        .expect("rotation activation should succeed");
+
+    let mut records = lifecycle.audit_records();
+    records[1].sequence = 99;
+
+    assert_eq!(
+        KeyLifecycle::verify_audit_records(&records),
+        Err(KeyLifecycleAuditError::SequenceGap {
+            expected: 2,
+            found: 99,
+        })
     );
 }

--- a/crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs
+++ b/crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs
@@ -1,0 +1,24 @@
+const DOC: &str = include_str!("../../../docs/foundation/key-lifecycle-audit-trails.md");
+
+#[test]
+fn doc_contains_audit_record_schema_and_verification_rules() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("KeyLifecycleAuditRecord"));
+    assert!(DOC.contains("KeyLifecycle::audit_records()"));
+    assert!(DOC.contains("KeyLifecycle::verify_audit_records(...)"));
+    assert!(DOC.contains("KeyLifecycleAuditError"));
+}
+
+#[test]
+fn doc_contains_tamper_evident_chain_requirements() {
+    assert!(DOC.contains("## Tamper-Evident Rules"));
+    assert!(DOC.contains("genesis marker `GENESIS`"));
+    assert!(DOC.contains("Sequence IDs must be contiguous and start at `1`."));
+    assert!(DOC.contains("Verification fails when sequence continuity, chain links, or record hashes are inconsistent."));
+}
+
+#[test]
+fn regression_requires_chain_link_mismatch_detection_rule() {
+    // Regression: #158
+    assert!(DOC.contains("chain links"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -49,6 +49,7 @@ For multi-AZ topology and failover operations, see `docs/foundation/multi-az-fai
 For security control ownership and enforcement mapping, see `docs/foundation/threat-control-matrix.md`.
 For anti-hallucination instruction validation controls, see `docs/foundation/instruction-verification.md`.
 For deterministic key lifecycle and rotation transitions, see `docs/foundation/key-lifecycle.md`.
+For tamper-evident key lifecycle audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
 For key compromise containment and recovery workflows, see `docs/foundation/key-recovery.md`.
 For Python SDK parity slice, see `docs/foundation/python-sdk-beta.md`.
 For DID method and canonical DID document schema controls, see `docs/foundation/did-method.md`.

--- a/docs/foundation/key-lifecycle-audit-trails.md
+++ b/docs/foundation/key-lifecycle-audit-trails.md
@@ -1,0 +1,35 @@
+# Key Lifecycle Tamper-Evident Audit Trails (Issue #158)
+
+This document captures the first implementation slice for tamper-evident key lifecycle audit trails and verification checks.
+
+## Scope Delivered
+- Added deterministic audit record construction in `crates/kamn-core/src/key_lifecycle.rs`:
+  - `KeyLifecycleAuditRecord` with `sequence`, `event_kind`, `event_payload`, `previous_hash`, and `record_hash`.
+  - `KeyLifecycle::audit_records()` to materialize a hash-chained audit trail from lifecycle events.
+  - `KeyLifecycle::verify_audit_trail()` and `KeyLifecycle::verify_audit_records(...)` for integrity validation.
+  - `KeyLifecycleAuditError` typed failures for empty trails, sequence gaps, broken chain links, and hash mismatches.
+- Extended integration tests in `crates/kamn-core/tests/key_lifecycle.rs` for chain construction and tamper detection.
+
+## Tamper-Evident Rules
+- The first record must reference the genesis marker `GENESIS`.
+- Sequence IDs must be contiguous and start at `1`.
+- Each record hash is computed from:
+  - sequence
+  - event kind
+  - canonical event payload
+  - previous hash
+- Verification fails when sequence continuity, chain links, or record hashes are inconsistent.
+
+## Limitations (First Slice)
+- Hashing currently uses a deterministic non-cryptographic fingerprint for low-dependency bootstrap compatibility.
+- A future slice can replace the digest with SHA-256/HMAC signing while preserving record format and verification semantics.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test key_lifecycle
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```

--- a/docs/foundation/key-lifecycle.md
+++ b/docs/foundation/key-lifecycle.md
@@ -1,6 +1,7 @@
 # Key Lifecycle and Rotation Protocol (Issues #146, #147)
 
 This document captures the first implementation slice for deterministic key lifecycle and rotation transitions.
+For tamper-evident audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
 
 ## Scope Delivered
 - Added `crates/kamn-core/src/key_lifecycle.rs` with:


### PR DESCRIPTION
## Summary
Implements the first slice of tamper-evident key lifecycle audit trails by adding hash-chained audit records and explicit verification APIs. Extends integration and docs tests to enforce chain integrity, sequence continuity, and regression behavior.

## Changes
- `crates/kamn-core/src/key_lifecycle.rs`: Added `KeyLifecycleAuditRecord`, `KeyLifecycleAuditError`, deterministic hash-chain record builder, and audit verification APIs.
- `crates/kamn-core/src/lib.rs`: Exported new audit trail types.
- `crates/kamn-core/tests/key_lifecycle.rs`: Added functional/regression tests for tamper-evident chain validation.
- `docs/foundation/key-lifecycle-audit-trails.md`: Added implementation and verification contract documentation.
- `crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs`: Added docs contract/regression tests.
- `docs/foundation/key-lifecycle.md`: Added reference to audit trail controls.
- `docs/foundation/bootstrap.md`: Added index link for audit trail controls.

## Risks & Compatibility
- No breaking API removals; additive surface only.
- First slice uses deterministic non-cryptographic hashing and documents this limitation for a future cryptographic-hardening follow-up.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed sequence/hash-chain failure paths and docs linkage.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test key_lifecycle` |
| Functional  | ✅     | Tamper-evident chain creation and verification behavior asserted in `key_lifecycle` integration tests |
| Integration | ✅     | `cargo test -p kamn-core` full crate suite passes with new lifecycle audit APIs exported via `lib.rs` |
| Regression  | ✅     | Sequence-gap and broken-link regressions enforced in `key_lifecycle` + docs regression guards |

Closes #159
Closes #158
