### PR TITLE
feat(keys): implement pluggable signer backends (#160)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod operator_binding;
 pub mod redaction_compliance;
 pub mod retention_engine;
 pub mod runtime;
+pub mod signer_backend;
 pub mod smoke;
 pub mod state;
 pub mod task_artifacts;
@@ -124,6 +125,10 @@ pub use retention_engine::{
     RetentionPolicyEngine, RetentionPolicyError, RetentionRecord, RetentionStatus,
 };
 pub use runtime::RuntimeWiring;
+pub use signer_backend::{
+    BackendSignature, LocalSignerBackend, SecureSignerBackend, SignerBackend, SignerBackendError,
+    SignerBackendRouter, SigningRequest,
+};
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,

--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -1,0 +1,282 @@
+use crate::transaction::BaselineTransaction;
+
+const LOCAL_BACKEND_NAME: &str = "local-software";
+const SECURE_BACKEND_NAME: &str = "secure-mock";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SigningRequest {
+    pub key_id: String,
+    pub sender: String,
+    pub nonce: u64,
+    pub payload: String,
+    pub state_hash: String,
+}
+
+impl SigningRequest {
+    pub fn new(
+        key_id: &str,
+        sender: &str,
+        nonce: u64,
+        payload: &str,
+        state_hash: &str,
+    ) -> Result<Self, SignerBackendError> {
+        if key_id.trim().is_empty() {
+            return Err(SignerBackendError::EmptyField("key_id"));
+        }
+        if sender.trim().is_empty() {
+            return Err(SignerBackendError::EmptyField("sender"));
+        }
+        if nonce == 0 {
+            return Err(SignerBackendError::InvalidNonce);
+        }
+        if payload.trim().is_empty() {
+            return Err(SignerBackendError::EmptyField("payload"));
+        }
+        if state_hash.trim().is_empty() {
+            return Err(SignerBackendError::EmptyField("state_hash"));
+        }
+
+        Ok(Self {
+            key_id: key_id.to_owned(),
+            sender: sender.to_owned(),
+            nonce,
+            payload: payload.to_owned(),
+            state_hash: state_hash.to_owned(),
+        })
+    }
+
+    pub fn for_transaction(
+        key_id: &str,
+        tx: &BaselineTransaction,
+    ) -> Result<Self, SignerBackendError> {
+        if tx.id.trim().is_empty() {
+            return Err(SignerBackendError::EmptyField("transaction_id"));
+        }
+        Self::new(key_id, &tx.sender, tx.nonce, &tx.payload, &tx.state_hash)
+    }
+
+    fn expected_signature(&self) -> String {
+        format!(
+            "sig:{}:{}:{}:{}",
+            self.sender,
+            self.nonce,
+            self.state_hash,
+            self.payload.len()
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendSignature {
+    pub backend: String,
+    pub signature: String,
+}
+
+pub trait SignerBackend {
+    fn backend_name(&self) -> &'static str;
+    fn sign(&self, request: &SigningRequest) -> Result<String, SignerBackendError>;
+    fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalSignerBackend;
+
+impl SignerBackend for LocalSignerBackend {
+    fn backend_name(&self) -> &'static str {
+        LOCAL_BACKEND_NAME
+    }
+
+    fn sign(&self, request: &SigningRequest) -> Result<String, SignerBackendError> {
+        Ok(request.expected_signature())
+    }
+
+    fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
+        let expected = request.expected_signature();
+        if expected != signature {
+            return Err(SignerBackendError::SignatureMismatch {
+                backend: self.backend_name().to_owned(),
+                expected,
+                found: signature.to_owned(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecureSignerBackend {
+    available: bool,
+}
+
+impl SecureSignerBackend {
+    pub fn new(available: bool) -> Self {
+        Self { available }
+    }
+}
+
+impl SignerBackend for SecureSignerBackend {
+    fn backend_name(&self) -> &'static str {
+        SECURE_BACKEND_NAME
+    }
+
+    fn sign(&self, request: &SigningRequest) -> Result<String, SignerBackendError> {
+        if !self.available {
+            return Err(SignerBackendError::ProviderUnavailable {
+                backend: self.backend_name().to_owned(),
+            });
+        }
+        if !request.key_id.starts_with("secure:") {
+            return Err(SignerBackendError::UnsupportedKeyReference {
+                backend: self.backend_name().to_owned(),
+                key_id: request.key_id.clone(),
+            });
+        }
+
+        Ok(request.expected_signature())
+    }
+
+    fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
+        if !self.available {
+            return Err(SignerBackendError::ProviderUnavailable {
+                backend: self.backend_name().to_owned(),
+            });
+        }
+        if !request.key_id.starts_with("secure:") {
+            return Err(SignerBackendError::UnsupportedKeyReference {
+                backend: self.backend_name().to_owned(),
+                key_id: request.key_id.clone(),
+            });
+        }
+
+        let expected = request.expected_signature();
+        if expected != signature {
+            return Err(SignerBackendError::SignatureMismatch {
+                backend: self.backend_name().to_owned(),
+                expected,
+                found: signature.to_owned(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignerBackendRouter {
+    local: LocalSignerBackend,
+    secure: SecureSignerBackend,
+}
+
+impl SignerBackendRouter {
+    pub fn with_secure_availability(secure_available: bool) -> Self {
+        Self {
+            local: LocalSignerBackend,
+            secure: SecureSignerBackend::new(secure_available),
+        }
+    }
+
+    pub fn sign_with_secure_fallback(
+        &self,
+        request: &SigningRequest,
+    ) -> Result<BackendSignature, SignerBackendError> {
+        match self.secure.sign(request) {
+            Ok(signature) => Ok(BackendSignature {
+                backend: self.secure.backend_name().to_owned(),
+                signature,
+            }),
+            Err(SignerBackendError::ProviderUnavailable { .. }) => {
+                let signature = self.local.sign(request)?;
+                Ok(BackendSignature {
+                    backend: self.local.backend_name().to_owned(),
+                    signature,
+                })
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn verify_with_backend(
+        &self,
+        backend: &str,
+        request: &SigningRequest,
+        signature: &str,
+    ) -> Result<(), SignerBackendError> {
+        match backend {
+            LOCAL_BACKEND_NAME => self.local.verify(request, signature),
+            SECURE_BACKEND_NAME => self.secure.verify(request, signature),
+            _ => Err(SignerBackendError::UnknownBackend(backend.to_owned())),
+        }
+    }
+}
+
+impl Default for SignerBackendRouter {
+    fn default() -> Self {
+        Self::with_secure_availability(true)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignerBackendError {
+    EmptyField(&'static str),
+    InvalidNonce,
+    ProviderUnavailable {
+        backend: String,
+    },
+    SignatureMismatch {
+        backend: String,
+        expected: String,
+        found: String,
+    },
+    UnknownBackend(String),
+    UnsupportedKeyReference {
+        backend: String,
+        key_id: String,
+    },
+}
+
+impl std::fmt::Display for SignerBackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "{field} must not be empty"),
+            Self::InvalidNonce => write!(f, "nonce must be positive"),
+            Self::ProviderUnavailable { backend } => {
+                write!(f, "signer backend unavailable: {backend}")
+            }
+            Self::SignatureMismatch {
+                backend,
+                expected,
+                found,
+            } => write!(
+                f,
+                "signature mismatch for backend {backend}; expected {expected}, found {found}"
+            ),
+            Self::UnknownBackend(backend) => write!(f, "unknown signer backend: {backend}"),
+            Self::UnsupportedKeyReference { backend, key_id } => {
+                write!(
+                    f,
+                    "unsupported key reference for backend {backend}: {key_id}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SignerBackendError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{SignerBackendError, SigningRequest};
+
+    #[test]
+    fn signing_request_rejects_invalid_fields() {
+        assert_eq!(
+            SigningRequest::new("", "agent-a", 1, "payload", "state:genesis"),
+            Err(SignerBackendError::EmptyField("key_id"))
+        );
+        assert_eq!(
+            SigningRequest::new("secure:key-1", "agent-a", 0, "payload", "state:genesis"),
+            Err(SignerBackendError::InvalidNonce)
+        );
+    }
+}

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -1,0 +1,105 @@
+use kamn_core::{
+    BaselineTransaction, SignerBackendError, SignerBackendRouter, SigningRequest,
+    TransactionGuards, GENESIS_STATE_HASH,
+};
+
+#[test]
+fn functional_secure_backend_signs_and_verifies_when_available() {
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("secure backend should sign");
+    assert_eq!(signed.backend, "secure-mock");
+
+    router
+        .verify_with_backend(&signed.backend, &request, &signed.signature)
+        .expect("signature should verify");
+}
+
+#[test]
+fn functional_secure_unavailable_falls_back_to_local_backend() {
+    let router = SignerBackendRouter::with_secure_availability(false);
+    let request = SigningRequest::new(
+        "secure:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("fallback should sign");
+    assert_eq!(signed.backend, "local-software");
+
+    router
+        .verify_with_backend(&signed.backend, &request, &signed.signature)
+        .expect("fallback signature should verify");
+}
+
+#[test]
+fn integration_router_signed_transaction_passes_transaction_guards() {
+    let router = SignerBackendRouter::default();
+    let mut guards = TransactionGuards::new();
+    let mut tx = BaselineTransaction::signed(
+        "tx-sign-1",
+        "agent-a",
+        1,
+        "payload-sign-1",
+        guards.expected_state_hash(),
+    );
+
+    let request = SigningRequest::for_transaction("secure:key-ops-2", &tx)
+        .expect("request should map from transaction");
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("signing should succeed");
+    tx.signature = signed.signature;
+
+    guards
+        .validate_and_record(&tx)
+        .expect("signed transaction should validate");
+}
+
+#[test]
+fn regression_unsupported_secure_key_reference_does_not_fallback() {
+    // Regression: #160
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new("local:key-1", "agent-a", 1, "payload-1", GENESIS_STATE_HASH)
+        .expect("request should be valid");
+
+    assert_eq!(
+        router.sign_with_secure_fallback(&request),
+        Err(SignerBackendError::UnsupportedKeyReference {
+            backend: "secure-mock".to_owned(),
+            key_id: "local:key-1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn for_transaction_rejects_empty_transaction_id() {
+    let tx = BaselineTransaction {
+        id: String::new(),
+        sender: "agent-a".to_owned(),
+        nonce: 1,
+        payload: "payload-1".to_owned(),
+        state_hash: GENESIS_STATE_HASH.to_owned(),
+        signature: "sig:placeholder".to_owned(),
+    };
+
+    assert_eq!(
+        SigningRequest::for_transaction("secure:key-ops-3", &tx),
+        Err(SignerBackendError::EmptyField("transaction_id"))
+    );
+}

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -1,0 +1,26 @@
+const DOC: &str = include_str!("../../../docs/foundation/signer-backend-abstraction.md");
+
+#[test]
+fn doc_contains_signer_backend_contract_and_router_rules() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("SigningRequest"));
+    assert!(DOC.contains("SignerBackend"));
+    assert!(DOC.contains("LocalSignerBackend"));
+    assert!(DOC.contains("SecureSignerBackend"));
+    assert!(DOC.contains("sign_with_secure_fallback"));
+}
+
+#[test]
+fn doc_contains_fallback_semantics_and_transaction_integration() {
+    assert!(DOC.contains("## Backend Compatibility Rules"));
+    assert!(DOC.contains("falls back from secure to local only for `ProviderUnavailable`."));
+    assert!(DOC.contains("does not fallback on hard request errors"));
+    assert!(DOC.contains("## Transaction Path Integration"));
+    assert!(DOC.contains("SigningRequest::for_transaction(...)"));
+}
+
+#[test]
+fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
+    // Regression: #160
+    assert!(DOC.contains("does not fallback on hard request errors"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -50,6 +50,7 @@ For security control ownership and enforcement mapping, see `docs/foundation/thr
 For anti-hallucination instruction validation controls, see `docs/foundation/instruction-verification.md`.
 For deterministic key lifecycle and rotation transitions, see `docs/foundation/key-lifecycle.md`.
 For tamper-evident key lifecycle audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
+For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.
 For key compromise containment and recovery workflows, see `docs/foundation/key-recovery.md`.
 For Python SDK parity slice, see `docs/foundation/python-sdk-beta.md`.
 For DID method and canonical DID document schema controls, see `docs/foundation/did-method.md`.

--- a/docs/foundation/key-lifecycle.md
+++ b/docs/foundation/key-lifecycle.md
@@ -2,6 +2,7 @@
 
 This document captures the first implementation slice for deterministic key lifecycle and rotation transitions.
 For tamper-evident audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
+For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.
 
 ## Scope Delivered
 - Added `crates/kamn-core/src/key_lifecycle.rs` with:

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -1,0 +1,36 @@
+# Pluggable Signer Backend Abstraction (Issue #160)
+
+This document captures the first implementation slice for signer backend abstraction with deterministic secure-to-local fallback behavior.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/signer_backend.rs` with:
+  - `SigningRequest` contract and validation.
+  - `SignerBackend` trait (`sign` and `verify`).
+  - `LocalSignerBackend` and `SecureSignerBackend`.
+  - `SignerBackendRouter` with deterministic `sign_with_secure_fallback(...)` semantics.
+  - `BackendSignature` and typed `SignerBackendError`.
+- Added integration tests in `crates/kamn-core/tests/signer_backend.rs`.
+
+## Backend Compatibility Rules
+- `local-software` backend:
+  - signs and verifies deterministic signatures for valid requests.
+- `secure-mock` backend:
+  - requires key IDs with `secure:` prefix.
+  - returns explicit `ProviderUnavailable` when disabled/unavailable.
+- Router fallback:
+  - falls back from secure to local only for `ProviderUnavailable`.
+  - does not fallback on hard request errors (for example, unsupported secure key references).
+
+## Transaction Path Integration
+- `SigningRequest::for_transaction(...)` maps `BaselineTransaction` fields into signer requests.
+- Signed output remains compatible with `TransactionGuards::validate_and_record(...)`.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test signer_backend
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first signer backend abstraction slice with local and secure backends plus deterministic secure-to-local fallback behavior. Adds transaction-path integration through `SigningRequest::for_transaction(...)` and expands docs/test coverage for fallback and misconfiguration safeguards.

## Changes
- `crates/kamn-core/src/signer_backend.rs`: Added signer trait, request contract, local/secure backends, router fallback semantics, typed errors, and request-level validation.
- `crates/kamn-core/src/lib.rs`: Exported signer backend module/types.
- `crates/kamn-core/tests/signer_backend.rs`: Added unit/functional/integration/regression coverage for backend compatibility and fallback semantics.
- `docs/foundation/signer-backend-abstraction.md`: Added implementation and operational contract docs.
- `crates/kamn-core/tests/signer_backend_docs.rs`: Added docs contract/regression tests.
- `docs/foundation/key-lifecycle.md`: Added signer abstraction cross-reference.
- `docs/foundation/bootstrap.md`: Added signer abstraction index link.

## Risks & Compatibility
- Additive API only; no breaking behavior for existing transaction guards.
- Secure backend is a deterministic mock adapter in this slice (explicitly documented), not a production cloud KMS integration.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated secure backend success path, secure-unavailable fallback path, and no-fallback behavior for unsupported secure key references.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `signing_request_rejects_invalid_fields` plus transaction-ID mapping guard in `tests/signer_backend.rs` |
| Functional  | ✅     | Secure signing/verification and secure-unavailable fallback behavior covered in `tests/signer_backend.rs` |
| Integration | ✅     | Router-signed `BaselineTransaction` validation through `TransactionGuards::validate_and_record(...)` |
| Regression  | ✅     | `regression_unsupported_secure_key_reference_does_not_fallback` and docs regression guard enforce deterministic fallback boundaries |

Closes #161
Closes #160
