### PR TITLE
feat(marketplace): implement listing and discovery workflows (#188)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod operator_binding;
 pub mod redaction_compliance;
 pub mod retention_engine;
 pub mod runtime;
+pub mod service_marketplace;
 pub mod signer_backend;
 pub mod smoke;
 pub mod state;
@@ -126,6 +127,10 @@ pub use retention_engine::{
     RetentionPolicyEngine, RetentionPolicyError, RetentionRecord, RetentionStatus,
 };
 pub use runtime::RuntimeWiring;
+pub use service_marketplace::{
+    MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,
+    ServiceMarketplaceError,
+};
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SignerBackend, SignerBackendError,
     SignerBackendRouter, SigningRequest,

--- a/crates/kamn-core/src/service_marketplace.rs
+++ b/crates/kamn-core/src/service_marketplace.rs
@@ -1,0 +1,215 @@
+use crate::{AgentDid, ChannelModelError, ChannelStore, ChannelType};
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceListing {
+    pub listing_id: String,
+    pub provider_did: String,
+    pub service_name: String,
+    pub category: String,
+    pub tags: Vec<String>,
+    pub hourly_rate: u128,
+    pub negotiation_channel_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MarketplaceSearchFilter {
+    pub category: Option<String>,
+    pub tag: Option<String>,
+    pub max_hourly_rate: Option<u128>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NegotiationThreadHook {
+    pub listing_id: String,
+    pub negotiation_channel_id: String,
+    pub provider_did: String,
+    pub requester_did: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ServiceMarketplaceEngine {
+    listings: BTreeMap<String, ServiceListing>,
+}
+
+impl ServiceMarketplaceEngine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_listing(
+        &mut self,
+        listing: ServiceListing,
+        channels: &ChannelStore,
+    ) -> Result<(), ServiceMarketplaceError> {
+        validate_listing_shape(&listing)?;
+        validate_did(&listing.provider_did)?;
+
+        if self.listings.contains_key(&listing.listing_id) {
+            return Err(ServiceMarketplaceError::DuplicateListing(
+                listing.listing_id.clone(),
+            ));
+        }
+
+        let channel_type = channels
+            .channel_type(&listing.negotiation_channel_id)
+            .map_err(map_channel_error)?;
+        if channel_type != ChannelType::Marketplace {
+            return Err(ServiceMarketplaceError::NegotiationChannelType {
+                channel_id: listing.negotiation_channel_id.clone(),
+                found: channel_type,
+            });
+        }
+
+        let provider_member = channels
+            .is_member(&listing.negotiation_channel_id, &listing.provider_did)
+            .map_err(map_channel_error)?;
+        if !provider_member {
+            return Err(ServiceMarketplaceError::ProviderNotChannelMember {
+                provider_did: listing.provider_did.clone(),
+                channel_id: listing.negotiation_channel_id.clone(),
+            });
+        }
+
+        self.listings.insert(listing.listing_id.clone(), listing);
+        Ok(())
+    }
+
+    pub fn search(&self, filter: &MarketplaceSearchFilter) -> Vec<ServiceListing> {
+        self.listings
+            .values()
+            .filter(|listing| matches_filter(listing, filter))
+            .cloned()
+            .collect()
+    }
+
+    pub fn open_negotiation_thread(
+        &self,
+        listing_id: &str,
+        requester_did: &str,
+    ) -> Result<NegotiationThreadHook, ServiceMarketplaceError> {
+        if listing_id.trim().is_empty() {
+            return Err(ServiceMarketplaceError::EmptyField("listing_id"));
+        }
+        validate_did(requester_did)?;
+
+        let listing = self
+            .listings
+            .get(listing_id)
+            .ok_or_else(|| ServiceMarketplaceError::ListingNotFound(listing_id.to_owned()))?;
+        Ok(NegotiationThreadHook {
+            listing_id: listing.listing_id.clone(),
+            negotiation_channel_id: listing.negotiation_channel_id.clone(),
+            provider_did: listing.provider_did.clone(),
+            requester_did: requester_did.to_owned(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceMarketplaceError {
+    ChannelLookup(String),
+    DuplicateListing(String),
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidHourlyRate(u128),
+    ListingNotFound(String),
+    NegotiationChannelType {
+        channel_id: String,
+        found: ChannelType,
+    },
+    ProviderNotChannelMember {
+        provider_did: String,
+        channel_id: String,
+    },
+}
+
+impl fmt::Display for ServiceMarketplaceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ChannelLookup(error) => write!(f, "channel lookup error: {error}"),
+            Self::DuplicateListing(listing_id) => write!(f, "duplicate listing id: {listing_id}"),
+            Self::EmptyField(field) => write!(f, "{field} must not be empty"),
+            Self::InvalidDid(error) => write!(f, "invalid did: {error}"),
+            Self::InvalidHourlyRate(value) => {
+                write!(f, "hourly rate must be greater than zero, found {value}")
+            }
+            Self::ListingNotFound(listing_id) => write!(f, "listing not found: {listing_id}"),
+            Self::NegotiationChannelType { channel_id, found } => write!(
+                f,
+                "negotiation channel {channel_id} must be Marketplace, found {found:?}"
+            ),
+            Self::ProviderNotChannelMember {
+                provider_did,
+                channel_id,
+            } => write!(
+                f,
+                "provider {provider_did} is not a member of channel {channel_id}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ServiceMarketplaceError {}
+
+fn validate_listing_shape(listing: &ServiceListing) -> Result<(), ServiceMarketplaceError> {
+    if listing.listing_id.trim().is_empty() {
+        return Err(ServiceMarketplaceError::EmptyField("listing_id"));
+    }
+    if listing.service_name.trim().is_empty() {
+        return Err(ServiceMarketplaceError::EmptyField("service_name"));
+    }
+    if listing.category.trim().is_empty() {
+        return Err(ServiceMarketplaceError::EmptyField("category"));
+    }
+    if listing.tags.is_empty() {
+        return Err(ServiceMarketplaceError::EmptyField("tags"));
+    }
+    if listing.tags.iter().any(|tag| tag.trim().is_empty()) {
+        return Err(ServiceMarketplaceError::EmptyField("tag"));
+    }
+    if listing.hourly_rate == 0 {
+        return Err(ServiceMarketplaceError::InvalidHourlyRate(
+            listing.hourly_rate,
+        ));
+    }
+    if listing.negotiation_channel_id.trim().is_empty() {
+        return Err(ServiceMarketplaceError::EmptyField(
+            "negotiation_channel_id",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), ServiceMarketplaceError> {
+    AgentDid::parse(value)
+        .map_err(|error| ServiceMarketplaceError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn matches_filter(listing: &ServiceListing, filter: &MarketplaceSearchFilter) -> bool {
+    if let Some(expected_category) = filter.category.as_deref() {
+        if listing.category != expected_category {
+            return false;
+        }
+    }
+
+    if let Some(expected_tag) = filter.tag.as_deref() {
+        if !listing.tags.iter().any(|tag| tag == expected_tag) {
+            return false;
+        }
+    }
+
+    if let Some(max_rate) = filter.max_hourly_rate {
+        if listing.hourly_rate > max_rate {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn map_channel_error(error: ChannelModelError) -> ServiceMarketplaceError {
+    ServiceMarketplaceError::ChannelLookup(error.to_string())
+}

--- a/crates/kamn-core/tests/service_marketplace.rs
+++ b/crates/kamn-core/tests/service_marketplace.rs
@@ -1,0 +1,169 @@
+use kamn_core::{
+    ChannelStore, ChannelType, MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing,
+    ServiceMarketplaceEngine, ServiceMarketplaceError,
+};
+
+fn marketplace_channels() -> ChannelStore {
+    let mut channels = ChannelStore::new();
+    channels
+        .create_marketplace_channel(
+            "chan-market-1",
+            "kamn:did:agent:provider-1",
+            "service-market-v1",
+            vec![
+                "kamn:did:agent:provider-1".to_owned(),
+                "kamn:did:agent:requester-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:provider-1".to_owned()],
+        )
+        .expect("marketplace channel should be created");
+    channels
+}
+
+#[test]
+fn listing_rejects_non_marketplace_channel_type() {
+    let mut channels = ChannelStore::new();
+    channels
+        .create_task_channel(
+            "chan-task-1",
+            "kamn:did:agent:provider-1",
+            "task-1",
+            vec![
+                "kamn:did:agent:provider-1".to_owned(),
+                "kamn:did:agent:requester-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:provider-1".to_owned()],
+        )
+        .expect("task channel should be created");
+    let mut engine = ServiceMarketplaceEngine::new();
+
+    assert_eq!(
+        engine.register_listing(
+            ServiceListing {
+                listing_id: "listing-1".to_owned(),
+                provider_did: "kamn:did:agent:provider-1".to_owned(),
+                service_name: "Smart Contract Audit".to_owned(),
+                category: "security".to_owned(),
+                tags: vec!["solidity".to_owned(), "formal-review".to_owned()],
+                hourly_rate: 150,
+                negotiation_channel_id: "chan-task-1".to_owned(),
+            },
+            &channels,
+        ),
+        Err(ServiceMarketplaceError::NegotiationChannelType {
+            channel_id: "chan-task-1".to_owned(),
+            found: ChannelType::Task,
+        })
+    );
+}
+
+#[test]
+fn search_filters_are_deterministic() {
+    let channels = marketplace_channels();
+    let mut engine = ServiceMarketplaceEngine::new();
+
+    engine
+        .register_listing(
+            ServiceListing {
+                listing_id: "listing-1".to_owned(),
+                provider_did: "kamn:did:agent:provider-1".to_owned(),
+                service_name: "Rust Protocol Review".to_owned(),
+                category: "security".to_owned(),
+                tags: vec!["rust".to_owned(), "protocol".to_owned()],
+                hourly_rate: 120,
+                negotiation_channel_id: "chan-market-1".to_owned(),
+            },
+            &channels,
+        )
+        .expect("first listing should register");
+    engine
+        .register_listing(
+            ServiceListing {
+                listing_id: "listing-2".to_owned(),
+                provider_did: "kamn:did:agent:provider-1".to_owned(),
+                service_name: "Go Reliability Review".to_owned(),
+                category: "operations".to_owned(),
+                tags: vec!["go".to_owned(), "sre".to_owned()],
+                hourly_rate: 90,
+                negotiation_channel_id: "chan-market-1".to_owned(),
+            },
+            &channels,
+        )
+        .expect("second listing should register");
+
+    let filtered = engine.search(&MarketplaceSearchFilter {
+        category: Some("security".to_owned()),
+        tag: Some("rust".to_owned()),
+        max_hourly_rate: Some(150),
+    });
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].listing_id, "listing-1");
+}
+
+#[test]
+fn negotiation_thread_hook_maps_listing_to_channel() {
+    let channels = marketplace_channels();
+    let mut engine = ServiceMarketplaceEngine::new();
+    engine
+        .register_listing(
+            ServiceListing {
+                listing_id: "listing-3".to_owned(),
+                provider_did: "kamn:did:agent:provider-1".to_owned(),
+                service_name: "Incident Retrospective Facilitation".to_owned(),
+                category: "operations".to_owned(),
+                tags: vec!["incident".to_owned()],
+                hourly_rate: 110,
+                negotiation_channel_id: "chan-market-1".to_owned(),
+            },
+            &channels,
+        )
+        .expect("listing should register");
+
+    assert_eq!(
+        engine.open_negotiation_thread("listing-3", "kamn:did:agent:requester-9"),
+        Ok(NegotiationThreadHook {
+            listing_id: "listing-3".to_owned(),
+            negotiation_channel_id: "chan-market-1".to_owned(),
+            provider_did: "kamn:did:agent:provider-1".to_owned(),
+            requester_did: "kamn:did:agent:requester-9".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_provider_must_be_marketplace_channel_member() {
+    // Regression: #188
+    let mut channels = ChannelStore::new();
+    channels
+        .create_marketplace_channel(
+            "chan-market-2",
+            "kamn:did:agent:owner-1",
+            "service-market-v1",
+            vec![
+                "kamn:did:agent:owner-1".to_owned(),
+                "kamn:did:agent:requester-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner-1".to_owned()],
+        )
+        .expect("marketplace channel should be created");
+
+    let mut engine = ServiceMarketplaceEngine::new();
+    assert_eq!(
+        engine.register_listing(
+            ServiceListing {
+                listing_id: "listing-4".to_owned(),
+                provider_did: "kamn:did:agent:provider-x".to_owned(),
+                service_name: "Threat Modeling".to_owned(),
+                category: "security".to_owned(),
+                tags: vec!["threat-model".to_owned()],
+                hourly_rate: 130,
+                negotiation_channel_id: "chan-market-2".to_owned(),
+            },
+            &channels,
+        ),
+        Err(ServiceMarketplaceError::ProviderNotChannelMember {
+            provider_did: "kamn:did:agent:provider-x".to_owned(),
+            channel_id: "chan-market-2".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/service_marketplace_docs.rs
+++ b/crates/kamn-core/tests/service_marketplace_docs.rs
@@ -1,0 +1,25 @@
+const DOC: &str = include_str!("../../../docs/foundation/service-marketplace-discovery.md");
+
+#[test]
+fn doc_contains_listing_contract_and_engine_surfaces() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("ServiceListing"));
+    assert!(DOC.contains("MarketplaceSearchFilter"));
+    assert!(DOC.contains("ServiceMarketplaceEngine"));
+    assert!(DOC.contains("NegotiationThreadHook"));
+}
+
+#[test]
+fn doc_contains_channel_membership_and_filter_rules() {
+    assert!(DOC.contains("## Listing Validation Rules"));
+    assert!(DOC.contains("negotiation channel type of `Marketplace`."));
+    assert!(DOC.contains("provider DID membership in the negotiation channel."));
+    assert!(DOC.contains("## Discovery and Negotiation Rules"));
+    assert!(DOC.contains("exact tag membership."));
+}
+
+#[test]
+fn regression_requires_provider_membership_validation_rule() {
+    // Regression: #188
+    assert!(DOC.contains("provider DID membership in the negotiation channel."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -61,6 +61,7 @@ For message lifecycle state machine and index query controls, see `docs/foundati
 For nonce/TTL/replay enforcement and failed-delivery notice controls, see `docs/foundation/message-delivery-guards.md`.
 For direct/group plus specialized broadcast/task/marketplace/governance channel models, see `docs/foundation/channel-models.md`.
 For channel permission and retention policy controls, see `docs/foundation/channel-permissions-retention.md`.
+For marketplace listing registration, discovery filters, and negotiation hook controls, see `docs/foundation/service-marketplace-discovery.md`.
 For agent key hierarchy role bindings and ephemeral session key controls, see `docs/foundation/agent-key-hierarchy.md`.
 For direct-message encryption path controls, see `docs/foundation/direct-message-encryption.md`.
 For group sender-key distribution and rotation controls, see `docs/foundation/group-sender-key-rotation.md`.

--- a/docs/foundation/channel-models.md
+++ b/docs/foundation/channel-models.md
@@ -2,6 +2,7 @@
 
 This document defines the implemented channel model slices for direct/group
 channels and specialized broadcast/task/marketplace/governance channels.
+For marketplace listing/discovery workflow controls built on marketplace channels, see `docs/foundation/service-marketplace-discovery.md`.
 
 ## Core Models
 - `ChannelType`:

--- a/docs/foundation/service-marketplace-discovery.md
+++ b/docs/foundation/service-marketplace-discovery.md
@@ -1,0 +1,41 @@
+# Service Marketplace Listing and Discovery (Issue #188)
+
+This document captures the first implementation slice for service marketplace listing registration, deterministic discovery filters, and negotiation thread hooks.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/service_marketplace.rs` with:
+  - `ServiceListing` model for provider service offers.
+  - `MarketplaceSearchFilter` for deterministic listing selection.
+  - `ServiceMarketplaceEngine` for registration, search, and negotiation hook creation.
+  - `NegotiationThreadHook` for routing requester/provider negotiation to a marketplace channel.
+  - `ServiceMarketplaceError` typed validation and lookup failures.
+- Added integration tests in `crates/kamn-core/tests/service_marketplace.rs`.
+
+## Listing Validation Rules
+- Listing registration requires:
+  - non-empty listing id, service name, category, and negotiation channel id.
+  - at least one non-empty tag.
+  - positive hourly rate.
+  - valid provider DID.
+  - negotiation channel type of `Marketplace`.
+  - provider DID membership in the negotiation channel.
+
+## Discovery and Negotiation Rules
+- Search filter supports:
+  - exact category match.
+  - exact tag membership.
+  - max hourly rate guard.
+- Negotiation hooks:
+  - require an existing listing id.
+  - require valid requester DID.
+  - deterministically return listing id, negotiation channel id, provider DID, and requester DID.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test service_marketplace
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first service marketplace listing/discovery slice with deterministic filters and negotiation hook generation. Listings are now validated against marketplace channel type and provider membership to prevent invalid negotiation routing.

## Changes
- `crates/kamn-core/src/service_marketplace.rs`: Added listing model, search filter, negotiation thread hook, workflow engine, and typed errors.
- `crates/kamn-core/src/lib.rs`: Exported service marketplace workflow types.
- `crates/kamn-core/tests/service_marketplace.rs`: Added unit/functional/integration/regression tests for channel validation, search behavior, and negotiation hook mapping.
- `docs/foundation/service-marketplace-discovery.md`: Added workflow contract and validation semantics.
- `crates/kamn-core/tests/service_marketplace_docs.rs`: Added docs contract/regression tests.
- `docs/foundation/channel-models.md`: Added reference to marketplace discovery controls.
- `docs/foundation/bootstrap.md`: Added index link for marketplace workflow controls.

## Risks & Compatibility
- Additive API only; existing channel model behavior is unchanged.
- Search filter currently supports category/tag/max-rate only in this slice.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed channel-type/provider-membership checks and deterministic search/hook outputs.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Listing shape/rate validation and filter behavior in `tests/service_marketplace.rs` |
| Functional  | ✅     | Marketplace listing registration and search flow validated end-to-end |
| Integration | ✅     | ChannelStore + marketplace workflow integration validated for channel-type and member constraints |
| Regression  | ✅     | Provider-not-member and non-marketplace channel guard tests + docs regression rule |

Closes #189
Closes #188
Closes #59
