### PR TITLE
feat(devops): add PRD performance target benchmark evidence

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod migrations;
 pub mod namespaces;
 pub mod observability;
 pub mod operator_binding;
+pub mod performance_targets;
 pub mod redaction_compliance;
 pub mod retention_engine;
 pub mod runtime;
@@ -123,6 +124,11 @@ pub use observability::{
 pub use operator_binding::{
     OperatorBindingAction, OperatorBindingEngine, OperatorBindingError, OperatorBindingProof,
     OperatorBindingRecord,
+};
+pub use performance_targets::{
+    evaluate_performance_from_observability, evaluate_performance_run, PerformanceAggregate,
+    PerformanceMetric, PerformanceMetricResult, PerformanceRunError, PerformanceRunReport,
+    PerformanceSample, PrdPerformanceTargets,
 };
 pub use redaction_compliance::{
     RedactionAction, RedactionAuditEvent, RedactionAuditEventKind, RedactionComplianceEngine,

--- a/crates/kamn-core/src/performance_targets.rs
+++ b/crates/kamn-core/src/performance_targets.rs
@@ -1,0 +1,347 @@
+use crate::observability::ObservabilitySample;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PerformanceMetric {
+    LatencyP50,
+    LatencyP99,
+    Throughput,
+    Availability,
+}
+
+impl PerformanceMetric {
+    fn remediation_hint(self) -> &'static str {
+        match self {
+            Self::LatencyP50 => {
+                "Reduce average queue depth by tuning listener batching and message routing."
+            }
+            Self::LatencyP99 => {
+                "Investigate processor backlog and queue starvation before approval fan-out."
+            }
+            Self::Throughput => {
+                "Increase listener and approver parallelism and reduce serialization overhead."
+            }
+            Self::Availability => {
+                "Harden failover probes and standby promotion thresholds to prevent downtime."
+            }
+        }
+    }
+
+    fn bottleneck_priority(self) -> u8 {
+        match self {
+            Self::Throughput => 0,
+            Self::LatencyP99 => 1,
+            Self::Availability => 2,
+            Self::LatencyP50 => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrdPerformanceTargets {
+    pub max_latency_p50_ms: u64,
+    pub max_latency_p99_ms: u64,
+    pub min_throughput_tps: u64,
+    pub min_availability_pct: f64,
+}
+
+impl PrdPerformanceTargets {
+    pub fn v13_2() -> Self {
+        Self {
+            max_latency_p50_ms: 100,
+            max_latency_p99_ms: 500,
+            min_throughput_tps: 10_000,
+            min_availability_pct: 99.9,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerformanceSample {
+    pub latency_p50_ms: u64,
+    pub latency_p99_ms: u64,
+    pub throughput_tps: u64,
+    pub availability_pct: f64,
+    pub timestamp_epoch_s: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerformanceAggregate {
+    pub latency_p50_ms: u64,
+    pub latency_p99_ms: u64,
+    pub throughput_tps: u64,
+    pub availability_pct: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerformanceMetricResult {
+    pub metric: PerformanceMetric,
+    pub observed: f64,
+    pub threshold: f64,
+    pub met: bool,
+    pub deviation_pct: f64,
+    pub remediation: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerformanceRunReport {
+    pub run_id: String,
+    pub sample_count: usize,
+    pub aggregate: PerformanceAggregate,
+    pub results: Vec<PerformanceMetricResult>,
+    pub meets_targets: bool,
+}
+
+impl PerformanceRunReport {
+    pub fn metric_result(&self, metric: PerformanceMetric) -> Option<&PerformanceMetricResult> {
+        self.results.iter().find(|result| result.metric == metric)
+    }
+
+    pub fn bottlenecks(&self) -> Vec<PerformanceMetric> {
+        let mut failed: Vec<&PerformanceMetricResult> =
+            self.results.iter().filter(|result| !result.met).collect();
+        failed.sort_by(|left, right| {
+            left.metric
+                .bottleneck_priority()
+                .cmp(&right.metric.bottleneck_priority())
+                .then_with(|| right.deviation_pct.total_cmp(&left.deviation_pct))
+        });
+
+        failed.into_iter().map(|result| result.metric).collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PerformanceRunError {
+    EmptySamples,
+    InvalidAvailability { value: f64 },
+    InvalidLatencyOrder { p50: u64, p99: u64 },
+    ZeroThroughput,
+}
+
+impl fmt::Display for PerformanceRunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptySamples => write!(f, "at least one benchmark sample is required"),
+            Self::InvalidAvailability { value } => {
+                write!(
+                    f,
+                    "availability_pct must be between 0 and 100, found {value}"
+                )
+            }
+            Self::InvalidLatencyOrder { p50, p99 } => {
+                write!(
+                    f,
+                    "latency ordering invalid: p99 ({p99}) must be >= p50 ({p50})"
+                )
+            }
+            Self::ZeroThroughput => write!(f, "throughput_tps must be greater than zero"),
+        }
+    }
+}
+
+impl std::error::Error for PerformanceRunError {}
+
+pub fn evaluate_performance_run(
+    run_id: impl Into<String>,
+    samples: &[PerformanceSample],
+    targets: &PrdPerformanceTargets,
+) -> Result<PerformanceRunReport, PerformanceRunError> {
+    if samples.is_empty() {
+        return Err(PerformanceRunError::EmptySamples);
+    }
+
+    for sample in samples {
+        validate_sample(sample)?;
+    }
+
+    let aggregate = aggregate_samples(samples);
+    let results = vec![
+        evaluate_upper_exclusive(
+            PerformanceMetric::LatencyP50,
+            aggregate.latency_p50_ms as f64,
+            targets.max_latency_p50_ms as f64,
+        ),
+        evaluate_upper_exclusive(
+            PerformanceMetric::LatencyP99,
+            aggregate.latency_p99_ms as f64,
+            targets.max_latency_p99_ms as f64,
+        ),
+        evaluate_lower_inclusive(
+            PerformanceMetric::Throughput,
+            aggregate.throughput_tps as f64,
+            targets.min_throughput_tps as f64,
+        ),
+        evaluate_lower_inclusive(
+            PerformanceMetric::Availability,
+            aggregate.availability_pct,
+            targets.min_availability_pct,
+        ),
+    ];
+
+    let meets_targets = results.iter().all(|result| result.met);
+
+    Ok(PerformanceRunReport {
+        run_id: run_id.into(),
+        sample_count: samples.len(),
+        aggregate,
+        results,
+        meets_targets,
+    })
+}
+
+pub fn evaluate_performance_from_observability(
+    run_id: impl Into<String>,
+    samples: &[ObservabilitySample],
+    targets: &PrdPerformanceTargets,
+) -> Result<PerformanceRunReport, PerformanceRunError> {
+    let converted: Vec<PerformanceSample> = samples
+        .iter()
+        .map(|sample| PerformanceSample {
+            latency_p50_ms: sample.latency_p50_ms,
+            latency_p99_ms: sample.latency_p99_ms,
+            throughput_tps: sample.throughput_tps,
+            availability_pct: sample.availability_pct,
+            timestamp_epoch_s: sample.timestamp_epoch_s,
+        })
+        .collect();
+
+    evaluate_performance_run(run_id, &converted, targets)
+}
+
+fn evaluate_upper_exclusive(
+    metric: PerformanceMetric,
+    observed: f64,
+    threshold: f64,
+) -> PerformanceMetricResult {
+    let met = observed < threshold;
+    let deviation_pct = if met {
+        0.0
+    } else {
+        ((observed - threshold) / threshold) * 100.0
+    };
+
+    PerformanceMetricResult {
+        metric,
+        observed,
+        threshold,
+        met,
+        deviation_pct,
+        remediation: metric.remediation_hint(),
+    }
+}
+
+fn evaluate_lower_inclusive(
+    metric: PerformanceMetric,
+    observed: f64,
+    threshold: f64,
+) -> PerformanceMetricResult {
+    let met = observed >= threshold;
+    let deviation_pct = if met {
+        0.0
+    } else {
+        ((threshold - observed) / threshold) * 100.0
+    };
+
+    PerformanceMetricResult {
+        metric,
+        observed,
+        threshold,
+        met,
+        deviation_pct,
+        remediation: metric.remediation_hint(),
+    }
+}
+
+fn aggregate_samples(samples: &[PerformanceSample]) -> PerformanceAggregate {
+    let mut p50_values: Vec<u64> = samples.iter().map(|sample| sample.latency_p50_ms).collect();
+    p50_values.sort_unstable();
+
+    PerformanceAggregate {
+        latency_p50_ms: median_u64(&p50_values),
+        latency_p99_ms: samples
+            .iter()
+            .map(|sample| sample.latency_p99_ms)
+            .max()
+            .unwrap_or(0),
+        throughput_tps: samples
+            .iter()
+            .map(|sample| sample.throughput_tps)
+            .min()
+            .unwrap_or(0),
+        availability_pct: samples
+            .iter()
+            .map(|sample| sample.availability_pct)
+            .fold(100.0, f64::min),
+    }
+}
+
+fn median_u64(sorted_values: &[u64]) -> u64 {
+    let mid = sorted_values.len() / 2;
+    if sorted_values.len() % 2 == 1 {
+        sorted_values[mid]
+    } else {
+        ((sorted_values[mid - 1] as u128 + sorted_values[mid] as u128) / 2) as u64
+    }
+}
+
+fn validate_sample(sample: &PerformanceSample) -> Result<(), PerformanceRunError> {
+    if !(0.0..=100.0).contains(&sample.availability_pct) {
+        return Err(PerformanceRunError::InvalidAvailability {
+            value: sample.availability_pct,
+        });
+    }
+
+    if sample.latency_p99_ms < sample.latency_p50_ms {
+        return Err(PerformanceRunError::InvalidLatencyOrder {
+            p50: sample.latency_p50_ms,
+            p99: sample.latency_p99_ms,
+        });
+    }
+
+    if sample.throughput_tps == 0 {
+        return Err(PerformanceRunError::ZeroThroughput);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_even_size_rounds_down_integer_average() {
+        assert_eq!(median_u64(&[20, 40, 60, 100]), 50);
+    }
+
+    #[test]
+    fn latency_threshold_is_strictly_less_than_target() {
+        let result = evaluate_upper_exclusive(PerformanceMetric::LatencyP50, 100.0, 100.0);
+        assert!(!result.met);
+        assert_eq!(result.deviation_pct, 0.0);
+    }
+
+    #[test]
+    fn throughput_threshold_is_inclusive() {
+        let result = evaluate_lower_inclusive(PerformanceMetric::Throughput, 10_000.0, 10_000.0);
+        assert!(result.met);
+        assert_eq!(result.deviation_pct, 0.0);
+    }
+
+    #[test]
+    fn validate_rejects_bad_availability() {
+        let sample = PerformanceSample {
+            latency_p50_ms: 10,
+            latency_p99_ms: 20,
+            throughput_tps: 10,
+            availability_pct: 101.0,
+            timestamp_epoch_s: 1,
+        };
+
+        assert_eq!(
+            validate_sample(&sample),
+            Err(PerformanceRunError::InvalidAvailability { value: 101.0 })
+        );
+    }
+}

--- a/crates/kamn-core/tests/performance_target_benchmarking_docs.rs
+++ b/crates/kamn-core/tests/performance_target_benchmarking_docs.rs
@@ -1,0 +1,27 @@
+const DOC: &str = include_str!("../../../docs/foundation/performance-target-benchmarking.md");
+
+#[test]
+fn doc_contains_prd_13_2_thresholds() {
+    assert!(DOC.contains("## PRD 13.2 Target Profile"));
+    assert!(DOC.contains("Message Latency (p50) | `< 100ms`"));
+    assert!(DOC.contains("Message Latency (p99) | `< 500ms`"));
+    assert!(DOC.contains("Throughput | `>= 10,000 msg/sec`"));
+    assert!(DOC.contains("Availability | `>= 99.9%`"));
+}
+
+#[test]
+fn doc_contains_deterministic_aggregation_rules() {
+    assert!(DOC.contains("## Deterministic Aggregation Rules"));
+    assert!(DOC.contains("`latency_p50_ms`: median across benchmark windows."));
+    assert!(DOC.contains("`latency_p99_ms`: max across benchmark windows."));
+    assert!(DOC.contains("`throughput_tps`: min across benchmark windows."));
+    assert!(DOC.contains("`availability_pct`: min across benchmark windows."));
+}
+
+#[test]
+fn regression_requires_cost_effective_fast_lane_policy() {
+    // Regression: #184
+    assert!(DOC.contains("## Fast and Cost-Effective Validation Strategy"));
+    assert!(DOC.contains("PR gate (fast lane):"));
+    assert!(DOC.contains("Deferred deep validation (slow lane):"));
+}

--- a/crates/kamn-core/tests/performance_targets.rs
+++ b/crates/kamn-core/tests/performance_targets.rs
@@ -1,0 +1,168 @@
+use kamn_core::observability::ObservabilitySample;
+use kamn_core::{
+    evaluate_performance_from_observability, evaluate_performance_run, PerformanceMetric,
+    PerformanceRunError, PerformanceSample, PrdPerformanceTargets,
+};
+
+fn prd_compliant_samples() -> Vec<PerformanceSample> {
+    vec![
+        PerformanceSample {
+            latency_p50_ms: 80,
+            latency_p99_ms: 410,
+            throughput_tps: 10_800,
+            availability_pct: 99.95,
+            timestamp_epoch_s: 1,
+        },
+        PerformanceSample {
+            latency_p50_ms: 92,
+            latency_p99_ms: 455,
+            throughput_tps: 10_250,
+            availability_pct: 99.92,
+            timestamp_epoch_s: 2,
+        },
+        PerformanceSample {
+            latency_p50_ms: 87,
+            latency_p99_ms: 430,
+            throughput_tps: 10_100,
+            availability_pct: 99.90,
+            timestamp_epoch_s: 3,
+        },
+    ]
+}
+
+#[test]
+fn benchmark_run_meets_prd_targets_with_stable_aggregate() {
+    let report = evaluate_performance_run(
+        "bench-q1-2026",
+        &prd_compliant_samples(),
+        &PrdPerformanceTargets::v13_2(),
+    )
+    .expect("report should evaluate");
+
+    assert!(report.meets_targets);
+    assert_eq!(report.sample_count, 3);
+    assert_eq!(report.aggregate.latency_p50_ms, 87);
+    assert_eq!(report.aggregate.latency_p99_ms, 455);
+    assert_eq!(report.aggregate.throughput_tps, 10_100);
+    assert_eq!(report.aggregate.availability_pct, 99.90);
+
+    let throughput = report
+        .metric_result(PerformanceMetric::Throughput)
+        .expect("throughput result present");
+    assert!(throughput.met);
+    assert_eq!(throughput.threshold, 10_000.0);
+
+    assert!(report.bottlenecks().is_empty());
+}
+
+#[test]
+fn benchmark_run_surfaces_bottlenecks_in_deviation_order() {
+    let report = evaluate_performance_run(
+        "bench-q1-2026-regression",
+        &[
+            PerformanceSample {
+                latency_p50_ms: 130,
+                latency_p99_ms: 680,
+                throughput_tps: 7_000,
+                availability_pct: 99.10,
+                timestamp_epoch_s: 20,
+            },
+            PerformanceSample {
+                latency_p50_ms: 122,
+                latency_p99_ms: 650,
+                throughput_tps: 7_200,
+                availability_pct: 99.25,
+                timestamp_epoch_s: 21,
+            },
+        ],
+        &PrdPerformanceTargets::v13_2(),
+    )
+    .expect("report should evaluate");
+
+    assert!(!report.meets_targets);
+    assert_eq!(
+        report.bottlenecks(),
+        vec![
+            PerformanceMetric::Throughput,
+            PerformanceMetric::LatencyP99,
+            PerformanceMetric::Availability,
+            PerformanceMetric::LatencyP50,
+        ]
+    );
+
+    let p99 = report
+        .metric_result(PerformanceMetric::LatencyP99)
+        .expect("p99 result present");
+    assert!(!p99.met);
+    assert!(p99.deviation_pct > 30.0);
+    assert!(p99.remediation.contains("processor backlog"));
+}
+
+#[test]
+fn integration_observability_samples_feed_benchmark_evidence() {
+    let report = evaluate_performance_from_observability(
+        "obs-bridge-run",
+        &[
+            ObservabilitySample {
+                latency_p50_ms: 89,
+                latency_p99_ms: 470,
+                throughput_tps: 10_050,
+                error_rate_pct: 0.8,
+                availability_pct: 99.91,
+                timestamp_epoch_s: 100,
+            },
+            ObservabilitySample {
+                latency_p50_ms: 93,
+                latency_p99_ms: 490,
+                throughput_tps: 10_200,
+                error_rate_pct: 0.7,
+                availability_pct: 99.93,
+                timestamp_epoch_s: 101,
+            },
+        ],
+        &PrdPerformanceTargets::v13_2(),
+    )
+    .expect("conversion should evaluate");
+
+    assert!(report.meets_targets);
+    assert_eq!(report.aggregate.latency_p99_ms, 490);
+}
+
+#[test]
+fn regression_availability_floor_breach_is_always_reported() {
+    // Regression: #184
+    let report = evaluate_performance_run(
+        "bench-availability-regression",
+        &[
+            PerformanceSample {
+                latency_p50_ms: 82,
+                latency_p99_ms: 420,
+                throughput_tps: 10_450,
+                availability_pct: 99.89,
+                timestamp_epoch_s: 30,
+            },
+            PerformanceSample {
+                latency_p50_ms: 84,
+                latency_p99_ms: 430,
+                throughput_tps: 10_420,
+                availability_pct: 99.97,
+                timestamp_epoch_s: 31,
+            },
+        ],
+        &PrdPerformanceTargets::v13_2(),
+    )
+    .expect("report should evaluate");
+
+    assert!(!report.meets_targets);
+    assert!(report
+        .bottlenecks()
+        .contains(&PerformanceMetric::Availability));
+}
+
+#[test]
+fn rejects_empty_sample_set() {
+    assert_eq!(
+        evaluate_performance_run("empty-run", &[], &PrdPerformanceTargets::v13_2()),
+        Err(PerformanceRunError::EmptySamples)
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -87,3 +87,4 @@ For configurable retention policy enforcement controls, see `docs/foundation/ret
 For data classification tiers and write-path tagging enforcement controls, see `docs/foundation/data-classification-tagging.md`.
 For optional operator binding proof validation and configure/revoke/read-history permission controls, see `docs/foundation/operator-binding-permissions.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
+For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/performance-target-benchmarking.md
+++ b/docs/foundation/performance-target-benchmarking.md
@@ -1,0 +1,63 @@
+# PRD 13.2 Performance Target Benchmark Evidence (Issue #184)
+
+This document captures the first implementation slice for validating benchmark evidence against PRD Section 13.2 targets.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/performance_targets.rs` with:
+  - `PrdPerformanceTargets::v13_2()` target profile.
+  - `PerformanceSample` benchmark input model.
+  - `evaluate_performance_run(...)` deterministic aggregation + target evaluation.
+  - `evaluate_performance_from_observability(...)` bridge from observability samples.
+  - `PerformanceRunReport`, `PerformanceMetricResult`, and `PerformanceRunError` outputs.
+  - `PerformanceRunReport::bottlenecks()` prioritized bottleneck list and remediation hints.
+- Added integration tests in `crates/kamn-core/tests/performance_targets.rs`.
+
+## PRD 13.2 Target Profile
+| Metric | Target | Rule |
+| --- | --- | --- |
+| Message Latency (p50) | `< 100ms` | strict upper bound |
+| Message Latency (p99) | `< 500ms` | strict upper bound |
+| Throughput | `>= 10,000 msg/sec` | lower bound |
+| Availability | `>= 99.9%` | lower bound |
+
+## Deterministic Aggregation Rules
+- `latency_p50_ms`: median across benchmark windows.
+- `latency_p99_ms`: max across benchmark windows.
+- `throughput_tps`: min across benchmark windows.
+- `availability_pct`: min across benchmark windows.
+
+These rules provide stable results for CI and avoid expensive full-load replay for every PR.
+
+## Bottleneck and Remediation Output
+Failed metrics are surfaced in this priority order:
+1. Throughput
+2. Latency p99
+3. Availability
+4. Latency p50
+
+Each failed metric includes:
+- observed value
+- threshold value
+- deviation percentage
+- remediation hint (for example, processor backlog triage for p99 latency)
+
+## Fast and Cost-Effective Validation Strategy
+- PR gate (fast lane):
+  - run targeted benchmark logic tests only (`performance_targets` + doc checks).
+  - enforce deterministic fixtures, no long-running synthetic load.
+- Deferred deep validation (slow lane):
+  - run heavier benchmark replay suites on schedule/nightly or manual dispatch.
+  - attach evidence bundles to issue/PR comments.
+
+This keeps per-PR compute cost low while preserving confidence in target conformance trends.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test performance_targets
+cargo test -p kamn-core --test performance_target_benchmarking_docs
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core
+```


### PR DESCRIPTION
Closes #185
Closes #184
Closes #63

## Summary
Adds a deterministic performance-target benchmarking module that evaluates PRD 13.2 thresholds (p50, p99, throughput, availability) and emits actionable bottleneck evidence.
This provides a fast, low-cost PR validation lane while preserving deeper benchmark guidance for deferred runs.

## Changes
- `crates/kamn-core/src/performance_targets.rs`: implemented PRD target profile, benchmark sample validation, deterministic aggregation, metric evaluation, bottleneck prioritization, and observability-bridge evaluation.
- `crates/kamn-core/src/lib.rs`: exported the performance target API surfaces.
- `crates/kamn-core/tests/performance_targets.rs`: added functional/integration/regression coverage for pass/fail target evaluation, observability conversion, availability floor regression, and empty-sample validation.
- `docs/foundation/performance-target-benchmarking.md`: documented PRD 13.2 rules, aggregation semantics, bottleneck/remediation outputs, and fast-vs-deferred validation strategy.
- `crates/kamn-core/tests/performance_target_benchmarking_docs.rs`: added documentation regression checks.
- `docs/foundation/bootstrap.md`: linked new benchmark evidence runbook.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed generated report semantics against PRD 13.2 thresholds and verified deterministic aggregation behavior.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `performance_targets` unit tests + `cargo test -p kamn-core` |
| Functional  | ✅ | `cargo test -p kamn-core --test performance_targets` |
| Integration | ✅ | observability bridge path covered in `performance_targets` integration test |
| Regression  | ✅ | availability floor regression + docs regression checks |
