### PR TITLE
feat(sdk): add TypeScript SDK beta and shared schema package

### DIFF
--- a/crates/kamn-core/tests/typescript_sdk_beta_docs.rs
+++ b/crates/kamn-core/tests/typescript_sdk_beta_docs.rs
@@ -1,0 +1,25 @@
+const DOC: &str = include_str!("../../../docs/foundation/typescript-sdk-beta.md");
+
+#[test]
+fn doc_contains_schema_and_sdk_scope() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("packages/kamn-schema"));
+    assert!(DOC.contains("packages/kamn-sdk"));
+    assert!(DOC.contains("validateCanonicalMessageEnvelope(...)"));
+    assert!(DOC.contains("KAMNClient"));
+}
+
+#[test]
+fn doc_contains_fast_validation_strategy() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("node --experimental-strip-types --test"));
+    assert!(DOC.contains("npm --prefix packages/kamn-schema test"));
+    assert!(DOC.contains("npm --prefix packages/kamn-sdk test"));
+}
+
+#[test]
+fn regression_requires_nonce_rule_and_proof_binding_rule() {
+    // Regression: #218
+    assert!(DOC.contains("nonce must be a positive integer."));
+    assert!(DOC.contains("proof verification method must be bound to sender DID"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -55,6 +55,7 @@ For tamper-evident key lifecycle audit trail verification controls, see `docs/fo
 For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.
 For key compromise containment and recovery workflows, see `docs/foundation/key-recovery.md`.
 For Python SDK parity slice, see `docs/foundation/python-sdk-beta.md`.
+For TypeScript SDK beta and shared schema package parity slice, see `docs/foundation/typescript-sdk-beta.md`.
 For DID method and canonical DID document schema controls, see `docs/foundation/did-method.md`.
 For DID register/resolve/update/revoke transaction behavior, see `docs/foundation/did-registry-transactions.md`.
 For canonical message envelope schema and validation controls, see `docs/foundation/message-envelope-schema.md`.

--- a/docs/foundation/typescript-sdk-beta.md
+++ b/docs/foundation/typescript-sdk-beta.md
@@ -1,0 +1,58 @@
+# TypeScript SDK Beta and Shared Schema Package (Issues #218, #219)
+
+This document captures the first TypeScript SDK implementation slice and the shared protocol schema package used to keep language SDK behavior aligned.
+
+## Scope Delivered
+- Added `packages/kamn-schema` with canonical message envelope primitives:
+  - constants for canonical type, encryption algorithm, and proof purpose.
+  - `createCanonicalMessageEnvelope(...)` helper.
+  - `validateCanonicalMessageEnvelope(...)` strict validation rules.
+  - `canonicalPayload(...)` deterministic payload serialization.
+- Added `packages/kamn-sdk` with dependency-light in-memory SDK parity:
+  - `KAMNClient` for register/resolve/send/receive/task/escrow/search/reputation flows.
+  - `SDKError` explicit typed errors.
+  - send path enforces schema validation through `kamn-schema`.
+
+## Shared Schema Rules (Parity Targets)
+The TypeScript schema package mirrors canonical constraints used by core protocol docs:
+- envelope type must be `kamn:message:v1`.
+- sender and recipients must be valid `kamn:did:agent:*` values.
+- expiry must be strictly after creation.
+- nonce must be a positive integer.
+- message type must be in canonical allowed set.
+- encryption algorithm must be `X25519-XChaCha20-Poly1305`.
+- recipient keys and body entries must be non-empty.
+- proof purpose must be `authentication`.
+- proof verification method must be bound to sender DID (`<from>#...`).
+
+## TypeScript SDK Beta Behavior
+- IDs are deterministic (`agent_<n>`, `msg_<n>`, `task_<n>`, `escrow_<n>`).
+- inbox reads are draining by design.
+- escrow release is one-way and idempotency-protected.
+- search results are deterministic and sorted by DID.
+- schema violations in send path are surfaced as `SDKError`.
+
+## Fast and Cost-Effective Validation
+This slice avoids dependency-heavy toolchains and uses Node 22 native TypeScript stripping:
+- `node --experimental-strip-types --test ...`
+
+PR-fast validation commands:
+
+```bash
+npm --prefix packages/kamn-schema test
+npm --prefix packages/kamn-sdk test
+```
+
+These tests are deterministic, run in milliseconds, and require no package install at this stage.
+
+## Local Validation
+Run from repository root:
+
+```bash
+npm --prefix packages/kamn-schema test
+npm --prefix packages/kamn-sdk test
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test typescript_sdk_beta_docs
+cargo test -p kamn-core
+```

--- a/packages/kamn-schema/package.json
+++ b/packages/kamn-schema/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@kamn/schema",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-strip-types --test ./tests/*.test.ts"
+  }
+}

--- a/packages/kamn-schema/src/index.ts
+++ b/packages/kamn-schema/src/index.ts
@@ -1,0 +1,24 @@
+export {
+  canonicalPayload,
+  createCanonicalMessageEnvelope,
+  SchemaError,
+  validateCanonicalMessageEnvelope,
+} from "./message_envelope.ts";
+
+export {
+  ALLOWED_MESSAGE_TYPES,
+  CANONICAL_ENCRYPTION_ALGORITHM,
+  CANONICAL_MESSAGE_ENVELOPE_TYPE,
+  CANONICAL_PROOF_PURPOSE,
+} from "./types.ts";
+
+export type {
+  AttachmentRef,
+  CanonicalMessageEnvelope,
+  CanonicalMessageType,
+  CreateCanonicalEnvelopeInput,
+  EnvelopeEncryption,
+  EnvelopeHeader,
+  EnvelopeMetadata,
+  EnvelopeProof,
+} from "./types.ts";

--- a/packages/kamn-schema/src/message_envelope.ts
+++ b/packages/kamn-schema/src/message_envelope.ts
@@ -1,0 +1,219 @@
+import {
+  ALLOWED_MESSAGE_TYPES,
+  CANONICAL_ENCRYPTION_ALGORITHM,
+  CANONICAL_MESSAGE_ENVELOPE_TYPE,
+  CANONICAL_PROOF_PURPOSE,
+  type CanonicalMessageEnvelope,
+  type CreateCanonicalEnvelopeInput,
+} from "./types.ts";
+
+const DID_PATTERN = /^kamn:did:agent:[A-Za-z0-9._:-]+$/;
+
+export class SchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SchemaError";
+  }
+}
+
+export function createCanonicalMessageEnvelope(
+  input: CreateCanonicalEnvelopeInput,
+): CanonicalMessageEnvelope {
+  const created = input.created ?? timestampFromNonce(input.nonce, 0);
+  const expires = input.expires ?? timestampFromNonce(input.nonce, 60);
+
+  return {
+    envelope: {
+      id: input.id,
+      typeName: CANONICAL_MESSAGE_ENVELOPE_TYPE,
+      from: input.from,
+      to: [...input.to],
+      created,
+      expires,
+      threadId: input.threadId,
+      parentId: input.parentId,
+      nonce: input.nonce,
+    },
+    header: {
+      messageType: input.messageType,
+      priority: input.priority ?? "normal",
+      contentType: input.contentType ?? "application/json",
+      encryption: {
+        algorithm: CANONICAL_ENCRYPTION_ALGORITHM,
+        recipientKeys: [...input.recipientKeys],
+      },
+    },
+    body: { ...input.body },
+    attachments: [...(input.attachments ?? [])],
+    proof: {
+      typeName: "Ed25519Signature2020",
+      created,
+      verificationMethod: `${input.from}#key-1`,
+      proofPurpose: CANONICAL_PROOF_PURPOSE,
+      proofValue: input.proofValue ?? "proof-placeholder",
+    },
+  };
+}
+
+export function validateCanonicalMessageEnvelope(
+  envelope: CanonicalMessageEnvelope,
+): void {
+  requireNonEmpty("envelope.id", envelope.envelope.id);
+  if (envelope.envelope.typeName !== CANONICAL_MESSAGE_ENVELOPE_TYPE) {
+    throw new SchemaError(
+      `envelope.type_name must be ${CANONICAL_MESSAGE_ENVELOPE_TYPE}`,
+    );
+  }
+
+  if (!DID_PATTERN.test(envelope.envelope.from)) {
+    throw new SchemaError(`invalid sender did: ${envelope.envelope.from}`);
+  }
+  if (envelope.envelope.to.length === 0) {
+    throw new SchemaError("envelope.to must not be empty");
+  }
+  for (const recipient of envelope.envelope.to) {
+    if (!DID_PATTERN.test(recipient)) {
+      throw new SchemaError(`invalid recipient did: ${recipient}`);
+    }
+  }
+
+  requireNonEmpty("envelope.created", envelope.envelope.created);
+  requireNonEmpty("envelope.expires", envelope.envelope.expires);
+  const createdMs = Date.parse(envelope.envelope.created);
+  const expiresMs = Date.parse(envelope.envelope.expires);
+  if (Number.isNaN(createdMs) || Number.isNaN(expiresMs)) {
+    throw new SchemaError("envelope.created and envelope.expires must be valid ISO timestamps");
+  }
+  if (expiresMs <= createdMs) {
+    throw new SchemaError("envelope.expires must be strictly after envelope.created");
+  }
+
+  if (!Number.isInteger(envelope.envelope.nonce) || envelope.envelope.nonce <= 0) {
+    throw new SchemaError("envelope.nonce must be a positive integer");
+  }
+
+  requireNonEmpty("header.message_type", envelope.header.messageType);
+  if (!ALLOWED_MESSAGE_TYPES.includes(envelope.header.messageType as never)) {
+    throw new SchemaError(
+      "header.message_type must be one of the canonical values",
+    );
+  }
+  requireNonEmpty("header.priority", envelope.header.priority);
+  requireNonEmpty("header.content_type", envelope.header.contentType);
+
+  if (envelope.header.encryption.algorithm !== CANONICAL_ENCRYPTION_ALGORITHM) {
+    throw new SchemaError(
+      `header.encryption.algorithm must be ${CANONICAL_ENCRYPTION_ALGORITHM}`,
+    );
+  }
+  if (envelope.header.encryption.recipientKeys.length === 0) {
+    throw new SchemaError("header.encryption.recipient_keys must not be empty");
+  }
+  for (const keyRef of envelope.header.encryption.recipientKeys) {
+    if (!keyRef.trim()) {
+      throw new SchemaError("header.encryption.recipient_keys[] must not be empty");
+    }
+  }
+
+  const entries = Object.entries(envelope.body);
+  if (entries.length === 0) {
+    throw new SchemaError("body must not be empty");
+  }
+  for (const [key, value] of entries) {
+    if (!key.trim() || !value.trim()) {
+      throw new SchemaError("body entries must have non-empty key/value");
+    }
+  }
+
+  for (const attachment of envelope.attachments) {
+    if (!attachment.id.trim()) {
+      throw new SchemaError("attachment.id must not be empty");
+    }
+    if (!attachment.mediaType.trim()) {
+      throw new SchemaError("attachment.media_type must not be empty");
+    }
+    if (!attachment.uri.trim()) {
+      throw new SchemaError("attachment.uri must not be empty");
+    }
+  }
+
+  requireNonEmpty("proof.type_name", envelope.proof.typeName);
+  requireNonEmpty("proof.created", envelope.proof.created);
+  requireNonEmpty("proof.verification_method", envelope.proof.verificationMethod);
+  if (envelope.proof.proofPurpose !== CANONICAL_PROOF_PURPOSE) {
+    throw new SchemaError(`proof.proof_purpose must be ${CANONICAL_PROOF_PURPOSE}`);
+  }
+  requireNonEmpty("proof.proof_value", envelope.proof.proofValue);
+
+  const expectedPrefix = `${envelope.envelope.from}#`;
+  if (!envelope.proof.verificationMethod.startsWith(expectedPrefix)) {
+    throw new SchemaError(
+      `proof.verification_method must start with ${expectedPrefix}`,
+    );
+  }
+}
+
+export function canonicalPayload(envelope: CanonicalMessageEnvelope): string {
+  const recipients = [...envelope.envelope.to].sort();
+  const recipientKeys = [...envelope.header.encryption.recipientKeys].sort();
+  const attachments = [...envelope.attachments].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+  const bodyEntries = Object.entries(envelope.body).sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+
+  const parts: string[] = [];
+  parts.push("envelope");
+  parts.push(envelope.envelope.id);
+  parts.push(envelope.envelope.typeName);
+  parts.push(envelope.envelope.from);
+  parts.push(recipients.join(","));
+  parts.push(envelope.envelope.created);
+  parts.push(envelope.envelope.expires);
+  parts.push(envelope.envelope.threadId ?? "");
+  parts.push(envelope.envelope.parentId ?? "");
+  parts.push(String(envelope.envelope.nonce));
+
+  parts.push("header");
+  parts.push(envelope.header.messageType);
+  parts.push(envelope.header.priority);
+  parts.push(envelope.header.contentType);
+  parts.push(envelope.header.encryption.algorithm);
+  parts.push(recipientKeys.join(","));
+
+  parts.push("body");
+  let bodyPayload = "";
+  for (const [key, value] of bodyEntries) {
+    bodyPayload += `${key}=${value};`;
+  }
+  parts.push(bodyPayload);
+
+  parts.push("attachments");
+  let attachmentPayload = "";
+  for (const attachment of attachments) {
+    attachmentPayload += `${attachment.id}:${attachment.mediaType}:${attachment.uri};`;
+  }
+  parts.push(attachmentPayload);
+
+  parts.push("proof");
+  parts.push(envelope.proof.typeName);
+  parts.push(envelope.proof.created);
+  parts.push(envelope.proof.verificationMethod);
+  parts.push(envelope.proof.proofPurpose);
+  parts.push(envelope.proof.proofValue);
+
+  return parts.join("|");
+}
+
+function requireNonEmpty(field: string, value: string): void {
+  if (!value.trim()) {
+    throw new SchemaError(`${field} must not be empty`);
+  }
+}
+
+function timestampFromNonce(nonce: number, offsetSeconds: number): string {
+  const baseMs = Date.UTC(2026, 0, 1, 0, 0, 0);
+  const nonceSeconds = Number.isFinite(nonce) ? Math.max(0, nonce) : 0;
+  return new Date(baseMs + (nonceSeconds + offsetSeconds) * 1000).toISOString();
+}

--- a/packages/kamn-schema/src/types.ts
+++ b/packages/kamn-schema/src/types.ts
@@ -1,0 +1,83 @@
+export const CANONICAL_MESSAGE_ENVELOPE_TYPE = "kamn:message:v1";
+export const CANONICAL_ENCRYPTION_ALGORITHM = "X25519-XChaCha20-Poly1305";
+export const CANONICAL_PROOF_PURPOSE = "authentication";
+
+export const ALLOWED_MESSAGE_TYPES = [
+  "Request",
+  "Response",
+  "Proposal",
+  "Acceptance",
+  "Rejection",
+  "Delegation",
+  "StatusUpdate",
+  "PaymentOffer",
+  "PaymentConfirm",
+  "Heartbeat",
+  "Revocation",
+] as const;
+
+export type CanonicalMessageType = (typeof ALLOWED_MESSAGE_TYPES)[number];
+
+export interface EnvelopeMetadata {
+  id: string;
+  typeName: string;
+  from: string;
+  to: string[];
+  created: string;
+  expires: string;
+  threadId?: string;
+  parentId?: string;
+  nonce: number;
+}
+
+export interface EnvelopeEncryption {
+  algorithm: string;
+  recipientKeys: string[];
+}
+
+export interface EnvelopeHeader {
+  messageType: string;
+  priority: string;
+  contentType: string;
+  encryption: EnvelopeEncryption;
+}
+
+export interface AttachmentRef {
+  id: string;
+  mediaType: string;
+  uri: string;
+}
+
+export interface EnvelopeProof {
+  typeName: string;
+  created: string;
+  verificationMethod: string;
+  proofPurpose: string;
+  proofValue: string;
+}
+
+export interface CanonicalMessageEnvelope {
+  envelope: EnvelopeMetadata;
+  header: EnvelopeHeader;
+  body: Record<string, string>;
+  attachments: AttachmentRef[];
+  proof: EnvelopeProof;
+}
+
+export interface CreateCanonicalEnvelopeInput {
+  id: string;
+  from: string;
+  to: string[];
+  nonce: number;
+  messageType: string;
+  body: Record<string, string>;
+  recipientKeys: string[];
+  created?: string;
+  expires?: string;
+  priority?: string;
+  contentType?: string;
+  attachments?: AttachmentRef[];
+  threadId?: string;
+  parentId?: string;
+  proofValue?: string;
+}

--- a/packages/kamn-schema/tests/message_envelope.test.ts
+++ b/packages/kamn-schema/tests/message_envelope.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  canonicalPayload,
+  createCanonicalMessageEnvelope,
+  SchemaError,
+  validateCanonicalMessageEnvelope,
+} from "../src/index.ts";
+
+test("valid canonical envelope passes and payload is deterministic", () => {
+  const envelope = createCanonicalMessageEnvelope({
+    id: "msg-1",
+    from: "kamn:did:agent:sender-1",
+    to: ["kamn:did:agent:recipient-b", "kamn:did:agent:recipient-a"],
+    nonce: 1,
+    messageType: "Request",
+    body: {
+      zeta: "2",
+      alpha: "1",
+    },
+    recipientKeys: [
+      "kamn:did:agent:recipient-b#enc-1",
+      "kamn:did:agent:recipient-a#enc-1",
+    ],
+    attachments: [
+      { id: "b", mediaType: "text/plain", uri: "ipfs://b" },
+      { id: "a", mediaType: "text/plain", uri: "ipfs://a" },
+    ],
+  });
+
+  validateCanonicalMessageEnvelope(envelope);
+  const payload = canonicalPayload(envelope);
+
+  assert.match(payload, /recipient-a,kamn:did:agent:recipient-b/);
+  assert.match(payload, /alpha=1;zeta=2;/);
+  assert.match(payload, /a:text\/plain:ipfs:\/\/a;b:text\/plain:ipfs:\/\/b;/);
+});
+
+test("rejects invalid message type", () => {
+  const envelope = createCanonicalMessageEnvelope({
+    id: "msg-2",
+    from: "kamn:did:agent:sender-1",
+    to: ["kamn:did:agent:recipient-1"],
+    nonce: 2,
+    messageType: "UnknownType",
+    body: { text: "hello" },
+    recipientKeys: ["kamn:did:agent:recipient-1#enc-1"],
+  });
+
+  assert.throws(() => validateCanonicalMessageEnvelope(envelope), {
+    name: "SchemaError",
+    message: /header\.message_type must be one of the canonical values/,
+  });
+});
+
+test("regression rejects nonce zero", () => {
+  // Regression: #218
+  const envelope = createCanonicalMessageEnvelope({
+    id: "msg-3",
+    from: "kamn:did:agent:sender-1",
+    to: ["kamn:did:agent:recipient-1"],
+    nonce: 0,
+    messageType: "Request",
+    body: { text: "hello" },
+    recipientKeys: ["kamn:did:agent:recipient-1#enc-1"],
+  });
+
+  assert.throws(() => validateCanonicalMessageEnvelope(envelope), SchemaError);
+});

--- a/packages/kamn-sdk/package.json
+++ b/packages/kamn-sdk/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@kamn/sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-strip-types --test ./tests/*.test.ts"
+  }
+}

--- a/packages/kamn-sdk/src/index.ts
+++ b/packages/kamn-sdk/src/index.ts
@@ -1,0 +1,13 @@
+export { KAMNClient, SDKError } from "./memory_client.ts";
+
+export type {
+  AgentMetadata,
+  AgentRecord,
+  EscrowRecord,
+  InboxMessage,
+  ReputationRecord,
+  ResolveRecord,
+  SearchAgentResult,
+  SearchAgentsQuery,
+  TaskRecord,
+} from "./types.ts";

--- a/packages/kamn-sdk/src/memory_client.ts
+++ b/packages/kamn-sdk/src/memory_client.ts
@@ -1,0 +1,269 @@
+import {
+  createCanonicalMessageEnvelope,
+  SchemaError,
+  validateCanonicalMessageEnvelope,
+} from "../../kamn-schema/src/index.ts";
+import type {
+  AgentRecord,
+  InboxMessage,
+  EscrowRecord,
+  ReputationRecord,
+  ResolveRecord,
+  SearchAgentResult,
+  SearchAgentsQuery,
+  TaskRecord,
+} from "./types.ts";
+
+export class SDKError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SDKError";
+  }
+}
+
+export class KAMNClient {
+  private agentSeq = 1;
+  private messageSeq = 1;
+  private taskSeq = 1;
+  private escrowSeq = 1;
+
+  private readonly agents = new Map<string, AgentRecord>();
+  private readonly inboxes = new Map<string, InboxMessage[]>();
+  private readonly tasks = new Map<string, TaskRecord>();
+  private readonly escrows = new Map<string, EscrowRecord>();
+  private readonly balances = new Map<string, number>();
+  private readonly reputation = new Map<string, ReputationRecord>();
+
+  register(agentType: string, modelFamily: string, capabilities: string[]): string {
+    if (!agentType.trim()) {
+      throw new SDKError("agentType must not be empty");
+    }
+    if (!modelFamily.trim()) {
+      throw new SDKError("modelFamily must not be empty");
+    }
+    if (capabilities.length === 0) {
+      throw new SDKError("capabilities must not be empty");
+    }
+
+    const did = `kamn:did:agent:agent_${this.agentSeq}`;
+    this.agentSeq += 1;
+
+    const record: AgentRecord = {
+      did,
+      metadata: {
+        agentType,
+        modelFamily,
+        capabilities: [...capabilities],
+      },
+    };
+    this.agents.set(did, record);
+    this.inboxes.set(did, []);
+    this.balances.set(did, 100);
+    this.reputation.set(did, { id: did, score: 500 });
+
+    return did;
+  }
+
+  resolve(did: string): ResolveRecord {
+    const agent = this.agents.get(did);
+    if (!agent) {
+      throw new SDKError(`unknown did: ${did}`);
+    }
+
+    return {
+      id: agent.did,
+      metadata: {
+        agentType: agent.metadata.agentType,
+        modelFamily: agent.metadata.modelFamily,
+        capabilities: [...agent.metadata.capabilities],
+      },
+      serviceEndpoint: `kamn://messaging/${agent.did}`,
+    };
+  }
+
+  send(fromDid: string, toDid: string, body: string): string {
+    this.ensureKnownAgent(fromDid);
+    this.ensureKnownAgent(toDid);
+    if (!body.trim()) {
+      throw new SDKError("message body must not be empty");
+    }
+
+    const messageId = `msg_${this.messageSeq}`;
+    const messageNonce = this.messageSeq;
+    this.messageSeq += 1;
+
+    try {
+      const envelope = createCanonicalMessageEnvelope({
+        id: messageId,
+        from: fromDid,
+        to: [toDid],
+        nonce: messageNonce,
+        messageType: "Request",
+        body: { text: body },
+        recipientKeys: [`${toDid}#enc-1`],
+      });
+      validateCanonicalMessageEnvelope(envelope);
+
+      const inbox = this.inboxes.get(toDid);
+      if (!inbox) {
+        throw new SDKError(`missing inbox for did: ${toDid}`);
+      }
+      inbox.push({
+        id: messageId,
+        from: fromDid,
+        to: toDid,
+        body,
+        envelope,
+      });
+    } catch (error) {
+      if (error instanceof SchemaError) {
+        throw new SDKError(`schema validation failed: ${error.message}`);
+      }
+      throw error;
+    }
+
+    return messageId;
+  }
+
+  receive(did: string): InboxMessage[] {
+    this.ensureKnownAgent(did);
+    const inbox = this.inboxes.get(did);
+    if (!inbox) {
+      throw new SDKError(`missing inbox for did: ${did}`);
+    }
+
+    const drained = [...inbox];
+    inbox.length = 0;
+    return drained;
+  }
+
+  createTask(creatorDid: string, taskType: string, description: string): string {
+    this.ensureKnownAgent(creatorDid);
+    if (!taskType.trim()) {
+      throw new SDKError("taskType must not be empty");
+    }
+    if (!description.trim()) {
+      throw new SDKError("description must not be empty");
+    }
+
+    const taskId = `task_${this.taskSeq}`;
+    this.taskSeq += 1;
+
+    this.tasks.set(taskId, {
+      creator: creatorDid,
+      taskType,
+      description,
+      accepted: false,
+    });
+
+    return taskId;
+  }
+
+  acceptTask(taskId: string, assigneeDid: string): void {
+    this.ensureKnownAgent(assigneeDid);
+    const task = this.tasks.get(taskId);
+    if (!task) {
+      throw new SDKError(`unknown task: ${taskId}`);
+    }
+    if (task.accepted) {
+      throw new SDKError("task already accepted");
+    }
+
+    task.assignee = assigneeDid;
+    task.accepted = true;
+  }
+
+  createEscrow(payerDid: string, payeeDid: string, amount: number): string {
+    this.ensureKnownAgent(payerDid);
+    this.ensureKnownAgent(payeeDid);
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new SDKError("escrow amount must be a positive integer");
+    }
+
+    const payerBalance = this.balance(payerDid);
+    if (payerBalance < amount) {
+      throw new SDKError("insufficient funds");
+    }
+
+    const escrowId = `escrow_${this.escrowSeq}`;
+    this.escrowSeq += 1;
+
+    this.balances.set(payerDid, payerBalance - amount);
+    this.escrows.set(escrowId, {
+      payer: payerDid,
+      payee: payeeDid,
+      amount,
+      released: false,
+    });
+
+    return escrowId;
+  }
+
+  releaseEscrow(escrowId: string): void {
+    const escrow = this.escrows.get(escrowId);
+    if (!escrow) {
+      throw new SDKError(`unknown escrow: ${escrowId}`);
+    }
+    if (escrow.released) {
+      throw new SDKError("escrow already released");
+    }
+
+    const payeeBalance = this.balance(escrow.payee);
+    this.balances.set(escrow.payee, payeeBalance + escrow.amount);
+    escrow.released = true;
+  }
+
+  balance(did: string): number {
+    this.ensureKnownAgent(did);
+    const balance = this.balances.get(did);
+    if (balance === undefined) {
+      throw new SDKError(`missing balance for did: ${did}`);
+    }
+    return balance;
+  }
+
+  searchAgents(query: SearchAgentsQuery = {}): SearchAgentResult[] {
+    const results: SearchAgentResult[] = [];
+    for (const agent of this.agents.values()) {
+      if (
+        query.modelFamily &&
+        agent.metadata.modelFamily !== query.modelFamily
+      ) {
+        continue;
+      }
+      if (
+        query.capability &&
+        !agent.metadata.capabilities.includes(query.capability)
+      ) {
+        continue;
+      }
+      results.push({
+        id: agent.did,
+        metadata: {
+          agentType: agent.metadata.agentType,
+          modelFamily: agent.metadata.modelFamily,
+          capabilities: [...agent.metadata.capabilities],
+        },
+      });
+    }
+
+    results.sort((left, right) => left.id.localeCompare(right.id));
+    return results;
+  }
+
+  getReputation(did: string): ReputationRecord {
+    this.ensureKnownAgent(did);
+    const reputation = this.reputation.get(did);
+    if (!reputation) {
+      throw new SDKError(`missing reputation for did: ${did}`);
+    }
+
+    return { ...reputation };
+  }
+
+  private ensureKnownAgent(did: string): void {
+    if (!this.agents.has(did)) {
+      throw new SDKError(`unknown did: ${did}`);
+    }
+  }
+}

--- a/packages/kamn-sdk/src/types.ts
+++ b/packages/kamn-sdk/src/types.ts
@@ -1,0 +1,56 @@
+import type { CanonicalMessageEnvelope } from "../../kamn-schema/src/index.ts";
+
+export interface AgentMetadata {
+  agentType: string;
+  modelFamily: string;
+  capabilities: string[];
+}
+
+export interface AgentRecord {
+  did: string;
+  metadata: AgentMetadata;
+}
+
+export interface InboxMessage {
+  id: string;
+  from: string;
+  to: string;
+  body: string;
+  envelope: CanonicalMessageEnvelope;
+}
+
+export interface TaskRecord {
+  creator: string;
+  taskType: string;
+  description: string;
+  assignee?: string;
+  accepted: boolean;
+}
+
+export interface EscrowRecord {
+  payer: string;
+  payee: string;
+  amount: number;
+  released: boolean;
+}
+
+export interface ReputationRecord {
+  id: string;
+  score: number;
+}
+
+export interface SearchAgentsQuery {
+  capability?: string;
+  modelFamily?: string;
+}
+
+export interface SearchAgentResult {
+  id: string;
+  metadata: AgentMetadata;
+}
+
+export interface ResolveRecord {
+  id: string;
+  metadata: AgentMetadata;
+  serviceEndpoint: string;
+}

--- a/packages/kamn-sdk/tests/memory_client.test.ts
+++ b/packages/kamn-sdk/tests/memory_client.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { KAMNClient, SDKError } from "../src/index.ts";
+
+test("register and resolve round trip", () => {
+  const client = new KAMNClient();
+  const did = client.register("autonomous", "claude-4", ["text", "code"]);
+
+  const resolved = client.resolve(did);
+  assert.equal(resolved.id, did);
+  assert.equal(resolved.metadata.modelFamily, "claude-4");
+});
+
+test("send receive and drain", () => {
+  const client = new KAMNClient();
+  const sender = client.register("autonomous", "claude-4", ["text"]);
+  const receiver = client.register("assistant", "gpt-5", ["text"]);
+
+  const messageId = client.send(sender, receiver, "hello");
+  assert.match(messageId, /^msg_/);
+
+  const first = client.receive(receiver);
+  const second = client.receive(receiver);
+
+  assert.equal(first.length, 1);
+  assert.equal(first[0].body, "hello");
+  assert.equal(second.length, 0);
+});
+
+test("task and escrow flow", () => {
+  const client = new KAMNClient();
+  const creator = client.register("autonomous", "claude-4", ["research"]);
+  const assignee = client.register("assistant", "gpt-5", ["research"]);
+
+  const taskId = client.createTask(creator, "analysis", "analyze benchmark");
+  client.acceptTask(taskId, assignee);
+
+  const payerBefore = client.balance(creator);
+  const payeeBefore = client.balance(assignee);
+
+  const escrowId = client.createEscrow(creator, assignee, 15);
+  client.releaseEscrow(escrowId);
+
+  assert.equal(client.balance(creator), payerBefore - 15);
+  assert.equal(client.balance(assignee), payeeBefore + 15);
+});
+
+test("search and reputation", () => {
+  const client = new KAMNClient();
+  const did = client.register("autonomous", "claude-4", ["text", "code"]);
+  client.register("assistant", "gpt-5", ["text"]);
+
+  const results = client.searchAgents({ capability: "code" });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].id, did);
+
+  const reputation = client.getReputation(did);
+  assert.ok(reputation.score > 0);
+});
+
+test("regression rejects duplicate escrow release", () => {
+  // Regression: #218
+  const client = new KAMNClient();
+  const payer = client.register("autonomous", "claude-4", ["payments"]);
+  const payee = client.register("assistant", "gpt-5", ["payments"]);
+  const escrowId = client.createEscrow(payer, payee, 10);
+
+  client.releaseEscrow(escrowId);
+
+  assert.throws(() => client.releaseEscrow(escrowId), SDKError);
+});


### PR DESCRIPTION
Closes #219
Closes #218
Closes #39

## Summary
Adds a dependency-light TypeScript shared schema package and TypeScript SDK beta slice with deterministic in-memory workflows.
The implementation is designed for fast, low-cost validation by using Node 22 native type-stripping and built-in test runner (no install-heavy toolchain required).

## Changes
- `packages/kamn-schema/src/*`: added canonical message envelope constants, types, validation, envelope factory, and deterministic payload serialization.
- `packages/kamn-schema/tests/message_envelope.test.ts`: added unit/functional/regression tests for schema behavior and canonical payload stability.
- `packages/kamn-sdk/src/*`: added `KAMNClient` in-memory TypeScript SDK with register/resolve/send/receive/task/escrow/search/reputation flows and explicit `SDKError` handling.
- `packages/kamn-sdk/tests/memory_client.test.ts`: added parity tests for core SDK workflows and duplicate-escrow regression guard.
- `docs/foundation/typescript-sdk-beta.md`: documented schema parity rules, SDK behavior contract, and fast validation approach.
- `docs/foundation/bootstrap.md`: linked TypeScript SDK documentation.
- `crates/kamn-core/tests/typescript_sdk_beta_docs.rs`: added doc regression checks.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed TypeScript schema rules against canonical envelope constraints and exercised SDK parity flows.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `npm --prefix packages/kamn-schema test` |
| Functional  | ✅ | `npm --prefix packages/kamn-sdk test` |
| Integration | ✅ | SDK send path enforces shared schema validation + `cargo test -p kamn-core` |
| Regression  | ✅ | nonce-zero schema guard, duplicate escrow release guard, doc regression tests |
