### PR TITLE
feat(security): add watchdog node prototype alerts

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod task_payment;
 pub mod telegram_bridge;
 pub mod token;
 pub mod transaction;
+pub mod watchdog;
 
 pub use agent_key_hierarchy::{
     AgentKeyHierarchy, AgentKeyHierarchyError, EphemeralSessionKey, KeyRole,
@@ -168,4 +169,8 @@ pub use token::{
 };
 pub use transaction::{
     BaselineTransaction, TransactionGuardError, TransactionGuards, GENESIS_STATE_HASH,
+};
+pub use watchdog::{
+    WatchdogAlert, WatchdogAlertKind, WatchdogConfig, WatchdogError, WatchdogNode,
+    WatchdogObservation, WatchdogSeverity, WatchdogSnapshot,
 };

--- a/crates/kamn-core/src/watchdog.rs
+++ b/crates/kamn-core/src/watchdog.rs
@@ -1,0 +1,369 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchdogSeverity {
+    Warning,
+    Critical,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchdogAlertKind {
+    InvalidBlockParent {
+        block_id: String,
+        expected_parent: String,
+        observed_parent: String,
+    },
+    CensorshipSignal {
+        message_id: String,
+        delivered_recipients: usize,
+        expected_recipients: usize,
+        observed_ratio_pct: u8,
+    },
+    QuorumAnomaly {
+        block_id: String,
+        observed_signatures: u16,
+        min_required_signatures: u16,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatchdogAlert {
+    pub severity: WatchdogSeverity,
+    pub kind: WatchdogAlertKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WatchdogConfig {
+    pub min_quorum_signatures: u16,
+    pub min_delivery_ratio_pct: u8,
+}
+
+impl Default for WatchdogConfig {
+    fn default() -> Self {
+        Self {
+            min_quorum_signatures: 3,
+            min_delivery_ratio_pct: 70,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchdogObservation {
+    Block {
+        block_id: String,
+        state_hash: String,
+        parent_state_hash: String,
+        quorum_signatures: u16,
+        expected_validator_count: u16,
+    },
+    GossipDelivery {
+        message_id: String,
+        target_recipients: usize,
+        delivered_recipients: usize,
+        expected_recipients: usize,
+    },
+}
+
+impl WatchdogObservation {
+    pub fn block(
+        block_id: &str,
+        state_hash: &str,
+        parent_state_hash: &str,
+        quorum_signatures: u16,
+        expected_validator_count: u16,
+    ) -> Self {
+        Self::Block {
+            block_id: block_id.to_owned(),
+            state_hash: state_hash.to_owned(),
+            parent_state_hash: parent_state_hash.to_owned(),
+            quorum_signatures,
+            expected_validator_count,
+        }
+    }
+
+    pub fn gossip_delivery(
+        message_id: &str,
+        target_recipients: usize,
+        delivered_recipients: usize,
+        expected_recipients: usize,
+    ) -> Self {
+        Self::GossipDelivery {
+            message_id: message_id.to_owned(),
+            target_recipients,
+            delivered_recipients,
+            expected_recipients,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WatchdogSnapshot {
+    pub total_observations: usize,
+    pub total_alerts: usize,
+    pub warning_alerts: usize,
+    pub critical_alerts: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatchdogNode {
+    config: WatchdogConfig,
+    last_state_hash: Option<String>,
+    total_observations: usize,
+    warning_alerts: usize,
+    critical_alerts: usize,
+}
+
+impl WatchdogNode {
+    pub fn new(config: WatchdogConfig) -> Result<Self, WatchdogError> {
+        validate_config(config)?;
+
+        Ok(Self {
+            config,
+            last_state_hash: None,
+            total_observations: 0,
+            warning_alerts: 0,
+            critical_alerts: 0,
+        })
+    }
+
+    pub fn observe(
+        &mut self,
+        observation: WatchdogObservation,
+    ) -> Result<Vec<WatchdogAlert>, WatchdogError> {
+        let alerts = match observation {
+            WatchdogObservation::Block {
+                block_id,
+                state_hash,
+                parent_state_hash,
+                quorum_signatures,
+                expected_validator_count,
+            } => self.observe_block(
+                block_id,
+                state_hash,
+                parent_state_hash,
+                quorum_signatures,
+                expected_validator_count,
+            )?,
+            WatchdogObservation::GossipDelivery {
+                message_id,
+                target_recipients,
+                delivered_recipients,
+                expected_recipients,
+            } => self.observe_gossip(
+                message_id,
+                target_recipients,
+                delivered_recipients,
+                expected_recipients,
+            )?,
+        };
+
+        self.total_observations += 1;
+        for alert in &alerts {
+            match alert.severity {
+                WatchdogSeverity::Warning => self.warning_alerts += 1,
+                WatchdogSeverity::Critical => self.critical_alerts += 1,
+            }
+        }
+
+        Ok(alerts)
+    }
+
+    pub fn snapshot(&self) -> WatchdogSnapshot {
+        WatchdogSnapshot {
+            total_observations: self.total_observations,
+            total_alerts: self.warning_alerts + self.critical_alerts,
+            warning_alerts: self.warning_alerts,
+            critical_alerts: self.critical_alerts,
+        }
+    }
+
+    fn observe_block(
+        &mut self,
+        block_id: String,
+        state_hash: String,
+        parent_state_hash: String,
+        quorum_signatures: u16,
+        expected_validator_count: u16,
+    ) -> Result<Vec<WatchdogAlert>, WatchdogError> {
+        require_non_empty("block_id", &block_id)?;
+        require_non_empty("state_hash", &state_hash)?;
+        require_non_empty("parent_state_hash", &parent_state_hash)?;
+        if expected_validator_count == 0 {
+            return Err(WatchdogError::InvalidObservation(
+                "expected_validator_count must be greater than zero".to_owned(),
+            ));
+        }
+
+        let mut alerts = Vec::new();
+
+        if let Some(expected_parent) = &self.last_state_hash {
+            if &parent_state_hash != expected_parent {
+                alerts.push(WatchdogAlert {
+                    severity: WatchdogSeverity::Critical,
+                    kind: WatchdogAlertKind::InvalidBlockParent {
+                        block_id: block_id.clone(),
+                        expected_parent: expected_parent.clone(),
+                        observed_parent: parent_state_hash,
+                    },
+                });
+            }
+        }
+
+        if quorum_signatures < self.config.min_quorum_signatures {
+            alerts.push(WatchdogAlert {
+                severity: WatchdogSeverity::Critical,
+                kind: WatchdogAlertKind::QuorumAnomaly {
+                    block_id,
+                    observed_signatures: quorum_signatures,
+                    min_required_signatures: self.config.min_quorum_signatures,
+                },
+            });
+        }
+
+        self.last_state_hash = Some(state_hash);
+        Ok(alerts)
+    }
+
+    fn observe_gossip(
+        &self,
+        message_id: String,
+        target_recipients: usize,
+        delivered_recipients: usize,
+        expected_recipients: usize,
+    ) -> Result<Vec<WatchdogAlert>, WatchdogError> {
+        require_non_empty("message_id", &message_id)?;
+        if expected_recipients == 0 {
+            return Err(WatchdogError::InvalidObservation(
+                "expected_recipients must be greater than zero".to_owned(),
+            ));
+        }
+        if target_recipients == 0 {
+            return Err(WatchdogError::InvalidObservation(
+                "target_recipients must be greater than zero".to_owned(),
+            ));
+        }
+        if delivered_recipients > expected_recipients {
+            return Err(WatchdogError::InvalidObservation(
+                "delivered_recipients cannot exceed expected_recipients".to_owned(),
+            ));
+        }
+
+        // Direct single-recipient traffic should not be classified as censorship.
+        if expected_recipients <= 1 {
+            return Ok(Vec::new());
+        }
+
+        let observed_ratio_pct =
+            ((delivered_recipients as f64 / expected_recipients as f64) * 100.0).floor() as u8;
+        if observed_ratio_pct >= self.config.min_delivery_ratio_pct {
+            return Ok(Vec::new());
+        }
+
+        Ok(vec![WatchdogAlert {
+            severity: WatchdogSeverity::Warning,
+            kind: WatchdogAlertKind::CensorshipSignal {
+                message_id,
+                delivered_recipients,
+                expected_recipients,
+                observed_ratio_pct,
+            },
+        }])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchdogError {
+    InvalidConfig(String),
+    InvalidObservation(String),
+}
+
+impl fmt::Display for WatchdogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfig(message) => write!(f, "invalid config: {message}"),
+            Self::InvalidObservation(message) => write!(f, "invalid observation: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for WatchdogError {}
+
+fn validate_config(config: WatchdogConfig) -> Result<(), WatchdogError> {
+    if config.min_quorum_signatures == 0 {
+        return Err(WatchdogError::InvalidConfig(
+            "min_quorum_signatures must be greater than zero".to_owned(),
+        ));
+    }
+    if config.min_delivery_ratio_pct == 0 || config.min_delivery_ratio_pct > 100 {
+        return Err(WatchdogError::InvalidConfig(
+            "min_delivery_ratio_pct must be between 1 and 100".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), WatchdogError> {
+    if value.trim().is_empty() {
+        return Err(WatchdogError::InvalidObservation(format!(
+            "{field} must not be empty"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        WatchdogConfig, WatchdogError, WatchdogNode, WatchdogObservation, WatchdogSeverity,
+    };
+
+    #[test]
+    fn config_rejects_out_of_range_delivery_ratio() {
+        assert_eq!(
+            WatchdogNode::new(WatchdogConfig {
+                min_quorum_signatures: 2,
+                min_delivery_ratio_pct: 101,
+            }),
+            Err(WatchdogError::InvalidConfig(
+                "min_delivery_ratio_pct must be between 1 and 100".to_owned(),
+            ))
+        );
+    }
+
+    #[test]
+    fn gossip_rejects_delivered_above_expected() {
+        let watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("valid config");
+        let result = watchdog.observe_gossip("msg-1".to_owned(), 5, 6, 5);
+        assert_eq!(
+            result,
+            Err(WatchdogError::InvalidObservation(
+                "delivered_recipients cannot exceed expected_recipients".to_owned(),
+            ))
+        );
+    }
+
+    #[test]
+    fn high_delivery_ratio_is_not_flagged() {
+        let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("valid config");
+        let alerts = watchdog
+            .observe(WatchdogObservation::gossip_delivery("msg-1", 10, 8, 10))
+            .expect("observation should be valid");
+        assert!(alerts.is_empty());
+        assert_eq!(watchdog.snapshot().warning_alerts, 0);
+        assert_eq!(watchdog.snapshot().critical_alerts, 0);
+    }
+
+    #[test]
+    fn low_quorum_is_critical() {
+        let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("valid config");
+        let alerts = watchdog
+            .observe(WatchdogObservation::block(
+                "block-1", "state-1", "state-0", 1, 5,
+            ))
+            .expect("observation should be valid");
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].severity, WatchdogSeverity::Critical);
+    }
+}

--- a/crates/kamn-core/tests/watchdog_node.rs
+++ b/crates/kamn-core/tests/watchdog_node.rs
@@ -1,0 +1,118 @@
+use kamn_core::{
+    WatchdogAlertKind, WatchdogConfig, WatchdogError, WatchdogNode, WatchdogObservation,
+    WatchdogSeverity,
+};
+
+#[test]
+fn invalid_block_parent_link_triggers_critical_alert() {
+    let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("config should build");
+
+    watchdog
+        .observe(WatchdogObservation::block(
+            "block-1", "state-1", "state-0", 3, 5,
+        ))
+        .expect("first block should be accepted");
+
+    let alerts = watchdog
+        .observe(WatchdogObservation::block(
+            "block-2",
+            "state-2",
+            "unexpected-parent",
+            3,
+            4,
+        ))
+        .expect("second block should evaluate");
+
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts[0].severity, WatchdogSeverity::Critical);
+    assert!(matches!(
+        alerts[0].kind,
+        WatchdogAlertKind::InvalidBlockParent { .. }
+    ));
+}
+
+#[test]
+fn censorship_signal_triggers_alert_when_delivery_below_threshold() {
+    let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("config should build");
+
+    let alerts = watchdog
+        .observe(WatchdogObservation::gossip_delivery("msg-1", 10, 6, 10))
+        .expect("gossip should evaluate");
+
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts[0].severity, WatchdogSeverity::Warning);
+    assert!(matches!(
+        alerts[0].kind,
+        WatchdogAlertKind::CensorshipSignal { .. }
+    ));
+}
+
+#[test]
+fn quorum_anomaly_triggers_critical_alert() {
+    let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("config should build");
+
+    let alerts = watchdog
+        .observe(WatchdogObservation::block(
+            "block-1", "state-1", "state-0", 2, 5,
+        ))
+        .expect("block should evaluate");
+
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts[0].severity, WatchdogSeverity::Critical);
+    assert!(matches!(
+        alerts[0].kind,
+        WatchdogAlertKind::QuorumAnomaly { .. }
+    ));
+}
+
+#[test]
+fn integration_snapshot_rolls_alert_counts_by_severity() {
+    let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("config should build");
+
+    watchdog
+        .observe(WatchdogObservation::gossip_delivery("msg-ok", 12, 11, 12))
+        .expect("healthy gossip should evaluate");
+    watchdog
+        .observe(WatchdogObservation::gossip_delivery("msg-warn", 12, 7, 12))
+        .expect("degraded gossip should evaluate");
+    watchdog
+        .observe(WatchdogObservation::block(
+            "block-critical",
+            "state-10",
+            "state-9",
+            1,
+            5,
+        ))
+        .expect("critical block should evaluate");
+
+    let snapshot = watchdog.snapshot();
+    assert_eq!(snapshot.total_observations, 3);
+    assert_eq!(snapshot.warning_alerts, 1);
+    assert_eq!(snapshot.critical_alerts, 1);
+    assert_eq!(snapshot.total_alerts, 2);
+}
+
+#[test]
+fn regression_single_recipient_target_not_flagged_as_censorship() {
+    // Regression: #204
+    let mut watchdog = WatchdogNode::new(WatchdogConfig::default()).expect("config should build");
+
+    let alerts = watchdog
+        .observe(WatchdogObservation::gossip_delivery("msg-direct", 1, 1, 1))
+        .expect("single-recipient delivery should evaluate");
+
+    assert!(alerts.is_empty());
+}
+
+#[test]
+fn rejects_invalid_configuration() {
+    assert_eq!(
+        WatchdogNode::new(WatchdogConfig {
+            min_quorum_signatures: 0,
+            min_delivery_ratio_pct: 60,
+        }),
+        Err(WatchdogError::InvalidConfig(
+            "min_quorum_signatures must be greater than zero".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/watchdog_node_docs.rs
+++ b/crates/kamn-core/tests/watchdog_node_docs.rs
@@ -1,0 +1,27 @@
+const DOC: &str = include_str!("../../../docs/foundation/watchdog-node-prototype.md");
+
+#[test]
+fn doc_contains_watchdog_scope_and_detection_rules() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("WatchdogNode"));
+    assert!(DOC.contains("## Detection Rules"));
+    assert!(DOC.contains("Invalid block parent"));
+    assert!(DOC.contains("Quorum anomaly"));
+    assert!(DOC.contains("Censorship signal"));
+}
+
+#[test]
+fn doc_contains_snapshot_and_validation_semantics() {
+    assert!(DOC.contains("## Snapshot Semantics"));
+    assert!(DOC.contains("WatchdogSnapshot"));
+    assert!(DOC.contains("## Validation and Error Handling"));
+    assert!(DOC.contains("Config rejects zero quorum threshold."));
+}
+
+#[test]
+fn regression_requires_single_recipient_censorship_exclusion_rule() {
+    // Regression: #204
+    assert!(
+        DOC.contains("single-recipient deliveries are excluded from censorship classification.")
+    );
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -50,6 +50,7 @@ For multi-AZ topology and failover operations, see `docs/foundation/multi-az-fai
 For observability SLO evaluation and dashboard rollup controls, see `docs/foundation/observability-slo-dashboards.md`.
 For security control ownership and enforcement mapping, see `docs/foundation/threat-control-matrix.md`.
 For anti-hallucination instruction validation controls, see `docs/foundation/instruction-verification.md`.
+For watchdog prototype detection controls (invalid blocks, censorship, quorum anomalies), see `docs/foundation/watchdog-node-prototype.md`.
 For deterministic key lifecycle and rotation transitions, see `docs/foundation/key-lifecycle.md`.
 For tamper-evident key lifecycle audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
 For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.

--- a/docs/foundation/watchdog-node-prototype.md
+++ b/docs/foundation/watchdog-node-prototype.md
@@ -1,0 +1,55 @@
+# Watchdog Node Prototype for Integrity and Censorship Signals (Issue #204)
+
+This document captures the first watchdog implementation slice for detecting invalid blocks, censorship indicators, and quorum anomalies.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/watchdog.rs` with:
+  - `WatchdogNode` observation evaluator.
+  - `WatchdogConfig` configurable thresholds.
+  - `WatchdogObservation` block and gossip delivery inputs.
+  - `WatchdogAlert` + `WatchdogAlertKind` outputs.
+  - `WatchdogSnapshot` rollup counts.
+  - `WatchdogError` typed validation failures.
+- Added tests in `crates/kamn-core/tests/watchdog_node.rs`.
+
+## Detection Rules
+- Invalid block parent:
+  - critical alert when observed block parent does not match previously observed state hash.
+- Quorum anomaly:
+  - critical alert when block signatures are below minimum configured quorum threshold.
+- Censorship signal:
+  - warning alert when gossip delivery ratio is below configured threshold.
+  - single-recipient deliveries are excluded from censorship classification.
+
+## Snapshot Semantics
+`WatchdogSnapshot` tracks deterministic counters:
+- total observations
+- total alerts
+- warning alerts
+- critical alerts
+
+## Validation and Error Handling
+- Config rejects zero quorum threshold.
+- Config rejects delivery ratio outside `1..=100`.
+- Observations reject empty identifiers and impossible recipient counts.
+- Invalid observation inputs return explicit typed errors.
+
+## Fast and Cost-Effective Validation
+This slice keeps PR verification lightweight:
+
+```bash
+cargo test -p kamn-core --test watchdog_node
+```
+
+The test set is deterministic and sub-second, minimizing CI runtime and cost.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test watchdog_node
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test watchdog_node_docs
+cargo test -p kamn-core
+```


### PR DESCRIPTION
Closes #205
Closes #204
Closes #51

## Summary
Adds a deterministic watchdog prototype for security hardening that detects invalid block parent linkage, censorship signals, and quorum anomalies.
This slice is intentionally lightweight and fast to validate for low-cost CI feedback.

## Changes
- `crates/kamn-core/src/watchdog.rs`: added watchdog domain model, observation evaluator, alert kinds/severity, snapshot rollup, and typed errors.
- `crates/kamn-core/src/lib.rs`: exported watchdog surfaces.
- `crates/kamn-core/tests/watchdog_node.rs`: added functional/integration/regression tests for block parent mismatch, censorship signals, quorum anomalies, and snapshot accounting.
- `docs/foundation/watchdog-node-prototype.md`: documented detection rules, validation semantics, and fast validation commands.
- `crates/kamn-core/tests/watchdog_node_docs.rs`: added doc regression checks.
- `docs/foundation/bootstrap.md`: linked watchdog prototype doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised all watchdog alert paths and checked alert rollups against deterministic fixtures.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | watchdog config/input validation tests |
| Functional  | ✅ | `cargo test -p kamn-core --test watchdog_node` |
| Integration | ✅ | snapshot + multi-observation flow in watchdog integration test |
| Regression  | ✅ | single-recipient censorship exclusion + doc regression checks |
