### PR TITLE
feat(security): add anti-spam deposit and rate controls

### DIFF
--- a/crates/kamn-core/src/anti_spam.rs
+++ b/crates/kamn-core/src/anti_spam.rs
@@ -1,0 +1,272 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AntiSpamConfig {
+    pub max_messages_per_window: usize,
+    pub window_seconds: u64,
+    pub minimum_sybil_deposit: u64,
+    pub suspension_violation_threshold: u32,
+    pub suspension_seconds: u64,
+}
+
+impl Default for AntiSpamConfig {
+    fn default() -> Self {
+        Self {
+            max_messages_per_window: 3,
+            window_seconds: 5,
+            minimum_sybil_deposit: 10,
+            suspension_violation_threshold: 2,
+            suspension_seconds: 60,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AntiSpamDecision {
+    Accepted,
+    Rejected(AntiSpamRejection),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AntiSpamRejection {
+    InsufficientDeposit {
+        required: u64,
+        provided: u64,
+    },
+    RateLimitExceeded {
+        limit: usize,
+        observed: usize,
+        window_seconds: u64,
+    },
+    SenderSuspended {
+        until_unix: u64,
+    },
+    DuplicateMessageId(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AntiSpamTelemetry {
+    pub total_processed: u64,
+    pub accepted: u64,
+    pub rejected_insufficient_deposit: u64,
+    pub rejected_rate_limit: u64,
+    pub rejected_suspended: u64,
+    pub rejected_duplicate_message: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AntiSpamError {
+    InvalidConfig(String),
+    InvalidInput(String),
+}
+
+impl fmt::Display for AntiSpamError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfig(message) => write!(f, "invalid config: {message}"),
+            Self::InvalidInput(message) => write!(f, "invalid input: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for AntiSpamError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct SenderState {
+    recent_timestamps: VecDeque<u64>,
+    consecutive_rate_violations: u32,
+    suspended_until_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AntiSpamEngine {
+    config: AntiSpamConfig,
+    deposits: HashMap<String, u64>,
+    seen_message_ids: HashSet<String>,
+    sender_state: HashMap<String, SenderState>,
+    telemetry: AntiSpamTelemetry,
+}
+
+impl AntiSpamEngine {
+    pub fn new(config: AntiSpamConfig) -> Result<Self, AntiSpamError> {
+        validate_config(config)?;
+
+        Ok(Self {
+            config,
+            deposits: HashMap::new(),
+            seen_message_ids: HashSet::new(),
+            sender_state: HashMap::new(),
+            telemetry: AntiSpamTelemetry::default(),
+        })
+    }
+
+    pub fn set_deposit(&mut self, sender_did: &str, deposit: u64) -> Result<(), AntiSpamError> {
+        validate_sender_did(sender_did)?;
+        self.deposits.insert(sender_did.to_owned(), deposit);
+        Ok(())
+    }
+
+    pub fn evaluate(
+        &mut self,
+        sender_did: &str,
+        message_id: &str,
+        now_unix: u64,
+    ) -> Result<AntiSpamDecision, AntiSpamError> {
+        validate_sender_did(sender_did)?;
+        require_non_empty("message_id", message_id)?;
+
+        self.telemetry.total_processed += 1;
+
+        if !self.seen_message_ids.insert(message_id.to_owned()) {
+            self.telemetry.rejected_duplicate_message += 1;
+            return Ok(AntiSpamDecision::Rejected(
+                AntiSpamRejection::DuplicateMessageId(message_id.to_owned()),
+            ));
+        }
+
+        let deposit = *self.deposits.get(sender_did).unwrap_or(&0);
+        if deposit < self.config.minimum_sybil_deposit {
+            self.telemetry.rejected_insufficient_deposit += 1;
+            return Ok(AntiSpamDecision::Rejected(
+                AntiSpamRejection::InsufficientDeposit {
+                    required: self.config.minimum_sybil_deposit,
+                    provided: deposit,
+                },
+            ));
+        }
+
+        let state = self.sender_state.entry(sender_did.to_owned()).or_default();
+
+        if let Some(until_unix) = state.suspended_until_unix {
+            if now_unix < until_unix {
+                self.telemetry.rejected_suspended += 1;
+                return Ok(AntiSpamDecision::Rejected(
+                    AntiSpamRejection::SenderSuspended { until_unix },
+                ));
+            }
+        }
+
+        while let Some(oldest) = state.recent_timestamps.front() {
+            if now_unix.saturating_sub(*oldest) < self.config.window_seconds {
+                break;
+            }
+            state.recent_timestamps.pop_front();
+        }
+
+        let observed = state.recent_timestamps.len();
+        if observed >= self.config.max_messages_per_window {
+            state.consecutive_rate_violations = state.consecutive_rate_violations.saturating_add(1);
+            if state.consecutive_rate_violations >= self.config.suspension_violation_threshold {
+                state.suspended_until_unix =
+                    Some(now_unix.saturating_add(self.config.suspension_seconds));
+            }
+            self.telemetry.rejected_rate_limit += 1;
+            return Ok(AntiSpamDecision::Rejected(
+                AntiSpamRejection::RateLimitExceeded {
+                    limit: self.config.max_messages_per_window,
+                    observed,
+                    window_seconds: self.config.window_seconds,
+                },
+            ));
+        }
+
+        state.recent_timestamps.push_back(now_unix);
+        state.consecutive_rate_violations = 0;
+
+        self.telemetry.accepted += 1;
+        Ok(AntiSpamDecision::Accepted)
+    }
+
+    pub fn telemetry(&self) -> AntiSpamTelemetry {
+        self.telemetry
+    }
+}
+
+fn validate_config(config: AntiSpamConfig) -> Result<(), AntiSpamError> {
+    if config.max_messages_per_window == 0 {
+        return Err(AntiSpamError::InvalidConfig(
+            "max_messages_per_window must be greater than zero".to_owned(),
+        ));
+    }
+    if config.window_seconds == 0 {
+        return Err(AntiSpamError::InvalidConfig(
+            "window_seconds must be greater than zero".to_owned(),
+        ));
+    }
+    if config.suspension_violation_threshold == 0 {
+        return Err(AntiSpamError::InvalidConfig(
+            "suspension_violation_threshold must be greater than zero".to_owned(),
+        ));
+    }
+    if config.suspension_seconds == 0 {
+        return Err(AntiSpamError::InvalidConfig(
+            "suspension_seconds must be greater than zero".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_sender_did(value: &str) -> Result<(), AntiSpamError> {
+    require_non_empty("sender_did", value)?;
+    if !value.starts_with("kamn:did:agent:") {
+        return Err(AntiSpamError::InvalidInput(
+            "sender_did must use kamn:did:agent:* format".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), AntiSpamError> {
+    if value.trim().is_empty() {
+        return Err(AntiSpamError::InvalidInput(format!(
+            "{field} must not be empty"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamError};
+
+    #[test]
+    fn invalid_sender_did_is_rejected() {
+        let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("valid config");
+        let result = engine.set_deposit("did:example:abc", 10);
+        assert_eq!(
+            result,
+            Err(AntiSpamError::InvalidInput(
+                "sender_did must use kamn:did:agent:* format".to_owned(),
+            ))
+        );
+    }
+
+    #[test]
+    fn default_engine_accepts_first_message_with_sufficient_deposit() {
+        let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("valid config");
+        engine
+            .set_deposit("kamn:did:agent:sender-1", 20)
+            .expect("deposit should be accepted");
+
+        let decision = engine
+            .evaluate("kamn:did:agent:sender-1", "msg-1", 1)
+            .expect("evaluation should succeed");
+        assert_eq!(decision, AntiSpamDecision::Accepted);
+    }
+
+    #[test]
+    fn unknown_sender_without_deposit_is_rejected() {
+        let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("valid config");
+        let decision = engine
+            .evaluate("kamn:did:agent:sender-unknown", "msg-1", 1)
+            .expect("evaluation should succeed");
+        assert!(matches!(
+            decision,
+            AntiSpamDecision::Rejected(super::AntiSpamRejection::InsufficientDeposit { .. })
+        ));
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_key_hierarchy;
+pub mod anti_spam;
 pub mod audit_exports;
 pub mod bootstrap;
 pub mod bridge_adapter;
@@ -43,6 +44,10 @@ pub mod watchdog;
 
 pub use agent_key_hierarchy::{
     AgentKeyHierarchy, AgentKeyHierarchyError, EphemeralSessionKey, KeyRole,
+};
+pub use anti_spam::{
+    AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamError, AntiSpamRejection,
+    AntiSpamTelemetry,
 };
 pub use audit_exports::{
     AuditDomain, AuditEventRecord, AuditExportBundle, AuditExportEngine, AuditExportError,

--- a/crates/kamn-core/tests/anti_spam_controls.rs
+++ b/crates/kamn-core/tests/anti_spam_controls.rs
@@ -1,0 +1,123 @@
+use kamn_core::{
+    AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamError, AntiSpamRejection,
+};
+
+#[test]
+fn sufficient_deposit_and_within_limit_is_accepted() {
+    let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("config should build");
+    engine
+        .set_deposit("kamn:did:agent:sender-1", 100)
+        .expect("deposit registration should succeed");
+
+    let decision = engine
+        .evaluate("kamn:did:agent:sender-1", "msg-1", 1)
+        .expect("evaluation should succeed");
+
+    assert_eq!(decision, AntiSpamDecision::Accepted);
+}
+
+#[test]
+fn insufficient_deposit_is_rejected() {
+    let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("config should build");
+    engine
+        .set_deposit("kamn:did:agent:sender-1", 5)
+        .expect("deposit registration should succeed");
+
+    let decision = engine
+        .evaluate("kamn:did:agent:sender-1", "msg-1", 1)
+        .expect("evaluation should succeed");
+
+    assert_eq!(
+        decision,
+        AntiSpamDecision::Rejected(AntiSpamRejection::InsufficientDeposit {
+            required: 10,
+            provided: 5,
+        })
+    );
+}
+
+#[test]
+fn rate_limit_overrun_is_rejected_and_suspends_after_threshold() {
+    let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("config should build");
+    engine
+        .set_deposit("kamn:did:agent:sender-1", 100)
+        .expect("deposit registration should succeed");
+
+    for index in 0..3 {
+        let message_id = format!("msg-ok-{index}");
+        let decision = engine
+            .evaluate("kamn:did:agent:sender-1", &message_id, 10 + index)
+            .expect("evaluation should succeed");
+        assert_eq!(decision, AntiSpamDecision::Accepted);
+    }
+
+    for index in 0..2 {
+        let message_id = format!("msg-spam-{index}");
+        let decision = engine
+            .evaluate("kamn:did:agent:sender-1", &message_id, 13 + index)
+            .expect("evaluation should succeed");
+        assert!(matches!(
+            decision,
+            AntiSpamDecision::Rejected(AntiSpamRejection::RateLimitExceeded { .. })
+        ));
+    }
+
+    let suspended = engine
+        .evaluate("kamn:did:agent:sender-1", "msg-suspended", 15)
+        .expect("evaluation should succeed");
+    assert!(matches!(
+        suspended,
+        AntiSpamDecision::Rejected(AntiSpamRejection::SenderSuspended { .. })
+    ));
+}
+
+#[test]
+fn integration_telemetry_tracks_rejection_categories() {
+    let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("config should build");
+    engine
+        .set_deposit("kamn:did:agent:sender-1", 8)
+        .expect("deposit registration should succeed");
+
+    let _ = engine
+        .evaluate("kamn:did:agent:sender-1", "msg-1", 1)
+        .expect("evaluation should succeed");
+    let _ = engine
+        .evaluate("kamn:did:agent:sender-1", "msg-1", 2)
+        .expect("evaluation should succeed");
+
+    let telemetry = engine.telemetry();
+    assert_eq!(telemetry.total_processed, 2);
+    assert_eq!(telemetry.accepted, 0);
+    assert_eq!(telemetry.rejected_insufficient_deposit, 1);
+    assert_eq!(telemetry.rejected_duplicate_message, 1);
+}
+
+#[test]
+fn regression_deposit_equal_to_minimum_is_accepted() {
+    // Regression: #186
+    let mut engine = AntiSpamEngine::new(AntiSpamConfig::default()).expect("config should build");
+    engine
+        .set_deposit("kamn:did:agent:sender-1", 10)
+        .expect("deposit registration should succeed");
+
+    let decision = engine
+        .evaluate("kamn:did:agent:sender-1", "msg-eq-min", 1)
+        .expect("evaluation should succeed");
+    assert_eq!(decision, AntiSpamDecision::Accepted);
+}
+
+#[test]
+fn rejects_invalid_configuration() {
+    assert_eq!(
+        AntiSpamEngine::new(AntiSpamConfig {
+            max_messages_per_window: 0,
+            window_seconds: 10,
+            minimum_sybil_deposit: 10,
+            suspension_violation_threshold: 2,
+            suspension_seconds: 60,
+        }),
+        Err(AntiSpamError::InvalidConfig(
+            "max_messages_per_window must be greater than zero".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/anti_spam_controls_docs.rs
+++ b/crates/kamn-core/tests/anti_spam_controls_docs.rs
@@ -1,0 +1,24 @@
+const DOC: &str = include_str!("../../../docs/foundation/anti-spam-controls.md");
+
+#[test]
+fn doc_contains_enforcement_rules_and_telemetry() {
+    assert!(DOC.contains("## Enforcement Rules"));
+    assert!(DOC.contains("Deposit gate"));
+    assert!(DOC.contains("Per-agent rate limit"));
+    assert!(DOC.contains("Suspension policy"));
+    assert!(DOC.contains("## Telemetry Surface"));
+    assert!(DOC.contains("rejected due to duplicate message ID"));
+}
+
+#[test]
+fn doc_contains_fast_validation_commands() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test anti_spam_controls"));
+    assert!(DOC.contains("cargo clippy -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_deposit_threshold_boundary_rule() {
+    // Regression: #186
+    assert!(DOC.contains("sender deposit must be at least `minimum_sybil_deposit`."));
+}

--- a/docs/foundation/anti-spam-controls.md
+++ b/docs/foundation/anti-spam-controls.md
@@ -1,0 +1,57 @@
+# Anti-Spam Controls with Per-Agent Limits and Anti-Sybil Deposits (Issue #186)
+
+This document captures the first implementation slice for anti-spam controls and anti-sybil deposit enforcement.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/anti_spam.rs` with:
+  - `AntiSpamEngine` evaluation pipeline.
+  - `AntiSpamConfig` policy thresholds.
+  - `AntiSpamDecision` and `AntiSpamRejection` outcomes.
+  - `AntiSpamTelemetry` counters for abuse tuning.
+  - `AntiSpamError` typed validation failures.
+- Added tests in `crates/kamn-core/tests/anti_spam_controls.rs`.
+
+## Enforcement Rules
+- Deposit gate:
+  - sender deposit must be at least `minimum_sybil_deposit`.
+- Per-agent rate limit:
+  - each sender can emit up to `max_messages_per_window` within `window_seconds`.
+- Suspension policy:
+  - repeated rate-limit violations trigger temporary sender suspension.
+- Replay/spam guard:
+  - duplicate message IDs are rejected deterministically.
+
+## Telemetry Surface
+`AntiSpamTelemetry` tracks:
+- total processed requests
+- accepted requests
+- rejected due to insufficient deposit
+- rejected due to rate limit
+- rejected due to suspension
+- rejected due to duplicate message ID
+
+## Validation and Error Handling
+- Config rejects zero/invalid thresholds.
+- Sender DID must use `kamn:did:agent:*` format.
+- Empty message IDs are rejected.
+- Invalid inputs produce explicit typed errors.
+
+## Fast and Cost-Effective Validation
+This slice uses focused deterministic tests for PR fast gates:
+
+```bash
+cargo test -p kamn-core --test anti_spam_controls
+```
+
+No long-running integration harness is required for this stage.
+
+## Local Validation
+Run from repository root:
+
+```bash
+cargo test -p kamn-core --test anti_spam_controls
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p kamn-core --test anti_spam_controls_docs
+cargo test -p kamn-core
+```

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -51,6 +51,7 @@ For observability SLO evaluation and dashboard rollup controls, see `docs/founda
 For security control ownership and enforcement mapping, see `docs/foundation/threat-control-matrix.md`.
 For anti-hallucination instruction validation controls, see `docs/foundation/instruction-verification.md`.
 For watchdog prototype detection controls (invalid blocks, censorship, quorum anomalies), see `docs/foundation/watchdog-node-prototype.md`.
+For anti-spam controls with deposit gating and abuse telemetry, see `docs/foundation/anti-spam-controls.md`.
 For deterministic key lifecycle and rotation transitions, see `docs/foundation/key-lifecycle.md`.
 For tamper-evident key lifecycle audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
 For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.


### PR DESCRIPTION
Closes #187
Closes #186
Closes #61

## Summary
Adds anti-spam controls for per-agent rate limiting and anti-sybil deposit enforcement with explicit telemetry for abuse tuning.
The slice is deterministic and intentionally optimized for fast, low-cost PR validation.

## Changes
- `crates/kamn-core/src/anti_spam.rs`: implemented anti-spam policy engine, config validation, rejection taxonomy, suspension policy, and telemetry counters.
- `crates/kamn-core/src/lib.rs`: exported anti-spam surfaces.
- `crates/kamn-core/tests/anti_spam_controls.rs`: added functional/integration/regression coverage for deposit boundaries, rate-limit behavior, suspension, and telemetry accounting.
- `docs/foundation/anti-spam-controls.md`: documented enforcement rules, telemetry surface, and fast validation commands.
- `crates/kamn-core/tests/anti_spam_controls_docs.rs`: added doc regression checks.
- `docs/foundation/bootstrap.md`: linked anti-spam controls documentation.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised acceptance/rejection paths and confirmed telemetry category counters align with fixture outcomes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | anti-spam config/input validation and boundary behavior tests |
| Functional  | ✅ | `cargo test -p kamn-core --test anti_spam_controls` |
| Integration | ✅ | telemetry + suspension flow coverage across repeated evaluations |
| Regression  | ✅ | deposit-equals-minimum acceptance guard + docs regression checks |
