### PR TITLE
feat(reputation): add deterministic reputation state persistence slice (#215)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod observability;
 pub mod operator_binding;
 pub mod performance_targets;
 pub mod redaction_compliance;
+pub mod reputation_state;
 pub mod retention_engine;
 pub mod runtime;
 pub mod service_marketplace;
@@ -140,6 +141,11 @@ pub use performance_targets::{
 pub use redaction_compliance::{
     RedactionAction, RedactionAuditEvent, RedactionAuditEventKind, RedactionComplianceEngine,
     RedactionComplianceError, RedactionRequestStatus, RedactionVisibility,
+};
+pub use reputation_state::{
+    agent_state_key, AgentReputation, CapabilityVerification, DisputeRecord, Endorsement,
+    ReputationError, ReputationPersistedRecord, ReputationStore, ReputationTaskOutcome,
+    ScoreSnapshot, DEFAULT_TRUST_SCORE, MAX_TRUST_SCORE,
 };
 pub use retention_engine::{
     RetentionClass, RetentionDomain, RetentionEnginePolicy, RetentionEvaluation,

--- a/crates/kamn-core/src/reputation_state.rs
+++ b/crates/kamn-core/src/reputation_state.rs
@@ -1,0 +1,509 @@
+use crate::{canonical_state_key, AgentDid, StateKeyError, StateVersion, APP_STATE_VERSION};
+use std::collections::HashMap;
+use std::fmt;
+
+pub const DEFAULT_TRUST_SCORE: u32 = 500;
+pub const MAX_TRUST_SCORE: u32 = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReputationTaskOutcome {
+    Completed,
+    Failed,
+    Delegated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Endorsement {
+    pub endorsement_id: String,
+    pub from_agent_did: String,
+    pub note: String,
+    pub block_height: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisputeRecord {
+    pub dispute_id: String,
+    pub opened_by: String,
+    pub reason: String,
+    pub block_height: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityVerification {
+    pub capability: String,
+    pub verifier_did: String,
+    pub proof_ref: String,
+    pub block_height: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScoreSnapshot {
+    pub trust_score: u32,
+    pub block_height: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentReputation {
+    pub agent_did: String,
+    pub trust_score: u32,
+    pub delivery_rate: f64,
+    pub response_time_avg_ms: u64,
+    pub dispute_rate: f64,
+    pub tasks_completed: u64,
+    pub tasks_failed: u64,
+    pub tasks_delegated: u64,
+    pub total_earned: u64,
+    pub total_spent: u64,
+    pub endorsements: Vec<Endorsement>,
+    pub disputes: Vec<DisputeRecord>,
+    pub verified_capabilities: Vec<CapabilityVerification>,
+    pub last_updated_block: u64,
+    pub score_history: Vec<ScoreSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReputationPersistedRecord {
+    pub state_key: String,
+    pub state_version: StateVersion,
+    pub reputation: AgentReputation,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReputationStore {
+    state_version: StateVersion,
+    agents: HashMap<String, AgentReputation>,
+}
+
+impl Default for ReputationStore {
+    fn default() -> Self {
+        Self {
+            state_version: APP_STATE_VERSION,
+            agents: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReputationError {
+    InvalidAgentDid(String),
+    AgentAlreadyExists(String),
+    AgentNotFound(String),
+    EmptyField(&'static str),
+    InvalidBlockHeight,
+    MissingResponseTime {
+        outcome: ReputationTaskOutcome,
+    },
+    DuplicateEndorsementId(String),
+    DuplicateDisputeId(String),
+    DuplicateCapabilityVerification {
+        capability: String,
+        verifier_did: String,
+    },
+    ScoreOutOfRange(u32),
+    StateKey(StateKeyError),
+    StateKeyMismatch {
+        expected: String,
+        actual: String,
+    },
+    DuplicateStateKey(String),
+    VersionMismatch {
+        expected: StateVersion,
+        found: StateVersion,
+    },
+}
+
+impl fmt::Display for ReputationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidAgentDid(message) => write!(f, "invalid agent did: {message}"),
+            Self::AgentAlreadyExists(agent_did) => {
+                write!(f, "agent already exists: {agent_did}")
+            }
+            Self::AgentNotFound(agent_did) => write!(f, "agent not found: {agent_did}"),
+            Self::EmptyField(field) => write!(f, "{field} must not be empty"),
+            Self::InvalidBlockHeight => write!(f, "block_height must be greater than zero"),
+            Self::MissingResponseTime { outcome } => {
+                write!(f, "response_time_ms is required for outcome {outcome:?}")
+            }
+            Self::DuplicateEndorsementId(endorsement_id) => {
+                write!(f, "duplicate endorsement_id: {endorsement_id}")
+            }
+            Self::DuplicateDisputeId(dispute_id) => {
+                write!(f, "duplicate dispute_id: {dispute_id}")
+            }
+            Self::DuplicateCapabilityVerification {
+                capability,
+                verifier_did,
+            } => write!(
+                f,
+                "duplicate capability verification for capability `{capability}` by `{verifier_did}`"
+            ),
+            Self::ScoreOutOfRange(score) => {
+                write!(f, "trust_score must be between 0 and {MAX_TRUST_SCORE}, found {score}")
+            }
+            Self::StateKey(error) => write!(f, "state key error: {error}"),
+            Self::StateKeyMismatch { expected, actual } => write!(
+                f,
+                "state key mismatch, expected `{expected}` but found `{actual}`"
+            ),
+            Self::DuplicateStateKey(state_key) => write!(f, "duplicate state key: {state_key}"),
+            Self::VersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "state version mismatch, expected {}, found {}",
+                    expected.0, found.0
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReputationError {}
+
+impl ReputationStore {
+    pub fn state_version(&self) -> StateVersion {
+        self.state_version
+    }
+
+    pub fn get_agent(&self, agent_did: &str) -> Option<&AgentReputation> {
+        self.agents.get(agent_did)
+    }
+
+    pub fn register_agent(
+        &mut self,
+        agent_did: &str,
+        block_height: u64,
+    ) -> Result<(), ReputationError> {
+        validate_block_height(block_height)?;
+        validate_agent_did(agent_did)?;
+
+        if self.agents.contains_key(agent_did) {
+            return Err(ReputationError::AgentAlreadyExists(agent_did.to_owned()));
+        }
+
+        self.agents.insert(
+            agent_did.to_owned(),
+            AgentReputation {
+                agent_did: agent_did.to_owned(),
+                trust_score: DEFAULT_TRUST_SCORE,
+                delivery_rate: 0.0,
+                response_time_avg_ms: 0,
+                dispute_rate: 0.0,
+                tasks_completed: 0,
+                tasks_failed: 0,
+                tasks_delegated: 0,
+                total_earned: 0,
+                total_spent: 0,
+                endorsements: Vec::new(),
+                disputes: Vec::new(),
+                verified_capabilities: Vec::new(),
+                last_updated_block: block_height,
+                score_history: vec![ScoreSnapshot {
+                    trust_score: DEFAULT_TRUST_SCORE,
+                    block_height,
+                }],
+            },
+        );
+        Ok(())
+    }
+
+    pub fn record_task_outcome(
+        &mut self,
+        agent_did: &str,
+        outcome: ReputationTaskOutcome,
+        response_time_ms: Option<u64>,
+        earned_delta: u64,
+        spent_delta: u64,
+        block_height: u64,
+    ) -> Result<(), ReputationError> {
+        validate_block_height(block_height)?;
+        let agent = self.agent_mut(agent_did)?;
+        let prior_samples = agent.tasks_completed.saturating_add(agent.tasks_failed);
+
+        match outcome {
+            ReputationTaskOutcome::Completed => {
+                agent.tasks_completed = agent.tasks_completed.saturating_add(1);
+            }
+            ReputationTaskOutcome::Failed => {
+                agent.tasks_failed = agent.tasks_failed.saturating_add(1);
+            }
+            ReputationTaskOutcome::Delegated => {
+                agent.tasks_delegated = agent.tasks_delegated.saturating_add(1);
+            }
+        }
+
+        if matches!(
+            outcome,
+            ReputationTaskOutcome::Completed | ReputationTaskOutcome::Failed
+        ) {
+            let response =
+                response_time_ms.ok_or(ReputationError::MissingResponseTime { outcome })?;
+            let weighted_total = u128::from(agent.response_time_avg_ms) * u128::from(prior_samples)
+                + u128::from(response);
+            let sample_count = prior_samples.saturating_add(1);
+            agent.response_time_avg_ms = (weighted_total / u128::from(sample_count)) as u64;
+        }
+
+        agent.total_earned = agent.total_earned.saturating_add(earned_delta);
+        agent.total_spent = agent.total_spent.saturating_add(spent_delta);
+
+        let completed_and_failed = agent.tasks_completed.saturating_add(agent.tasks_failed);
+        agent.delivery_rate = if completed_and_failed == 0 {
+            0.0
+        } else {
+            agent.tasks_completed as f64 / completed_and_failed as f64
+        };
+
+        agent.dispute_rate =
+            calculate_dispute_rate(agent.disputes.len() as u64, completed_and_failed);
+        agent.last_updated_block = block_height;
+        Ok(())
+    }
+
+    pub fn record_endorsement(
+        &mut self,
+        agent_did: &str,
+        endorsement: Endorsement,
+    ) -> Result<(), ReputationError> {
+        validate_block_height(endorsement.block_height)?;
+        validate_agent_did(&endorsement.from_agent_did)?;
+        require_non_empty("endorsement.endorsement_id", &endorsement.endorsement_id)?;
+        require_non_empty("endorsement.note", &endorsement.note)?;
+
+        let agent = self.agent_mut(agent_did)?;
+        if agent
+            .endorsements
+            .iter()
+            .any(|entry| entry.endorsement_id == endorsement.endorsement_id)
+        {
+            return Err(ReputationError::DuplicateEndorsementId(
+                endorsement.endorsement_id,
+            ));
+        }
+        agent.last_updated_block = endorsement.block_height;
+        agent.endorsements.push(endorsement);
+        Ok(())
+    }
+
+    pub fn record_dispute(
+        &mut self,
+        agent_did: &str,
+        dispute: DisputeRecord,
+    ) -> Result<(), ReputationError> {
+        validate_block_height(dispute.block_height)?;
+        validate_agent_did(&dispute.opened_by)?;
+        require_non_empty("dispute.dispute_id", &dispute.dispute_id)?;
+        require_non_empty("dispute.reason", &dispute.reason)?;
+
+        let agent = self.agent_mut(agent_did)?;
+        if agent
+            .disputes
+            .iter()
+            .any(|entry| entry.dispute_id == dispute.dispute_id)
+        {
+            return Err(ReputationError::DuplicateDisputeId(dispute.dispute_id));
+        }
+
+        agent.disputes.push(dispute);
+        let completed_and_failed = agent.tasks_completed.saturating_add(agent.tasks_failed);
+        agent.dispute_rate =
+            calculate_dispute_rate(agent.disputes.len() as u64, completed_and_failed);
+        agent.last_updated_block = agent
+            .disputes
+            .last()
+            .map(|entry| entry.block_height)
+            .unwrap_or(agent.last_updated_block);
+        Ok(())
+    }
+
+    pub fn record_capability_verification(
+        &mut self,
+        agent_did: &str,
+        verification: CapabilityVerification,
+    ) -> Result<(), ReputationError> {
+        validate_block_height(verification.block_height)?;
+        validate_agent_did(&verification.verifier_did)?;
+        require_non_empty("verification.capability", &verification.capability)?;
+        require_non_empty("verification.proof_ref", &verification.proof_ref)?;
+
+        let agent = self.agent_mut(agent_did)?;
+        if agent.verified_capabilities.iter().any(|entry| {
+            entry.capability == verification.capability
+                && entry.verifier_did == verification.verifier_did
+        }) {
+            return Err(ReputationError::DuplicateCapabilityVerification {
+                capability: verification.capability,
+                verifier_did: verification.verifier_did,
+            });
+        }
+        agent.last_updated_block = verification.block_height;
+        agent.verified_capabilities.push(verification);
+        Ok(())
+    }
+
+    pub fn set_trust_score(
+        &mut self,
+        agent_did: &str,
+        trust_score: u32,
+        block_height: u64,
+    ) -> Result<(), ReputationError> {
+        validate_block_height(block_height)?;
+        if trust_score > MAX_TRUST_SCORE {
+            return Err(ReputationError::ScoreOutOfRange(trust_score));
+        }
+
+        let agent = self.agent_mut(agent_did)?;
+        agent.trust_score = trust_score;
+        agent.last_updated_block = block_height;
+        agent.score_history.push(ScoreSnapshot {
+            trust_score,
+            block_height,
+        });
+        Ok(())
+    }
+
+    pub fn export_records(&self) -> Vec<ReputationPersistedRecord> {
+        let mut records = self
+            .agents
+            .values()
+            .filter_map(|agent| {
+                agent_state_key(&agent.agent_did)
+                    .ok()
+                    .map(|state_key| ReputationPersistedRecord {
+                        state_key,
+                        state_version: self.state_version,
+                        reputation: agent.clone(),
+                    })
+            })
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| left.state_key.cmp(&right.state_key));
+        records
+    }
+
+    pub fn restore_from_records(
+        records: &[ReputationPersistedRecord],
+    ) -> Result<Self, ReputationError> {
+        let mut store = ReputationStore::default();
+        let mut seen_keys = HashMap::new();
+
+        for record in records {
+            if record.state_version != APP_STATE_VERSION {
+                return Err(ReputationError::VersionMismatch {
+                    expected: APP_STATE_VERSION,
+                    found: record.state_version,
+                });
+            }
+
+            let expected_key = agent_state_key(&record.reputation.agent_did)?;
+            if record.state_key != expected_key {
+                return Err(ReputationError::StateKeyMismatch {
+                    expected: expected_key,
+                    actual: record.state_key.clone(),
+                });
+            }
+
+            if seen_keys.insert(record.state_key.clone(), ()).is_some() {
+                return Err(ReputationError::DuplicateStateKey(record.state_key.clone()));
+            }
+
+            if store
+                .agents
+                .insert(
+                    record.reputation.agent_did.clone(),
+                    record.reputation.clone(),
+                )
+                .is_some()
+            {
+                return Err(ReputationError::AgentAlreadyExists(
+                    record.reputation.agent_did.clone(),
+                ));
+            }
+        }
+
+        Ok(store)
+    }
+
+    fn agent_mut(&mut self, agent_did: &str) -> Result<&mut AgentReputation, ReputationError> {
+        self.agents
+            .get_mut(agent_did)
+            .ok_or_else(|| ReputationError::AgentNotFound(agent_did.to_owned()))
+    }
+}
+
+pub fn agent_state_key(agent_did: &str) -> Result<String, ReputationError> {
+    let did = AgentDid::parse(agent_did)
+        .map_err(|error| ReputationError::InvalidAgentDid(error.to_string()))?;
+    canonical_state_key("kamn.reputation.scores", "agent", did.method_specific_id())
+        .map_err(ReputationError::StateKey)
+}
+
+fn calculate_dispute_rate(disputes: u64, completed_and_failed: u64) -> f64 {
+    if completed_and_failed == 0 {
+        if disputes == 0 {
+            0.0
+        } else {
+            1.0
+        }
+    } else {
+        disputes as f64 / completed_and_failed as f64
+    }
+}
+
+fn validate_agent_did(agent_did: &str) -> Result<(), ReputationError> {
+    AgentDid::parse(agent_did)
+        .map_err(|error| ReputationError::InvalidAgentDid(error.to_string()))?;
+    Ok(())
+}
+
+fn validate_block_height(block_height: u64) -> Result<(), ReputationError> {
+    if block_height == 0 {
+        return Err(ReputationError::InvalidBlockHeight);
+    }
+    Ok(())
+}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), ReputationError> {
+    if value.trim().is_empty() {
+        return Err(ReputationError::EmptyField(field));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{agent_state_key, ReputationError, ReputationStore};
+
+    #[test]
+    fn state_key_uses_reputation_namespace() {
+        let key = agent_state_key("kamn:did:agent:agent-1").expect("state key should build");
+        assert_eq!(key, "kamn.reputation.scores:agent:agent-1");
+    }
+
+    #[test]
+    fn export_skips_invalid_agents() {
+        let mut store = ReputationStore::default();
+        store
+            .register_agent("kamn:did:agent:agent-1", 1)
+            .expect("registration should succeed");
+        assert_eq!(store.export_records().len(), 1);
+    }
+
+    #[test]
+    fn restore_rejects_version_mismatch() {
+        let mut store = ReputationStore::default();
+        store
+            .register_agent("kamn:did:agent:agent-1", 1)
+            .expect("registration should succeed");
+        let mut records = store.export_records();
+        records[0].state_version = super::StateVersion(99);
+
+        let result = ReputationStore::restore_from_records(&records);
+        assert_eq!(
+            result,
+            Err(ReputationError::VersionMismatch {
+                expected: super::APP_STATE_VERSION,
+                found: super::StateVersion(99),
+            })
+        );
+    }
+}

--- a/crates/kamn-core/tests/reputation_state_model.rs
+++ b/crates/kamn-core/tests/reputation_state_model.rs
@@ -1,0 +1,188 @@
+use kamn_core::{
+    AgentReputation, CapabilityVerification, DisputeRecord, Endorsement, ReputationError,
+    ReputationStore, ReputationTaskOutcome,
+};
+
+fn sample_endorsement(id: &str) -> Endorsement {
+    Endorsement {
+        endorsement_id: id.to_owned(),
+        from_agent_did: "kamn:did:agent:endorser-1".to_owned(),
+        note: "high quality delivery".to_owned(),
+        block_height: 11,
+    }
+}
+
+fn sample_dispute(id: &str) -> DisputeRecord {
+    DisputeRecord {
+        dispute_id: id.to_owned(),
+        opened_by: "kamn:did:agent:requester-2".to_owned(),
+        reason: "late artifact submission".to_owned(),
+        block_height: 12,
+    }
+}
+
+fn sample_capability(capability: &str) -> CapabilityVerification {
+    CapabilityVerification {
+        capability: capability.to_owned(),
+        verifier_did: "kamn:did:agent:verifier-1".to_owned(),
+        proof_ref: "ipfs://QmCapabilityProof".to_owned(),
+        block_height: 13,
+    }
+}
+
+fn read_agent(store: &ReputationStore, did: &str) -> AgentReputation {
+    store
+        .get_agent(did)
+        .expect("agent should exist in reputation store")
+        .clone()
+}
+
+#[test]
+fn reputation_state_registers_agent_and_updates_core_metrics() {
+    let mut store = ReputationStore::default();
+    store
+        .register_agent("kamn:did:agent:agent-1", 10)
+        .expect("registration should succeed");
+
+    store
+        .record_task_outcome(
+            "kamn:did:agent:agent-1",
+            ReputationTaskOutcome::Completed,
+            Some(1_200),
+            250,
+            20,
+            11,
+        )
+        .expect("completed task update should succeed");
+    store
+        .record_task_outcome(
+            "kamn:did:agent:agent-1",
+            ReputationTaskOutcome::Failed,
+            Some(4_000),
+            0,
+            12,
+            12,
+        )
+        .expect("failed task update should succeed");
+    store
+        .record_task_outcome(
+            "kamn:did:agent:agent-1",
+            ReputationTaskOutcome::Delegated,
+            None,
+            0,
+            0,
+            13,
+        )
+        .expect("delegated task update should succeed");
+
+    let agent = read_agent(&store, "kamn:did:agent:agent-1");
+    assert_eq!(agent.tasks_completed, 1);
+    assert_eq!(agent.tasks_failed, 1);
+    assert_eq!(agent.tasks_delegated, 1);
+    assert_eq!(agent.total_earned, 250);
+    assert_eq!(agent.total_spent, 32);
+    assert_eq!(agent.delivery_rate, 0.5);
+    assert_eq!(agent.response_time_avg_ms, 2_600);
+}
+
+#[test]
+fn reputation_state_persists_attestations_and_capabilities() {
+    let mut store = ReputationStore::default();
+    store
+        .register_agent("kamn:did:agent:agent-2", 20)
+        .expect("registration should succeed");
+
+    store
+        .record_endorsement("kamn:did:agent:agent-2", sample_endorsement("endorse-1"))
+        .expect("endorsement should succeed");
+    store
+        .record_dispute("kamn:did:agent:agent-2", sample_dispute("dispute-1"))
+        .expect("dispute should succeed");
+    store
+        .record_capability_verification(
+            "kamn:did:agent:agent-2",
+            sample_capability("market-analysis"),
+        )
+        .expect("capability verification should succeed");
+
+    let agent = read_agent(&store, "kamn:did:agent:agent-2");
+    assert_eq!(agent.endorsements.len(), 1);
+    assert_eq!(agent.disputes.len(), 1);
+    assert_eq!(agent.verified_capabilities.len(), 1);
+    assert_eq!(agent.dispute_rate, 1.0);
+}
+
+#[test]
+fn reputation_state_exports_and_restores_deterministic_records() {
+    let mut store = ReputationStore::default();
+    store
+        .register_agent("kamn:did:agent:agent-1", 5)
+        .expect("registration should succeed");
+    store
+        .register_agent("kamn:did:agent:agent-2", 6)
+        .expect("registration should succeed");
+    store
+        .set_trust_score("kamn:did:agent:agent-1", 620, 7)
+        .expect("score update should succeed");
+
+    let exported = store.export_records();
+    assert_eq!(exported.len(), 2);
+    assert_eq!(
+        exported[0].state_key,
+        "kamn.reputation.scores:agent:agent-1".to_owned()
+    );
+    assert_eq!(
+        exported[1].state_key,
+        "kamn.reputation.scores:agent:agent-2".to_owned()
+    );
+
+    let restored = ReputationStore::restore_from_records(&exported)
+        .expect("restore from persisted records should succeed");
+    let restored_agent = read_agent(&restored, "kamn:did:agent:agent-1");
+    assert_eq!(restored_agent.trust_score, 620);
+    assert_eq!(restored_agent.score_history.len(), 2);
+}
+
+#[test]
+fn reputation_state_rejects_invalid_agent_did() {
+    let mut store = ReputationStore::default();
+    assert_eq!(
+        store.register_agent("did:example:agent-1", 1),
+        Err(ReputationError::InvalidAgentDid(
+            "invalid agent did prefix: did:example:agent-1".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn reputation_state_rejects_duplicate_endorsement_id() {
+    let mut store = ReputationStore::default();
+    store
+        .register_agent("kamn:did:agent:agent-4", 15)
+        .expect("registration should succeed");
+    store
+        .record_endorsement("kamn:did:agent:agent-4", sample_endorsement("endorse-1"))
+        .expect("first endorsement should succeed");
+
+    assert_eq!(
+        store.record_endorsement("kamn:did:agent:agent-4", sample_endorsement("endorse-1")),
+        Err(ReputationError::DuplicateEndorsementId(
+            "endorse-1".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn reputation_state_regression_accepts_upper_bound_trust_score() {
+    // Regression: #215
+    let mut store = ReputationStore::default();
+    store
+        .register_agent("kamn:did:agent:agent-5", 30)
+        .expect("registration should succeed");
+
+    store
+        .set_trust_score("kamn:did:agent:agent-5", 1_000, 31)
+        .expect("upper bound score should be accepted");
+    let agent = read_agent(&store, "kamn:did:agent:agent-5");
+    assert_eq!(agent.trust_score, 1_000);
+}

--- a/crates/kamn-core/tests/reputation_state_model_docs.rs
+++ b/crates/kamn-core/tests/reputation_state_model_docs.rs
@@ -1,0 +1,33 @@
+const DOC: &str = include_str!("../../../docs/foundation/reputation-state-model.md");
+
+#[test]
+fn doc_contains_prd_metrics_and_persistence_contract() {
+    assert!(DOC.contains("## PRD 8.1 Metrics Coverage"));
+    assert!(DOC.contains("trust_score"));
+    assert!(DOC.contains("delivery_rate"));
+    assert!(DOC.contains("endorsements"));
+    assert!(DOC.contains("verified_capabilities"));
+    assert!(DOC.contains("## Persistence Contract"));
+    assert!(DOC.contains("kamn.reputation.scores:agent:<method-specific-id>"));
+}
+
+#[test]
+fn doc_contains_error_handling_and_validation_rules() {
+    assert!(DOC.contains("## Validation and Error Handling"));
+    assert!(DOC.contains("Invalid agent DID"));
+    assert!(DOC.contains("Duplicate endorsement IDs"));
+    assert!(DOC.contains("Trust score updates reject values above 1000"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test reputation_state_model"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_upper_bound_score_inclusive_rule() {
+    // Regression: #215
+    assert!(DOC.contains("Trust score boundary checks are inclusive for `1000`."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -53,6 +53,7 @@ For anti-hallucination instruction validation controls, see `docs/foundation/ins
 For watchdog prototype detection controls (invalid blocks, censorship, quorum anomalies), see `docs/foundation/watchdog-node-prototype.md`.
 For anti-spam controls with deposit gating and abuse telemetry, see `docs/foundation/anti-spam-controls.md`.
 For PRD Phase 4 zero-knowledge message-proof feasibility design and rollout guidance, see `docs/foundation/zk-message-proof-design.md`.
+For PRD 8.1 reputation state model and persistence controls, see `docs/foundation/reputation-state-model.md`.
 For deterministic key lifecycle and rotation transitions, see `docs/foundation/key-lifecycle.md`.
 For tamper-evident key lifecycle audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
 For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.

--- a/docs/foundation/reputation-state-model.md
+++ b/docs/foundation/reputation-state-model.md
@@ -1,0 +1,60 @@
+# Reputation State Model and Persistence (Issue #214 / #215)
+
+This document captures the first implementation slice of the PRD Section 8 reputation system: state shape, persistence contract, and deterministic validation behavior.
+
+## PRD 8.1 Metrics Coverage
+`AgentReputation` persists the PRD core metrics:
+
+- `trust_score` (0-1000)
+- `delivery_rate`
+- `response_time_avg_ms`
+- `dispute_rate`
+- `tasks_completed`, `tasks_failed`, `tasks_delegated`
+- `total_earned`, `total_spent`
+- `endorsements`
+- `disputes`
+- `verified_capabilities`
+- `last_updated_block`
+- `score_history`
+
+The initial default score is `500` and history starts with an initial snapshot at registration.
+
+## Persistence Contract
+- State namespace: `kamn.reputation.scores`
+- Canonical key shape: `kamn.reputation.scores:agent:<method-specific-id>`
+- Persisted record payload:
+  - canonical `state_key`
+  - `state_version`
+  - full `AgentReputation` snapshot
+
+`ReputationStore::export_records()` returns records sorted by canonical state key for deterministic persistence ordering.
+`ReputationStore::restore_from_records(...)` enforces:
+- state-version compatibility
+- state-key and DID consistency
+- duplicate state-key rejection
+
+## Validation and Error Handling
+- Invalid agent DID values are rejected on registration and all attestation/capability paths.
+- Empty IDs/reasons/notes/proof references are rejected with explicit field-specific errors.
+- Invalid or zero block heights are rejected.
+- Duplicate endorsement IDs and duplicate dispute IDs are rejected.
+- Duplicate capability verification entries for the same `(capability, verifier)` pair are rejected.
+- Trust score updates reject values above 1000.
+- Missing response time is rejected for `Completed` and `Failed` task outcomes.
+
+Trust score boundary checks are inclusive for `1000`.
+
+## Fast and Cost-Effective Validation
+Use the targeted lane first:
+
+```bash
+cargo test -p kamn-core --test reputation_state_model --test reputation_state_model_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run regression coverage for the crate:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implemented the first reputation-engine delivery slice for PRD 8.1 by adding a deterministic reputation state model, persistence/export-restore contract, and explicit validation/error handling.

## Changes
- `crates/kamn-core/src/reputation_state.rs`: added `ReputationStore`, PRD-metric state structs, attestation/capability recording, score snapshots, canonical state keys, and deterministic export/restore.
- `crates/kamn-core/src/lib.rs`: exported reputation state APIs.
- `crates/kamn-core/tests/reputation_state_model.rs`: added unit/functional/integration/regression coverage.
- `crates/kamn-core/tests/reputation_state_model_docs.rs`: added documentation contract tests.
- `docs/foundation/reputation-state-model.md`: documented PRD 8.1 mapping, persistence contract, and validation rules.
- `docs/foundation/bootstrap.md`: linked the new reputation state doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test reputation_state_model --test reputation_state_model_docs
```
Observed failures before implementation:
- missing `docs/foundation/reputation-state-model.md`
- unresolved imports for `AgentReputation`, `CapabilityVerification`, `DisputeRecord`, `Endorsement`, `ReputationError`, `ReputationStore`, `ReputationTaskOutcome`

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test reputation_state_model --test reputation_state_model_docs
```
Result:
- `reputation_state_model`: 6 passed
- `reputation_state_model_docs`: 4 passed

### 🔁 Regression
```bash
cargo test -p kamn-core
```
Result:
- full `kamn-core` suite passed

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | invalid DID and duplicate attestation validation in `reputation_state_model.rs` | |
| Functional   | ✅ | `reputation_state_registers_agent_and_updates_core_metrics` | |
| Integration  | ✅ | `reputation_state_exports_and_restores_deterministic_records` | |
| Regression   | ✅ | `reputation_state_regression_accepts_upper_bound_trust_score`, docs regression rule | |
| Performance  | N/A | N/A | No hotspot/prover path introduced in this state-model slice. |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit.

## Documentation Updates
- `docs/foundation/reputation-state-model.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #215
Closes #214
Closes #43
