### PR TITLE
feat(reputation): implement deterministic trust score engine (#213)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod task_payment;
 pub mod telegram_bridge;
 pub mod token;
 pub mod transaction;
+pub mod trust_score;
 pub mod watchdog;
 pub mod zk_message_proofs;
 
@@ -181,6 +182,10 @@ pub use token::{
 };
 pub use transaction::{
     BaselineTransaction, TransactionGuardError, TransactionGuards, GENESIS_STATE_HASH,
+};
+pub use trust_score::{
+    calculate_trust_score, recalculate_and_persist_trust_score, TrustScoreBreakdown,
+    TrustScoreError, TRUST_SCORE_ENGINE_VERSION, TRUST_SCORE_MAX, TRUST_SCORE_MIN,
 };
 pub use watchdog::{
     WatchdogAlert, WatchdogAlertKind, WatchdogConfig, WatchdogError, WatchdogNode,

--- a/crates/kamn-core/src/trust_score.rs
+++ b/crates/kamn-core/src/trust_score.rs
@@ -1,0 +1,149 @@
+use crate::{AgentReputation, ReputationError, ReputationStore};
+use std::fmt;
+
+pub const TRUST_SCORE_ENGINE_VERSION: &str = "v1-prd-8-2";
+pub const TRUST_SCORE_MIN: i32 = 0;
+pub const TRUST_SCORE_MAX: i32 = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrustScoreBreakdown {
+    pub base_score: i32,
+    pub delivery_component: i32,
+    pub response_component: i32,
+    pub dispute_penalty: i32,
+    pub volume_bonus: i32,
+    pub endorsement_bonus: i32,
+    pub raw_score: i32,
+    pub final_score: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TrustScoreError {
+    InvalidDeliveryRate(f64),
+    InvalidDisputeRate(f64),
+    Reputation(ReputationError),
+}
+
+impl fmt::Display for TrustScoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDeliveryRate(value) => {
+                write!(f, "delivery_rate must be within 0.0..=1.0, found {value}")
+            }
+            Self::InvalidDisputeRate(value) => {
+                write!(f, "dispute_rate must be within 0.0..=1.0, found {value}")
+            }
+            Self::Reputation(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for TrustScoreError {}
+
+impl From<ReputationError> for TrustScoreError {
+    fn from(value: ReputationError) -> Self {
+        Self::Reputation(value)
+    }
+}
+
+pub fn calculate_trust_score(
+    agent: &AgentReputation,
+) -> Result<TrustScoreBreakdown, TrustScoreError> {
+    if !(0.0..=1.0).contains(&agent.delivery_rate) {
+        return Err(TrustScoreError::InvalidDeliveryRate(agent.delivery_rate));
+    }
+    if !(0.0..=1.0).contains(&agent.dispute_rate) {
+        return Err(TrustScoreError::InvalidDisputeRate(agent.dispute_rate));
+    }
+
+    let base_score = 500;
+    let delivery_component = ((agent.delivery_rate - 0.5) * 400.0) as i32;
+    let response_component = match agent.response_time_avg_ms {
+        0..=1_000 => 100,
+        1_001..=5_000 => 50,
+        5_001..=30_000 => 0,
+        _ => -50,
+    };
+    let dispute_penalty = (agent.dispute_rate * 150.0) as i32;
+    let volume_bonus = (agent.tasks_completed.min(1_000) as f64 * 0.1) as i32;
+    let endorsement_bonus = agent.endorsements.len().min(50) as i32;
+
+    let raw_score = base_score + delivery_component + response_component - dispute_penalty
+        + volume_bonus
+        + endorsement_bonus;
+    let final_score = raw_score.clamp(TRUST_SCORE_MIN, TRUST_SCORE_MAX) as u32;
+
+    Ok(TrustScoreBreakdown {
+        base_score,
+        delivery_component,
+        response_component,
+        dispute_penalty,
+        volume_bonus,
+        endorsement_bonus,
+        raw_score,
+        final_score,
+    })
+}
+
+pub fn recalculate_and_persist_trust_score(
+    store: &mut ReputationStore,
+    agent_did: &str,
+    block_height: u64,
+) -> Result<TrustScoreBreakdown, TrustScoreError> {
+    let agent = store
+        .get_agent(agent_did)
+        .cloned()
+        .ok_or_else(|| ReputationError::AgentNotFound(agent_did.to_owned()))?;
+    let breakdown = calculate_trust_score(&agent)?;
+    store.set_trust_score(agent_did, breakdown.final_score, block_height)?;
+    Ok(breakdown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{calculate_trust_score, TrustScoreError, TRUST_SCORE_ENGINE_VERSION};
+    use crate::AgentReputation;
+
+    fn baseline() -> AgentReputation {
+        AgentReputation {
+            agent_did: "kamn:did:agent:baseline".to_owned(),
+            trust_score: 500,
+            delivery_rate: 0.5,
+            response_time_avg_ms: 5_000,
+            dispute_rate: 0.0,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            tasks_delegated: 0,
+            total_earned: 0,
+            total_spent: 0,
+            endorsements: vec![],
+            disputes: vec![],
+            verified_capabilities: vec![],
+            last_updated_block: 1,
+            score_history: vec![],
+        }
+    }
+
+    #[test]
+    fn response_bucket_is_inclusive_at_1000() {
+        let mut rep = baseline();
+        rep.response_time_avg_ms = 1_000;
+        let breakdown = calculate_trust_score(&rep).expect("score should calculate");
+        assert_eq!(breakdown.response_component, 100);
+    }
+
+    #[test]
+    fn engine_version_is_stable() {
+        assert_eq!(TRUST_SCORE_ENGINE_VERSION, "v1-prd-8-2");
+    }
+
+    #[test]
+    fn rejects_dispute_rate_above_one() {
+        let mut rep = baseline();
+        rep.dispute_rate = 1.4;
+        assert_eq!(
+            calculate_trust_score(&rep),
+            Err(TrustScoreError::InvalidDisputeRate(1.4))
+        );
+    }
+}

--- a/crates/kamn-core/tests/trust_score_engine.rs
+++ b/crates/kamn-core/tests/trust_score_engine.rs
@@ -1,0 +1,178 @@
+use kamn_core::{
+    recalculate_and_persist_trust_score, AgentReputation, CapabilityVerification, DisputeRecord,
+    Endorsement, ReputationStore, TrustScoreError,
+};
+
+fn sample_reputation() -> AgentReputation {
+    AgentReputation {
+        agent_did: "kamn:did:agent:agent-1".to_owned(),
+        trust_score: 500,
+        delivery_rate: 0.9,
+        response_time_avg_ms: 900,
+        dispute_rate: 0.1,
+        tasks_completed: 120,
+        tasks_failed: 10,
+        tasks_delegated: 4,
+        total_earned: 10_000,
+        total_spent: 4_000,
+        endorsements: vec![
+            Endorsement {
+                endorsement_id: "endorse-1".to_owned(),
+                from_agent_did: "kamn:did:agent:endorser-1".to_owned(),
+                note: "consistent delivery".to_owned(),
+                block_height: 10,
+            },
+            Endorsement {
+                endorsement_id: "endorse-2".to_owned(),
+                from_agent_did: "kamn:did:agent:endorser-2".to_owned(),
+                note: "strong collaboration".to_owned(),
+                block_height: 11,
+            },
+            Endorsement {
+                endorsement_id: "endorse-3".to_owned(),
+                from_agent_did: "kamn:did:agent:endorser-3".to_owned(),
+                note: "accurate responses".to_owned(),
+                block_height: 12,
+            },
+            Endorsement {
+                endorsement_id: "endorse-4".to_owned(),
+                from_agent_did: "kamn:did:agent:endorser-4".to_owned(),
+                note: "excellent reliability".to_owned(),
+                block_height: 13,
+            },
+            Endorsement {
+                endorsement_id: "endorse-5".to_owned(),
+                from_agent_did: "kamn:did:agent:endorser-5".to_owned(),
+                note: "clear communication".to_owned(),
+                block_height: 14,
+            },
+        ],
+        disputes: vec![DisputeRecord {
+            dispute_id: "dispute-1".to_owned(),
+            opened_by: "kamn:did:agent:requester-9".to_owned(),
+            reason: "timeout".to_owned(),
+            block_height: 15,
+        }],
+        verified_capabilities: vec![CapabilityVerification {
+            capability: "market-analysis".to_owned(),
+            verifier_did: "kamn:did:agent:verifier-1".to_owned(),
+            proof_ref: "ipfs://QmCapabilityProof".to_owned(),
+            block_height: 16,
+        }],
+        last_updated_block: 16,
+        score_history: vec![],
+    }
+}
+
+#[test]
+fn trust_score_engine_matches_prd_8_2_formula() {
+    let breakdown =
+        kamn_core::calculate_trust_score(&sample_reputation()).expect("calculation should succeed");
+
+    assert_eq!(breakdown.base_score, 500);
+    assert_eq!(breakdown.delivery_component, 160);
+    assert_eq!(breakdown.response_component, 100);
+    assert_eq!(breakdown.dispute_penalty, 15);
+    assert_eq!(breakdown.volume_bonus, 12);
+    assert_eq!(breakdown.endorsement_bonus, 5);
+    assert_eq!(breakdown.final_score, 762);
+}
+
+#[test]
+fn trust_score_engine_rejects_invalid_rate_inputs() {
+    let mut reputation = sample_reputation();
+    reputation.delivery_rate = 1.2;
+
+    assert_eq!(
+        kamn_core::calculate_trust_score(&reputation),
+        Err(TrustScoreError::InvalidDeliveryRate(1.2))
+    );
+}
+
+#[test]
+fn trust_score_engine_caps_volume_and_endorsement_bonus() {
+    let mut reputation = sample_reputation();
+    reputation.tasks_completed = 10_000;
+    reputation.endorsements = (0..150)
+        .map(|index| Endorsement {
+            endorsement_id: format!("endorse-{index}"),
+            from_agent_did: "kamn:did:agent:endorser-x".to_owned(),
+            note: "bulk endorsement".to_owned(),
+            block_height: 20 + index as u64,
+        })
+        .collect();
+
+    let breakdown =
+        kamn_core::calculate_trust_score(&reputation).expect("calculation should succeed");
+    assert_eq!(breakdown.volume_bonus, 100);
+    assert_eq!(breakdown.endorsement_bonus, 50);
+}
+
+#[test]
+fn trust_score_engine_is_deterministic_for_same_input() {
+    let first =
+        kamn_core::calculate_trust_score(&sample_reputation()).expect("calculation should succeed");
+    let second =
+        kamn_core::calculate_trust_score(&sample_reputation()).expect("calculation should succeed");
+    assert_eq!(first, second);
+}
+
+#[test]
+fn trust_score_engine_integration_persists_score_to_store() {
+    let mut store = ReputationStore::default();
+    store
+        .register_agent("kamn:did:agent:agent-1", 10)
+        .expect("registration should succeed");
+    store
+        .record_task_outcome(
+            "kamn:did:agent:agent-1",
+            kamn_core::ReputationTaskOutcome::Completed,
+            Some(900),
+            100,
+            0,
+            11,
+        )
+        .expect("task update should succeed");
+    store
+        .record_task_outcome(
+            "kamn:did:agent:agent-1",
+            kamn_core::ReputationTaskOutcome::Failed,
+            Some(1_100),
+            0,
+            25,
+            12,
+        )
+        .expect("task update should succeed");
+    store
+        .record_endorsement(
+            "kamn:did:agent:agent-1",
+            Endorsement {
+                endorsement_id: "endorse-1".to_owned(),
+                from_agent_did: "kamn:did:agent:endorser-1".to_owned(),
+                note: "high quality".to_owned(),
+                block_height: 12,
+            },
+        )
+        .expect("endorsement should succeed");
+
+    let persisted = recalculate_and_persist_trust_score(&mut store, "kamn:did:agent:agent-1", 13)
+        .expect("recalculation should succeed");
+    let state = store
+        .get_agent("kamn:did:agent:agent-1")
+        .expect("agent should exist");
+    assert_eq!(state.trust_score, persisted.final_score);
+    assert_eq!(
+        state.score_history.last().map(|entry| entry.block_height),
+        Some(13)
+    );
+}
+
+#[test]
+fn trust_score_engine_regression_response_1000_uses_fastest_bucket() {
+    // Regression: #213
+    let mut reputation = sample_reputation();
+    reputation.response_time_avg_ms = 1_000;
+    let breakdown =
+        kamn_core::calculate_trust_score(&reputation).expect("calculation should succeed");
+    assert_eq!(breakdown.response_component, 100);
+}

--- a/crates/kamn-core/tests/trust_score_engine_docs.rs
+++ b/crates/kamn-core/tests/trust_score_engine_docs.rs
@@ -1,0 +1,33 @@
+const DOC: &str = include_str!("../../../docs/foundation/trust-score-engine.md");
+
+#[test]
+fn doc_contains_prd_formula_components() {
+    assert!(DOC.contains("## PRD 8.2 Formula Mapping"));
+    assert!(DOC.contains("base_score = 500"));
+    assert!(DOC.contains("delivery_component"));
+    assert!(DOC.contains("response_component"));
+    assert!(DOC.contains("dispute_penalty"));
+    assert!(DOC.contains("volume_bonus"));
+    assert!(DOC.contains("endorsement_bonus"));
+}
+
+#[test]
+fn doc_contains_bounds_and_versioning_controls() {
+    assert!(DOC.contains("## Deterministic Bounds and Versioning"));
+    assert!(DOC.contains("TRUST_SCORE_ENGINE_VERSION"));
+    assert!(DOC.contains("clamped to `0..=1000`"));
+    assert!(DOC.contains("delivery_rate and dispute_rate must be within `0.0..=1.0`"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test trust_score_engine"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_1000ms_bucket_boundary_rule() {
+    // Regression: #213
+    assert!(DOC.contains("`1000ms` remains in the highest response bucket."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -54,6 +54,7 @@ For watchdog prototype detection controls (invalid blocks, censorship, quorum an
 For anti-spam controls with deposit gating and abuse telemetry, see `docs/foundation/anti-spam-controls.md`.
 For PRD Phase 4 zero-knowledge message-proof feasibility design and rollout guidance, see `docs/foundation/zk-message-proof-design.md`.
 For PRD 8.1 reputation state model and persistence controls, see `docs/foundation/reputation-state-model.md`.
+For PRD 8.2 deterministic trust score calculation controls, see `docs/foundation/trust-score-engine.md`.
 For deterministic key lifecycle and rotation transitions, see `docs/foundation/key-lifecycle.md`.
 For tamper-evident key lifecycle audit trail verification controls, see `docs/foundation/key-lifecycle-audit-trails.md`.
 For pluggable local/secure signer backend controls, see `docs/foundation/signer-backend-abstraction.md`.

--- a/docs/foundation/trust-score-engine.md
+++ b/docs/foundation/trust-score-engine.md
@@ -1,0 +1,52 @@
+# Trust Score Engine (Issue #212 / #213)
+
+This document defines the deterministic trust score calculator for PRD Section 8.2 and its integration with persisted reputation state.
+
+## PRD 8.2 Formula Mapping
+Engine constants and components:
+
+- `base_score = 500`
+- `delivery_component = ((delivery_rate - 0.5) * 400.0) as i32`
+- `response_component` buckets:
+  - `0..=1000 => 100`
+  - `1001..=5000 => 50`
+  - `5001..=30000 => 0`
+  - `>30000 => -50`
+- `dispute_penalty = (dispute_rate * 150.0) as i32`
+- `volume_bonus = (tasks_completed.min(1000) as f64 * 0.1) as i32`
+- `endorsement_bonus = endorsements.len().min(50) as i32`
+
+Final score formula:
+
+`score = base_score + delivery_component + response_component - dispute_penalty + volume_bonus + endorsement_bonus`
+
+## Deterministic Bounds and Versioning
+- Engine version constant: `TRUST_SCORE_ENGINE_VERSION` (`v1-prd-8-2`).
+- Raw score is clamped to `0..=1000`.
+- Input validation is explicit and deterministic:
+  - delivery_rate and dispute_rate must be within `0.0..=1.0`.
+- `recalculate_and_persist_trust_score(...)` computes the score and writes it through `ReputationStore::set_trust_score(...)`, appending score history.
+
+Regression guard:
+- `1000ms` remains in the highest response bucket.
+
+## Validation and Error Handling
+- Invalid rate inputs return typed errors:
+  - `InvalidDeliveryRate(f64)`
+  - `InvalidDisputeRate(f64)`
+- Persistence failures are propagated as `TrustScoreError::Reputation(...)`.
+
+## Fast and Cost-Effective Validation
+Use the targeted lane first:
+
+```bash
+cargo test -p kamn-core --test trust_score_engine --test trust_score_engine_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run full crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implemented PRD 8.2 deterministic trust-score calculation engine with explicit bounds/validation and persistence integration into `ReputationStore`.

## Changes
- `crates/kamn-core/src/trust_score.rs`: added PRD 8.2 formula engine, typed errors, score breakdown struct, version constant, and persistence helper `recalculate_and_persist_trust_score`.
- `crates/kamn-core/src/lib.rs`: exported trust-score APIs/constants.
- `crates/kamn-core/tests/trust_score_engine.rs`: added unit/functional/integration/regression coverage.
- `crates/kamn-core/tests/trust_score_engine_docs.rs`: added docs contract tests.
- `docs/foundation/trust-score-engine.md`: documented formula mapping, bounds/versioning, and validation behavior.
- `docs/foundation/bootstrap.md`: linked trust-score documentation.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test trust_score_engine --test trust_score_engine_docs
```
Observed failures before implementation:
- missing `docs/foundation/trust-score-engine.md`
- unresolved APIs: `calculate_trust_score`, `recalculate_and_persist_trust_score`, `TrustScoreError`

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test trust_score_engine --test trust_score_engine_docs
```
Result:
- `trust_score_engine`: 6 passed
- `trust_score_engine_docs`: 4 passed

### 🔁 Regression
```bash
cargo test -p kamn-core
```
Result:
- full `kamn-core` suite passed

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | invalid rate checks and bucket boundary checks in `trust_score_engine.rs` | |
| Functional   | ✅ | `trust_score_engine_matches_prd_8_2_formula` | |
| Integration  | ✅ | `trust_score_engine_integration_persists_score_to_store` | |
| Regression   | ✅ | `trust_score_engine_regression_response_1000_uses_fastest_bucket`, docs regression rule | |
| Performance  | N/A | N/A | Deterministic arithmetic only; no heavy runtime lane introduced. |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit.

## Documentation Updates
- `docs/foundation/trust-score-engine.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #213
Closes #212
Closes #44
