### PR TITLE
feat(storage): content-addressed adapter contract and integrity checks

### DIFF
--- a/crates/kamn-core/src/content_storage.rs
+++ b/crates/kamn-core/src/content_storage.rs
@@ -1,0 +1,247 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+const CID_PREFIX: &str = "kamn:cid:v1:";
+const CONTENT_URI_PREFIX: &str = "kamn:content:v1:";
+const CID_HASH_HEX_LEN: usize = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentObject {
+    pub cid: String,
+    pub media_type: String,
+    pub payload: Vec<u8>,
+    pub integrity_tag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentHead {
+    pub cid: String,
+    pub media_type: String,
+    pub size_bytes: u64,
+    pub integrity_tag: String,
+}
+
+pub trait ContentStorageAdapter {
+    fn put(&mut self, media_type: &str, payload: &[u8])
+        -> Result<ContentHead, ContentStorageError>;
+    fn get(&self, cid: &str) -> Result<ContentObject, ContentStorageError>;
+    fn head(&self, cid: &str) -> Result<ContentHead, ContentStorageError>;
+    fn verify(&self, cid: &str) -> Result<(), ContentStorageError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct InMemoryContentAdapter {
+    objects: BTreeMap<String, StoredObject>,
+}
+
+impl InMemoryContentAdapter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn replace_payload_unchecked(
+        &mut self,
+        cid: &str,
+        payload: Vec<u8>,
+    ) -> Result<(), ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get_mut(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+        object.payload = payload;
+        Ok(())
+    }
+}
+
+impl ContentStorageAdapter for InMemoryContentAdapter {
+    fn put(
+        &mut self,
+        media_type: &str,
+        payload: &[u8],
+    ) -> Result<ContentHead, ContentStorageError> {
+        if media_type.trim().is_empty() {
+            return Err(ContentStorageError::EmptyField("media_type"));
+        }
+
+        let cid = cid_for_payload(payload);
+        let record = StoredObject {
+            media_type: media_type.to_owned(),
+            payload: payload.to_vec(),
+            integrity_tag: integrity_tag_for_payload(payload),
+        };
+        self.objects.insert(cid.clone(), record.clone());
+        Ok(content_head_from_stored(&cid, &record))
+    }
+
+    fn get(&self, cid: &str) -> Result<ContentObject, ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+        Ok(ContentObject {
+            cid: cid.to_owned(),
+            media_type: object.media_type.clone(),
+            payload: object.payload.clone(),
+            integrity_tag: object.integrity_tag.clone(),
+        })
+    }
+
+    fn head(&self, cid: &str) -> Result<ContentHead, ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+        Ok(content_head_from_stored(cid, object))
+    }
+
+    fn verify(&self, cid: &str) -> Result<(), ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+
+        let expected_cid = cid_for_payload(&object.payload);
+        let expected_integrity_tag = integrity_tag_for_payload(&object.payload);
+        if expected_cid != cid || expected_integrity_tag != object.integrity_tag {
+            return Err(ContentStorageError::IntegrityMismatch {
+                cid: cid.to_owned(),
+                expected: expected_integrity_tag,
+                found: object.integrity_tag.clone(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+pub fn content_uri_for_cid(cid: &str) -> Result<String, ContentStorageError> {
+    validate_cid(cid)?;
+    Ok(format!("{CONTENT_URI_PREFIX}{cid}"))
+}
+
+pub fn cid_from_content_uri(uri: &str) -> Result<String, ContentStorageError> {
+    let cid = uri
+        .strip_prefix(CONTENT_URI_PREFIX)
+        .ok_or_else(|| ContentStorageError::InvalidContentUri(uri.to_owned()))?;
+    validate_cid(cid)?;
+    Ok(cid.to_owned())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentStorageError {
+    EmptyField(&'static str),
+    InvalidCid(String),
+    InvalidContentUri(String),
+    NotFound(String),
+    IntegrityMismatch {
+        cid: String,
+        expected: String,
+        found: String,
+    },
+}
+
+impl fmt::Display for ContentStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidCid(value) => write!(f, "invalid content identifier: {value}"),
+            Self::InvalidContentUri(value) => write!(f, "invalid content uri: {value}"),
+            Self::NotFound(value) => write!(f, "content not found: {value}"),
+            Self::IntegrityMismatch {
+                cid,
+                expected,
+                found,
+            } => write!(
+                f,
+                "content integrity mismatch for {cid}; expected {expected}, found {found}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContentStorageError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StoredObject {
+    media_type: String,
+    payload: Vec<u8>,
+    integrity_tag: String,
+}
+
+fn content_head_from_stored(cid: &str, object: &StoredObject) -> ContentHead {
+    ContentHead {
+        cid: cid.to_owned(),
+        media_type: object.media_type.clone(),
+        size_bytes: object.payload.len() as u64,
+        integrity_tag: object.integrity_tag.clone(),
+    }
+}
+
+fn cid_for_payload(payload: &[u8]) -> String {
+    format!("{CID_PREFIX}{}", fnv1a_hex(payload))
+}
+
+fn integrity_tag_for_payload(payload: &[u8]) -> String {
+    format!("fnv1a64:{}", fnv1a_hex(payload))
+}
+
+fn validate_cid(cid: &str) -> Result<(), ContentStorageError> {
+    let Some(digest) = cid.strip_prefix(CID_PREFIX) else {
+        return Err(ContentStorageError::InvalidCid(cid.to_owned()));
+    };
+    if digest.len() != CID_HASH_HEX_LEN || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(ContentStorageError::InvalidCid(cid.to_owned()));
+    }
+    Ok(())
+}
+
+fn fnv1a_hex(payload: &[u8]) -> String {
+    let mut acc: u64 = 0xcbf29ce484222325;
+    for byte in payload {
+        acc = acc.wrapping_mul(0x00000100000001B3);
+        acc ^= u64::from(*byte);
+    }
+    format!("{acc:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cid_for_payload, cid_from_content_uri, content_uri_for_cid, fnv1a_hex, validate_cid,
+        ContentStorageError,
+    };
+
+    #[test]
+    fn cid_for_payload_is_deterministic() {
+        let first = cid_for_payload(b"payload");
+        let second = cid_for_payload(b"payload");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn validate_cid_rejects_invalid_digest() {
+        assert_eq!(
+            validate_cid("kamn:cid:v1:nothex"),
+            Err(ContentStorageError::InvalidCid(
+                "kamn:cid:v1:nothex".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn content_uri_round_trip_preserves_cid() {
+        let cid = cid_for_payload(b"round-trip");
+        let uri = content_uri_for_cid(&cid).expect("uri should be valid");
+        let decoded = cid_from_content_uri(&uri).expect("uri should decode");
+        assert_eq!(decoded, cid);
+    }
+
+    #[test]
+    fn fnv1a_hex_produces_expected_width() {
+        assert_eq!(fnv1a_hex(b"abc").len(), 16);
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bridge_adapter;
 pub mod channel_models;
 pub mod channel_policies;
 pub mod config;
+pub mod content_storage;
 pub mod cross_chain_bridge;
 pub mod data_classification;
 pub mod did;
@@ -71,6 +72,10 @@ pub use channel_policies::{
 pub use config::{
     ConfigError, NodeConfig, NodeRole, SyncMode, SyncOperationalProfile, SyncRecoveryStrategy,
     SyncStartupStrategy,
+};
+pub use content_storage::{
+    cid_from_content_uri, content_uri_for_cid, ContentHead, ContentObject, ContentStorageAdapter,
+    ContentStorageError, InMemoryContentAdapter,
 };
 pub use cross_chain_bridge::{
     CrossChainBridgeConfig, CrossChainBridgeEngine, CrossChainBridgeError,

--- a/crates/kamn-core/tests/content_storage_adapter.rs
+++ b/crates/kamn-core/tests/content_storage_adapter.rs
@@ -1,0 +1,91 @@
+use kamn_core::{
+    cid_from_content_uri, content_uri_for_cid, ContentStorageAdapter, ContentStorageError,
+    InMemoryContentAdapter, TaskArtifactRegistry, TaskArtifactSubmission,
+};
+
+#[test]
+fn content_storage_adapter_generates_deterministic_cid_for_same_payload() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let first = adapter
+        .put("application/json", br#"{"task":"analyze"}"#)
+        .expect("first put should succeed");
+    let second = adapter
+        .put("application/json", br#"{"task":"analyze"}"#)
+        .expect("second put should succeed");
+
+    assert_eq!(first.cid, second.cid);
+    assert_eq!(first.integrity_tag, second.integrity_tag);
+}
+
+#[test]
+fn content_storage_adapter_put_get_head_verify_round_trip() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("text/plain", b"hello-kamn")
+        .expect("put should succeed");
+
+    let object = adapter.get(&head.cid).expect("get should succeed");
+    assert_eq!(object.media_type, "text/plain");
+    assert_eq!(object.payload, b"hello-kamn");
+
+    let fetched_head = adapter.head(&head.cid).expect("head should succeed");
+    assert_eq!(fetched_head.size_bytes, head.size_bytes);
+
+    adapter.verify(&head.cid).expect("verify should succeed");
+}
+
+#[test]
+fn content_storage_adapter_integration_supports_task_artifact_uri_reference() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/pdf", b"%PDF-1.7 artifact content")
+        .expect("put should succeed");
+
+    let uri = content_uri_for_cid(&head.cid).expect("uri generation should succeed");
+    let cid = cid_from_content_uri(&uri).expect("uri should decode cid");
+    assert_eq!(cid, head.cid);
+
+    let mut registry = TaskArtifactRegistry::new();
+    let on_chain_hash =
+        TaskArtifactRegistry::integrity_fingerprint("task-88", "kamn:did:agent:builder-1", &uri);
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-88".to_owned(),
+            task_id: "task-88".to_owned(),
+            creator: "kamn:did:agent:builder-1".to_owned(),
+            created_at_unix: 1_716_000_000,
+            on_chain_hash,
+            off_chain_uri: uri,
+            content_type: "application/pdf".to_owned(),
+        })
+        .expect("artifact registration should succeed");
+}
+
+#[test]
+fn content_storage_adapter_rejects_invalid_cid_lookup() {
+    let adapter = InMemoryContentAdapter::new();
+    assert_eq!(
+        adapter.get("kamn:cid:v1:nothexvalue"),
+        Err(ContentStorageError::InvalidCid(
+            "kamn:cid:v1:nothexvalue".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn content_storage_adapter_regression_detects_tampered_payload() {
+    // Regression: #169
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/octet-stream", b"original")
+        .expect("put should succeed");
+    adapter
+        .replace_payload_unchecked(&head.cid, b"tampered".to_vec())
+        .expect("tamper operation should succeed");
+
+    let result = adapter.verify(&head.cid);
+    assert!(matches!(
+        result,
+        Err(ContentStorageError::IntegrityMismatch { .. })
+    ));
+}

--- a/crates/kamn-core/tests/content_storage_adapter_docs.rs
+++ b/crates/kamn-core/tests/content_storage_adapter_docs.rs
@@ -1,0 +1,31 @@
+const DOC: &str = include_str!("../../../docs/foundation/content-storage-adapter.md");
+
+#[test]
+fn doc_contains_adapter_contract_scope_and_helpers() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("ContentStorageAdapter"));
+    assert!(DOC.contains("InMemoryContentAdapter"));
+    assert!(DOC.contains("content_uri_for_cid"));
+    assert!(DOC.contains("cid_from_content_uri"));
+}
+
+#[test]
+fn doc_contains_integrity_and_task_artifact_integration_rules() {
+    assert!(DOC.contains("## Integrity Verification Rules"));
+    assert!(DOC.contains("IntegrityMismatch"));
+    assert!(DOC.contains("## Task Artifact Integration Path"));
+    assert!(DOC.contains("TaskArtifactRegistry::integrity_fingerprint"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test content_storage_adapter"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_tamper_detection_behavior() {
+    // Regression: #169
+    assert!(DOC.contains("Corruption/tampering returns `ContentStorageError::IntegrityMismatch`."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -77,6 +77,7 @@ For group sender-key distribution and rotation controls, see `docs/foundation/gr
 For task state machine and legal transition validation controls, see `docs/foundation/task-state-machine.md`.
 For task operation command handling controls, see `docs/foundation/task-operations.md`.
 For task artifact integrity references and provenance metadata controls, see `docs/foundation/task-artifacts-provenance.md`.
+For content-addressed storage adapter contract and integrity verification controls, see `docs/foundation/content-storage-adapter.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
 For Discord bridge approver-gated outbound flow controls, see `docs/foundation/discord-bridge-approver-gating.md`.

--- a/docs/foundation/content-storage-adapter.md
+++ b/docs/foundation/content-storage-adapter.md
@@ -1,0 +1,42 @@
+# Content Storage Adapter Contract (Issues #168 / #169)
+
+This document captures the first implementation slice for PRD-aligned content-addressed storage contracts and integrity verification.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/content_storage.rs` with:
+  - `ContentStorageAdapter` trait covering `put`, `get`, `head`, and `verify`.
+  - `InMemoryContentAdapter` for deterministic local/dev behavior.
+  - `ContentHead` and `ContentObject` records for metadata and payload retrieval.
+  - typed errors via `ContentStorageError`.
+- Added integration and regression tests in `crates/kamn-core/tests/content_storage_adapter.rs`.
+
+## CID and URI Contract
+- Canonical CID format: `kamn:cid:v1:<16-hex-fnv1a64>`.
+- Canonical content URI format: `kamn:content:v1:<cid>`.
+- Helper APIs:
+  - `content_uri_for_cid(cid)` validates and serializes URI form.
+  - `cid_from_content_uri(uri)` validates URI prefix and decodes CID.
+
+## Integrity Verification Rules
+- `put` computes deterministic CID + integrity tag from payload bytes.
+- `verify` recomputes expected CID/integrity from persisted payload and fails on mismatch.
+- Corruption/tampering returns `ContentStorageError::IntegrityMismatch`.
+
+## Task Artifact Integration Path
+- Content URIs produced by the adapter integrate with `TaskArtifactRegistry` via `off_chain_uri`.
+- `TaskArtifactRegistry::integrity_fingerprint(task_id, creator, off_chain_uri)` can use adapter-produced URIs without format translation.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test content_storage_adapter --test content_storage_adapter_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first content-addressed storage slice for off-chain payload references by adding a strict adapter contract, deterministic CID/URI helpers, and an in-memory adapter with integrity verification.
This closes the subtask/task/story chain for this slice with full TDD evidence and docs updates.

Closes #169
Closes #168
Closes #92

## Changes
- `crates/kamn-core/src/content_storage.rs`: added `ContentStorageAdapter`, `InMemoryContentAdapter`, `ContentHead`, `ContentObject`, CID/URI helpers, typed errors, and unit tests.
- `crates/kamn-core/src/lib.rs`: exported the content storage API surface.
- `crates/kamn-core/tests/content_storage_adapter.rs`: added functional/integration/regression coverage for put/get/head/verify and task-artifact URI path.
- `crates/kamn-core/tests/content_storage_adapter_docs.rs`: added doc assertions and regression doc guard.
- `docs/foundation/content-storage-adapter.md`: documented contract, integrity rules, and low-cost validation lane.
- `docs/foundation/bootstrap.md`: linked new content storage foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test content_storage_adapter
```
Output excerpt:
```text
error[E0432]: unresolved imports `kamn_core::cid_from_content_uri`, `kamn_core::content_uri_for_cid`, `kamn_core::ContentStorageAdapter`, `kamn_core::ContentStorageError`, `kamn_core::InMemoryContentAdapter`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test content_storage_adapter --test content_storage_adapter_docs
```
Output summary:
```text
test result: ok. 5 passed; 0 failed (content_storage_adapter)
test result: ok. 4 passed; 0 failed (content_storage_adapter_docs)
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Output summary:
```text
fmt check: clean
clippy: Finished with no warnings
kamn-core tests: all passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `content_storage::tests::*` in `crates/kamn-core/src/content_storage.rs` | |
| Functional   | ✅     | `content_storage_adapter_put_get_head_verify_round_trip`, `content_storage_adapter_generates_deterministic_cid_for_same_payload` | |
| Integration  | ✅     | `content_storage_adapter_integration_supports_task_artifact_uri_reference` | |
| Regression   | ✅     | `content_storage_adapter_regression_detects_tampered_payload` (`// Regression: #169`) and docs regression assertion | |
| Performance  | N/A    | None | No throughput/network hotspot introduced; deterministic in-memory contract slice only |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove the new adapter contract and restore previous behavior.

## Documentation Updates
- `docs/foundation/content-storage-adapter.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate lane: `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
