### PR TITLE
feat(storage): add deterministic replication and repair policy loops

### DIFF
--- a/crates/kamn-core/src/content_replication.rs
+++ b/crates/kamn-core/src/content_replication.rs
@@ -1,0 +1,356 @@
+use crate::{ContentStorageAdapter, ContentStorageError};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentReplicationPolicy {
+    pub minimum_replicas: u16,
+    pub target_replicas: u16,
+    pub max_repair_attempts: u8,
+}
+
+impl ContentReplicationPolicy {
+    pub fn new(
+        minimum_replicas: u16,
+        target_replicas: u16,
+        max_repair_attempts: u8,
+    ) -> Result<Self, ContentReplicationError> {
+        if minimum_replicas == 0 {
+            return Err(ContentReplicationError::InvalidPolicy("minimum_replicas"));
+        }
+        if target_replicas < minimum_replicas {
+            return Err(ContentReplicationError::InvalidPolicy(
+                "target_replicas must be >= minimum_replicas",
+            ));
+        }
+        if max_repair_attempts == 0 {
+            return Err(ContentReplicationError::InvalidPolicy(
+                "max_repair_attempts",
+            ));
+        }
+
+        Ok(Self {
+            minimum_replicas,
+            target_replicas,
+            max_repair_attempts,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentAvailabilityHealth {
+    Healthy,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentAvailabilitySnapshot {
+    pub cid: String,
+    pub health: ContentAvailabilityHealth,
+    pub available_replicas: u16,
+    pub minimum_replicas: u16,
+    pub target_replicas: u16,
+    pub repair_attempts: u8,
+    pub last_checked_unix: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentAvailabilityAlert {
+    pub cid: String,
+    pub health: ContentAvailabilityHealth,
+    pub available_replicas: u16,
+    pub minimum_replicas: u16,
+    pub target_replicas: u16,
+    pub repair_attempts: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentRepairReason {
+    UnderReplicated,
+    MissingContent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentRepairAction {
+    pub cid: String,
+    pub missing_replicas: u16,
+    pub reason: ContentRepairReason,
+    pub attempt: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentReplicationManager {
+    policy: ContentReplicationPolicy,
+    records: BTreeMap<String, ContentReplicationRecord>,
+}
+
+impl ContentReplicationManager {
+    pub fn new(policy: ContentReplicationPolicy) -> Self {
+        Self {
+            policy,
+            records: BTreeMap::new(),
+        }
+    }
+
+    pub fn register_content<A: ContentStorageAdapter>(
+        &mut self,
+        adapter: &A,
+        cid: &str,
+        replica_nodes: &[&str],
+        checked_at_unix: u64,
+    ) -> Result<ContentAvailabilitySnapshot, ContentReplicationError> {
+        if checked_at_unix == 0 {
+            return Err(ContentReplicationError::EmptyField("checked_at_unix"));
+        }
+
+        adapter
+            .head(cid)
+            .map_err(ContentReplicationError::Storage)?;
+        adapter
+            .verify(cid)
+            .map_err(ContentReplicationError::Storage)?;
+
+        let replicas = normalize_replica_nodes(replica_nodes)?;
+        let previous = self.records.get(cid).cloned();
+        let mut record = previous.unwrap_or_default();
+        record.replicas = replicas;
+        record.last_checked_unix = checked_at_unix;
+        record.pending_repair = None;
+
+        self.records.insert(cid.to_owned(), record);
+        self.availability(cid)
+    }
+
+    pub fn availability(
+        &self,
+        cid: &str,
+    ) -> Result<ContentAvailabilitySnapshot, ContentReplicationError> {
+        let record = self
+            .records
+            .get(cid)
+            .ok_or_else(|| ContentReplicationError::UnknownContent(cid.to_owned()))?;
+        Ok(build_snapshot(cid, record, &self.policy))
+    }
+
+    pub fn availability_alerts(&self) -> Vec<ContentAvailabilityAlert> {
+        self.records
+            .iter()
+            .filter_map(|(cid, record)| {
+                let available_replicas = record.replicas.len() as u16;
+                let health = health_for_replicas(self.policy.minimum_replicas, available_replicas);
+                match health {
+                    ContentAvailabilityHealth::Healthy => None,
+                    _ => Some(ContentAvailabilityAlert {
+                        cid: cid.clone(),
+                        health,
+                        available_replicas,
+                        minimum_replicas: self.policy.minimum_replicas,
+                        target_replicas: self.policy.target_replicas,
+                        repair_attempts: record.repair_attempts,
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    pub fn plan_repairs(&mut self) -> Vec<ContentRepairAction> {
+        let mut actions = Vec::new();
+
+        for (cid, record) in &mut self.records {
+            let available_replicas = record.replicas.len() as u16;
+            if available_replicas >= self.policy.target_replicas {
+                record.pending_repair = None;
+                continue;
+            }
+            if record.repair_attempts >= self.policy.max_repair_attempts {
+                record.pending_repair = None;
+                continue;
+            }
+            if record.pending_repair.is_some() {
+                continue;
+            }
+
+            let reason = if available_replicas == 0 {
+                ContentRepairReason::MissingContent
+            } else {
+                ContentRepairReason::UnderReplicated
+            };
+            let action = ContentRepairAction {
+                cid: cid.clone(),
+                missing_replicas: self
+                    .policy
+                    .target_replicas
+                    .saturating_sub(available_replicas),
+                reason: reason.clone(),
+                attempt: record.repair_attempts + 1,
+            };
+            record.pending_repair = Some(reason);
+            actions.push(action);
+        }
+
+        actions
+    }
+
+    pub fn apply_repair_success(
+        &mut self,
+        cid: &str,
+        replica_node: &str,
+        checked_at_unix: u64,
+    ) -> Result<ContentAvailabilitySnapshot, ContentReplicationError> {
+        if replica_node.trim().is_empty() {
+            return Err(ContentReplicationError::EmptyField("replica_node"));
+        }
+        if checked_at_unix == 0 {
+            return Err(ContentReplicationError::EmptyField("checked_at_unix"));
+        }
+
+        let record = self
+            .records
+            .get_mut(cid)
+            .ok_or_else(|| ContentReplicationError::UnknownContent(cid.to_owned()))?;
+        record.replicas.insert(replica_node.to_owned());
+        record.last_checked_unix = checked_at_unix;
+        record.repair_attempts = 0;
+        record.pending_repair = None;
+        Ok(build_snapshot(cid, record, &self.policy))
+    }
+
+    pub fn apply_repair_failure(
+        &mut self,
+        cid: &str,
+        checked_at_unix: u64,
+    ) -> Result<(), ContentReplicationError> {
+        if checked_at_unix == 0 {
+            return Err(ContentReplicationError::EmptyField("checked_at_unix"));
+        }
+
+        let record = self
+            .records
+            .get_mut(cid)
+            .ok_or_else(|| ContentReplicationError::UnknownContent(cid.to_owned()))?;
+
+        if record.repair_attempts >= self.policy.max_repair_attempts {
+            return Err(ContentReplicationError::RepairAttemptsExceeded {
+                cid: cid.to_owned(),
+                max_attempts: self.policy.max_repair_attempts,
+            });
+        }
+
+        record.repair_attempts += 1;
+        record.last_checked_unix = checked_at_unix;
+        record.pending_repair = None;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentReplicationError {
+    InvalidPolicy(&'static str),
+    EmptyField(&'static str),
+    UnknownContent(String),
+    RepairAttemptsExceeded { cid: String, max_attempts: u8 },
+    Storage(ContentStorageError),
+}
+
+impl fmt::Display for ContentReplicationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPolicy(field) => write!(f, "invalid replication policy: {field}"),
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::UnknownContent(cid) => write!(f, "content not tracked for replication: {cid}"),
+            Self::RepairAttemptsExceeded { cid, max_attempts } => write!(
+                f,
+                "repair attempts exceeded for {cid}; maximum configured attempts: {max_attempts}"
+            ),
+            Self::Storage(error) => write!(f, "storage validation failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ContentReplicationError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct ContentReplicationRecord {
+    replicas: BTreeSet<String>,
+    last_checked_unix: u64,
+    repair_attempts: u8,
+    pending_repair: Option<ContentRepairReason>,
+}
+
+fn normalize_replica_nodes(
+    replica_nodes: &[&str],
+) -> Result<BTreeSet<String>, ContentReplicationError> {
+    let mut replicas = BTreeSet::new();
+    for node in replica_nodes {
+        if node.trim().is_empty() {
+            return Err(ContentReplicationError::EmptyField("replica_node"));
+        }
+        replicas.insert((*node).to_owned());
+    }
+    Ok(replicas)
+}
+
+fn health_for_replicas(
+    minimum_replicas: u16,
+    available_replicas: u16,
+) -> ContentAvailabilityHealth {
+    if available_replicas == 0 {
+        return ContentAvailabilityHealth::Unavailable;
+    }
+    if available_replicas < minimum_replicas {
+        return ContentAvailabilityHealth::Degraded;
+    }
+    ContentAvailabilityHealth::Healthy
+}
+
+fn build_snapshot(
+    cid: &str,
+    record: &ContentReplicationRecord,
+    policy: &ContentReplicationPolicy,
+) -> ContentAvailabilitySnapshot {
+    let available_replicas = record.replicas.len() as u16;
+    ContentAvailabilitySnapshot {
+        cid: cid.to_owned(),
+        health: health_for_replicas(policy.minimum_replicas, available_replicas),
+        available_replicas,
+        minimum_replicas: policy.minimum_replicas,
+        target_replicas: policy.target_replicas,
+        repair_attempts: record.repair_attempts,
+        last_checked_unix: record.last_checked_unix,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        health_for_replicas, normalize_replica_nodes, ContentAvailabilityHealth,
+        ContentReplicationError, ContentReplicationPolicy,
+    };
+
+    #[test]
+    fn policy_rejects_target_below_minimum() {
+        assert_eq!(
+            ContentReplicationPolicy::new(2, 1, 1),
+            Err(ContentReplicationError::InvalidPolicy(
+                "target_replicas must be >= minimum_replicas"
+            ))
+        );
+    }
+
+    #[test]
+    fn normalize_replica_nodes_rejects_empty_node_id() {
+        assert_eq!(
+            normalize_replica_nodes(&["node-a", ""]),
+            Err(ContentReplicationError::EmptyField("replica_node"))
+        );
+    }
+
+    #[test]
+    fn health_classification_marks_unavailable_when_zero_replicas() {
+        assert_eq!(
+            health_for_replicas(2, 0),
+            ContentAvailabilityHealth::Unavailable
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bridge_adapter;
 pub mod channel_models;
 pub mod channel_policies;
 pub mod config;
+pub mod content_replication;
 pub mod content_storage;
 pub mod cross_chain_bridge;
 pub mod data_classification;
@@ -72,6 +73,11 @@ pub use channel_policies::{
 pub use config::{
     ConfigError, NodeConfig, NodeRole, SyncMode, SyncOperationalProfile, SyncRecoveryStrategy,
     SyncStartupStrategy,
+};
+pub use content_replication::{
+    ContentAvailabilityAlert, ContentAvailabilityHealth, ContentAvailabilitySnapshot,
+    ContentRepairAction, ContentRepairReason, ContentReplicationError, ContentReplicationManager,
+    ContentReplicationPolicy,
 };
 pub use content_storage::{
     cid_from_content_uri, content_uri_for_cid, ContentHead, ContentObject, ContentStorageAdapter,

--- a/crates/kamn-core/tests/content_replication_repair.rs
+++ b/crates/kamn-core/tests/content_replication_repair.rs
@@ -1,0 +1,125 @@
+use kamn_core::{
+    ContentAvailabilityHealth, ContentRepairReason, ContentReplicationError,
+    ContentReplicationManager, ContentReplicationPolicy, ContentStorageAdapter,
+    InMemoryContentAdapter,
+};
+
+#[test]
+fn content_replication_policy_rejects_invalid_thresholds() {
+    assert_eq!(
+        ContentReplicationPolicy::new(0, 2, 2),
+        Err(ContentReplicationError::InvalidPolicy("minimum_replicas"))
+    );
+    assert_eq!(
+        ContentReplicationPolicy::new(2, 1, 2),
+        Err(ContentReplicationError::InvalidPolicy(
+            "target_replicas must be >= minimum_replicas"
+        ))
+    );
+    assert_eq!(
+        ContentReplicationPolicy::new(1, 2, 0),
+        Err(ContentReplicationError::InvalidPolicy(
+            "max_repair_attempts"
+        ))
+    );
+}
+
+#[test]
+fn content_replication_detects_degraded_availability_and_surfaces_alerts() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/octet-stream", b"artifact-1")
+        .expect("put should succeed");
+
+    let policy = ContentReplicationPolicy::new(2, 3, 2).expect("policy should be valid");
+    let mut manager = ContentReplicationManager::new(policy);
+    let snapshot = manager
+        .register_content(&adapter, &head.cid, &["node-a"], 1_716_000_100)
+        .expect("register should succeed");
+    assert_eq!(snapshot.health, ContentAvailabilityHealth::Degraded);
+
+    let alerts = manager.availability_alerts();
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts[0].cid, head.cid);
+    assert_eq!(alerts[0].health, ContentAvailabilityHealth::Degraded);
+}
+
+#[test]
+fn content_replication_repair_flow_is_idempotent_until_resolution() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/octet-stream", b"artifact-2")
+        .expect("put should succeed");
+
+    let policy = ContentReplicationPolicy::new(1, 3, 3).expect("policy should be valid");
+    let mut manager = ContentReplicationManager::new(policy);
+    manager
+        .register_content(&adapter, &head.cid, &["node-a"], 1_716_000_200)
+        .expect("register should succeed");
+
+    let first_plan = manager.plan_repairs();
+    assert_eq!(first_plan.len(), 1);
+    assert_eq!(first_plan[0].missing_replicas, 2);
+    assert_eq!(first_plan[0].reason, ContentRepairReason::UnderReplicated);
+
+    let second_plan = manager.plan_repairs();
+    assert!(second_plan.is_empty());
+
+    manager
+        .apply_repair_success(&head.cid, "node-b", 1_716_000_201)
+        .expect("repair success should apply");
+    let third_plan = manager.plan_repairs();
+    assert_eq!(third_plan.len(), 1);
+    assert_eq!(third_plan[0].missing_replicas, 1);
+}
+
+#[test]
+fn content_replication_integration_validates_storage_integrity_before_tracking() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/octet-stream", b"artifact-3")
+        .expect("put should succeed");
+    adapter
+        .replace_payload_unchecked(&head.cid, b"tampered".to_vec())
+        .expect("tamper should succeed");
+
+    let policy = ContentReplicationPolicy::new(1, 2, 2).expect("policy should be valid");
+    let mut manager = ContentReplicationManager::new(policy);
+    let result = manager.register_content(&adapter, &head.cid, &["node-a"], 1_716_000_300);
+    assert!(matches!(result, Err(ContentReplicationError::Storage(_))));
+}
+
+#[test]
+fn content_replication_regression_repair_retries_do_not_duplicate_or_corrupt_content() {
+    // Regression: #167
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/octet-stream", b"artifact-4")
+        .expect("put should succeed");
+
+    let policy = ContentReplicationPolicy::new(1, 2, 2).expect("policy should be valid");
+    let mut manager = ContentReplicationManager::new(policy);
+    manager
+        .register_content(&adapter, &head.cid, &["node-a"], 1_716_000_400)
+        .expect("register should succeed");
+
+    let first = manager.plan_repairs();
+    assert_eq!(first.len(), 1);
+    assert_eq!(manager.plan_repairs().len(), 0);
+
+    manager
+        .apply_repair_failure(&head.cid, 1_716_000_401)
+        .expect("first failure should be recorded");
+    assert_eq!(manager.plan_repairs().len(), 1);
+
+    manager
+        .apply_repair_failure(&head.cid, 1_716_000_402)
+        .expect("second failure should be recorded");
+    let blocked = manager.plan_repairs();
+    assert!(blocked.is_empty());
+
+    let stored = adapter
+        .get(&head.cid)
+        .expect("payload should remain retrievable");
+    assert_eq!(stored.payload, b"artifact-4");
+}

--- a/crates/kamn-core/tests/content_replication_repair_docs.rs
+++ b/crates/kamn-core/tests/content_replication_repair_docs.rs
@@ -1,0 +1,31 @@
+const DOC: &str = include_str!("../../../docs/foundation/content-replication-repair.md");
+
+#[test]
+fn doc_contains_policy_and_repair_scope() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("ContentReplicationPolicy"));
+    assert!(DOC.contains("ContentReplicationManager"));
+    assert!(DOC.contains("ContentRepairAction"));
+}
+
+#[test]
+fn doc_contains_health_and_retry_rules() {
+    assert!(DOC.contains("## Availability and Repair Rules"));
+    assert!(DOC.contains("Healthy"));
+    assert!(DOC.contains("Degraded"));
+    assert!(DOC.contains("Unavailable"));
+    assert!(DOC.contains("suppresses duplicate repair actions while a repair is pending"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test content_replication_repair"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_duplicate_repair_suppression_rule() {
+    // Regression: #167
+    assert!(DOC.contains("suppresses duplicate repair actions while a repair is pending"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -78,6 +78,7 @@ For task state machine and legal transition validation controls, see `docs/found
 For task operation command handling controls, see `docs/foundation/task-operations.md`.
 For task artifact integrity references and provenance metadata controls, see `docs/foundation/task-artifacts-provenance.md`.
 For content-addressed storage adapter contract and integrity verification controls, see `docs/foundation/content-storage-adapter.md`.
+For content pinning, replication, and repair policy controls, see `docs/foundation/content-replication-repair.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
 For Discord bridge approver-gated outbound flow controls, see `docs/foundation/discord-bridge-approver-gating.md`.

--- a/docs/foundation/content-replication-repair.md
+++ b/docs/foundation/content-replication-repair.md
@@ -1,0 +1,45 @@
+# Content Pinning, Replication, and Repair Policy Loops (Issues #166 / #167)
+
+This document captures the first implementation slice for content availability policy and deterministic repair planning.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/content_replication.rs` with:
+  - `ContentReplicationPolicy` validation for minimum/target replicas and retry bounds.
+  - `ContentReplicationManager` with deterministic tracking, repair planning, and repair result application.
+  - `ContentAvailabilityHealth`, `ContentAvailabilitySnapshot`, and `ContentAvailabilityAlert`.
+  - `ContentRepairAction` and `ContentRepairReason` for explicit repair work units.
+  - typed errors via `ContentReplicationError`.
+- Added integration and regression tests in `crates/kamn-core/tests/content_replication_repair.rs`.
+
+## Availability and Repair Rules
+- Health states:
+  - `Healthy` when available replicas meet minimum threshold.
+  - `Degraded` when replicas are non-zero but below minimum threshold.
+  - `Unavailable` when replica count is zero.
+- Repair planning:
+  - plans repairs when available replicas are below target threshold.
+  - uses deterministic CID ordering.
+  - suppresses duplicate repair actions while a repair is pending.
+- Retry safety:
+  - repair failures increment per-content attempt counters.
+  - repair planning stops after `max_repair_attempts`.
+
+## Storage Integrity Integration
+- `register_content(...)` validates content through storage adapter `head` and `verify`.
+- Tampered storage content is rejected via `ContentReplicationError::Storage(...)`.
+- Repair manager does not mutate payload bytes; it only tracks replica health metadata.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test content_replication_repair --test content_replication_repair_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first content-availability slice for pinning/replication/repair loops by adding a deterministic replication policy manager, explicit repair actions, and degraded/unavailable alert signaling.
This delivers idempotent retry-safe repair planning with storage-integrity validation and docs updates.

Closes #167
Closes #166
Closes #93

## Changes
- `crates/kamn-core/src/content_replication.rs`: added `ContentReplicationPolicy`, `ContentReplicationManager`, availability models, repair models, typed errors, and unit tests.
- `crates/kamn-core/src/lib.rs`: exported replication/repair API surface.
- `crates/kamn-core/tests/content_replication_repair.rs`: added functional/integration/regression coverage for policy checks, deterministic planning, idempotency, and storage-integrity gating.
- `crates/kamn-core/tests/content_replication_repair_docs.rs`: added doc assertions and regression doc guard.
- `docs/foundation/content-replication-repair.md`: documented behavior, retry limits, and low-cost validation lane.
- `docs/foundation/bootstrap.md`: linked new replication/repair foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test content_replication_repair
```
Output excerpt:
```text
error[E0432]: unresolved imports `kamn_core::ContentAvailabilityHealth`, `kamn_core::ContentReplicationError`, `kamn_core::ContentReplicationManager`, `kamn_core::ContentReplicationPolicy`, `kamn_core::ContentRepairReason`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test content_replication_repair --test content_replication_repair_docs
```
Output summary:
```text
test result: ok. 5 passed; 0 failed (content_replication_repair)
test result: ok. 4 passed; 0 failed (content_replication_repair_docs)
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Output summary:
```text
fmt check: clean
clippy: Finished with no warnings
kamn-core tests: all passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `content_replication::tests::*` in `crates/kamn-core/src/content_replication.rs` | |
| Functional   | ✅     | policy/health/repair flow tests in `crates/kamn-core/tests/content_replication_repair.rs` | |
| Integration  | ✅     | `content_replication_integration_validates_storage_integrity_before_tracking` | |
| Regression   | ✅     | `content_replication_regression_repair_retries_do_not_duplicate_or_corrupt_content` (`// Regression: #167`) and docs regression assertion | |
| Performance  | N/A    | None | No network throughput/load hotspot introduced in this first slice |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove replication/repair manager behavior.

## Documentation Updates
- `docs/foundation/content-replication-repair.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate lane: `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
