### PR TITLE
feat(storage): secure retrieval access checks and cache controls

### DIFF
--- a/crates/kamn-core/src/content_retrieval.rs
+++ b/crates/kamn-core/src/content_retrieval.rs
@@ -1,0 +1,366 @@
+use crate::{
+    AgentDid, ChannelAction, ChannelPermissionEngine, ChannelPolicyError, ContentStorageAdapter,
+    ContentStorageError,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentRetrievalConfig {
+    pub cache_ttl_secs: u64,
+}
+
+impl ContentRetrievalConfig {
+    pub fn new(cache_ttl_secs: u64) -> Result<Self, ContentRetrievalError> {
+        if cache_ttl_secs == 0 {
+            return Err(ContentRetrievalError::InvalidConfig("cache_ttl_secs"));
+        }
+        Ok(Self { cache_ttl_secs })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentRetrievalScope {
+    Channel(String),
+    Task(String),
+}
+
+impl ContentRetrievalScope {
+    fn key(&self) -> String {
+        match self {
+            Self::Channel(value) => format!("channel:{value}"),
+            Self::Task(value) => format!("task:{value}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentRetrievalRequest {
+    pub cid: String,
+    pub requester: String,
+    pub scope: ContentRetrievalScope,
+    pub requested_at_unix: u64,
+}
+
+impl ContentRetrievalRequest {
+    pub fn new(
+        cid: &str,
+        requester: &str,
+        scope: ContentRetrievalScope,
+        requested_at_unix: u64,
+    ) -> Result<Self, ContentRetrievalError> {
+        if cid.trim().is_empty() {
+            return Err(ContentRetrievalError::EmptyField("cid"));
+        }
+        validate_did(requester)?;
+        validate_scope(&scope)?;
+        if requested_at_unix == 0 {
+            return Err(ContentRetrievalError::EmptyField("requested_at_unix"));
+        }
+
+        Ok(Self {
+            cid: cid.to_owned(),
+            requester: requester.to_owned(),
+            scope,
+            requested_at_unix,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentRetrievalOutcome {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentRetrievalAuditEvent {
+    pub cid: String,
+    pub requester: String,
+    pub scope: ContentRetrievalScope,
+    pub requested_at_unix: u64,
+    pub outcome: ContentRetrievalOutcome,
+    pub cache_hit: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentRetrievalResult {
+    pub cid: String,
+    pub media_type: String,
+    pub payload: Vec<u8>,
+    pub from_cache: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentRetrievalEngine {
+    config: ContentRetrievalConfig,
+    task_read_allowlist: BTreeMap<String, BTreeSet<String>>,
+    cache: BTreeMap<String, CachedContent>,
+    audit_events: Vec<ContentRetrievalAuditEvent>,
+}
+
+impl ContentRetrievalEngine {
+    pub fn new(config: ContentRetrievalConfig) -> Self {
+        Self {
+            config,
+            task_read_allowlist: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            audit_events: Vec::new(),
+        }
+    }
+
+    pub fn grant_task_read(
+        &mut self,
+        task_id: &str,
+        requester: &str,
+    ) -> Result<(), ContentRetrievalError> {
+        if task_id.trim().is_empty() {
+            return Err(ContentRetrievalError::EmptyField("task_id"));
+        }
+        validate_did(requester)?;
+        self.task_read_allowlist
+            .entry(task_id.to_owned())
+            .or_default()
+            .insert(requester.to_owned());
+        Ok(())
+    }
+
+    pub fn invalidate_cache_for_cid(&mut self, cid: &str) {
+        self.cache.retain(|_, entry| entry.cid != cid);
+    }
+
+    pub fn audit_events(&self) -> Vec<ContentRetrievalAuditEvent> {
+        self.audit_events.clone()
+    }
+
+    pub fn retrieve<A: ContentStorageAdapter>(
+        &mut self,
+        adapter: &A,
+        request: &ContentRetrievalRequest,
+        channel_permissions: Option<&ChannelPermissionEngine>,
+    ) -> Result<ContentRetrievalResult, ContentRetrievalError> {
+        if let Err(error) = self.authorize(request, channel_permissions) {
+            self.audit_events.push(ContentRetrievalAuditEvent {
+                cid: request.cid.clone(),
+                requester: request.requester.clone(),
+                scope: request.scope.clone(),
+                requested_at_unix: request.requested_at_unix,
+                outcome: ContentRetrievalOutcome::Denied,
+                cache_hit: false,
+            });
+            return Err(error);
+        }
+
+        let cache_key = cache_key(request);
+        if let Some(cached) = self.cache.get(&cache_key) {
+            if request.requested_at_unix <= cached.expires_at_unix {
+                let result = ContentRetrievalResult {
+                    cid: cached.cid.clone(),
+                    media_type: cached.media_type.clone(),
+                    payload: cached.payload.clone(),
+                    from_cache: true,
+                };
+                self.audit_events.push(ContentRetrievalAuditEvent {
+                    cid: request.cid.clone(),
+                    requester: request.requester.clone(),
+                    scope: request.scope.clone(),
+                    requested_at_unix: request.requested_at_unix,
+                    outcome: ContentRetrievalOutcome::Allowed,
+                    cache_hit: true,
+                });
+                return Ok(result);
+            }
+        }
+
+        adapter
+            .verify(&request.cid)
+            .map_err(ContentRetrievalError::Storage)?;
+        let object = adapter
+            .get(&request.cid)
+            .map_err(ContentRetrievalError::Storage)?;
+        let expires_at_unix = request
+            .requested_at_unix
+            .saturating_add(self.config.cache_ttl_secs);
+
+        self.cache.insert(
+            cache_key,
+            CachedContent {
+                cid: object.cid.clone(),
+                media_type: object.media_type.clone(),
+                payload: object.payload.clone(),
+                expires_at_unix,
+            },
+        );
+
+        let result = ContentRetrievalResult {
+            cid: object.cid,
+            media_type: object.media_type,
+            payload: object.payload,
+            from_cache: false,
+        };
+        self.audit_events.push(ContentRetrievalAuditEvent {
+            cid: request.cid.clone(),
+            requester: request.requester.clone(),
+            scope: request.scope.clone(),
+            requested_at_unix: request.requested_at_unix,
+            outcome: ContentRetrievalOutcome::Allowed,
+            cache_hit: false,
+        });
+        Ok(result)
+    }
+
+    fn authorize(
+        &self,
+        request: &ContentRetrievalRequest,
+        channel_permissions: Option<&ChannelPermissionEngine>,
+    ) -> Result<(), ContentRetrievalError> {
+        match &request.scope {
+            ContentRetrievalScope::Task(task_id) => {
+                let allowed = self
+                    .task_read_allowlist
+                    .get(task_id)
+                    .map(|allowlist| allowlist.contains(&request.requester))
+                    .unwrap_or(false);
+                if !allowed {
+                    return Err(ContentRetrievalError::Unauthorized {
+                        requester: request.requester.clone(),
+                        scope: request.scope.clone(),
+                    });
+                }
+                Ok(())
+            }
+            ContentRetrievalScope::Channel(channel_id) => {
+                let Some(engine) = channel_permissions else {
+                    return Err(ContentRetrievalError::MissingChannelPermissions(
+                        channel_id.clone(),
+                    ));
+                };
+                engine
+                    .authorize(channel_id, &request.requester, ChannelAction::Read)
+                    .map_err(ContentRetrievalError::ChannelPolicy)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentRetrievalError {
+    InvalidConfig(&'static str),
+    EmptyField(&'static str),
+    InvalidDid(String),
+    Unauthorized {
+        requester: String,
+        scope: ContentRetrievalScope,
+    },
+    MissingChannelPermissions(String),
+    ChannelPolicy(ChannelPolicyError),
+    Storage(ContentStorageError),
+}
+
+impl fmt::Display for ContentRetrievalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfig(field) => write!(f, "invalid retrieval config field: {field}"),
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::Unauthorized { requester, scope } => {
+                write!(f, "unauthorized requester {requester} for scope {scope:?}")
+            }
+            Self::MissingChannelPermissions(channel_id) => {
+                write!(
+                    f,
+                    "missing channel permission engine for channel scope {channel_id}"
+                )
+            }
+            Self::ChannelPolicy(error) => write!(f, "channel policy error: {error}"),
+            Self::Storage(error) => write!(f, "storage retrieval error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ContentRetrievalError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CachedContent {
+    cid: String,
+    media_type: String,
+    payload: Vec<u8>,
+    expires_at_unix: u64,
+}
+
+fn cache_key(request: &ContentRetrievalRequest) -> String {
+    format!(
+        "{}|{}|{}",
+        request.requester,
+        request.scope.key(),
+        request.cid
+    )
+}
+
+fn validate_did(value: &str) -> Result<(), ContentRetrievalError> {
+    AgentDid::parse(value).map_err(|error| ContentRetrievalError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn validate_scope(scope: &ContentRetrievalScope) -> Result<(), ContentRetrievalError> {
+    match scope {
+        ContentRetrievalScope::Channel(value) => {
+            if value.trim().is_empty() {
+                return Err(ContentRetrievalError::EmptyField("channel_id"));
+            }
+        }
+        ContentRetrievalScope::Task(value) => {
+            if value.trim().is_empty() {
+                return Err(ContentRetrievalError::EmptyField("task_id"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cache_key, ContentRetrievalConfig, ContentRetrievalError, ContentRetrievalRequest,
+        ContentRetrievalScope,
+    };
+
+    #[test]
+    fn config_rejects_zero_ttl() {
+        assert_eq!(
+            ContentRetrievalConfig::new(0),
+            Err(ContentRetrievalError::InvalidConfig("cache_ttl_secs"))
+        );
+    }
+
+    #[test]
+    fn request_rejects_invalid_did() {
+        assert_eq!(
+            ContentRetrievalRequest::new(
+                "kamn:cid:v1:aaaaaaaaaaaaaaaa",
+                "invalid-did",
+                ContentRetrievalScope::Task("task-1".to_owned()),
+                1,
+            ),
+            Err(ContentRetrievalError::InvalidDid(
+                "invalid agent did prefix: invalid-did".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn cache_key_is_scope_and_requester_specific() {
+        let request = ContentRetrievalRequest::new(
+            "kamn:cid:v1:aaaaaaaaaaaaaaaa",
+            "kamn:did:agent:reader-1",
+            ContentRetrievalScope::Task("task-1".to_owned()),
+            1,
+        )
+        .expect("request should be valid");
+        assert_eq!(
+            cache_key(&request),
+            "kamn:did:agent:reader-1|task:task-1|kamn:cid:v1:aaaaaaaaaaaaaaaa".to_owned()
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod channel_models;
 pub mod channel_policies;
 pub mod config;
 pub mod content_replication;
+pub mod content_retrieval;
 pub mod content_storage;
 pub mod cross_chain_bridge;
 pub mod data_classification;
@@ -78,6 +79,11 @@ pub use content_replication::{
     ContentAvailabilityAlert, ContentAvailabilityHealth, ContentAvailabilitySnapshot,
     ContentRepairAction, ContentRepairReason, ContentReplicationError, ContentReplicationManager,
     ContentReplicationPolicy,
+};
+pub use content_retrieval::{
+    ContentRetrievalAuditEvent, ContentRetrievalConfig, ContentRetrievalEngine,
+    ContentRetrievalError, ContentRetrievalOutcome, ContentRetrievalRequest,
+    ContentRetrievalResult, ContentRetrievalScope,
 };
 pub use content_storage::{
     cid_from_content_uri, content_uri_for_cid, ContentHead, ContentObject, ContentStorageAdapter,

--- a/crates/kamn-core/tests/content_retrieval_access_cache.rs
+++ b/crates/kamn-core/tests/content_retrieval_access_cache.rs
@@ -1,0 +1,171 @@
+use kamn_core::{
+    ChannelAction, ChannelPermissionEngine, ChannelPermissions, ContentRetrievalConfig,
+    ContentRetrievalEngine, ContentRetrievalError, ContentRetrievalOutcome,
+    ContentRetrievalRequest, ContentRetrievalScope, ContentStorageAdapter, InMemoryContentAdapter,
+    PermissionRule, RetentionPolicy,
+};
+
+fn member_permissions() -> ChannelPermissions {
+    ChannelPermissions {
+        send: PermissionRule::Members,
+        read: PermissionRule::Members,
+        invite: PermissionRule::Admins,
+        remove: PermissionRule::Admins,
+        configure: PermissionRule::Admins,
+        retention: RetentionPolicy::Forever,
+    }
+}
+
+#[test]
+fn content_retrieval_config_rejects_zero_cache_ttl() {
+    assert_eq!(
+        ContentRetrievalConfig::new(0),
+        Err(ContentRetrievalError::InvalidConfig("cache_ttl_secs"))
+    );
+}
+
+#[test]
+fn content_retrieval_allows_authorized_task_reader_and_uses_cache() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("text/plain", b"cached-payload")
+        .expect("put should succeed");
+
+    let mut engine = ContentRetrievalEngine::new(
+        ContentRetrievalConfig::new(60).expect("config should be valid"),
+    );
+    engine
+        .grant_task_read("task-100", "kamn:did:agent:reader-1")
+        .expect("grant should succeed");
+
+    let request = ContentRetrievalRequest::new(
+        &head.cid,
+        "kamn:did:agent:reader-1",
+        ContentRetrievalScope::Task("task-100".to_owned()),
+        1_716_000_500,
+    )
+    .expect("request should be valid");
+
+    let first = engine
+        .retrieve(&adapter, &request, None)
+        .expect("first retrieval should pass");
+    assert_eq!(first.payload, b"cached-payload");
+    assert!(!first.from_cache);
+
+    let second = engine
+        .retrieve(&adapter, &request, None)
+        .expect("second retrieval should pass");
+    assert!(second.from_cache);
+}
+
+#[test]
+fn content_retrieval_denied_access_is_auditable() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("text/plain", b"private-payload")
+        .expect("put should succeed");
+
+    let mut engine = ContentRetrievalEngine::new(
+        ContentRetrievalConfig::new(60).expect("config should be valid"),
+    );
+    let request = ContentRetrievalRequest::new(
+        &head.cid,
+        "kamn:did:agent:reader-2",
+        ContentRetrievalScope::Task("task-200".to_owned()),
+        1_716_000_600,
+    )
+    .expect("request should be valid");
+
+    let result = engine.retrieve(&adapter, &request, None);
+    assert!(matches!(
+        result,
+        Err(ContentRetrievalError::Unauthorized { .. })
+    ));
+
+    let audits = engine.audit_events();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].outcome, ContentRetrievalOutcome::Denied);
+}
+
+#[test]
+fn content_retrieval_integration_enforces_channel_read_permissions() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/json", br#"{"ok":true}"#)
+        .expect("put should succeed");
+
+    let mut policy_engine = ChannelPermissionEngine::new();
+    policy_engine
+        .register_channel(
+            "channel:ops:1",
+            vec![
+                "kamn:did:agent:member-1".to_owned(),
+                "kamn:did:agent:admin-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:admin-1".to_owned()],
+            member_permissions(),
+        )
+        .expect("channel should register");
+    policy_engine
+        .authorize(
+            "channel:ops:1",
+            "kamn:did:agent:member-1",
+            ChannelAction::Read,
+        )
+        .expect("member should have read permission");
+
+    let mut engine = ContentRetrievalEngine::new(
+        ContentRetrievalConfig::new(45).expect("config should be valid"),
+    );
+    let request = ContentRetrievalRequest::new(
+        &head.cid,
+        "kamn:did:agent:member-1",
+        ContentRetrievalScope::Channel("channel:ops:1".to_owned()),
+        1_716_000_700,
+    )
+    .expect("request should be valid");
+
+    let result = engine
+        .retrieve(&adapter, &request, Some(&policy_engine))
+        .expect("authorized member retrieval should pass");
+    assert_eq!(result.media_type, "application/json");
+}
+
+#[test]
+fn content_retrieval_regression_cache_does_not_bypass_authorization() {
+    // Regression: #165
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("text/plain", b"scope-sensitive")
+        .expect("put should succeed");
+
+    let mut engine = ContentRetrievalEngine::new(
+        ContentRetrievalConfig::new(120).expect("config should be valid"),
+    );
+    engine
+        .grant_task_read("task-300", "kamn:did:agent:reader-ok")
+        .expect("grant should succeed");
+
+    let allowed = ContentRetrievalRequest::new(
+        &head.cid,
+        "kamn:did:agent:reader-ok",
+        ContentRetrievalScope::Task("task-300".to_owned()),
+        1_716_000_800,
+    )
+    .expect("request should be valid");
+    engine
+        .retrieve(&adapter, &allowed, None)
+        .expect("authorized reader should warm cache");
+
+    let denied = ContentRetrievalRequest::new(
+        &head.cid,
+        "kamn:did:agent:reader-nope",
+        ContentRetrievalScope::Task("task-300".to_owned()),
+        1_716_000_801,
+    )
+    .expect("request should be valid");
+    assert!(matches!(
+        engine.retrieve(&adapter, &denied, None),
+        Err(ContentRetrievalError::Unauthorized { .. })
+    ));
+}

--- a/crates/kamn-core/tests/content_retrieval_access_cache_docs.rs
+++ b/crates/kamn-core/tests/content_retrieval_access_cache_docs.rs
@@ -1,0 +1,31 @@
+const DOC: &str = include_str!("../../../docs/foundation/content-retrieval-access-cache.md");
+
+#[test]
+fn doc_contains_retrieval_scope_and_engine_contract() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("ContentRetrievalConfig"));
+    assert!(DOC.contains("ContentRetrievalRequest"));
+    assert!(DOC.contains("ContentRetrievalEngine"));
+}
+
+#[test]
+fn doc_contains_authorization_and_cache_binding_rules() {
+    assert!(DOC.contains("## Authorization and Cache Rules"));
+    assert!(DOC.contains("grant_task_read"));
+    assert!(DOC.contains("ChannelPermissionEngine"));
+    assert!(DOC.contains("cache key binds `requester + scope + cid`."));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test content_retrieval_access_cache"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_scope_bound_cache_rule() {
+    // Regression: #165
+    assert!(DOC
+        .contains("Cache entries cannot be reused across different requester/scope combinations."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -79,6 +79,7 @@ For task operation command handling controls, see `docs/foundation/task-operatio
 For task artifact integrity references and provenance metadata controls, see `docs/foundation/task-artifacts-provenance.md`.
 For content-addressed storage adapter contract and integrity verification controls, see `docs/foundation/content-storage-adapter.md`.
 For content pinning, replication, and repair policy controls, see `docs/foundation/content-replication-repair.md`.
+For secure off-chain retrieval access, cache TTL, and audit controls, see `docs/foundation/content-retrieval-access-cache.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
 For Discord bridge approver-gated outbound flow controls, see `docs/foundation/discord-bridge-approver-gating.md`.

--- a/docs/foundation/content-retrieval-access-cache.md
+++ b/docs/foundation/content-retrieval-access-cache.md
@@ -1,0 +1,46 @@
+# Secure Off-Chain Retrieval, Cache, and Access Controls (Issues #164 / #165)
+
+This document captures the first implementation slice for secure retrieval paths with authorization checks, cache TTL handling, and auditability.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/content_retrieval.rs` with:
+  - `ContentRetrievalConfig` for bounded cache TTL.
+  - `ContentRetrievalRequest` and `ContentRetrievalScope` for task/channel-scoped retrieval context.
+  - `ContentRetrievalEngine` with authorization, cache, and retrieval workflow.
+  - `ContentRetrievalAuditEvent` and `ContentRetrievalOutcome` for deterministic audit signals.
+  - typed errors via `ContentRetrievalError`.
+- Added integration and regression tests in `crates/kamn-core/tests/content_retrieval_access_cache.rs`.
+
+## Authorization and Cache Rules
+- Task scope:
+  - explicit allowlist via `grant_task_read(task_id, requester)`.
+  - unauthorized task reads return `ContentRetrievalError::Unauthorized`.
+- Channel scope:
+  - retrieval requires `ChannelPermissionEngine` and `ChannelAction::Read` authorization.
+- Cache behavior:
+  - cache key binds `requester + scope + cid`.
+  - authorization checks always run before cache access.
+  - TTL expiry forces re-fetch from storage and cache refresh.
+
+## Audit and Security Guarantees
+- Each retrieval attempt appends an audit event:
+  - outcome `Allowed` or `Denied`
+  - scope, requester, CID, timestamp
+  - cache-hit marker
+- Storage integrity checks are enforced (`verify`) before payload retrieval.
+- Cache entries cannot be reused across different requester/scope combinations.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test content_retrieval_access_cache --test content_retrieval_access_cache_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first secure retrieval slice for off-chain content by enforcing authorization checks before retrieval, adding deterministic cache TTL behavior, and emitting retrieval audit events for allowed/denied attempts.
This delivers scope-bound cache keys so cached payloads cannot bypass access controls.

Closes #165
Closes #164
Closes #94

## Changes
- `crates/kamn-core/src/content_retrieval.rs`: added `ContentRetrievalEngine`, request/config/scope models, auth checks, cache handling, audit event model, typed errors, and unit tests.
- `crates/kamn-core/src/lib.rs`: exported retrieval API surface.
- `crates/kamn-core/tests/content_retrieval_access_cache.rs`: added functional/integration/regression tests for authorization, cache use, and auditability.
- `crates/kamn-core/tests/content_retrieval_access_cache_docs.rs`: added doc assertions and regression doc guard.
- `docs/foundation/content-retrieval-access-cache.md`: documented contract, rules, and low-cost validation lane.
- `docs/foundation/bootstrap.md`: linked new retrieval foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test content_retrieval_access_cache
```
Output excerpt:
```text
error[E0432]: unresolved imports `kamn_core::ContentRetrievalConfig`, `kamn_core::ContentRetrievalEngine`, `kamn_core::ContentRetrievalError`, `kamn_core::ContentRetrievalOutcome`, `kamn_core::ContentRetrievalRequest`, `kamn_core::ContentRetrievalScope`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test content_retrieval_access_cache --test content_retrieval_access_cache_docs
```
Output summary:
```text
test result: ok. 5 passed; 0 failed (content_retrieval_access_cache)
test result: ok. 4 passed; 0 failed (content_retrieval_access_cache_docs)
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Output summary:
```text
fmt check: clean
clippy: Finished with no warnings
kamn-core tests: all passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `content_retrieval::tests::*` in `crates/kamn-core/src/content_retrieval.rs` | |
| Functional   | ✅     | authorized/denied retrieval and cache behavior tests in `content_retrieval_access_cache.rs` | |
| Integration  | ✅     | `content_retrieval_integration_enforces_channel_read_permissions` | |
| Regression   | ✅     | `content_retrieval_regression_cache_does_not_bypass_authorization` (`// Regression: #165`) and docs regression assertion | |
| Performance  | N/A    | None | No throughput hotspot introduced in this first retrieval control slice |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove retrieval control module and associated wiring.

## Documentation Updates
- `docs/foundation/content-retrieval-access-cache.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate lane: `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
