### PR TITLE
feat(storage): add retention tombstone cleanup lifecycle controls

### DIFF
--- a/crates/kamn-core/src/content_lifecycle.rs
+++ b/crates/kamn-core/src/content_lifecycle.rs
@@ -1,0 +1,318 @@
+use crate::{cid_from_content_uri, content_uri_for_cid, ContentStorageError};
+use std::collections::BTreeMap;
+use std::fmt;
+
+const SHORT_LIVED_RETAIN_SECS: u64 = 3_600;
+const SHORT_LIVED_TOMBSTONE_SECS: u64 = 3_600;
+const STANDARD_RETAIN_SECS: u64 = 86_400;
+const STANDARD_TOMBSTONE_SECS: u64 = 86_400;
+const COMPLIANCE_RETAIN_SECS: u64 = 31_536_000;
+const COMPLIANCE_TOMBSTONE_SECS: u64 = 31_536_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentRetentionClass {
+    ShortLived,
+    Standard,
+    Compliance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContentRetentionProfile {
+    pub retain_for_secs: u64,
+    pub tombstone_for_secs: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentLifecycleStatus {
+    Active,
+    Expired,
+    Tombstoned,
+    Purged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentCleanupActionKind {
+    Tombstone,
+    Purge,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentCleanupAction {
+    pub cid: String,
+    pub action: ContentCleanupActionKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentLifecycleRecord {
+    pub cid: String,
+    pub retention_class: ContentRetentionClass,
+    pub created_at_unix: u64,
+    pub expires_at_unix: u64,
+    pub tombstoned_at_unix: Option<u64>,
+    pub purge_after_unix: Option<u64>,
+    pub purged_at_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ContentLifecycleManager {
+    records: BTreeMap<String, ContentLifecycleRecord>,
+}
+
+impl ContentLifecycleManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn retention_profile(class: ContentRetentionClass) -> ContentRetentionProfile {
+        match class {
+            ContentRetentionClass::ShortLived => ContentRetentionProfile {
+                retain_for_secs: SHORT_LIVED_RETAIN_SECS,
+                tombstone_for_secs: SHORT_LIVED_TOMBSTONE_SECS,
+            },
+            ContentRetentionClass::Standard => ContentRetentionProfile {
+                retain_for_secs: STANDARD_RETAIN_SECS,
+                tombstone_for_secs: STANDARD_TOMBSTONE_SECS,
+            },
+            ContentRetentionClass::Compliance => ContentRetentionProfile {
+                retain_for_secs: COMPLIANCE_RETAIN_SECS,
+                tombstone_for_secs: COMPLIANCE_TOMBSTONE_SECS,
+            },
+        }
+    }
+
+    pub fn register(
+        &mut self,
+        cid: &str,
+        retention_class: ContentRetentionClass,
+        created_at_unix: u64,
+    ) -> Result<ContentLifecycleRecord, ContentLifecycleError> {
+        validate_cid(cid)?;
+        if created_at_unix == 0 {
+            return Err(ContentLifecycleError::EmptyField("created_at_unix"));
+        }
+        if self.records.contains_key(cid) {
+            return Err(ContentLifecycleError::DuplicateContent(cid.to_owned()));
+        }
+
+        let profile = Self::retention_profile(retention_class);
+        let record = ContentLifecycleRecord {
+            cid: cid.to_owned(),
+            retention_class,
+            created_at_unix,
+            expires_at_unix: created_at_unix.saturating_add(profile.retain_for_secs),
+            tombstoned_at_unix: None,
+            purge_after_unix: None,
+            purged_at_unix: None,
+        };
+        self.records.insert(cid.to_owned(), record.clone());
+        Ok(record)
+    }
+
+    pub fn apply_tombstone(
+        &mut self,
+        cid: &str,
+        tombstoned_at_unix: u64,
+    ) -> Result<ContentLifecycleRecord, ContentLifecycleError> {
+        if tombstoned_at_unix == 0 {
+            return Err(ContentLifecycleError::EmptyField("tombstoned_at_unix"));
+        }
+        let record = self
+            .records
+            .get_mut(cid)
+            .ok_or_else(|| ContentLifecycleError::NotFound(cid.to_owned()))?;
+        if record.purged_at_unix.is_some() {
+            return Err(ContentLifecycleError::Purged(cid.to_owned()));
+        }
+        if record.tombstoned_at_unix.is_none() {
+            let profile = Self::retention_profile(record.retention_class);
+            record.tombstoned_at_unix = Some(tombstoned_at_unix);
+            record.purge_after_unix =
+                Some(tombstoned_at_unix.saturating_add(profile.tombstone_for_secs));
+        }
+        Ok(record.clone())
+    }
+
+    pub fn lifecycle_status(
+        &self,
+        cid: &str,
+        now_unix: u64,
+    ) -> Result<ContentLifecycleStatus, ContentLifecycleError> {
+        let record = self
+            .records
+            .get(cid)
+            .ok_or_else(|| ContentLifecycleError::NotFound(cid.to_owned()))?;
+        if record.purged_at_unix.is_some() {
+            return Ok(ContentLifecycleStatus::Purged);
+        }
+        if record.tombstoned_at_unix.is_some() {
+            return Ok(ContentLifecycleStatus::Tombstoned);
+        }
+        if now_unix > record.expires_at_unix {
+            return Ok(ContentLifecycleStatus::Expired);
+        }
+        Ok(ContentLifecycleStatus::Active)
+    }
+
+    pub fn cleanup_due(&self, now_unix: u64) -> Vec<ContentCleanupAction> {
+        let mut actions = Vec::new();
+        for (cid, record) in &self.records {
+            if record.purged_at_unix.is_some() {
+                continue;
+            }
+            if let Some(purge_after_unix) = record.purge_after_unix {
+                if now_unix > purge_after_unix {
+                    actions.push(ContentCleanupAction {
+                        cid: cid.clone(),
+                        action: ContentCleanupActionKind::Purge,
+                    });
+                }
+                continue;
+            }
+            if now_unix > record.expires_at_unix {
+                actions.push(ContentCleanupAction {
+                    cid: cid.clone(),
+                    action: ContentCleanupActionKind::Tombstone,
+                });
+            }
+        }
+        actions
+    }
+
+    pub fn execute_cleanup(
+        &mut self,
+        cid: &str,
+        now_unix: u64,
+    ) -> Result<ContentCleanupActionKind, ContentLifecycleError> {
+        let record = self
+            .records
+            .get_mut(cid)
+            .ok_or_else(|| ContentLifecycleError::NotFound(cid.to_owned()))?;
+        if record.purged_at_unix.is_some() {
+            return Err(ContentLifecycleError::Purged(cid.to_owned()));
+        }
+        if let Some(purge_after_unix) = record.purge_after_unix {
+            if now_unix > purge_after_unix {
+                record.purged_at_unix = Some(now_unix);
+                return Ok(ContentCleanupActionKind::Purge);
+            }
+            return Err(ContentLifecycleError::NoCleanupDue(cid.to_owned()));
+        }
+        if now_unix > record.expires_at_unix {
+            let profile = Self::retention_profile(record.retention_class);
+            record.tombstoned_at_unix = Some(now_unix);
+            record.purge_after_unix = Some(now_unix.saturating_add(profile.tombstone_for_secs));
+            return Ok(ContentCleanupActionKind::Tombstone);
+        }
+        Err(ContentLifecycleError::NoCleanupDue(cid.to_owned()))
+    }
+
+    pub fn assert_accessible(&self, cid: &str, now_unix: u64) -> Result<(), ContentLifecycleError> {
+        match self.lifecycle_status(cid, now_unix)? {
+            ContentLifecycleStatus::Active => Ok(()),
+            ContentLifecycleStatus::Expired => Err(ContentLifecycleError::Expired(cid.to_owned())),
+            ContentLifecycleStatus::Tombstoned => {
+                Err(ContentLifecycleError::Tombstoned(cid.to_owned()))
+            }
+            ContentLifecycleStatus::Purged => Err(ContentLifecycleError::Purged(cid.to_owned())),
+        }
+    }
+
+    pub fn assert_uri_accessible(
+        &self,
+        content_uri: &str,
+        now_unix: u64,
+    ) -> Result<String, ContentLifecycleError> {
+        let cid = cid_from_content_uri(content_uri)
+            .map_err(|_| ContentLifecycleError::InvalidContentUri(content_uri.to_owned()))?;
+        self.assert_accessible(&cid, now_unix)?;
+        Ok(cid)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentLifecycleError {
+    EmptyField(&'static str),
+    InvalidCid(String),
+    InvalidContentUri(String),
+    DuplicateContent(String),
+    NotFound(String),
+    NoCleanupDue(String),
+    Expired(String),
+    Tombstoned(String),
+    Purged(String),
+}
+
+impl fmt::Display for ContentLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidCid(cid) => write!(f, "invalid cid: {cid}"),
+            Self::InvalidContentUri(uri) => write!(f, "invalid content uri: {uri}"),
+            Self::DuplicateContent(cid) => write!(f, "duplicate lifecycle registration: {cid}"),
+            Self::NotFound(cid) => write!(f, "content lifecycle record not found: {cid}"),
+            Self::NoCleanupDue(cid) => write!(f, "no cleanup action due for {cid}"),
+            Self::Expired(cid) => write!(f, "content is expired: {cid}"),
+            Self::Tombstoned(cid) => write!(f, "content is tombstoned: {cid}"),
+            Self::Purged(cid) => write!(f, "content is purged: {cid}"),
+        }
+    }
+}
+
+impl std::error::Error for ContentLifecycleError {}
+
+fn validate_cid(cid: &str) -> Result<(), ContentLifecycleError> {
+    content_uri_for_cid(cid)
+        .map(|_| ())
+        .map_err(|error| match error {
+            ContentStorageError::InvalidCid(_) => ContentLifecycleError::InvalidCid(cid.to_owned()),
+            _ => ContentLifecycleError::InvalidCid(cid.to_owned()),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ContentLifecycleError, ContentLifecycleManager, ContentLifecycleStatus,
+        ContentRetentionClass,
+    };
+
+    #[test]
+    fn register_rejects_duplicate_cid() {
+        let mut manager = ContentLifecycleManager::new();
+        manager
+            .register(
+                "kamn:cid:v1:aaaaaaaaaaaaaaaa",
+                ContentRetentionClass::ShortLived,
+                1,
+            )
+            .expect("first registration should succeed");
+        assert_eq!(
+            manager.register(
+                "kamn:cid:v1:aaaaaaaaaaaaaaaa",
+                ContentRetentionClass::ShortLived,
+                2,
+            ),
+            Err(ContentLifecycleError::DuplicateContent(
+                "kamn:cid:v1:aaaaaaaaaaaaaaaa".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn status_reports_expired_after_ttl_boundary() {
+        let mut manager = ContentLifecycleManager::new();
+        let record = manager
+            .register(
+                "kamn:cid:v1:bbbbbbbbbbbbbbbb",
+                ContentRetentionClass::ShortLived,
+                10,
+            )
+            .expect("register should succeed");
+        assert_eq!(
+            manager
+                .lifecycle_status("kamn:cid:v1:bbbbbbbbbbbbbbbb", record.expires_at_unix + 1)
+                .expect("status should resolve"),
+            ContentLifecycleStatus::Expired
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bridge_adapter;
 pub mod channel_models;
 pub mod channel_policies;
 pub mod config;
+pub mod content_lifecycle;
 pub mod content_replication;
 pub mod content_retrieval;
 pub mod content_storage;
@@ -74,6 +75,10 @@ pub use channel_policies::{
 pub use config::{
     ConfigError, NodeConfig, NodeRole, SyncMode, SyncOperationalProfile, SyncRecoveryStrategy,
     SyncStartupStrategy,
+};
+pub use content_lifecycle::{
+    ContentCleanupAction, ContentCleanupActionKind, ContentLifecycleError, ContentLifecycleManager,
+    ContentLifecycleRecord, ContentLifecycleStatus, ContentRetentionClass, ContentRetentionProfile,
 };
 pub use content_replication::{
     ContentAvailabilityAlert, ContentAvailabilityHealth, ContentAvailabilitySnapshot,

--- a/crates/kamn-core/tests/content_retention_tombstones.rs
+++ b/crates/kamn-core/tests/content_retention_tombstones.rs
@@ -1,0 +1,141 @@
+use kamn_core::{
+    content_uri_for_cid, ContentCleanupActionKind, ContentLifecycleError, ContentLifecycleManager,
+    ContentLifecycleStatus, ContentRetentionClass, ContentStorageAdapter, InMemoryContentAdapter,
+    TaskArtifactRegistry, TaskArtifactSubmission,
+};
+
+#[test]
+fn content_retention_profiles_define_positive_ttl_windows() {
+    let short = ContentLifecycleManager::retention_profile(ContentRetentionClass::ShortLived);
+    let standard = ContentLifecycleManager::retention_profile(ContentRetentionClass::Standard);
+    let compliance = ContentLifecycleManager::retention_profile(ContentRetentionClass::Compliance);
+
+    assert!(short.retain_for_secs > 0);
+    assert!(short.tombstone_for_secs > 0);
+    assert!(standard.retain_for_secs >= short.retain_for_secs);
+    assert!(compliance.retain_for_secs >= standard.retain_for_secs);
+}
+
+#[test]
+fn content_retention_transitions_active_to_expired_to_tombstoned() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/json", br#"{"v":1}"#)
+        .expect("put should succeed");
+
+    let mut manager = ContentLifecycleManager::new();
+    let record = manager
+        .register(&head.cid, ContentRetentionClass::ShortLived, 1_716_001_000)
+        .expect("register should succeed");
+
+    let active = manager
+        .lifecycle_status(&head.cid, record.created_at_unix)
+        .expect("status lookup should succeed");
+    assert_eq!(active, ContentLifecycleStatus::Active);
+
+    let expired = manager
+        .lifecycle_status(&head.cid, record.expires_at_unix + 1)
+        .expect("status lookup should succeed");
+    assert_eq!(expired, ContentLifecycleStatus::Expired);
+
+    manager
+        .execute_cleanup(&head.cid, record.expires_at_unix + 1)
+        .expect("cleanup should tombstone expired content");
+    let tombstoned = manager
+        .lifecycle_status(&head.cid, record.expires_at_unix + 1)
+        .expect("status lookup should succeed");
+    assert_eq!(tombstoned, ContentLifecycleStatus::Tombstoned);
+}
+
+#[test]
+fn content_retention_cleanup_plan_is_deterministic_and_safe() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let first = adapter
+        .put("application/octet-stream", b"a")
+        .expect("put should succeed");
+    let second = adapter
+        .put("application/octet-stream", b"b")
+        .expect("put should succeed");
+
+    let mut manager = ContentLifecycleManager::new();
+    manager
+        .register(
+            &second.cid,
+            ContentRetentionClass::ShortLived,
+            1_716_002_000,
+        )
+        .expect("register should succeed");
+    manager
+        .register(&first.cid, ContentRetentionClass::ShortLived, 1_716_002_000)
+        .expect("register should succeed");
+
+    let after_expiry = 1_716_006_000;
+    let plan = manager.cleanup_due(after_expiry);
+    assert_eq!(plan.len(), 2);
+    assert_eq!(plan[0].action, ContentCleanupActionKind::Tombstone);
+    assert!(plan[0].cid < plan[1].cid);
+}
+
+#[test]
+fn content_retention_integration_blocks_tombstoned_task_artifact_reference() {
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/pdf", b"%PDF-1.7 content")
+        .expect("put should succeed");
+    let uri = content_uri_for_cid(&head.cid).expect("uri should build");
+
+    let mut registry = TaskArtifactRegistry::new();
+    let on_chain_hash =
+        TaskArtifactRegistry::integrity_fingerprint("task-901", "kamn:did:agent:builder-1", &uri);
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-901".to_owned(),
+            task_id: "task-901".to_owned(),
+            creator: "kamn:did:agent:builder-1".to_owned(),
+            created_at_unix: 1_716_002_500,
+            on_chain_hash,
+            off_chain_uri: uri.clone(),
+            content_type: "application/pdf".to_owned(),
+        })
+        .expect("artifact registration should succeed");
+
+    let mut manager = ContentLifecycleManager::new();
+    manager
+        .register(&head.cid, ContentRetentionClass::ShortLived, 1_716_002_500)
+        .expect("register should succeed");
+    manager
+        .apply_tombstone(&head.cid, 1_716_003_000)
+        .expect("tombstone should succeed");
+
+    assert!(matches!(
+        manager.assert_uri_accessible(&uri, 1_716_003_001),
+        Err(ContentLifecycleError::Tombstoned(_))
+    ));
+}
+
+#[test]
+fn content_retention_regression_deleted_reference_replay_stays_blocked() {
+    // Regression: #163
+    let mut adapter = InMemoryContentAdapter::new();
+    let head = adapter
+        .put("application/octet-stream", b"to-delete")
+        .expect("put should succeed");
+
+    let mut manager = ContentLifecycleManager::new();
+    manager
+        .register(&head.cid, ContentRetentionClass::ShortLived, 1_716_004_000)
+        .expect("register should succeed");
+    manager
+        .apply_tombstone(&head.cid, 1_716_004_100)
+        .expect("tombstone should succeed");
+
+    let profile = ContentLifecycleManager::retention_profile(ContentRetentionClass::ShortLived);
+    manager
+        .execute_cleanup(&head.cid, 1_716_004_100 + profile.tombstone_for_secs + 1)
+        .expect("cleanup should purge tombstone");
+
+    assert!(matches!(
+        manager.assert_accessible(&head.cid, 1_716_004_100 + profile.tombstone_for_secs + 2),
+        Err(ContentLifecycleError::Purged(_))
+    ));
+}

--- a/crates/kamn-core/tests/content_retention_tombstones_docs.rs
+++ b/crates/kamn-core/tests/content_retention_tombstones_docs.rs
@@ -1,0 +1,30 @@
+const DOC: &str = include_str!("../../../docs/foundation/content-retention-tombstones.md");
+
+#[test]
+fn doc_contains_retention_class_and_lifecycle_scope() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("ContentRetentionClass"));
+    assert!(DOC.contains("ContentLifecycleManager"));
+    assert!(DOC.contains("ContentCleanupActionKind"));
+}
+
+#[test]
+fn doc_contains_cleanup_and_deleted_reference_rules() {
+    assert!(DOC.contains("## Lifecycle and Cleanup Rules"));
+    assert!(DOC.contains("Active` -> `Expired` -> `Tombstoned` -> `Purged"));
+    assert!(DOC.contains("## Deleted Reference Semantics"));
+    assert!(DOC.contains("assert_uri_accessible(...)"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test content_retention_tombstones"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_deleted_reference_replay_block_rule() {
+    // Regression: #163
+    assert!(DOC.contains("Deleted/tombstoned references remain blocked under replay attempts."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -80,6 +80,7 @@ For task artifact integrity references and provenance metadata controls, see `do
 For content-addressed storage adapter contract and integrity verification controls, see `docs/foundation/content-storage-adapter.md`.
 For content pinning, replication, and repair policy controls, see `docs/foundation/content-replication-repair.md`.
 For secure off-chain retrieval access, cache TTL, and audit controls, see `docs/foundation/content-retrieval-access-cache.md`.
+For retention-class tombstone and cleanup lifecycle controls, see `docs/foundation/content-retention-tombstones.md`.
 For bridge inbound/outbound adapter abstraction controls, see `docs/foundation/bridge-adapter-abstraction.md`.
 For Telegram bridge listener-validated inbound flow controls, see `docs/foundation/telegram-bridge-listener-validation.md`.
 For Discord bridge approver-gated outbound flow controls, see `docs/foundation/discord-bridge-approver-gating.md`.

--- a/docs/foundation/content-retention-tombstones.md
+++ b/docs/foundation/content-retention-tombstones.md
@@ -1,0 +1,43 @@
+# Off-Chain Retention, Tombstones, and Cleanup Lifecycle Controls (Issues #162 / #163)
+
+This document captures the first implementation slice for retention-class lifecycle controls and deterministic cleanup handling.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/content_lifecycle.rs` with:
+  - `ContentRetentionClass` and `ContentRetentionProfile`.
+  - `ContentLifecycleManager` for registration, tombstoning, cleanup planning, and cleanup execution.
+  - `ContentLifecycleStatus` and `ContentCleanupActionKind`.
+  - URI accessibility enforcement via `assert_uri_accessible(...)`.
+  - typed errors via `ContentLifecycleError`.
+- Added integration and regression tests in `crates/kamn-core/tests/content_retention_tombstones.rs`.
+
+## Lifecycle and Cleanup Rules
+- Retention classes map to deterministic retention and tombstone windows.
+- Lifecycle progression:
+  - `Active` -> `Expired` -> `Tombstoned` -> `Purged`
+- Cleanup planning:
+  - expired content yields deterministic tombstone actions.
+  - tombstoned content past `purge_after_unix` yields purge actions.
+- Cleanup safety:
+  - purge operations require tombstone retention window to elapse.
+  - no-op cleanup calls return explicit `NoCleanupDue` errors.
+
+## Deleted Reference Semantics
+- `assert_accessible(...)` blocks access for `Expired`, `Tombstoned`, and `Purged` records with explicit typed errors.
+- `assert_uri_accessible(...)` parses canonical content URI and enforces the same lifecycle gate.
+- Deleted/tombstoned references remain blocked under replay attempts.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test content_retention_tombstones --test content_retention_tombstones_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first off-chain retention/tombstone lifecycle slice by adding retention class profiles, deterministic cleanup planning, and explicit deleted-reference failure semantics.
This delivers tombstone-to-purge progression and URI-level accessibility enforcement for referenced content.

Closes #163
Closes #162
Closes #95

## Changes
- `crates/kamn-core/src/content_lifecycle.rs`: added retention classes/profiles, lifecycle manager, status model, cleanup actions, URI accessibility checks, typed errors, and unit tests.
- `crates/kamn-core/src/lib.rs`: exported content lifecycle API surface.
- `crates/kamn-core/tests/content_retention_tombstones.rs`: added functional/integration/regression coverage for lifecycle transitions, deterministic cleanup, and replay blocking.
- `crates/kamn-core/tests/content_retention_tombstones_docs.rs`: added doc assertions and regression doc guard.
- `docs/foundation/content-retention-tombstones.md`: documented lifecycle contract and low-cost validation lane.
- `docs/foundation/bootstrap.md`: linked new lifecycle foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test content_retention_tombstones
```
Output excerpt:
```text
error[E0432]: unresolved imports `kamn_core::ContentCleanupActionKind`, `kamn_core::ContentLifecycleError`, `kamn_core::ContentLifecycleManager`, `kamn_core::ContentLifecycleStatus`, `kamn_core::ContentRetentionClass`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test content_retention_tombstones --test content_retention_tombstones_docs
```
Output summary:
```text
test result: ok. 5 passed; 0 failed (content_retention_tombstones)
test result: ok. 4 passed; 0 failed (content_retention_tombstones_docs)
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Output summary:
```text
fmt check: clean
clippy: Finished with no warnings
kamn-core tests: all passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `content_lifecycle::tests::*` in `crates/kamn-core/src/content_lifecycle.rs` | |
| Functional   | ✅     | lifecycle transition and cleanup planning tests in `content_retention_tombstones.rs` | |
| Integration  | ✅     | `content_retention_integration_blocks_tombstoned_task_artifact_reference` | |
| Regression   | ✅     | `content_retention_regression_deleted_reference_replay_stays_blocked` (`// Regression: #163`) and docs regression assertion | |
| Performance  | N/A    | None | No throughput/load hotspot introduced in this lifecycle control slice |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove lifecycle module and wiring.

## Documentation Updates
- `docs/foundation/content-retention-tombstones.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate lane: `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
