### PR TITLE
feat(dashboard): add operator backend API read models

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod migrations;
 pub mod namespaces;
 pub mod observability;
 pub mod operator_binding;
+pub mod operator_dashboard_api;
 pub mod performance_targets;
 pub mod redaction_compliance;
 pub mod reputation_signals;
@@ -156,6 +157,11 @@ pub use observability::{
 pub use operator_binding::{
     OperatorBindingAction, OperatorBindingEngine, OperatorBindingError, OperatorBindingProof,
     OperatorBindingRecord,
+};
+pub use operator_dashboard_api::{
+    DashboardPage, DashboardPageRequest, OperatorAgentView, OperatorDashboardApi,
+    OperatorDashboardApiError, OperatorDashboardSnapshot, OperatorEscrowView, OperatorMessageView,
+    OperatorReputationView, OperatorTaskView,
 };
 pub use performance_targets::{
     evaluate_performance_from_observability, evaluate_performance_run, PerformanceAggregate,

--- a/crates/kamn-core/src/operator_dashboard_api.rs
+++ b/crates/kamn-core/src/operator_dashboard_api.rs
@@ -1,0 +1,381 @@
+use crate::{
+    AgentDid, AgentKeyHierarchy, EscrowLifecycle, EscrowStatus, KeyRole, MessageLifecycleStore,
+    MessageStatus, ReputationError, TaskOperationError, TaskOperationRecord, TaskState,
+};
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DashboardPageRequest {
+    pub limit: usize,
+    pub cursor: Option<String>,
+    pub filter_prefix: Option<String>,
+}
+
+impl DashboardPageRequest {
+    pub fn new(
+        limit: usize,
+        cursor: Option<String>,
+        filter_prefix: Option<String>,
+    ) -> Result<Self, OperatorDashboardApiError> {
+        if limit == 0 {
+            return Err(OperatorDashboardApiError::InvalidPageLimit(0));
+        }
+        Ok(Self {
+            limit,
+            cursor,
+            filter_prefix,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DashboardPage<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorAgentView {
+    pub agent_did: String,
+    pub identity_key_id: String,
+    pub signing_key_id: String,
+    pub agreement_key_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorTaskView {
+    pub task_id: String,
+    pub requester: String,
+    pub assignee: Option<String>,
+    pub state: TaskState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorMessageView {
+    pub message_id: String,
+    pub sender: String,
+    pub recipients: Vec<String>,
+    pub status: MessageStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorEscrowView {
+    pub escrow_id: String,
+    pub payer: String,
+    pub payee: String,
+    pub status: EscrowStatus,
+    pub remaining_amount: u128,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorReputationView {
+    pub agent_did: String,
+    pub trust_score: u32,
+    pub delivery_rate: f64,
+    pub dispute_rate: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorDashboardSnapshot {
+    pub agents: DashboardPage<OperatorAgentView>,
+    pub tasks: DashboardPage<OperatorTaskView>,
+    pub messages: DashboardPage<OperatorMessageView>,
+    pub escrows: DashboardPage<OperatorEscrowView>,
+    pub reputation: DashboardPage<OperatorReputationView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct OperatorDashboardApi {
+    agents: BTreeMap<String, OperatorAgentView>,
+    tasks: BTreeMap<String, OperatorTaskView>,
+    messages: BTreeMap<String, OperatorMessageView>,
+    escrows: BTreeMap<String, OperatorEscrowView>,
+    reputation: BTreeMap<String, OperatorReputationView>,
+}
+
+impl OperatorDashboardApi {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn upsert_agent_from_hierarchy(
+        &mut self,
+        agent_did: &str,
+        hierarchy: &AgentKeyHierarchy,
+    ) -> Result<(), OperatorDashboardApiError> {
+        validate_did(agent_did)?;
+        let identity_key_id = hierarchy
+            .current_key(KeyRole::Identity)
+            .map_err(|error| OperatorDashboardApiError::Hierarchy(error.to_string()))?
+            .to_owned();
+        let signing_key_id = hierarchy
+            .current_key(KeyRole::Signing)
+            .map_err(|error| OperatorDashboardApiError::Hierarchy(error.to_string()))?
+            .to_owned();
+        let agreement_key_id = hierarchy
+            .current_key(KeyRole::Agreement)
+            .map_err(|error| OperatorDashboardApiError::Hierarchy(error.to_string()))?
+            .to_owned();
+
+        self.agents.insert(
+            agent_did.to_owned(),
+            OperatorAgentView {
+                agent_did: agent_did.to_owned(),
+                identity_key_id,
+                signing_key_id,
+                agreement_key_id,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn upsert_task(
+        &mut self,
+        task: &TaskOperationRecord,
+    ) -> Result<(), OperatorDashboardApiError> {
+        if task.task_id.trim().is_empty() {
+            return Err(OperatorDashboardApiError::EmptyField("task_id"));
+        }
+        validate_did(&task.requester)?;
+        if let Some(assignee) = task.assignee.as_deref() {
+            validate_did(assignee)?;
+        }
+        self.tasks.insert(
+            task.task_id.clone(),
+            OperatorTaskView {
+                task_id: task.task_id.clone(),
+                requester: task.requester.clone(),
+                assignee: task.assignee.clone(),
+                state: task.lifecycle.state(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn upsert_message_from_store(
+        &mut self,
+        store: &MessageLifecycleStore,
+        message_id: &str,
+    ) -> Result<(), OperatorDashboardApiError> {
+        let status = store
+            .status(message_id)
+            .map_err(|error| OperatorDashboardApiError::Message(error.to_string()))?;
+        let (sender, recipients) = store
+            .participants(message_id)
+            .map_err(|error| OperatorDashboardApiError::Message(error.to_string()))?;
+        validate_did(sender)?;
+        for recipient in recipients {
+            validate_did(recipient)?;
+        }
+
+        self.messages.insert(
+            message_id.to_owned(),
+            OperatorMessageView {
+                message_id: message_id.to_owned(),
+                sender: sender.to_owned(),
+                recipients: recipients.to_vec(),
+                status,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn upsert_escrow(
+        &mut self,
+        escrow_id: &str,
+        payer: &str,
+        payee: &str,
+        escrow: &EscrowLifecycle,
+    ) -> Result<(), OperatorDashboardApiError> {
+        if escrow_id.trim().is_empty() {
+            return Err(OperatorDashboardApiError::EmptyField("escrow_id"));
+        }
+        validate_did(payer)?;
+        validate_did(payee)?;
+
+        self.escrows.insert(
+            escrow_id.to_owned(),
+            OperatorEscrowView {
+                escrow_id: escrow_id.to_owned(),
+                payer: payer.to_owned(),
+                payee: payee.to_owned(),
+                status: escrow.status(),
+                remaining_amount: escrow.remaining_amount(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn upsert_reputation(
+        &mut self,
+        reputation: &crate::AgentReputation,
+    ) -> Result<(), OperatorDashboardApiError> {
+        validate_did(&reputation.agent_did)?;
+        self.reputation.insert(
+            reputation.agent_did.clone(),
+            OperatorReputationView {
+                agent_did: reputation.agent_did.clone(),
+                trust_score: reputation.trust_score,
+                delivery_rate: reputation.delivery_rate,
+                dispute_rate: reputation.dispute_rate,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn list_agents(
+        &self,
+        request: &DashboardPageRequest,
+    ) -> Result<DashboardPage<OperatorAgentView>, OperatorDashboardApiError> {
+        paginate_map(&self.agents, request)
+    }
+
+    pub fn list_tasks(
+        &self,
+        request: &DashboardPageRequest,
+    ) -> Result<DashboardPage<OperatorTaskView>, OperatorDashboardApiError> {
+        paginate_map(&self.tasks, request)
+    }
+
+    pub fn list_messages(
+        &self,
+        request: &DashboardPageRequest,
+    ) -> Result<DashboardPage<OperatorMessageView>, OperatorDashboardApiError> {
+        paginate_map(&self.messages, request)
+    }
+
+    pub fn list_escrows(
+        &self,
+        request: &DashboardPageRequest,
+    ) -> Result<DashboardPage<OperatorEscrowView>, OperatorDashboardApiError> {
+        paginate_map(&self.escrows, request)
+    }
+
+    pub fn list_reputation(
+        &self,
+        request: &DashboardPageRequest,
+    ) -> Result<DashboardPage<OperatorReputationView>, OperatorDashboardApiError> {
+        paginate_map(&self.reputation, request)
+    }
+
+    pub fn snapshot(
+        &self,
+        request: &DashboardPageRequest,
+    ) -> Result<OperatorDashboardSnapshot, OperatorDashboardApiError> {
+        Ok(OperatorDashboardSnapshot {
+            agents: self.list_agents(request)?,
+            tasks: self.list_tasks(request)?,
+            messages: self.list_messages(request)?,
+            escrows: self.list_escrows(request)?,
+            reputation: self.list_reputation(request)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperatorDashboardApiError {
+    InvalidPageLimit(usize),
+    InvalidPaginationCursor(String),
+    EmptyField(&'static str),
+    InvalidDid(String),
+    Hierarchy(String),
+    Message(String),
+    Task(String),
+    Reputation(String),
+}
+
+impl fmt::Display for OperatorDashboardApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPageLimit(limit) => {
+                write!(f, "page limit must be positive, found {limit}")
+            }
+            Self::InvalidPaginationCursor(cursor) => {
+                write!(f, "invalid pagination cursor: {cursor}")
+            }
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::Hierarchy(value) => write!(f, "key hierarchy error: {value}"),
+            Self::Message(value) => write!(f, "message lifecycle error: {value}"),
+            Self::Task(value) => write!(f, "task operation error: {value}"),
+            Self::Reputation(value) => write!(f, "reputation error: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for OperatorDashboardApiError {}
+
+impl From<TaskOperationError> for OperatorDashboardApiError {
+    fn from(value: TaskOperationError) -> Self {
+        Self::Task(value.to_string())
+    }
+}
+
+impl From<ReputationError> for OperatorDashboardApiError {
+    fn from(value: ReputationError) -> Self {
+        Self::Reputation(value.to_string())
+    }
+}
+
+fn validate_did(value: &str) -> Result<(), OperatorDashboardApiError> {
+    AgentDid::parse(value)
+        .map_err(|error| OperatorDashboardApiError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn paginate_map<T: Clone>(
+    values: &BTreeMap<String, T>,
+    request: &DashboardPageRequest,
+) -> Result<DashboardPage<T>, OperatorDashboardApiError> {
+    if request.limit == 0 {
+        return Err(OperatorDashboardApiError::InvalidPageLimit(0));
+    }
+
+    let mut keys: Vec<String> = values.keys().cloned().collect();
+    if let Some(prefix) = request.filter_prefix.as_deref() {
+        keys.retain(|key| key.starts_with(prefix));
+    }
+
+    let start_idx = if let Some(cursor) = request.cursor.as_deref() {
+        let Some(position) = keys.iter().position(|key| key == cursor) else {
+            return Err(OperatorDashboardApiError::InvalidPaginationCursor(
+                cursor.to_owned(),
+            ));
+        };
+        position + 1
+    } else {
+        0
+    };
+
+    let page_keys: Vec<String> = keys
+        .iter()
+        .skip(start_idx)
+        .take(request.limit)
+        .cloned()
+        .collect();
+    let items = page_keys
+        .iter()
+        .filter_map(|key| values.get(key).cloned())
+        .collect();
+    let next_cursor = if start_idx + page_keys.len() < keys.len() {
+        page_keys.last().cloned()
+    } else {
+        None
+    };
+
+    Ok(DashboardPage { items, next_cursor })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DashboardPageRequest, OperatorDashboardApiError};
+
+    #[test]
+    fn request_rejects_zero_limit() {
+        assert_eq!(
+            DashboardPageRequest::new(0, None, None),
+            Err(OperatorDashboardApiError::InvalidPageLimit(0))
+        );
+    }
+}

--- a/crates/kamn-core/tests/operator_dashboard_api.rs
+++ b/crates/kamn-core/tests/operator_dashboard_api.rs
@@ -1,0 +1,137 @@
+use kamn_core::{
+    AgentKeyHierarchy, DashboardPageRequest, EscrowLifecycle, MessageLifecycleStore,
+    OperatorDashboardApi, OperatorDashboardApiError, ReputationStore, TaskOperationEngine,
+};
+
+#[test]
+fn operator_dashboard_api_rejects_zero_page_limit() {
+    assert_eq!(
+        DashboardPageRequest::new(0, None, None),
+        Err(OperatorDashboardApiError::InvalidPageLimit(0))
+    );
+}
+
+#[test]
+fn operator_dashboard_api_lists_agents_with_deterministic_pagination_and_filtering() {
+    let mut api = OperatorDashboardApi::new();
+    let base_hierarchy =
+        AgentKeyHierarchy::new("id-1", "sig-1", "agr-1").expect("hierarchy should initialize");
+    api.upsert_agent_from_hierarchy("kamn:did:agent:alpha-1", &base_hierarchy)
+        .expect("agent should upsert");
+    api.upsert_agent_from_hierarchy("kamn:did:agent:alpha-2", &base_hierarchy)
+        .expect("agent should upsert");
+    api.upsert_agent_from_hierarchy("kamn:did:agent:beta-1", &base_hierarchy)
+        .expect("agent should upsert");
+
+    let first = api
+        .list_agents(&DashboardPageRequest::new(2, None, None).expect("request should be valid"))
+        .expect("list should succeed");
+    assert_eq!(first.items.len(), 2);
+    assert_eq!(first.items[0].agent_did, "kamn:did:agent:alpha-1");
+    assert_eq!(first.items[1].agent_did, "kamn:did:agent:alpha-2");
+    assert_eq!(first.next_cursor, Some("kamn:did:agent:alpha-2".to_owned()));
+
+    let second = api
+        .list_agents(
+            &DashboardPageRequest::new(2, first.next_cursor.clone(), None)
+                .expect("request should be valid"),
+        )
+        .expect("second page should succeed");
+    assert_eq!(second.items.len(), 1);
+    assert_eq!(second.items[0].agent_did, "kamn:did:agent:beta-1");
+
+    let filtered = api
+        .list_agents(
+            &DashboardPageRequest::new(10, None, Some("kamn:did:agent:alpha".to_owned()))
+                .expect("request should be valid"),
+        )
+        .expect("filtered list should succeed");
+    assert_eq!(filtered.items.len(), 2);
+}
+
+#[test]
+fn operator_dashboard_api_builds_cross_domain_snapshot_from_core_modules() {
+    let mut api = OperatorDashboardApi::new();
+
+    let mut hierarchy =
+        AgentKeyHierarchy::new("id-2", "sig-2", "agr-2").expect("hierarchy should initialize");
+    hierarchy
+        .register_ephemeral("session-1", "ephemeral-1", 1_800_000_000)
+        .expect("ephemeral should register");
+    api.upsert_agent_from_hierarchy("kamn:did:agent:operator-1", &hierarchy)
+        .expect("agent should upsert");
+
+    let mut tasks = TaskOperationEngine::new();
+    tasks
+        .submit(
+            "task-operator-1",
+            "kamn:did:agent:operator-1",
+            "investigate incident",
+        )
+        .expect("task should submit");
+    api.upsert_task(tasks.task("task-operator-1").expect("task should exist"))
+        .expect("task should upsert");
+
+    let mut messages = MessageLifecycleStore::new();
+    messages
+        .register(
+            "urn:uuid:msg-operator-1",
+            "kamn:did:agent:operator-1",
+            vec!["kamn:did:agent:operator-2".to_owned()],
+            "2026-02-08T12:00:00Z",
+            "2026-02-08T12:30:00Z",
+        )
+        .expect("message should register");
+    api.upsert_message_from_store(&messages, "urn:uuid:msg-operator-1")
+        .expect("message should upsert");
+
+    let mut escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+    escrow.release(40).expect("escrow release should succeed");
+    api.upsert_escrow(
+        "escrow-operator-1",
+        "kamn:did:agent:payer-1",
+        "kamn:did:agent:payee-1",
+        &escrow,
+    )
+    .expect("escrow should upsert");
+
+    let mut reputation = ReputationStore::default();
+    reputation
+        .register_agent("kamn:did:agent:operator-1", 10)
+        .expect("agent should register");
+    api.upsert_reputation(
+        reputation
+            .get_agent("kamn:did:agent:operator-1")
+            .expect("reputation should exist"),
+    )
+    .expect("reputation should upsert");
+
+    let snapshot = api
+        .snapshot(&DashboardPageRequest::new(10, None, None).expect("request should be valid"))
+        .expect("snapshot should build");
+    assert_eq!(snapshot.agents.items.len(), 1);
+    assert_eq!(snapshot.tasks.items.len(), 1);
+    assert_eq!(snapshot.messages.items.len(), 1);
+    assert_eq!(snapshot.escrows.items.len(), 1);
+    assert_eq!(snapshot.reputation.items.len(), 1);
+}
+
+#[test]
+fn operator_dashboard_api_regression_rejects_tampered_cursor_tokens() {
+    // Regression: #203
+    let mut api = OperatorDashboardApi::new();
+    let hierarchy =
+        AgentKeyHierarchy::new("id-3", "sig-3", "agr-3").expect("hierarchy should initialize");
+    api.upsert_agent_from_hierarchy("kamn:did:agent:cursor-1", &hierarchy)
+        .expect("agent should upsert");
+
+    assert_eq!(
+        api.list_agents(
+            &DashboardPageRequest::new(10, Some("tampered-cursor".to_owned()), None)
+                .expect("request should be valid"),
+        ),
+        Err(OperatorDashboardApiError::InvalidPaginationCursor(
+            "tampered-cursor".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/operator_dashboard_api_docs.rs
+++ b/crates/kamn-core/tests/operator_dashboard_api_docs.rs
@@ -1,0 +1,29 @@
+const DOC: &str = include_str!("../../../docs/foundation/operator-dashboard-backend-apis.md");
+
+#[test]
+fn doc_contains_dashboard_backend_scope_and_contracts() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("OperatorDashboardApi"));
+    assert!(DOC.contains("DashboardPageRequest"));
+    assert!(DOC.contains("snapshot(...)"));
+}
+
+#[test]
+fn doc_contains_pagination_and_filter_rules() {
+    assert!(DOC.contains("## Pagination and Filter Rules"));
+    assert!(DOC.contains("Cursor tokens must match an existing key"));
+    assert!(DOC.contains("Optional prefix filter applies before pagination."));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test operator_dashboard_api"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_tampered_cursor_rejection_rule() {
+    // Regression: #203
+    assert!(DOC.contains("Cursor tokens must match an existing key"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -98,5 +98,6 @@ For compliance audit export interface controls, see `docs/foundation/audit-expor
 For configurable retention policy enforcement controls, see `docs/foundation/retention-policy-engine.md`.
 For data classification tiers and write-path tagging enforcement controls, see `docs/foundation/data-classification-tagging.md`.
 For optional operator binding proof validation and configure/revoke/read-history permission controls, see `docs/foundation/operator-binding-permissions.md`.
+For operator dashboard backend read-model APIs and deterministic pagination controls, see `docs/foundation/operator-dashboard-backend-apis.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/operator-dashboard-backend-apis.md
+++ b/docs/foundation/operator-dashboard-backend-apis.md
@@ -1,0 +1,45 @@
+# Operator Dashboard Backend APIs (Issues #202 / #203)
+
+This document captures the first implementation slice for backend read APIs that power human-operator dashboard visibility.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/operator_dashboard_api.rs` with:
+  - `OperatorDashboardApi` read-model registry for agents, tasks, messages, escrows, and reputation.
+  - deterministic pagination/filtering via `DashboardPageRequest` and `DashboardPage<T>`.
+  - cross-domain upsert adapters:
+    - `upsert_agent_from_hierarchy(...)`
+    - `upsert_task(...)`
+    - `upsert_message_from_store(...)`
+    - `upsert_escrow(...)`
+    - `upsert_reputation(...)`
+  - unified snapshot response via `snapshot(...)`.
+  - typed errors via `OperatorDashboardApiError`.
+- Added integration and regression tests in `crates/kamn-core/tests/operator_dashboard_api.rs`.
+
+## Pagination and Filter Rules
+- Page limit must be positive.
+- Cursor tokens must match an existing key in the current filtered result set.
+- Optional prefix filter applies before pagination.
+- Ordering is deterministic (lexical key ordering from `BTreeMap`).
+
+## Operational Read Models
+- Agent view includes DID and key-role references.
+- Task view includes requester, assignee, and lifecycle state.
+- Message view includes participants and lifecycle status.
+- Escrow view includes status and remaining amount.
+- Reputation view includes trust/delivery/dispute metrics.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test operator_dashboard_api --test operator_dashboard_api_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first operator dashboard backend API slice with deterministic read models for agents, tasks, messages, escrows, and reputation.
Adds explicit pagination/filter semantics and cross-domain snapshot aggregation for operator visibility workflows.

Closes #203
Closes #202
Closes #52

## Changes
- `crates/kamn-core/src/operator_dashboard_api.rs`: added dashboard API read-model registry, page request/page response models, domain-specific view models, snapshot aggregation, typed errors, and unit tests.
- `crates/kamn-core/src/lib.rs`: exported operator dashboard API types.
- `crates/kamn-core/tests/operator_dashboard_api.rs`: added functional/integration/regression coverage for pagination/filtering, multi-domain snapshot ingestion, and cursor tampering rejection.
- `crates/kamn-core/tests/operator_dashboard_api_docs.rs`: added doc assertions and regression doc guard.
- `docs/foundation/operator-dashboard-backend-apis.md`: documented backend API contract and low-cost validation lane.
- `docs/foundation/bootstrap.md`: linked the new dashboard backend API doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test operator_dashboard_api
```
Output excerpt:
```text
error[E0432]: unresolved imports `kamn_core::DashboardPageRequest`, `kamn_core::OperatorDashboardApi`, `kamn_core::OperatorDashboardApiError`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test operator_dashboard_api --test operator_dashboard_api_docs
```
Output summary:
```text
test result: ok. 4 passed; 0 failed (operator_dashboard_api)
test result: ok. 4 passed; 0 failed (operator_dashboard_api_docs)
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Output summary:
```text
fmt check: clean
clippy: Finished with no warnings
kamn-core tests: all passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `operator_dashboard_api::tests::request_rejects_zero_limit` | |
| Functional   | ✅     | deterministic pagination/filtering and listing tests in `operator_dashboard_api.rs` | |
| Integration  | ✅     | cross-domain snapshot ingestion test using key hierarchy/task/message/escrow/reputation modules | |
| Regression   | ✅     | `operator_dashboard_api_regression_rejects_tampered_cursor_tokens` (`// Regression: #203`) and docs regression assertion | |
| Performance  | N/A    | None | No throughput hotspot introduced in this first backend API slice |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove operator dashboard backend API module and wiring.

## Documentation Updates
- `docs/foundation/operator-dashboard-backend-apis.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate lane: `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
