### PR TITLE
feat(dashboard): permissioned operator actions via binding rules

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod message_lifecycle;
 pub mod migrations;
 pub mod namespaces;
 pub mod observability;
+pub mod operator_actions;
 pub mod operator_binding;
 pub mod operator_dashboard_api;
 pub mod performance_targets;
@@ -153,6 +154,10 @@ pub use observability::{
     ObservabilityAlert, ObservabilityError, ObservabilityHealth, ObservabilityMetric,
     ObservabilityMonitor, ObservabilityReport, ObservabilitySample, ObservabilitySeverity,
     ObservabilitySloProfile, ObservabilitySnapshot,
+};
+pub use operator_actions::{
+    OperatorActionAuditRecord, OperatorActionOutcome, OperatorActionServiceError,
+    PermissionedOperatorActionService,
 };
 pub use operator_binding::{
     OperatorBindingAction, OperatorBindingEngine, OperatorBindingError, OperatorBindingProof,

--- a/crates/kamn-core/src/operator_actions.rs
+++ b/crates/kamn-core/src/operator_actions.rs
@@ -1,0 +1,214 @@
+use crate::{OperatorBindingAction, OperatorBindingEngine, OperatorBindingError};
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperatorActionOutcome {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorActionAuditRecord {
+    pub agent_did: String,
+    pub operator_did: String,
+    pub action: OperatorBindingAction,
+    pub target: String,
+    pub value: Option<String>,
+    pub requested_at_unix: u64,
+    pub outcome: OperatorActionOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionedOperatorActionService {
+    bindings: OperatorBindingEngine,
+    settings: BTreeMap<(String, String), String>,
+    audit_log: Vec<OperatorActionAuditRecord>,
+}
+
+impl PermissionedOperatorActionService {
+    pub fn new(bindings: OperatorBindingEngine) -> Self {
+        Self {
+            bindings,
+            settings: BTreeMap::new(),
+            audit_log: Vec::new(),
+        }
+    }
+
+    pub fn configure(
+        &mut self,
+        agent_did: &str,
+        operator_did: &str,
+        config_key: &str,
+        config_value: &str,
+        requested_at_unix: u64,
+    ) -> Result<(), OperatorActionServiceError> {
+        if config_key.trim().is_empty() {
+            return Err(OperatorActionServiceError::EmptyField("config_key"));
+        }
+        if config_value.trim().is_empty() {
+            return Err(OperatorActionServiceError::EmptyField("config_value"));
+        }
+        if requested_at_unix == 0 {
+            return Err(OperatorActionServiceError::EmptyField("requested_at_unix"));
+        }
+
+        if let Err(error) =
+            self.bindings
+                .authorize(agent_did, operator_did, OperatorBindingAction::Configure)
+        {
+            self.push_audit(OperatorActionAuditRecord {
+                agent_did: agent_did.to_owned(),
+                operator_did: operator_did.to_owned(),
+                action: OperatorBindingAction::Configure,
+                target: config_key.to_owned(),
+                value: Some(config_value.to_owned()),
+                requested_at_unix,
+                outcome: OperatorActionOutcome::Denied,
+            });
+            return Err(OperatorActionServiceError::Binding(error.to_string()));
+        }
+
+        self.settings.insert(
+            (agent_did.to_owned(), config_key.to_owned()),
+            config_value.to_owned(),
+        );
+        self.push_audit(OperatorActionAuditRecord {
+            agent_did: agent_did.to_owned(),
+            operator_did: operator_did.to_owned(),
+            action: OperatorBindingAction::Configure,
+            target: config_key.to_owned(),
+            value: Some(config_value.to_owned()),
+            requested_at_unix,
+            outcome: OperatorActionOutcome::Allowed,
+        });
+        Ok(())
+    }
+
+    pub fn revoke_binding(
+        &mut self,
+        agent_did: &str,
+        operator_did: &str,
+        requested_at_unix: u64,
+    ) -> Result<(), OperatorActionServiceError> {
+        if requested_at_unix == 0 {
+            return Err(OperatorActionServiceError::EmptyField("requested_at_unix"));
+        }
+        match self.bindings.revoke_binding(agent_did, operator_did) {
+            Ok(()) => {
+                self.push_audit(OperatorActionAuditRecord {
+                    agent_did: agent_did.to_owned(),
+                    operator_did: operator_did.to_owned(),
+                    action: OperatorBindingAction::Revoke,
+                    target: "binding".to_owned(),
+                    value: None,
+                    requested_at_unix,
+                    outcome: OperatorActionOutcome::Allowed,
+                });
+                Ok(())
+            }
+            Err(error) => {
+                self.push_audit(OperatorActionAuditRecord {
+                    agent_did: agent_did.to_owned(),
+                    operator_did: operator_did.to_owned(),
+                    action: OperatorBindingAction::Revoke,
+                    target: "binding".to_owned(),
+                    value: None,
+                    requested_at_unix,
+                    outcome: OperatorActionOutcome::Denied,
+                });
+                Err(OperatorActionServiceError::Binding(error.to_string()))
+            }
+        }
+    }
+
+    pub fn read_history(
+        &mut self,
+        agent_did: &str,
+        operator_did: &str,
+        requested_at_unix: u64,
+    ) -> Result<Vec<OperatorActionAuditRecord>, OperatorActionServiceError> {
+        if requested_at_unix == 0 {
+            return Err(OperatorActionServiceError::EmptyField("requested_at_unix"));
+        }
+
+        if let Err(error) =
+            self.bindings
+                .authorize(agent_did, operator_did, OperatorBindingAction::ReadHistory)
+        {
+            self.push_audit(OperatorActionAuditRecord {
+                agent_did: agent_did.to_owned(),
+                operator_did: operator_did.to_owned(),
+                action: OperatorBindingAction::ReadHistory,
+                target: "audit_log".to_owned(),
+                value: None,
+                requested_at_unix,
+                outcome: OperatorActionOutcome::Denied,
+            });
+            return Err(OperatorActionServiceError::Binding(error.to_string()));
+        }
+
+        self.push_audit(OperatorActionAuditRecord {
+            agent_did: agent_did.to_owned(),
+            operator_did: operator_did.to_owned(),
+            action: OperatorBindingAction::ReadHistory,
+            target: "audit_log".to_owned(),
+            value: None,
+            requested_at_unix,
+            outcome: OperatorActionOutcome::Allowed,
+        });
+        Ok(self.audit_log.clone())
+    }
+
+    pub fn setting(&self, agent_did: &str, config_key: &str) -> Option<String> {
+        self.settings
+            .get(&(agent_did.to_owned(), config_key.to_owned()))
+            .cloned()
+    }
+
+    pub fn audit_log(&self) -> Vec<OperatorActionAuditRecord> {
+        self.audit_log.clone()
+    }
+
+    fn push_audit(&mut self, record: OperatorActionAuditRecord) {
+        self.audit_log.push(record);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperatorActionServiceError {
+    EmptyField(&'static str),
+    Binding(String),
+}
+
+impl fmt::Display for OperatorActionServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::Binding(message) => write!(f, "operator binding error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for OperatorActionServiceError {}
+
+impl From<OperatorBindingError> for OperatorActionServiceError {
+    fn from(value: OperatorBindingError) -> Self {
+        Self::Binding(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OperatorActionServiceError, PermissionedOperatorActionService};
+    use crate::OperatorBindingEngine;
+
+    #[test]
+    fn configure_rejects_empty_key() {
+        let mut service = PermissionedOperatorActionService::new(OperatorBindingEngine::new());
+        assert_eq!(
+            service.configure("kamn:did:agent:ops", "kamn:did:human:op", "", "on", 1),
+            Err(OperatorActionServiceError::EmptyField("config_key"))
+        );
+    }
+}

--- a/crates/kamn-core/tests/operator_permissioned_actions.rs
+++ b/crates/kamn-core/tests/operator_permissioned_actions.rs
@@ -1,0 +1,176 @@
+use kamn_core::{
+    OperatorActionServiceError, OperatorBindingAction, OperatorBindingEngine, OperatorBindingProof,
+    PermissionedOperatorActionService,
+};
+use std::collections::BTreeSet;
+
+fn permissions(actions: &[OperatorBindingAction]) -> BTreeSet<OperatorBindingAction> {
+    actions.iter().copied().collect()
+}
+
+fn proof_for(operator_did: &str) -> OperatorBindingProof {
+    OperatorBindingProof {
+        type_name: "Ed25519Signature2020".to_owned(),
+        created: "2026-02-08T12:00:00Z".to_owned(),
+        verification_method: format!("{operator_did}#keys-1"),
+        proof_value: "z58proof".to_owned(),
+    }
+}
+
+#[test]
+fn operator_actions_reject_empty_configuration_keys() {
+    let mut bindings = OperatorBindingEngine::new();
+    bindings
+        .register_binding(
+            "kamn:did:agent:ops-1",
+            "kamn:did:human:alice-1",
+            Some(proof_for("kamn:did:human:alice-1")),
+            permissions(&[OperatorBindingAction::Configure]),
+        )
+        .expect("binding should register");
+
+    let mut service = PermissionedOperatorActionService::new(bindings);
+    assert_eq!(
+        service.configure(
+            "kamn:did:agent:ops-1",
+            "kamn:did:human:alice-1",
+            "",
+            "on",
+            1_716_100_000,
+        ),
+        Err(OperatorActionServiceError::EmptyField("config_key"))
+    );
+}
+
+#[test]
+fn operator_actions_authorized_configure_updates_state_and_audit() {
+    let mut bindings = OperatorBindingEngine::new();
+    bindings
+        .register_binding(
+            "kamn:did:agent:ops-2",
+            "kamn:did:human:alice-2",
+            Some(proof_for("kamn:did:human:alice-2")),
+            permissions(&[
+                OperatorBindingAction::Configure,
+                OperatorBindingAction::ReadHistory,
+            ]),
+        )
+        .expect("binding should register");
+
+    let mut service = PermissionedOperatorActionService::new(bindings);
+    service
+        .configure(
+            "kamn:did:agent:ops-2",
+            "kamn:did:human:alice-2",
+            "maintenance_mode",
+            "enabled",
+            1_716_100_100,
+        )
+        .expect("configure should pass");
+    assert_eq!(
+        service.setting("kamn:did:agent:ops-2", "maintenance_mode"),
+        Some("enabled".to_owned())
+    );
+    assert_eq!(service.audit_log().len(), 1);
+}
+
+#[test]
+fn operator_actions_revoke_binding_blocks_follow_up_configure() {
+    let mut bindings = OperatorBindingEngine::new();
+    bindings
+        .register_binding(
+            "kamn:did:agent:ops-3",
+            "kamn:did:human:alice-3",
+            Some(proof_for("kamn:did:human:alice-3")),
+            permissions(&[
+                OperatorBindingAction::Configure,
+                OperatorBindingAction::Revoke,
+            ]),
+        )
+        .expect("binding should register");
+
+    let mut service = PermissionedOperatorActionService::new(bindings);
+    service
+        .revoke_binding(
+            "kamn:did:agent:ops-3",
+            "kamn:did:human:alice-3",
+            1_716_100_200,
+        )
+        .expect("revoke should pass");
+    assert!(matches!(
+        service.configure(
+            "kamn:did:agent:ops-3",
+            "kamn:did:human:alice-3",
+            "maintenance_mode",
+            "enabled",
+            1_716_100_201,
+        ),
+        Err(OperatorActionServiceError::Binding(_))
+    ));
+}
+
+#[test]
+fn operator_actions_integration_read_history_requires_binding_permission() {
+    let mut bindings = OperatorBindingEngine::new();
+    bindings
+        .register_binding(
+            "kamn:did:agent:ops-4",
+            "kamn:did:human:alice-4",
+            Some(proof_for("kamn:did:human:alice-4")),
+            permissions(&[
+                OperatorBindingAction::Configure,
+                OperatorBindingAction::ReadHistory,
+            ]),
+        )
+        .expect("binding should register");
+
+    let mut service = PermissionedOperatorActionService::new(bindings);
+    service
+        .configure(
+            "kamn:did:agent:ops-4",
+            "kamn:did:human:alice-4",
+            "throttle_profile",
+            "strict",
+            1_716_100_300,
+        )
+        .expect("configure should pass");
+
+    let history = service
+        .read_history(
+            "kamn:did:agent:ops-4",
+            "kamn:did:human:alice-4",
+            1_716_100_301,
+        )
+        .expect("history read should pass");
+    assert!(!history.is_empty());
+}
+
+#[test]
+fn operator_actions_regression_unauthorized_operator_cannot_mutate_settings() {
+    // Regression: #199
+    let mut bindings = OperatorBindingEngine::new();
+    bindings
+        .register_binding(
+            "kamn:did:agent:ops-5",
+            "kamn:did:human:alice-5",
+            Some(proof_for("kamn:did:human:alice-5")),
+            permissions(&[OperatorBindingAction::ReadHistory]),
+        )
+        .expect("binding should register");
+
+    let mut service = PermissionedOperatorActionService::new(bindings);
+    assert!(matches!(
+        service.configure(
+            "kamn:did:agent:ops-5",
+            "kamn:did:human:alice-5",
+            "maintenance_mode",
+            "enabled",
+            1_716_100_400,
+        ),
+        Err(OperatorActionServiceError::Binding(_))
+    ));
+    assert_eq!(
+        service.setting("kamn:did:agent:ops-5", "maintenance_mode"),
+        None
+    );
+}

--- a/crates/kamn-core/tests/operator_permissioned_actions_docs.rs
+++ b/crates/kamn-core/tests/operator_permissioned_actions_docs.rs
@@ -1,0 +1,30 @@
+const DOC: &str = include_str!("../../../docs/foundation/operator-permissioned-actions.md");
+
+#[test]
+fn doc_contains_scope_and_service_contracts() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("PermissionedOperatorActionService"));
+    assert!(DOC.contains("OperatorActionAuditRecord"));
+    assert!(DOC.contains("OperatorActionServiceError"));
+}
+
+#[test]
+fn doc_contains_binding_authorization_rules() {
+    assert!(DOC.contains("## Authorization Rules"));
+    assert!(DOC.contains("OperatorBindingAction::Configure"));
+    assert!(DOC.contains("OperatorBindingAction::ReadHistory"));
+    assert!(DOC.contains("Unauthorized requests return explicit binding errors"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test operator_permissioned_actions"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_post_revoke_blocking_rule() {
+    // Regression: #199
+    assert!(DOC.contains("Revoked bindings cannot be reused"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -99,5 +99,6 @@ For configurable retention policy enforcement controls, see `docs/foundation/ret
 For data classification tiers and write-path tagging enforcement controls, see `docs/foundation/data-classification-tagging.md`.
 For optional operator binding proof validation and configure/revoke/read-history permission controls, see `docs/foundation/operator-binding-permissions.md`.
 For operator dashboard backend read-model APIs and deterministic pagination controls, see `docs/foundation/operator-dashboard-backend-apis.md`.
+For permissioned operator configure/revoke/read-history control actions and audit trail outcomes, see `docs/foundation/operator-permissioned-actions.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/operator-permissioned-actions.md
+++ b/docs/foundation/operator-permissioned-actions.md
@@ -1,0 +1,38 @@
+# Permissioned Operator Actions via Operator-Binding Rules (Issues #198 / #199)
+
+This document captures the first implementation slice for permissioned operator control actions with explicit binding-based authorization.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/operator_actions.rs` with:
+  - `PermissionedOperatorActionService` for configure, revoke-binding, and read-history operations.
+  - `OperatorActionAuditRecord` and `OperatorActionOutcome`.
+  - deterministic per-agent configuration state mutation.
+  - typed errors via `OperatorActionServiceError`.
+- Added integration and regression tests in `crates/kamn-core/tests/operator_permissioned_actions.rs`.
+
+## Authorization Rules
+- `configure(...)` requires binding permission `OperatorBindingAction::Configure`.
+- `revoke_binding(...)` requires revoke capability enforced by `OperatorBindingEngine`.
+- `read_history(...)` requires binding permission `OperatorBindingAction::ReadHistory`.
+- Unauthorized requests return explicit binding errors and append denied audit entries.
+
+## Audit and Safety Guarantees
+- Every action attempt emits an audit record with:
+  - agent DID, operator DID, action, target, timestamp, and outcome.
+- Unauthorized configure attempts do not mutate configuration state.
+- Revoked bindings cannot be reused for follow-up configuration actions.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test operator_permissioned_actions --test operator_permissioned_actions_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first story slice for permissioned operator actions so operator control requests are binding-authorized, auditable, and deterministic. This delivers configure/revoke/read-history service behavior with explicit error surfaces and test/docs coverage.

Closes #199
Closes #198
Closes #54

## Changes
- `crates/kamn-core/src/operator_actions.rs`: added `PermissionedOperatorActionService`, audit record/outcome models, and binding-gated configure/revoke/read-history flows.
- `crates/kamn-core/src/lib.rs`: exported the new operator action module and public types.
- `crates/kamn-core/tests/operator_permissioned_actions.rs`: added unit/functional/integration/regression coverage for operator actions.
- `docs/foundation/operator-permissioned-actions.md`: documented scope, authorization rules, audit guarantees, and fast validation lane.
- `crates/kamn-core/tests/operator_permissioned_actions_docs.rs`: added docs assertions and issue-linked regression doc guard.
- `docs/foundation/bootstrap.md`: added foundation index link for permissioned operator actions.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified permission gating, post-revoke denial behavior, audit trail outcomes, and docs index linkage.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Empty field and validator guards (`operator_permissioned_actions`) |
| Functional  | ✅     | Authorized configure updates deterministic state |
| Integration | ✅     | Binding permission and read-history cross-module checks |
| Regression  | ✅     | Unauthorized configure cannot mutate state; revoked bindings stay blocked |
