### PR TITLE
feat(dashboard): compose operator dashboard UI MVP views

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod observability;
 pub mod operator_actions;
 pub mod operator_binding;
 pub mod operator_dashboard_api;
+pub mod operator_dashboard_ui;
 pub mod performance_targets;
 pub mod redaction_compliance;
 pub mod reputation_signals;
@@ -167,6 +168,12 @@ pub use operator_dashboard_api::{
     DashboardPage, DashboardPageRequest, OperatorAgentView, OperatorDashboardApi,
     OperatorDashboardApiError, OperatorDashboardSnapshot, OperatorEscrowView, OperatorMessageView,
     OperatorReputationView, OperatorTaskView,
+};
+pub use operator_dashboard_ui::{
+    DashboardAttentionLevel, DashboardSummary, OperatorAgentListRow, OperatorAuditTraceEntry,
+    OperatorDashboardUi, OperatorDashboardUiError, OperatorDashboardUiModel,
+    OperatorEscrowStatusEntry, OperatorMessageTraceEntry, OperatorReputationOverviewEntry,
+    OperatorTaskTimelineEntry, ReputationRiskTier,
 };
 pub use performance_targets::{
     evaluate_performance_from_observability, evaluate_performance_run, PerformanceAggregate,

--- a/crates/kamn-core/src/operator_dashboard_ui.rs
+++ b/crates/kamn-core/src/operator_dashboard_ui.rs
@@ -1,0 +1,423 @@
+use crate::{
+    EscrowStatus, MessageStatus, OperatorActionAuditRecord, OperatorActionOutcome,
+    OperatorBindingAction, OperatorDashboardSnapshot, TaskState,
+};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashboardAttentionLevel {
+    Info,
+    Warning,
+    Critical,
+    Success,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReputationRiskTier {
+    Stable,
+    Watch,
+    Critical,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DashboardSummary {
+    pub total_agents: usize,
+    pub active_tasks: usize,
+    pub blocked_tasks: usize,
+    pub failed_messages: usize,
+    pub disputed_escrows: usize,
+    pub critical_reputation_agents: usize,
+    pub denied_operator_actions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorAgentListRow {
+    pub agent_did: String,
+    pub key_summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorTaskTimelineEntry {
+    pub task_id: String,
+    pub owner: String,
+    pub state: TaskState,
+    pub attention: DashboardAttentionLevel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorMessageTraceEntry {
+    pub message_id: String,
+    pub sender: String,
+    pub recipient_count: usize,
+    pub status: MessageStatus,
+    pub attention: DashboardAttentionLevel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorEscrowStatusEntry {
+    pub escrow_id: String,
+    pub payer: String,
+    pub payee: String,
+    pub status: EscrowStatus,
+    pub remaining_amount: u128,
+    pub attention: DashboardAttentionLevel,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorReputationOverviewEntry {
+    pub agent_did: String,
+    pub trust_score: u32,
+    pub delivery_rate: f64,
+    pub dispute_rate: f64,
+    pub risk_tier: ReputationRiskTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorAuditTraceEntry {
+    pub agent_did: String,
+    pub operator_did: String,
+    pub action: OperatorBindingAction,
+    pub target: String,
+    pub value: Option<String>,
+    pub requested_at_unix: u64,
+    pub outcome: OperatorActionOutcome,
+    pub attention: DashboardAttentionLevel,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorDashboardUiModel {
+    pub summary: DashboardSummary,
+    pub agent_list: Vec<OperatorAgentListRow>,
+    pub task_timeline: Vec<OperatorTaskTimelineEntry>,
+    pub message_traces: Vec<OperatorMessageTraceEntry>,
+    pub escrow_status: Vec<OperatorEscrowStatusEntry>,
+    pub reputation_overview: Vec<OperatorReputationOverviewEntry>,
+    pub audit_traces: Vec<OperatorAuditTraceEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OperatorDashboardUi;
+
+impl OperatorDashboardUi {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn compose(
+        &self,
+        snapshot: &OperatorDashboardSnapshot,
+        audit_log: &[OperatorActionAuditRecord],
+    ) -> Result<OperatorDashboardUiModel, OperatorDashboardUiError> {
+        let mut agent_list = Vec::with_capacity(snapshot.agents.items.len());
+        for agent in &snapshot.agents.items {
+            if agent.identity_key_id.trim().is_empty() {
+                return Err(OperatorDashboardUiError::EmptyAgentKey {
+                    agent_did: agent.agent_did.clone(),
+                    key_role: "identity",
+                });
+            }
+            if agent.signing_key_id.trim().is_empty() {
+                return Err(OperatorDashboardUiError::EmptyAgentKey {
+                    agent_did: agent.agent_did.clone(),
+                    key_role: "signing",
+                });
+            }
+            if agent.agreement_key_id.trim().is_empty() {
+                return Err(OperatorDashboardUiError::EmptyAgentKey {
+                    agent_did: agent.agent_did.clone(),
+                    key_role: "agreement",
+                });
+            }
+
+            agent_list.push(OperatorAgentListRow {
+                agent_did: agent.agent_did.clone(),
+                key_summary: format!(
+                    "{}/{}/{}",
+                    agent.identity_key_id, agent.signing_key_id, agent.agreement_key_id
+                ),
+            });
+        }
+        agent_list.sort_by(|left, right| left.agent_did.cmp(&right.agent_did));
+
+        let mut task_timeline = Vec::with_capacity(snapshot.tasks.items.len());
+        for task in &snapshot.tasks.items {
+            task_timeline.push(OperatorTaskTimelineEntry {
+                task_id: task.task_id.clone(),
+                owner: task
+                    .assignee
+                    .clone()
+                    .unwrap_or_else(|| task.requester.clone()),
+                state: task.state,
+                attention: task_attention(task.state),
+            });
+        }
+        task_timeline.sort_by(|left, right| left.task_id.cmp(&right.task_id));
+
+        let mut message_traces = Vec::with_capacity(snapshot.messages.items.len());
+        for message in &snapshot.messages.items {
+            if message.recipients.is_empty() {
+                return Err(OperatorDashboardUiError::EmptyMessageRecipients(
+                    message.message_id.clone(),
+                ));
+            }
+
+            message_traces.push(OperatorMessageTraceEntry {
+                message_id: message.message_id.clone(),
+                sender: message.sender.clone(),
+                recipient_count: message.recipients.len(),
+                status: message.status,
+                attention: message_attention(message.status),
+            });
+        }
+        message_traces.sort_by(|left, right| left.message_id.cmp(&right.message_id));
+
+        let mut escrow_status = Vec::with_capacity(snapshot.escrows.items.len());
+        for escrow in &snapshot.escrows.items {
+            escrow_status.push(OperatorEscrowStatusEntry {
+                escrow_id: escrow.escrow_id.clone(),
+                payer: escrow.payer.clone(),
+                payee: escrow.payee.clone(),
+                status: escrow.status.clone(),
+                remaining_amount: escrow.remaining_amount,
+                attention: escrow_attention(&escrow.status),
+            });
+        }
+        escrow_status.sort_by(|left, right| left.escrow_id.cmp(&right.escrow_id));
+
+        let mut reputation_overview = Vec::with_capacity(snapshot.reputation.items.len());
+        for reputation in &snapshot.reputation.items {
+            validate_rate(
+                "delivery_rate",
+                &reputation.agent_did,
+                reputation.delivery_rate,
+            )?;
+            validate_rate(
+                "dispute_rate",
+                &reputation.agent_did,
+                reputation.dispute_rate,
+            )?;
+            reputation_overview.push(OperatorReputationOverviewEntry {
+                agent_did: reputation.agent_did.clone(),
+                trust_score: reputation.trust_score,
+                delivery_rate: reputation.delivery_rate,
+                dispute_rate: reputation.dispute_rate,
+                risk_tier: reputation_risk_tier(reputation.trust_score, reputation.dispute_rate),
+            });
+        }
+        reputation_overview.sort_by(|left, right| left.agent_did.cmp(&right.agent_did));
+
+        let mut audit_traces = Vec::with_capacity(audit_log.len());
+        for record in audit_log {
+            if record.requested_at_unix == 0 {
+                return Err(OperatorDashboardUiError::InvalidAuditTimestamp {
+                    operator_did: record.operator_did.clone(),
+                });
+            }
+
+            audit_traces.push(OperatorAuditTraceEntry {
+                agent_did: record.agent_did.clone(),
+                operator_did: record.operator_did.clone(),
+                action: record.action,
+                target: record.target.clone(),
+                value: record.value.clone(),
+                requested_at_unix: record.requested_at_unix,
+                outcome: record.outcome.clone(),
+                attention: match record.outcome {
+                    OperatorActionOutcome::Denied => DashboardAttentionLevel::Critical,
+                    OperatorActionOutcome::Allowed => DashboardAttentionLevel::Info,
+                },
+            });
+        }
+        audit_traces.sort_by(|left, right| {
+            right
+                .requested_at_unix
+                .cmp(&left.requested_at_unix)
+                .then_with(|| left.operator_did.cmp(&right.operator_did))
+                .then_with(|| left.target.cmp(&right.target))
+        });
+
+        let summary = DashboardSummary {
+            total_agents: agent_list.len(),
+            active_tasks: task_timeline
+                .iter()
+                .filter(|task| {
+                    !matches!(
+                        task.state,
+                        TaskState::Completed | TaskState::Failed | TaskState::Cancelled
+                    )
+                })
+                .count(),
+            blocked_tasks: task_timeline
+                .iter()
+                .filter(|task| matches!(task.state, TaskState::Blocked))
+                .count(),
+            failed_messages: message_traces
+                .iter()
+                .filter(|message| {
+                    matches!(
+                        message.status,
+                        MessageStatus::Rejected | MessageStatus::Expired
+                    )
+                })
+                .count(),
+            disputed_escrows: escrow_status
+                .iter()
+                .filter(|escrow| matches!(escrow.status, EscrowStatus::Disputed))
+                .count(),
+            critical_reputation_agents: reputation_overview
+                .iter()
+                .filter(|entry| matches!(entry.risk_tier, ReputationRiskTier::Critical))
+                .count(),
+            denied_operator_actions: audit_traces
+                .iter()
+                .filter(|trace| matches!(trace.outcome, OperatorActionOutcome::Denied))
+                .count(),
+        };
+
+        Ok(OperatorDashboardUiModel {
+            summary,
+            agent_list,
+            task_timeline,
+            message_traces,
+            escrow_status,
+            reputation_overview,
+            audit_traces,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OperatorDashboardUiError {
+    EmptyAgentKey {
+        agent_did: String,
+        key_role: &'static str,
+    },
+    EmptyMessageRecipients(String),
+    InvalidReputationRate {
+        agent_did: String,
+        field: &'static str,
+        value: f64,
+    },
+    InvalidAuditTimestamp {
+        operator_did: String,
+    },
+}
+
+impl fmt::Display for OperatorDashboardUiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyAgentKey {
+                agent_did,
+                key_role,
+            } => {
+                write!(f, "agent key role {key_role} is empty for {agent_did}")
+            }
+            Self::EmptyMessageRecipients(message_id) => {
+                write!(
+                    f,
+                    "message trace must include at least one recipient: {message_id}"
+                )
+            }
+            Self::InvalidReputationRate {
+                agent_did,
+                field,
+                value,
+            } => write!(
+                f,
+                "invalid reputation rate {field} for {agent_did}: expected 0..=1, found {value}"
+            ),
+            Self::InvalidAuditTimestamp { operator_did } => {
+                write!(
+                    f,
+                    "invalid audit timestamp: operator action timestamp must be > 0 for {operator_did}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for OperatorDashboardUiError {}
+
+fn validate_rate(
+    field: &'static str,
+    agent_did: &str,
+    value: f64,
+) -> Result<(), OperatorDashboardUiError> {
+    if !(0.0..=1.0).contains(&value) {
+        return Err(OperatorDashboardUiError::InvalidReputationRate {
+            agent_did: agent_did.to_owned(),
+            field,
+            value,
+        });
+    }
+    Ok(())
+}
+
+fn task_attention(state: TaskState) -> DashboardAttentionLevel {
+    match state {
+        TaskState::Blocked | TaskState::Failed => DashboardAttentionLevel::Critical,
+        TaskState::Cancelled | TaskState::Delegated => DashboardAttentionLevel::Warning,
+        TaskState::Completed => DashboardAttentionLevel::Success,
+        TaskState::Submitted | TaskState::Accepted | TaskState::InProgress => {
+            DashboardAttentionLevel::Info
+        }
+    }
+}
+
+fn message_attention(state: MessageStatus) -> DashboardAttentionLevel {
+    match state {
+        MessageStatus::Rejected | MessageStatus::Expired => DashboardAttentionLevel::Critical,
+        MessageStatus::Created
+        | MessageStatus::Signed
+        | MessageStatus::Broadcast
+        | MessageStatus::Included
+        | MessageStatus::Delivered => DashboardAttentionLevel::Warning,
+        MessageStatus::Validated => DashboardAttentionLevel::Success,
+    }
+}
+
+fn escrow_attention(state: &EscrowStatus) -> DashboardAttentionLevel {
+    match state {
+        EscrowStatus::Disputed => DashboardAttentionLevel::Critical,
+        EscrowStatus::Refunded | EscrowStatus::PartiallyReleased { .. } => {
+            DashboardAttentionLevel::Warning
+        }
+        EscrowStatus::Released | EscrowStatus::Resolved { .. } => DashboardAttentionLevel::Success,
+        EscrowStatus::Funded => DashboardAttentionLevel::Info,
+    }
+}
+
+fn reputation_risk_tier(trust_score: u32, dispute_rate: f64) -> ReputationRiskTier {
+    if trust_score < 300 || dispute_rate > 0.30 {
+        ReputationRiskTier::Critical
+    } else if trust_score < 600 || dispute_rate > 0.15 {
+        ReputationRiskTier::Watch
+    } else {
+        ReputationRiskTier::Stable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OperatorDashboardUiError, ReputationRiskTier};
+
+    #[test]
+    fn reputation_tier_marks_critical_for_high_dispute_rate() {
+        assert_eq!(
+            super::reputation_risk_tier(800, 0.45),
+            ReputationRiskTier::Critical
+        );
+    }
+
+    #[test]
+    fn validate_rate_rejects_out_of_range_values() {
+        assert_eq!(
+            super::validate_rate("delivery_rate", "kamn:did:agent:ops-1", 1.5),
+            Err(OperatorDashboardUiError::InvalidReputationRate {
+                agent_did: "kamn:did:agent:ops-1".to_owned(),
+                field: "delivery_rate",
+                value: 1.5
+            })
+        );
+    }
+}

--- a/crates/kamn-core/tests/operator_dashboard_ui.rs
+++ b/crates/kamn-core/tests/operator_dashboard_ui.rs
@@ -1,0 +1,222 @@
+use kamn_core::{
+    DashboardAttentionLevel, DashboardPage, MessageStatus, OperatorActionAuditRecord,
+    OperatorActionOutcome, OperatorBindingAction, OperatorDashboardSnapshot, OperatorDashboardUi,
+    OperatorDashboardUiError, OperatorEscrowView, OperatorMessageView, OperatorReputationView,
+    OperatorTaskView, TaskState,
+};
+
+fn page<T>(items: Vec<T>) -> DashboardPage<T> {
+    DashboardPage {
+        items,
+        next_cursor: None,
+    }
+}
+
+#[test]
+fn operator_dashboard_ui_rejects_empty_message_recipients() {
+    let snapshot = OperatorDashboardSnapshot {
+        agents: page(vec![]),
+        tasks: page(vec![]),
+        messages: page(vec![OperatorMessageView {
+            message_id: "urn:uuid:msg-empty-recipient".to_owned(),
+            sender: "kamn:did:agent:operator-1".to_owned(),
+            recipients: vec![],
+            status: MessageStatus::Rejected,
+        }]),
+        escrows: page(vec![]),
+        reputation: page(vec![]),
+    };
+
+    let ui = OperatorDashboardUi::new();
+    assert_eq!(
+        ui.compose(&snapshot, &[]),
+        Err(OperatorDashboardUiError::EmptyMessageRecipients(
+            "urn:uuid:msg-empty-recipient".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn operator_dashboard_ui_projects_all_mvp_sections() {
+    let snapshot = OperatorDashboardSnapshot {
+        agents: page(vec![
+            kamn_core::OperatorAgentView {
+                agent_did: "kamn:did:agent:beta-2".to_owned(),
+                identity_key_id: "id-beta".to_owned(),
+                signing_key_id: "sig-beta".to_owned(),
+                agreement_key_id: "agr-beta".to_owned(),
+            },
+            kamn_core::OperatorAgentView {
+                agent_did: "kamn:did:agent:alpha-1".to_owned(),
+                identity_key_id: "id-alpha".to_owned(),
+                signing_key_id: "sig-alpha".to_owned(),
+                agreement_key_id: "agr-alpha".to_owned(),
+            },
+        ]),
+        tasks: page(vec![
+            OperatorTaskView {
+                task_id: "task-b".to_owned(),
+                requester: "kamn:did:agent:alpha-1".to_owned(),
+                assignee: Some("kamn:did:agent:beta-2".to_owned()),
+                state: TaskState::Blocked,
+            },
+            OperatorTaskView {
+                task_id: "task-a".to_owned(),
+                requester: "kamn:did:agent:alpha-1".to_owned(),
+                assignee: Some("kamn:did:agent:beta-2".to_owned()),
+                state: TaskState::Completed,
+            },
+        ]),
+        messages: page(vec![
+            OperatorMessageView {
+                message_id: "urn:uuid:msg-2".to_owned(),
+                sender: "kamn:did:agent:alpha-1".to_owned(),
+                recipients: vec!["kamn:did:agent:beta-2".to_owned()],
+                status: MessageStatus::Validated,
+            },
+            OperatorMessageView {
+                message_id: "urn:uuid:msg-1".to_owned(),
+                sender: "kamn:did:agent:alpha-1".to_owned(),
+                recipients: vec!["kamn:did:agent:beta-2".to_owned()],
+                status: MessageStatus::Rejected,
+            },
+        ]),
+        escrows: page(vec![OperatorEscrowView {
+            escrow_id: "escrow-1".to_owned(),
+            payer: "kamn:did:agent:payer-1".to_owned(),
+            payee: "kamn:did:agent:payee-1".to_owned(),
+            status: kamn_core::EscrowStatus::Disputed,
+            remaining_amount: 35,
+        }]),
+        reputation: page(vec![OperatorReputationView {
+            agent_did: "kamn:did:agent:beta-2".to_owned(),
+            trust_score: 220,
+            delivery_rate: 0.74,
+            dispute_rate: 0.31,
+        }]),
+    };
+    let audit = vec![OperatorActionAuditRecord {
+        agent_did: "kamn:did:agent:alpha-1".to_owned(),
+        operator_did: "kamn:did:human:ops-1".to_owned(),
+        action: OperatorBindingAction::Configure,
+        target: "maintenance_mode".to_owned(),
+        value: Some("enabled".to_owned()),
+        requested_at_unix: 1_716_200_100,
+        outcome: OperatorActionOutcome::Allowed,
+    }];
+
+    let ui = OperatorDashboardUi::new();
+    let model = ui
+        .compose(&snapshot, &audit)
+        .expect("ui composition should succeed");
+
+    assert_eq!(model.agent_list.len(), 2);
+    assert_eq!(model.task_timeline.len(), 2);
+    assert_eq!(model.message_traces.len(), 2);
+    assert_eq!(model.escrow_status.len(), 1);
+    assert_eq!(model.reputation_overview.len(), 1);
+    assert_eq!(model.audit_traces.len(), 1);
+    assert_eq!(model.summary.total_agents, 2);
+    assert_eq!(model.summary.blocked_tasks, 1);
+    assert_eq!(model.summary.failed_messages, 1);
+    assert_eq!(model.summary.disputed_escrows, 1);
+    assert_eq!(
+        model.message_traces[0].attention,
+        DashboardAttentionLevel::Critical
+    );
+}
+
+#[test]
+fn operator_dashboard_ui_integration_surfaces_denied_audit_traces() {
+    let snapshot = OperatorDashboardSnapshot {
+        agents: page(vec![]),
+        tasks: page(vec![]),
+        messages: page(vec![]),
+        escrows: page(vec![]),
+        reputation: page(vec![]),
+    };
+    let audit = vec![
+        OperatorActionAuditRecord {
+            agent_did: "kamn:did:agent:ops-1".to_owned(),
+            operator_did: "kamn:did:human:ops-1".to_owned(),
+            action: OperatorBindingAction::ReadHistory,
+            target: "audit_log".to_owned(),
+            value: None,
+            requested_at_unix: 1_716_200_200,
+            outcome: OperatorActionOutcome::Allowed,
+        },
+        OperatorActionAuditRecord {
+            agent_did: "kamn:did:agent:ops-1".to_owned(),
+            operator_did: "kamn:did:human:ops-2".to_owned(),
+            action: OperatorBindingAction::Configure,
+            target: "maintenance_mode".to_owned(),
+            value: Some("enabled".to_owned()),
+            requested_at_unix: 1_716_200_300,
+            outcome: OperatorActionOutcome::Denied,
+        },
+    ];
+
+    let ui = OperatorDashboardUi::new();
+    let model = ui
+        .compose(&snapshot, &audit)
+        .expect("ui composition should succeed");
+    assert_eq!(model.audit_traces.len(), 2);
+    assert_eq!(model.summary.denied_operator_actions, 1);
+    assert_eq!(model.audit_traces[0].operator_did, "kamn:did:human:ops-2");
+    assert_eq!(
+        model.audit_traces[0].attention,
+        DashboardAttentionLevel::Critical
+    );
+}
+
+#[test]
+fn operator_dashboard_ui_regression_orders_audit_traces_newest_first() {
+    // Regression: #201
+    let snapshot = OperatorDashboardSnapshot {
+        agents: page(vec![]),
+        tasks: page(vec![]),
+        messages: page(vec![]),
+        escrows: page(vec![]),
+        reputation: page(vec![]),
+    };
+    let audit = vec![
+        OperatorActionAuditRecord {
+            agent_did: "kamn:did:agent:ops-1".to_owned(),
+            operator_did: "kamn:did:human:ops-1".to_owned(),
+            action: OperatorBindingAction::ReadHistory,
+            target: "audit_log".to_owned(),
+            value: None,
+            requested_at_unix: 3,
+            outcome: OperatorActionOutcome::Allowed,
+        },
+        OperatorActionAuditRecord {
+            agent_did: "kamn:did:agent:ops-1".to_owned(),
+            operator_did: "kamn:did:human:ops-2".to_owned(),
+            action: OperatorBindingAction::Configure,
+            target: "feature_x".to_owned(),
+            value: Some("on".to_owned()),
+            requested_at_unix: 9,
+            outcome: OperatorActionOutcome::Denied,
+        },
+        OperatorActionAuditRecord {
+            agent_did: "kamn:did:agent:ops-1".to_owned(),
+            operator_did: "kamn:did:human:ops-3".to_owned(),
+            action: OperatorBindingAction::Configure,
+            target: "feature_y".to_owned(),
+            value: Some("on".to_owned()),
+            requested_at_unix: 6,
+            outcome: OperatorActionOutcome::Allowed,
+        },
+    ];
+
+    let ui = OperatorDashboardUi::new();
+    let model = ui
+        .compose(&snapshot, &audit)
+        .expect("ui composition should succeed");
+    let ordered: Vec<u64> = model
+        .audit_traces
+        .iter()
+        .map(|entry| entry.requested_at_unix)
+        .collect();
+    assert_eq!(ordered, vec![9, 6, 3]);
+}

--- a/crates/kamn-core/tests/operator_dashboard_ui_docs.rs
+++ b/crates/kamn-core/tests/operator_dashboard_ui_docs.rs
@@ -1,0 +1,29 @@
+const DOC: &str = include_str!("../../../docs/foundation/operator-dashboard-ui-mvp.md");
+
+#[test]
+fn doc_contains_ui_scope_and_composer_contract() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("OperatorDashboardUi"));
+    assert!(DOC.contains("DashboardSummary"));
+    assert!(DOC.contains("OperatorDashboardUiError"));
+}
+
+#[test]
+fn doc_contains_section_and_audit_trace_rules() {
+    assert!(DOC.contains("## UI Composition Rules"));
+    assert!(DOC.contains("## Audit Trace Rules"));
+    assert!(DOC.contains("Denied operator actions are marked critical"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test operator_dashboard_ui"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_newest_first_audit_trace_ordering_rule() {
+    // Regression: #201
+    assert!(DOC.contains("newest `requested_at_unix` first"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -99,6 +99,7 @@ For configurable retention policy enforcement controls, see `docs/foundation/ret
 For data classification tiers and write-path tagging enforcement controls, see `docs/foundation/data-classification-tagging.md`.
 For optional operator binding proof validation and configure/revoke/read-history permission controls, see `docs/foundation/operator-binding-permissions.md`.
 For operator dashboard backend read-model APIs and deterministic pagination controls, see `docs/foundation/operator-dashboard-backend-apis.md`.
+For dashboard UI MVP composition controls across agent/task/message/escrow/reputation/audit sections, see `docs/foundation/operator-dashboard-ui-mvp.md`.
 For permissioned operator configure/revoke/read-history control actions and audit trail outcomes, see `docs/foundation/operator-permissioned-actions.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/operator-dashboard-ui-mvp.md
+++ b/docs/foundation/operator-dashboard-ui-mvp.md
@@ -1,0 +1,44 @@
+# Operator Dashboard UI MVP Composition (Issues #200 / #201)
+
+This document captures the first implementation slice for the operator dashboard UI presentation model.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/operator_dashboard_ui.rs` with:
+  - `OperatorDashboardUi` composer that builds deterministic UI sections from `OperatorDashboardSnapshot`.
+  - section models for:
+    - agent list
+    - task timeline
+    - message traces
+    - escrow status
+    - reputation overview
+    - operator audit traces
+  - summary counters in `DashboardSummary` for blocked tasks, failed messages, disputed escrows, and denied operator actions.
+  - typed validation errors via `OperatorDashboardUiError`.
+- Added integration and regression tests in `crates/kamn-core/tests/operator_dashboard_ui.rs`.
+
+## UI Composition Rules
+- Agent rows require non-empty identity/signing/agreement keys.
+- Task timeline rows derive deterministic attention levels from `TaskState`.
+- Message traces require at least one recipient and surface rejected/expired items as critical attention.
+- Escrow rows surface disputed escrows as critical attention.
+- Reputation overview enforces `delivery_rate` and `dispute_rate` in the `0..=1` range.
+
+## Audit Trace Rules
+- Audit traces are projected from `OperatorActionAuditRecord`.
+- Denied operator actions are marked critical in the UI model.
+- Audit trace ordering is deterministic: newest `requested_at_unix` first.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test operator_dashboard_ui --test operator_dashboard_ui_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Adds the first operator dashboard UI MVP composition layer on top of existing backend read models. This delivers deterministic section models for agent/task/message/escrow/reputation visibility plus operator audit traces and alert-oriented summary counters.

Closes #201
Closes #200
Closes #53

## Changes
- `crates/kamn-core/src/operator_dashboard_ui.rs`: added `OperatorDashboardUi` composer, section-level UI models, summary counters, attention/risk tiers, and typed validation errors.
- `crates/kamn-core/src/lib.rs`: exported dashboard UI module and public presentation types.
- `crates/kamn-core/tests/operator_dashboard_ui.rs`: added unit/functional/integration/regression test matrix for the MVP UI composition slice.
- `docs/foundation/operator-dashboard-ui-mvp.md`: documented delivered scope, composition rules, audit trace ordering, and validation lane.
- `crates/kamn-core/tests/operator_dashboard_ui_docs.rs`: added doc contract/regression assertions.
- `docs/foundation/bootstrap.md`: indexed new dashboard UI MVP foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated deterministic UI section projection, denied-action highlighting, and newest-first audit trace ordering.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Rejects invalid UI projection inputs (empty recipients, invalid rates) |
| Functional  | ✅     | Projects MVP sections and summary counters from dashboard snapshot |
| Integration | ✅     | Surfaces denied operator actions in composed audit traces |
| Regression  | ✅     | Enforces newest-first audit trace ordering stability |
