### PR TITLE
feat(governance): implement proposal vote execute workflow

### DIFF
--- a/crates/kamn-core/src/governance_workflow.rs
+++ b/crates/kamn-core/src/governance_workflow.rs
@@ -1,0 +1,441 @@
+use crate::AgentDid;
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceProposalDraft {
+    pub proposal_id: String,
+    pub title: String,
+    pub description: String,
+    pub proposer_did: String,
+    pub created_at_unix: u64,
+    pub voting_deadline_unix: u64,
+    pub quorum_threshold: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceVoteChoice {
+    Yes,
+    No,
+    Abstain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceProposalStatus {
+    Voting,
+    Approved,
+    Rejected,
+    Executed,
+    Expired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceVoteRecord {
+    pub proposal_id: String,
+    pub voter_did: String,
+    pub choice: GovernanceVoteChoice,
+    pub cast_at_unix: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceExecutionRecord {
+    pub proposal_id: String,
+    pub executed_by: String,
+    pub executed_at_unix: u64,
+    pub operation_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceProposalRecord {
+    pub proposal_id: String,
+    pub title: String,
+    pub description: String,
+    pub proposer_did: String,
+    pub created_at_unix: u64,
+    pub voting_deadline_unix: u64,
+    pub quorum_threshold: usize,
+    pub status: GovernanceProposalStatus,
+    pub yes_votes: usize,
+    pub no_votes: usize,
+    pub abstain_votes: usize,
+    pub executed_at_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GovernanceWorkflow {
+    proposals: BTreeMap<String, GovernanceProposalState>,
+    execution_history: Vec<GovernanceExecutionRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GovernanceProposalState {
+    record: GovernanceProposalRecord,
+    votes: BTreeMap<String, GovernanceVoteRecord>,
+}
+
+impl GovernanceWorkflow {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn submit_proposal(
+        &mut self,
+        draft: GovernanceProposalDraft,
+    ) -> Result<(), GovernanceWorkflowError> {
+        require_non_empty("proposal_id", &draft.proposal_id)?;
+        require_non_empty("title", &draft.title)?;
+        require_non_empty("description", &draft.description)?;
+        validate_did(&draft.proposer_did)?;
+        if draft.created_at_unix == 0 {
+            return Err(GovernanceWorkflowError::InvalidTimestamp("created_at_unix"));
+        }
+        if draft.voting_deadline_unix <= draft.created_at_unix {
+            return Err(GovernanceWorkflowError::InvalidDeadline {
+                created_at_unix: draft.created_at_unix,
+                voting_deadline_unix: draft.voting_deadline_unix,
+            });
+        }
+        if draft.quorum_threshold == 0 {
+            return Err(GovernanceWorkflowError::InvalidQuorum(0));
+        }
+        if self.proposals.contains_key(&draft.proposal_id) {
+            return Err(GovernanceWorkflowError::DuplicateProposal(
+                draft.proposal_id.clone(),
+            ));
+        }
+
+        self.proposals.insert(
+            draft.proposal_id.clone(),
+            GovernanceProposalState {
+                record: GovernanceProposalRecord {
+                    proposal_id: draft.proposal_id,
+                    title: draft.title,
+                    description: draft.description,
+                    proposer_did: draft.proposer_did,
+                    created_at_unix: draft.created_at_unix,
+                    voting_deadline_unix: draft.voting_deadline_unix,
+                    quorum_threshold: draft.quorum_threshold,
+                    status: GovernanceProposalStatus::Voting,
+                    yes_votes: 0,
+                    no_votes: 0,
+                    abstain_votes: 0,
+                    executed_at_unix: None,
+                },
+                votes: BTreeMap::new(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn cast_vote(
+        &mut self,
+        proposal_id: &str,
+        voter_did: &str,
+        choice: GovernanceVoteChoice,
+        cast_at_unix: u64,
+    ) -> Result<(), GovernanceWorkflowError> {
+        let state = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| GovernanceWorkflowError::ProposalNotFound(proposal_id.to_owned()))?;
+
+        if cast_at_unix == 0 {
+            return Err(GovernanceWorkflowError::InvalidTimestamp("cast_at_unix"));
+        }
+        validate_did(voter_did)?;
+        if state.record.status != GovernanceProposalStatus::Voting {
+            return Err(GovernanceWorkflowError::ProposalClosed {
+                proposal_id: proposal_id.to_owned(),
+                status: state.record.status,
+            });
+        }
+        if cast_at_unix > state.record.voting_deadline_unix {
+            state.record.status = GovernanceProposalStatus::Expired;
+            return Err(GovernanceWorkflowError::ProposalClosed {
+                proposal_id: proposal_id.to_owned(),
+                status: state.record.status,
+            });
+        }
+        if state.votes.contains_key(voter_did) {
+            return Err(GovernanceWorkflowError::DuplicateVote {
+                proposal_id: proposal_id.to_owned(),
+                voter_did: voter_did.to_owned(),
+            });
+        }
+
+        let vote = GovernanceVoteRecord {
+            proposal_id: proposal_id.to_owned(),
+            voter_did: voter_did.to_owned(),
+            choice,
+            cast_at_unix,
+        };
+        state.votes.insert(voter_did.to_owned(), vote);
+        match choice {
+            GovernanceVoteChoice::Yes => state.record.yes_votes += 1,
+            GovernanceVoteChoice::No => state.record.no_votes += 1,
+            GovernanceVoteChoice::Abstain => state.record.abstain_votes += 1,
+        }
+        reevaluate_status(&mut state.record, cast_at_unix);
+        Ok(())
+    }
+
+    pub fn evaluate(
+        &mut self,
+        proposal_id: &str,
+        evaluated_at_unix: u64,
+    ) -> Result<GovernanceProposalStatus, GovernanceWorkflowError> {
+        if evaluated_at_unix == 0 {
+            return Err(GovernanceWorkflowError::InvalidTimestamp(
+                "evaluated_at_unix",
+            ));
+        }
+        let state = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| GovernanceWorkflowError::ProposalNotFound(proposal_id.to_owned()))?;
+
+        reevaluate_status(&mut state.record, evaluated_at_unix);
+        Ok(state.record.status)
+    }
+
+    pub fn execute(
+        &mut self,
+        proposal_id: &str,
+        executed_by: &str,
+        executed_at_unix: u64,
+        operation_hash: &str,
+    ) -> Result<GovernanceExecutionRecord, GovernanceWorkflowError> {
+        if executed_at_unix == 0 {
+            return Err(GovernanceWorkflowError::InvalidTimestamp(
+                "executed_at_unix",
+            ));
+        }
+        validate_did(executed_by)?;
+        require_non_empty("operation_hash", operation_hash)?;
+
+        let state = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| GovernanceWorkflowError::ProposalNotFound(proposal_id.to_owned()))?;
+
+        if state.record.status == GovernanceProposalStatus::Executed {
+            return Err(GovernanceWorkflowError::AlreadyExecuted(
+                proposal_id.to_owned(),
+            ));
+        }
+
+        reevaluate_status(&mut state.record, executed_at_unix);
+        if state.record.status != GovernanceProposalStatus::Approved {
+            return Err(GovernanceWorkflowError::ProposalNotApproved {
+                proposal_id: proposal_id.to_owned(),
+                status: state.record.status,
+            });
+        }
+
+        state.record.status = GovernanceProposalStatus::Executed;
+        state.record.executed_at_unix = Some(executed_at_unix);
+        let record = GovernanceExecutionRecord {
+            proposal_id: proposal_id.to_owned(),
+            executed_by: executed_by.to_owned(),
+            executed_at_unix,
+            operation_hash: operation_hash.to_owned(),
+        };
+        self.execution_history.push(record.clone());
+        Ok(record)
+    }
+
+    pub fn proposal(&self, proposal_id: &str) -> Option<GovernanceProposalRecord> {
+        self.proposals
+            .get(proposal_id)
+            .map(|state| state.record.clone())
+    }
+
+    pub fn vote_history(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Vec<GovernanceVoteRecord>, GovernanceWorkflowError> {
+        let state = self
+            .proposals
+            .get(proposal_id)
+            .ok_or_else(|| GovernanceWorkflowError::ProposalNotFound(proposal_id.to_owned()))?;
+        Ok(state.votes.values().cloned().collect())
+    }
+
+    pub fn execution_history(&self) -> Vec<GovernanceExecutionRecord> {
+        self.execution_history.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GovernanceWorkflowError {
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidTimestamp(&'static str),
+    InvalidDeadline {
+        created_at_unix: u64,
+        voting_deadline_unix: u64,
+    },
+    InvalidQuorum(usize),
+    DuplicateProposal(String),
+    ProposalNotFound(String),
+    DuplicateVote {
+        proposal_id: String,
+        voter_did: String,
+    },
+    ProposalClosed {
+        proposal_id: String,
+        status: GovernanceProposalStatus,
+    },
+    ProposalNotApproved {
+        proposal_id: String,
+        status: GovernanceProposalStatus,
+    },
+    AlreadyExecuted(String),
+}
+
+impl fmt::Display for GovernanceWorkflowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidTimestamp(field) => write!(f, "timestamp must be > 0: {field}"),
+            Self::InvalidDeadline {
+                created_at_unix,
+                voting_deadline_unix,
+            } => write!(
+                f,
+                "invalid voting deadline: created_at_unix={created_at_unix}, voting_deadline_unix={voting_deadline_unix}"
+            ),
+            Self::InvalidQuorum(value) => write!(f, "invalid quorum threshold: {value}"),
+            Self::DuplicateProposal(proposal_id) => {
+                write!(f, "duplicate governance proposal id: {proposal_id}")
+            }
+            Self::ProposalNotFound(proposal_id) => {
+                write!(f, "governance proposal not found: {proposal_id}")
+            }
+            Self::DuplicateVote {
+                proposal_id,
+                voter_did,
+            } => write!(
+                f,
+                "duplicate governance vote: proposal={proposal_id}, voter={voter_did}"
+            ),
+            Self::ProposalClosed {
+                proposal_id,
+                status,
+            } => write!(
+                f,
+                "proposal is closed for voting: proposal={proposal_id}, status={status:?}"
+            ),
+            Self::ProposalNotApproved {
+                proposal_id,
+                status,
+            } => write!(
+                f,
+                "proposal is not approved for execution: proposal={proposal_id}, status={status:?}"
+            ),
+            Self::AlreadyExecuted(proposal_id) => {
+                write!(f, "proposal already executed: {proposal_id}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GovernanceWorkflowError {}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), GovernanceWorkflowError> {
+    if value.trim().is_empty() {
+        return Err(GovernanceWorkflowError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), GovernanceWorkflowError> {
+    AgentDid::parse(value)
+        .map_err(|error| GovernanceWorkflowError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn reevaluate_status(record: &mut GovernanceProposalRecord, now_unix: u64) {
+    if record.status != GovernanceProposalStatus::Voting {
+        return;
+    }
+    if record.yes_votes >= record.quorum_threshold {
+        record.status = GovernanceProposalStatus::Approved;
+        return;
+    }
+    if record.no_votes >= record.quorum_threshold {
+        record.status = GovernanceProposalStatus::Rejected;
+        return;
+    }
+    if now_unix > record.voting_deadline_unix {
+        record.status = GovernanceProposalStatus::Expired;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GovernanceProposalDraft, GovernanceProposalStatus, GovernanceVoteChoice,
+        GovernanceWorkflow, GovernanceWorkflowError,
+    };
+
+    #[test]
+    fn submit_rejects_invalid_deadline() {
+        let mut workflow = GovernanceWorkflow::new();
+        assert_eq!(
+            workflow.submit_proposal(GovernanceProposalDraft {
+                proposal_id: "gov-deadline".to_owned(),
+                title: "Invalid deadline".to_owned(),
+                description: "Should fail".to_owned(),
+                proposer_did: "kamn:did:agent:validator-1".to_owned(),
+                created_at_unix: 100,
+                voting_deadline_unix: 99,
+                quorum_threshold: 1,
+            }),
+            Err(GovernanceWorkflowError::InvalidDeadline {
+                created_at_unix: 100,
+                voting_deadline_unix: 99
+            })
+        );
+    }
+
+    #[test]
+    fn no_quorum_transitions_to_rejected() {
+        let mut workflow = GovernanceWorkflow::new();
+        workflow
+            .submit_proposal(GovernanceProposalDraft {
+                proposal_id: "gov-reject".to_owned(),
+                title: "Reject path".to_owned(),
+                description: "No votes should reject".to_owned(),
+                proposer_did: "kamn:did:agent:validator-1".to_owned(),
+                created_at_unix: 100,
+                voting_deadline_unix: 200,
+                quorum_threshold: 2,
+            })
+            .expect("proposal should submit");
+        workflow
+            .cast_vote(
+                "gov-reject",
+                "kamn:did:agent:validator-2",
+                GovernanceVoteChoice::No,
+                110,
+            )
+            .expect("first no vote should pass");
+        workflow
+            .cast_vote(
+                "gov-reject",
+                "kamn:did:agent:validator-3",
+                GovernanceVoteChoice::No,
+                111,
+            )
+            .expect("second no vote should pass");
+
+        assert_eq!(
+            workflow
+                .evaluate("gov-reject", 112)
+                .expect("evaluation should succeed"),
+            GovernanceProposalStatus::Rejected
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod did_registry;
 pub mod direct_message_crypto;
 pub mod discord_bridge;
 pub mod escrow;
+pub mod governance_workflow;
 pub mod group_channel_crypto;
 pub mod instruction_verify;
 pub mod invariants;
@@ -120,6 +121,11 @@ pub use discord_bridge::{
     DiscordOutboundApproval, DiscordOutboundDispatch,
 };
 pub use escrow::{EscrowLifecycle, EscrowLifecycleError, EscrowStatus};
+pub use governance_workflow::{
+    GovernanceExecutionRecord, GovernanceProposalDraft, GovernanceProposalRecord,
+    GovernanceProposalStatus, GovernanceVoteChoice, GovernanceVoteRecord, GovernanceWorkflow,
+    GovernanceWorkflowError,
+};
 pub use group_channel_crypto::{
     GroupChannelCryptoEngine, GroupChannelCryptoError, GroupMessageCiphertext,
     SenderKeyDistributionRecord, GROUP_MESSAGE_CIPHER_ALGORITHM,

--- a/crates/kamn-core/tests/governance_workflow.rs
+++ b/crates/kamn-core/tests/governance_workflow.rs
@@ -1,0 +1,167 @@
+use kamn_core::{
+    ChannelStore, GovernanceProposalDraft, GovernanceProposalStatus, GovernanceVoteChoice,
+    GovernanceWorkflow, GovernanceWorkflowError,
+};
+
+#[test]
+fn governance_workflow_rejects_zero_quorum_threshold() {
+    let mut workflow = GovernanceWorkflow::new();
+    assert_eq!(
+        workflow.submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-1".to_owned(),
+            title: "Rotate signer backend".to_owned(),
+            description: "Switch secure signer endpoint".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_300_000,
+            voting_deadline_unix: 1_716_300_500,
+            quorum_threshold: 0,
+        }),
+        Err(GovernanceWorkflowError::InvalidQuorum(0))
+    );
+}
+
+#[test]
+fn governance_workflow_functional_submit_vote_execute_flow() {
+    let mut workflow = GovernanceWorkflow::new();
+    workflow
+        .submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-2".to_owned(),
+            title: "Enable upgrade lane".to_owned(),
+            description: "Allow protocol v0.2 rollout".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_301_000,
+            voting_deadline_unix: 1_716_302_000,
+            quorum_threshold: 2,
+        })
+        .expect("proposal should submit");
+
+    workflow
+        .cast_vote(
+            "gov-proposal-2",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_301_100,
+        )
+        .expect("first vote should be accepted");
+    assert_eq!(
+        workflow
+            .evaluate("gov-proposal-2", 1_716_301_101)
+            .expect("evaluation should succeed"),
+        GovernanceProposalStatus::Voting
+    );
+    workflow
+        .cast_vote(
+            "gov-proposal-2",
+            "kamn:did:agent:validator-3",
+            GovernanceVoteChoice::Yes,
+            1_716_301_200,
+        )
+        .expect("second vote should satisfy quorum");
+    assert_eq!(
+        workflow
+            .evaluate("gov-proposal-2", 1_716_301_201)
+            .expect("evaluation should succeed"),
+        GovernanceProposalStatus::Approved
+    );
+
+    let execution = workflow
+        .execute(
+            "gov-proposal-2",
+            "kamn:did:agent:validator-1",
+            1_716_301_300,
+            "op-hash-1",
+        )
+        .expect("approved proposal should execute");
+    assert_eq!(execution.proposal_id, "gov-proposal-2");
+    assert_eq!(execution.executed_by, "kamn:did:agent:validator-1");
+
+    let proposal = workflow
+        .proposal("gov-proposal-2")
+        .expect("proposal should exist");
+    assert_eq!(proposal.status, GovernanceProposalStatus::Executed);
+    assert_eq!(proposal.yes_votes, 2);
+}
+
+#[test]
+fn governance_workflow_integration_with_governance_channel_members() {
+    let mut channels = ChannelStore::default();
+    channels
+        .create_governance_channel(
+            "governance-core",
+            "kamn:did:agent:validator-1",
+            "protocol-upgrades",
+            vec![
+                "kamn:did:agent:validator-1".to_owned(),
+                "kamn:did:agent:validator-2".to_owned(),
+                "kamn:did:agent:validator-3".to_owned(),
+            ],
+            vec!["kamn:did:agent:validator-1".to_owned()],
+        )
+        .expect("governance channel should be created");
+
+    let mut workflow = GovernanceWorkflow::new();
+    workflow
+        .submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-3".to_owned(),
+            title: "Update quorum".to_owned(),
+            description: "Adjust listener quorum threshold".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_302_000,
+            voting_deadline_unix: 1_716_303_000,
+            quorum_threshold: 2,
+        })
+        .expect("proposal should submit");
+    workflow
+        .cast_vote(
+            "gov-proposal-3",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_302_100,
+        )
+        .expect("vote should succeed");
+    workflow
+        .cast_vote(
+            "gov-proposal-3",
+            "kamn:did:agent:validator-3",
+            GovernanceVoteChoice::Yes,
+            1_716_302_200,
+        )
+        .expect("vote should succeed");
+
+    assert_eq!(
+        workflow
+            .evaluate("gov-proposal-3", 1_716_302_201)
+            .expect("proposal should evaluate"),
+        GovernanceProposalStatus::Approved
+    );
+}
+
+#[test]
+fn governance_workflow_regression_rejects_late_votes_after_deadline() {
+    // Regression: #197
+    let mut workflow = GovernanceWorkflow::new();
+    workflow
+        .submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-4".to_owned(),
+            title: "Rotate validator set".to_owned(),
+            description: "Adjust validator roster for maintenance".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 100,
+            voting_deadline_unix: 120,
+            quorum_threshold: 2,
+        })
+        .expect("proposal should submit");
+
+    assert_eq!(
+        workflow.cast_vote(
+            "gov-proposal-4",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            121,
+        ),
+        Err(GovernanceWorkflowError::ProposalClosed {
+            proposal_id: "gov-proposal-4".to_owned(),
+            status: GovernanceProposalStatus::Expired
+        })
+    );
+}

--- a/crates/kamn-core/tests/governance_workflow_docs.rs
+++ b/crates/kamn-core/tests/governance_workflow_docs.rs
@@ -1,0 +1,29 @@
+const DOC: &str = include_str!("../../../docs/foundation/governance-proposal-vote-execution.md");
+
+#[test]
+fn doc_contains_governance_workflow_scope_and_models() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("GovernanceWorkflow"));
+    assert!(DOC.contains("GovernanceProposalDraft"));
+    assert!(DOC.contains("GovernanceWorkflowError"));
+}
+
+#[test]
+fn doc_contains_lifecycle_and_quorum_rules() {
+    assert!(DOC.contains("## Proposal Lifecycle Rules"));
+    assert!(DOC.contains("## Vote and Quorum Rules"));
+    assert!(DOC.contains("yes votes reaching quorum => `Approved`."));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test governance_workflow"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_late_vote_rejection_rule() {
+    // Regression: #197
+    assert!(DOC.contains("Late votes after deadline are rejected"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -101,5 +101,6 @@ For optional operator binding proof validation and configure/revoke/read-history
 For operator dashboard backend read-model APIs and deterministic pagination controls, see `docs/foundation/operator-dashboard-backend-apis.md`.
 For dashboard UI MVP composition controls across agent/task/message/escrow/reputation/audit sections, see `docs/foundation/operator-dashboard-ui-mvp.md`.
 For permissioned operator configure/revoke/read-history control actions and audit trail outcomes, see `docs/foundation/operator-permissioned-actions.md`.
+For governance proposal, voting, and execution workflow controls, see `docs/foundation/governance-proposal-vote-execution.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/governance-proposal-vote-execution.md
+++ b/docs/foundation/governance-proposal-vote-execution.md
@@ -1,0 +1,66 @@
+# Governance Proposal, Vote, and Execution Workflows (Issues #196 / #197)
+
+This document captures the first implementation slice for protocol governance message workflows.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/governance_workflow.rs` with:
+  - `GovernanceWorkflow` for proposal submission, vote casting, status evaluation, and execution recording.
+  - proposal/vote/execution models:
+    - `GovernanceProposalDraft`
+    - `GovernanceProposalRecord`
+    - `GovernanceVoteRecord`
+    - `GovernanceExecutionRecord`
+  - lifecycle and decision enums:
+    - `GovernanceProposalStatus`
+    - `GovernanceVoteChoice`
+  - typed errors via `GovernanceWorkflowError`.
+- Added integration and regression tests in `crates/kamn-core/tests/governance_workflow.rs`.
+
+## Proposal Lifecycle Rules
+- Proposal submission requires:
+  - non-empty id/title/description.
+  - valid proposer DID.
+  - `created_at_unix > 0`.
+  - voting deadline strictly greater than creation timestamp.
+  - quorum threshold greater than zero.
+- Proposal statuses:
+  - `Voting`
+  - `Approved`
+  - `Rejected`
+  - `Executed`
+  - `Expired`
+
+## Vote and Quorum Rules
+- Vote casting requires:
+  - existing proposal id.
+  - valid voter DID.
+  - unique voter per proposal (duplicate votes rejected).
+  - cast timestamp within voting window.
+- Deterministic outcome rules:
+  - yes votes reaching quorum => `Approved`.
+  - no votes reaching quorum => `Rejected`.
+  - voting window elapsed without quorum => `Expired`.
+
+## Execution and Audit Rules
+- Execution requires:
+  - proposal in `Approved` status.
+  - valid executor DID.
+  - non-empty operation hash.
+  - positive execution timestamp.
+- Execution appends an immutable execution history record.
+- Late votes after deadline are rejected with `ProposalClosed` + `Expired` status.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test governance_workflow --test governance_workflow_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first governance workflow slice for protocol-level proposal, voting, and execution flows. This introduces deterministic quorum evaluation, explicit lifecycle statuses, and execution/audit records required for validator-governed changes.

Closes #197
Closes #196
Closes #55

## Changes
- `crates/kamn-core/src/governance_workflow.rs`: added governance proposal/vote/evaluate/execute engine, lifecycle models, quorum state transitions, and typed errors.
- `crates/kamn-core/src/lib.rs`: exported governance workflow module and public types.
- `crates/kamn-core/tests/governance_workflow.rs`: added unit/functional/integration/regression coverage for governance message workflows.
- `docs/foundation/governance-proposal-vote-execution.md`: documented lifecycle, quorum, and execution rules.
- `crates/kamn-core/tests/governance_workflow_docs.rs`: added docs assertions and regression doc guard.
- `docs/foundation/bootstrap.md`: indexed governance workflow foundation doc.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated quorum transition behavior, late vote rejection, and execution history recording.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Invalid quorum/deadline validation and typed errors |
| Functional  | ✅     | Submit/vote/evaluate/execute path reaches expected lifecycle states |
| Integration | ✅     | Governance workflow exercised with governance-channel member DIDs |
| Regression  | ✅     | Late votes after deadline are rejected with `ProposalClosed` + `Expired` |
