### PR TITLE
feat(governance): add governed upgrade orchestration and audit views

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod telegram_bridge;
 pub mod token;
 pub mod transaction;
 pub mod trust_score;
+pub mod upgrade_orchestration;
 pub mod validator_lifecycle;
 pub mod watchdog;
 pub mod zk_message_proofs;
@@ -238,6 +239,10 @@ pub use transaction::{
 pub use trust_score::{
     calculate_trust_score, recalculate_and_persist_trust_score, TrustScoreBreakdown,
     TrustScoreError, TRUST_SCORE_ENGINE_VERSION, TRUST_SCORE_MAX, TRUST_SCORE_MIN,
+};
+pub use upgrade_orchestration::{
+    UpgradeAuditEvent, UpgradeAuditEventKind, UpgradeOrchestrationError, UpgradeProposalRecord,
+    UpgradeProposalState, VersionUpgradeAuditView, VersionUpgradeOrchestrator,
 };
 pub use validator_lifecycle::{
     ValidatorLifecycleError, ValidatorLifecycleManager, ValidatorSetSnapshot,

--- a/crates/kamn-core/src/upgrade_orchestration.rs
+++ b/crates/kamn-core/src/upgrade_orchestration.rs
@@ -1,0 +1,427 @@
+use crate::{AgentDid, GovernanceProposalStatus};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpgradeAuditEventKind {
+    Proposed,
+    Approved,
+    GovernanceStatusSynced,
+    Activated,
+    RolledBack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpgradeAuditEvent {
+    pub proposal_id: String,
+    pub target_version: String,
+    pub actor_did: String,
+    pub event_at_unix: u64,
+    pub kind: UpgradeAuditEventKind,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionUpgradeAuditView {
+    pub current_version: String,
+    pub events: Vec<UpgradeAuditEvent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpgradeProposalState {
+    Pending,
+    Activated,
+    RolledBack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpgradeProposalRecord {
+    pub proposal_id: String,
+    pub target_version: String,
+    pub proposed_by: String,
+    pub proposed_at_unix: u64,
+    pub required_quorum: usize,
+    pub approvals: BTreeSet<String>,
+    pub governance_status: GovernanceProposalStatus,
+    pub state: UpgradeProposalState,
+    pub activated_at_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionUpgradeOrchestrator {
+    current_version: String,
+    proposals: BTreeMap<String, UpgradeProposalRecord>,
+    events: Vec<UpgradeAuditEvent>,
+}
+
+impl VersionUpgradeOrchestrator {
+    pub fn new(current_version: &str) -> Result<Self, UpgradeOrchestrationError> {
+        validate_version_format(current_version)?;
+        Ok(Self {
+            current_version: current_version.to_owned(),
+            proposals: BTreeMap::new(),
+            events: Vec::new(),
+        })
+    }
+
+    pub fn propose_upgrade(
+        &mut self,
+        proposal_id: &str,
+        target_version: &str,
+        proposed_by: &str,
+        required_quorum: usize,
+        proposed_at_unix: u64,
+    ) -> Result<(), UpgradeOrchestrationError> {
+        require_non_empty("proposal_id", proposal_id)?;
+        validate_did(proposed_by)?;
+        validate_timestamp("proposed_at_unix", proposed_at_unix)?;
+        validate_version_format(target_version)?;
+        if required_quorum == 0 {
+            return Err(UpgradeOrchestrationError::InvalidRequiredQuorum(0));
+        }
+        if self.proposals.contains_key(proposal_id) {
+            return Err(UpgradeOrchestrationError::DuplicateProposal(
+                proposal_id.to_owned(),
+            ));
+        }
+        if !is_version_advance(&self.current_version, target_version)? {
+            return Err(UpgradeOrchestrationError::InvalidTargetVersionTransition {
+                current_version: self.current_version.clone(),
+                target_version: target_version.to_owned(),
+            });
+        }
+
+        self.proposals.insert(
+            proposal_id.to_owned(),
+            UpgradeProposalRecord {
+                proposal_id: proposal_id.to_owned(),
+                target_version: target_version.to_owned(),
+                proposed_by: proposed_by.to_owned(),
+                proposed_at_unix,
+                required_quorum,
+                approvals: BTreeSet::new(),
+                governance_status: GovernanceProposalStatus::Voting,
+                state: UpgradeProposalState::Pending,
+                activated_at_unix: None,
+            },
+        );
+        self.events.push(UpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            target_version: target_version.to_owned(),
+            actor_did: proposed_by.to_owned(),
+            event_at_unix: proposed_at_unix,
+            kind: UpgradeAuditEventKind::Proposed,
+            note: None,
+        });
+        Ok(())
+    }
+
+    pub fn approve_upgrade(
+        &mut self,
+        proposal_id: &str,
+        validator_did: &str,
+        approved_at_unix: u64,
+    ) -> Result<(), UpgradeOrchestrationError> {
+        validate_did(validator_did)?;
+        validate_timestamp("approved_at_unix", approved_at_unix)?;
+        let proposal = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| UpgradeOrchestrationError::ProposalNotFound(proposal_id.to_owned()))?;
+
+        if !proposal.approvals.insert(validator_did.to_owned()) {
+            return Err(UpgradeOrchestrationError::DuplicateApproval {
+                proposal_id: proposal_id.to_owned(),
+                validator_did: validator_did.to_owned(),
+            });
+        }
+
+        self.events.push(UpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            target_version: proposal.target_version.clone(),
+            actor_did: validator_did.to_owned(),
+            event_at_unix: approved_at_unix,
+            kind: UpgradeAuditEventKind::Approved,
+            note: Some("validator approval registered".to_owned()),
+        });
+        Ok(())
+    }
+
+    pub fn mark_governance_status(
+        &mut self,
+        proposal_id: &str,
+        status: GovernanceProposalStatus,
+        updated_at_unix: u64,
+    ) -> Result<(), UpgradeOrchestrationError> {
+        validate_timestamp("updated_at_unix", updated_at_unix)?;
+        let proposal = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| UpgradeOrchestrationError::ProposalNotFound(proposal_id.to_owned()))?;
+        proposal.governance_status = status;
+
+        self.events.push(UpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            target_version: proposal.target_version.clone(),
+            actor_did: proposal.proposed_by.clone(),
+            event_at_unix: updated_at_unix,
+            kind: UpgradeAuditEventKind::GovernanceStatusSynced,
+            note: Some(format!("governance status updated to {status:?}")),
+        });
+        Ok(())
+    }
+
+    pub fn activate_upgrade(
+        &mut self,
+        proposal_id: &str,
+        activated_by: &str,
+        activated_at_unix: u64,
+    ) -> Result<(), UpgradeOrchestrationError> {
+        validate_did(activated_by)?;
+        validate_timestamp("activated_at_unix", activated_at_unix)?;
+
+        let proposal = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| UpgradeOrchestrationError::ProposalNotFound(proposal_id.to_owned()))?;
+        if proposal.state == UpgradeProposalState::Activated {
+            return Err(UpgradeOrchestrationError::AlreadyActivated(
+                proposal_id.to_owned(),
+            ));
+        }
+        if proposal.governance_status != GovernanceProposalStatus::Approved {
+            return Err(UpgradeOrchestrationError::GovernanceNotApproved {
+                proposal_id: proposal_id.to_owned(),
+                status: proposal.governance_status,
+            });
+        }
+        if proposal.approvals.len() < proposal.required_quorum {
+            return Err(UpgradeOrchestrationError::InsufficientApprovals {
+                required: proposal.required_quorum,
+                provided: proposal.approvals.len(),
+            });
+        }
+        if !is_version_advance(&self.current_version, &proposal.target_version)? {
+            return Err(UpgradeOrchestrationError::InvalidTargetVersionTransition {
+                current_version: self.current_version.clone(),
+                target_version: proposal.target_version.clone(),
+            });
+        }
+
+        self.current_version = proposal.target_version.clone();
+        proposal.state = UpgradeProposalState::Activated;
+        proposal.activated_at_unix = Some(activated_at_unix);
+        self.events.push(UpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            target_version: proposal.target_version.clone(),
+            actor_did: activated_by.to_owned(),
+            event_at_unix: activated_at_unix,
+            kind: UpgradeAuditEventKind::Activated,
+            note: None,
+        });
+        Ok(())
+    }
+
+    pub fn rollback_upgrade(
+        &mut self,
+        proposal_id: &str,
+        rollback_version: &str,
+        rolled_back_by: &str,
+        rolled_back_at_unix: u64,
+        reason: &str,
+    ) -> Result<(), UpgradeOrchestrationError> {
+        validate_did(rolled_back_by)?;
+        validate_timestamp("rolled_back_at_unix", rolled_back_at_unix)?;
+        validate_version_format(rollback_version)?;
+        require_non_empty("reason", reason)?;
+
+        let proposal = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| UpgradeOrchestrationError::ProposalNotFound(proposal_id.to_owned()))?;
+        if proposal.state != UpgradeProposalState::Activated {
+            return Err(UpgradeOrchestrationError::RollbackNotAllowed(
+                proposal_id.to_owned(),
+            ));
+        }
+
+        self.current_version = rollback_version.to_owned();
+        proposal.state = UpgradeProposalState::RolledBack;
+        self.events.push(UpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            target_version: rollback_version.to_owned(),
+            actor_did: rolled_back_by.to_owned(),
+            event_at_unix: rolled_back_at_unix,
+            kind: UpgradeAuditEventKind::RolledBack,
+            note: Some(reason.to_owned()),
+        });
+        Ok(())
+    }
+
+    pub fn proposal(&self, proposal_id: &str) -> Option<UpgradeProposalRecord> {
+        self.proposals.get(proposal_id).cloned()
+    }
+
+    pub fn audit_view(&self) -> VersionUpgradeAuditView {
+        VersionUpgradeAuditView {
+            current_version: self.current_version.clone(),
+            events: self.events.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpgradeOrchestrationError {
+    EmptyField(&'static str),
+    InvalidTimestamp(&'static str),
+    InvalidDid(String),
+    InvalidVersionFormat(String),
+    InvalidTargetVersionTransition {
+        current_version: String,
+        target_version: String,
+    },
+    InvalidRequiredQuorum(usize),
+    DuplicateProposal(String),
+    ProposalNotFound(String),
+    DuplicateApproval {
+        proposal_id: String,
+        validator_did: String,
+    },
+    GovernanceNotApproved {
+        proposal_id: String,
+        status: GovernanceProposalStatus,
+    },
+    InsufficientApprovals {
+        required: usize,
+        provided: usize,
+    },
+    AlreadyActivated(String),
+    RollbackNotAllowed(String),
+}
+
+impl fmt::Display for UpgradeOrchestrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidTimestamp(field) => write!(f, "timestamp must be > 0: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidVersionFormat(value) => {
+                write!(f, "invalid version format, expected vX.Y.Z: {value}")
+            }
+            Self::InvalidTargetVersionTransition {
+                current_version,
+                target_version,
+            } => write!(
+                f,
+                "invalid target version transition: current={current_version}, target={target_version}"
+            ),
+            Self::InvalidRequiredQuorum(value) => write!(f, "invalid required quorum: {value}"),
+            Self::DuplicateProposal(proposal_id) => {
+                write!(f, "duplicate upgrade proposal id: {proposal_id}")
+            }
+            Self::ProposalNotFound(proposal_id) => {
+                write!(f, "upgrade proposal not found: {proposal_id}")
+            }
+            Self::DuplicateApproval {
+                proposal_id,
+                validator_did,
+            } => write!(
+                f,
+                "duplicate upgrade approval: proposal={proposal_id}, validator={validator_did}"
+            ),
+            Self::GovernanceNotApproved {
+                proposal_id,
+                status,
+            } => write!(
+                f,
+                "governance not approved for upgrade activation: proposal={proposal_id}, status={status:?}"
+            ),
+            Self::InsufficientApprovals { required, provided } => write!(
+                f,
+                "insufficient approvals for upgrade activation: required {required}, provided {provided}"
+            ),
+            Self::AlreadyActivated(proposal_id) => {
+                write!(f, "upgrade proposal already activated: {proposal_id}")
+            }
+            Self::RollbackNotAllowed(proposal_id) => {
+                write!(f, "upgrade rollback not allowed for proposal: {proposal_id}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UpgradeOrchestrationError {}
+
+fn validate_timestamp(field: &'static str, value: u64) -> Result<(), UpgradeOrchestrationError> {
+    if value == 0 {
+        return Err(UpgradeOrchestrationError::InvalidTimestamp(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), UpgradeOrchestrationError> {
+    AgentDid::parse(value)
+        .map_err(|error| UpgradeOrchestrationError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), UpgradeOrchestrationError> {
+    if value.trim().is_empty() {
+        return Err(UpgradeOrchestrationError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn parse_version(value: &str) -> Result<(u64, u64, u64), UpgradeOrchestrationError> {
+    let normalized = value.strip_prefix('v').unwrap_or(value);
+    let parts: Vec<&str> = normalized.split('.').collect();
+    if parts.len() != 3 {
+        return Err(UpgradeOrchestrationError::InvalidVersionFormat(
+            value.to_owned(),
+        ));
+    }
+    let major = parts[0]
+        .parse::<u64>()
+        .map_err(|_| UpgradeOrchestrationError::InvalidVersionFormat(value.to_owned()))?;
+    let minor = parts[1]
+        .parse::<u64>()
+        .map_err(|_| UpgradeOrchestrationError::InvalidVersionFormat(value.to_owned()))?;
+    let patch = parts[2]
+        .parse::<u64>()
+        .map_err(|_| UpgradeOrchestrationError::InvalidVersionFormat(value.to_owned()))?;
+    Ok((major, minor, patch))
+}
+
+fn validate_version_format(value: &str) -> Result<(), UpgradeOrchestrationError> {
+    parse_version(value).map(|_| ())
+}
+
+fn is_version_advance(
+    current_version: &str,
+    target_version: &str,
+) -> Result<bool, UpgradeOrchestrationError> {
+    Ok(parse_version(target_version)? > parse_version(current_version)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_version_advance, UpgradeOrchestrationError, VersionUpgradeOrchestrator};
+
+    #[test]
+    fn parse_version_requires_three_segments() {
+        assert_eq!(
+            VersionUpgradeOrchestrator::new("v0.1"),
+            Err(UpgradeOrchestrationError::InvalidVersionFormat(
+                "v0.1".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn version_advance_is_semver_ordered() {
+        assert!(
+            is_version_advance("v0.9.9", "v1.0.0").expect("comparison should succeed"),
+            "major version advance should be valid"
+        );
+    }
+}

--- a/crates/kamn-core/tests/upgrade_orchestration.rs
+++ b/crates/kamn-core/tests/upgrade_orchestration.rs
@@ -1,0 +1,157 @@
+use kamn_core::{
+    GovernanceProposalDraft, GovernanceProposalStatus, GovernanceVoteChoice, GovernanceWorkflow,
+    UpgradeAuditEventKind, UpgradeOrchestrationError, VersionUpgradeOrchestrator,
+};
+
+#[test]
+fn upgrade_orchestration_rejects_non_advancing_version_target() {
+    let mut orchestrator =
+        VersionUpgradeOrchestrator::new("v0.2.0").expect("orchestrator should initialize");
+    assert_eq!(
+        orchestrator.propose_upgrade(
+            "gov-upgrade-1",
+            "v0.1.9",
+            "kamn:did:agent:validator-1",
+            2,
+            1_716_500_000,
+        ),
+        Err(UpgradeOrchestrationError::InvalidTargetVersionTransition {
+            current_version: "v0.2.0".to_owned(),
+            target_version: "v0.1.9".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn upgrade_orchestration_functional_propose_approve_activate_flow() {
+    let mut orchestrator =
+        VersionUpgradeOrchestrator::new("v0.1.0").expect("orchestrator should initialize");
+    orchestrator
+        .propose_upgrade(
+            "gov-upgrade-2",
+            "v0.2.0",
+            "kamn:did:agent:validator-1",
+            2,
+            1_716_500_100,
+        )
+        .expect("proposal should register");
+    orchestrator
+        .approve_upgrade("gov-upgrade-2", "kamn:did:agent:validator-1", 1_716_500_110)
+        .expect("approval should pass");
+    orchestrator
+        .approve_upgrade("gov-upgrade-2", "kamn:did:agent:validator-2", 1_716_500_120)
+        .expect("approval should pass");
+    orchestrator
+        .mark_governance_status(
+            "gov-upgrade-2",
+            GovernanceProposalStatus::Approved,
+            1_716_500_130,
+        )
+        .expect("governance status update should pass");
+    orchestrator
+        .activate_upgrade("gov-upgrade-2", "kamn:did:agent:validator-1", 1_716_500_140)
+        .expect("activation should pass");
+
+    let audit = orchestrator.audit_view();
+    assert_eq!(audit.current_version, "v0.2.0");
+    assert_eq!(
+        audit.events.last().map(|event| event.kind),
+        Some(UpgradeAuditEventKind::Activated)
+    );
+}
+
+#[test]
+fn upgrade_orchestration_integration_uses_governance_vote_outcome() {
+    let mut governance = GovernanceWorkflow::new();
+    governance
+        .submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-upgrade-3".to_owned(),
+            title: "Upgrade to v0.3.0".to_owned(),
+            description: "protocol upgrade".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_501_000,
+            voting_deadline_unix: 1_716_501_600,
+            quorum_threshold: 2,
+        })
+        .expect("proposal should submit");
+    governance
+        .cast_vote(
+            "gov-upgrade-3",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_501_100,
+        )
+        .expect("vote should pass");
+    governance
+        .cast_vote(
+            "gov-upgrade-3",
+            "kamn:did:agent:validator-3",
+            GovernanceVoteChoice::Yes,
+            1_716_501_200,
+        )
+        .expect("vote should pass");
+    let governance_status = governance
+        .evaluate("gov-upgrade-3", 1_716_501_201)
+        .expect("evaluation should pass");
+    assert_eq!(governance_status, GovernanceProposalStatus::Approved);
+
+    let mut orchestrator =
+        VersionUpgradeOrchestrator::new("v0.2.0").expect("orchestrator should initialize");
+    orchestrator
+        .propose_upgrade(
+            "gov-upgrade-3",
+            "v0.3.0",
+            "kamn:did:agent:validator-1",
+            2,
+            1_716_501_300,
+        )
+        .expect("upgrade proposal should register");
+    orchestrator
+        .approve_upgrade("gov-upgrade-3", "kamn:did:agent:validator-1", 1_716_501_310)
+        .expect("approval should pass");
+    orchestrator
+        .approve_upgrade("gov-upgrade-3", "kamn:did:agent:validator-2", 1_716_501_320)
+        .expect("approval should pass");
+    orchestrator
+        .mark_governance_status("gov-upgrade-3", governance_status, 1_716_501_330)
+        .expect("governance status should sync");
+
+    orchestrator
+        .activate_upgrade("gov-upgrade-3", "kamn:did:agent:validator-1", 1_716_501_340)
+        .expect("activation should pass");
+    assert_eq!(orchestrator.audit_view().current_version, "v0.3.0");
+}
+
+#[test]
+fn upgrade_orchestration_regression_rejects_activation_without_quorum_approvals() {
+    // Regression: #193
+    let mut orchestrator =
+        VersionUpgradeOrchestrator::new("v0.4.0").expect("orchestrator should initialize");
+    orchestrator
+        .propose_upgrade(
+            "gov-upgrade-4",
+            "v0.5.0",
+            "kamn:did:agent:validator-1",
+            2,
+            1_716_502_100,
+        )
+        .expect("proposal should register");
+    orchestrator
+        .approve_upgrade("gov-upgrade-4", "kamn:did:agent:validator-1", 1_716_502_110)
+        .expect("single approval should pass");
+    orchestrator
+        .mark_governance_status(
+            "gov-upgrade-4",
+            GovernanceProposalStatus::Approved,
+            1_716_502_120,
+        )
+        .expect("governance approved status should set");
+
+    assert_eq!(
+        orchestrator.activate_upgrade("gov-upgrade-4", "kamn:did:agent:validator-1", 1_716_502_130),
+        Err(UpgradeOrchestrationError::InsufficientApprovals {
+            required: 2,
+            provided: 1,
+        })
+    );
+}

--- a/crates/kamn-core/tests/upgrade_orchestration_docs.rs
+++ b/crates/kamn-core/tests/upgrade_orchestration_docs.rs
@@ -1,0 +1,29 @@
+const DOC: &str = include_str!("../../../docs/foundation/version-upgrade-orchestration-audit.md");
+
+#[test]
+fn doc_contains_upgrade_orchestrator_scope_and_models() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("VersionUpgradeOrchestrator"));
+    assert!(DOC.contains("UpgradeAuditEventKind"));
+    assert!(DOC.contains("UpgradeOrchestrationError"));
+}
+
+#[test]
+fn doc_contains_upgrade_gating_and_audit_rules() {
+    assert!(DOC.contains("## Upgrade Gating Rules"));
+    assert!(DOC.contains("## Governance Audit View Rules"));
+    assert!(DOC.contains("Activation requires:"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test upgrade_orchestration"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_activation_quorum_gating_rule() {
+    // Regression: #193
+    assert!(DOC.contains("sufficient unique validator approvals"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -103,5 +103,6 @@ For dashboard UI MVP composition controls across agent/task/message/escrow/reput
 For permissioned operator configure/revoke/read-history control actions and audit trail outcomes, see `docs/foundation/operator-permissioned-actions.md`.
 For governance proposal, voting, and execution workflow controls, see `docs/foundation/governance-proposal-vote-execution.md`.
 For validator onboarding/offboarding lifecycle and quorum reconfiguration controls, see `docs/foundation/validator-lifecycle-quorum-reconfiguration.md`.
+For governed version-upgrade orchestration and governance audit-view controls, see `docs/foundation/version-upgrade-orchestration-audit.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/version-upgrade-orchestration-audit.md
+++ b/docs/foundation/version-upgrade-orchestration-audit.md
@@ -1,0 +1,55 @@
+# Version Upgrade Orchestration and Governance Audit Views (Issues #192 / #193)
+
+This document captures the first implementation slice for governed chain-version upgrade orchestration.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/upgrade_orchestration.rs` with:
+  - `VersionUpgradeOrchestrator` for:
+    - `propose_upgrade(...)`
+    - `approve_upgrade(...)`
+    - `mark_governance_status(...)`
+    - `activate_upgrade(...)`
+    - `rollback_upgrade(...)`
+  - governance-aware proposal models:
+    - `UpgradeProposalRecord`
+    - `UpgradeProposalState`
+  - audit projection surfaces:
+    - `UpgradeAuditEvent`
+    - `UpgradeAuditEventKind`
+    - `VersionUpgradeAuditView`
+  - typed errors via `UpgradeOrchestrationError`.
+- Added integration and regression tests in `crates/kamn-core/tests/upgrade_orchestration.rs`.
+
+## Upgrade Gating Rules
+- Upgrade proposals require:
+  - valid proposer DID.
+  - non-empty proposal id.
+  - valid semantic version target (`vX.Y.Z`).
+  - target version strictly greater than current version.
+  - positive required quorum.
+- Activation requires:
+  - governance status `Approved`.
+  - sufficient unique validator approvals to satisfy required quorum.
+  - positive activation timestamp.
+
+## Governance Audit View Rules
+- All proposal/approval/governance-status/activation/rollback actions emit audit events.
+- Audit view is deterministic and includes:
+  - current chain version
+  - ordered event history with event kind, actor DID, and timestamp
+- Rollback is allowed only for previously activated proposals.
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test upgrade_orchestration --test upgrade_orchestration_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements governed version-upgrade orchestration and governance audit views for the first delivery slice of Story #57. The change adds proposal/approval/activation/rollback orchestration with strict gating and deterministic audit projection surfaces.

Closes #193
Closes #192
Closes #57

## Changes
- `crates/kamn-core/src/upgrade_orchestration.rs`: added `VersionUpgradeOrchestrator`, proposal/audit models, and typed errors.
- `crates/kamn-core/tests/upgrade_orchestration.rs`: added functional, integration, and regression coverage (Regression: #193).
- `crates/kamn-core/tests/upgrade_orchestration_docs.rs`: added doc contract assertions.
- `crates/kamn-core/src/lib.rs`: exported upgrade orchestration module and public types.
- `docs/foundation/version-upgrade-orchestration-audit.md`: documented scope, gating rules, audit semantics, and fast validation lane.
- `docs/foundation/bootstrap.md`: linked new foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test upgrade_orchestration
```
Failure evidence (before implementation): test target failed with unresolved imports/types from missing upgrade orchestration API (`UpgradeAuditEventKind`, `UpgradeOrchestrationError`, `VersionUpgradeOrchestrator`).

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test upgrade_orchestration --test upgrade_orchestration_docs
```
Result: all upgrade orchestration tests and doc-contract tests passed.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Result: all commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `crates/kamn-core/src/upgrade_orchestration.rs` module tests | |
| Functional   | ✅     | `upgrade_orchestration_functional_propose_approve_activate_flow` | |
| Integration  | ✅     | `upgrade_orchestration_integration_uses_governance_vote_outcome` | |
| Regression   | ✅     | `upgrade_orchestration_regression_rejects_activation_without_quorum_approvals` | |
| Performance  | N/A    | None | No new throughput/latency hotspot introduced in this slice |

## Risks & Rollback
- None identified; change is additive and isolated to `kamn-core` orchestration models.
- Rollback plan: revert this PR commit to remove module exports and associated tests/docs.

## Documentation Updates
- `docs/foundation/version-upgrade-orchestration-audit.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped strict lane)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-core`)
- [x] Docs updated
