### PR TITLE
feat(governance): add agent-driven upgrade proposal workflow pilot

### DIFF
--- a/crates/kamn-core/src/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/src/agent_upgrade_workflow.rs
@@ -1,0 +1,565 @@
+use crate::{
+    AgentDid, GovernanceProposalDraft, GovernanceProposalRecord, GovernanceProposalStatus,
+    GovernanceVoteChoice, GovernanceVoteRecord, GovernanceWorkflow, GovernanceWorkflowError,
+    UpgradeOrchestrationError, VersionUpgradeAuditView, VersionUpgradeOrchestrator,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentUpgradeWorkflowConfig {
+    pub current_version: String,
+    pub allowed_agent_proposers: Vec<String>,
+    pub required_human_reviews: usize,
+    pub required_validator_quorum: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentUpgradeProposalDraft {
+    pub proposal_id: String,
+    pub target_version: String,
+    pub agent_did: String,
+    pub rationale: String,
+    pub created_at_unix: u64,
+    pub voting_deadline_unix: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentUpgradeProposalState {
+    PendingHumanReview,
+    GovernanceVoting,
+    GovernanceApproved,
+    Activated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentUpgradeProposalRecord {
+    pub proposal_id: String,
+    pub target_version: String,
+    pub agent_did: String,
+    pub rationale: String,
+    pub created_at_unix: u64,
+    pub voting_deadline_unix: u64,
+    pub human_reviewers: BTreeSet<String>,
+    pub state: AgentUpgradeProposalState,
+    pub governance_status: GovernanceProposalStatus,
+    pub activated_at_unix: Option<u64>,
+    pub operation_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentUpgradeAuditEventKind {
+    AgentProposed,
+    HumanReviewApproved,
+    GovernanceSubmitted,
+    GovernanceApproved,
+    GovernanceExecuted,
+    UpgradeActivated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentUpgradeAuditEvent {
+    pub proposal_id: String,
+    pub actor_did: String,
+    pub event_at_unix: u64,
+    pub kind: AgentUpgradeAuditEventKind,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDrivenUpgradeWorkflow {
+    allowed_agent_proposers: BTreeSet<String>,
+    required_human_reviews: usize,
+    required_validator_quorum: usize,
+    governance: GovernanceWorkflow,
+    orchestrator: VersionUpgradeOrchestrator,
+    proposals: BTreeMap<String, AgentUpgradeProposalRecord>,
+    events: Vec<AgentUpgradeAuditEvent>,
+}
+
+impl AgentDrivenUpgradeWorkflow {
+    pub fn new(config: AgentUpgradeWorkflowConfig) -> Result<Self, AgentUpgradeWorkflowError> {
+        if config.required_human_reviews == 0 {
+            return Err(AgentUpgradeWorkflowError::InvalidRequiredHumanReviews(0));
+        }
+        if config.required_validator_quorum == 0 {
+            return Err(AgentUpgradeWorkflowError::InvalidRequiredValidatorQuorum(0));
+        }
+        if config.allowed_agent_proposers.is_empty() {
+            return Err(AgentUpgradeWorkflowError::MissingAllowedAgentProposers);
+        }
+
+        let mut allowed_agent_proposers = BTreeSet::new();
+        for proposer in config.allowed_agent_proposers {
+            validate_did(&proposer)?;
+            allowed_agent_proposers.insert(proposer);
+        }
+
+        let orchestrator =
+            VersionUpgradeOrchestrator::new(&config.current_version).map_err(Self::map_upgrade)?;
+
+        Ok(Self {
+            allowed_agent_proposers,
+            required_human_reviews: config.required_human_reviews,
+            required_validator_quorum: config.required_validator_quorum,
+            governance: GovernanceWorkflow::new(),
+            orchestrator,
+            proposals: BTreeMap::new(),
+            events: Vec::new(),
+        })
+    }
+
+    pub fn submit_agent_proposal(
+        &mut self,
+        draft: AgentUpgradeProposalDraft,
+    ) -> Result<(), AgentUpgradeWorkflowError> {
+        require_non_empty("proposal_id", &draft.proposal_id)?;
+        require_non_empty("rationale", &draft.rationale)?;
+        validate_did(&draft.agent_did)?;
+        validate_timestamp("created_at_unix", draft.created_at_unix)?;
+        if draft.voting_deadline_unix <= draft.created_at_unix {
+            return Err(AgentUpgradeWorkflowError::InvalidDeadline {
+                created_at_unix: draft.created_at_unix,
+                voting_deadline_unix: draft.voting_deadline_unix,
+            });
+        }
+        if !self.allowed_agent_proposers.contains(&draft.agent_did) {
+            return Err(AgentUpgradeWorkflowError::UnauthorizedAgentProposer(
+                draft.agent_did,
+            ));
+        }
+        if self.proposals.contains_key(&draft.proposal_id) {
+            return Err(AgentUpgradeWorkflowError::ProposalAlreadyExists(
+                draft.proposal_id,
+            ));
+        }
+
+        self.orchestrator
+            .propose_upgrade(
+                &draft.proposal_id,
+                &draft.target_version,
+                &draft.agent_did,
+                self.required_validator_quorum,
+                draft.created_at_unix,
+            )
+            .map_err(Self::map_upgrade)?;
+
+        self.proposals.insert(
+            draft.proposal_id.clone(),
+            AgentUpgradeProposalRecord {
+                proposal_id: draft.proposal_id.clone(),
+                target_version: draft.target_version,
+                agent_did: draft.agent_did.clone(),
+                rationale: draft.rationale,
+                created_at_unix: draft.created_at_unix,
+                voting_deadline_unix: draft.voting_deadline_unix,
+                human_reviewers: BTreeSet::new(),
+                state: AgentUpgradeProposalState::PendingHumanReview,
+                governance_status: GovernanceProposalStatus::Voting,
+                activated_at_unix: None,
+                operation_hash: None,
+            },
+        );
+        self.events.push(AgentUpgradeAuditEvent {
+            proposal_id: draft.proposal_id,
+            actor_did: draft.agent_did,
+            event_at_unix: draft.created_at_unix,
+            kind: AgentUpgradeAuditEventKind::AgentProposed,
+            note: Some("agent proposal submitted".to_owned()),
+        });
+        Ok(())
+    }
+
+    pub fn approve_human_review(
+        &mut self,
+        proposal_id: &str,
+        reviewer_did: &str,
+        reviewed_at_unix: u64,
+    ) -> Result<(), AgentUpgradeWorkflowError> {
+        validate_did(reviewer_did)?;
+        validate_timestamp("reviewed_at_unix", reviewed_at_unix)?;
+        let proposal = self
+            .proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| AgentUpgradeWorkflowError::ProposalNotFound(proposal_id.to_owned()))?;
+
+        if !proposal.human_reviewers.insert(reviewer_did.to_owned()) {
+            return Err(AgentUpgradeWorkflowError::DuplicateHumanReview {
+                proposal_id: proposal_id.to_owned(),
+                reviewer_did: reviewer_did.to_owned(),
+            });
+        }
+        self.events.push(AgentUpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            actor_did: reviewer_did.to_owned(),
+            event_at_unix: reviewed_at_unix,
+            kind: AgentUpgradeAuditEventKind::HumanReviewApproved,
+            note: Some("human review approval registered".to_owned()),
+        });
+        Ok(())
+    }
+
+    pub fn submit_to_governance(
+        &mut self,
+        proposal_id: &str,
+        submitted_at_unix: u64,
+    ) -> Result<(), AgentUpgradeWorkflowError> {
+        validate_timestamp("submitted_at_unix", submitted_at_unix)?;
+        let mut proposal =
+            self.proposals.get(proposal_id).cloned().ok_or_else(|| {
+                AgentUpgradeWorkflowError::ProposalNotFound(proposal_id.to_owned())
+            })?;
+
+        if proposal.state != AgentUpgradeProposalState::PendingHumanReview {
+            return Err(AgentUpgradeWorkflowError::GovernanceSubmissionNotAllowed {
+                proposal_id: proposal_id.to_owned(),
+                state: proposal.state,
+            });
+        }
+        let provided_reviews = proposal.human_reviewers.len();
+        if provided_reviews < self.required_human_reviews {
+            return Err(AgentUpgradeWorkflowError::InsufficientHumanReviews {
+                required: self.required_human_reviews,
+                provided: provided_reviews,
+            });
+        }
+        if proposal.voting_deadline_unix <= submitted_at_unix {
+            return Err(AgentUpgradeWorkflowError::InvalidDeadline {
+                created_at_unix: submitted_at_unix,
+                voting_deadline_unix: proposal.voting_deadline_unix,
+            });
+        }
+
+        self.governance
+            .submit_proposal(GovernanceProposalDraft {
+                proposal_id: proposal.proposal_id.clone(),
+                title: format!("Agent-driven upgrade to {}", proposal.target_version),
+                description: proposal.rationale.clone(),
+                proposer_did: proposal.agent_did.clone(),
+                created_at_unix: submitted_at_unix,
+                voting_deadline_unix: proposal.voting_deadline_unix,
+                quorum_threshold: self.required_validator_quorum,
+            })
+            .map_err(Self::map_governance)?;
+
+        proposal.state = AgentUpgradeProposalState::GovernanceVoting;
+        proposal.governance_status = GovernanceProposalStatus::Voting;
+        self.proposals.insert(proposal_id.to_owned(), proposal);
+        self.events.push(AgentUpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            actor_did: "workflow".to_owned(),
+            event_at_unix: submitted_at_unix,
+            kind: AgentUpgradeAuditEventKind::GovernanceSubmitted,
+            note: Some("proposal promoted to governance workflow".to_owned()),
+        });
+        Ok(())
+    }
+
+    pub fn cast_validator_vote(
+        &mut self,
+        proposal_id: &str,
+        validator_did: &str,
+        choice: GovernanceVoteChoice,
+        cast_at_unix: u64,
+    ) -> Result<(), AgentUpgradeWorkflowError> {
+        self.governance
+            .cast_vote(proposal_id, validator_did, choice, cast_at_unix)
+            .map_err(Self::map_governance)?;
+        let status = self
+            .governance
+            .evaluate(proposal_id, cast_at_unix)
+            .map_err(Self::map_governance)?;
+        if let Some(record) = self.proposals.get_mut(proposal_id) {
+            record.governance_status = status;
+            if status == GovernanceProposalStatus::Approved {
+                record.state = AgentUpgradeProposalState::GovernanceApproved;
+                self.events.push(AgentUpgradeAuditEvent {
+                    proposal_id: proposal_id.to_owned(),
+                    actor_did: validator_did.to_owned(),
+                    event_at_unix: cast_at_unix,
+                    kind: AgentUpgradeAuditEventKind::GovernanceApproved,
+                    note: Some("governance quorum reached".to_owned()),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn finalize_upgrade(
+        &mut self,
+        proposal_id: &str,
+        executed_by: &str,
+        executed_at_unix: u64,
+        operation_hash: &str,
+    ) -> Result<(), AgentUpgradeWorkflowError> {
+        validate_did(executed_by)?;
+        validate_timestamp("executed_at_unix", executed_at_unix)?;
+        require_non_empty("operation_hash", operation_hash)?;
+
+        let mut proposal =
+            self.proposals.get(proposal_id).cloned().ok_or_else(|| {
+                AgentUpgradeWorkflowError::ProposalNotFound(proposal_id.to_owned())
+            })?;
+        let governance_status = self
+            .governance
+            .evaluate(proposal_id, executed_at_unix)
+            .map_err(Self::map_governance)?;
+        if governance_status != GovernanceProposalStatus::Approved {
+            return Err(AgentUpgradeWorkflowError::GovernanceStatusNotApproved {
+                proposal_id: proposal_id.to_owned(),
+                status: governance_status,
+            });
+        }
+
+        self.governance
+            .execute(proposal_id, executed_by, executed_at_unix, operation_hash)
+            .map_err(Self::map_governance)?;
+        let votes = self
+            .governance
+            .vote_history(proposal_id)
+            .map_err(Self::map_governance)?;
+        apply_yes_votes_as_upgrade_approvals(&mut self.orchestrator, proposal_id, votes)
+            .map_err(Self::map_upgrade)?;
+        self.orchestrator
+            .mark_governance_status(
+                proposal_id,
+                GovernanceProposalStatus::Approved,
+                executed_at_unix,
+            )
+            .map_err(Self::map_upgrade)?;
+        self.orchestrator
+            .activate_upgrade(proposal_id, executed_by, executed_at_unix)
+            .map_err(Self::map_upgrade)?;
+
+        proposal.governance_status = GovernanceProposalStatus::Executed;
+        proposal.state = AgentUpgradeProposalState::Activated;
+        proposal.activated_at_unix = Some(executed_at_unix);
+        proposal.operation_hash = Some(operation_hash.to_owned());
+        self.proposals.insert(proposal_id.to_owned(), proposal);
+
+        self.events.push(AgentUpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            actor_did: executed_by.to_owned(),
+            event_at_unix: executed_at_unix,
+            kind: AgentUpgradeAuditEventKind::GovernanceExecuted,
+            note: Some("governance execution completed".to_owned()),
+        });
+        self.events.push(AgentUpgradeAuditEvent {
+            proposal_id: proposal_id.to_owned(),
+            actor_did: executed_by.to_owned(),
+            event_at_unix: executed_at_unix,
+            kind: AgentUpgradeAuditEventKind::UpgradeActivated,
+            note: Some("version upgrade activated".to_owned()),
+        });
+        Ok(())
+    }
+
+    pub fn proposal(&self, proposal_id: &str) -> Option<AgentUpgradeProposalRecord> {
+        self.proposals.get(proposal_id).cloned()
+    }
+
+    pub fn governance_record(&self, proposal_id: &str) -> Option<GovernanceProposalRecord> {
+        self.governance.proposal(proposal_id)
+    }
+
+    pub fn upgrade_audit_view(&self) -> VersionUpgradeAuditView {
+        self.orchestrator.audit_view()
+    }
+
+    pub fn agent_audit_log(&self) -> Vec<AgentUpgradeAuditEvent> {
+        self.events.clone()
+    }
+
+    fn map_governance(error: GovernanceWorkflowError) -> AgentUpgradeWorkflowError {
+        AgentUpgradeWorkflowError::GovernanceWorkflow(error)
+    }
+
+    fn map_upgrade(error: UpgradeOrchestrationError) -> AgentUpgradeWorkflowError {
+        AgentUpgradeWorkflowError::UpgradeOrchestration(error)
+    }
+}
+
+fn apply_yes_votes_as_upgrade_approvals(
+    orchestrator: &mut VersionUpgradeOrchestrator,
+    proposal_id: &str,
+    votes: Vec<GovernanceVoteRecord>,
+) -> Result<(), UpgradeOrchestrationError> {
+    for vote in votes {
+        if vote.choice == GovernanceVoteChoice::Yes {
+            orchestrator.approve_upgrade(proposal_id, &vote.voter_did, vote.cast_at_unix)?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentUpgradeWorkflowError {
+    EmptyField(&'static str),
+    InvalidDid(String),
+    InvalidTimestamp(&'static str),
+    InvalidDeadline {
+        created_at_unix: u64,
+        voting_deadline_unix: u64,
+    },
+    InvalidRequiredHumanReviews(usize),
+    InvalidRequiredValidatorQuorum(usize),
+    MissingAllowedAgentProposers,
+    UnauthorizedAgentProposer(String),
+    ProposalAlreadyExists(String),
+    ProposalNotFound(String),
+    DuplicateHumanReview {
+        proposal_id: String,
+        reviewer_did: String,
+    },
+    InsufficientHumanReviews {
+        required: usize,
+        provided: usize,
+    },
+    GovernanceSubmissionNotAllowed {
+        proposal_id: String,
+        state: AgentUpgradeProposalState,
+    },
+    GovernanceStatusNotApproved {
+        proposal_id: String,
+        status: GovernanceProposalStatus,
+    },
+    GovernanceWorkflow(GovernanceWorkflowError),
+    UpgradeOrchestration(UpgradeOrchestrationError),
+}
+
+impl fmt::Display for AgentUpgradeWorkflowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidTimestamp(field) => write!(f, "timestamp must be > 0: {field}"),
+            Self::InvalidDeadline {
+                created_at_unix,
+                voting_deadline_unix,
+            } => write!(
+                f,
+                "invalid voting deadline: created_at_unix={created_at_unix}, voting_deadline_unix={voting_deadline_unix}"
+            ),
+            Self::InvalidRequiredHumanReviews(value) => {
+                write!(f, "invalid required human reviews: {value}")
+            }
+            Self::InvalidRequiredValidatorQuorum(value) => {
+                write!(f, "invalid required validator quorum: {value}")
+            }
+            Self::MissingAllowedAgentProposers => {
+                write!(f, "allowed agent proposer set must not be empty")
+            }
+            Self::UnauthorizedAgentProposer(agent_did) => {
+                write!(f, "unauthorized agent proposer: {agent_did}")
+            }
+            Self::ProposalAlreadyExists(proposal_id) => {
+                write!(f, "proposal already exists: {proposal_id}")
+            }
+            Self::ProposalNotFound(proposal_id) => write!(f, "proposal not found: {proposal_id}"),
+            Self::DuplicateHumanReview {
+                proposal_id,
+                reviewer_did,
+            } => write!(
+                f,
+                "duplicate human review: proposal={proposal_id}, reviewer={reviewer_did}"
+            ),
+            Self::InsufficientHumanReviews { required, provided } => write!(
+                f,
+                "insufficient human reviews: required {required}, provided {provided}"
+            ),
+            Self::GovernanceSubmissionNotAllowed { proposal_id, state } => write!(
+                f,
+                "governance submission not allowed: proposal={proposal_id}, state={state:?}"
+            ),
+            Self::GovernanceStatusNotApproved {
+                proposal_id,
+                status,
+            } => write!(
+                f,
+                "governance status is not approved: proposal={proposal_id}, status={status:?}"
+            ),
+            Self::GovernanceWorkflow(error) => write!(f, "{error}"),
+            Self::UpgradeOrchestration(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentUpgradeWorkflowError {}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), AgentUpgradeWorkflowError> {
+    if value.trim().is_empty() {
+        return Err(AgentUpgradeWorkflowError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_timestamp(field: &'static str, value: u64) -> Result<(), AgentUpgradeWorkflowError> {
+    if value == 0 {
+        return Err(AgentUpgradeWorkflowError::InvalidTimestamp(field));
+    }
+    Ok(())
+}
+
+fn validate_did(value: &str) -> Result<(), AgentUpgradeWorkflowError> {
+    AgentDid::parse(value)
+        .map_err(|error| AgentUpgradeWorkflowError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AgentDrivenUpgradeWorkflow, AgentUpgradeProposalDraft, AgentUpgradeProposalState,
+        AgentUpgradeWorkflowConfig, AgentUpgradeWorkflowError,
+    };
+
+    #[test]
+    fn constructor_requires_allowlisted_agent_set() {
+        assert_eq!(
+            AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+                current_version: "v0.1.0".to_owned(),
+                allowed_agent_proposers: Vec::new(),
+                required_human_reviews: 1,
+                required_validator_quorum: 2,
+            }),
+            Err(AgentUpgradeWorkflowError::MissingAllowedAgentProposers)
+        );
+    }
+
+    #[test]
+    fn duplicate_human_review_is_rejected() {
+        let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+            current_version: "v0.1.0".to_owned(),
+            allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+            required_human_reviews: 1,
+            required_validator_quorum: 2,
+        })
+        .expect("workflow should initialize");
+        workflow
+            .submit_agent_proposal(AgentUpgradeProposalDraft {
+                proposal_id: "agent-upgrade-a".to_owned(),
+                target_version: "v0.2.0".to_owned(),
+                agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+                rationale: "initial proposal".to_owned(),
+                created_at_unix: 100,
+                voting_deadline_unix: 200,
+            })
+            .expect("proposal should register");
+
+        workflow
+            .approve_human_review("agent-upgrade-a", "kamn:did:agent:validator-1", 110)
+            .expect("first review should pass");
+        assert_eq!(
+            workflow.approve_human_review("agent-upgrade-a", "kamn:did:agent:validator-1", 111),
+            Err(AgentUpgradeWorkflowError::DuplicateHumanReview {
+                proposal_id: "agent-upgrade-a".to_owned(),
+                reviewer_did: "kamn:did:agent:validator-1".to_owned(),
+            })
+        );
+
+        let record = workflow
+            .proposal("agent-upgrade-a")
+            .expect("proposal should exist");
+        assert_eq!(record.state, AgentUpgradeProposalState::PendingHumanReview);
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_key_hierarchy;
+pub mod agent_upgrade_workflow;
 pub mod anti_spam;
 pub mod audit_exports;
 pub mod bootstrap;
@@ -58,6 +59,11 @@ pub mod zk_message_proofs;
 
 pub use agent_key_hierarchy::{
     AgentKeyHierarchy, AgentKeyHierarchyError, EphemeralSessionKey, KeyRole,
+};
+pub use agent_upgrade_workflow::{
+    AgentDrivenUpgradeWorkflow, AgentUpgradeAuditEvent, AgentUpgradeAuditEventKind,
+    AgentUpgradeProposalDraft, AgentUpgradeProposalRecord, AgentUpgradeProposalState,
+    AgentUpgradeWorkflowConfig, AgentUpgradeWorkflowError,
 };
 pub use anti_spam::{
     AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamError, AntiSpamRejection,

--- a/crates/kamn-core/tests/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow.rs
@@ -1,0 +1,213 @@
+use kamn_core::{
+    AgentDrivenUpgradeWorkflow, AgentUpgradeAuditEventKind, AgentUpgradeProposalDraft,
+    AgentUpgradeProposalState, AgentUpgradeWorkflowConfig, AgentUpgradeWorkflowError,
+    GovernanceProposalStatus, GovernanceVoteChoice,
+};
+
+#[test]
+fn agent_upgrade_workflow_rejects_unallowlisted_agent_proposer() {
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v0.5.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        required_human_reviews: 1,
+        required_validator_quorum: 2,
+    })
+    .expect("workflow should initialize");
+
+    assert_eq!(
+        workflow.submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-1".to_owned(),
+            target_version: "v0.6.0".to_owned(),
+            agent_did: "kamn:did:agent:rogue-bot".to_owned(),
+            rationale: "unsafe source".to_owned(),
+            created_at_unix: 1_716_610_000,
+            voting_deadline_unix: 1_716_610_600,
+        }),
+        Err(AgentUpgradeWorkflowError::UnauthorizedAgentProposer(
+            "kamn:did:agent:rogue-bot".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn agent_upgrade_workflow_functional_human_review_governance_activation_flow() {
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v0.5.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        required_human_reviews: 2,
+        required_validator_quorum: 2,
+    })
+    .expect("workflow should initialize");
+    workflow
+        .submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-2".to_owned(),
+            target_version: "v0.6.0".to_owned(),
+            agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+            rationale: "batch safety checks passed".to_owned(),
+            created_at_unix: 1_716_611_000,
+            voting_deadline_unix: 1_716_611_600,
+        })
+        .expect("agent proposal should register");
+    workflow
+        .approve_human_review(
+            "pilot-upgrade-2",
+            "kamn:did:agent:validator-1",
+            1_716_611_050,
+        )
+        .expect("first review should pass");
+    workflow
+        .approve_human_review(
+            "pilot-upgrade-2",
+            "kamn:did:agent:validator-2",
+            1_716_611_060,
+        )
+        .expect("second review should pass");
+
+    workflow
+        .submit_to_governance("pilot-upgrade-2", 1_716_611_100)
+        .expect("governance submission should pass");
+    workflow
+        .cast_validator_vote(
+            "pilot-upgrade-2",
+            "kamn:did:agent:validator-1",
+            GovernanceVoteChoice::Yes,
+            1_716_611_120,
+        )
+        .expect("yes vote should pass");
+    workflow
+        .cast_validator_vote(
+            "pilot-upgrade-2",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_611_130,
+        )
+        .expect("yes vote should pass");
+    workflow
+        .finalize_upgrade(
+            "pilot-upgrade-2",
+            "kamn:did:agent:validator-1",
+            1_716_611_200,
+            "op-hash-pilot-upgrade-2",
+        )
+        .expect("approved governance proposal should activate");
+
+    let record = workflow
+        .proposal("pilot-upgrade-2")
+        .expect("proposal record should exist");
+    assert_eq!(record.state, AgentUpgradeProposalState::Activated);
+    assert_eq!(
+        workflow.upgrade_audit_view().current_version,
+        "v0.6.0".to_owned()
+    );
+}
+
+#[test]
+fn agent_upgrade_workflow_integration_records_governance_and_upgrade_audit_traces() {
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v0.6.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        required_human_reviews: 1,
+        required_validator_quorum: 2,
+    })
+    .expect("workflow should initialize");
+    workflow
+        .submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-3".to_owned(),
+            target_version: "v0.7.0".to_owned(),
+            agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+            rationale: "performance baseline green".to_owned(),
+            created_at_unix: 1_716_612_000,
+            voting_deadline_unix: 1_716_612_500,
+        })
+        .expect("proposal should register");
+    workflow
+        .approve_human_review(
+            "pilot-upgrade-3",
+            "kamn:did:agent:validator-1",
+            1_716_612_050,
+        )
+        .expect("review should pass");
+    workflow
+        .submit_to_governance("pilot-upgrade-3", 1_716_612_100)
+        .expect("governance submission should pass");
+    workflow
+        .cast_validator_vote(
+            "pilot-upgrade-3",
+            "kamn:did:agent:validator-1",
+            GovernanceVoteChoice::Yes,
+            1_716_612_120,
+        )
+        .expect("yes vote should pass");
+    workflow
+        .cast_validator_vote(
+            "pilot-upgrade-3",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_612_130,
+        )
+        .expect("yes vote should pass");
+    workflow
+        .finalize_upgrade(
+            "pilot-upgrade-3",
+            "kamn:did:agent:validator-1",
+            1_716_612_200,
+            "op-hash-pilot-upgrade-3",
+        )
+        .expect("finalization should pass");
+
+    let governance_record = workflow
+        .governance_record("pilot-upgrade-3")
+        .expect("governance record should exist");
+    assert_eq!(governance_record.status, GovernanceProposalStatus::Executed);
+
+    let events = workflow.agent_audit_log();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == AgentUpgradeAuditEventKind::GovernanceSubmitted),
+        "governance submission event should be emitted"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == AgentUpgradeAuditEventKind::UpgradeActivated),
+        "upgrade activation event should be emitted"
+    );
+}
+
+#[test]
+fn agent_upgrade_workflow_regression_blocks_governance_submission_without_human_quorum() {
+    // Regression: #235
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v0.7.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        required_human_reviews: 2,
+        required_validator_quorum: 2,
+    })
+    .expect("workflow should initialize");
+    workflow
+        .submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-4".to_owned(),
+            target_version: "v0.8.0".to_owned(),
+            agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+            rationale: "insufficient review gate".to_owned(),
+            created_at_unix: 1_716_613_000,
+            voting_deadline_unix: 1_716_613_700,
+        })
+        .expect("proposal should register");
+    workflow
+        .approve_human_review(
+            "pilot-upgrade-4",
+            "kamn:did:agent:validator-1",
+            1_716_613_010,
+        )
+        .expect("single review should pass");
+
+    assert_eq!(
+        workflow.submit_to_governance("pilot-upgrade-4", 1_716_613_020),
+        Err(AgentUpgradeWorkflowError::InsufficientHumanReviews {
+            required: 2,
+            provided: 1,
+        })
+    );
+}

--- a/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
@@ -1,0 +1,30 @@
+const DOC: &str =
+    include_str!("../../../docs/foundation/agent-driven-upgrade-proposal-workflow.md");
+
+#[test]
+fn doc_contains_agent_upgrade_scope_and_models() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("AgentDrivenUpgradeWorkflow"));
+    assert!(DOC.contains("AgentUpgradeWorkflowConfig"));
+    assert!(DOC.contains("AgentUpgradeWorkflowError"));
+}
+
+#[test]
+fn doc_contains_workflow_safeguards_and_audit_rules() {
+    assert!(DOC.contains("## Workflow Safeguards"));
+    assert!(DOC.contains("## Governance and Audit Rules"));
+    assert!(DOC.contains("Governance submission requires:"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core --test agent_upgrade_workflow"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_human_review_quorum_gating_rule() {
+    // Regression: #235
+    assert!(DOC.contains("sufficient unique human reviewer approvals"));
+}

--- a/docs/foundation/agent-driven-upgrade-proposal-workflow.md
+++ b/docs/foundation/agent-driven-upgrade-proposal-workflow.md
@@ -1,0 +1,62 @@
+# Agent-Driven Protocol Upgrade Proposal Workflow (Issues #234 / #235)
+
+This document captures the first implementation slice for a pilot agent-driven protocol upgrade workflow with mandatory human and validator safeguards.
+
+## Scope Delivered
+- Added `crates/kamn-core/src/agent_upgrade_workflow.rs` with:
+  - `AgentDrivenUpgradeWorkflow` orchestration across:
+    - `submit_agent_proposal(...)`
+    - `approve_human_review(...)`
+    - `submit_to_governance(...)`
+    - `cast_validator_vote(...)`
+    - `finalize_upgrade(...)`
+  - workflow models:
+    - `AgentUpgradeWorkflowConfig`
+    - `AgentUpgradeProposalDraft`
+    - `AgentUpgradeProposalRecord`
+    - `AgentUpgradeProposalState`
+  - audit projection surfaces:
+    - `AgentUpgradeAuditEvent`
+    - `AgentUpgradeAuditEventKind`
+  - typed errors via `AgentUpgradeWorkflowError`.
+- Added integration and regression tests in `crates/kamn-core/tests/agent_upgrade_workflow.rs`.
+
+## Workflow Safeguards
+- Agent proposal submission requires:
+  - allowlisted proposer DID.
+  - non-empty proposal id and rationale.
+  - valid timestamps with deadline strictly after creation.
+- Governance submission requires:
+  - sufficient unique human reviewer approvals.
+  - pending-human-review proposal state.
+- Upgrade finalization requires:
+  - governance status `Approved`.
+  - governance execution recording.
+  - application of validator `Yes` votes as upgrade approvals before activation.
+
+## Governance and Audit Rules
+- Agent workflow emits deterministic audit events for:
+  - agent proposal intake
+  - human review approvals
+  - governance submission/approval/execution
+  - final upgrade activation
+- Governance and version-upgrade records remain queryable through:
+  - `governance_record(...)`
+  - `proposal(...)`
+  - `upgrade_audit_view(...)`
+  - `agent_audit_log(...)`
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test agent_upgrade_workflow --test agent_upgrade_workflow_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```
+
+Then run crate regression:
+
+```bash
+cargo test -p kamn-core
+```

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -104,5 +104,6 @@ For permissioned operator configure/revoke/read-history control actions and audi
 For governance proposal, voting, and execution workflow controls, see `docs/foundation/governance-proposal-vote-execution.md`.
 For validator onboarding/offboarding lifecycle and quorum reconfiguration controls, see `docs/foundation/validator-lifecycle-quorum-reconfiguration.md`.
 For governed version-upgrade orchestration and governance audit-view controls, see `docs/foundation/version-upgrade-orchestration-audit.md`.
+For pilot agent-driven upgrade proposal workflow controls with human-review safeguards, see `docs/foundation/agent-driven-upgrade-proposal-workflow.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.


### PR DESCRIPTION
## Summary
Implements the first Story #64 slice for a pilot agent-driven protocol upgrade proposal workflow. The change introduces a workflow engine that enforces allowlisted agent proposers, human-review quorum gating, governance promotion/execution, and deterministic upgrade activation audit traces.

Closes #235
Closes #234
Closes #64

## Changes
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: added workflow engine, proposal/audit models, and typed errors.
- `crates/kamn-core/tests/agent_upgrade_workflow.rs`: added unit/functional/integration/regression tests for pilot workflow safeguards.
- `crates/kamn-core/tests/agent_upgrade_workflow_docs.rs`: added documentation contract tests.
- `crates/kamn-core/src/lib.rs`: exported module and public API surface.
- `docs/foundation/agent-driven-upgrade-proposal-workflow.md`: documented workflow scope, safeguards, audit semantics, and validation lane.
- `docs/foundation/bootstrap.md`: linked new foundation document.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test agent_upgrade_workflow
```
Failure evidence (before implementation): unresolved imports for missing workflow API types (`AgentDrivenUpgradeWorkflow`, `AgentUpgradeWorkflowConfig`, `AgentUpgradeProposalDraft`, `AgentUpgradeProposalState`, `AgentUpgradeAuditEventKind`, `AgentUpgradeWorkflowError`).

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test agent_upgrade_workflow --test agent_upgrade_workflow_docs
```
Result: all targeted workflow and docs tests passed.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Result: all commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `agent_upgrade_workflow_rejects_unallowlisted_agent_proposer`, module unit tests | |
| Functional   | ✅     | `agent_upgrade_workflow_functional_human_review_governance_activation_flow` | |
| Integration  | ✅     | `agent_upgrade_workflow_integration_records_governance_and_upgrade_audit_traces` | |
| Regression   | ✅     | `agent_upgrade_workflow_regression_blocks_governance_submission_without_human_quorum` (Regression: #235) | |
| Performance  | N/A    | None | No new throughput-critical path introduced in this slice |

## Risks & Rollback
- Low risk; additive workflow module layered on existing governance and upgrade orchestration primitives.
- Rollback plan: revert this PR commit to remove workflow API, tests, and docs.

## Documentation Updates
- `docs/foundation/agent-driven-upgrade-proposal-workflow.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped strict lane)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-core`)
- [x] Docs updated
