### PR TITLE
feat(node): add deterministic text/json bootstrap output mode

### DIFF
--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -148,6 +148,7 @@ pub enum ConfigError {
     TokenModel(String),
     InvalidRole(String),
     InvalidSyncMode(String),
+    InvalidOutputMode(String),
     UnknownArgument(String),
     MissingArgumentValue(&'static str),
 }
@@ -162,6 +163,7 @@ impl fmt::Display for ConfigError {
             Self::TokenModel(message) => write!(f, "token model validation failed: {message}"),
             Self::InvalidRole(value) => write!(f, "invalid role: {value}"),
             Self::InvalidSyncMode(value) => write!(f, "invalid sync mode: {value}"),
+            Self::InvalidOutputMode(value) => write!(f, "invalid output mode: {value}"),
             Self::UnknownArgument(value) => write!(f, "unknown argument: {value}"),
             Self::MissingArgumentValue(flag) => {
                 write!(f, "missing value for argument: {flag}")

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1,7 +1,40 @@
 use std::env;
 use std::process::ExitCode;
 
-use kamn_core::{bootstrap, ConfigError, NodeConfig, NodeRole, SyncMode};
+use kamn_core::{bootstrap, BootstrapPlan, ConfigError, NodeConfig, NodeRole, SyncMode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputMode {
+    kind: OutputModeKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputModeKind {
+    Text,
+    Json,
+}
+
+impl OutputMode {
+    fn text() -> Self {
+        Self {
+            kind: OutputModeKind::Text,
+        }
+    }
+
+    fn json() -> Self {
+        Self {
+            kind: OutputModeKind::Json,
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, ConfigError> {
+        match value {
+            "text" => Ok(Self::text()),
+            "json" => Ok(Self::json()),
+            other => Err(ConfigError::InvalidOutputMode(other.to_owned())),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NodeCli {
@@ -11,6 +44,22 @@ struct NodeCli {
     storage_dir: String,
     enable_gossip: bool,
     sync_mode: SyncMode,
+    output_mode: OutputMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NodeBootstrapReport {
+    role: String,
+    chain_id: String,
+    chain_version: String,
+    storage_dir: String,
+    gossip_enabled: bool,
+    sync_mode: String,
+    sync_startup: String,
+    sync_recovery: String,
+    state_version: u32,
+    pending_migrations: usize,
+    components: Vec<String>,
 }
 
 fn parse_args<I>(args: I) -> Result<NodeCli, ConfigError>
@@ -23,6 +72,7 @@ where
     let mut storage_dir = String::from("./data");
     let mut enable_gossip = true;
     let mut sync_mode = SyncMode::Fast;
+    let mut output_mode = OutputMode::text();
 
     let mut iter = args.into_iter();
     let _bin = iter.next();
@@ -59,6 +109,12 @@ where
                     .ok_or(ConfigError::MissingArgumentValue("--sync-mode"))?;
                 sync_mode = value.parse::<SyncMode>()?;
             }
+            "--output" => {
+                let value = iter
+                    .next()
+                    .ok_or(ConfigError::MissingArgumentValue("--output"))?;
+                output_mode = OutputMode::parse(&value)?;
+            }
             unknown => {
                 return Err(ConfigError::UnknownArgument(unknown.to_owned()));
             }
@@ -74,6 +130,7 @@ where
         storage_dir,
         enable_gossip,
         sync_mode,
+        output_mode,
     })
 }
 
@@ -90,28 +147,90 @@ fn run() -> Result<(), ConfigError> {
     };
 
     let plan = bootstrap(config)?;
-    let profile = plan.config.operational_profile();
+    let report = build_bootstrap_report(&plan);
+    println!("{}", render_bootstrap_report(&report, cli.output_mode));
 
-    println!(
-        "KAMN node bootstrap\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  sync_mode: {}\n  sync_startup: {:?}\n  sync_recovery: {:?}\n  state_version: {}\n  pending_migrations: {}\n  components: {}",
-        plan.config.role.as_str(),
-        plan.config.chain_id,
-        plan.config.chain_version,
-        plan.config.storage_dir,
-        if plan.config.enable_gossip {
+    Ok(())
+}
+
+fn build_bootstrap_report(plan: &BootstrapPlan) -> NodeBootstrapReport {
+    let profile = plan.config.operational_profile();
+    NodeBootstrapReport {
+        role: plan.config.role.as_str().to_owned(),
+        chain_id: plan.config.chain_id.clone(),
+        chain_version: plan.config.chain_version.clone(),
+        storage_dir: plan.config.storage_dir.clone(),
+        gossip_enabled: plan.config.enable_gossip,
+        sync_mode: plan.config.sync_mode.as_str().to_owned(),
+        sync_startup: format!("{:?}", profile.startup_strategy),
+        sync_recovery: format!("{:?}", profile.recovery_strategy),
+        state_version: plan.state_schema.version.0,
+        pending_migrations: plan.migration_plan.steps.len(),
+        components: plan
+            .wiring
+            .all_components()
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+    }
+}
+
+fn render_bootstrap_report(report: &NodeBootstrapReport, mode: OutputMode) -> String {
+    match mode.kind {
+        OutputModeKind::Text => render_text_report(report),
+        OutputModeKind::Json => render_json_report(report),
+    }
+}
+
+fn render_text_report(report: &NodeBootstrapReport) -> String {
+    format!(
+        "KAMN node bootstrap\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  sync_mode: {}\n  sync_startup: {}\n  sync_recovery: {}\n  state_version: {}\n  pending_migrations: {}\n  components: {}",
+        report.role,
+        report.chain_id,
+        report.chain_version,
+        report.storage_dir,
+        if report.gossip_enabled {
             "enabled"
         } else {
             "disabled"
         },
-        plan.config.sync_mode.as_str(),
-        profile.startup_strategy,
-        profile.recovery_strategy,
-        plan.state_schema.version.0,
-        plan.migration_plan.steps.len(),
-        plan.wiring.all_components().join(", ")
-    );
+        report.sync_mode,
+        report.sync_startup,
+        report.sync_recovery,
+        report.state_version,
+        report.pending_migrations,
+        report.components.join(", "),
+    )
+}
 
-    Ok(())
+fn render_json_report(report: &NodeBootstrapReport) -> String {
+    let components = report
+        .components
+        .iter()
+        .map(|component| format!("\"{}\"", json_escape(component)))
+        .collect::<Vec<String>>()
+        .join(",");
+    format!(
+        "{{\"role\":\"{}\",\"chain_id\":\"{}\",\"chain_version\":\"{}\",\"storage_dir\":\"{}\",\"gossip_enabled\":{},\"sync_mode\":\"{}\",\"sync_startup\":\"{}\",\"sync_recovery\":\"{}\",\"state_version\":{},\"pending_migrations\":{},\"components\":[{}]}}",
+        json_escape(&report.role),
+        json_escape(&report.chain_id),
+        json_escape(&report.chain_version),
+        json_escape(&report.storage_dir),
+        report.gossip_enabled,
+        json_escape(&report.sync_mode),
+        json_escape(&report.sync_startup),
+        json_escape(&report.sync_recovery),
+        report.state_version,
+        report.pending_migrations,
+        components,
+    )
+}
+
+fn json_escape(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('\"', "\\\"")
+        .replace('\n', "\\n")
 }
 
 fn main() -> ExitCode {
@@ -126,8 +245,11 @@ fn main() -> ExitCode {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_args;
-    use kamn_core::{ConfigError, NodeRole, SyncMode};
+    use super::{
+        build_bootstrap_report, parse_args, render_bootstrap_report, NodeBootstrapReport,
+        OutputMode,
+    };
+    use kamn_core::{bootstrap, ConfigError, NodeConfig, NodeRole, SyncMode};
 
     #[test]
     fn parses_required_role_and_defaults() {
@@ -144,6 +266,7 @@ mod tests {
         assert_eq!(parsed.storage_dir, "./data");
         assert!(parsed.enable_gossip);
         assert_eq!(parsed.sync_mode, SyncMode::Fast);
+        assert_eq!(parsed.output_mode, OutputMode::text());
     }
 
     #[test]
@@ -176,6 +299,71 @@ mod tests {
     }
 
     #[test]
+    fn parses_output_mode_json_flag() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--output".to_owned(),
+            "json".to_owned(),
+        ];
+
+        let parsed = parse_args(args).expect("args should parse");
+        assert_eq!(parsed.output_mode, OutputMode::json());
+    }
+
+    #[test]
+    fn functional_json_render_is_deterministic() {
+        let report = NodeBootstrapReport {
+            role: "processor".to_owned(),
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            storage_dir: "./data".to_owned(),
+            gossip_enabled: true,
+            sync_mode: "fast".to_owned(),
+            sync_startup: "StateSyncToLatest".to_owned(),
+            sync_recovery: "ResumeRecentState".to_owned(),
+            state_version: 1,
+            pending_migrations: 0,
+            components: vec!["processor".to_owned(), "listener".to_owned()],
+        };
+
+        let first = render_bootstrap_report(&report, OutputMode::json());
+        let second = render_bootstrap_report(&report, OutputMode::json());
+        assert_eq!(first, second, "json output should be deterministic");
+        assert!(first.contains("\"role\":\"processor\""));
+        assert!(first.contains("\"components\":[\"processor\",\"listener\"]"));
+    }
+
+    #[test]
+    fn integration_parse_bootstrap_and_render_json() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--output".to_owned(),
+            "json".to_owned(),
+        ];
+        let parsed = parse_args(args).expect("args should parse");
+        let config = NodeConfig {
+            chain_id: parsed.chain_id,
+            chain_version: parsed.chain_version,
+            role: parsed.role,
+            storage_dir: parsed.storage_dir,
+            enable_gossip: parsed.enable_gossip,
+            sync_mode: parsed.sync_mode,
+        };
+        let plan = bootstrap(config).expect("bootstrap should succeed");
+        let report = build_bootstrap_report(&plan);
+        let rendered = render_bootstrap_report(&report, parsed.output_mode);
+
+        assert!(rendered.contains("\"role\":\"processor\""));
+        assert!(rendered.contains("\"chain_id\":\"kamn-devnet\""));
+        assert!(rendered.contains("\"sync_mode\":\"fast\""));
+        assert!(rendered.contains("\"components\":["));
+    }
+
+    #[test]
     fn rejects_missing_role() {
         let args = vec!["kamn-node".to_owned()];
         assert_eq!(
@@ -195,6 +383,22 @@ mod tests {
         assert_eq!(
             parse_args(args),
             Err(ConfigError::UnknownArgument("--unknown".to_owned()))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_output_mode() {
+        // Regression: #307
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "approver".to_owned(),
+            "--output".to_owned(),
+            "yaml".to_owned(),
+        ];
+        assert_eq!(
+            parse_args(args),
+            Err(ConfigError::InvalidOutputMode("yaml".to_owned()))
         );
     }
 }

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -1,0 +1,29 @@
+const DOC: &str = include_str!("../../../docs/foundation/node-runtime-cli.md");
+
+#[test]
+fn doc_contains_output_mode_scope_and_rules() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("--output text"));
+    assert!(DOC.contains("--output json"));
+    assert!(DOC.contains("ConfigError::InvalidOutputMode"));
+}
+
+#[test]
+fn doc_contains_deterministic_json_fields() {
+    assert!(DOC.contains("JSON output is deterministic and includes:"));
+    assert!(DOC.contains("sync_mode"));
+    assert!(DOC.contains("components"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-node"));
+    assert!(DOC.contains("cargo clippy -p kamn-node -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_invalid_output_mode_rule() {
+    // Regression: #307
+    assert!(DOC.contains("Invalid modes are rejected with explicit typed error."));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -105,5 +105,6 @@ For governance proposal, voting, and execution workflow controls, see `docs/foun
 For validator onboarding/offboarding lifecycle and quorum reconfiguration controls, see `docs/foundation/validator-lifecycle-quorum-reconfiguration.md`.
 For governed version-upgrade orchestration and governance audit-view controls, see `docs/foundation/version-upgrade-orchestration-audit.md`.
 For pilot agent-driven upgrade proposal workflow controls with human-review safeguards, see `docs/foundation/agent-driven-upgrade-proposal-workflow.md`.
+For node runtime CLI output-mode contracts and deterministic text/json report surfaces, see `docs/foundation/node-runtime-cli.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -1,0 +1,53 @@
+# Node Runtime CLI Contracts (Issues #306 / #307)
+
+This document captures the first node-runtime productionization slice for machine-readable CLI output.
+
+## Scope Delivered
+- Added output-mode support to `crates/kamn-node/src/main.rs`:
+  - `--output text` (default)
+  - `--output json`
+- Added deterministic report rendering helpers:
+  - `build_bootstrap_report(...)`
+  - `render_bootstrap_report(...)`
+- Added explicit invalid-mode handling through `ConfigError::InvalidOutputMode`.
+
+## Output Mode Rules
+- Default behavior remains text output when `--output` is omitted.
+- JSON output is deterministic and includes:
+  - `role`
+  - `chain_id`
+  - `chain_version`
+  - `storage_dir`
+  - `gossip_enabled`
+  - `sync_mode`
+  - `sync_startup`
+  - `sync_recovery`
+  - `state_version`
+  - `pending_migrations`
+  - `components`
+- Invalid modes are rejected with explicit typed error.
+
+## Test Coverage Mapping
+- Unit:
+  - default mode behavior and mode parsing checks
+- Functional:
+  - deterministic JSON rendering contract
+- Integration:
+  - CLI parse -> bootstrap -> render projection path
+- Regression:
+  - invalid output mode rejection (`Regression: #307`)
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-node
+cargo fmt --check
+cargo clippy -p kamn-node -- -D warnings
+```
+
+Then run broader regression:
+
+```bash
+cargo test -p kamn-core
+```


### PR DESCRIPTION
## Summary
Implements the first node-runtime productionization slice by adding deterministic `kamn-node` output modes (`text` and `json`) with explicit invalid-mode handling. This enables low-friction automation consumption of bootstrap/runtime state without changing default human-readable behavior.

Closes #307
Closes #306
Closes #303

## Changes
- `crates/kamn-node/src/main.rs`: added output mode parsing (`--output`), deterministic report model/rendering, and expanded CLI behavior tests.
- `crates/kamn-core/src/config.rs`: added `ConfigError::InvalidOutputMode`.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added docs-contract assertions.
- `docs/foundation/node-runtime-cli.md`: documented node CLI output contracts and fast validation lane.
- `docs/foundation/bootstrap.md`: linked new node runtime CLI foundation doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node
```
Failure evidence (before implementation):
- `error[E0609]: no field output_mode on type NodeCli`
- `error[E0599]: no variant or associated item named InvalidOutputMode found for enum ConfigError`

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-node
```
Result:
- `9` unit/behavior tests passed in `src/main.rs`
- `4` docs-contract tests passed in `tests/node_runtime_cli_docs.rs`

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -p kamn-node -- -D warnings
cargo test -p kamn-node
cargo test -p kamn-core
```
Result: all commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `parses_required_role_and_defaults`, `parses_output_mode_json_flag`, parser/validation tests in `crates/kamn-node/src/main.rs` | |
| Functional   | ✅     | `functional_json_render_is_deterministic` in `crates/kamn-node/src/main.rs` | |
| Integration  | ✅     | `integration_parse_bootstrap_and_render_json` in `crates/kamn-node/src/main.rs` | |
| Regression   | ✅     | `rejects_invalid_output_mode` (`Regression: #307`) and docs regression assertion | |
| Performance  | N/A    | None | Rendering-only change, no throughput-critical runtime path added |

## Risks & Rollback
- Low risk; additive CLI mode surface with backward-compatible default output mode.
- Rollback plan: revert this PR commit to remove `--output` support and restore previous output-only behavior.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/foundation/bootstrap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated
