### PR TITLE
feat(runtime): add peer lifecycle and bounded queue guards

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -211,7 +211,10 @@ pub use retention_engine::{
     RetentionClass, RetentionDomain, RetentionEnginePolicy, RetentionEvaluation,
     RetentionPolicyEngine, RetentionPolicyError, RetentionRecord, RetentionStatus,
 };
-pub use runtime::RuntimeWiring;
+pub use runtime::{
+    BoundedRuntimeQueue, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
+    RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
+};
 pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,
     ServiceMarketplaceError,

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -1,4 +1,195 @@
 use crate::config::{NodeConfig, NodeRole};
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerLifecycleState {
+    Disconnected,
+    Connecting,
+    Active,
+    Degraded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerLifecycleEvent {
+    StartConnect,
+    HandshakeSucceeded,
+    HeartbeatMissed,
+    HeartbeatRestored,
+    Disconnect,
+    Rejoin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeLifecycleError {
+    InvalidPeerId,
+    InvalidTransition {
+        from: PeerLifecycleState,
+        event: PeerLifecycleEvent,
+    },
+}
+
+impl Display for RuntimeLifecycleError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPeerId => write!(f, "runtime peer id cannot be empty"),
+            Self::InvalidTransition { from, event } => {
+                write!(
+                    f,
+                    "invalid peer lifecycle transition from {from:?} via {event:?}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for RuntimeLifecycleError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerLifecycle {
+    peer_id: String,
+    state: PeerLifecycleState,
+}
+
+impl PeerLifecycle {
+    pub fn new(peer_id: &str) -> Result<Self, RuntimeLifecycleError> {
+        if peer_id.trim().is_empty() {
+            return Err(RuntimeLifecycleError::InvalidPeerId);
+        }
+        Ok(Self {
+            peer_id: peer_id.to_owned(),
+            state: PeerLifecycleState::Disconnected,
+        })
+    }
+
+    pub fn peer_id(&self) -> &str {
+        &self.peer_id
+    }
+
+    pub fn state(&self) -> PeerLifecycleState {
+        self.state
+    }
+
+    pub fn transition(
+        &mut self,
+        event: PeerLifecycleEvent,
+    ) -> Result<PeerLifecycleState, RuntimeLifecycleError> {
+        let Some(next_state) = next_peer_state(self.state, event) else {
+            return Err(RuntimeLifecycleError::InvalidTransition {
+                from: self.state,
+                event,
+            });
+        };
+        self.state = next_state;
+        Ok(next_state)
+    }
+}
+
+fn next_peer_state(
+    from: PeerLifecycleState,
+    event: PeerLifecycleEvent,
+) -> Option<PeerLifecycleState> {
+    match (from, event) {
+        (PeerLifecycleState::Disconnected, PeerLifecycleEvent::StartConnect)
+        | (PeerLifecycleState::Disconnected, PeerLifecycleEvent::Rejoin) => {
+            Some(PeerLifecycleState::Connecting)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::HandshakeSucceeded) => {
+            Some(PeerLifecycleState::Active)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Active, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Degraded, PeerLifecycleEvent::Disconnect) => {
+            Some(PeerLifecycleState::Disconnected)
+        }
+        (PeerLifecycleState::Active, PeerLifecycleEvent::HeartbeatMissed) => {
+            Some(PeerLifecycleState::Degraded)
+        }
+        (PeerLifecycleState::Degraded, PeerLifecycleEvent::HeartbeatRestored) => {
+            Some(PeerLifecycleState::Active)
+        }
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeQueueError {
+    InvalidCapacity {
+        capacity: usize,
+    },
+    Overflow {
+        capacity: usize,
+        attempted_len: usize,
+    },
+}
+
+impl Display for RuntimeQueueError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCapacity { capacity } => {
+                write!(
+                    f,
+                    "runtime queue capacity must be at least 1 (got {capacity})"
+                )
+            }
+            Self::Overflow {
+                capacity,
+                attempted_len,
+            } => write!(
+                f,
+                "runtime queue overflow: capacity {capacity}, attempted length {attempted_len}"
+            ),
+        }
+    }
+}
+
+impl Error for RuntimeQueueError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedRuntimeQueue<T> {
+    capacity: usize,
+    entries: VecDeque<T>,
+}
+
+impl<T> BoundedRuntimeQueue<T> {
+    pub fn new(capacity: usize) -> Result<Self, RuntimeQueueError> {
+        if capacity == 0 {
+            return Err(RuntimeQueueError::InvalidCapacity { capacity });
+        }
+        Ok(Self {
+            capacity,
+            entries: VecDeque::with_capacity(capacity),
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn enqueue(&mut self, item: T) -> Result<(), RuntimeQueueError> {
+        if self.entries.len() >= self.capacity {
+            return Err(RuntimeQueueError::Overflow {
+                capacity: self.capacity,
+                attempted_len: self.entries.len() + 1,
+            });
+        }
+        self.entries.push_back(item);
+        Ok(())
+    }
+
+    pub fn dequeue(&mut self) -> Option<T> {
+        self.entries.pop_front()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeWiring {
@@ -31,7 +222,10 @@ pub fn build_runtime_wiring(config: &NodeConfig) -> RuntimeWiring {
 
 #[cfg(test)]
 mod tests {
-    use super::build_runtime_wiring;
+    use super::{
+        build_runtime_wiring, BoundedRuntimeQueue, PeerLifecycle, PeerLifecycleEvent,
+        PeerLifecycleState, RuntimeLifecycleError, RuntimeQueueError,
+    };
     use crate::config::{NodeConfig, NodeRole, SyncMode};
 
     fn sample_config(role: NodeRole) -> NodeConfig {
@@ -61,5 +255,112 @@ mod tests {
     fn approver_wiring_contains_quorum_approver() {
         let wiring = build_runtime_wiring(&sample_config(NodeRole::Approver));
         assert!(wiring.role_components.contains(&"quorum-approver"));
+    }
+
+    #[test]
+    fn functional_peer_lifecycle_allows_connect_heartbeat_recover_disconnect_flow() {
+        let mut lifecycle = PeerLifecycle::new("peer-1").expect("valid peer id");
+        assert_eq!(lifecycle.peer_id(), "peer-1");
+        assert_eq!(lifecycle.state(), PeerLifecycleState::Disconnected);
+        assert!(lifecycle
+            .transition(PeerLifecycleEvent::StartConnect)
+            .is_ok());
+        assert!(lifecycle
+            .transition(PeerLifecycleEvent::HandshakeSucceeded)
+            .is_ok());
+        assert_eq!(lifecycle.state(), PeerLifecycleState::Active);
+        assert!(lifecycle
+            .transition(PeerLifecycleEvent::HeartbeatMissed)
+            .is_ok());
+        assert_eq!(lifecycle.state(), PeerLifecycleState::Degraded);
+        assert!(lifecycle
+            .transition(PeerLifecycleEvent::HeartbeatRestored)
+            .is_ok());
+        assert_eq!(lifecycle.state(), PeerLifecycleState::Active);
+        assert!(lifecycle.transition(PeerLifecycleEvent::Disconnect).is_ok());
+        assert_eq!(lifecycle.state(), PeerLifecycleState::Disconnected);
+    }
+
+    #[test]
+    fn integration_bounded_runtime_queue_preserves_fifo_until_capacity() {
+        let mut queue = BoundedRuntimeQueue::new(2).expect("queue should build");
+        assert_eq!(queue.capacity(), 2);
+        assert!(queue.is_empty());
+        assert!(queue.enqueue("evt-1".to_owned()).is_ok());
+        assert!(queue.enqueue("evt-2".to_owned()).is_ok());
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.dequeue(), Some("evt-1".to_owned()));
+        assert_eq!(queue.dequeue(), Some("evt-2".to_owned()));
+        assert!(queue.dequeue().is_none());
+    }
+
+    #[test]
+    fn unit_rejects_invalid_peer_lifecycle_transition() {
+        let mut lifecycle = PeerLifecycle::new("peer-1").expect("valid peer id");
+        let error = lifecycle
+            .transition(PeerLifecycleEvent::HandshakeSucceeded)
+            .expect_err("handshake cannot complete before connect");
+        assert_eq!(
+            error,
+            RuntimeLifecycleError::InvalidTransition {
+                from: PeerLifecycleState::Disconnected,
+                event: PeerLifecycleEvent::HandshakeSucceeded
+            }
+        );
+    }
+
+    #[test]
+    fn regression_rejoin_without_disconnect_is_rejected() {
+        // Regression: #324
+        let mut lifecycle = PeerLifecycle::new("peer-1").expect("valid peer id");
+        assert!(lifecycle
+            .transition(PeerLifecycleEvent::StartConnect)
+            .is_ok());
+        assert!(lifecycle
+            .transition(PeerLifecycleEvent::HandshakeSucceeded)
+            .is_ok());
+        let error = lifecycle
+            .transition(PeerLifecycleEvent::Rejoin)
+            .expect_err("rejoin should require disconnected state");
+        assert_eq!(
+            error,
+            RuntimeLifecycleError::InvalidTransition {
+                from: PeerLifecycleState::Active,
+                event: PeerLifecycleEvent::Rejoin
+            }
+        );
+    }
+
+    #[test]
+    fn regression_queue_overflow_rejects_new_event() {
+        // Regression: #324
+        let mut queue = BoundedRuntimeQueue::new(1).expect("queue should build");
+        assert!(queue.enqueue("evt-1".to_owned()).is_ok());
+        let error = queue
+            .enqueue("evt-2".to_owned())
+            .expect_err("second enqueue must overflow");
+        assert_eq!(
+            error,
+            RuntimeQueueError::Overflow {
+                capacity: 1,
+                attempted_len: 2
+            }
+        );
+    }
+
+    #[test]
+    fn unit_rejects_empty_peer_id() {
+        assert_eq!(
+            PeerLifecycle::new(""),
+            Err(RuntimeLifecycleError::InvalidPeerId)
+        );
+    }
+
+    #[test]
+    fn unit_rejects_zero_queue_capacity() {
+        assert_eq!(
+            BoundedRuntimeQueue::<String>::new(0),
+            Err(RuntimeQueueError::InvalidCapacity { capacity: 0 })
+        );
     }
 }

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -1,0 +1,31 @@
+const DOC: &str = include_str!("../../../docs/foundation/runtime-network.md");
+
+#[test]
+fn doc_contains_runtime_network_scope_and_models() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("PeerLifecycle"));
+    assert!(DOC.contains("BoundedRuntimeQueue<T>"));
+    assert!(DOC.contains("RuntimeLifecycleError"));
+}
+
+#[test]
+fn doc_contains_peer_lifecycle_and_queue_rules() {
+    assert!(DOC.contains("## Peer Lifecycle Rules"));
+    assert!(DOC.contains("## Queue Guard Rules"));
+    assert!(DOC.contains("Overflow does not evict existing entries"));
+    assert!(DOC.contains("Empty peer IDs are rejected"));
+}
+
+#[test]
+fn doc_contains_fast_and_cost_effective_validation_lane() {
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("cargo test -p kamn-core runtime::tests::"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_rejoin_and_overflow_rejection_rules() {
+    // Regression: #324
+    assert!(DOC.contains("rejoin without disconnect is rejected"));
+    assert!(DOC.contains("queue overflow rejects new event"));
+}

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -106,5 +106,6 @@ For validator onboarding/offboarding lifecycle and quorum reconfiguration contro
 For governed version-upgrade orchestration and governance audit-view controls, see `docs/foundation/version-upgrade-orchestration-audit.md`.
 For pilot agent-driven upgrade proposal workflow controls with human-review safeguards, see `docs/foundation/agent-driven-upgrade-proposal-workflow.md`.
 For node runtime CLI output-mode contracts and deterministic text/json report surfaces, see `docs/foundation/node-runtime-cli.md`.
+For runtime peer lifecycle and bounded queue guard controls, see `docs/foundation/runtime-network.md`.
 For fast/slow/archive sync-mode operational profile controls, see `docs/foundation/sync-mode-profiles.md`.
 For PRD 13.2 benchmark target validation evidence controls, see `docs/foundation/performance-target-benchmarking.md`.

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -1,0 +1,61 @@
+# Runtime Network Contracts (Issues #315 / #317 / #320 / #324)
+
+This document captures the initial runtime-network foundation slice for peer lifecycle and bounded queue behavior in `kamn-core`.
+
+## Scope Delivered
+- Added peer lifecycle state machine primitives in `crates/kamn-core/src/runtime.rs`:
+  - `PeerLifecycleState`
+  - `PeerLifecycleEvent`
+  - `PeerLifecycle`
+  - `RuntimeLifecycleError`
+- Added bounded FIFO queue primitives in `crates/kamn-core/src/runtime.rs`:
+  - `BoundedRuntimeQueue<T>`
+  - `RuntimeQueueError`
+- Kept runtime role wiring behavior unchanged and covered by existing tests.
+
+## Peer Lifecycle Rules
+- `PeerLifecycle` starts in `Disconnected`.
+- Valid transitions:
+  - `Disconnected` + `StartConnect` -> `Connecting`
+  - `Disconnected` + `Rejoin` -> `Connecting`
+  - `Connecting` + `HandshakeSucceeded` -> `Active`
+  - `Active` + `HeartbeatMissed` -> `Degraded`
+  - `Degraded` + `HeartbeatRestored` -> `Active`
+  - `Connecting|Active|Degraded` + `Disconnect` -> `Disconnected`
+- Invalid transitions return `RuntimeLifecycleError::InvalidTransition`.
+- Empty peer IDs are rejected with `RuntimeLifecycleError::InvalidPeerId`.
+
+## Queue Guard Rules
+- `BoundedRuntimeQueue<T>` is FIFO and preserves insertion order.
+- Capacity must be greater than zero.
+- Overflow does not evict existing entries; new enqueue attempts fail with:
+  - `RuntimeQueueError::Overflow { capacity, attempted_len }`
+- Zero-capacity queues fail with:
+  - `RuntimeQueueError::InvalidCapacity { capacity: 0 }`
+
+## Test Coverage Mapping
+- Unit:
+  - invalid transition checks
+  - empty peer ID and zero-capacity queue rejection
+- Functional:
+  - peer lifecycle connect/degrade/recover/disconnect flow
+- Integration:
+  - bounded FIFO queue behavior under capacity
+- Regression:
+  - rejoin without disconnect is rejected (`Regression: #324`)
+  - queue overflow rejects new event (`Regression: #324`)
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core runtime::tests::
+cargo test -p kamn-core --test runtime_network_docs
+```
+
+Then run strict lint/format gates:
+
+```bash
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```


### PR DESCRIPTION
Closes #324
Closes #320

## Summary
Implements the first runtime-network foundation slice by adding deterministic peer lifecycle transitions and bounded FIFO runtime queue guards in `kamn-core`, with explicit typed errors and regression coverage.

## Changes
- `crates/kamn-core/src/runtime.rs`: added `PeerLifecycleState`, `PeerLifecycleEvent`, `PeerLifecycle`, `RuntimeLifecycleError`, `BoundedRuntimeQueue<T>`, and `RuntimeQueueError` with deterministic transition and overflow semantics.
- `crates/kamn-core/src/lib.rs`: exported new runtime lifecycle/queue APIs.
- `docs/foundation/runtime-network.md`: added runtime-network contract documentation for lifecycle and queue rules.
- `crates/kamn-core/tests/runtime_network_docs.rs`: added docs contract tests including regression rule assertions.
- `docs/foundation/bootstrap.md`: linked the new runtime-network foundation document.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised red-first then green runtime lifecycle/queue test flow and strict crate-level validation.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Lifecycle invalid transition, empty peer id, and zero-capacity queue tests in `runtime.rs`. |
| Functional  | ✅     | Connect/degrade/recover/disconnect lifecycle flow test in `runtime.rs`. |
| Integration | ✅     | Bounded FIFO queue behavior test plus full `kamn-core` integration suite pass. |
| Regression  | ✅     | Rejoin-without-disconnect and queue-overflow rejection tests marked `Regression: #324`. |
