### PR TITLE
feat(runtime): add deterministic proposal planner and replay guards

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -212,7 +212,8 @@ pub use retention_engine::{
     RetentionPolicyEngine, RetentionPolicyError, RetentionRecord, RetentionStatus,
 };
 pub use runtime::{
-    BoundedRuntimeQueue, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
+    BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle, PeerLifecycleEvent,
+    PeerLifecycleState, ProposalCandidate, ProposalPlan, ProposalPlannerError,
     RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
 };
 pub use service_marketplace::{

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -1,5 +1,5 @@
 use crate::config::{NodeConfig, NodeRole};
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
@@ -192,6 +192,152 @@ impl<T> BoundedRuntimeQueue<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalCandidate {
+    id: String,
+    sender_did: String,
+    nonce: u64,
+    state_hash: String,
+}
+
+impl ProposalCandidate {
+    pub fn new(
+        id: &str,
+        sender_did: &str,
+        nonce: u64,
+        state_hash: &str,
+    ) -> Result<Self, ProposalPlannerError> {
+        if id.trim().is_empty() {
+            return Err(ProposalPlannerError::InvalidCandidateId);
+        }
+        if sender_did.trim().is_empty() {
+            return Err(ProposalPlannerError::InvalidSenderDid);
+        }
+        if state_hash.trim().is_empty() {
+            return Err(ProposalPlannerError::InvalidStateHash);
+        }
+        if nonce == 0 {
+            return Err(ProposalPlannerError::InvalidNonce);
+        }
+        Ok(Self {
+            id: id.to_owned(),
+            sender_did: sender_did.to_owned(),
+            nonce,
+            state_hash: state_hash.to_owned(),
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn sender_did(&self) -> &str {
+        &self.sender_did
+    }
+
+    pub fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    pub fn state_hash(&self) -> &str {
+        &self.state_hash
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalPlan {
+    ordered_candidates: Vec<ProposalCandidate>,
+}
+
+impl ProposalPlan {
+    pub fn ordered_candidates(&self) -> &[ProposalCandidate] {
+        &self.ordered_candidates
+    }
+
+    pub fn ordered_candidate_ids(&self) -> Vec<String> {
+        self.ordered_candidates
+            .iter()
+            .map(|candidate| candidate.id.clone())
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProposalPlannerError {
+    InvalidCandidateId,
+    InvalidSenderDid,
+    InvalidStateHash,
+    InvalidNonce,
+    DuplicateCandidateId(String),
+    StaleStateHash { expected: String, found: String },
+}
+
+impl Display for ProposalPlannerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCandidateId => write!(f, "proposal candidate id cannot be empty"),
+            Self::InvalidSenderDid => write!(f, "proposal candidate sender DID cannot be empty"),
+            Self::InvalidStateHash => write!(f, "proposal candidate state hash cannot be empty"),
+            Self::InvalidNonce => write!(f, "proposal candidate nonce must be positive"),
+            Self::DuplicateCandidateId(id) => {
+                write!(f, "duplicate proposal candidate id: {id}")
+            }
+            Self::StaleStateHash { expected, found } => {
+                write!(
+                    f,
+                    "proposal candidate state hash mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for ProposalPlannerError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeterministicProposalPlanner {
+    expected_state_hash: String,
+}
+
+impl DeterministicProposalPlanner {
+    pub fn new(expected_state_hash: &str) -> Self {
+        Self {
+            expected_state_hash: expected_state_hash.to_owned(),
+        }
+    }
+
+    pub fn plan(
+        &self,
+        mut candidates: Vec<ProposalCandidate>,
+    ) -> Result<ProposalPlan, ProposalPlannerError> {
+        let mut seen_ids = HashSet::new();
+        for candidate in &candidates {
+            if !seen_ids.insert(candidate.id.as_str()) {
+                return Err(ProposalPlannerError::DuplicateCandidateId(
+                    candidate.id.clone(),
+                ));
+            }
+            if candidate.state_hash != self.expected_state_hash {
+                return Err(ProposalPlannerError::StaleStateHash {
+                    expected: self.expected_state_hash.clone(),
+                    found: candidate.state_hash.clone(),
+                });
+            }
+        }
+
+        candidates.sort_by(|left, right| {
+            left.nonce
+                .cmp(&right.nonce)
+                .then_with(|| left.sender_did.cmp(&right.sender_did))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        Ok(ProposalPlan {
+            ordered_candidates: candidates,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeWiring {
     pub common_components: Vec<&'static str>,
     pub role_components: Vec<&'static str>,
@@ -223,8 +369,9 @@ pub fn build_runtime_wiring(config: &NodeConfig) -> RuntimeWiring {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_runtime_wiring, BoundedRuntimeQueue, PeerLifecycle, PeerLifecycleEvent,
-        PeerLifecycleState, RuntimeLifecycleError, RuntimeQueueError,
+        build_runtime_wiring, BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle,
+        PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
+        RuntimeLifecycleError, RuntimeQueueError,
     };
     use crate::config::{NodeConfig, NodeRole, SyncMode};
 
@@ -361,6 +508,96 @@ mod tests {
         assert_eq!(
             BoundedRuntimeQueue::<String>::new(0),
             Err(RuntimeQueueError::InvalidCapacity { capacity: 0 })
+        );
+    }
+
+    #[test]
+    fn functional_planner_orders_candidates_deterministically() {
+        let candidates = vec![
+            ProposalCandidate::new("tx-3", "did:kamn:agent:bbb", 2, "state-1").expect("valid"),
+            ProposalCandidate::new("tx-1", "did:kamn:agent:aaa", 1, "state-1").expect("valid"),
+            ProposalCandidate::new("tx-2", "did:kamn:agent:bbb", 1, "state-1").expect("valid"),
+        ];
+
+        let planner = DeterministicProposalPlanner::new("state-1");
+        let plan = planner.plan(candidates).expect("plan should build");
+        assert_eq!(
+            plan.ordered_candidate_ids(),
+            vec!["tx-1".to_owned(), "tx-2".to_owned(), "tx-3".to_owned()]
+        );
+    }
+
+    #[test]
+    fn integration_queue_drains_into_planner_without_order_loss() {
+        let mut queue = BoundedRuntimeQueue::new(3).expect("queue should build");
+        assert!(queue
+            .enqueue(
+                ProposalCandidate::new("tx-3", "did:kamn:agent:bbb", 2, "state-1").expect("valid"),
+            )
+            .is_ok());
+        assert!(queue
+            .enqueue(
+                ProposalCandidate::new("tx-1", "did:kamn:agent:aaa", 1, "state-1").expect("valid"),
+            )
+            .is_ok());
+        assert!(queue
+            .enqueue(
+                ProposalCandidate::new("tx-2", "did:kamn:agent:bbb", 1, "state-1").expect("valid"),
+            )
+            .is_ok());
+
+        let mut drained = Vec::new();
+        while let Some(candidate) = queue.dequeue() {
+            drained.push(candidate);
+        }
+
+        let planner = DeterministicProposalPlanner::new("state-1");
+        let plan = planner.plan(drained).expect("plan should build");
+        assert_eq!(
+            plan.ordered_candidate_ids(),
+            vec!["tx-1".to_owned(), "tx-2".to_owned(), "tx-3".to_owned()]
+        );
+    }
+
+    #[test]
+    fn unit_rejects_empty_candidate_id() {
+        let candidate = ProposalCandidate::new("", "did:kamn:agent:aaa", 1, "state-1");
+        assert_eq!(candidate, Err(ProposalPlannerError::InvalidCandidateId));
+    }
+
+    #[test]
+    fn regression_duplicate_candidate_id_is_rejected() {
+        // Regression: #323
+        let candidates = vec![
+            ProposalCandidate::new("tx-1", "did:kamn:agent:aaa", 1, "state-1").expect("valid"),
+            ProposalCandidate::new("tx-1", "did:kamn:agent:bbb", 2, "state-1").expect("valid"),
+        ];
+        let planner = DeterministicProposalPlanner::new("state-1");
+        let error = planner
+            .plan(candidates)
+            .expect_err("duplicate candidate id must fail");
+        assert_eq!(
+            error,
+            ProposalPlannerError::DuplicateCandidateId("tx-1".to_owned())
+        );
+    }
+
+    #[test]
+    fn regression_stale_state_hash_is_rejected() {
+        // Regression: #323
+        let candidates = vec![
+            ProposalCandidate::new("tx-1", "did:kamn:agent:aaa", 1, "state-2").expect("valid"),
+        ];
+        let planner = DeterministicProposalPlanner::new("state-1");
+        let error = planner
+            .plan(candidates)
+            .expect_err("candidate state mismatch must fail");
+        assert_eq!(
+            error,
+            ProposalPlannerError::StaleStateHash {
+                expected: "state-1".to_owned(),
+                found: "state-2".to_owned()
+            }
         );
     }
 }

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -12,6 +12,7 @@ fn doc_contains_runtime_network_scope_and_models() {
 fn doc_contains_peer_lifecycle_and_queue_rules() {
     assert!(DOC.contains("## Peer Lifecycle Rules"));
     assert!(DOC.contains("## Queue Guard Rules"));
+    assert!(DOC.contains("## Scheduler Determinism Rules"));
     assert!(DOC.contains("Overflow does not evict existing entries"));
     assert!(DOC.contains("Empty peer IDs are rejected"));
 }
@@ -28,4 +29,6 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
     // Regression: #324
     assert!(DOC.contains("rejoin without disconnect is rejected"));
     assert!(DOC.contains("queue overflow rejects new event"));
+    assert!(DOC.contains("duplicate candidate ID is rejected"));
+    assert!(DOC.contains("stale state hash is rejected"));
 }

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -1,4 +1,4 @@
-# Runtime Network Contracts (Issues #315 / #317 / #320 / #324)
+# Runtime Network Contracts (Issues #315 / #317 / #320 / #324 / #319 / #323)
 
 This document captures the initial runtime-network foundation slice for peer lifecycle and bounded queue behavior in `kamn-core`.
 
@@ -11,6 +11,11 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Added bounded FIFO queue primitives in `crates/kamn-core/src/runtime.rs`:
   - `BoundedRuntimeQueue<T>`
   - `RuntimeQueueError`
+- Added deterministic proposal-planner primitives in `crates/kamn-core/src/runtime.rs`:
+  - `ProposalCandidate`
+  - `DeterministicProposalPlanner`
+  - `ProposalPlan`
+  - `ProposalPlannerError`
 - Kept runtime role wiring behavior unchanged and covered by existing tests.
 
 ## Peer Lifecycle Rules
@@ -33,17 +38,36 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Zero-capacity queues fail with:
   - `RuntimeQueueError::InvalidCapacity { capacity: 0 }`
 
+## Scheduler Determinism Rules
+- `ProposalCandidate` requires non-empty:
+  - candidate ID
+  - sender DID
+  - state hash
+- Candidate nonce must be positive.
+- `DeterministicProposalPlanner` rejects candidate sets when:
+  - duplicate candidate IDs are present (`ProposalPlannerError::DuplicateCandidateId`)
+  - candidate state hash differs from planner expectation (`ProposalPlannerError::StaleStateHash`)
+- Valid candidate sets are ordered deterministically by:
+  - nonce ascending
+  - sender DID ascending
+  - candidate ID ascending
+
 ## Test Coverage Mapping
 - Unit:
   - invalid transition checks
   - empty peer ID and zero-capacity queue rejection
+  - empty proposal candidate ID rejection
 - Functional:
   - peer lifecycle connect/degrade/recover/disconnect flow
+  - planner deterministic ordering contract
 - Integration:
   - bounded FIFO queue behavior under capacity
+  - queue-drain to planner ordering preservation
 - Regression:
   - rejoin without disconnect is rejected (`Regression: #324`)
   - queue overflow rejects new event (`Regression: #324`)
+  - duplicate candidate ID is rejected (`Regression: #323`)
+  - stale state hash is rejected (`Regression: #323`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:


### PR DESCRIPTION
Closes #323
Closes #319
Closes #316

## Summary
Adds deterministic proposal-planner primitives for runtime scheduling with explicit replay/stale-state guards and stable candidate ordering, extending the runtime-network foundation delivered in #325.

## Changes
- `crates/kamn-core/src/runtime.rs`: added `ProposalCandidate`, `DeterministicProposalPlanner`, `ProposalPlan`, and `ProposalPlannerError` with deterministic sort semantics and duplicate/stale suppression.
- `crates/kamn-core/src/lib.rs`: exported proposal-planner runtime APIs.
- `docs/foundation/runtime-network.md`: extended runtime-network contract with scheduler determinism rules and regression mapping.
- `crates/kamn-core/tests/runtime_network_docs.rs`: expanded docs contract assertions for scheduler section and replay guard rules.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed red-first failure phase, then green targeted tests and strict crate-wide validation.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Candidate validation and guard tests in `runtime.rs` (`InvalidCandidateId`, stale-state checks). |
| Functional  | ✅     | Deterministic planner ordering test (`functional_planner_orders_candidates_deterministically`). |
| Integration | ✅     | Queue drain into planner preserves deterministic ordering (`integration_queue_drains_into_planner_without_order_loss`). |
| Regression  | ✅     | Duplicate candidate ID and stale state hash rejection tests marked `Regression: #323`. |
