### PR TITLE
feat(runtime): add recovery rejoin guards and catch-up status

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -213,8 +213,9 @@ pub use retention_engine::{
 };
 pub use runtime::{
     BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle, PeerLifecycleEvent,
-    PeerLifecycleState, ProposalCandidate, ProposalPlan, ProposalPlannerError,
-    RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
+    PeerLifecycleState, ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError,
+    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeLifecycleError, RuntimeQueueError,
+    RuntimeWiring,
 };
 pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -338,6 +338,164 @@ impl DeterministicProposalPlanner {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejoinAttempt {
+    node_id: String,
+    state_version: u64,
+    state_hash: String,
+    resume_token: String,
+}
+
+impl RejoinAttempt {
+    pub fn new(
+        node_id: &str,
+        state_version: u64,
+        state_hash: &str,
+        resume_token: &str,
+    ) -> Result<Self, RecoveryGuardError> {
+        if node_id.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidNodeId);
+        }
+        if state_version == 0 {
+            return Err(RecoveryGuardError::InvalidStateVersion);
+        }
+        if state_hash.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidStateHash);
+        }
+        if resume_token.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidResumeToken);
+        }
+        Ok(Self {
+            node_id: node_id.to_owned(),
+            state_version,
+            state_hash: state_hash.to_owned(),
+            resume_token: resume_token.to_owned(),
+        })
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    pub fn state_version(&self) -> u64 {
+        self.state_version
+    }
+
+    pub fn state_hash(&self) -> &str {
+        &self.state_hash
+    }
+
+    pub fn resume_token(&self) -> &str {
+        &self.resume_token
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoveryStatus {
+    RejoinAccepted,
+    CatchUpRequired { from_version: u64, to_version: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoveryGuardError {
+    InvalidNodeId,
+    InvalidStateVersion,
+    InvalidStateHash,
+    InvalidResumeToken,
+    ReplayResumeToken(String),
+    StateVersionMismatch { expected: u64, found: u64 },
+    StateHashMismatch { expected: String, found: String },
+}
+
+impl Display for RecoveryGuardError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidNodeId => write!(f, "rejoin node id cannot be empty"),
+            Self::InvalidStateVersion => write!(f, "rejoin state version must be positive"),
+            Self::InvalidStateHash => write!(f, "rejoin state hash cannot be empty"),
+            Self::InvalidResumeToken => write!(f, "rejoin resume token cannot be empty"),
+            Self::ReplayResumeToken(token) => {
+                write!(f, "rejoin resume token replayed: {token}")
+            }
+            Self::StateVersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "rejoin state version mismatch: expected {expected}, found {found}"
+                )
+            }
+            Self::StateHashMismatch { expected, found } => {
+                write!(
+                    f,
+                    "rejoin state hash mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for RecoveryGuardError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryRejoinGuard {
+    expected_state_version: u64,
+    expected_state_hash: String,
+    consumed_resume_tokens: HashSet<String>,
+}
+
+impl RecoveryRejoinGuard {
+    pub fn new(
+        expected_state_version: u64,
+        expected_state_hash: &str,
+    ) -> Result<Self, RecoveryGuardError> {
+        if expected_state_version == 0 {
+            return Err(RecoveryGuardError::InvalidStateVersion);
+        }
+        if expected_state_hash.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidStateHash);
+        }
+        Ok(Self {
+            expected_state_version,
+            expected_state_hash: expected_state_hash.to_owned(),
+            consumed_resume_tokens: HashSet::new(),
+        })
+    }
+
+    pub fn evaluate(
+        &mut self,
+        attempt: RejoinAttempt,
+    ) -> Result<RecoveryStatus, RecoveryGuardError> {
+        if self.consumed_resume_tokens.contains(attempt.resume_token()) {
+            return Err(RecoveryGuardError::ReplayResumeToken(
+                attempt.resume_token.clone(),
+            ));
+        }
+
+        if attempt.state_version < self.expected_state_version {
+            return Ok(RecoveryStatus::CatchUpRequired {
+                from_version: attempt.state_version,
+                to_version: self.expected_state_version,
+            });
+        }
+
+        if attempt.state_version > self.expected_state_version {
+            return Err(RecoveryGuardError::StateVersionMismatch {
+                expected: self.expected_state_version,
+                found: attempt.state_version,
+            });
+        }
+
+        if attempt.state_hash != self.expected_state_hash {
+            return Err(RecoveryGuardError::StateHashMismatch {
+                expected: self.expected_state_hash.clone(),
+                found: attempt.state_hash,
+            });
+        }
+
+        self.consumed_resume_tokens.insert(attempt.resume_token);
+        Ok(RecoveryStatus::RejoinAccepted)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeWiring {
     pub common_components: Vec<&'static str>,
     pub role_components: Vec<&'static str>,
@@ -371,6 +529,7 @@ mod tests {
     use super::{
         build_runtime_wiring, BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle,
         PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
+        RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
         RuntimeLifecycleError, RuntimeQueueError,
     };
     use crate::config::{NodeConfig, NodeRole, SyncMode};
@@ -597,6 +756,70 @@ mod tests {
             ProposalPlannerError::StaleStateHash {
                 expected: "state-1".to_owned(),
                 found: "state-2".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn functional_rejoin_guard_accepts_matching_snapshot() {
+        let mut guard = RecoveryRejoinGuard::new(42, "state-42").expect("guard should build");
+        let attempt = RejoinAttempt::new("node-a", 42, "state-42", "resume-1").expect("valid");
+        let status = guard.evaluate(attempt).expect("rejoin should be accepted");
+        assert_eq!(status, RecoveryStatus::RejoinAccepted);
+    }
+
+    #[test]
+    fn integration_rejoin_guard_emits_catch_up_required_for_lagging_node() {
+        let mut guard = RecoveryRejoinGuard::new(42, "state-42").expect("guard should build");
+        let attempt = RejoinAttempt::new("node-a", 40, "state-40", "resume-1").expect("valid");
+        let status = guard
+            .evaluate(attempt)
+            .expect("lagging node should receive catch-up guidance");
+        assert_eq!(
+            status,
+            RecoveryStatus::CatchUpRequired {
+                from_version: 40,
+                to_version: 42
+            }
+        );
+    }
+
+    #[test]
+    fn unit_rejoin_guard_rejects_empty_resume_token() {
+        let attempt = RejoinAttempt::new("node-a", 42, "state-42", "");
+        assert_eq!(attempt, Err(RecoveryGuardError::InvalidResumeToken));
+    }
+
+    #[test]
+    fn regression_rejoin_replay_token_is_rejected() {
+        // Regression: #322
+        let mut guard = RecoveryRejoinGuard::new(42, "state-42").expect("guard should build");
+        let first = RejoinAttempt::new("node-a", 42, "state-42", "resume-1").expect("valid");
+        assert_eq!(guard.evaluate(first), Ok(RecoveryStatus::RejoinAccepted));
+
+        let replay = RejoinAttempt::new("node-a", 42, "state-42", "resume-1").expect("valid");
+        let error = guard
+            .evaluate(replay)
+            .expect_err("replay token should be rejected");
+        assert_eq!(
+            error,
+            RecoveryGuardError::ReplayResumeToken("resume-1".to_owned())
+        );
+    }
+
+    #[test]
+    fn regression_rejoin_state_hash_mismatch_is_rejected() {
+        // Regression: #322
+        let mut guard = RecoveryRejoinGuard::new(42, "state-42").expect("guard should build");
+        let attempt = RejoinAttempt::new("node-a", 42, "state-41", "resume-1").expect("valid");
+        let error = guard
+            .evaluate(attempt)
+            .expect_err("hash mismatch should be rejected");
+        assert_eq!(
+            error,
+            RecoveryGuardError::StateHashMismatch {
+                expected: "state-42".to_owned(),
+                found: "state-41".to_owned()
             }
         );
     }

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -13,6 +13,7 @@ fn doc_contains_peer_lifecycle_and_queue_rules() {
     assert!(DOC.contains("## Peer Lifecycle Rules"));
     assert!(DOC.contains("## Queue Guard Rules"));
     assert!(DOC.contains("## Scheduler Determinism Rules"));
+    assert!(DOC.contains("## Recovery and Rejoin Guard Rules"));
     assert!(DOC.contains("Overflow does not evict existing entries"));
     assert!(DOC.contains("Empty peer IDs are rejected"));
 }
@@ -31,4 +32,6 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
     assert!(DOC.contains("queue overflow rejects new event"));
     assert!(DOC.contains("duplicate candidate ID is rejected"));
     assert!(DOC.contains("stale state hash is rejected"));
+    assert!(DOC.contains("rejoin replay token is rejected"));
+    assert!(DOC.contains("rejoin state hash mismatch is rejected"));
 }

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -1,4 +1,4 @@
-# Runtime Network Contracts (Issues #315 / #317 / #320 / #324 / #319 / #323)
+# Runtime Network Contracts (Issues #315 / #317 / #320 / #324 / #319 / #323 / #321 / #322)
 
 This document captures the initial runtime-network foundation slice for peer lifecycle and bounded queue behavior in `kamn-core`.
 
@@ -16,6 +16,11 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `DeterministicProposalPlanner`
   - `ProposalPlan`
   - `ProposalPlannerError`
+- Added recovery/rejoin guard primitives in `crates/kamn-core/src/runtime.rs`:
+  - `RejoinAttempt`
+  - `RecoveryRejoinGuard`
+  - `RecoveryStatus`
+  - `RecoveryGuardError`
 - Kept runtime role wiring behavior unchanged and covered by existing tests.
 
 ## Peer Lifecycle Rules
@@ -52,22 +57,40 @@ This document captures the initial runtime-network foundation slice for peer lif
   - sender DID ascending
   - candidate ID ascending
 
+## Recovery and Rejoin Guard Rules
+- `RejoinAttempt` requires non-empty:
+  - node ID
+  - state hash
+  - resume token
+- Rejoin state version must be positive.
+- `RecoveryRejoinGuard` behavior:
+  - lagging state versions produce `CatchUpRequired { from_version, to_version }`
+  - newer-than-expected state versions are rejected (`StateVersionMismatch`)
+  - matching version with mismatched state hash is rejected (`StateHashMismatch`)
+  - replayed resume tokens are rejected (`ReplayResumeToken`)
+  - matching version/hash with unique resume token is accepted (`RejoinAccepted`)
+
 ## Test Coverage Mapping
 - Unit:
   - invalid transition checks
   - empty peer ID and zero-capacity queue rejection
   - empty proposal candidate ID rejection
+  - empty resume-token rejoin attempt rejection
 - Functional:
   - peer lifecycle connect/degrade/recover/disconnect flow
   - planner deterministic ordering contract
+  - rejoin acceptance with matching snapshot
 - Integration:
   - bounded FIFO queue behavior under capacity
   - queue-drain to planner ordering preservation
+  - lagging-node catch-up guidance output
 - Regression:
   - rejoin without disconnect is rejected (`Regression: #324`)
   - queue overflow rejects new event (`Regression: #324`)
   - duplicate candidate ID is rejected (`Regression: #323`)
   - stale state hash is rejected (`Regression: #323`)
+  - rejoin replay token is rejected (`Regression: #322`)
+  - rejoin state hash mismatch is rejected (`Regression: #322`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:


### PR DESCRIPTION
Closes #322
Closes #321
Closes #318

## Summary
Adds deterministic recovery/rejoin guard primitives for runtime nodes, including catch-up guidance, replay token suppression, and state-version/hash mismatch handling.

## Changes
- `crates/kamn-core/src/runtime.rs`: added `RejoinAttempt`, `RecoveryRejoinGuard`, `RecoveryStatus`, and `RecoveryGuardError` with typed validation and deterministic decision semantics.
- `crates/kamn-core/src/lib.rs`: exported recovery/rejoin runtime APIs.
- `docs/foundation/runtime-network.md`: extended runtime-network contract with recovery/rejoin guard rules and regression mappings.
- `crates/kamn-core/tests/runtime_network_docs.rs`: expanded docs contract assertions for recovery section and replay/hash mismatch rules.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed red-first test failure, implemented minimal guard pipeline, then reran targeted + strict validation lanes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Empty resume token and guard input validation tests in `runtime.rs`. |
| Functional  | ✅     | Rejoin acceptance for matching snapshot test (`functional_rejoin_guard_accepts_matching_snapshot`). |
| Integration | ✅     | Catch-up guidance for lagging nodes (`integration_rejoin_guard_emits_catch_up_required_for_lagging_node`). |
| Regression  | ✅     | Replay token and state-hash mismatch rejoin rejections marked `Regression: #322`. |
