### PR TITLE
docs(runtime): expand docs contract assertions and fast-lane examples (#337)

### DIFF
--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -22,9 +22,15 @@ fn doc_contains_peer_lifecycle_and_queue_rules() {
 }
 
 #[test]
+fn doc_contains_recovery_check_cli_command_example() {
+    assert!(DOC.contains("`kamn-node --role processor --runtime-mode recovery-check`"));
+}
+
+#[test]
 fn doc_contains_fast_and_cost_effective_validation_lane() {
     assert!(DOC.contains("## Fast and Cost-Effective Validation"));
     assert!(DOC.contains("cargo test -p kamn-core runtime::tests::"));
+    assert!(DOC.contains("cargo test -p kamn-node --test node_runtime_cli_docs"));
     assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
 }
 

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -66,10 +66,22 @@ fn doc_contains_runtime_recovery_check_rules() {
 }
 
 #[test]
+fn doc_contains_runtime_mode_command_examples() {
+    assert!(DOC.contains("`kamn-node --role processor --runtime-mode planning`"));
+    assert!(DOC.contains("`kamn-node --role processor --runtime-mode recovery-check`"));
+}
+
+#[test]
 fn doc_contains_fast_and_cost_effective_validation_lane() {
     assert!(DOC.contains("## Fast and Cost-Effective Validation"));
     assert!(DOC.contains("cargo test -p kamn-node"));
     assert!(DOC.contains("cargo clippy -p kamn-node -- -D warnings"));
+}
+
+#[test]
+fn doc_contains_docs_fast_lane_command_checks() {
+    assert!(DOC.contains("cargo test -p kamn-node --test node_runtime_cli_docs"));
+    assert!(DOC.contains("cargo test -p kamn-core --test runtime_network_docs"));
 }
 
 #[test]
@@ -102,4 +114,12 @@ fn regression_requires_runtime_planning_candidate_rules() {
 fn regression_requires_runtime_recovery_rejection_rules() {
     // Regression: #336
     assert!(DOC.contains("replay/version/hash recovery-check rejection (`Regression: #336`)"));
+}
+
+#[test]
+fn regression_requires_runtime_recovery_error_rule_references() {
+    // Regression: #337
+    assert!(DOC.contains("ConfigError::InvalidExpectedStateVersion"));
+    assert!(DOC.contains("ConfigError::InvalidRejoinAttemptArgument"));
+    assert!(DOC.contains("ConfigError::RuntimeRecovery"));
 }

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -129,6 +129,14 @@ This document captures node-runtime productionization slices for machine-readabl
   - `recovery_attempt_count`
   - `recovery_decisions`
 
+## Runtime Mode Command Examples
+- Planning mode:
+  - `kamn-node --role processor --runtime-mode planning`
+  - `kamn-node --role processor --runtime-mode planning --expected-state-hash state-1 --proposal tx-1|did:kamn:agent:aaa|1|state-1`
+- Recovery-check mode:
+  - `kamn-node --role processor --runtime-mode recovery-check`
+  - `kamn-node --role processor --runtime-mode recovery-check --expected-state-version 42 --expected-state-hash state-42 --rejoin-attempt node-a|42|state-42|resume-1`
+
 ## Test Coverage Mapping
 - Unit:
   - default mode behavior and mode parsing checks
@@ -148,6 +156,8 @@ Run targeted checks first:
 
 ```bash
 cargo test -p kamn-node
+cargo test -p kamn-node --test node_runtime_cli_docs
+cargo test -p kamn-core --test runtime_network_docs
 cargo fmt --check
 cargo clippy -p kamn-node -- -D warnings
 ```

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -25,6 +25,9 @@ This document captures the initial runtime-network foundation slice for peer lif
 
 ## Node CLI Recovery-Check Mapping
 - `kamn-node --runtime-mode recovery-check` maps directly to `RecoveryRejoinGuard` evaluation flow.
+- Command example:
+  - `kamn-node --role processor --runtime-mode recovery-check`
+  - `kamn-node --role processor --runtime-mode recovery-check --expected-state-version 42 --expected-state-hash state-42 --rejoin-attempt node-a|42|state-42|resume-1`
 - CLI argument mapping:
   - `--expected-state-version` -> `RecoveryRejoinGuard::new(expected_state_version, ...)`
   - `--expected-state-hash` -> `RecoveryRejoinGuard::new(..., expected_state_hash)`
@@ -112,6 +115,7 @@ Run targeted checks first:
 ```bash
 cargo test -p kamn-core runtime::tests::
 cargo test -p kamn-core --test runtime_network_docs
+cargo test -p kamn-node --test node_runtime_cli_docs
 ```
 
 Then run strict lint/format gates:


### PR DESCRIPTION
## Summary
Strengthens runtime execution documentation contracts by adding explicit runtime-mode command examples and docs-focused fast-lane validation references, enforced by docs tests. This closes the final docs chain under epic #328.

Closes #337
Closes #334
Closes #331

## Changes
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added assertions for runtime command examples, docs-only fast-lane checks, and recovery error rule references.
- `crates/kamn-core/tests/runtime_network_docs.rs`: added assertions for recovery-check CLI command example and node docs test command in fast-lane section.
- `docs/foundation/node-runtime-cli.md`: added runtime mode command examples and explicit docs-focused fast-lane commands.
- `docs/foundation/runtime-network.md`: added recovery-check CLI example and docs-lane command reference.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-node --test node_runtime_cli_docs
cargo test -p kamn-core --test runtime_network_docs
```
Failed before docs updates with missing contract text assertions:
- missing `` `kamn-node --role processor --runtime-mode planning` ``
- missing `` `kamn-node --role processor --runtime-mode recovery-check` ``
- missing `cargo test -p kamn-node --test node_runtime_cli_docs`

### 🟢 Green Phase
```bash
cargo test -p kamn-node --test node_runtime_cli_docs
cargo test -p kamn-core --test runtime_network_docs
```
Passed after docs updates:
- `15 passed; 0 failed` in `node_runtime_cli_docs`
- `5 passed; 0 failed` in `runtime_network_docs`

### 🔁 Regression
```bash
cargo fmt --check
cargo clippy -p kamn-core -p kamn-node -- -D warnings
cargo test -p kamn-core -p kamn-node
```
All commands passed.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | docs-only task; no runtime logic change |
| Functional   | ✅ | docs section assertions for runtime planning/recovery command examples and contract sections | |
| Integration  | ✅ | docs command references validated against both node and runtime-network docs test suites | |
| Regression   | ✅ | required error-rule/recovery text assertions maintained and extended (`Regression: #337`) | |
| Performance  | N/A | | docs-only task; no performance path change |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(runtime): expand docs contract assertions and fast-lane examples (#337)`.

## Documentation Updates
- Updated `docs/foundation/node-runtime-cli.md` and `docs/foundation/runtime-network.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
