### PR TITLE
docs(runtime): enforce daemon docs fast-lane assertions

### DIFF
--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -33,6 +33,9 @@ fn doc_contains_fast_and_cost_effective_validation_lane() {
     assert!(DOC.contains("## Fast and Cost-Effective Validation"));
     assert!(DOC.contains("cargo test -p kamn-core runtime::tests::"));
     assert!(DOC.contains("cargo test -p kamn-node --test node_runtime_cli_docs"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition"
+    ));
     assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
 }
 

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -104,6 +104,17 @@ fn doc_contains_docs_fast_lane_command_checks() {
 }
 
 #[test]
+fn doc_contains_daemon_focused_fast_lane_commands() {
+    assert!(DOC.contains("### Daemon-focused fast lane"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node integration_runtime_daemon_renders_bounded_completion_output"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition"
+    ));
+}
+
+#[test]
 fn regression_requires_invalid_output_mode_rule() {
     // Regression: #307
     assert!(DOC.contains("Invalid modes are rejected with explicit typed error."));

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -206,3 +206,10 @@ Then run broader regression:
 ```bash
 cargo test -p kamn-core
 ```
+
+### Daemon-focused fast lane
+
+```bash
+cargo test -p kamn-node integration_runtime_daemon_renders_bounded_completion_output
+cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
+```

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -137,6 +137,7 @@ Run targeted checks first:
 cargo test -p kamn-core runtime::tests::
 cargo test -p kamn-core --test runtime_network_docs
 cargo test -p kamn-node --test node_runtime_cli_docs
+cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
 ```
 
 Then run strict lint/format gates:


### PR DESCRIPTION
Closes #350

## Summary
Adds daemon-focused docs contract assertions and low-cost fast-lane command guidance for runtime docs.
The change hardens documentation drift protection for daemon runtime behavior without changing runtime code paths.

## Changes
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added daemon-focused fast-lane docs assertions.
- `crates/kamn-core/tests/runtime_network_docs.rs`: added daemon regression command assertion in fast-lane coverage.
- `docs/foundation/node-runtime-cli.md`: added `Daemon-focused fast lane` command block.
- `docs/foundation/runtime-network.md`: added daemon lifecycle regression command in validation lane.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed docs sections and command references required by docs tests are present.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅  | Docs assertion tests executed under `cargo test -p kamn-core -p kamn-node`. |
| Functional  | ✅  | `node_runtime_cli_docs` and `runtime_network_docs` functional contract assertions pass. |
| Integration | ✅  | Full crate test runs include integration suites for changed crates. |
| Regression  | ✅  | Daemon regression command/rule assertions are now enforced in docs tests. |
