### PR TITLE
docs(runtime): add processor HA docs contract assertions

### DIFF
--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -115,6 +115,12 @@ fn doc_contains_daemon_focused_fast_lane_commands() {
 }
 
 #[test]
+fn doc_contains_processor_ha_reference_section() {
+    assert!(DOC.contains("## Processor HA Runtime References"));
+    assert!(DOC.contains("docs/foundation/runtime-processor-ha.md"));
+}
+
+#[test]
 fn regression_requires_invalid_output_mode_rule() {
     // Regression: #307
     assert!(DOC.contains("Invalid modes are rejected with explicit typed error."));

--- a/crates/kamn-node/tests/runtime_processor_ha_docs.rs
+++ b/crates/kamn-node/tests/runtime_processor_ha_docs.rs
@@ -1,0 +1,28 @@
+const DOC: &str = include_str!("../../../docs/foundation/runtime-processor-ha.md");
+
+#[test]
+fn doc_contains_processor_ha_scope_and_models() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("## Snapshot Restore Rules"));
+    assert!(DOC.contains("## Construct Lock Rules"));
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+}
+
+#[test]
+fn doc_contains_fast_lane_command_references() {
+    assert!(DOC.contains("cargo test -p kamn-node --test runtime_processor_ha_docs"));
+    assert!(DOC.contains("cargo test -p kamn-node --test node_runtime_cli_docs"));
+}
+
+#[test]
+fn regression_requires_snapshot_restore_guard_rules() {
+    // Regression: #361
+    assert!(DOC.contains("snapshot version/hash mismatch restores are rejected"));
+}
+
+#[test]
+fn regression_requires_construct_lock_guard_rules() {
+    // Regression: #362
+    assert!(DOC.contains("split-brain lock acquisition attempts are rejected"));
+    assert!(DOC.contains("stale lease renewal attempts are rejected"));
+}

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -213,3 +213,8 @@ cargo test -p kamn-core
 cargo test -p kamn-node integration_runtime_daemon_renders_bounded_completion_output
 cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
 ```
+
+## Processor HA Runtime References
+
+- Processor HA snapshot restore and construct-lock contract details:
+  - `docs/foundation/runtime-processor-ha.md`

--- a/docs/foundation/runtime-processor-ha.md
+++ b/docs/foundation/runtime-processor-ha.md
@@ -1,0 +1,41 @@
+# Processor HA Runtime Contracts (Issues #354 / #357 / #360 / #363)
+
+This document captures processor high-availability runtime contract text for snapshot restore guards and construct-lock safety rules.
+
+## Scope Delivered
+- Added processor HA docs contract baseline for runtime snapshot restore safeguards.
+- Added construct-lock safety rules for split-brain and stale-lease boundaries.
+- Added low-cost validation lane commands for docs-focused PR checks.
+
+## Snapshot Restore Rules
+- Snapshot restore requires deterministic expected state version and expected state hash inputs.
+- Snapshot payloads must preserve stable state lineage fields for restore decisions.
+- snapshot version/hash mismatch restores are rejected.
+
+## Construct Lock Rules
+- Processor construct-lock ownership must enforce single active lease semantics.
+- split-brain lock acquisition attempts are rejected.
+- stale lease renewal attempts are rejected.
+
+## Test Coverage Mapping
+- Unit: N/A (docs-focused contract slice).
+- Functional: docs section assertions for snapshot and lock rules.
+- Integration: docs command mapping assertions for runtime docs test lane.
+- Regression:
+  - snapshot restore mismatch rejection (`Regression: #361`)
+  - split-brain and stale-renew lock rejection (`Regression: #362`)
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-node --test runtime_processor_ha_docs
+cargo test -p kamn-node --test node_runtime_cli_docs
+```
+
+Then run strict formatting/lint gates:
+
+```bash
+cargo fmt --check
+cargo clippy -p kamn-node -- -D warnings
+```


### PR DESCRIPTION
Closes #363
Refs #360
Refs #357
Refs #354

## Summary
Adds a new processor-HA docs contract and docs-regression assertion suite for snapshot restore and construct-lock guard rules.
This hardens documentation drift prevention before runtime HA behavior implementation starts.

## Changes
- `crates/kamn-node/tests/runtime_processor_ha_docs.rs`: new docs contract tests for processor HA scope, fast lane commands, and regression guard rules.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added processor HA reference-section assertion.
- `docs/foundation/runtime-processor-ha.md`: added processor HA docs contract baseline and validation lane.
- `docs/foundation/node-runtime-cli.md`: added processor HA reference section linking the new doc.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:

cargo test -p kamn-node --test runtime_processor_ha_docs --test node_runtime_cli_docs

Output (failed):

error: couldn't read crates/kamn-node/tests/../../../docs/foundation/runtime-processor-ha.md: No such file or directory (os error 2)
error: could not compile kamn-node (test runtime_processor_ha_docs) due to previous error

### 🟢 Green Phase
Command:

cargo test -p kamn-node --test runtime_processor_ha_docs --test node_runtime_cli_docs

Output (passed):

- node_runtime_cli_docs: 20 passed, 0 failed
- runtime_processor_ha_docs: 4 passed, 0 failed

### 🔁 Regression
Commands:

cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node

Output (passed):

- fmt check clean
- clippy clean
- kamn-node test suite: 66 passed, 0 failed

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Docs-contract subtask; no runtime logic changed. |
| Functional   | ✅     | `runtime_processor_ha_docs` | Validates docs contract sections and command references. |
| Integration  | ✅     | `node_runtime_cli_docs` + `runtime_processor_ha_docs` lane execution | Confirms docs command mapping across runtime docs surfaces. |
| Regression   | ✅     | `regression_requires_snapshot_restore_guard_rules`, `regression_requires_construct_lock_guard_rules` | Guards #361/#362 rule text from drift. |
| Performance  | N/A    | None                 | No runtime/perf behavior change in this docs-only slice. |

## Risks & Rollback
- None.
- Rollback plan: revert PR #384 commit to restore prior docs/tests baseline.

## Documentation Updates
- `docs/foundation/runtime-processor-ha.md`
- `docs/foundation/node-runtime-cli.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-node -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
