### PR TITLE
feat(runtime): add snapshot restore mismatch guard model

### DIFF
--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -390,6 +390,106 @@ impl RejoinAttempt {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeSnapshot {
+    state_version: u64,
+    state_hash: String,
+}
+
+impl RuntimeSnapshot {
+    pub fn new(state_version: u64, state_hash: &str) -> Result<Self, SnapshotRestoreError> {
+        if state_version == 0 {
+            return Err(SnapshotRestoreError::InvalidStateVersion);
+        }
+        if state_hash.trim().is_empty() {
+            return Err(SnapshotRestoreError::InvalidStateHash);
+        }
+        Ok(Self {
+            state_version,
+            state_hash: state_hash.to_owned(),
+        })
+    }
+
+    pub fn state_version(&self) -> u64 {
+        self.state_version
+    }
+
+    pub fn state_hash(&self) -> &str {
+        &self.state_hash
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnapshotRestoreError {
+    InvalidStateVersion,
+    InvalidStateHash,
+    StateVersionMismatch { expected: u64, found: u64 },
+    StateHashMismatch { expected: String, found: String },
+}
+
+impl Display for SnapshotRestoreError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidStateVersion => write!(f, "snapshot state version must be positive"),
+            Self::InvalidStateHash => write!(f, "snapshot state hash cannot be empty"),
+            Self::StateVersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "snapshot state version mismatch: expected {expected}, found {found}"
+                )
+            }
+            Self::StateHashMismatch { expected, found } => {
+                write!(
+                    f,
+                    "snapshot state hash mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for SnapshotRestoreError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotRestoreGuard {
+    expected_state_version: u64,
+    expected_state_hash: String,
+}
+
+impl SnapshotRestoreGuard {
+    pub fn new(
+        expected_state_version: u64,
+        expected_state_hash: &str,
+    ) -> Result<Self, SnapshotRestoreError> {
+        if expected_state_version == 0 {
+            return Err(SnapshotRestoreError::InvalidStateVersion);
+        }
+        if expected_state_hash.trim().is_empty() {
+            return Err(SnapshotRestoreError::InvalidStateHash);
+        }
+        Ok(Self {
+            expected_state_version,
+            expected_state_hash: expected_state_hash.to_owned(),
+        })
+    }
+
+    pub fn validate(&self, snapshot: RuntimeSnapshot) -> Result<(), SnapshotRestoreError> {
+        if snapshot.state_version() != self.expected_state_version {
+            return Err(SnapshotRestoreError::StateVersionMismatch {
+                expected: self.expected_state_version,
+                found: snapshot.state_version(),
+            });
+        }
+        if snapshot.state_hash() != self.expected_state_hash {
+            return Err(SnapshotRestoreError::StateHashMismatch {
+                expected: self.expected_state_hash.clone(),
+                found: snapshot.state_hash().to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecoveryStatus {
     RejoinAccepted,
     CatchUpRequired { from_version: u64, to_version: u64 },
@@ -530,7 +630,8 @@ mod tests {
         build_runtime_wiring, BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle,
         PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
         RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
-        RuntimeLifecycleError, RuntimeQueueError,
+        RuntimeLifecycleError, RuntimeQueueError, RuntimeSnapshot, SnapshotRestoreError,
+        SnapshotRestoreGuard,
     };
     use crate::config::{NodeConfig, NodeRole, SyncMode};
 
@@ -818,6 +919,56 @@ mod tests {
         assert_eq!(
             error,
             RecoveryGuardError::StateHashMismatch {
+                expected: "state-42".to_owned(),
+                found: "state-41".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn functional_snapshot_restore_guard_accepts_matching_snapshot() {
+        let guard =
+            SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
+        let snapshot = RuntimeSnapshot::new(42, "state-42").expect("snapshot should be valid");
+        assert!(guard.validate(snapshot).is_ok());
+    }
+
+    #[test]
+    fn unit_snapshot_restore_guard_rejects_invalid_state_hash() {
+        let snapshot = RuntimeSnapshot::new(42, "");
+        assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidStateHash));
+    }
+
+    #[test]
+    fn regression_snapshot_restore_version_mismatch_is_rejected() {
+        // Regression: #361
+        let guard =
+            SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
+        let snapshot = RuntimeSnapshot::new(41, "state-42").expect("snapshot should be valid");
+        let error = guard
+            .validate(snapshot)
+            .expect_err("version mismatch should be rejected");
+        assert_eq!(
+            error,
+            SnapshotRestoreError::StateVersionMismatch {
+                expected: 42,
+                found: 41
+            }
+        );
+    }
+
+    #[test]
+    fn regression_snapshot_restore_hash_mismatch_is_rejected() {
+        // Regression: #361
+        let guard =
+            SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
+        let snapshot = RuntimeSnapshot::new(42, "state-41").expect("snapshot should be valid");
+        let error = guard
+            .validate(snapshot)
+            .expect_err("hash mismatch should be rejected");
+        assert_eq!(
+            error,
+            SnapshotRestoreError::StateHashMismatch {
                 expected: "state-42".to_owned(),
                 found: "state-41".to_owned()
             }

--- a/docs/foundation/runtime-processor-ha.md
+++ b/docs/foundation/runtime-processor-ha.md
@@ -5,12 +5,19 @@ This document captures processor high-availability runtime contract text for sna
 ## Scope Delivered
 - Added processor HA docs contract baseline for runtime snapshot restore safeguards.
 - Added construct-lock safety rules for split-brain and stale-lease boundaries.
+- Added runtime snapshot restore guard model references:
+  - `RuntimeSnapshot`
+  - `SnapshotRestoreGuard`
+  - `SnapshotRestoreError`
 - Added low-cost validation lane commands for docs-focused PR checks.
 
 ## Snapshot Restore Rules
 - Snapshot restore requires deterministic expected state version and expected state hash inputs.
 - Snapshot payloads must preserve stable state lineage fields for restore decisions.
 - snapshot version/hash mismatch restores are rejected.
+- Typed restore mismatches:
+  - `SnapshotRestoreError::StateVersionMismatch`
+  - `SnapshotRestoreError::StateHashMismatch`
 
 ## Construct Lock Rules
 - Processor construct-lock ownership must enforce single active lease semantics.


### PR DESCRIPTION
Closes #361
Refs #358
Refs #355
Refs #354

## Summary
Implements deterministic snapshot restore guard primitives in `kamn-core` to reject version/hash mismatch restores.
Adds explicit regression tests for mismatch rejection paths before broader snapshot adapter work.

## Changes
- `crates/kamn-core/src/runtime.rs`: added `RuntimeSnapshot`, `SnapshotRestoreGuard`, and `SnapshotRestoreError` with typed mismatch validation.
- `crates/kamn-core/src/runtime.rs`: added functional/unit/regression tests for snapshot restore acceptance and mismatch rejection (`Regression: #361`).
- `docs/foundation/runtime-processor-ha.md`: documented new restore guard model types and mismatch error contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:

cargo test -p kamn-core runtime::tests::regression_snapshot_restore_version_mismatch_is_rejected

Output (failed):

error[E0432]: unresolved imports `super::RuntimeSnapshot`, `super::SnapshotRestoreError`, `super::SnapshotRestoreGuard`
error: could not compile kamn-core (lib test) due to 1 previous error

### 🟢 Green Phase
Command:

cargo test -p kamn-core snapshot_restore

Output (passed):

- runtime::tests::functional_snapshot_restore_guard_accepts_matching_snapshot ... ok
- runtime::tests::unit_snapshot_restore_guard_rejects_invalid_state_hash ... ok
- runtime::tests::regression_snapshot_restore_version_mismatch_is_rejected ... ok
- runtime::tests::regression_snapshot_restore_hash_mismatch_is_rejected ... ok

### 🔁 Regression
Commands:

cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core

Output (passed):

- fmt check clean
- clippy clean
- kamn-core test suite: all tests passing

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_snapshot_restore_guard_rejects_invalid_state_hash` | N/A |
| Functional   | ✅     | `functional_snapshot_restore_guard_accepts_matching_snapshot` | N/A |
| Integration  | ✅     | `cargo test -p kamn-core` full crate regression lane | Validates cross-module compatibility after runtime additions. |
| Regression   | ✅     | `regression_snapshot_restore_version_mismatch_is_rejected`, `regression_snapshot_restore_hash_mismatch_is_rejected` | N/A |
| Performance  | N/A    | None | No throughput/latency path changes in this guard-model slice. |

## Risks & Rollback
- None.
- Rollback plan: revert PR #385 commit to remove snapshot guard additions.

## Documentation Updates
- `docs/foundation/runtime-processor-ha.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
