### PR TITLE
feat(runtime): add construct-lock split-brain and stale-token guards

### DIFF
--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -490,6 +490,145 @@ impl SnapshotRestoreGuard {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstructLockLease {
+    owner_id: String,
+    fencing_token: u64,
+}
+
+impl ConstructLockLease {
+    fn new(owner_id: String, fencing_token: u64) -> Self {
+        Self {
+            owner_id,
+            fencing_token,
+        }
+    }
+
+    pub fn owner_id(&self) -> &str {
+        &self.owner_id
+    }
+
+    pub fn fencing_token(&self) -> u64 {
+        self.fencing_token
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstructLockError {
+    InvalidLeaseTtl,
+    InvalidOwnerId,
+    NoActiveLease,
+    LeaseAlreadyHeld { owner: String },
+    LeaseOwnerMismatch { expected: String, found: String },
+    StaleFencingToken { expected: u64, found: u64 },
+}
+
+impl Display for ConstructLockError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidLeaseTtl => write!(f, "construct lock lease ttl must be positive"),
+            Self::InvalidOwnerId => write!(f, "construct lock owner id cannot be empty"),
+            Self::NoActiveLease => write!(f, "construct lock has no active lease"),
+            Self::LeaseAlreadyHeld { owner } => {
+                write!(f, "construct lock lease already held by {owner}")
+            }
+            Self::LeaseOwnerMismatch { expected, found } => {
+                write!(
+                    f,
+                    "construct lock owner mismatch: expected {expected}, found {found}"
+                )
+            }
+            Self::StaleFencingToken { expected, found } => {
+                write!(
+                    f,
+                    "construct lock stale fencing token: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for ConstructLockError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstructLockGuard {
+    lease_ttl_ticks: u64,
+    current_lease: Option<ConstructLockLease>,
+}
+
+impl ConstructLockGuard {
+    pub fn new(lease_ttl_ticks: u64) -> Result<Self, ConstructLockError> {
+        if lease_ttl_ticks == 0 {
+            return Err(ConstructLockError::InvalidLeaseTtl);
+        }
+        Ok(Self {
+            lease_ttl_ticks,
+            current_lease: None,
+        })
+    }
+
+    pub fn lease_ttl_ticks(&self) -> u64 {
+        self.lease_ttl_ticks
+    }
+
+    pub fn acquire_for(
+        &mut self,
+        owner_id: &str,
+    ) -> Result<ConstructLockLease, ConstructLockError> {
+        if owner_id.trim().is_empty() {
+            return Err(ConstructLockError::InvalidOwnerId);
+        }
+
+        if let Some(lease) = &self.current_lease {
+            if lease.owner_id() != owner_id {
+                return Err(ConstructLockError::LeaseAlreadyHeld {
+                    owner: lease.owner_id().to_owned(),
+                });
+            }
+            return Ok(lease.clone());
+        }
+
+        let lease = ConstructLockLease::new(owner_id.to_owned(), 1);
+        self.current_lease = Some(lease.clone());
+        Ok(lease)
+    }
+
+    pub fn renew(
+        &mut self,
+        owner_id: &str,
+        fencing_token: u64,
+    ) -> Result<ConstructLockLease, ConstructLockError> {
+        if owner_id.trim().is_empty() {
+            return Err(ConstructLockError::InvalidOwnerId);
+        }
+        let current_lease = self
+            .current_lease
+            .as_ref()
+            .ok_or(ConstructLockError::NoActiveLease)?;
+
+        if current_lease.owner_id() != owner_id {
+            return Err(ConstructLockError::LeaseOwnerMismatch {
+                expected: current_lease.owner_id().to_owned(),
+                found: owner_id.to_owned(),
+            });
+        }
+
+        if current_lease.fencing_token() != fencing_token {
+            return Err(ConstructLockError::StaleFencingToken {
+                expected: current_lease.fencing_token(),
+                found: fencing_token,
+            });
+        }
+
+        let renewed = ConstructLockLease::new(
+            current_lease.owner_id().to_owned(),
+            current_lease.fencing_token() + 1,
+        );
+        self.current_lease = Some(renewed.clone());
+        Ok(renewed)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecoveryStatus {
     RejoinAccepted,
     CatchUpRequired { from_version: u64, to_version: u64 },
@@ -627,11 +766,11 @@ pub fn build_runtime_wiring(config: &NodeConfig) -> RuntimeWiring {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_runtime_wiring, BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle,
-        PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
-        RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
-        RuntimeLifecycleError, RuntimeQueueError, RuntimeSnapshot, SnapshotRestoreError,
-        SnapshotRestoreGuard,
+        build_runtime_wiring, BoundedRuntimeQueue, ConstructLockError, ConstructLockGuard,
+        DeterministicProposalPlanner, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
+        ProposalCandidate, ProposalPlannerError, RecoveryGuardError, RecoveryRejoinGuard,
+        RecoveryStatus, RejoinAttempt, RuntimeLifecycleError, RuntimeQueueError, RuntimeSnapshot,
+        SnapshotRestoreError, SnapshotRestoreGuard,
     };
     use crate::config::{NodeConfig, NodeRole, SyncMode};
 
@@ -971,6 +1110,62 @@ mod tests {
             SnapshotRestoreError::StateHashMismatch {
                 expected: "state-42".to_owned(),
                 found: "state-41".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn functional_construct_lock_allows_acquire_then_renew_flow() {
+        let mut lock = ConstructLockGuard::new(5).expect("construct lock should build");
+        let lease = lock
+            .acquire_for("processor-a")
+            .expect("initial lease acquisition should succeed");
+        let renewed = lock
+            .renew("processor-a", lease.fencing_token())
+            .expect("lease renewal should succeed");
+        assert!(renewed.fencing_token() > lease.fencing_token());
+    }
+
+    #[test]
+    fn unit_construct_lock_rejects_empty_owner_id() {
+        let mut lock = ConstructLockGuard::new(5).expect("construct lock should build");
+        let error = lock
+            .acquire_for("")
+            .expect_err("empty owner id must be rejected");
+        assert_eq!(error, ConstructLockError::InvalidOwnerId);
+    }
+
+    #[test]
+    fn regression_split_brain_lock_acquisition_is_rejected() {
+        // Regression: #362
+        let mut lock = ConstructLockGuard::new(5).expect("construct lock should build");
+        assert!(lock.acquire_for("processor-a").is_ok());
+        let error = lock
+            .acquire_for("processor-b")
+            .expect_err("second owner acquisition must be rejected");
+        assert_eq!(
+            error,
+            ConstructLockError::LeaseAlreadyHeld {
+                owner: "processor-a".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn regression_stale_lease_renewal_is_rejected() {
+        // Regression: #362
+        let mut lock = ConstructLockGuard::new(5).expect("construct lock should build");
+        let lease = lock
+            .acquire_for("processor-a")
+            .expect("initial lease acquisition should succeed");
+        let error = lock
+            .renew("processor-a", lease.fencing_token().saturating_sub(1))
+            .expect_err("stale fencing token must be rejected");
+        assert_eq!(
+            error,
+            ConstructLockError::StaleFencingToken {
+                expected: lease.fencing_token(),
+                found: lease.fencing_token().saturating_sub(1)
             }
         );
     }

--- a/docs/foundation/runtime-processor-ha.md
+++ b/docs/foundation/runtime-processor-ha.md
@@ -9,6 +9,10 @@ This document captures processor high-availability runtime contract text for sna
   - `RuntimeSnapshot`
   - `SnapshotRestoreGuard`
   - `SnapshotRestoreError`
+- Added construct-lock guard model references:
+  - `ConstructLockLease`
+  - `ConstructLockGuard`
+  - `ConstructLockError`
 - Added low-cost validation lane commands for docs-focused PR checks.
 
 ## Snapshot Restore Rules
@@ -23,6 +27,9 @@ This document captures processor high-availability runtime contract text for sna
 - Processor construct-lock ownership must enforce single active lease semantics.
 - split-brain lock acquisition attempts are rejected.
 - stale lease renewal attempts are rejected.
+- Typed lock/fencing guard failures:
+  - `ConstructLockError::LeaseAlreadyHeld`
+  - `ConstructLockError::StaleFencingToken`
 
 ## Test Coverage Mapping
 - Unit: N/A (docs-focused contract slice).


### PR DESCRIPTION
Closes #362
Refs #359
Refs #356
Refs #354

## Summary
Implements construct-lock guard primitives in `kamn-core` to prevent split-brain lease acquisition and stale fencing-token renewal.
Adds explicit regression tests for both guard paths and updates processor HA docs contract references.

## Changes
- `crates/kamn-core/src/runtime.rs`: added `ConstructLockLease`, `ConstructLockGuard`, and `ConstructLockError`.
- `crates/kamn-core/src/runtime.rs`: added functional/unit/regression tests for construct-lock acquire/renew behavior and rejection paths (`Regression: #362`).
- `docs/foundation/runtime-processor-ha.md`: documented construct-lock model types and typed guard failures.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:

cargo test -p kamn-core construct_lock

Output (failed):

error[E0432]: unresolved imports super::ConstructLockError, super::ConstructLockGuard
error: could not compile kamn-core (lib test) due to 1 previous error

### 🟢 Green Phase
Commands:

cargo test -p kamn-core construct_lock
cargo test -p kamn-core regression_split_brain_lock_acquisition_is_rejected
cargo test -p kamn-core regression_stale_lease_renewal_is_rejected

Output (passed):

- functional_construct_lock_allows_acquire_then_renew_flow ... ok
- unit_construct_lock_rejects_empty_owner_id ... ok
- regression_split_brain_lock_acquisition_is_rejected ... ok
- regression_stale_lease_renewal_is_rejected ... ok

### 🔁 Regression
Commands:

cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core

Output (passed):

- fmt check clean
- clippy clean
- kamn-core test suite: all tests passing

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_construct_lock_rejects_empty_owner_id` | N/A |
| Functional   | ✅     | `functional_construct_lock_allows_acquire_then_renew_flow` | N/A |
| Integration  | ✅     | `cargo test -p kamn-core` full crate regression lane | Validates compatibility across runtime module consumers. |
| Regression   | ✅     | `regression_split_brain_lock_acquisition_is_rejected`, `regression_stale_lease_renewal_is_rejected` | N/A |
| Performance  | N/A    | None | No throughput/latency changes in this guard-only slice. |

## Risks & Rollback
- None.
- Rollback plan: revert PR #386 commit to remove construct-lock additions.

## Documentation Updates
- `docs/foundation/runtime-processor-ha.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
