### PR TITLE
docs(runtime): add bridge quorum docs assertions and fast-lane checks (#373)

### DIFF
--- a/crates/kamn-core/tests/bridge_quorum_runtime_docs.rs
+++ b/crates/kamn-core/tests/bridge_quorum_runtime_docs.rs
@@ -1,0 +1,27 @@
+const DOC: &str = include_str!("../../../docs/foundation/bridge-quorum-runtime.md");
+
+#[test]
+fn doc_contains_bridge_quorum_scope_and_models() {
+    assert!(DOC.contains("## Scope Delivered"));
+    assert!(DOC.contains("## Listener Quorum Workflow Rules"));
+    assert!(DOC.contains("## Approver Quorum Workflow Rules"));
+    assert!(DOC.contains("## Fast and Cost-Effective Validation"));
+    assert!(DOC.contains("listener attestation"));
+    assert!(DOC.contains("approver attestation"));
+}
+
+#[test]
+fn doc_contains_bridge_quorum_fast_lane_commands() {
+    assert!(DOC.contains("cargo test -p kamn-core --test bridge_quorum_runtime_docs"));
+    assert!(DOC.contains("cargo test -p kamn-core --test runtime_network_docs"));
+    assert!(DOC.contains("cargo fmt --check"));
+    assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
+}
+
+#[test]
+fn regression_requires_listener_and_approver_quorum_guard_rules() {
+    // Regression: #373
+    assert!(DOC.contains("Duplicate listener attestation replay is rejected."));
+    assert!(DOC.contains("Outbound under-quorum approval sets are rejected."));
+    assert!(DOC.contains("Malformed approver attestation payload is rejected."));
+}

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -5,6 +5,7 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("## Scope Delivered"));
     assert!(DOC.contains("## Node CLI Recovery-Check Mapping"));
     assert!(DOC.contains("## Node CLI Daemon Lifecycle Mapping"));
+    assert!(DOC.contains("## Bridge Quorum Runtime Mapping"));
     assert!(DOC.contains("PeerLifecycle"));
     assert!(DOC.contains("BoundedRuntimeQueue<T>"));
     assert!(DOC.contains("RuntimeLifecycleError"));
@@ -32,6 +33,7 @@ fn doc_contains_recovery_check_cli_command_example() {
 fn doc_contains_fast_and_cost_effective_validation_lane() {
     assert!(DOC.contains("## Fast and Cost-Effective Validation"));
     assert!(DOC.contains("cargo test -p kamn-core runtime::tests::"));
+    assert!(DOC.contains("cargo test -p kamn-core --test bridge_quorum_runtime_docs"));
     assert!(DOC.contains("cargo test -p kamn-node --test node_runtime_cli_docs"));
     assert!(DOC.contains(
         "cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition"
@@ -50,4 +52,6 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
     assert!(DOC.contains("rejoin state hash mismatch is rejected"));
     assert!(DOC.contains("CLI recovery-check replay/version/hash mismatch rejection"));
     assert!(DOC.contains("daemon lifecycle invalid transition rejection"));
+    assert!(DOC.contains("listener attestation replay rejection (`Regression: #371`)"));
+    assert!(DOC.contains("outbound under-quorum rejection (`Regression: #372`)"));
 }

--- a/docs/foundation/bridge-quorum-runtime.md
+++ b/docs/foundation/bridge-quorum-runtime.md
@@ -1,0 +1,39 @@
+# Bridge Quorum Runtime Contracts (Issues #364 / #367 / #370 / #373)
+
+This document captures deterministic bridge quorum runtime contracts for listener-confirmed inbound events and approver-gated outbound actions.
+
+## Scope Delivered
+- Added bridge quorum docs contract baseline for runtime listener and approver workflows.
+- Added deterministic guard text for replay, malformed payload, and under-quorum rejection paths.
+- Added low-cost validation lane commands for bridge quorum docs assertions.
+
+## Listener Quorum Workflow Rules
+- Inbound bridge decisions require canonical listener attestation normalization before threshold evaluation.
+- Listener confirmation sets are deduplicated and sorted deterministically for stable outcomes.
+- Duplicate listener attestation replay is rejected.
+- Listener quorum outcomes emit deterministic accept/reject decision evidence in runtime reporting.
+
+## Approver Quorum Workflow Rules
+- Outbound bridge actions require canonical approver attestation set evaluation against configured quorum thresholds.
+- Outbound under-quorum approval sets are rejected.
+- Malformed approver attestation payload is rejected.
+- Outbound authorization decisions emit deterministic typed rejection reasons when quorum requirements are unmet.
+
+## Test Coverage Mapping
+- Unit: N/A (docs-focused scope).
+- Functional: listener and approver workflow rule assertions.
+- Integration: command-to-contract mapping assertions for bridge quorum validation lanes.
+- Regression:
+  - duplicate listener attestation replay rejection (`Regression: #371`)
+  - malformed approver payload rejection (`Regression: #372`)
+  - outbound under-quorum rejection (`Regression: #372`)
+
+## Fast and Cost-Effective Validation
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test bridge_quorum_runtime_docs
+cargo test -p kamn-core --test runtime_network_docs
+cargo fmt --check
+cargo clippy -p kamn-core -- -D warnings
+```

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -59,6 +59,13 @@ This document captures the initial runtime-network foundation slice for peer lif
   - invalid lifecycle event argument -> `ConfigError::InvalidDaemonLifecycleEvent`
   - invalid transition from lifecycle state machine -> `ConfigError::RuntimeDaemonLifecycle`
 
+## Bridge Quorum Runtime Mapping
+- Listener and approver bridge quorum runtime contracts are documented in:
+  - `docs/foundation/bridge-quorum-runtime.md`
+- Inbound bridge event handling maps listener attestation normalization and quorum evaluation before acceptance.
+- Outbound bridge authorization maps approver attestation threshold validation before action dispatch.
+- Bridge runtime guard outcomes are deterministic and include replay, malformed payload, and under-quorum rejection semantics.
+
 ## Peer Lifecycle Rules
 - `PeerLifecycle` starts in `Disconnected`.
 - Valid transitions:
@@ -129,6 +136,8 @@ This document captures the initial runtime-network foundation slice for peer lif
   - rejoin state hash mismatch is rejected (`Regression: #322`)
   - CLI recovery-check replay/version/hash mismatch rejection (`Regression: #336`)
   - daemon lifecycle invalid transition rejection (`Regression: #349`)
+  - listener attestation replay rejection (`Regression: #371`)
+  - outbound under-quorum rejection (`Regression: #372`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
@@ -136,6 +145,7 @@ Run targeted checks first:
 ```bash
 cargo test -p kamn-core runtime::tests::
 cargo test -p kamn-core --test runtime_network_docs
+cargo test -p kamn-core --test bridge_quorum_runtime_docs
 cargo test -p kamn-node --test node_runtime_cli_docs
 cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
 ```


### PR DESCRIPTION
Closes #373
Refs #370
Refs #367
Refs #364

## Summary
Added bridge quorum runtime docs contracts and docs assertions to lock deterministic listener/approver quorum semantics and low-cost validation commands. Updated runtime network docs to map bridge quorum workflow coverage and regression references.

## Changes
- `crates/kamn-core/tests/bridge_quorum_runtime_docs.rs`: new docs assertion suite for bridge quorum sections, fast-lane commands, and regression guard text.
- `crates/kamn-core/tests/runtime_network_docs.rs`: added assertions for bridge quorum runtime mapping, bridge docs test lane command, and regression references (#371/#372).
- `docs/foundation/bridge-quorum-runtime.md`: new bridge quorum runtime contract doc with listener/approver guard rules and fast-lane commands.
- `docs/foundation/runtime-network.md`: added bridge quorum mapping section and bridge quorum regression/validation lane references.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified bridge quorum doc contract text and command references through dedicated docs tests and runtime-network docs assertions.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | N/A for docs-focused scope (per issue) |
| Functional  | ✅     | `doc_contains_bridge_quorum_scope_and_models` |
| Integration | ✅     | `doc_contains_bridge_quorum_fast_lane_commands`, runtime-network command mapping assertions |
| Regression  | ✅     | `regression_requires_listener_and_approver_quorum_guard_rules`, runtime-network regression references |