### PR TITLE
refactor: share canonical signature profile across transaction and signer paths

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod reputation_state;
 pub mod retention_engine;
 pub mod runtime;
 pub mod service_marketplace;
+pub mod signature_profile;
 pub mod signer_backend;
 pub mod smoke;
 pub mod state;
@@ -221,6 +222,7 @@ pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,
     ServiceMarketplaceError,
 };
+pub use signature_profile::baseline_signature_for_fields;
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SignerBackend, SignerBackendError,
     SignerBackendRouter, SigningRequest,

--- a/crates/kamn-core/src/signature_profile.rs
+++ b/crates/kamn-core/src/signature_profile.rs
@@ -1,0 +1,26 @@
+pub fn baseline_signature_for_fields(
+    sender: &str,
+    nonce: u64,
+    state_hash: &str,
+    payload: &str,
+) -> String {
+    format!("sig:{}:{}:{}:{}", sender, nonce, state_hash, payload.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::baseline_signature_for_fields;
+
+    #[test]
+    fn baseline_signature_profile_is_deterministic() {
+        let signature_a = baseline_signature_for_fields("agent-a", 1, "state:genesis", "payload-1");
+        let signature_b = baseline_signature_for_fields("agent-a", 1, "state:genesis", "payload-1");
+        assert_eq!(signature_a, signature_b);
+    }
+
+    #[test]
+    fn baseline_signature_profile_includes_nonce_and_payload_length() {
+        let signature = baseline_signature_for_fields("agent-a", 9, "state:x", "abcdef");
+        assert_eq!(signature, "sig:agent-a:9:state:x:6");
+    }
+}

--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -1,3 +1,4 @@
+use crate::signature_profile::baseline_signature_for_fields;
 use crate::transaction::BaselineTransaction;
 
 const LOCAL_BACKEND_NAME: &str = "local-software";
@@ -56,13 +57,7 @@ impl SigningRequest {
     }
 
     fn expected_signature(&self) -> String {
-        format!(
-            "sig:{}:{}:{}:{}",
-            self.sender,
-            self.nonce,
-            self.state_hash,
-            self.payload.len()
-        )
+        baseline_signature_for_fields(&self.sender, self.nonce, &self.state_hash, &self.payload)
     }
 }
 

--- a/crates/kamn-core/src/transaction.rs
+++ b/crates/kamn-core/src/transaction.rs
@@ -1,3 +1,4 @@
+use crate::signature_profile::baseline_signature_for_fields;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
@@ -28,14 +29,7 @@ impl BaselineTransaction {
     }
 
     pub fn expected_signature(&self) -> String {
-        // Lightweight deterministic placeholder for baseline integrity checks.
-        format!(
-            "sig:{}:{}:{}:{}",
-            self.sender,
-            self.nonce,
-            self.state_hash,
-            self.payload.len()
-        )
+        baseline_signature_for_fields(&self.sender, self.nonce, &self.state_hash, &self.payload)
     }
 
     fn validate_shape(&self) -> Result<(), TransactionGuardError> {

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -1,6 +1,6 @@
 use kamn_core::{
-    BaselineTransaction, SignerBackendError, SignerBackendRouter, SigningRequest,
-    TransactionGuards, GENESIS_STATE_HASH,
+    baseline_signature_for_fields, BaselineTransaction, SignerBackendError, SignerBackendRouter,
+    SigningRequest, TransactionGuards, GENESIS_STATE_HASH,
 };
 
 #[test]
@@ -102,4 +102,24 @@ fn for_transaction_rejects_empty_transaction_id() {
         SigningRequest::for_transaction("secure:key-ops-3", &tx),
         Err(SignerBackendError::EmptyField("transaction_id"))
     );
+}
+
+#[test]
+fn regression_signing_request_matches_canonical_signature_profile() {
+    // Regression: #400
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("signature should be produced");
+    let canonical = baseline_signature_for_fields("agent-a", 1, GENESIS_STATE_HASH, "payload-1");
+    assert_eq!(signed.signature, canonical);
 }

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -17,10 +17,12 @@ fn doc_contains_fallback_semantics_and_transaction_integration() {
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("## Transaction Path Integration"));
     assert!(DOC.contains("SigningRequest::for_transaction(...)"));
+    assert!(DOC.contains("baseline_signature_for_fields(...)"));
 }
 
 #[test]
 fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
     // Regression: #160
     assert!(DOC.contains("does not fallback on hard request errors"));
+    assert!(DOC.contains("canonical signature-profile helper consumed by both paths"));
 }

--- a/crates/kamn-core/tests/transaction_guards.rs
+++ b/crates/kamn-core/tests/transaction_guards.rs
@@ -1,5 +1,6 @@
 use kamn_core::{
-    BaselineTransaction, RoleSmokeNetwork, SmokeError, TransactionGuardError, GENESIS_STATE_HASH,
+    baseline_signature_for_fields, BaselineTransaction, RoleSmokeNetwork, SmokeError,
+    TransactionGuardError, GENESIS_STATE_HASH,
 };
 
 fn signed_tx(
@@ -91,4 +92,12 @@ fn regression_tampered_signature_is_rejected() {
             TransactionGuardError::InvalidSignature { .. }
         ))
     ));
+}
+
+#[test]
+fn regression_signature_profile_matches_transaction_expected_signature() {
+    // Regression: #400
+    let tx = BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-tx-1", GENESIS_STATE_HASH);
+    let canonical = baseline_signature_for_fields("agent-a", 1, GENESIS_STATE_HASH, "payload-tx-1");
+    assert_eq!(canonical, tx.expected_signature());
 }

--- a/crates/kamn-core/tests/transaction_guards_docs.rs
+++ b/crates/kamn-core/tests/transaction_guards_docs.rs
@@ -1,0 +1,24 @@
+const DOC: &str = include_str!("../../../docs/foundation/transaction-guards.md");
+
+#[test]
+fn doc_contains_transaction_guard_scope_and_components() {
+    assert!(DOC.contains("## Invariants Enforced"));
+    assert!(DOC.contains("BaselineTransaction"));
+    assert!(DOC.contains("TransactionGuards"));
+    assert!(DOC.contains("TransactionGuardError"));
+}
+
+#[test]
+fn doc_contains_canonical_signature_profile_contract() {
+    assert!(DOC.contains("## Canonical Signature Profile"));
+    assert!(DOC.contains("baseline_signature_for_fields(...)"));
+    assert!(DOC.contains("shared between `transaction` and `signer_backend` paths"));
+}
+
+#[test]
+fn regression_requires_signature_profile_drift_guard_rule() {
+    // Regression: #400
+    assert!(DOC.contains(
+        "signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).",
+    ));
+}

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -24,12 +24,14 @@ This document captures the first implementation slice for signer backend abstrac
 ## Transaction Path Integration
 - `SigningRequest::for_transaction(...)` maps `BaselineTransaction` fields into signer requests.
 - Signed output remains compatible with `TransactionGuards::validate_and_record(...)`.
+- `baseline_signature_for_fields(...)` provides the canonical signature-profile helper consumed by both paths.
 
 ## Local Validation
 Run from repository root:
 
 ```bash
 cargo test -p kamn-core --test signer_backend
+cargo test -p kamn-core --test transaction_guards_docs
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -17,6 +17,11 @@ This document defines the baseline deterministic transaction guards implemented 
 - `RoleSmokeNetwork`: integrates guard checks on `submit_transaction(...)` and advances state hash on `produce_block(...)`.
 - `INVARIANT_CATALOG`: canonical invariant IDs and failure-code taxonomy mapping (`docs/foundation/invariants.md`).
 
+## Canonical Signature Profile
+- `baseline_signature_for_fields(...)` is the canonical baseline signing profile helper.
+- Signature profile is shared between `transaction` and `signer_backend` paths.
+- signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).
+
 ## Validation
 Run from repository root:
 


### PR DESCRIPTION
Closes #400
Refs #399
Refs #398
Refs #397

## Summary
Centralizes baseline signature payload/profile generation in one shared helper and routes both `transaction` and `signer_backend` through it.
Adds regression tests and docs contract assertions that prevent signature-profile drift between the two paths.

## Changes
- `crates/kamn-core/src/signature_profile.rs`: new canonical helper `baseline_signature_for_fields(...)` with unit tests.
- `crates/kamn-core/src/transaction.rs`: `BaselineTransaction::expected_signature()` now uses shared helper.
- `crates/kamn-core/src/signer_backend.rs`: `SigningRequest::expected_signature()` now uses shared helper.
- `crates/kamn-core/src/lib.rs`: exports shared helper.
- `crates/kamn-core/tests/transaction_guards.rs`: regression test for transaction/profile consistency.
- `crates/kamn-core/tests/signer_backend.rs`: regression test for signer/profile consistency.
- `crates/kamn-core/tests/transaction_guards_docs.rs`: new docs contract tests for canonical profile section.
- `crates/kamn-core/tests/signer_backend_docs.rs`: asserts canonical helper reference in signer docs.
- `docs/foundation/transaction-guards.md`: added canonical signature profile contract + regression rule.
- `docs/foundation/signer-backend-abstraction.md`: added canonical helper integration note and docs test command.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: red compile failure captured before helper existed; green targeted lane confirms shared-path compatibility and docs contract assertions.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `signature_profile` unit tests + signer/transaction field validation tests |
| Functional  | ✅     | `regression_signing_request_matches_canonical_signature_profile` |
| Integration | ✅     | router-signed transaction remains guard-compatible (`signer_backend` integration test) |
| Regression  | ✅     | `regression_signature_profile_matches_transaction_expected_signature` + docs regression assertions |
