### PR TITLE
feat(signature): enforce baseline-v1 profile identifier in canonical signatures

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -222,7 +222,9 @@ pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,
     ServiceMarketplaceError,
 };
-pub use signature_profile::baseline_signature_for_fields;
+pub use signature_profile::{
+    baseline_signature_for_fields, baseline_signature_profile_id, BASELINE_SIGNATURE_PROFILE_ID,
+};
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SignerBackend, SignerBackendError,
     SignerBackendRouter, SigningRequest,

--- a/crates/kamn-core/src/signature_profile.rs
+++ b/crates/kamn-core/src/signature_profile.rs
@@ -1,15 +1,30 @@
+pub const BASELINE_SIGNATURE_PROFILE_ID: &str = "baseline-v1";
+
+pub fn baseline_signature_profile_id() -> &'static str {
+    BASELINE_SIGNATURE_PROFILE_ID
+}
+
 pub fn baseline_signature_for_fields(
     sender: &str,
     nonce: u64,
     state_hash: &str,
     payload: &str,
 ) -> String {
-    format!("sig:{}:{}:{}:{}", sender, nonce, state_hash, payload.len())
+    format!(
+        "sig:{}:{}:{}:{}:{}",
+        baseline_signature_profile_id(),
+        sender,
+        nonce,
+        state_hash,
+        payload.len()
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::baseline_signature_for_fields;
+    use super::{
+        baseline_signature_for_fields, baseline_signature_profile_id, BASELINE_SIGNATURE_PROFILE_ID,
+    };
 
     #[test]
     fn baseline_signature_profile_is_deterministic() {
@@ -21,6 +36,14 @@ mod tests {
     #[test]
     fn baseline_signature_profile_includes_nonce_and_payload_length() {
         let signature = baseline_signature_for_fields("agent-a", 9, "state:x", "abcdef");
-        assert_eq!(signature, "sig:agent-a:9:state:x:6");
+        assert_eq!(signature, "sig:baseline-v1:agent-a:9:state:x:6");
+    }
+
+    #[test]
+    fn baseline_signature_profile_id_helper_matches_constant() {
+        assert_eq!(
+            baseline_signature_profile_id(),
+            BASELINE_SIGNATURE_PROFILE_ID
+        );
     }
 }

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -123,3 +123,22 @@ fn regression_signing_request_matches_canonical_signature_profile() {
     let canonical = baseline_signature_for_fields("agent-a", 1, GENESIS_STATE_HASH, "payload-1");
     assert_eq!(signed.signature, canonical);
 }
+
+#[test]
+fn regression_signatures_include_profile_identifier_segment() {
+    // Regression: #404
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("signature should be produced");
+    assert!(signed.signature.starts_with("sig:baseline-v1:"));
+}

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -18,6 +18,7 @@ fn doc_contains_fallback_semantics_and_transaction_integration() {
     assert!(DOC.contains("## Transaction Path Integration"));
     assert!(DOC.contains("SigningRequest::for_transaction(...)"));
     assert!(DOC.contains("baseline_signature_for_fields(...)"));
+    assert!(DOC.contains("baseline signature profile id: `baseline-v1`"));
 }
 
 #[test]
@@ -25,4 +26,5 @@ fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
     // Regression: #160
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("canonical signature-profile helper consumed by both paths"));
+    assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)"));
 }

--- a/crates/kamn-core/tests/transaction_guards.rs
+++ b/crates/kamn-core/tests/transaction_guards.rs
@@ -101,3 +101,19 @@ fn regression_signature_profile_matches_transaction_expected_signature() {
     let canonical = baseline_signature_for_fields("agent-a", 1, GENESIS_STATE_HASH, "payload-tx-1");
     assert_eq!(canonical, tx.expected_signature());
 }
+
+#[test]
+fn regression_non_versioned_signature_profile_is_rejected() {
+    // Regression: #404
+    let mut network = RoleSmokeNetwork::new(true);
+    let mut tx =
+        BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-tx-1", GENESIS_STATE_HASH);
+    tx.signature = "sig:agent-a:1:state:genesis:12".to_owned();
+
+    assert!(matches!(
+        network.submit_transaction(tx),
+        Err(SmokeError::Guard(
+            TransactionGuardError::InvalidSignature { .. }
+        ))
+    ));
+}

--- a/crates/kamn-core/tests/transaction_guards_docs.rs
+++ b/crates/kamn-core/tests/transaction_guards_docs.rs
@@ -13,6 +13,7 @@ fn doc_contains_canonical_signature_profile_contract() {
     assert!(DOC.contains("## Canonical Signature Profile"));
     assert!(DOC.contains("baseline_signature_for_fields(...)"));
     assert!(DOC.contains("shared between `transaction` and `signer_backend` paths"));
+    assert!(DOC.contains("baseline signature profile id: `baseline-v1`"));
 }
 
 #[test]
@@ -21,4 +22,5 @@ fn regression_requires_signature_profile_drift_guard_rule() {
     assert!(DOC.contains(
         "signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).",
     ));
+    assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)."));
 }

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -25,6 +25,8 @@ This document captures the first implementation slice for signer backend abstrac
 - `SigningRequest::for_transaction(...)` maps `BaselineTransaction` fields into signer requests.
 - Signed output remains compatible with `TransactionGuards::validate_and_record(...)`.
 - `baseline_signature_for_fields(...)` provides the canonical signature-profile helper consumed by both paths.
+- baseline signature profile id: `baseline-v1`.
+- non-versioned signature profile is rejected (`Regression: #404`).
 
 ## Local Validation
 Run from repository root:

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -20,7 +20,9 @@ This document defines the baseline deterministic transaction guards implemented 
 ## Canonical Signature Profile
 - `baseline_signature_for_fields(...)` is the canonical baseline signing profile helper.
 - Signature profile is shared between `transaction` and `signer_backend` paths.
+- baseline signature profile id: `baseline-v1`.
 - signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).
+- non-versioned signature profile is rejected (`Regression: #404`).
 
 ## Validation
 Run from repository root:


### PR DESCRIPTION
## Summary
Versioned the canonical baseline signature profile so signatures carry explicit profile identity (`baseline-v1`) across transaction and signer flows. Added regression tests and docs contract checks to prevent non-versioned format drift.

## Changes
- `crates/kamn-core/src/signature_profile.rs`: added `BASELINE_SIGNATURE_PROFILE_ID`, `baseline_signature_profile_id()`, and updated canonical signature output format.
- `crates/kamn-core/src/lib.rs`: re-exported profile identifier constant/helper.
- `crates/kamn-core/tests/signer_backend.rs`: added regression for profile-id segment in produced signatures.
- `crates/kamn-core/tests/transaction_guards.rs`: added regression that rejects non-versioned legacy-style signature payloads.
- `crates/kamn-core/tests/signer_backend_docs.rs`: added docs contract assertions for profile-id + regression rule text.
- `crates/kamn-core/tests/transaction_guards_docs.rs`: added docs contract assertions for profile-id + regression rule text.
- `docs/foundation/signer-backend-abstraction.md`: documented baseline profile id and non-versioned rejection rule.
- `docs/foundation/transaction-guards.md`: documented baseline profile id and non-versioned rejection rule.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core regression_ -- --nocapture
```
Observed failure before implementation:
```text
thread 'regression_signatures_include_profile_identifier_segment' panicked at crates/kamn-core/tests/signer_backend.rs:143:5:
assertion failed: signed.signature.starts_with("sig:baseline-v1:")
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test signer_backend regression_signatures_include_profile_identifier_segment -- --nocapture
cargo test -p kamn-core --test transaction_guards regression_non_versioned_signature_profile_is_rejected -- --nocapture
cargo test -p kamn-core --test signer_backend_docs -- --nocapture
cargo test -p kamn-core --test transaction_guards_docs -- --nocapture
```
Result: all passing.

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test signer_backend --test transaction_guards --test signer_backend_docs --test transaction_guards_docs
cargo test -p kamn-core signature_profile::tests -- --nocapture
```
Result: passing (`7 + 6 + 3 + 3` integration/doc tests and `3` unit tests).

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `signature_profile::tests::baseline_signature_profile_id_helper_matches_constant`; updated signature format assertion | |
| Functional   | ✅ | `regression_signatures_include_profile_identifier_segment` | |
| Integration  | ✅ | `regression_non_versioned_signature_profile_is_rejected` via `RoleSmokeNetwork`/guards path | |
| Regression   | ✅ | Both new `Regression: #404` tests and docs contract checks | |
| Performance  | N/A | | Pure signature-format/docs contract change; no throughput path change |

## Risks & Rollback
- Breaking compatibility for legacy non-versioned signatures is intentional and covered by regression tests.
- Rollback plan: revert this PR to restore previous non-versioned canonical signature format.

## Documentation Updates
- `docs/foundation/signer-backend-abstraction.md`
- `docs/foundation/transaction-guards.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — blocked by pre-existing unrelated lint failures in `crates/kamn-core/src/runtime.rs` (`default_constructed_unit_structs`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #404
Refs #403
Refs #402
