### PR TITLE
fix(security): add replay-aware instruction claim verification

### DIFF
--- a/crates/kamn-core/src/instruction_verify.rs
+++ b/crates/kamn-core/src/instruction_verify.rs
@@ -25,6 +25,7 @@ pub struct VerificationContext {
     pub instructions: HashMap<String, InstructionRecord>,
     pub authorized_senders: HashSet<String>,
     pub max_claim_validity_window_secs: u64,
+    pub consumed_instruction_ids: HashSet<String>,
 }
 
 impl VerificationContext {
@@ -34,6 +35,7 @@ impl VerificationContext {
             instructions: HashMap::new(),
             authorized_senders: HashSet::new(),
             max_claim_validity_window_secs: DEFAULT_MAX_CLAIM_VALIDITY_WINDOW_SECS,
+            consumed_instruction_ids: HashSet::new(),
         }
     }
 
@@ -49,6 +51,12 @@ impl VerificationContext {
 
     pub fn with_max_claim_validity_window_secs(mut self, max_window_secs: u64) -> Self {
         self.max_claim_validity_window_secs = max_window_secs;
+        self
+    }
+
+    pub fn with_consumed_instruction_id(mut self, instruction_id: &str) -> Self {
+        self.consumed_instruction_ids
+            .insert(instruction_id.to_owned());
         self
     }
 }
@@ -70,6 +78,9 @@ pub enum VerificationFailure {
     OverlongValidityWindow {
         max_window_secs: u64,
         requested_window_secs: u64,
+    },
+    ReplayClaim {
+        instruction_id: String,
     },
 }
 
@@ -123,6 +134,28 @@ impl InstructionVerifier {
             });
         }
         VerificationOutcome::Valid
+    }
+
+    pub fn verify_and_record(
+        claim: &InstructionClaim,
+        context: &mut VerificationContext,
+    ) -> VerificationOutcome {
+        if context
+            .consumed_instruction_ids
+            .contains(&claim.instruction_id)
+        {
+            return VerificationOutcome::Rejected(VerificationFailure::ReplayClaim {
+                instruction_id: claim.instruction_id.clone(),
+            });
+        }
+
+        let outcome = Self::verify(claim, context);
+        if outcome == VerificationOutcome::Valid {
+            context
+                .consumed_instruction_ids
+                .insert(claim.instruction_id.clone());
+        }
+        outcome
     }
 }
 
@@ -190,6 +223,36 @@ mod tests {
             VerificationOutcome::Rejected(VerificationFailure::OverlongValidityWindow {
                 max_window_secs: 60,
                 requested_window_secs: 100,
+            })
+        );
+    }
+
+    #[test]
+    fn verify_and_record_rejects_replayed_claim() {
+        let mut context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "kamn:did:agent:alpha".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: "sig".to_owned(),
+            })
+            .with_authorized_sender("kamn:did:agent:alpha");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "kamn:did:agent:alpha".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: "sig".to_owned(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify_and_record(&claim, &mut context),
+            VerificationOutcome::Valid
+        );
+        assert_eq!(
+            InstructionVerifier::verify_and_record(&claim, &mut context),
+            VerificationOutcome::Rejected(VerificationFailure::ReplayClaim {
+                instruction_id: "ins_1".to_owned(),
             })
         );
     }

--- a/crates/kamn-core/tests/instruction_verification.rs
+++ b/crates/kamn-core/tests/instruction_verification.rs
@@ -114,3 +114,24 @@ fn regression_rejects_overlong_claim_validity_window() {
         })
     );
 }
+
+#[test]
+fn regression_replayed_claim_is_rejected_after_first_use() {
+    // Regression: #414
+    let record = sample_record();
+    let claim = sample_claim();
+    let mut context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("kamn:did:agent:alpha");
+
+    assert_eq!(
+        InstructionVerifier::verify_and_record(&claim, &mut context),
+        VerificationOutcome::Valid
+    );
+    assert_eq!(
+        InstructionVerifier::verify_and_record(&claim, &mut context),
+        VerificationOutcome::Rejected(VerificationFailure::ReplayClaim {
+            instruction_id: "ins_001".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/instruction_verification_docs.rs
+++ b/crates/kamn-core/tests/instruction_verification_docs.rs
@@ -14,3 +14,11 @@ fn regression_requires_overlong_claim_window_rejection_rule() {
     assert!(DOC.contains("OverlongValidityWindow"));
     assert!(DOC.contains("overlong validity window is rejected (`Regression: #409`)"));
 }
+
+#[test]
+fn regression_requires_replay_claim_rejection_rule() {
+    // Regression: #414
+    assert!(DOC.contains("one-time claim consumption"));
+    assert!(DOC.contains("ReplayClaim"));
+    assert!(DOC.contains("replayed claim is rejected (`Regression: #414`)"));
+}

--- a/docs/foundation/instruction-verification.md
+++ b/docs/foundation/instruction-verification.md
@@ -19,6 +19,7 @@ This document captures the first implementation slice of anti-hallucination inst
 5. Sender is explicitly authorized.
 6. Claim is not expired relative to deterministic current time.
 7. bounded claim validity window is enforced against context policy.
+8. one-time claim consumption is enforced on replay-aware verification path.
 
 ## Rejection Outcomes
 - `MissingInstruction`
@@ -28,7 +29,9 @@ This document captures the first implementation slice of anti-hallucination inst
 - `UnauthorizedSender`
 - `Expired`
 - `OverlongValidityWindow`
+- `ReplayClaim`
 - overlong validity window is rejected (`Regression: #409`).
+- replayed claim is rejected (`Regression: #414`).
 
 ## Local Validation
 Run from repository root:


### PR DESCRIPTION
## Summary
Added replay-aware instruction claim verification with one-time consumption semantics. The new `verify_and_record(...)` path accepts first use and rejects replayed claims via typed `ReplayClaim` failure, with regression and docs contract coverage.

## Changes
- `crates/kamn-core/src/instruction_verify.rs`: added claim-consumption state in `VerificationContext`, `VerificationFailure::ReplayClaim`, and `InstructionVerifier::verify_and_record(...)` replay guard.
- `crates/kamn-core/tests/instruction_verification.rs`: added `Regression: #414` test ensuring second use of same claim is rejected.
- `crates/kamn-core/tests/instruction_verification_docs.rs`: added docs contract assertion for replay rejection language.
- `docs/foundation/instruction-verification.md`: documented one-time claim consumption and replay rejection contract.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
cargo test -p kamn-core --test instruction_verification regression_replayed_claim_is_rejected_after_first_use -- --nocapture
cargo test -p kamn-core --test instruction_verification_docs -- --nocapture
```
Observed failures before implementation:
```text
no function or associated item named `verify_and_record` found for struct `InstructionVerifier`
no variant named `ReplayClaim` found for enum `VerificationFailure`
```
```text
assertion failed: DOC.contains("one-time claim consumption")
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core instruction_verify::tests::verify_and_record_rejects_replayed_claim -- --nocapture
cargo test -p kamn-core --test instruction_verification regression_replayed_claim_is_rejected_after_first_use -- --nocapture
cargo test -p kamn-core --test instruction_verification_docs regression_requires_replay_claim_rejection_rule -- --nocapture
```
Result: all passing.

### 🔁 Regression
Commands:
```bash
cargo clippy -p kamn-core --test instruction_verification --test instruction_verification_docs -- -D warnings
cargo test -p kamn-core --test instruction_verification --test instruction_verification_docs
```
Result: passing (`7` integration tests + `3` docs contract tests).

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `instruction_verify::tests::verify_and_record_rejects_replayed_claim` | |
| Functional   | ✅ | `regression_replayed_claim_is_rejected_after_first_use` | |
| Integration  | ✅ | `instruction_verification` suite covers replay-aware verify-and-record path | |
| Regression   | ✅ | `Regression: #414` replay behavior + docs contract test | |
| Performance  | N/A | | Hash-set membership/insert; no throughput path change |

## Risks & Rollback
- Risk: replayed claims now fail deterministically by design; consumers must use fresh instruction IDs.
- Rollback plan: revert this PR to restore prior stateless verifier behavior.

## Documentation Updates
- `docs/foundation/instruction-verification.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — full-target run has unrelated existing baseline failures outside this scope; targeted strict clippy for touched tests is clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #414
Refs #413
Refs #412
Refs #411
