### PR TITLE
fix(ci): add deterministic fallback-safe target matrix

### DIFF
--- a/docs/foundation/ci-caching-parallelism.md
+++ b/docs/foundation/ci-caching-parallelism.md
@@ -12,6 +12,10 @@ This document captures the first implementation slice for CI runtime/cost optimi
   - `scripts/ci/run_invariant_harness.sh --parallelism <n>`
   - Deep validation lane now uses `--parallelism 2`.
 - Added CI regression checks for workflow cache policy and deep-lane parallel harness configuration.
+- Added deterministic fast-lane target selection fallback safety:
+  - Critical CI paths (`.github/workflows/*`, `scripts/ci/*`) escalate to full Rust validation scope.
+  - Unknown non-doc paths escalate to full Rust validation scope.
+  - duplicate/unknown matrix drift is guarded by selector regression tests (`Regression: #419`).
 
 ## Operational Guidance
 - Cache invalidation:
@@ -20,6 +24,7 @@ This document captures the first implementation slice for CI runtime/cost optimi
 - Cost control:
   - Keep cache saves on main only unless there is a measured need to populate PR-branch-specific caches.
   - Keep harness parallelism bounded (current limit: 2 in deep lane) to avoid unstable load spikes.
+  - Prefer targeted crate scopes for known Rust module edits, but keep strict full-scope fallback for critical/unknown paths.
 - Troubleshooting:
   - If deep invariant lane becomes unstable, temporarily reduce to `--parallelism 1` and compare budget telemetry.
   - If cache hit rates drop unexpectedly, verify lockfile churn and key continuity before changing workflow logic.

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -28,6 +28,8 @@ append_summary() {
     echo "- Run Rust checks: ${RUN_RUST}"
     echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
+    echo "- Critical path fallback: ${CRITICAL_PATH_CHANGED}"
+    echo "- Unknown path fallback: ${UNKNOWN_RISK_CHANGED}"
     if [ -n "$CHANGED_MANIFESTS" ]; then
       echo "- Targeted manifests: ${CHANGED_MANIFESTS}"
     fi
@@ -99,10 +101,17 @@ else
   mapfile -t CHANGED_FILES < <(git ls-files | sed '/^$/d')
 fi
 
+if [ -n "${CI_CHANGED_FILES:-}" ]; then
+  BASE_REF_DISPLAY="(env:CI_CHANGED_FILES)"
+  mapfile -t CHANGED_FILES < <(printf '%s\n' "$CI_CHANGED_FILES" | sed '/^$/d')
+fi
+
 CHANGED_COUNT="${#CHANGED_FILES[@]}"
 DOCS_ONLY=true
 RUST_CHANGED=false
 CI_INFRA_CHANGED=false
+CRITICAL_PATH_CHANGED=false
+UNKNOWN_RISK_CHANGED=false
 FULL_SUITE=false
 INVARIANT_RELATED_CHANGED=false
 
@@ -111,8 +120,11 @@ INVARIANT_RELATED_CHANGED=false
 declare -A MANIFESTS=()
 
 for file in "${CHANGED_FILES[@]}"; do
+  classified=false
+
   case "$file" in
     *.md|*.txt|docs/*)
+      classified=true
       ;;
     *)
       DOCS_ONLY=false
@@ -122,12 +134,15 @@ for file in "${CHANGED_FILES[@]}"; do
   case "$file" in
     *.rs|Cargo.toml|Cargo.lock|*/Cargo.toml|*/Cargo.lock|rust-toolchain.toml|.cargo/*)
       RUST_CHANGED=true
+      classified=true
       ;;
   esac
 
   case "$file" in
     .github/workflows/*|scripts/ci/*)
       CI_INFRA_CHANGED=true
+      CRITICAL_PATH_CHANGED=true
+      classified=true
       ;;
   esac
 
@@ -143,10 +158,18 @@ for file in "${CHANGED_FILES[@]}"; do
       ;;
   esac
 
+  if [ "$DOCS_ONLY" = false ] && [ "$classified" = false ]; then
+    UNKNOWN_RISK_CHANGED=true
+  fi
+
   if manifest="$(find_manifest_for_path "$file" 2>/dev/null)"; then
     MANIFESTS["$manifest"]=1
   fi
 done
+
+if [ "$CRITICAL_PATH_CHANGED" = true ] || [ "$UNKNOWN_RISK_CHANGED" = true ]; then
+  FULL_SUITE=true
+fi
 
 RUN_RUST=false
 FMT_CMD=":"
@@ -156,7 +179,7 @@ TEST_SCOPE="none"
 CHANGED_MANIFESTS=""
 RUN_INVARIANT_HARNESS=false
 
-if [ "$REPO_HAS_RUST" = true ] && { [ "$RUST_CHANGED" = true ] || [ "$CI_INFRA_CHANGED" = true ]; }; then
+if [ "$REPO_HAS_RUST" = true ] && { [ "$RUST_CHANGED" = true ] || [ "$CI_INFRA_CHANGED" = true ] || [ "$FULL_SUITE" = true ]; }; then
   RUN_RUST=true
 
   mapfile -t manifest_list < <(printf '%s\n' "${!MANIFESTS[@]}" | sed '/^$/d' | sort)
@@ -198,6 +221,8 @@ write_output "docs_only" "$DOCS_ONLY"
 write_output "run_rust" "$RUN_RUST"
 write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"
+write_output "critical_path_changed" "$CRITICAL_PATH_CHANGED"
+write_output "unknown_risk_changed" "$UNKNOWN_RISK_CHANGED"
 write_output "changed_files" "$CHANGED_COUNT"
 write_output "changed_manifests" "$CHANGED_MANIFESTS"
 write_output "fmt_cmd" "$FMT_CMD"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -4,18 +4,48 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/ci/select_targets.sh"
 
-output="$(GITHUB_BASE_REF=__missing__ bash "$SCRIPT")"
+extract_output() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { sub($1 "=",""); print; exit }'
+}
 
-run_rust="$(printf '%s\n' "$output" | awk -F= '/^run_rust=/{print $2}')"
-if [ "$run_rust" != "true" ]; then
-  echo "expected run_rust=true for current CI/workflow changes" >&2
-  exit 1
-fi
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
 
-test_cmd="$(printf '%s\n' "$output" | awk -F= '/^test_cmd=/{sub(/^test_cmd=/,""); print}')"
+run_selector() {
+  local changed_files="$1"
+  CI_CHANGED_FILES="$changed_files" GITHUB_BASE_REF=__missing__ bash "$SCRIPT"
+}
+
+docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
+assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selection mismatch"
+assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only should not run rust"
+assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
+
+critical_output="$(run_selector $'.github/workflows/ci-fast-gate.yml')"
+assert_eq "$(extract_output "$critical_output" "run_rust")" "true" "workflow changes must run rust"
+assert_eq "$(extract_output "$critical_output" "test_scope")" "full" "workflow changes must use full scope"
+
+unknown_output="$(run_selector $'config/runtime-policy.json')"
+assert_eq "$(extract_output "$unknown_output" "run_rust")" "true" "unknown paths must run rust fallback"
+assert_eq "$(extract_output "$unknown_output" "test_scope")" "full" "unknown paths must use full fallback"
+
+targeted_output="$(run_selector $'crates/kamn-core/src/bridge_adapter.rs')"
+assert_eq "$(extract_output "$targeted_output" "run_rust")" "true" "rust path should run rust"
+assert_eq "$(extract_output "$targeted_output" "test_scope")" "targeted" "crate path should be targeted"
+
+test_cmd="$(extract_output "$targeted_output" "test_cmd")"
 if ! printf '%s\n' "$test_cmd" | grep -q "run_cargo_test_with_quarantine.sh"; then
-  echo "expected select_targets test_cmd to use quarantine wrapper" >&2
+  echo "targeted test command must use quarantine wrapper" >&2
   exit 1
 fi
 
-echo "select_targets tests passed."
+echo "select_targets matrix regression tests passed."


### PR DESCRIPTION
## Summary
Hardened fast-lane target selection with deterministic fallback safety so critical CI paths and unknown non-doc changes cannot bypass mandatory Rust validation. Added matrix regression tests using deterministic changed-file overrides and updated CI optimization documentation.

## Changes
- `scripts/ci/select_targets.sh`: added `CI_CHANGED_FILES` override for deterministic matrix tests; added explicit fallback guards:
  - critical CI paths (`.github/workflows/*`, `scripts/ci/*`) force full Rust scope.
  - unknown non-doc paths force full Rust scope.
  - exposed `critical_path_changed` and `unknown_risk_changed` outputs.
- `scripts/ci/test_select_targets.sh`: expanded from single assertion to regression matrix coverage for docs-only, critical-path fallback, unknown-path fallback, and targeted crate path behavior.
- `docs/foundation/ci-caching-parallelism.md`: documented fallback safety contract and `Regression: #419` behavior.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Observed failure before implementation:
```text
docs_only selection mismatch: expected 'true', got 'false'
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_tools.sh
```
Result: all passing.

### 🔁 Regression
Commands:
```bash
bash -n scripts/ci/*.sh
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_tools.sh
```
Result: passing; selector matrix regression + full CI tool regression suite green.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/ci/test_select_targets.sh` assertions for docs-only, critical fallback, unknown fallback, targeted scope | |
| Functional   | ✅ | End-to-end selector command/output behavior via deterministic changed-file cases | |
| Integration  | ✅ | `scripts/ci/test_ci_tools.sh` includes selector regression plus surrounding CI tool chain checks | |
| Regression   | ✅ | `Regression: #419` fallback guarantees locked in selector matrix tests + docs contract | |
| Performance  | N/A | | Scope-level behavior change; no benchmark harness update in this subtask |

## Risks & Rollback
- Risk: more paths escalate to full scope; this intentionally trades a small runtime increase for safety against under-testing.
- Rollback plan: revert this PR to restore previous selector behavior.

## Documentation Updates
- `docs/foundation/ci-caching-parallelism.md`

## Validation Checklist
- [x] `cargo fmt --check` — N/A (no Rust formatting impact; shell/docs-only change)
- [x] `cargo clippy -- -D warnings` — N/A (no Rust code changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #419
Refs #418
Refs #417
Refs #416
