### PR TITLE
feat(ci): emit narrow-diff budget telemetry metrics

### DIFF
--- a/docs/foundation/ci-caching-parallelism.md
+++ b/docs/foundation/ci-caching-parallelism.md
@@ -16,6 +16,10 @@ This document captures the first implementation slice for CI runtime/cost optimi
   - Critical CI paths (`.github/workflows/*`, `scripts/ci/*`) escalate to full Rust validation scope.
   - Unknown non-doc paths escalate to full Rust validation scope.
   - duplicate/unknown matrix drift is guarded by selector regression tests (`Regression: #419`).
+- Added narrow-diff telemetry summary metrics for CI budget artifact rollups:
+  - narrow-diff records are defined as runs with `changed_files <= 3`.
+  - summary reports narrow-diff elapsed and runner-minute means.
+  - summary reports narrow-diff full-scope count to track safety fallback frequency (`Regression: #428`).
 
 ## Operational Guidance
 - Cache invalidation:
@@ -28,6 +32,7 @@ This document captures the first implementation slice for CI runtime/cost optimi
 - Troubleshooting:
   - If deep invariant lane becomes unstable, temporarily reduce to `--parallelism 1` and compare budget telemetry.
   - If cache hit rates drop unexpectedly, verify lockfile churn and key continuity before changing workflow logic.
+  - If narrow-diff full-scope count rises unexpectedly, inspect path classification rules before relaxing fallback policy.
 
 ## Local Validation
 Run from repository root:

--- a/docs/foundation/performance-target-benchmarking.md
+++ b/docs/foundation/performance-target-benchmarking.md
@@ -51,6 +51,14 @@ Each failed metric includes:
 
 This keeps per-PR compute cost low while preserving confidence in target conformance trends.
 
+## CI Runtime/Cost Measurement Signals
+- `scripts/ci/summarize_budget_artifacts.sh` now emits narrow-diff telemetry slices from budget artifacts:
+  - `Narrow-diff records (<=3 changed files)`
+  - `Narrow-diff elapsed mean`
+  - `Narrow-diff runner mean`
+  - `Narrow-diff full-scope count`
+- These signals provide lightweight evidence of fast-lane cost efficiency while preserving safety fallback visibility (`Regression: #428`).
+
 ## Local Validation
 Run from repository root:
 

--- a/scripts/ci/summarize_budget_artifacts.sh
+++ b/scripts/ci/summarize_budget_artifacts.sh
@@ -58,8 +58,19 @@ for file in "$@"; do
   status="$(jq -r '.status // "unknown"' "$file")"
   cache_hit="$(jq -r '.cache_hit // "unknown"' "$file")"
   retry_used="$(jq -r '.retry_used // "unknown"' "$file")"
+  changed_files="$(jq -r '.changed_files // 0' "$file")"
+  test_scope="$(jq -r '.test_scope // "unknown"' "$file")"
 
-  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$lane" "$elapsed" "$runner" "$status" "$cache_hit" "$retry_used" >> "$VALUES_FILE"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$lane" \
+    "$elapsed" \
+    "$runner" \
+    "$status" \
+    "$cache_hit" \
+    "$retry_used" \
+    "$changed_files" \
+    "$test_scope" \
+    >> "$VALUES_FILE"
 done
 
 if [ ! -f "$VALUES_FILE" ] || [ ! -s "$VALUES_FILE" ]; then
@@ -108,6 +119,10 @@ cache_unknown="$(awk -F '\t' '$5 != "true" && $5 != "false" {c += 1} END {print 
 retry_true="$(awk -F '\t' '$6 == "true" {c += 1} END {print c+0}' "$VALUES_FILE")"
 retry_false="$(awk -F '\t' '$6 == "false" {c += 1} END {print c+0}' "$VALUES_FILE")"
 retry_unknown="$(awk -F '\t' '$6 != "true" && $6 != "false" {c += 1} END {print c+0}' "$VALUES_FILE")"
+narrow_records="$(awk -F '\t' '$7 ~ /^[0-9]+$/ && $7 <= 3 {c += 1} END {print c+0}' "$VALUES_FILE")"
+narrow_elapsed_mean="$(awk -F '\t' '$7 ~ /^[0-9]+$/ && $7 <= 3 {sum += $2; n += 1} END { if (n == 0) { print "0.00" } else { printf "%.2f", sum/n } }' "$VALUES_FILE")"
+narrow_runner_mean="$(awk -F '\t' '$7 ~ /^[0-9]+$/ && $7 <= 3 {sum += $3; n += 1} END { if (n == 0) { print "0.00" } else { printf "%.2f", sum/n } }' "$VALUES_FILE")"
+narrow_full_scope_count="$(awk -F '\t' '$7 ~ /^[0-9]+$/ && $7 <= 3 && $8 == "full" {c += 1} END {print c+0}' "$VALUES_FILE")"
 
 cat <<REPORT
 CI Budget Telemetry Summary
@@ -125,6 +140,12 @@ Runner minutes:
 - p50: $runner_p50
 - p95: $runner_p95
 - mean: $runner_mean
+
+Narrow-diff slice:
+- Narrow-diff records (<=3 changed files): $narrow_records
+- Narrow-diff elapsed mean: $narrow_elapsed_mean
+- Narrow-diff runner mean: $narrow_runner_mean
+- Narrow-diff full-scope count: $narrow_full_scope_count
 
 Status counts:
 - pass: $status_pass

--- a/scripts/ci/test_summarize_budget_artifacts.sh
+++ b/scripts/ci/test_summarize_budget_artifacts.sh
@@ -13,6 +13,8 @@ cat > "$TMP_DIR/a.json" <<'JSON'
   "status": "pass",
   "elapsed_seconds": 100,
   "runner_minutes": 2,
+  "changed_files": 2,
+  "test_scope": "targeted",
   "cache_hit": "true",
   "retry_used": "false"
 }
@@ -24,6 +26,8 @@ cat > "$TMP_DIR/b.json" <<'JSON'
   "status": "warn",
   "elapsed_seconds": 700,
   "runner_minutes": 12,
+  "changed_files": 3,
+  "test_scope": "full",
   "cache_hit": "false",
   "retry_used": "true"
 }
@@ -35,6 +39,8 @@ cat > "$TMP_DIR/c.json" <<'JSON'
   "status": "pass",
   "elapsed_seconds": 2000,
   "runner_minutes": 35,
+  "changed_files": 12,
+  "test_scope": "full",
   "cache_hit": "unknown",
   "retry_used": "unknown"
 }
@@ -50,6 +56,10 @@ grep -q 'warn: 1' "$out_fast"
 grep -q 'fail: 0' "$out_fast"
 grep -q 'true: 1' "$out_fast"
 grep -q 'false: 1' "$out_fast"
+grep -q 'Narrow-diff records (<=3 changed files): 2' "$out_fast"
+grep -q 'Narrow-diff elapsed mean: 400.00' "$out_fast"
+grep -q 'Narrow-diff runner mean: 7.00' "$out_fast"
+grep -q 'Narrow-diff full-scope count: 1' "$out_fast"
 
 out_all="$TMP_DIR/out_all.txt"
 "$SCRIPT" "$TMP_DIR/a.json" "$TMP_DIR/b.json" "$TMP_DIR/c.json" > "$out_all"


### PR DESCRIPTION
## Summary
Extended CI budget artifact summaries with narrow-diff telemetry metrics so fast-lane runtime/cost impact is measurable for small PRs while preserving safety fallback visibility.

## Changes
- `scripts/ci/summarize_budget_artifacts.sh`:
  - parses `changed_files` and `test_scope` from each artifact
  - emits narrow-diff metrics (`<=3` changed files):
    - record count
    - elapsed mean
    - runner-minute mean
    - full-scope count
- `scripts/ci/test_summarize_budget_artifacts.sh`:
  - adds regression checks for new narrow-diff output lines and expected values
- `docs/foundation/ci-caching-parallelism.md`:
  - documents narrow-diff telemetry rollup semantics and fallback-frequency interpretation
- `docs/foundation/performance-target-benchmarking.md`:
  - documents CI runtime/cost measurement signals from summarizer output

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_summarize_budget_artifacts.sh
```
Observed failure before implementation:
```text
grep -q 'Narrow-diff records (<=3 changed files): 2' <output> failed
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/ci/test_summarize_budget_artifacts.sh
bash scripts/ci/test_ci_tools.sh
cargo test -p kamn-core --test performance_target_benchmarking_docs -- --nocapture
```
Result: all passing.

### 🔁 Regression
Commands:
```bash
bash -n scripts/ci/*.sh
bash scripts/ci/test_summarize_budget_artifacts.sh
bash scripts/ci/test_ci_tools.sh
```
Result: passing; narrow-diff telemetry contract is now locked by regression tests.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Narrow-diff metric calculations validated by deterministic fixture assertions in `test_summarize_budget_artifacts.sh` | |
| Functional   | ✅ | Mixed telemetry fixtures verify expected summary lines/values | |
| Integration  | ✅ | `test_ci_tools.sh` executes summarize tool in full CI toolchain regression suite | |
| Regression   | ✅ | `Regression: #428` output lines enforced in summarizer tests and docs | |
| Performance  | N/A | | This subtask adds measurement outputs; no runtime benchmark execution path changes |

## Risks & Rollback
- Risk: downstream parsers expecting old summary shape may need to ignore additional lines.
- Rollback plan: revert this PR to restore previous summary output format.

## Documentation Updates
- `docs/foundation/ci-caching-parallelism.md`
- `docs/foundation/performance-target-benchmarking.md`

## Validation Checklist
- [x] `cargo fmt --check` — N/A (no Rust source changed)
- [x] `cargo clippy -- -D warnings` — N/A (no Rust source changed)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #428
Refs #427
Refs #426
Refs #416
