### PR TITLE
fix(bridges): reject duplicate outbound request replay (#433)

### DIFF
--- a/crates/kamn-core/src/bridge_adapter.rs
+++ b/crates/kamn-core/src/bridge_adapter.rs
@@ -193,6 +193,7 @@ pub struct BridgeAdapterEngine<A, P> {
     adapter: A,
     policy: P,
     seen_inbound_message_ids: RefCell<BTreeSet<String>>,
+    seen_outbound_request_ids: RefCell<BTreeSet<String>>,
 }
 
 impl<A, P> BridgeAdapterEngine<A, P>
@@ -205,6 +206,7 @@ where
             adapter,
             policy,
             seen_inbound_message_ids: RefCell::new(BTreeSet::new()),
+            seen_outbound_request_ids: RefCell::new(BTreeSet::new()),
         }
     }
 
@@ -248,6 +250,15 @@ where
             &translated.destination_channel_id,
         )?;
         validate_non_empty("bridge_outbound_envelope.payload", &translated.payload)?;
+        if !self
+            .seen_outbound_request_ids
+            .borrow_mut()
+            .insert(request.request_id.clone())
+        {
+            return Err(BridgeAdapterError::DuplicateOutboundRequestId(
+                request.request_id.clone(),
+            ));
+        }
         Ok(translated)
     }
 
@@ -324,6 +335,7 @@ where
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BridgeAdapterError {
     DuplicateInboundMessageId(String),
+    DuplicateOutboundRequestId(String),
     EmptyField(&'static str),
     InvalidDid(String),
     InvalidNonce(u64),
@@ -343,6 +355,9 @@ impl fmt::Display for BridgeAdapterError {
         match self {
             Self::DuplicateInboundMessageId(message_id) => {
                 write!(f, "duplicate inbound message id: {message_id}")
+            }
+            Self::DuplicateOutboundRequestId(request_id) => {
+                write!(f, "duplicate outbound request id: {request_id}")
             }
             Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
             Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
@@ -571,6 +586,31 @@ mod tests {
             engine.process_inbound(&inbound),
             Err(BridgeAdapterError::DuplicateInboundMessageId(
                 "discord:ext-9".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn process_outbound_rejects_duplicate_request_id() {
+        let adapter = PassThroughBridgeAdapter::new(
+            BridgePlatform::Discord,
+            "kamn:did:agent:bridge-discord-1",
+        )
+        .expect("adapter should be valid");
+        let engine = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
+        let request = BridgeOutboundRequest {
+            request_id: "req-1".to_owned(),
+            from_agent_did: "kamn:did:agent:planner-1".to_owned(),
+            destination_channel_id: "discord:channel:1".to_owned(),
+            body: "hello".to_owned(),
+            created_at: "2026-02-08T09:00:00Z".to_owned(),
+        };
+
+        assert!(engine.process_outbound(&request).is_ok());
+        assert_eq!(
+            engine.process_outbound(&request),
+            Err(BridgeAdapterError::DuplicateOutboundRequestId(
+                "req-1".to_owned()
             ))
         );
     }

--- a/crates/kamn-core/tests/bridge_adapter.rs
+++ b/crates/kamn-core/tests/bridge_adapter.rs
@@ -191,3 +191,23 @@ fn regression_rejects_duplicate_inbound_event_replay() {
         ))
     );
 }
+
+#[test]
+fn regression_rejects_duplicate_outbound_request_replay() {
+    // Regression: #433
+    let adapter =
+        PassThroughBridgeAdapter::new(BridgePlatform::Discord, "kamn:did:agent:bridge-discord-1")
+            .expect("adapter should build");
+    let engine = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
+
+    engine
+        .process_outbound(&outbound_sample())
+        .expect("first outbound request should translate");
+    let replay_error = engine
+        .process_outbound(&outbound_sample())
+        .expect_err("duplicate outbound request id should be rejected");
+    assert_eq!(
+        replay_error.to_string(),
+        "duplicate outbound request id: req-7"
+    );
+}

--- a/crates/kamn-core/tests/bridge_adapter_docs.rs
+++ b/crates/kamn-core/tests/bridge_adapter_docs.rs
@@ -13,3 +13,10 @@ fn regression_requires_duplicate_inbound_replay_rejection_rule() {
     assert!(DOC.contains("DuplicateInboundMessageId"));
     assert!(DOC.contains("duplicate inbound event is rejected (`Regression: #423`)"));
 }
+
+#[test]
+fn regression_requires_duplicate_outbound_replay_rejection_rule() {
+    // Regression: #433
+    assert!(DOC.contains("DuplicateOutboundRequestId"));
+    assert!(DOC.contains("duplicate outbound request is rejected (`Regression: #433`)"));
+}

--- a/docs/foundation/bridge-adapter-abstraction.md
+++ b/docs/foundation/bridge-adapter-abstraction.md
@@ -28,6 +28,7 @@ This document describes the first implementation slice for bridge adapter abstra
   - Validate request fields and sender DID.
   - Apply policy hook before translation.
   - Enforce request ID stability to prevent adapter-side mutation.
+  - Reject duplicate outbound request IDs with `DuplicateOutboundRequestId`.
 - Cross-module integration:
   - `process_inbound_to_envelope(...)` maps normalized bridge ingress into `CanonicalMessageEnvelope` and runs envelope validation before returning.
 
@@ -45,3 +46,4 @@ cargo test -p kamn-core
 - Add platform-specific adapters (Telegram/Discord/Slack) with real credential and rate-limit hooks.
 - Replace static allow-all policy with channel and capability-aware policy implementations.
 - duplicate inbound event is rejected (`Regression: #423`).
+- duplicate outbound request is rejected (`Regression: #433`).


### PR DESCRIPTION
Closes #433

## Summary
Added outbound request-id replay protection in the bridge adapter engine so each outbound request id is consumed once after successful processing. Added regression coverage and docs contract checks to keep the behavior enforced.

## Changes
- `crates/kamn-core/src/bridge_adapter.rs`: tracked seen outbound request IDs, returned `DuplicateOutboundRequestId`, and added unit coverage for duplicate outbound rejection.
- `crates/kamn-core/tests/bridge_adapter.rs`: added replay regression proving first outbound request succeeds and duplicate replay is rejected (`Regression: #433`).
- `crates/kamn-core/tests/bridge_adapter_docs.rs`: added docs contract regression for outbound replay rejection rule text.
- `docs/foundation/bridge-adapter-abstraction.md`: documented `DuplicateOutboundRequestId` and explicit outbound replay rejection rule.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --test bridge_adapter --test bridge_adapter_docs -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed first outbound request is accepted and duplicate request ID replay is rejected in regression tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --lib process_outbound_rejects_duplicate_request_id` |
| Functional  | ✅     | `cargo test -p kamn-core --test bridge_adapter regression_rejects_duplicate_outbound_request_replay` |
| Integration | ✅     | `cargo test -p kamn-core --test bridge_adapter --test bridge_adapter_docs` |
| Regression  | ✅     | `Regression: #433` replay and docs contract assertions |
