### PR TITLE
fix(bridges): make inbound envelope projection single-pass (#438)

### DIFF
--- a/crates/kamn-core/src/discord_bridge.rs
+++ b/crates/kamn-core/src/discord_bridge.rs
@@ -84,6 +84,30 @@ impl DiscordBridgeEngine {
         &self,
         request: &DiscordInboundRequest,
     ) -> Result<NormalizedInboundMessage, DiscordBridgeError> {
+        self.validate_inbound_request(request)?;
+
+        self.bridge
+            .process_inbound(&request.inbound)
+            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_inbound_to_envelope(
+        &self,
+        request: &DiscordInboundRequest,
+        recipient_keys: Vec<String>,
+        expires: &str,
+        nonce: u64,
+    ) -> Result<CanonicalMessageEnvelope, DiscordBridgeError> {
+        self.validate_inbound_request(request)?;
+        self.bridge
+            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
+    }
+
+    fn validate_inbound_request(
+        &self,
+        request: &DiscordInboundRequest,
+    ) -> Result<(), DiscordBridgeError> {
         validate_did(&request.listener_did)?;
         if !self
             .config
@@ -109,23 +133,7 @@ impl DiscordBridgeEngine {
                 provided_target_did: request.inbound.target_agent_did.clone(),
             });
         }
-
-        self.bridge
-            .process_inbound(&request.inbound)
-            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
-    }
-
-    pub fn process_inbound_to_envelope(
-        &self,
-        request: &DiscordInboundRequest,
-        recipient_keys: Vec<String>,
-        expires: &str,
-        nonce: u64,
-    ) -> Result<CanonicalMessageEnvelope, DiscordBridgeError> {
-        self.process_inbound(request)?;
-        self.bridge
-            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
-            .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
+        Ok(())
     }
 
     pub fn process_outbound_with_approvals(

--- a/crates/kamn-core/src/telegram_bridge.rs
+++ b/crates/kamn-core/src/telegram_bridge.rs
@@ -53,6 +53,30 @@ impl TelegramBridgeEngine {
         &self,
         request: &TelegramInboundRequest,
     ) -> Result<NormalizedInboundMessage, TelegramBridgeError> {
+        self.validate_inbound_request(request)?;
+
+        self.bridge
+            .process_inbound(&request.inbound)
+            .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_inbound_to_envelope(
+        &self,
+        request: &TelegramInboundRequest,
+        recipient_keys: Vec<String>,
+        expires: &str,
+        nonce: u64,
+    ) -> Result<CanonicalMessageEnvelope, TelegramBridgeError> {
+        self.validate_inbound_request(request)?;
+        self.bridge
+            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
+    }
+
+    fn validate_inbound_request(
+        &self,
+        request: &TelegramInboundRequest,
+    ) -> Result<(), TelegramBridgeError> {
         validate_did(&request.listener_did)?;
         if !self
             .config
@@ -78,23 +102,7 @@ impl TelegramBridgeEngine {
                 provided_target_did: request.inbound.target_agent_did.clone(),
             });
         }
-
-        self.bridge
-            .process_inbound(&request.inbound)
-            .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
-    }
-
-    pub fn process_inbound_to_envelope(
-        &self,
-        request: &TelegramInboundRequest,
-        recipient_keys: Vec<String>,
-        expires: &str,
-        nonce: u64,
-    ) -> Result<CanonicalMessageEnvelope, TelegramBridgeError> {
-        self.process_inbound(request)?;
-        self.bridge
-            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
-            .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
+        Ok(())
     }
 }
 

--- a/crates/kamn-core/tests/bridge_adapter_docs.rs
+++ b/crates/kamn-core/tests/bridge_adapter_docs.rs
@@ -20,3 +20,12 @@ fn regression_requires_duplicate_outbound_replay_rejection_rule() {
     assert!(DOC.contains("DuplicateOutboundRequestId"));
     assert!(DOC.contains("duplicate outbound request is rejected (`Regression: #433`)"));
 }
+
+#[test]
+fn regression_requires_single_pass_projection_rule() {
+    // Regression: #438
+    assert!(DOC.contains("single-pass inbound projection"));
+    assert!(DOC.contains(
+        "first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`)"
+    ));
+}

--- a/crates/kamn-core/tests/discord_bridge.rs
+++ b/crates/kamn-core/tests/discord_bridge.rs
@@ -130,6 +130,36 @@ fn integration_processes_discord_inbound_to_envelope() {
 }
 
 #[test]
+fn regression_rejects_replayed_discord_inbound_projection_event() {
+    // Regression: #438
+    let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
+    let request = DiscordInboundRequest {
+        listener_did: "kamn:did:agent:listener-1".to_owned(),
+        inbound: inbound("kamn:did:agent:listener-target-1"),
+    };
+
+    engine
+        .process_inbound_to_envelope(
+            &request,
+            vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
+            "2026-02-08T04:30:00Z",
+            82,
+        )
+        .expect("first envelope projection should succeed");
+    assert_eq!(
+        engine.process_inbound_to_envelope(
+            &request,
+            vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
+            "2026-02-08T04:30:00Z",
+            83,
+        ),
+        Err(DiscordBridgeError::Bridge(
+            "duplicate inbound message id: discord:discord-msg-1".to_owned()
+        ))
+    );
+}
+
+#[test]
 fn regression_duplicate_approval_is_rejected() {
     let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
 

--- a/crates/kamn-core/tests/telegram_bridge.rs
+++ b/crates/kamn-core/tests/telegram_bridge.rs
@@ -76,6 +76,36 @@ fn integration_processes_inbound_to_canonical_envelope() {
 }
 
 #[test]
+fn regression_rejects_replayed_telegram_inbound_projection_event() {
+    // Regression: #438
+    let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
+    let request = TelegramInboundRequest {
+        listener_did: "kamn:did:agent:listener-1".to_owned(),
+        inbound: inbound("kamn:did:agent:listener-target-1"),
+    };
+
+    engine
+        .process_inbound_to_envelope(
+            &request,
+            vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
+            "2026-02-07T21:15:00Z",
+            42,
+        )
+        .expect("first envelope projection should succeed");
+    assert_eq!(
+        engine.process_inbound_to_envelope(
+            &request,
+            vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
+            "2026-02-07T21:15:00Z",
+            43,
+        ),
+        Err(TelegramBridgeError::Bridge(
+            "duplicate inbound message id: telegram:tg-msg-1".to_owned()
+        ))
+    );
+}
+
+#[test]
 fn route_target_mismatch_is_rejected() {
     let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
 

--- a/docs/foundation/bridge-adapter-abstraction.md
+++ b/docs/foundation/bridge-adapter-abstraction.md
@@ -31,6 +31,7 @@ This document describes the first implementation slice for bridge adapter abstra
   - Reject duplicate outbound request IDs with `DuplicateOutboundRequestId`.
 - Cross-module integration:
   - `process_inbound_to_envelope(...)` maps normalized bridge ingress into `CanonicalMessageEnvelope` and runs envelope validation before returning.
+  - Bridge engine wrappers apply route/listener checks while keeping single-pass inbound projection so replay guards run exactly once per logical projection flow.
 
 ## Local Validation
 Run from repository root:
@@ -47,3 +48,4 @@ cargo test -p kamn-core
 - Replace static allow-all policy with channel and capability-aware policy implementations.
 - duplicate inbound event is rejected (`Regression: #423`).
 - duplicate outbound request is rejected (`Regression: #433`).
+- first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`).


### PR DESCRIPTION
Closes #438

## Summary
Fixed a regression where Telegram and Discord inbound-to-envelope projection would fail on first use due to duplicate inbound processing in one logical flow. Bridge engines now validate listener/route once and delegate to a single projection call so replay checks execute exactly once.

## Changes
- `crates/kamn-core/src/discord_bridge.rs`: extracted inbound request validation helper and removed double-processing in `process_inbound_to_envelope(...)`.
- `crates/kamn-core/src/telegram_bridge.rs`: mirrored single-pass projection refactor for Telegram bridge flow.
- `crates/kamn-core/tests/discord_bridge.rs`: added regression proving first projection succeeds and true replay is still rejected (`Regression: #438`).
- `crates/kamn-core/tests/telegram_bridge.rs`: added equivalent projection replay regression for Telegram.
- `crates/kamn-core/tests/bridge_adapter_docs.rs`: added docs contract assertion for single-pass projection rule.
- `docs/foundation/bridge-adapter-abstraction.md`: documented single-pass projection replay-safety behavior and regression marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --test discord_bridge --test telegram_bridge --test bridge_adapter_docs -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed first inbound projection succeeds for valid request and second replay attempt is rejected in both bridge engines.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Bridge engine validation helper path covered through module behavior and constructor/unit guards |
| Functional  | ✅     | `integration_processes_discord_inbound_to_envelope`, `integration_processes_inbound_to_canonical_envelope` |
| Integration | ✅     | `cargo test -p kamn-core --test discord_bridge --test telegram_bridge --test bridge_adapter_docs` |
| Regression  | ✅     | `regression_rejects_replayed_discord_inbound_projection_event`, `regression_rejects_replayed_telegram_inbound_projection_event`, `Regression: #438` docs assertion |
