### PR TITLE
fix(bridges): make cross-chain inbound projection single-pass (#443)

### DIFF
--- a/crates/kamn-core/src/cross_chain_bridge.rs
+++ b/crates/kamn-core/src/cross_chain_bridge.rs
@@ -131,6 +131,29 @@ impl CrossChainBridgeEngine {
         &self,
         request: &CrossChainInboundRequest,
     ) -> Result<NormalizedInboundMessage, CrossChainBridgeError> {
+        self.validate_inbound_request(request)?;
+        self.bridge_engine(request.chain)
+            .process_inbound(&request.inbound)
+            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
+    }
+
+    pub fn process_inbound_to_envelope(
+        &self,
+        request: &CrossChainInboundRequest,
+        recipient_keys: Vec<String>,
+        expires: &str,
+        nonce: u64,
+    ) -> Result<CanonicalMessageEnvelope, CrossChainBridgeError> {
+        self.validate_inbound_request(request)?;
+        self.bridge_engine(request.chain)
+            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
+    }
+
+    fn validate_inbound_request(
+        &self,
+        request: &CrossChainInboundRequest,
+    ) -> Result<(), CrossChainBridgeError> {
         validate_did(&request.listener_did)?;
         if !self
             .config
@@ -160,23 +183,7 @@ impl CrossChainBridgeEngine {
                 provided_target_did: request.inbound.target_agent_did.clone(),
             });
         }
-
-        self.bridge_engine(request.chain)
-            .process_inbound(&request.inbound)
-            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
-    }
-
-    pub fn process_inbound_to_envelope(
-        &self,
-        request: &CrossChainInboundRequest,
-        recipient_keys: Vec<String>,
-        expires: &str,
-        nonce: u64,
-    ) -> Result<CanonicalMessageEnvelope, CrossChainBridgeError> {
-        self.process_inbound(request)?;
-        self.bridge_engine(request.chain)
-            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
-            .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
+        Ok(())
     }
 
     pub fn process_outbound_with_approvals(

--- a/crates/kamn-core/tests/bridge_adapter_docs.rs
+++ b/crates/kamn-core/tests/bridge_adapter_docs.rs
@@ -29,3 +29,11 @@ fn regression_requires_single_pass_projection_rule() {
         "first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`)"
     ));
 }
+
+#[test]
+fn regression_requires_cross_chain_single_pass_projection_rule() {
+    // Regression: #443
+    assert!(DOC.contains(
+        "cross-chain inbound projection also preserves single-pass replay safety (`Regression: #443`)"
+    ));
+}

--- a/crates/kamn-core/tests/cross_chain_bridge.rs
+++ b/crates/kamn-core/tests/cross_chain_bridge.rs
@@ -157,6 +157,37 @@ fn integration_projects_solana_inbound_to_envelope() {
 }
 
 #[test]
+fn regression_rejects_replayed_solana_inbound_projection_event() {
+    // Regression: #443
+    let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
+    let request = CrossChainInboundRequest {
+        listener_did: "kamn:did:agent:listener-1".to_owned(),
+        chain: CrossChainNetwork::Solana,
+        inbound: solana_inbound("kamn:did:agent:listener-target-sol"),
+    };
+
+    engine
+        .process_inbound_to_envelope(
+            &request,
+            vec!["kamn:did:agent:listener-target-sol#key-agreement-1".to_owned()],
+            "2026-02-08T09:30:00Z",
+            14,
+        )
+        .expect("first inbound projection should succeed");
+    assert_eq!(
+        engine.process_inbound_to_envelope(
+            &request,
+            vec!["kamn:did:agent:listener-target-sol#key-agreement-1".to_owned()],
+            "2026-02-08T09:30:00Z",
+            15,
+        ),
+        Err(CrossChainBridgeError::Bridge(
+            "duplicate inbound message id: solana:slot-881991:ix-2".to_owned()
+        ))
+    );
+}
+
+#[test]
 fn regression_unknown_ethereum_route_is_rejected() {
     let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
 

--- a/docs/foundation/bridge-adapter-abstraction.md
+++ b/docs/foundation/bridge-adapter-abstraction.md
@@ -49,3 +49,4 @@ cargo test -p kamn-core
 - duplicate inbound event is rejected (`Regression: #423`).
 - duplicate outbound request is rejected (`Regression: #433`).
 - first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`).
+- cross-chain inbound projection also preserves single-pass replay safety (`Regression: #443`).


### PR DESCRIPTION
Closes #443

## Summary
Fixed cross-chain inbound-to-envelope projection so first valid projection no longer fails with a duplicate-inbound false positive. The cross-chain bridge engine now validates listener/route once and delegates to a single projection call, preserving true replay rejection behavior.

## Changes
- `crates/kamn-core/src/cross_chain_bridge.rs`: extracted inbound request validation helper and removed duplicate inbound processing in `process_inbound_to_envelope(...)`.
- `crates/kamn-core/tests/cross_chain_bridge.rs`: added regression test proving first projection succeeds and replayed projection is rejected (`Regression: #443`).
- `crates/kamn-core/tests/bridge_adapter_docs.rs`: added docs contract assertion for cross-chain single-pass projection rule.
- `docs/foundation/bridge-adapter-abstraction.md`: documented cross-chain single-pass replay-safety rule.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --test cross_chain_bridge --test bridge_adapter_docs -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed first cross-chain inbound projection succeeds and replayed projection is still rejected.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Cross-chain bridge validation helper behavior covered by existing constructor/route validation tests and module checks |
| Functional  | ✅     | `integration_projects_solana_inbound_to_envelope` |
| Integration | ✅     | `cargo test -p kamn-core --test cross_chain_bridge --test bridge_adapter_docs` and full `cargo test -p kamn-core` |
| Regression  | ✅     | `regression_rejects_replayed_solana_inbound_projection_event`, docs assertion `Regression: #443` |
