### PR TITLE
fix(security): enforce instruction inclusion-proof binding (#448)

### DIFF
--- a/crates/kamn-core/src/instruction_verify.rs
+++ b/crates/kamn-core/src/instruction_verify.rs
@@ -8,6 +8,7 @@ pub struct InstructionRecord {
     pub from_did: String,
     pub payload_hash: String,
     pub signature: String,
+    pub inclusion_proof_ref: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,6 +17,7 @@ pub struct InstructionClaim {
     pub from_did: String,
     pub payload_hash: String,
     pub signature: String,
+    pub inclusion_proof_ref: String,
     pub expires_at_unix: u64,
 }
 
@@ -64,12 +66,17 @@ impl VerificationContext {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerificationFailure {
     MissingInstruction(String),
+    MissingInclusionProofReference,
     SenderMismatch {
         expected: String,
         actual: String,
     },
     PayloadMismatch,
     SignatureMismatch,
+    InclusionProofMismatch {
+        expected: String,
+        actual: String,
+    },
     UnauthorizedSender(String),
     Expired {
         expires_at: u64,
@@ -114,6 +121,19 @@ impl InstructionVerifier {
         }
         if record.signature != claim.signature {
             return VerificationOutcome::Rejected(VerificationFailure::SignatureMismatch);
+        }
+        if record.inclusion_proof_ref.trim().is_empty()
+            || claim.inclusion_proof_ref.trim().is_empty()
+        {
+            return VerificationOutcome::Rejected(
+                VerificationFailure::MissingInclusionProofReference,
+            );
+        }
+        if record.inclusion_proof_ref != claim.inclusion_proof_ref {
+            return VerificationOutcome::Rejected(VerificationFailure::InclusionProofMismatch {
+                expected: record.inclusion_proof_ref.clone(),
+                actual: claim.inclusion_proof_ref.clone(),
+            });
         }
         if !context.authorized_senders.contains(&claim.from_did) {
             return VerificationOutcome::Rejected(VerificationFailure::UnauthorizedSender(
@@ -174,6 +194,7 @@ mod tests {
                 from_did: "kamn:did:agent:alpha".to_owned(),
                 payload_hash: "hash_a".to_owned(),
                 signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
             })
             .with_authorized_sender("kamn:did:agent:alpha");
         let claim = InstructionClaim {
@@ -181,6 +202,7 @@ mod tests {
             from_did: "kamn:did:agent:alpha".to_owned(),
             payload_hash: "hash_b".to_owned(),
             signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
             expires_at_unix: 2,
         };
 
@@ -207,6 +229,7 @@ mod tests {
                 from_did: "kamn:did:agent:alpha".to_owned(),
                 payload_hash: "hash_a".to_owned(),
                 signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
             })
             .with_authorized_sender("kamn:did:agent:alpha")
             .with_max_claim_validity_window_secs(60);
@@ -215,6 +238,7 @@ mod tests {
             from_did: "kamn:did:agent:alpha".to_owned(),
             payload_hash: "hash_a".to_owned(),
             signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
             expires_at_unix: 200,
         };
 
@@ -235,6 +259,7 @@ mod tests {
                 from_did: "kamn:did:agent:alpha".to_owned(),
                 payload_hash: "hash_a".to_owned(),
                 signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
             })
             .with_authorized_sender("kamn:did:agent:alpha");
         let claim = InstructionClaim {
@@ -242,6 +267,7 @@ mod tests {
             from_did: "kamn:did:agent:alpha".to_owned(),
             payload_hash: "hash_a".to_owned(),
             signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
             expires_at_unix: 120,
         };
 
@@ -253,6 +279,61 @@ mod tests {
             InstructionVerifier::verify_and_record(&claim, &mut context),
             VerificationOutcome::Rejected(VerificationFailure::ReplayClaim {
                 instruction_id: "ins_1".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_missing_inclusion_proof_reference() {
+        let context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "kamn:did:agent:alpha".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            })
+            .with_authorized_sender("kamn:did:agent:alpha");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "kamn:did:agent:alpha".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: "sig".to_owned(),
+            inclusion_proof_ref: String::new(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify(&claim, &context),
+            VerificationOutcome::Rejected(VerificationFailure::MissingInclusionProofReference)
+        );
+    }
+
+    #[test]
+    fn rejects_inclusion_proof_reference_mismatch() {
+        let context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "kamn:did:agent:alpha".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            })
+            .with_authorized_sender("kamn:did:agent:alpha");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "kamn:did:agent:alpha".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-2".to_owned(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify(&claim, &context),
+            VerificationOutcome::Rejected(VerificationFailure::InclusionProofMismatch {
+                expected: "proof:chain:tx-1".to_owned(),
+                actual: "proof:chain:tx-2".to_owned(),
             })
         );
     }

--- a/crates/kamn-core/tests/instruction_verification.rs
+++ b/crates/kamn-core/tests/instruction_verification.rs
@@ -9,6 +9,7 @@ fn sample_record() -> InstructionRecord {
         from_did: "kamn:did:agent:alpha".to_owned(),
         payload_hash: "payload_hash_abc".to_owned(),
         signature: "sig_123".to_owned(),
+        inclusion_proof_ref: "proof:chain:tx-abc".to_owned(),
     }
 }
 
@@ -18,6 +19,7 @@ fn sample_claim() -> InstructionClaim {
         from_did: "kamn:did:agent:alpha".to_owned(),
         payload_hash: "payload_hash_abc".to_owned(),
         signature: "sig_123".to_owned(),
+        inclusion_proof_ref: "proof:chain:tx-abc".to_owned(),
         expires_at_unix: 200,
     }
 }
@@ -132,6 +134,41 @@ fn regression_replayed_claim_is_rejected_after_first_use() {
         InstructionVerifier::verify_and_record(&claim, &mut context),
         VerificationOutcome::Rejected(VerificationFailure::ReplayClaim {
             instruction_id: "ins_001".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_rejects_missing_inclusion_proof_reference() {
+    // Regression: #448
+    let record = sample_record();
+    let mut claim = sample_claim();
+    claim.inclusion_proof_ref.clear();
+    let context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("kamn:did:agent:alpha");
+
+    assert_eq!(
+        InstructionVerifier::verify(&claim, &context),
+        VerificationOutcome::Rejected(VerificationFailure::MissingInclusionProofReference)
+    );
+}
+
+#[test]
+fn regression_rejects_mismatched_inclusion_proof_reference() {
+    // Regression: #448
+    let record = sample_record();
+    let mut claim = sample_claim();
+    claim.inclusion_proof_ref = "proof:chain:tx-other".to_owned();
+    let context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("kamn:did:agent:alpha");
+
+    assert_eq!(
+        InstructionVerifier::verify(&claim, &context),
+        VerificationOutcome::Rejected(VerificationFailure::InclusionProofMismatch {
+            expected: "proof:chain:tx-abc".to_owned(),
+            actual: "proof:chain:tx-other".to_owned(),
         })
     );
 }

--- a/crates/kamn-core/tests/instruction_verification_docs.rs
+++ b/crates/kamn-core/tests/instruction_verification_docs.rs
@@ -22,3 +22,14 @@ fn regression_requires_replay_claim_rejection_rule() {
     assert!(DOC.contains("ReplayClaim"));
     assert!(DOC.contains("replayed claim is rejected (`Regression: #414`)"));
 }
+
+#[test]
+fn regression_requires_inclusion_proof_binding_rules() {
+    // Regression: #448
+    assert!(DOC.contains("inclusion proof reference"));
+    assert!(DOC.contains("MissingInclusionProofReference"));
+    assert!(DOC.contains("InclusionProofMismatch"));
+    assert!(DOC.contains(
+        "mismatched or missing inclusion proof reference is rejected (`Regression: #448`)"
+    ));
+}

--- a/docs/foundation/instruction-verification.md
+++ b/docs/foundation/instruction-verification.md
@@ -20,6 +20,7 @@ This document captures the first implementation slice of anti-hallucination inst
 6. Claim is not expired relative to deterministic current time.
 7. bounded claim validity window is enforced against context policy.
 8. one-time claim consumption is enforced on replay-aware verification path.
+9. inclusion proof reference must be present and match the on-chain record.
 
 ## Rejection Outcomes
 - `MissingInstruction`
@@ -30,8 +31,11 @@ This document captures the first implementation slice of anti-hallucination inst
 - `Expired`
 - `OverlongValidityWindow`
 - `ReplayClaim`
+- `MissingInclusionProofReference`
+- `InclusionProofMismatch`
 - overlong validity window is rejected (`Regression: #409`).
 - replayed claim is rejected (`Regression: #414`).
+- mismatched or missing inclusion proof reference is rejected (`Regression: #448`).
 
 ## Local Validation
 Run from repository root:


### PR DESCRIPTION
Closes #448

## Summary
Hardened instruction verification by binding claims to an explicit inclusion proof reference that must be present and must match the on-chain instruction record. Added typed rejection outcomes and regression coverage to keep this anti-hallucination control enforced.

## Changes
- `crates/kamn-core/src/instruction_verify.rs`: added `inclusion_proof_ref` to instruction record/claim models, enforced missing/mismatch checks, and introduced `MissingInclusionProofReference` + `InclusionProofMismatch` failures.
- `crates/kamn-core/tests/instruction_verification.rs`: added regression tests for missing and mismatched inclusion proof references (`Regression: #448`).
- `crates/kamn-core/tests/instruction_verification_docs.rs`: added docs contract regression for inclusion-proof binding rules.
- `docs/foundation/instruction-verification.md`: documented inclusion-proof verification check and new rejection outcomes.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --test instruction_verification --test instruction_verification_docs -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated that missing/mismatched inclusion proof references are rejected and matching references pass.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --lib instruction_verify::tests` |
| Functional  | ✅     | `verify_returns_valid_for_matching_authorized_nonexpired_claim` with matching proof reference |
| Integration | ✅     | `cargo test -p kamn-core --test instruction_verification --test instruction_verification_docs` and `cargo test -p kamn-core` |
| Regression  | ✅     | `regression_rejects_missing_inclusion_proof_reference`, `regression_rejects_mismatched_inclusion_proof_reference`, docs assertion for `Regression: #448` |
