### PR TITLE
fix(security): reject malformed instruction sender dids (#453)

### DIFF
--- a/crates/kamn-core/src/instruction_verify.rs
+++ b/crates/kamn-core/src/instruction_verify.rs
@@ -1,3 +1,4 @@
+use crate::AgentDid;
 use std::collections::{HashMap, HashSet};
 
 pub const DEFAULT_MAX_CLAIM_VALIDITY_WINDOW_SECS: u64 = 24 * 60 * 60;
@@ -67,6 +68,8 @@ impl VerificationContext {
 pub enum VerificationFailure {
     MissingInstruction(String),
     MissingInclusionProofReference,
+    InvalidClaimSenderDid(String),
+    InvalidRecordSenderDid(String),
     SenderMismatch {
         expected: String,
         actual: String,
@@ -109,6 +112,16 @@ impl InstructionVerifier {
                 ));
             }
         };
+        if AgentDid::parse(&claim.from_did).is_err() {
+            return VerificationOutcome::Rejected(VerificationFailure::InvalidClaimSenderDid(
+                claim.from_did.clone(),
+            ));
+        }
+        if AgentDid::parse(&record.from_did).is_err() {
+            return VerificationOutcome::Rejected(VerificationFailure::InvalidRecordSenderDid(
+                record.from_did.clone(),
+            ));
+        }
 
         if record.from_did != claim.from_did {
             return VerificationOutcome::Rejected(VerificationFailure::SenderMismatch {
@@ -335,6 +348,62 @@ mod tests {
                 expected: "proof:chain:tx-1".to_owned(),
                 actual: "proof:chain:tx-2".to_owned(),
             })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_claim_sender_did() {
+        let context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "kamn:did:agent:alpha".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            })
+            .with_authorized_sender("not-a-did");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "not-a-did".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify(&claim, &context),
+            VerificationOutcome::Rejected(VerificationFailure::InvalidClaimSenderDid(
+                "not-a-did".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_record_sender_did() {
+        let context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "bad-record-did".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            })
+            .with_authorized_sender("kamn:did:agent:alpha");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "kamn:did:agent:alpha".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify(&claim, &context),
+            VerificationOutcome::Rejected(VerificationFailure::InvalidRecordSenderDid(
+                "bad-record-did".to_owned()
+            ))
         );
     }
 }

--- a/crates/kamn-core/tests/instruction_verification.rs
+++ b/crates/kamn-core/tests/instruction_verification.rs
@@ -172,3 +172,39 @@ fn regression_rejects_mismatched_inclusion_proof_reference() {
         })
     );
 }
+
+#[test]
+fn regression_rejects_invalid_claim_sender_did() {
+    // Regression: #453
+    let record = sample_record();
+    let mut claim = sample_claim();
+    claim.from_did = "not-a-did".to_owned();
+    let context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("not-a-did");
+
+    assert_eq!(
+        InstructionVerifier::verify(&claim, &context),
+        VerificationOutcome::Rejected(VerificationFailure::InvalidClaimSenderDid(
+            "not-a-did".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn regression_rejects_invalid_record_sender_did() {
+    // Regression: #453
+    let mut record = sample_record();
+    record.from_did = "bad-record-did".to_owned();
+    let claim = sample_claim();
+    let context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("kamn:did:agent:alpha");
+
+    assert_eq!(
+        InstructionVerifier::verify(&claim, &context),
+        VerificationOutcome::Rejected(VerificationFailure::InvalidRecordSenderDid(
+            "bad-record-did".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/instruction_verification_docs.rs
+++ b/crates/kamn-core/tests/instruction_verification_docs.rs
@@ -33,3 +33,12 @@ fn regression_requires_inclusion_proof_binding_rules() {
         "mismatched or missing inclusion proof reference is rejected (`Regression: #448`)"
     ));
 }
+
+#[test]
+fn regression_requires_sender_did_validation_rules() {
+    // Regression: #453
+    assert!(DOC.contains("sender DID format validation"));
+    assert!(DOC.contains("InvalidClaimSenderDid"));
+    assert!(DOC.contains("InvalidRecordSenderDid"));
+    assert!(DOC.contains("malformed claim or record sender DID is rejected (`Regression: #453`)"));
+}

--- a/docs/foundation/instruction-verification.md
+++ b/docs/foundation/instruction-verification.md
@@ -13,20 +13,23 @@ This document captures the first implementation slice of anti-hallucination inst
 
 ## Verification Checks
 1. Instruction exists on-chain.
-2. Claim sender matches on-chain sender.
-3. Claim payload hash matches on-chain payload hash.
-4. Claim signature matches on-chain signature.
-5. Sender is explicitly authorized.
-6. Claim is not expired relative to deterministic current time.
-7. bounded claim validity window is enforced against context policy.
-8. one-time claim consumption is enforced on replay-aware verification path.
-9. inclusion proof reference must be present and match the on-chain record.
+2. sender DID format validation: claim sender DID and on-chain sender DID are syntactically valid.
+3. Claim sender matches on-chain sender.
+4. Claim payload hash matches on-chain payload hash.
+5. Claim signature matches on-chain signature.
+6. Sender is explicitly authorized.
+7. Claim is not expired relative to deterministic current time.
+8. bounded claim validity window is enforced against context policy.
+9. one-time claim consumption is enforced on replay-aware verification path.
+10. inclusion proof reference must be present and match the on-chain record.
 
 ## Rejection Outcomes
 - `MissingInstruction`
 - `SenderMismatch`
 - `PayloadMismatch`
 - `SignatureMismatch`
+- `InvalidClaimSenderDid`
+- `InvalidRecordSenderDid`
 - `UnauthorizedSender`
 - `Expired`
 - `OverlongValidityWindow`
@@ -36,6 +39,7 @@ This document captures the first implementation slice of anti-hallucination inst
 - overlong validity window is rejected (`Regression: #409`).
 - replayed claim is rejected (`Regression: #414`).
 - mismatched or missing inclusion proof reference is rejected (`Regression: #448`).
+- malformed claim or record sender DID is rejected (`Regression: #453`).
 
 ## Local Validation
 Run from repository root:


### PR DESCRIPTION
Closes #453

## Summary
Hardened instruction verification by enforcing DID format validation on both claim sender DID and on-chain record sender DID before trust checks. Added typed rejection outcomes and regression/doc assertions so malformed DID identities cannot pass verification.

## Changes
- `crates/kamn-core/src/instruction_verify.rs`: added sender DID parse checks using `AgentDid::parse`, plus `InvalidClaimSenderDid` and `InvalidRecordSenderDid` failure variants.
- `crates/kamn-core/tests/instruction_verification.rs`: added malformed claim DID and malformed record DID regression tests (`Regression: #453`).
- `crates/kamn-core/tests/instruction_verification_docs.rs`: added docs contract regression for sender DID validation rules.
- `docs/foundation/instruction-verification.md`: documented sender DID format validation in verification checks and new rejection outcomes.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --test instruction_verification --test instruction_verification_docs -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed malformed claim/record sender DIDs are rejected while valid DID paths remain successful.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --lib instruction_verify::tests` |
| Functional  | ✅     | `verify_returns_valid_for_matching_authorized_nonexpired_claim` remains valid with proper DID |
| Integration | ✅     | `cargo test -p kamn-core --test instruction_verification --test instruction_verification_docs` and `cargo test -p kamn-core` |
| Regression  | ✅     | `regression_rejects_invalid_claim_sender_did`, `regression_rejects_invalid_record_sender_did`, docs assertion for `Regression: #453` |
