### PR TITLE
fix(channel): reject malformed allowlist permission configs

### DIFF
--- a/crates/kamn-core/src/channel_policies.rs
+++ b/crates/kamn-core/src/channel_policies.rs
@@ -82,6 +82,7 @@ impl ChannelPermissionEngine {
         }
 
         validate_retention_policy(&permissions.retention)?;
+        validate_permission_rules(&permissions)?;
 
         let mut member_set = BTreeSet::new();
         for member in members {
@@ -194,6 +195,7 @@ pub enum ChannelPolicyError {
         action: ChannelAction,
         rule: PermissionRule,
     },
+    InvalidPermissionRule(String),
     InvalidRetentionPolicy(String),
 }
 
@@ -215,6 +217,7 @@ impl fmt::Display for ChannelPolicyError {
                 f,
                 "actor {actor} is unauthorized for action {action:?} under rule {rule:?}"
             ),
+            Self::InvalidPermissionRule(value) => write!(f, "invalid permission rule: {value}"),
             Self::InvalidRetentionPolicy(value) => write!(f, "invalid retention policy: {value}"),
         }
     }
@@ -232,6 +235,39 @@ fn validate_retention_policy(policy: &RetentionPolicy) -> Result<(), ChannelPoli
         RetentionPolicy::MaxMessageCount(0) => Err(ChannelPolicyError::InvalidRetentionPolicy(
             "max message count must be greater than zero".to_owned(),
         )),
+        _ => Ok(()),
+    }
+}
+
+fn validate_permission_rules(permissions: &ChannelPermissions) -> Result<(), ChannelPolicyError> {
+    validate_permission_rule("send", &permissions.send)?;
+    validate_permission_rule("read", &permissions.read)?;
+    validate_permission_rule("invite", &permissions.invite)?;
+    validate_permission_rule("remove", &permissions.remove)?;
+    validate_permission_rule("configure", &permissions.configure)?;
+    Ok(())
+}
+
+fn validate_permission_rule(
+    action: &'static str,
+    rule: &PermissionRule,
+) -> Result<(), ChannelPolicyError> {
+    match rule {
+        PermissionRule::Allowlist(values) => {
+            if values.is_empty() {
+                return Err(ChannelPolicyError::InvalidPermissionRule(format!(
+                    "allowlist for {action} must not be empty"
+                )));
+            }
+            for value in values {
+                if AgentDid::parse(value).is_err() {
+                    return Err(ChannelPolicyError::InvalidPermissionRule(format!(
+                        "allowlist for {action} contains invalid did: {value}"
+                    )));
+                }
+            }
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -256,6 +292,7 @@ mod tests {
         ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError,
         PermissionRule, RetentionMessage, RetentionPolicy,
     };
+    use std::collections::BTreeSet;
 
     fn permissions(retention: RetentionPolicy) -> ChannelPermissions {
         ChannelPermissions {
@@ -343,6 +380,50 @@ mod tests {
                 action: ChannelAction::Send,
                 rule: PermissionRule::Members,
             })
+        );
+    }
+
+    #[test]
+    fn registration_rejects_empty_allowlist_rule() {
+        let mut engine = ChannelPermissionEngine::new();
+        let mut config = permissions(RetentionPolicy::Forever);
+        config.send = PermissionRule::Allowlist(BTreeSet::new());
+
+        assert_eq!(
+            engine.register_channel(
+                "channel:group:4",
+                vec![
+                    "kamn:did:agent:member-1".to_owned(),
+                    "kamn:did:agent:member-2".to_owned(),
+                ],
+                vec!["kamn:did:agent:member-1".to_owned()],
+                config,
+            ),
+            Err(ChannelPolicyError::InvalidPermissionRule(
+                "allowlist for send must not be empty".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn registration_rejects_allowlist_rule_with_invalid_did_entry() {
+        let mut engine = ChannelPermissionEngine::new();
+        let mut config = permissions(RetentionPolicy::Forever);
+        config.send = PermissionRule::Allowlist(["bad-did".to_owned()].into_iter().collect());
+
+        assert_eq!(
+            engine.register_channel(
+                "channel:group:5",
+                vec![
+                    "kamn:did:agent:member-1".to_owned(),
+                    "kamn:did:agent:member-2".to_owned(),
+                ],
+                vec!["kamn:did:agent:member-1".to_owned()],
+                config,
+            ),
+            Err(ChannelPolicyError::InvalidPermissionRule(
+                "allowlist for send contains invalid did: bad-did".to_owned()
+            ))
         );
     }
 }

--- a/crates/kamn-core/tests/channel_permissions_retention.rs
+++ b/crates/kamn-core/tests/channel_permissions_retention.rs
@@ -204,3 +204,49 @@ fn zero_message_count_retention_is_rejected() {
         ))
     );
 }
+
+#[test]
+fn regression_allowlist_rule_rejects_empty_set() {
+    // Regression: #458
+    let mut engine = ChannelPermissionEngine::new();
+    let mut permissions = base_permissions();
+    permissions.send = PermissionRule::Allowlist(Default::default());
+
+    assert_eq!(
+        engine.register_channel(
+            "channel:group:perm-6",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            permissions,
+        ),
+        Err(ChannelPolicyError::InvalidPermissionRule(
+            "allowlist for send must not be empty".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn regression_allowlist_rule_rejects_invalid_did_entries() {
+    // Regression: #458
+    let mut engine = ChannelPermissionEngine::new();
+    let mut permissions = base_permissions();
+    permissions.send = PermissionRule::Allowlist(["not-a-did".to_owned()].into_iter().collect());
+
+    assert_eq!(
+        engine.register_channel(
+            "channel:group:perm-7",
+            vec![
+                "kamn:did:agent:owner".to_owned(),
+                "kamn:did:agent:member-1".to_owned(),
+            ],
+            vec!["kamn:did:agent:owner".to_owned()],
+            permissions,
+        ),
+        Err(ChannelPolicyError::InvalidPermissionRule(
+            "allowlist for send contains invalid did: not-a-did".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/channel_permissions_retention_docs.rs
+++ b/crates/kamn-core/tests/channel_permissions_retention_docs.rs
@@ -1,0 +1,16 @@
+const DOC: &str = include_str!("../../../docs/foundation/channel-permissions-retention.md");
+
+#[test]
+fn doc_contains_channel_permissions_scope_and_models() {
+    assert!(DOC.contains("# Channel Permissions and Retention Policies"));
+    assert!(DOC.contains("ChannelPermissionEngine"));
+    assert!(DOC.contains("PermissionRule"));
+}
+
+#[test]
+fn regression_requires_allowlist_validation_rule() {
+    // Regression: #458
+    assert!(DOC.contains("Allowlist permission rules must not be empty"));
+    assert!(DOC.contains("allowlist entries must be valid `kamn:did:agent:*` identifiers"));
+    assert!(DOC.contains("malformed allowlist configuration is rejected (`Regression: #458`)"));
+}

--- a/docs/foundation/channel-permissions-retention.md
+++ b/docs/foundation/channel-permissions-retention.md
@@ -31,6 +31,8 @@ evaluation and retention policy behavior.
   - non-empty members/admins
   - valid `kamn:did:agent:*` identifiers
   - admins must be members
+  - Allowlist permission rules must not be empty.
+  - allowlist entries must be valid `kamn:did:agent:*` identifiers.
 
 ## Retention Evaluation
 - `retention_candidates(channel_id, now_secs, messages)` returns message IDs eligible for pruning.
@@ -54,3 +56,4 @@ cargo test -p kamn-core
 ## Notes
 This slice is intentionally dependency-free and deterministic to keep CI fast
 and low-cost while establishing channel safety controls.
+- malformed allowlist configuration is rejected (`Regression: #458`).


### PR DESCRIPTION
Closes #458

## Summary
Adds allowlist permission validation during channel registration so malformed permission policies are rejected deterministically before runtime authorization.

## Changes
- crates/kamn-core/src/channel_policies.rs: validates each allowlist permission rule, rejects empty allowlists and invalid DID entries, and introduces `ChannelPolicyError::InvalidPermissionRule`.
- crates/kamn-core/tests/channel_permissions_retention.rs: adds regression tests for empty and malformed allowlist values.
- crates/kamn-core/tests/channel_permissions_retention_docs.rs: adds docs contract regression coverage for the new validation requirements.
- docs/foundation/channel-permissions-retention.md: documents allowlist validation requirements and regression contract reference.

## Risks & Compatibility
- Breaking changes: None
- Compatibility risk: Low. Invalid allowlist configs that previously passed now fail fast at registration with explicit errors.

## Validation
- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — blocked by pre-existing unrelated lints in `crates/kamn-core/src/runtime.rs`
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified error messages and docs contract updates for malformed allowlist config paths

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `channel_policies` registration validation tests |
| Functional  | ✅ | valid allowlist auth path remains green in `channel_permissions_retention` |
| Integration | ✅ | `cargo test -p kamn-core --test channel_permissions_retention --test channel_permissions_retention_docs` |
| Regression  | ✅ | `Regression: #458` tests for empty/malformed allowlists + docs contract |

## TDD Evidence
- Red: added failing tests for empty/malformed allowlist rules and docs contract assertion before implementation.
- Green: implemented validation and reran targeted and crate-level tests to green.
- Regression sweep: `cargo test -p kamn-core`.