### PR TITLE
fix(ci): stabilize selector regression tests in runner env

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -58,6 +58,7 @@ Enforced by `scripts/ci/check_pr_ci_declaration.sh` in fast-gate.
 - Budget evaluator (`test_evaluate_budget.sh`)
 - Retry helper (`test_run_with_retry.sh`)
 - Invariant harness runner (`test_run_invariant_harness.sh`)
+- Selector matrix runner with output-env isolation (`test_select_targets.sh`, `Regression: #463`)
 - Flaky registry validator (`test_check_flaky_registry.sh`)
 - Budget summarizer (`test_summarize_budget_artifacts.sh`)
 - PR CI declaration checker (`test_check_pr_ci_declaration.sh`)

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -22,13 +22,22 @@ assert_eq() {
 
 run_selector() {
   local changed_files="$1"
-  CI_CHANGED_FILES="$changed_files" GITHUB_BASE_REF=__missing__ bash "$SCRIPT"
+  env -u GITHUB_OUTPUT -u GITHUB_STEP_SUMMARY \
+    CI_CHANGED_FILES="$changed_files" \
+    GITHUB_BASE_REF=__missing__ \
+    bash "$SCRIPT"
 }
 
 docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
 assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selection mismatch"
 assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only should not run rust"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
+
+# Regression: #463
+runner_output_file="$(mktemp)"
+runner_docs_output="$(GITHUB_OUTPUT="$runner_output_file" run_selector $'docs/foundation/ci-caching-parallelism.md')"
+rm -f "$runner_output_file"
+assert_eq "$(extract_output "$runner_docs_output" "docs_only")" "true" "runner output env must not hide docs_only"
 
 critical_output="$(run_selector $'.github/workflows/ci-fast-gate.yml')"
 assert_eq "$(extract_output "$critical_output" "run_rust")" "true" "workflow changes must run rust"


### PR DESCRIPTION
Closes #463

## Summary
Fixes a CI fast-gate false failure by making selector regression tests invariant to GitHub runner output env variables. The change keeps selector behavior unchanged while ensuring test output extraction remains deterministic in both local and hosted runners.

## Changes
- scripts/ci/test_select_targets.sh: run_selector now unsets GITHUB_OUTPUT and GITHUB_STEP_SUMMARY before invoking the selector script.
- scripts/ci/test_select_targets.sh: adds a regression case that simulates inherited GITHUB_OUTPUT and asserts docs_only output remains visible (Regression: #463).
- docs/ci/strategy.md: documents selector test output-env isolation in script regression coverage.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
tmp_out=$(mktemp); GITHUB_OUTPUT="$tmp_out" bash scripts/ci/test_select_targets.sh
```
Observed output:
```text
docs_only selection mismatch: expected 'true', got ''
```
Exit code: 1

### 🟢 Green Phase
Commands:
```bash
tmp_out=$(mktemp); GITHUB_OUTPUT="$tmp_out" bash scripts/ci/test_select_targets.sh; rm -f "$tmp_out"
bash scripts/ci/test_select_targets.sh
```
Observed output:
```text
select_targets matrix regression tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/ci/test_ci_tools.sh
```
Observed summary:
```text
All CI tool regression tests passed.
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | test_select_targets.sh output extraction assertions | |
| Functional   | ✅ | docs/critical/unknown/targeted selector scenarios | |
| Integration  | ✅ | scripts/ci/test_ci_tools.sh end-to-end CI helper suite | |
| Regression   | ✅ | runner-env GITHUB_OUTPUT case (Regression: #463) | |
| Performance  | N/A | | no runtime logic or workload-path changes |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit acf0e98 to restore previous selector test harness behavior.

## Documentation Updates
- docs/ci/strategy.md: added selector runner output-env isolation coverage note.

## Validation Checklist
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

Workflow(s) touched: ci-fast-gate
Expected runtime delta: neutral to slight decrease by eliminating false-negative selector test failures.
Expected runner-minute delta: neutral to slight decrease from fewer failed fast-gate reruns.
Rollback plan if CI cost/runtime regresses: revert commit acf0e98 and re-run scripts/ci/test_ci_tools.sh to restore previous behavior while investigating.