### PR TITLE
feat(sdk): add python async receive stream generator

### DIFF
--- a/docs/foundation/python-sdk-beta.md
+++ b/docs/foundation/python-sdk-beta.md
@@ -1,4 +1,4 @@
-# Python SDK Beta Slice (Issues #134, #135)
+# Python SDK Beta Slice (Issues #134, #135, #483)
 
 This document captures the first Python SDK implementation slice for MVP workflow parity.
 
@@ -6,7 +6,7 @@ This document captures the first Python SDK implementation slice for MVP workflo
 - Added dependency-light Python SDK module: `kamn_sdk.py`.
 - Added in-memory `KAMNClient` implementation with:
   - `register`, `resolve`
-  - `send`, `receive`
+  - `send`, `receive`, `receive_stream` (async generator)
   - `create_task`, `accept_task`
   - `create_escrow`, `release_escrow`, `balance`
   - `search_agents`, `get_reputation`
@@ -15,6 +15,7 @@ This document captures the first Python SDK implementation slice for MVP workflo
 ## Deterministic Behavior
 - DIDs, message IDs, task IDs, and escrow IDs use deterministic sequence generators.
 - Inbox receives are drain-based and idempotent on repeated reads.
+- Async `receive_stream(...)` yields drained messages in deterministic FIFO order.
 - Escrow release is one-time and guarded against duplicate release.
 - Unknown DID/task/escrow access returns explicit `SDKError`.
 

--- a/kamn_sdk.py
+++ b/kamn_sdk.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import AsyncIterator, Dict, List, Optional
 
 
 class SDKError(Exception):
@@ -96,6 +96,10 @@ class KAMNClient:
         drained = list(inbox)
         inbox.clear()
         return drained
+
+    async def receive_stream(self, did: str) -> AsyncIterator[Dict[str, object]]:
+        for message in self.receive(did):
+            yield dict(message)
 
     def create_task(self, creator_did: str, task_type: str, description: str) -> str:
         self._ensure_known_agent(creator_did)

--- a/tests/python/test_sdk.py
+++ b/tests/python/test_sdk.py
@@ -1,4 +1,5 @@
 import unittest
+import asyncio
 
 from kamn_sdk import KAMNClient, SDKError
 
@@ -28,6 +29,36 @@ class PythonSDKTests(unittest.TestCase):
         self.assertEqual(len(first), 1)
         self.assertEqual(first[0]["body"], "hello")
         self.assertEqual(second, [])
+
+    def test_receive_stream_orders_messages_deterministically(self) -> None:
+        sender = self.client.register("autonomous", "claude-4", ["text"])
+        receiver = self.client.register("assistant", "gpt-5", ["text"])
+        self.client.send(sender, receiver, "first")
+        self.client.send(sender, receiver, "second")
+
+        async def collect() -> list[str]:
+            bodies: list[str] = []
+            async for message in self.client.receive_stream(receiver):
+                bodies.append(str(message["body"]))
+            return bodies
+
+        bodies = asyncio.run(collect())
+        self.assertEqual(bodies, ["first", "second"])
+
+    def test_receive_stream_does_not_replay_consumed_messages(self) -> None:
+        # Regression: #483
+        sender = self.client.register("autonomous", "claude-4", ["text"])
+        receiver = self.client.register("assistant", "gpt-5", ["text"])
+        self.client.send(sender, receiver, "once")
+
+        async def drain_counts() -> tuple[int, int]:
+            first = [message async for message in self.client.receive_stream(receiver)]
+            second = [message async for message in self.client.receive_stream(receiver)]
+            return len(first), len(second)
+
+        first_len, second_len = asyncio.run(drain_counts())
+        self.assertEqual(first_len, 1)
+        self.assertEqual(second_len, 0)
 
     def test_task_and_escrow_flow(self) -> None:
         creator = self.client.register("autonomous", "claude-4", ["research"])


### PR DESCRIPTION
Closes #483

## Summary
Adds deterministic async receive stream support to the Python SDK via `receive_stream`, aligned with PRD async workflow semantics and Rust SDK stream parity. Existing pull-based `receive` behavior remains unchanged.

## Changes
- kamn_sdk.py: adds `async def receive_stream(...)` generator that yields drained inbox messages in FIFO order.
- tests/python/test_sdk.py: adds async stream ordering and no-replay regression tests (`Regression: #483`).
- docs/foundation/python-sdk-beta.md: documents async stream API and deterministic behavior.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
python3 -m unittest tests/python/test_sdk.py
```
Observed output:
```text
AttributeError: 'KAMNClient' object has no attribute 'receive_stream'
```
Exit code: 1

### 🟢 Green Phase
Command:
```bash
python3 -m unittest tests/python/test_sdk.py
```
Observed summary:
```text
Ran 7 tests ... OK
```

### 🔁 Regression
Commands:
```bash
python3 -m unittest tests/python/test_sdk.py
cargo fmt --check
cargo clippy -- -D warnings
```
Observed summary:
```text
Python tests passed; fmt clean; clippy clean.
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | async stream generator behavior tests in Python suite | |
| Functional   | ✅ | send + async receive stream flow | |
| Integration  | ✅ | stream works with existing Python SDK register/send/receive contracts | |
| Regression   | ✅ | no-replay duplicate-drain guard (`Regression: #483`) | |
| Performance  | N/A | | in-memory generator API only |

## Risks & Rollback
- Breaking changes: None (additive API).
- Rollback plan: revert commit 0f18f22.

## Documentation Updates
- docs/foundation/python-sdk-beta.md: async stream contract and deterministic behavior note.

## Validation Checklist
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

Workflow(s) touched: None
Expected runtime delta: None
Expected runner-minute delta: None
Rollback plan if CI cost/runtime regresses: Revert commit 0f18f22.