### PR TITLE
feat(governance): validate parameter proposal payloads

### DIFF
--- a/crates/kamn-core/src/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/src/agent_upgrade_workflow.rs
@@ -239,6 +239,7 @@ impl AgentDrivenUpgradeWorkflow {
                 created_at_unix: submitted_at_unix,
                 voting_deadline_unix: proposal.voting_deadline_unix,
                 quorum_threshold: self.required_validator_quorum,
+                parameter_change: None,
             })
             .map_err(Self::map_governance)?;
 

--- a/crates/kamn-core/src/governance_workflow.rs
+++ b/crates/kamn-core/src/governance_workflow.rs
@@ -11,6 +11,16 @@ pub struct GovernanceProposalDraft {
     pub created_at_unix: u64,
     pub voting_deadline_unix: u64,
     pub quorum_threshold: usize,
+    pub parameter_change: Option<GovernanceParameterChangeDraft>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceParameterChangeDraft {
+    pub key: String,
+    pub proposed_value: u64,
+    pub min_value: u64,
+    pub max_value: u64,
+    pub target_version: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,6 +64,7 @@ pub struct GovernanceProposalRecord {
     pub created_at_unix: u64,
     pub voting_deadline_unix: u64,
     pub quorum_threshold: usize,
+    pub parameter_change: Option<GovernanceParameterChangeDraft>,
     pub status: GovernanceProposalStatus,
     pub yes_votes: usize,
     pub no_votes: usize,
@@ -98,6 +109,9 @@ impl GovernanceWorkflow {
         if draft.quorum_threshold == 0 {
             return Err(GovernanceWorkflowError::InvalidQuorum(0));
         }
+        if let Some(parameter_change) = &draft.parameter_change {
+            validate_parameter_change(parameter_change)?;
+        }
         if self.proposals.contains_key(&draft.proposal_id) {
             return Err(GovernanceWorkflowError::DuplicateProposal(
                 draft.proposal_id.clone(),
@@ -115,6 +129,7 @@ impl GovernanceWorkflow {
                     created_at_unix: draft.created_at_unix,
                     voting_deadline_unix: draft.voting_deadline_unix,
                     quorum_threshold: draft.quorum_threshold,
+                    parameter_change: draft.parameter_change,
                     status: GovernanceProposalStatus::Voting,
                     yes_votes: 0,
                     no_votes: 0,
@@ -276,6 +291,18 @@ pub enum GovernanceWorkflowError {
         voting_deadline_unix: u64,
     },
     InvalidQuorum(usize),
+    InvalidParameterTargetVersion(String),
+    InvalidParameterRange {
+        key: String,
+        min_value: u64,
+        max_value: u64,
+    },
+    ParameterOutOfBounds {
+        key: String,
+        proposed_value: u64,
+        min_value: u64,
+        max_value: u64,
+    },
     DuplicateProposal(String),
     ProposalNotFound(String),
     DuplicateVote {
@@ -307,6 +334,26 @@ impl fmt::Display for GovernanceWorkflowError {
                 "invalid voting deadline: created_at_unix={created_at_unix}, voting_deadline_unix={voting_deadline_unix}"
             ),
             Self::InvalidQuorum(value) => write!(f, "invalid quorum threshold: {value}"),
+            Self::InvalidParameterTargetVersion(value) => {
+                write!(f, "invalid parameter target version: {value}")
+            }
+            Self::InvalidParameterRange {
+                key,
+                min_value,
+                max_value,
+            } => write!(
+                f,
+                "invalid parameter range: key={key}, min_value={min_value}, max_value={max_value}"
+            ),
+            Self::ParameterOutOfBounds {
+                key,
+                proposed_value,
+                min_value,
+                max_value,
+            } => write!(
+                f,
+                "parameter value out of bounds: key={key}, proposed_value={proposed_value}, min_value={min_value}, max_value={max_value}"
+            ),
             Self::DuplicateProposal(proposal_id) => {
                 write!(f, "duplicate governance proposal id: {proposal_id}")
             }
@@ -356,6 +403,47 @@ fn validate_did(value: &str) -> Result<(), GovernanceWorkflowError> {
     Ok(())
 }
 
+fn validate_parameter_change(
+    parameter_change: &GovernanceParameterChangeDraft,
+) -> Result<(), GovernanceWorkflowError> {
+    require_non_empty("parameter_change.key", &parameter_change.key)?;
+    require_non_empty(
+        "parameter_change.target_version",
+        &parameter_change.target_version,
+    )?;
+    if !is_semver_version(&parameter_change.target_version) {
+        return Err(GovernanceWorkflowError::InvalidParameterTargetVersion(
+            parameter_change.target_version.clone(),
+        ));
+    }
+    if parameter_change.min_value > parameter_change.max_value {
+        return Err(GovernanceWorkflowError::InvalidParameterRange {
+            key: parameter_change.key.clone(),
+            min_value: parameter_change.min_value,
+            max_value: parameter_change.max_value,
+        });
+    }
+    if parameter_change.proposed_value < parameter_change.min_value
+        || parameter_change.proposed_value > parameter_change.max_value
+    {
+        return Err(GovernanceWorkflowError::ParameterOutOfBounds {
+            key: parameter_change.key.clone(),
+            proposed_value: parameter_change.proposed_value,
+            min_value: parameter_change.min_value,
+            max_value: parameter_change.max_value,
+        });
+    }
+    Ok(())
+}
+
+fn is_semver_version(value: &str) -> bool {
+    let segments: Vec<&str> = value.split('.').collect();
+    segments.len() == 3
+        && segments
+            .iter()
+            .all(|segment| !segment.is_empty() && segment.chars().all(|c| c.is_ascii_digit()))
+}
+
 fn reevaluate_status(record: &mut GovernanceProposalRecord, now_unix: u64) {
     if record.status != GovernanceProposalStatus::Voting {
         return;
@@ -392,6 +480,7 @@ mod tests {
                 created_at_unix: 100,
                 voting_deadline_unix: 99,
                 quorum_threshold: 1,
+                parameter_change: None,
             }),
             Err(GovernanceWorkflowError::InvalidDeadline {
                 created_at_unix: 100,
@@ -412,6 +501,7 @@ mod tests {
                 created_at_unix: 100,
                 voting_deadline_unix: 200,
                 quorum_threshold: 2,
+                parameter_change: None,
             })
             .expect("proposal should submit");
         workflow

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -131,9 +131,9 @@ pub use discord_bridge::{
 };
 pub use escrow::{EscrowLifecycle, EscrowLifecycleError, EscrowStatus};
 pub use governance_workflow::{
-    GovernanceExecutionRecord, GovernanceProposalDraft, GovernanceProposalRecord,
-    GovernanceProposalStatus, GovernanceVoteChoice, GovernanceVoteRecord, GovernanceWorkflow,
-    GovernanceWorkflowError,
+    GovernanceExecutionRecord, GovernanceParameterChangeDraft, GovernanceProposalDraft,
+    GovernanceProposalRecord, GovernanceProposalStatus, GovernanceVoteChoice, GovernanceVoteRecord,
+    GovernanceWorkflow, GovernanceWorkflowError,
 };
 pub use group_channel_crypto::{
     GroupChannelCryptoEngine, GroupChannelCryptoError, GroupMessageCiphertext,

--- a/crates/kamn-core/tests/governance_workflow.rs
+++ b/crates/kamn-core/tests/governance_workflow.rs
@@ -1,6 +1,6 @@
 use kamn_core::{
-    ChannelStore, GovernanceProposalDraft, GovernanceProposalStatus, GovernanceVoteChoice,
-    GovernanceWorkflow, GovernanceWorkflowError,
+    ChannelStore, GovernanceParameterChangeDraft, GovernanceProposalDraft,
+    GovernanceProposalStatus, GovernanceVoteChoice, GovernanceWorkflow, GovernanceWorkflowError,
 };
 
 #[test]
@@ -15,6 +15,7 @@ fn governance_workflow_rejects_zero_quorum_threshold() {
             created_at_unix: 1_716_300_000,
             voting_deadline_unix: 1_716_300_500,
             quorum_threshold: 0,
+            parameter_change: None,
         }),
         Err(GovernanceWorkflowError::InvalidQuorum(0))
     );
@@ -32,6 +33,7 @@ fn governance_workflow_functional_submit_vote_execute_flow() {
             created_at_unix: 1_716_301_000,
             voting_deadline_unix: 1_716_302_000,
             quorum_threshold: 2,
+            parameter_change: None,
         })
         .expect("proposal should submit");
 
@@ -109,6 +111,7 @@ fn governance_workflow_integration_with_governance_channel_members() {
             created_at_unix: 1_716_302_000,
             voting_deadline_unix: 1_716_303_000,
             quorum_threshold: 2,
+            parameter_change: None,
         })
         .expect("proposal should submit");
     workflow
@@ -149,6 +152,7 @@ fn governance_workflow_regression_rejects_late_votes_after_deadline() {
             created_at_unix: 100,
             voting_deadline_unix: 120,
             quorum_threshold: 2,
+            parameter_change: None,
         })
         .expect("proposal should submit");
 
@@ -162,6 +166,62 @@ fn governance_workflow_regression_rejects_late_votes_after_deadline() {
         Err(GovernanceWorkflowError::ProposalClosed {
             proposal_id: "gov-proposal-4".to_owned(),
             status: GovernanceProposalStatus::Expired
+        })
+    );
+}
+
+#[test]
+fn governance_workflow_rejects_parameter_change_with_invalid_target_version() {
+    let mut workflow = GovernanceWorkflow::new();
+    assert_eq!(
+        workflow.submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-5".to_owned(),
+            title: "Parameter update".to_owned(),
+            description: "Update listener quorum".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_303_000,
+            voting_deadline_unix: 1_716_304_000,
+            quorum_threshold: 2,
+            parameter_change: Some(GovernanceParameterChangeDraft {
+                key: "listener.quorum".to_owned(),
+                proposed_value: 2,
+                min_value: 1,
+                max_value: 5,
+                target_version: "vNext".to_owned(),
+            }),
+        }),
+        Err(GovernanceWorkflowError::InvalidParameterTargetVersion(
+            "vNext".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn governance_workflow_regression_rejects_parameter_change_out_of_bounds() {
+    // Regression: #476
+    let mut workflow = GovernanceWorkflow::new();
+    assert_eq!(
+        workflow.submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-6".to_owned(),
+            title: "Parameter update".to_owned(),
+            description: "Update listener quorum".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_304_000,
+            voting_deadline_unix: 1_716_305_000,
+            quorum_threshold: 2,
+            parameter_change: Some(GovernanceParameterChangeDraft {
+                key: "listener.quorum".to_owned(),
+                proposed_value: 0,
+                min_value: 1,
+                max_value: 5,
+                target_version: "1.2.0".to_owned(),
+            }),
+        }),
+        Err(GovernanceWorkflowError::ParameterOutOfBounds {
+            key: "listener.quorum".to_owned(),
+            proposed_value: 0,
+            min_value: 1,
+            max_value: 5,
         })
     );
 }

--- a/crates/kamn-core/tests/governance_workflow_docs.rs
+++ b/crates/kamn-core/tests/governance_workflow_docs.rs
@@ -27,3 +27,11 @@ fn regression_requires_late_vote_rejection_rule() {
     // Regression: #197
     assert!(DOC.contains("Late votes after deadline are rejected"));
 }
+
+#[test]
+fn regression_requires_parameter_payload_validation_rule() {
+    // Regression: #476
+    assert!(DOC.contains("## Parameter Proposal Validation Rules"));
+    assert!(DOC.contains("semver-style target version"));
+    assert!(DOC.contains("Regression: #476"));
+}

--- a/crates/kamn-core/tests/upgrade_orchestration.rs
+++ b/crates/kamn-core/tests/upgrade_orchestration.rs
@@ -72,6 +72,7 @@ fn upgrade_orchestration_integration_uses_governance_vote_outcome() {
             created_at_unix: 1_716_501_000,
             voting_deadline_unix: 1_716_501_600,
             quorum_threshold: 2,
+            parameter_change: None,
         })
         .expect("proposal should submit");
     governance

--- a/crates/kamn-core/tests/validator_lifecycle.rs
+++ b/crates/kamn-core/tests/validator_lifecycle.rs
@@ -114,6 +114,7 @@ fn validator_lifecycle_integration_requires_approved_governance_proposal_referen
             created_at_unix: 1_716_401_000,
             voting_deadline_unix: 1_716_401_600,
             quorum_threshold: 2,
+            parameter_change: None,
         })
         .expect("proposal should submit");
     governance

--- a/docs/foundation/governance-proposal-vote-execution.md
+++ b/docs/foundation/governance-proposal-vote-execution.md
@@ -1,4 +1,4 @@
-# Governance Proposal, Vote, and Execution Workflows (Issues #196 / #197)
+# Governance Proposal, Vote, and Execution Workflows (Issues #196 / #197 / #476)
 
 This document captures the first implementation slice for protocol governance message workflows.
 
@@ -7,6 +7,7 @@ This document captures the first implementation slice for protocol governance me
   - `GovernanceWorkflow` for proposal submission, vote casting, status evaluation, and execution recording.
   - proposal/vote/execution models:
     - `GovernanceProposalDraft`
+    - `GovernanceParameterChangeDraft`
     - `GovernanceProposalRecord`
     - `GovernanceVoteRecord`
     - `GovernanceExecutionRecord`
@@ -29,6 +30,15 @@ This document captures the first implementation slice for protocol governance me
   - `Rejected`
   - `Executed`
   - `Expired`
+
+## Parameter Proposal Validation Rules
+- Optional `parameter_change` payload supports typed governance parameter updates.
+- Parameter payload validation requires:
+  - non-empty `key` and `target_version`.
+  - semver-style target version (`major.minor.patch` numeric segments).
+  - `min_value <= max_value`.
+  - `proposed_value` within `[min_value, max_value]`.
+- Malformed or incompatible parameter payloads are rejected before proposal registration (`Regression: #476`).
 
 ## Vote and Quorum Rules
 - Vote casting requires:


### PR DESCRIPTION
## Summary
Adds typed governance parameter payload validation to proposal submission so malformed and incompatible updates are rejected deterministically before entering voting. This closes the regression gap for out-of-bounds and invalid target-version payloads while preserving existing governance lifecycle behavior.

Closes #476

## Changes
- `crates/kamn-core/src/governance_workflow.rs`: added optional `parameter_change` payload model, submission-time validators, and typed error variants for invalid target version/range/bounds.
- `crates/kamn-core/src/lib.rs`: exported `GovernanceParameterChangeDraft`.
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: updated governance draft construction to set `parameter_change: None` for existing upgrade proposals.
- `crates/kamn-core/tests/governance_workflow.rs`: added malformed target version and out-of-bounds regression coverage; updated legacy drafts for new optional field.
- `crates/kamn-core/tests/upgrade_orchestration.rs`: updated draft fixtures with `parameter_change: None`.
- `crates/kamn-core/tests/validator_lifecycle.rs`: updated draft fixtures with `parameter_change: None`.
- `crates/kamn-core/tests/governance_workflow_docs.rs`: added regression assertion for parameter validation docs.
- `docs/foundation/governance-proposal-vote-execution.md`: documented parameter proposal validation rules and `Regression: #476` guard.

## Risks & Compatibility
- Breaking changes: `GovernanceProposalDraft` now includes `parameter_change: Option<GovernanceParameterChangeDraft>`.
- Compatibility note: all current callsites are updated to pass `None`; existing governance behavior remains unchanged when no parameter payload is provided.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised malformed target-version and out-of-bounds proposal submissions via `governance_workflow` tests and ran full `cargo test -p kamn-core` regression suite.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Parameter payload semantic checks and typed errors validated in `governance_workflow` tests. |
| Functional  | ✅     | Existing submit/vote/execute flow remains green with new optional payload field. |
| Integration | ✅     | `upgrade_orchestration` and `validator_lifecycle` governance paths compile/run with the updated draft contract. |
| Regression  | ✅     | `governance_workflow_regression_rejects_parameter_change_out_of_bounds` with `Regression: #476` doc assertion. |
