### PR TITLE
feat(governance): enforce parameter compatibility policy

### DIFF
--- a/crates/kamn-core/src/governance_workflow.rs
+++ b/crates/kamn-core/src/governance_workflow.rs
@@ -84,6 +84,75 @@ struct GovernanceProposalState {
     votes: BTreeMap<String, GovernanceVoteRecord>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct SemanticVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+}
+
+impl SemanticVersion {
+    fn parse(value: &str) -> Option<Self> {
+        let mut parts = value.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+
+    fn canonical_string(self) -> String {
+        format!("{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ParameterPolicySpec {
+    key: &'static str,
+    min_value: u64,
+    max_value: u64,
+    min_supported_version: SemanticVersion,
+}
+
+const PARAMETER_POLICY_CATALOG: [ParameterPolicySpec; 3] = [
+    ParameterPolicySpec {
+        key: "listener.quorum",
+        min_value: 1,
+        max_value: 7,
+        min_supported_version: SemanticVersion {
+            major: 1,
+            minor: 0,
+            patch: 0,
+        },
+    },
+    ParameterPolicySpec {
+        key: "approver.required_approvals",
+        min_value: 1,
+        max_value: 7,
+        min_supported_version: SemanticVersion {
+            major: 1,
+            minor: 0,
+            patch: 0,
+        },
+    },
+    ParameterPolicySpec {
+        key: "watchdog.delivery_ratio_bps",
+        min_value: 9000,
+        max_value: 9999,
+        min_supported_version: SemanticVersion {
+            major: 1,
+            minor: 1,
+            patch: 0,
+        },
+    },
+];
+
 impl GovernanceWorkflow {
     pub fn new() -> Self {
         Self::default()
@@ -297,6 +366,19 @@ pub enum GovernanceWorkflowError {
         min_value: u64,
         max_value: u64,
     },
+    UnknownParameterKey(String),
+    ParameterRangeOutsidePolicy {
+        key: String,
+        min_value: u64,
+        max_value: u64,
+        policy_min_value: u64,
+        policy_max_value: u64,
+    },
+    ParameterUnsupportedForVersion {
+        key: String,
+        target_version: String,
+        min_supported_version: String,
+    },
     ParameterOutOfBounds {
         key: String,
         proposed_value: u64,
@@ -344,6 +426,27 @@ impl fmt::Display for GovernanceWorkflowError {
             } => write!(
                 f,
                 "invalid parameter range: key={key}, min_value={min_value}, max_value={max_value}"
+            ),
+            Self::UnknownParameterKey(key) => {
+                write!(f, "unknown governance parameter key: {key}")
+            }
+            Self::ParameterRangeOutsidePolicy {
+                key,
+                min_value,
+                max_value,
+                policy_min_value,
+                policy_max_value,
+            } => write!(
+                f,
+                "parameter range outside policy: key={key}, min_value={min_value}, max_value={max_value}, policy_min_value={policy_min_value}, policy_max_value={policy_max_value}"
+            ),
+            Self::ParameterUnsupportedForVersion {
+                key,
+                target_version,
+                min_supported_version,
+            } => write!(
+                f,
+                "parameter key unsupported for target version: key={key}, target_version={target_version}, min_supported_version={min_supported_version}"
             ),
             Self::ParameterOutOfBounds {
                 key,
@@ -411,16 +514,38 @@ fn validate_parameter_change(
         "parameter_change.target_version",
         &parameter_change.target_version,
     )?;
-    if !is_semver_version(&parameter_change.target_version) {
-        return Err(GovernanceWorkflowError::InvalidParameterTargetVersion(
-            parameter_change.target_version.clone(),
-        ));
-    }
+    let target_version =
+        SemanticVersion::parse(&parameter_change.target_version).ok_or_else(|| {
+            GovernanceWorkflowError::InvalidParameterTargetVersion(
+                parameter_change.target_version.clone(),
+            )
+        })?;
     if parameter_change.min_value > parameter_change.max_value {
         return Err(GovernanceWorkflowError::InvalidParameterRange {
             key: parameter_change.key.clone(),
             min_value: parameter_change.min_value,
             max_value: parameter_change.max_value,
+        });
+    }
+    let policy = parameter_policy_for_key(&parameter_change.key).ok_or_else(|| {
+        GovernanceWorkflowError::UnknownParameterKey(parameter_change.key.clone())
+    })?;
+    if target_version < policy.min_supported_version {
+        return Err(GovernanceWorkflowError::ParameterUnsupportedForVersion {
+            key: parameter_change.key.clone(),
+            target_version: parameter_change.target_version.clone(),
+            min_supported_version: policy.min_supported_version.canonical_string(),
+        });
+    }
+    if parameter_change.min_value < policy.min_value
+        || parameter_change.max_value > policy.max_value
+    {
+        return Err(GovernanceWorkflowError::ParameterRangeOutsidePolicy {
+            key: parameter_change.key.clone(),
+            min_value: parameter_change.min_value,
+            max_value: parameter_change.max_value,
+            policy_min_value: policy.min_value,
+            policy_max_value: policy.max_value,
         });
     }
     if parameter_change.proposed_value < parameter_change.min_value
@@ -436,12 +561,10 @@ fn validate_parameter_change(
     Ok(())
 }
 
-fn is_semver_version(value: &str) -> bool {
-    let segments: Vec<&str> = value.split('.').collect();
-    segments.len() == 3
-        && segments
-            .iter()
-            .all(|segment| !segment.is_empty() && segment.chars().all(|c| c.is_ascii_digit()))
+fn parameter_policy_for_key(key: &str) -> Option<&'static ParameterPolicySpec> {
+    PARAMETER_POLICY_CATALOG
+        .iter()
+        .find(|policy| policy.key == key)
 }
 
 fn reevaluate_status(record: &mut GovernanceProposalRecord, now_unix: u64) {

--- a/crates/kamn-core/tests/governance_workflow.rs
+++ b/crates/kamn-core/tests/governance_workflow.rs
@@ -225,3 +225,120 @@ fn governance_workflow_regression_rejects_parameter_change_out_of_bounds() {
         })
     );
 }
+
+#[test]
+fn governance_workflow_rejects_unknown_parameter_key() {
+    let mut workflow = GovernanceWorkflow::new();
+    assert_eq!(
+        workflow.submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-7".to_owned(),
+            title: "Parameter update".to_owned(),
+            description: "Attempt unknown parameter".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_305_000,
+            voting_deadline_unix: 1_716_306_000,
+            quorum_threshold: 2,
+            parameter_change: Some(GovernanceParameterChangeDraft {
+                key: "runtime.unknown-toggle".to_owned(),
+                proposed_value: 1,
+                min_value: 0,
+                max_value: 1,
+                target_version: "1.2.0".to_owned(),
+            }),
+        }),
+        Err(GovernanceWorkflowError::UnknownParameterKey(
+            "runtime.unknown-toggle".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn governance_workflow_regression_rejects_parameter_change_for_unsupported_version() {
+    // Regression: #476
+    let mut workflow = GovernanceWorkflow::new();
+    assert_eq!(
+        workflow.submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-8".to_owned(),
+            title: "Parameter update".to_owned(),
+            description: "Update watchdog threshold before supported version".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_306_000,
+            voting_deadline_unix: 1_716_307_000,
+            quorum_threshold: 2,
+            parameter_change: Some(GovernanceParameterChangeDraft {
+                key: "watchdog.delivery_ratio_bps".to_owned(),
+                proposed_value: 9700,
+                min_value: 9000,
+                max_value: 9999,
+                target_version: "1.0.0".to_owned(),
+            }),
+        }),
+        Err(GovernanceWorkflowError::ParameterUnsupportedForVersion {
+            key: "watchdog.delivery_ratio_bps".to_owned(),
+            target_version: "1.0.0".to_owned(),
+            min_supported_version: "1.1.0".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn governance_workflow_functional_executes_valid_parameter_change_proposal() {
+    let mut workflow = GovernanceWorkflow::new();
+    workflow
+        .submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-9".to_owned(),
+            title: "Parameter update".to_owned(),
+            description: "Adjust listener quorum for runtime quorum safety".to_owned(),
+            proposer_did: "kamn:did:agent:validator-1".to_owned(),
+            created_at_unix: 1_716_307_000,
+            voting_deadline_unix: 1_716_308_000,
+            quorum_threshold: 2,
+            parameter_change: Some(GovernanceParameterChangeDraft {
+                key: "listener.quorum".to_owned(),
+                proposed_value: 4,
+                min_value: 2,
+                max_value: 7,
+                target_version: "1.2.0".to_owned(),
+            }),
+        })
+        .expect("proposal should submit");
+    workflow
+        .cast_vote(
+            "gov-proposal-9",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_307_100,
+        )
+        .expect("vote should succeed");
+    workflow
+        .cast_vote(
+            "gov-proposal-9",
+            "kamn:did:agent:validator-3",
+            GovernanceVoteChoice::Yes,
+            1_716_307_200,
+        )
+        .expect("vote should succeed");
+    workflow
+        .execute(
+            "gov-proposal-9",
+            "kamn:did:agent:validator-1",
+            1_716_307_300,
+            "op-hash-9",
+        )
+        .expect("approved parameter proposal should execute");
+
+    let proposal = workflow
+        .proposal("gov-proposal-9")
+        .expect("proposal should exist");
+    assert_eq!(proposal.status, GovernanceProposalStatus::Executed);
+    assert_eq!(
+        proposal.parameter_change,
+        Some(GovernanceParameterChangeDraft {
+            key: "listener.quorum".to_owned(),
+            proposed_value: 4,
+            min_value: 2,
+            max_value: 7,
+            target_version: "1.2.0".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/governance_workflow_docs.rs
+++ b/crates/kamn-core/tests/governance_workflow_docs.rs
@@ -35,3 +35,10 @@ fn regression_requires_parameter_payload_validation_rule() {
     assert!(DOC.contains("semver-style target version"));
     assert!(DOC.contains("Regression: #476"));
 }
+
+#[test]
+fn doc_contains_parameter_catalog_and_compatibility_policy() {
+    assert!(DOC.contains("listener.quorum"));
+    assert!(DOC.contains("watchdog.delivery_ratio_bps"));
+    assert!(DOC.contains("supported from `1.1.0`"));
+}

--- a/crates/kamn-core/tests/upgrade_orchestration.rs
+++ b/crates/kamn-core/tests/upgrade_orchestration.rs
@@ -1,6 +1,7 @@
 use kamn_core::{
-    GovernanceProposalDraft, GovernanceProposalStatus, GovernanceVoteChoice, GovernanceWorkflow,
-    UpgradeAuditEventKind, UpgradeOrchestrationError, VersionUpgradeOrchestrator,
+    GovernanceParameterChangeDraft, GovernanceProposalDraft, GovernanceProposalStatus,
+    GovernanceVoteChoice, GovernanceWorkflow, UpgradeAuditEventKind, UpgradeOrchestrationError,
+    VersionUpgradeOrchestrator,
 };
 
 #[test]
@@ -72,7 +73,13 @@ fn upgrade_orchestration_integration_uses_governance_vote_outcome() {
             created_at_unix: 1_716_501_000,
             voting_deadline_unix: 1_716_501_600,
             quorum_threshold: 2,
-            parameter_change: None,
+            parameter_change: Some(GovernanceParameterChangeDraft {
+                key: "listener.quorum".to_owned(),
+                proposed_value: 3,
+                min_value: 2,
+                max_value: 7,
+                target_version: "1.1.0".to_owned(),
+            }),
         })
         .expect("proposal should submit");
     governance

--- a/docs/foundation/governance-proposal-vote-execution.md
+++ b/docs/foundation/governance-proposal-vote-execution.md
@@ -38,7 +38,11 @@ This document captures the first implementation slice for protocol governance me
   - semver-style target version (`major.minor.patch` numeric segments).
   - `min_value <= max_value`.
   - `proposed_value` within `[min_value, max_value]`.
-- Malformed or incompatible parameter payloads are rejected before proposal registration (`Regression: #476`).
+- Parameter catalog and compatibility policy:
+  - `listener.quorum`: allowed range `[1, 7]`, supported from `1.0.0`.
+  - `approver.required_approvals`: allowed range `[1, 7]`, supported from `1.0.0`.
+  - `watchdog.delivery_ratio_bps`: allowed range `[9000, 9999]`, supported from `1.1.0`.
+- Unknown keys, range-policy violations, and unsupported target-version combinations are rejected before proposal registration (`Regression: #476`).
 
 ## Vote and Quorum Rules
 - Vote casting requires:


### PR DESCRIPTION
## Summary
Implements deterministic governance parameter compatibility guards by introducing a bounded parameter catalog and semantic-version checks during proposal submission. This closes unsafe acceptance paths for unknown keys and unsupported version/parameter combinations while preserving valid proposal-vote-execute lifecycle behavior.

Closes #475

## Changes
- `crates/kamn-core/src/governance_workflow.rs`: added semantic-version parsing, parameter policy catalog, compatibility/range guard enforcement, and typed errors for unknown key, range outside policy, and unsupported target version.
- `crates/kamn-core/tests/governance_workflow.rs`: added coverage for unknown parameter key rejection, unsupported-version rejection (`Regression: #476`), and successful parameter proposal activation flow.
- `crates/kamn-core/tests/upgrade_orchestration.rs`: exercised governance+upgrade integration path with a valid parameter payload.
- `docs/foundation/governance-proposal-vote-execution.md`: documented parameter catalog bounds and minimum supported versions.
- `crates/kamn-core/tests/governance_workflow_docs.rs`: added doc assertions for catalog and compatibility policy content.

## Risks & Compatibility
- Breaking changes: `GovernanceWorkflowError` adds new variants (`UnknownParameterKey`, `ParameterRangeOutsidePolicy`, `ParameterUnsupportedForVersion`) which may require downstream exhaustive match updates.
- Compatibility: Existing proposals without `parameter_change` are unaffected; valid parameter proposals remain executable.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran targeted governance/upgrade suites and full `cargo test -p kamn-core` to confirm deterministic behavior and no regressions.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Validator behavior covered via parameter key, range, and semantic-version rejection assertions in `governance_workflow` tests. |
| Functional  | ✅     | `governance_workflow_functional_executes_valid_parameter_change_proposal` validates approve+execute lifecycle for valid parameter payloads. |
| Integration | ✅     | `upgrade_orchestration_integration_uses_governance_vote_outcome` now includes a valid parameter payload through governance to activation. |
| Regression  | ✅     | Unsupported version update remains blocked (`governance_workflow_regression_rejects_parameter_change_for_unsupported_version`, `Regression: #476`). |
