### PR TITLE
docs(governance): define parameter compatibility matrix policy

### DIFF
--- a/crates/kamn-core/tests/versioning_compatibility_docs.rs
+++ b/crates/kamn-core/tests/versioning_compatibility_docs.rs
@@ -27,6 +27,14 @@ fn policy_defines_support_and_deprecation_windows() {
 }
 
 #[test]
+fn policy_defines_governance_parameter_compatibility_contract() {
+    assert!(POLICY.contains("## Governance Parameter Compatibility Policy"));
+    assert!(POLICY.contains("| Parameter Key | Allowed Range | Minimum Supported Version |"));
+    assert!(POLICY.contains("| `listener.quorum` | `[1, 7]` | `1.0.0` |"));
+    assert!(POLICY.contains("| `watchdog.delivery_ratio_bps` | `[9000, 9999]` | `1.1.0` |"));
+}
+
+#[test]
 fn regression_requires_incompatible_downgrade_no_go_rule() {
     // Regression: #175
     assert!(POLICY.contains("Incompatible downgrade decision: NO-GO."));

--- a/docs/foundation/versioning-compatibility-matrix.md
+++ b/docs/foundation/versioning-compatibility-matrix.md
@@ -22,6 +22,17 @@ This document defines the first versioning policy slice for chain protocol, app-
 - Security fixes are backported only for supported minors.
 - Deprecated minors require explicit governance waiver for continued operation.
 
+## Governance Parameter Compatibility Policy
+| Parameter Key | Allowed Range | Minimum Supported Version |
+|---|---|---|
+| `listener.quorum` | `[1, 7]` | `1.0.0` |
+| `approver.required_approvals` | `[1, 7]` | `1.0.0` |
+| `watchdog.delivery_ratio_bps` | `[9000, 9999]` | `1.1.0` |
+
+- Unknown parameter keys are rejected before proposal registration.
+- Parameter ranges outside catalog bounds are rejected before voting.
+- Target versions below a parameter's minimum supported version are NO-GO.
+
 ## Decision Rules
 - Incompatible downgrade decision: NO-GO.
 - Any cross-major schema shift requires dry-run evidence before GO.


### PR DESCRIPTION
## Summary
Completes the remaining `#473` documentation requirement by adding explicit governance-parameter compatibility policy to the versioning matrix. This aligns governance parameter validation contracts with versioning policy and provides deterministic bounds/version expectations for rollout decisions.

Closes #473

## Changes
- `docs/foundation/versioning-compatibility-matrix.md`: added `## Governance Parameter Compatibility Policy` section with catalog table (parameter key, allowed range, minimum supported version) and explicit pre-vote rejection rules.
- `crates/kamn-core/tests/versioning_compatibility_docs.rs`: added assertions that enforce policy section and catalog entries.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `cargo test -p kamn-core --test versioning_compatibility_docs` and full `cargo test -p kamn-core` to ensure documentation contract and regression suite remain green.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Doc contract assertions in `versioning_compatibility_docs` enforce required policy entries. |
| Functional  | ✅     | Versioning policy semantics remain consistent with existing compatibility/deprecation rules. |
| Integration | ✅     | Full `kamn-core` regression suite remains green after policy updates. |
| Regression  | ✅     | Existing no-go downgrade regression guard remains asserted alongside new compatibility policy contract. |
