### PR TITLE
feat(tasks): add deterministic swarm DAG transition guards

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -238,7 +238,8 @@ pub use task_artifacts::{
 };
 pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 pub use task_operations::{
-    TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskOperationRecord,
+    SwarmTaskDraft, TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind,
+    TaskOperationRecord,
 };
 pub use task_payment::{PaymentConfirm, PaymentOffer, TaskPaymentError, TaskPaymentWorkflow};
 pub use telegram_bridge::{

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -1,5 +1,5 @@
-use crate::{AgentDid, TaskLifecycle, TaskLifecycleError, TaskTransition};
-use std::collections::BTreeMap;
+use crate::{AgentDid, TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -23,10 +23,19 @@ pub struct TaskOperationRecord {
     pub lifecycle: TaskLifecycle,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwarmTaskDraft {
+    pub task_id: String,
+    pub requester: String,
+    pub description: String,
+    pub dependencies: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TaskOperationEngine {
     tasks: BTreeMap<String, TaskOperationRecord>,
     notices_by_task: BTreeMap<String, Vec<TaskOperationNoticeKind>>,
+    dependencies_by_task: BTreeMap<String, BTreeSet<String>>,
 }
 
 impl TaskOperationEngine {
@@ -60,7 +69,76 @@ impl TaskOperationEngine {
                 lifecycle,
             },
         );
+        self.dependencies_by_task
+            .entry(task_id.to_owned())
+            .or_default();
         self.push_notice(task_id, TaskOperationNoticeKind::Submitted);
+        Ok(())
+    }
+
+    pub fn submit_swarm_tasks(
+        &mut self,
+        drafts: Vec<SwarmTaskDraft>,
+    ) -> Result<(), TaskOperationError> {
+        if drafts.is_empty() {
+            return Err(TaskOperationError::EmptySwarmTaskSet);
+        }
+
+        let mut graph = BTreeMap::new();
+        let mut draft_ids = BTreeSet::new();
+        for draft in &drafts {
+            if self.tasks.contains_key(&draft.task_id) || !draft_ids.insert(draft.task_id.clone()) {
+                return Err(TaskOperationError::DuplicateTaskId(draft.task_id.clone()));
+            }
+            validate_did(&draft.requester)?;
+            if draft.description.trim().is_empty() {
+                return Err(TaskOperationError::EmptyDescription);
+            }
+
+            let mut unique_dependencies = BTreeSet::new();
+            for dependency_id in &draft.dependencies {
+                if !unique_dependencies.insert(dependency_id.clone()) {
+                    return Err(TaskOperationError::DuplicateDependency {
+                        task_id: draft.task_id.clone(),
+                        dependency_id: dependency_id.clone(),
+                    });
+                }
+            }
+            graph.insert(draft.task_id.clone(), unique_dependencies);
+        }
+
+        for (task_id, dependencies) in &graph {
+            for dependency_id in dependencies {
+                if !draft_ids.contains(dependency_id) && !self.tasks.contains_key(dependency_id) {
+                    return Err(TaskOperationError::UnknownDependency {
+                        task_id: task_id.clone(),
+                        dependency_id: dependency_id.clone(),
+                    });
+                }
+            }
+        }
+
+        let cycle_task_id = detect_cycle_task_id(&graph);
+        if let Some(task_id) = cycle_task_id {
+            return Err(TaskOperationError::CyclicDependency { task_id });
+        }
+
+        let mut dependencies_by_task = BTreeMap::new();
+        for draft in &drafts {
+            dependencies_by_task.insert(
+                draft.task_id.clone(),
+                graph.get(&draft.task_id).cloned().unwrap_or_default(),
+            );
+        }
+
+        for draft in drafts {
+            self.submit(&draft.task_id, &draft.requester, &draft.description)?;
+            let dependencies = dependencies_by_task
+                .remove(&draft.task_id)
+                .unwrap_or_default();
+            self.dependencies_by_task
+                .insert(draft.task_id, dependencies);
+        }
         Ok(())
     }
 
@@ -108,6 +186,12 @@ impl TaskOperationEngine {
 
     pub fn start_work(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
         validate_did(actor)?;
+        if let Some(dependency_id) = self.unsatisfied_dependency(task_id)? {
+            return Err(TaskOperationError::DependencyNotSatisfied {
+                task_id: task_id.to_owned(),
+                dependency_id,
+            });
+        }
         let record = self.task_mut(task_id)?;
         Self::require_assignee(record, actor)?;
         record
@@ -203,6 +287,27 @@ impl TaskOperationEngine {
             .unwrap_or_default()
     }
 
+    pub fn ready_tasks(&self) -> Vec<String> {
+        self.tasks
+            .iter()
+            .filter_map(|(task_id, record)| {
+                let state = record.lifecycle.state();
+                if state != TaskState::Accepted && state != TaskState::Delegated {
+                    return None;
+                }
+                if self
+                    .unsatisfied_dependency(task_id)
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    return None;
+                }
+                Some(task_id.clone())
+            })
+            .collect()
+    }
+
     fn task_mut(&mut self, task_id: &str) -> Result<&mut TaskOperationRecord, TaskOperationError> {
         self.tasks
             .get_mut(task_id)
@@ -228,12 +333,50 @@ impl TaskOperationEngine {
             .or_default()
             .push(notice);
     }
+
+    fn unsatisfied_dependency(&self, task_id: &str) -> Result<Option<String>, TaskOperationError> {
+        if !self.tasks.contains_key(task_id) {
+            return Err(TaskOperationError::NotFound(task_id.to_owned()));
+        }
+        let dependencies = match self.dependencies_by_task.get(task_id) {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+        for dependency_id in dependencies {
+            let dependency = self.tasks.get(dependency_id).ok_or_else(|| {
+                TaskOperationError::UnknownDependency {
+                    task_id: task_id.to_owned(),
+                    dependency_id: dependency_id.clone(),
+                }
+            })?;
+            if dependency.lifecycle.state() != TaskState::Completed {
+                return Ok(Some(dependency_id.clone()));
+            }
+        }
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskOperationError {
     NotFound(String),
     DuplicateTaskId(String),
+    EmptySwarmTaskSet,
+    DuplicateDependency {
+        task_id: String,
+        dependency_id: String,
+    },
+    UnknownDependency {
+        task_id: String,
+        dependency_id: String,
+    },
+    CyclicDependency {
+        task_id: String,
+    },
+    DependencyNotSatisfied {
+        task_id: String,
+        dependency_id: String,
+    },
     InvalidDid(String),
     EmptyDescription,
     EmptyReason(&'static str),
@@ -249,6 +392,25 @@ impl fmt::Display for TaskOperationError {
         match self {
             Self::NotFound(value) => write!(f, "task not found: {value}"),
             Self::DuplicateTaskId(value) => write!(f, "duplicate task id: {value}"),
+            Self::EmptySwarmTaskSet => write!(f, "swarm task set must not be empty"),
+            Self::DuplicateDependency {
+                task_id,
+                dependency_id,
+            } => write!(f, "duplicate dependency {dependency_id} for task {task_id}"),
+            Self::UnknownDependency {
+                task_id,
+                dependency_id,
+            } => write!(f, "unknown dependency {dependency_id} for task {task_id}"),
+            Self::CyclicDependency { task_id } => {
+                write!(f, "cyclic task dependency detected at task {task_id}")
+            }
+            Self::DependencyNotSatisfied {
+                task_id,
+                dependency_id,
+            } => write!(
+                f,
+                "task {task_id} cannot start before dependency {dependency_id} is completed"
+            ),
             Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
             Self::EmptyDescription => write!(f, "task description must not be empty"),
             Self::EmptyReason(action) => write!(f, "reason must not be empty for {action}"),
@@ -271,9 +433,54 @@ fn lifecycle_error(error: TaskLifecycleError) -> TaskOperationError {
     TaskOperationError::Lifecycle(error.to_string())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VisitState {
+    Visiting,
+    Visited,
+}
+
+fn detect_cycle_task_id(graph: &BTreeMap<String, BTreeSet<String>>) -> Option<String> {
+    fn dfs(
+        task_id: &str,
+        graph: &BTreeMap<String, BTreeSet<String>>,
+        states: &mut BTreeMap<String, VisitState>,
+    ) -> Option<String> {
+        states.insert(task_id.to_owned(), VisitState::Visiting);
+        if let Some(dependencies) = graph.get(task_id) {
+            for dependency_id in dependencies {
+                if !graph.contains_key(dependency_id) {
+                    continue;
+                }
+                match states.get(dependency_id) {
+                    Some(VisitState::Visiting) => return Some(dependency_id.clone()),
+                    Some(VisitState::Visited) => continue,
+                    None => {
+                        if let Some(task_id) = dfs(dependency_id, graph, states) {
+                            return Some(task_id);
+                        }
+                    }
+                }
+            }
+        }
+        states.insert(task_id.to_owned(), VisitState::Visited);
+        None
+    }
+
+    let mut states = BTreeMap::new();
+    for task_id in graph.keys() {
+        if states.contains_key(task_id) {
+            continue;
+        }
+        if let Some(cycle_task_id) = dfs(task_id, graph, &mut states) {
+            return Some(cycle_task_id);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{TaskOperationEngine, TaskOperationError};
+    use super::{SwarmTaskDraft, TaskOperationEngine, TaskOperationError};
     use crate::TaskState;
 
     #[test]
@@ -301,5 +508,62 @@ mod tests {
             Err(error) => panic!("task lookup failed: {error}"),
         };
         assert_eq!(state, TaskState::Cancelled);
+    }
+
+    #[test]
+    fn submit_swarm_rejects_cyclic_dependencies() {
+        let mut engine = TaskOperationEngine::new();
+        assert!(matches!(
+            engine.submit_swarm_tasks(vec![
+                SwarmTaskDraft {
+                    task_id: "cycle-a".to_owned(),
+                    requester: "kamn:did:agent:req-1".to_owned(),
+                    description: "a".to_owned(),
+                    dependencies: vec!["cycle-b".to_owned()],
+                },
+                SwarmTaskDraft {
+                    task_id: "cycle-b".to_owned(),
+                    requester: "kamn:did:agent:req-1".to_owned(),
+                    description: "b".to_owned(),
+                    dependencies: vec!["cycle-a".to_owned()],
+                },
+            ]),
+            Err(TaskOperationError::CyclicDependency { .. })
+        ));
+    }
+
+    #[test]
+    fn start_work_rejects_unsatisfied_dependency() {
+        let mut engine = TaskOperationEngine::new();
+        engine
+            .submit_swarm_tasks(vec![
+                SwarmTaskDraft {
+                    task_id: "dep-root".to_owned(),
+                    requester: "kamn:did:agent:req-1".to_owned(),
+                    description: "root".to_owned(),
+                    dependencies: vec![],
+                },
+                SwarmTaskDraft {
+                    task_id: "dep-child".to_owned(),
+                    requester: "kamn:did:agent:req-1".to_owned(),
+                    description: "child".to_owned(),
+                    dependencies: vec!["dep-root".to_owned()],
+                },
+            ])
+            .expect("swarm submission should succeed");
+        engine
+            .accept("dep-root", "kamn:did:agent:worker-1")
+            .expect("root accept should succeed");
+        engine
+            .accept("dep-child", "kamn:did:agent:worker-1")
+            .expect("child accept should succeed");
+
+        assert_eq!(
+            engine.start_work("dep-child", "kamn:did:agent:worker-1"),
+            Err(TaskOperationError::DependencyNotSatisfied {
+                task_id: "dep-child".to_owned(),
+                dependency_id: "dep-root".to_owned(),
+            })
+        );
     }
 }

--- a/crates/kamn-core/tests/swarm_task_dag.rs
+++ b/crates/kamn-core/tests/swarm_task_dag.rs
@@ -1,0 +1,171 @@
+use kamn_core::{
+    SwarmTaskDraft, TaskArtifactRegistry, TaskArtifactSubmission, TaskOperationEngine,
+    TaskOperationError, TaskState,
+};
+
+#[test]
+fn swarm_dag_rejects_cyclic_dependency_graph_submission() {
+    let mut engine = TaskOperationEngine::new();
+
+    // Regression: #472
+    assert!(matches!(
+        engine.submit_swarm_tasks(vec![
+            SwarmTaskDraft {
+                task_id: "swarm-a".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "A".to_owned(),
+                dependencies: vec!["swarm-b".to_owned()],
+            },
+            SwarmTaskDraft {
+                task_id: "swarm-b".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "B".to_owned(),
+                dependencies: vec!["swarm-a".to_owned()],
+            },
+        ]),
+        Err(TaskOperationError::CyclicDependency { .. })
+    ));
+}
+
+#[test]
+fn swarm_dag_functional_dependency_gates_task_start() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit_swarm_tasks(vec![
+            SwarmTaskDraft {
+                task_id: "swarm-root".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "Root task".to_owned(),
+                dependencies: vec![],
+            },
+            SwarmTaskDraft {
+                task_id: "swarm-child".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "Child task".to_owned(),
+                dependencies: vec!["swarm-root".to_owned()],
+            },
+        ])
+        .expect("swarm DAG should submit");
+
+    engine
+        .accept("swarm-root", "kamn:did:agent:worker-1")
+        .expect("root accept should pass");
+    engine
+        .accept("swarm-child", "kamn:did:agent:worker-1")
+        .expect("child accept should pass");
+
+    assert_eq!(engine.ready_tasks(), vec!["swarm-root".to_owned()]);
+    assert_eq!(
+        engine.start_work("swarm-child", "kamn:did:agent:worker-1"),
+        Err(TaskOperationError::DependencyNotSatisfied {
+            task_id: "swarm-child".to_owned(),
+            dependency_id: "swarm-root".to_owned(),
+        })
+    );
+
+    engine
+        .start_work("swarm-root", "kamn:did:agent:worker-1")
+        .expect("root start should pass");
+    engine
+        .complete("swarm-root", "kamn:did:agent:worker-1")
+        .expect("root complete should pass");
+
+    assert_eq!(engine.ready_tasks(), vec!["swarm-child".to_owned()]);
+    engine
+        .start_work("swarm-child", "kamn:did:agent:worker-1")
+        .expect("child start should pass once dependency is complete");
+    let child = engine.task("swarm-child").expect("child task should exist");
+    assert_eq!(child.lifecycle.state(), TaskState::InProgress);
+}
+
+#[test]
+fn swarm_dag_integration_interops_with_task_artifacts_after_dependency_completion() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit_swarm_tasks(vec![
+            SwarmTaskDraft {
+                task_id: "swarm-art-root".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "Root task".to_owned(),
+                dependencies: vec![],
+            },
+            SwarmTaskDraft {
+                task_id: "swarm-art-child".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "Child task".to_owned(),
+                dependencies: vec!["swarm-art-root".to_owned()],
+            },
+        ])
+        .expect("swarm DAG should submit");
+    engine
+        .accept("swarm-art-root", "kamn:did:agent:worker-1")
+        .expect("root accept should pass");
+    engine
+        .accept("swarm-art-child", "kamn:did:agent:worker-1")
+        .expect("child accept should pass");
+    engine
+        .start_work("swarm-art-root", "kamn:did:agent:worker-1")
+        .expect("root start should pass");
+    engine
+        .complete("swarm-art-root", "kamn:did:agent:worker-1")
+        .expect("root complete should pass");
+    engine
+        .start_work("swarm-art-child", "kamn:did:agent:worker-1")
+        .expect("child start should pass");
+    engine
+        .complete("swarm-art-child", "kamn:did:agent:worker-1")
+        .expect("child complete should pass");
+
+    let mut artifacts = TaskArtifactRegistry::new();
+    let integrity_hash = TaskArtifactRegistry::integrity_fingerprint(
+        "swarm-art-child",
+        "kamn:did:agent:worker-1",
+        "ipfs://artifact/swarm-child",
+    );
+    artifacts
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-swarm-1".to_owned(),
+            task_id: "swarm-art-child".to_owned(),
+            creator: "kamn:did:agent:worker-1".to_owned(),
+            off_chain_uri: "ipfs://artifact/swarm-child".to_owned(),
+            on_chain_hash: integrity_hash,
+            content_type: "application/json".to_owned(),
+            created_at_unix: 1_716_700_100,
+        })
+        .expect("artifact registration should pass");
+
+    assert_eq!(
+        artifacts.artifacts_for_task("swarm-art-child"),
+        vec!["artifact-swarm-1".to_owned()]
+    );
+}
+
+#[test]
+fn swarm_dag_regression_rejects_replayed_dependency_completion() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit_swarm_tasks(vec![SwarmTaskDraft {
+            task_id: "swarm-single".to_owned(),
+            requester: "kamn:did:agent:requester-1".to_owned(),
+            description: "Single task".to_owned(),
+            dependencies: vec![],
+        }])
+        .expect("swarm DAG should submit");
+    engine
+        .accept("swarm-single", "kamn:did:agent:worker-1")
+        .expect("accept should pass");
+    engine
+        .start_work("swarm-single", "kamn:did:agent:worker-1")
+        .expect("start should pass");
+    engine
+        .complete("swarm-single", "kamn:did:agent:worker-1")
+        .expect("first complete should pass");
+
+    // Regression: #472
+    assert_eq!(
+        engine.complete("swarm-single", "kamn:did:agent:worker-1"),
+        Err(TaskOperationError::Lifecycle(
+            "task is in terminal state: Completed".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/task_swarm_dag_docs.rs
+++ b/crates/kamn-core/tests/task_swarm_dag_docs.rs
@@ -1,0 +1,25 @@
+const OPERATIONS_DOC: &str = include_str!("../../../docs/foundation/task-operations.md");
+const STATE_MACHINE_DOC: &str = include_str!("../../../docs/foundation/task-state-machine.md");
+
+#[test]
+fn docs_define_swarm_dag_command_surface() {
+    assert!(OPERATIONS_DOC.contains("SwarmTaskDraft"));
+    assert!(OPERATIONS_DOC.contains("submit_swarm_tasks(drafts)"));
+    assert!(OPERATIONS_DOC.contains("ready_tasks()"));
+    assert!(OPERATIONS_DOC.contains("DependencyNotSatisfied"));
+}
+
+#[test]
+fn docs_define_dependency_aware_transition_gates() {
+    assert!(STATE_MACHINE_DOC.contains("## Dependency-Aware Transition Gates"));
+    assert!(STATE_MACHINE_DOC.contains("TaskOperationEngine::start_work"));
+    assert!(STATE_MACHINE_DOC
+        .contains("all declared dependencies must already be in `Completed` state."));
+}
+
+#[test]
+fn regression_requires_cyclic_and_premature_transition_guards() {
+    // Regression: #472
+    assert!(OPERATIONS_DOC.contains("Regression: #472"));
+    assert!(STATE_MACHINE_DOC.contains("Regression: #472"));
+}

--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -1,4 +1,4 @@
-# Task Operations Command Surface (Issue #128)
+# Task Operations Command Surface (Issue #128 / #472)
 
 This document defines the first implementation slice for task operation command
 handling across `submit`, `accept`, `delegate`, `block`, `complete`, `fail`,
@@ -21,6 +21,11 @@ and `cancel`.
   - `Completed`
   - `Failed`
   - `Cancelled`
+- `SwarmTaskDraft`: swarm DAG registration payload:
+  - `task_id`
+  - `requester`
+  - `description`
+  - `dependencies`
 
 ## Command Behavior
 - `submit(task_id, requester, description)`:
@@ -55,12 +60,23 @@ and `cancel`.
   - requester or current assignee.
   - transitions via `Cancel`.
   - emits `Cancelled` notice.
+- `submit_swarm_tasks(drafts)`:
+  - registers a bounded DAG-linked task set in a single deterministic pass.
+  - rejects duplicate task IDs, duplicate dependency edges, unknown dependency references, and cyclic graphs.
+  - initializes dependency metadata used by readiness checks.
+- `ready_tasks()`:
+  - returns deterministic ready-task IDs (sorted) where lifecycle state is `Accepted` or `Delegated` and all dependencies are `Completed`.
 
 ## Validation and Safety Rules
 - Task IDs must be unique.
 - DIDs must parse as `kamn:did:agent:*`.
 - Unauthorized actors are rejected with explicit required-role context.
 - Underlying illegal or terminal lifecycle transitions bubble as typed lifecycle errors.
+- Swarm dependency rules:
+  - dependency IDs must reference registered tasks.
+  - cyclic dependency graphs are rejected with `CyclicDependency`.
+  - `start_work` is blocked when any dependency is not `Completed` (`DependencyNotSatisfied`).
+  - replayed completion attempts remain rejected by terminal-state lifecycle guards (`Regression: #472`).
 
 ## Local Validation
 Run from repository root:
@@ -69,6 +85,7 @@ Run from repository root:
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core --test task_operations
+cargo test -p kamn-core --test swarm_task_dag
 cargo test -p kamn-core
 ```
 

--- a/docs/foundation/task-state-machine.md
+++ b/docs/foundation/task-state-machine.md
@@ -1,4 +1,4 @@
-# Task State Machine and Transition Validator (Issue #126)
+# Task State Machine and Transition Validator (Issue #126 / #472)
 
 This document defines the first implementation slice for deterministic task
 state transitions and legal transition validation.
@@ -22,6 +22,13 @@ state transitions and legal transition validation.
 
 Any transition outside this map is rejected.
 
+## Dependency-Aware Transition Gates
+- For standalone tasks, lifecycle transition rules above apply directly.
+- For swarm DAG tasks, `TaskOperationEngine::start_work` adds a dependency gate:
+  - all declared dependencies must already be in `Completed` state.
+  - unsatisfied dependencies are rejected with `DependencyNotSatisfied`.
+  - cyclic DAG registration is rejected before lifecycle transitions begin (`Regression: #472`).
+
 ## APIs
 - `TaskLifecycle::new(task_id)` initializes task in `Submitted`.
 - `transition(TaskTransition)` validates and applies a transition.
@@ -40,6 +47,7 @@ Run from repository root:
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core --test task_state_machine
+cargo test -p kamn-core --test swarm_task_dag
 cargo test -p kamn-core
 ```
 


### PR DESCRIPTION
## Summary
Introduces deterministic swarm DAG orchestration guards in `TaskOperationEngine` so cyclic dependency graphs and premature task starts are rejected before unsafe execution. The slice adds bounded DAG registration, readiness projection, dependency-aware transition gating, and docs/test contracts for stable low-cost CI coverage.

Closes #472

## Changes
- `crates/kamn-core/src/task_operations.rs`: added `SwarmTaskDraft`, `submit_swarm_tasks`, `ready_tasks`, dependency metadata tracking, cycle detection, and typed errors for dependency/cycle violations.
- `crates/kamn-core/src/lib.rs`: exported `SwarmTaskDraft`.
- `crates/kamn-core/tests/swarm_task_dag.rs`: added functional/integration/regression swarm DAG behavior tests.
- `crates/kamn-core/tests/task_swarm_dag_docs.rs`: added docs contract assertions for DAG command surface and dependency gates.
- `docs/foundation/task-operations.md`: documented swarm DAG APIs and validation rules.
- `docs/foundation/task-state-machine.md`: documented dependency-aware transition gate semantics.

## Risks & Compatibility
- API change: `TaskOperationError` now includes new variants for swarm dependency validation.
- Existing non-DAG task flows remain unchanged (dependency metadata defaults empty on `submit`).

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran targeted DAG suites plus full `cargo test -p kamn-core`; readiness and dependency gates behave deterministically.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `task_operations` unit tests validate cycle detection and dependency gate rejection paths. |
| Functional  | ✅     | `swarm_dag_functional_dependency_gates_task_start` validates deterministic DAG progression. |
| Integration | ✅     | `swarm_dag_integration_interops_with_task_artifacts_after_dependency_completion` validates interop with artifact registry. |
| Regression  | ✅     | `swarm_dag_rejects_cyclic_dependency_graph_submission` and replayed-completion guard include `Regression: #472`. |
