### PR TITLE
test(tasks): add bounded DAG benchmark coverage

### DIFF
--- a/crates/kamn-core/tests/swarm_task_dag.rs
+++ b/crates/kamn-core/tests/swarm_task_dag.rs
@@ -2,6 +2,7 @@ use kamn_core::{
     SwarmTaskDraft, TaskArtifactRegistry, TaskArtifactSubmission, TaskOperationEngine,
     TaskOperationError, TaskState,
 };
+use std::time::Instant;
 
 #[test]
 fn swarm_dag_rejects_cyclic_dependency_graph_submission() {
@@ -168,4 +169,46 @@ fn swarm_dag_regression_rejects_replayed_dependency_completion() {
             "task is in terminal state: Completed".to_owned()
         ))
     );
+}
+
+fn linear_swarm_drafts(task_count: usize) -> Vec<SwarmTaskDraft> {
+    (0..task_count)
+        .map(|index| {
+            let dependencies = if index == 0 {
+                vec![]
+            } else {
+                vec![format!("swarm-bench-{}", index - 1)]
+            };
+            SwarmTaskDraft {
+                task_id: format!("swarm-bench-{index}"),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: format!("benchmark task {index}"),
+                dependencies,
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn swarm_dag_bounded_graph_validation_benchmark_is_fast_for_ci() {
+    const TASK_COUNT: usize = 128;
+    let drafts = linear_swarm_drafts(TASK_COUNT);
+    let mut engine = TaskOperationEngine::new();
+
+    let started_at = Instant::now();
+    engine
+        .submit_swarm_tasks(drafts)
+        .expect("bounded swarm DAG should submit");
+    let elapsed_millis = started_at.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 2_000,
+        "bounded graph validation exceeded CI budget: {elapsed_millis}ms"
+    );
+
+    for index in 0..TASK_COUNT {
+        engine
+            .accept(&format!("swarm-bench-{index}"), "kamn:did:agent:worker-1")
+            .expect("accept should pass for benchmark task");
+    }
+    assert_eq!(engine.ready_tasks(), vec!["swarm-bench-0".to_owned()]);
 }

--- a/crates/kamn-core/tests/task_swarm_dag_docs.rs
+++ b/crates/kamn-core/tests/task_swarm_dag_docs.rs
@@ -23,3 +23,9 @@ fn regression_requires_cyclic_and_premature_transition_guards() {
     assert!(OPERATIONS_DOC.contains("Regression: #472"));
     assert!(STATE_MACHINE_DOC.contains("Regression: #472"));
 }
+
+#[test]
+fn docs_define_bounded_graph_benchmark_lane() {
+    assert!(OPERATIONS_DOC.contains("bounded graph benchmark"));
+    assert!(OPERATIONS_DOC.contains("cargo test -p kamn-core --test swarm_task_dag"));
+}

--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -78,6 +78,10 @@ and `cancel`.
   - `start_work` is blocked when any dependency is not `Completed` (`DependencyNotSatisfied`).
   - replayed completion attempts remain rejected by terminal-state lifecycle guards (`Regression: #472`).
 
+## Bounded Graph Benchmark
+- A bounded graph benchmark keeps CI cost low while validating DAG guard performance characteristics.
+- The benchmark covers a 128-task linear DAG registration path and enforces a generous local CI budget.
+
 ## Local Validation
 Run from repository root:
 


### PR DESCRIPTION
## Summary
Adds bounded DAG benchmark evidence for swarm task validation/readiness to complete #471 acceptance while keeping CI fast and low-cost. This extends existing swarm DAG coverage with an explicit benchmark lane and docs contract assertions.

Closes #471

## Changes
- `crates/kamn-core/tests/swarm_task_dag.rs`: added `swarm_dag_bounded_graph_validation_benchmark_is_fast_for_ci` covering 128-node linear DAG registration/readiness.
- `docs/foundation/task-operations.md`: documented bounded graph benchmark lane and validation intent.
- `crates/kamn-core/tests/task_swarm_dag_docs.rs`: added assertions for bounded benchmark docs presence.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `cargo test -p kamn-core --test swarm_task_dag --test task_swarm_dag_docs` and full `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Bounded DAG benchmark test validates deterministic registration/readiness path for fixed-size graph. |
| Functional  | ✅     | Existing swarm DAG functional gate test remains green with benchmark lane in place. |
| Integration | ✅     | Full `kamn-core` suite stays green; swarm DAG integration with artifacts remains intact. |
| Regression  | ✅     | Existing `Regression: #472` guard tests remain green and co-located with benchmark lane. |
