### PR TITLE
feat(tasks): add snapshot restore tamper guards

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -239,7 +239,8 @@ pub use task_artifacts::{
 pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 pub use task_operations::{
     SwarmTaskDraft, TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind,
-    TaskOperationRecord,
+    TaskOperationRecord, TaskOperationRecordSnapshot, TaskOperationSnapshot,
+    TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use task_payment::{PaymentConfirm, PaymentOffer, TaskPaymentError, TaskPaymentWorkflow};
 pub use telegram_bridge::{

--- a/crates/kamn-core/src/task_lifecycle.rs
+++ b/crates/kamn-core/src/task_lifecycle.rs
@@ -91,11 +91,44 @@ impl TaskLifecycle {
         self.history.push(next);
         Ok(())
     }
+
+    pub fn restore(task_id: &str, history: Vec<TaskState>) -> Result<Self, TaskLifecycleError> {
+        if history.is_empty() {
+            return Err(TaskLifecycleError::InvalidHistory(
+                "history must not be empty".to_owned(),
+            ));
+        }
+        if history[0] != TaskState::Submitted {
+            return Err(TaskLifecycleError::InvalidHistory(
+                "history must begin with Submitted".to_owned(),
+            ));
+        }
+
+        let mut lifecycle = Self::new(task_id)?;
+        for states in history.windows(2) {
+            let from = states[0];
+            let to = states[1];
+            let transition = transition_between(from, to).ok_or_else(|| {
+                TaskLifecycleError::InvalidHistory(format!(
+                    "invalid state step from {from:?} to {to:?}"
+                ))
+            })?;
+            lifecycle.transition(transition)?;
+        }
+
+        if lifecycle.history != history {
+            return Err(TaskLifecycleError::InvalidHistory(
+                "restored history does not match replayed history".to_owned(),
+            ));
+        }
+        Ok(lifecycle)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskLifecycleError {
     EmptyTaskId,
+    InvalidHistory(String),
     InvalidTransition {
         from: TaskState,
         transition: TaskTransition,
@@ -107,6 +140,7 @@ impl fmt::Display for TaskLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyTaskId => write!(f, "task_id must not be empty"),
+            Self::InvalidHistory(value) => write!(f, "invalid task history: {value}"),
             Self::InvalidTransition { from, transition } => {
                 write!(
                     f,
@@ -120,6 +154,31 @@ impl fmt::Display for TaskLifecycleError {
 }
 
 impl std::error::Error for TaskLifecycleError {}
+
+fn transition_between(from: TaskState, to: TaskState) -> Option<TaskTransition> {
+    match (from, to) {
+        (TaskState::Submitted, TaskState::Accepted) => Some(TaskTransition::Accept),
+        (TaskState::Submitted, TaskState::Cancelled) => Some(TaskTransition::Cancel),
+
+        (TaskState::Accepted, TaskState::Delegated) => Some(TaskTransition::Delegate),
+        (TaskState::Accepted, TaskState::InProgress) => Some(TaskTransition::StartWork),
+        (TaskState::Accepted, TaskState::Cancelled) => Some(TaskTransition::Cancel),
+
+        (TaskState::Delegated, TaskState::InProgress) => Some(TaskTransition::StartWork),
+        (TaskState::Delegated, TaskState::Cancelled) => Some(TaskTransition::Cancel),
+
+        (TaskState::InProgress, TaskState::Blocked) => Some(TaskTransition::Block),
+        (TaskState::InProgress, TaskState::Completed) => Some(TaskTransition::Complete),
+        (TaskState::InProgress, TaskState::Failed) => Some(TaskTransition::Fail),
+        (TaskState::InProgress, TaskState::Cancelled) => Some(TaskTransition::Cancel),
+
+        (TaskState::Blocked, TaskState::InProgress) => Some(TaskTransition::StartWork),
+        (TaskState::Blocked, TaskState::Failed) => Some(TaskTransition::Fail),
+        (TaskState::Blocked, TaskState::Cancelled) => Some(TaskTransition::Cancel),
+
+        _ => None,
+    }
+}
 
 fn is_terminal(state: TaskState) -> bool {
     matches!(
@@ -148,5 +207,39 @@ mod tests {
         assert!(lifecycle.transition(TaskTransition::Block).is_ok());
         assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
         assert_eq!(lifecycle.state(), TaskState::InProgress);
+    }
+
+    #[test]
+    fn restore_rejects_empty_history() {
+        assert_eq!(
+            TaskLifecycle::restore("task-restore-1", vec![]),
+            Err(TaskLifecycleError::InvalidHistory(
+                "history must not be empty".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn restore_replays_valid_history() {
+        let lifecycle = TaskLifecycle::restore(
+            "task-restore-2",
+            vec![
+                TaskState::Submitted,
+                TaskState::Accepted,
+                TaskState::InProgress,
+                TaskState::Completed,
+            ],
+        )
+        .expect("restore should pass");
+        assert_eq!(lifecycle.state(), TaskState::Completed);
+        assert_eq!(
+            lifecycle.history(),
+            vec![
+                TaskState::Submitted,
+                TaskState::Accepted,
+                TaskState::InProgress,
+                TaskState::Completed,
+            ]
+        );
     }
 }

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -31,6 +31,25 @@ pub struct SwarmTaskDraft {
     pub dependencies: Vec<String>,
 }
 
+pub const TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskOperationRecordSnapshot {
+    pub task_id: String,
+    pub requester: String,
+    pub assignee: Option<String>,
+    pub description: String,
+    pub lifecycle_history: Vec<TaskState>,
+    pub dependencies: Vec<String>,
+    pub notices: Vec<TaskOperationNoticeKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskOperationSnapshot {
+    pub schema_version: u16,
+    pub tasks: Vec<TaskOperationRecordSnapshot>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TaskOperationEngine {
     tasks: BTreeMap<String, TaskOperationRecord>,
@@ -308,6 +327,138 @@ impl TaskOperationEngine {
             .collect()
     }
 
+    pub fn export_snapshot(&self) -> TaskOperationSnapshot {
+        let tasks = self
+            .tasks
+            .iter()
+            .map(|(task_id, record)| TaskOperationRecordSnapshot {
+                task_id: task_id.clone(),
+                requester: record.requester.clone(),
+                assignee: record.assignee.clone(),
+                description: record.description.clone(),
+                lifecycle_history: record.lifecycle.history(),
+                dependencies: self
+                    .dependencies_by_task
+                    .get(task_id)
+                    .map(|values| values.iter().cloned().collect())
+                    .unwrap_or_default(),
+                notices: self.notices(task_id),
+            })
+            .collect();
+        TaskOperationSnapshot {
+            schema_version: TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION,
+            tasks,
+        }
+    }
+
+    pub fn restore_snapshot(
+        &mut self,
+        snapshot: TaskOperationSnapshot,
+    ) -> Result<(), TaskOperationError> {
+        if snapshot.schema_version != TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION {
+            return Err(TaskOperationError::SnapshotVersionMismatch {
+                expected: TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION,
+                found: snapshot.schema_version,
+            });
+        }
+
+        let mut restored_tasks = BTreeMap::new();
+        let mut restored_notices = BTreeMap::new();
+        let mut restored_dependencies = BTreeMap::new();
+
+        for task in snapshot.tasks {
+            if restored_tasks.contains_key(&task.task_id) {
+                return Err(TaskOperationError::DuplicateTaskId(task.task_id));
+            }
+            validate_did(&task.requester)?;
+            if let Some(assignee) = &task.assignee {
+                validate_did(assignee)?;
+            }
+            if task.description.trim().is_empty() {
+                return Err(TaskOperationError::InvalidSnapshot(format!(
+                    "task {} has empty description",
+                    task.task_id
+                )));
+            }
+            let lifecycle = TaskLifecycle::restore(&task.task_id, task.lifecycle_history.clone())
+                .map_err(|error| {
+                TaskOperationError::InvalidSnapshot(format!(
+                    "task {} has invalid lifecycle history: {error}",
+                    task.task_id
+                ))
+            })?;
+
+            let mut dependency_set = BTreeSet::new();
+            for dependency_id in &task.dependencies {
+                if !dependency_set.insert(dependency_id.clone()) {
+                    return Err(TaskOperationError::DuplicateDependency {
+                        task_id: task.task_id.clone(),
+                        dependency_id: dependency_id.clone(),
+                    });
+                }
+            }
+
+            restored_notices.insert(task.task_id.clone(), task.notices);
+            restored_dependencies.insert(task.task_id.clone(), dependency_set);
+            restored_tasks.insert(
+                task.task_id.clone(),
+                TaskOperationRecord {
+                    task_id: task.task_id,
+                    requester: task.requester,
+                    assignee: task.assignee,
+                    description: task.description,
+                    lifecycle,
+                },
+            );
+        }
+
+        for (task_id, dependencies) in &restored_dependencies {
+            for dependency_id in dependencies {
+                if !restored_tasks.contains_key(dependency_id) {
+                    return Err(TaskOperationError::UnknownDependency {
+                        task_id: task_id.clone(),
+                        dependency_id: dependency_id.clone(),
+                    });
+                }
+            }
+        }
+
+        if let Some(task_id) = detect_cycle_task_id(&restored_dependencies) {
+            return Err(TaskOperationError::CyclicDependency { task_id });
+        }
+
+        for (task_id, dependencies) in &restored_dependencies {
+            let task_state = restored_tasks
+                .get(task_id)
+                .map(|task| task.lifecycle.state())
+                .ok_or_else(|| TaskOperationError::NotFound(task_id.clone()))?;
+            if !requires_completed_dependencies(task_state) {
+                continue;
+            }
+            for dependency_id in dependencies {
+                let dependency_state = restored_tasks
+                    .get(dependency_id)
+                    .map(|task| task.lifecycle.state())
+                    .ok_or_else(|| TaskOperationError::UnknownDependency {
+                        task_id: task_id.clone(),
+                        dependency_id: dependency_id.clone(),
+                    })?;
+                if dependency_state != TaskState::Completed {
+                    return Err(TaskOperationError::SnapshotDependencyNotCompleted {
+                        task_id: task_id.clone(),
+                        dependency_id: dependency_id.clone(),
+                        dependency_state,
+                    });
+                }
+            }
+        }
+
+        self.tasks = restored_tasks;
+        self.notices_by_task = restored_notices;
+        self.dependencies_by_task = restored_dependencies;
+        Ok(())
+    }
+
     fn task_mut(&mut self, task_id: &str) -> Result<&mut TaskOperationRecord, TaskOperationError> {
         self.tasks
             .get_mut(task_id)
@@ -377,6 +528,16 @@ pub enum TaskOperationError {
         task_id: String,
         dependency_id: String,
     },
+    SnapshotVersionMismatch {
+        expected: u16,
+        found: u16,
+    },
+    SnapshotDependencyNotCompleted {
+        task_id: String,
+        dependency_id: String,
+        dependency_state: TaskState,
+    },
+    InvalidSnapshot(String),
     InvalidDid(String),
     EmptyDescription,
     EmptyReason(&'static str),
@@ -411,6 +572,19 @@ impl fmt::Display for TaskOperationError {
                 f,
                 "task {task_id} cannot start before dependency {dependency_id} is completed"
             ),
+            Self::SnapshotVersionMismatch { expected, found } => write!(
+                f,
+                "snapshot schema version mismatch, expected {expected}, found {found}"
+            ),
+            Self::SnapshotDependencyNotCompleted {
+                task_id,
+                dependency_id,
+                dependency_state,
+            } => write!(
+                f,
+                "task {task_id} has dependency {dependency_id} in {dependency_state:?} during snapshot restore"
+            ),
+            Self::InvalidSnapshot(value) => write!(f, "invalid task operation snapshot: {value}"),
             Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
             Self::EmptyDescription => write!(f, "task description must not be empty"),
             Self::EmptyReason(action) => write!(f, "reason must not be empty for {action}"),
@@ -476,6 +650,13 @@ fn detect_cycle_task_id(graph: &BTreeMap<String, BTreeSet<String>>) -> Option<St
         }
     }
     None
+}
+
+fn requires_completed_dependencies(state: TaskState) -> bool {
+    matches!(
+        state,
+        TaskState::InProgress | TaskState::Blocked | TaskState::Completed | TaskState::Failed
+    )
 }
 
 #[cfg(test)]

--- a/crates/kamn-core/tests/task_operation_snapshot.rs
+++ b/crates/kamn-core/tests/task_operation_snapshot.rs
@@ -1,0 +1,148 @@
+use kamn_core::{
+    EscrowLifecycle, PaymentOffer, SwarmTaskDraft, TaskOperationEngine, TaskOperationError,
+    TaskPaymentWorkflow, TaskState,
+};
+
+fn build_dependency_engine() -> TaskOperationEngine {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit_swarm_tasks(vec![
+            SwarmTaskDraft {
+                task_id: "snapshot-root".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "Root".to_owned(),
+                dependencies: vec![],
+            },
+            SwarmTaskDraft {
+                task_id: "snapshot-child".to_owned(),
+                requester: "kamn:did:agent:requester-1".to_owned(),
+                description: "Child".to_owned(),
+                dependencies: vec!["snapshot-root".to_owned()],
+            },
+        ])
+        .expect("swarm DAG should submit");
+    engine
+        .accept("snapshot-root", "kamn:did:agent:worker-1")
+        .expect("root accept should pass");
+    engine
+        .accept("snapshot-child", "kamn:did:agent:worker-1")
+        .expect("child accept should pass");
+    engine
+}
+
+#[test]
+fn task_operation_snapshot_functional_restore_resumes_dependency_gates() {
+    let mut engine = build_dependency_engine();
+    engine
+        .start_work("snapshot-root", "kamn:did:agent:worker-1")
+        .expect("root start should pass");
+    engine
+        .complete("snapshot-root", "kamn:did:agent:worker-1")
+        .expect("root complete should pass");
+
+    let snapshot = engine.export_snapshot();
+    let mut restored = TaskOperationEngine::new();
+    restored
+        .restore_snapshot(snapshot)
+        .expect("snapshot restore should pass");
+    assert_eq!(restored.ready_tasks(), vec!["snapshot-child".to_owned()]);
+    restored
+        .start_work("snapshot-child", "kamn:did:agent:worker-1")
+        .expect("child should start after restore");
+}
+
+#[test]
+fn task_operation_snapshot_rejects_schema_version_mismatch() {
+    let engine = TaskOperationEngine::new();
+    let mut snapshot = engine.export_snapshot();
+    snapshot.schema_version = 99;
+
+    let mut restored = TaskOperationEngine::new();
+    assert_eq!(
+        restored.restore_snapshot(snapshot),
+        Err(TaskOperationError::SnapshotVersionMismatch {
+            expected: 1,
+            found: 99,
+        })
+    );
+}
+
+#[test]
+fn task_operation_snapshot_integration_supports_payment_flow_after_restore() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit("snapshot-pay", "kamn:did:agent:requester-1", "Payable task")
+        .expect("submit should pass");
+    engine
+        .accept("snapshot-pay", "kamn:did:agent:worker-1")
+        .expect("accept should pass");
+    engine
+        .start_work("snapshot-pay", "kamn:did:agent:worker-1")
+        .expect("start should pass");
+    engine
+        .complete("snapshot-pay", "kamn:did:agent:worker-1")
+        .expect("complete should pass");
+
+    let snapshot = engine.export_snapshot();
+    let mut restored = TaskOperationEngine::new();
+    restored
+        .restore_snapshot(snapshot)
+        .expect("snapshot restore should pass");
+    assert_eq!(
+        restored
+            .task("snapshot-pay")
+            .expect("restored task should exist")
+            .lifecycle
+            .state(),
+        TaskState::Completed
+    );
+
+    let escrow = EscrowLifecycle::new(10).expect("escrow should initialize");
+    let mut payments = TaskPaymentWorkflow::new();
+    payments
+        .submit_offer(
+            PaymentOffer {
+                task_id: "snapshot-pay".to_owned(),
+                escrow_id: "escrow-snapshot-1".to_owned(),
+                payer_did: "kamn:did:agent:requester-1".to_owned(),
+                payee_did: "kamn:did:agent:worker-1".to_owned(),
+                amount: 10,
+            },
+            &restored,
+            &escrow,
+        )
+        .expect("offer submission should pass against restored state");
+}
+
+#[test]
+fn task_operation_snapshot_regression_rejects_tampered_dependency_completion_state() {
+    // Regression: #502
+    let mut engine = build_dependency_engine();
+    engine
+        .start_work("snapshot-root", "kamn:did:agent:worker-1")
+        .expect("root start should pass");
+    engine
+        .complete("snapshot-root", "kamn:did:agent:worker-1")
+        .expect("root complete should pass");
+    engine
+        .start_work("snapshot-child", "kamn:did:agent:worker-1")
+        .expect("child start should pass");
+
+    let mut snapshot = engine.export_snapshot();
+    let root = snapshot
+        .tasks
+        .iter_mut()
+        .find(|task| task.task_id == "snapshot-root")
+        .expect("root snapshot should exist");
+    root.lifecycle_history = vec![TaskState::Submitted];
+
+    let mut restored = TaskOperationEngine::new();
+    assert_eq!(
+        restored.restore_snapshot(snapshot),
+        Err(TaskOperationError::SnapshotDependencyNotCompleted {
+            task_id: "snapshot-child".to_owned(),
+            dependency_id: "snapshot-root".to_owned(),
+            dependency_state: TaskState::Submitted,
+        })
+    );
+}

--- a/crates/kamn-core/tests/task_swarm_dag_docs.rs
+++ b/crates/kamn-core/tests/task_swarm_dag_docs.rs
@@ -29,3 +29,18 @@ fn docs_define_bounded_graph_benchmark_lane() {
     assert!(OPERATIONS_DOC.contains("bounded graph benchmark"));
     assert!(OPERATIONS_DOC.contains("cargo test -p kamn-core --test swarm_task_dag"));
 }
+
+#[test]
+fn docs_define_snapshot_recovery_validation_rules() {
+    assert!(OPERATIONS_DOC.contains("export_snapshot()"));
+    assert!(OPERATIONS_DOC.contains("restore_snapshot(snapshot)"));
+    assert!(OPERATIONS_DOC.contains("schema version mismatch is rejected."));
+    assert!(STATE_MACHINE_DOC.contains("Snapshot restore invariants"));
+}
+
+#[test]
+fn regression_requires_tampered_snapshot_rejection_rule() {
+    // Regression: #502
+    assert!(OPERATIONS_DOC.contains("Regression: #502"));
+    assert!(STATE_MACHINE_DOC.contains("Regression: #502"));
+}

--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -66,6 +66,11 @@ and `cancel`.
   - initializes dependency metadata used by readiness checks.
 - `ready_tasks()`:
   - returns deterministic ready-task IDs (sorted) where lifecycle state is `Accepted` or `Delegated` and all dependencies are `Completed`.
+- `export_snapshot()`:
+  - returns deterministic snapshot payload with schema version, task records, notices, lifecycle history, and dependency metadata.
+- `restore_snapshot(snapshot)`:
+  - validates schema version, lifecycle history, dependency references, and cycle safety before mutating engine state.
+  - rejects tampered restore payloads where dependency-complete invariants are violated (`Regression: #502`).
 
 ## Validation and Safety Rules
 - Task IDs must be unique.
@@ -77,6 +82,11 @@ and `cancel`.
   - cyclic dependency graphs are rejected with `CyclicDependency`.
   - `start_work` is blocked when any dependency is not `Completed` (`DependencyNotSatisfied`).
   - replayed completion attempts remain rejected by terminal-state lifecycle guards (`Regression: #472`).
+- Snapshot recovery rules:
+  - schema version mismatch is rejected.
+  - lifecycle history shape must be replayable from `Submitted`.
+  - dependency references must resolve and remain acyclic.
+  - tasks restored in execution states (`InProgress`/`Blocked`/`Completed`/`Failed`) require dependencies already `Completed` (`Regression: #502`).
 
 ## Bounded Graph Benchmark
 - A bounded graph benchmark keeps CI cost low while validating DAG guard performance characteristics.
@@ -90,6 +100,7 @@ cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core --test task_operations
 cargo test -p kamn-core --test swarm_task_dag
+cargo test -p kamn-core --test task_operation_snapshot
 cargo test -p kamn-core
 ```
 

--- a/docs/foundation/task-state-machine.md
+++ b/docs/foundation/task-state-machine.md
@@ -28,6 +28,9 @@ Any transition outside this map is rejected.
   - all declared dependencies must already be in `Completed` state.
   - unsatisfied dependencies are rejected with `DependencyNotSatisfied`.
   - cyclic DAG registration is rejected before lifecycle transitions begin (`Regression: #472`).
+- Snapshot restore invariants:
+  - lifecycle history must replay deterministically from `Submitted`.
+  - restore rejects dependency-state tampering where execution states appear before dependency completion (`Regression: #502`).
 
 ## APIs
 - `TaskLifecycle::new(task_id)` initializes task in `Submitted`.
@@ -48,6 +51,7 @@ cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core --test task_state_machine
 cargo test -p kamn-core --test swarm_task_dag
+cargo test -p kamn-core --test task_operation_snapshot
 cargo test -p kamn-core
 ```
 


### PR DESCRIPTION
## Summary
Adds deterministic task orchestration snapshot export/restore contracts with schema and dependency-state validation guards so tampered restore payloads are rejected safely. This delivers the regression-focused #502 slice while preserving existing task and swarm DAG behavior.

Closes #502

## Changes
- `crates/kamn-core/src/task_operations.rs`: added snapshot models (`TaskOperationSnapshot`, `TaskOperationRecordSnapshot`), export/restore APIs, schema/version validation, dependency tamper checks, and typed snapshot restore errors.
- `crates/kamn-core/src/task_lifecycle.rs`: added lifecycle history restore/replay API with history-shape validation.
- `crates/kamn-core/src/lib.rs`: exported snapshot types/constants.
- `crates/kamn-core/tests/task_operation_snapshot.rs`: added functional/integration/regression snapshot restore tests.
- `docs/foundation/task-operations.md`: documented snapshot export/restore and validation rules (`Regression: #502`).
- `docs/foundation/task-state-machine.md`: documented snapshot restore invariants.
- `crates/kamn-core/tests/task_swarm_dag_docs.rs`: added docs contract assertions for snapshot recovery semantics.

## Risks & Compatibility
- API expansion: new snapshot types/methods and error variants in task orchestration module.
- Backward compatibility: existing task operation methods remain unchanged; snapshot schema is versioned (`TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION`).

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran targeted snapshot/doc suites and full `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Snapshot schema/version/history validation covered in `task_operation_snapshot` and lifecycle restore unit tests. |
| Functional  | ✅     | `task_operation_snapshot_functional_restore_resumes_dependency_gates` verifies restore->resume behavior. |
| Integration | ✅     | `task_operation_snapshot_integration_supports_payment_flow_after_restore` validates payment workflow interop after restore. |
| Regression  | ✅     | `task_operation_snapshot_regression_rejects_tampered_dependency_completion_state` enforces `Regression: #502`. |
