### PR TITLE
test(tasks): add snapshot roundtrip benchmark lane (#501)

### DIFF
--- a/crates/kamn-core/tests/task_operation_snapshot.rs
+++ b/crates/kamn-core/tests/task_operation_snapshot.rs
@@ -2,6 +2,7 @@ use kamn_core::{
     EscrowLifecycle, PaymentOffer, SwarmTaskDraft, TaskOperationEngine, TaskOperationError,
     TaskPaymentWorkflow, TaskState,
 };
+use std::time::Instant;
 
 fn build_dependency_engine() -> TaskOperationEngine {
     let mut engine = TaskOperationEngine::new();
@@ -145,4 +146,46 @@ fn task_operation_snapshot_regression_rejects_tampered_dependency_completion_sta
             dependency_state: TaskState::Submitted,
         })
     );
+}
+
+#[test]
+fn task_operation_snapshot_bounded_roundtrip_benchmark_is_fast_for_ci() {
+    const TASK_COUNT: usize = 128;
+    let mut engine = TaskOperationEngine::new();
+    let drafts: Vec<SwarmTaskDraft> = (0..TASK_COUNT)
+        .map(|index| SwarmTaskDraft {
+            task_id: format!("snapshot-bench-{index}"),
+            requester: "kamn:did:agent:requester-1".to_owned(),
+            description: format!("snapshot benchmark task {index}"),
+            dependencies: if index == 0 {
+                vec![]
+            } else {
+                vec![format!("snapshot-bench-{}", index - 1)]
+            },
+        })
+        .collect();
+    engine
+        .submit_swarm_tasks(drafts)
+        .expect("benchmark DAG should submit");
+    for index in 0..TASK_COUNT {
+        engine
+            .accept(
+                &format!("snapshot-bench-{index}"),
+                "kamn:did:agent:worker-1",
+            )
+            .expect("accept should pass for benchmark task");
+    }
+
+    let started_at = Instant::now();
+    let snapshot = engine.export_snapshot();
+    let mut restored = TaskOperationEngine::new();
+    restored
+        .restore_snapshot(snapshot)
+        .expect("benchmark snapshot restore should pass");
+    let elapsed_millis = started_at.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 2_000,
+        "snapshot roundtrip exceeded CI budget: {elapsed_millis}ms"
+    );
+    assert_eq!(restored.ready_tasks(), vec!["snapshot-bench-0".to_owned()]);
 }

--- a/crates/kamn-core/tests/task_swarm_dag_docs.rs
+++ b/crates/kamn-core/tests/task_swarm_dag_docs.rs
@@ -44,3 +44,9 @@ fn regression_requires_tampered_snapshot_rejection_rule() {
     assert!(OPERATIONS_DOC.contains("Regression: #502"));
     assert!(STATE_MACHINE_DOC.contains("Regression: #502"));
 }
+
+#[test]
+fn docs_define_snapshot_roundtrip_benchmark_lane() {
+    assert!(OPERATIONS_DOC.contains("snapshot roundtrip benchmark"));
+    assert!(OPERATIONS_DOC.contains("cargo test -p kamn-core --test task_operation_snapshot"));
+}

--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -91,6 +91,7 @@ and `cancel`.
 ## Bounded Graph Benchmark
 - A bounded graph benchmark keeps CI cost low while validating DAG guard performance characteristics.
 - The benchmark covers a 128-task linear DAG registration path and enforces a generous local CI budget.
+- A snapshot roundtrip benchmark validates export+restore overhead for a bounded 128-task DAG without requiring expensive integration infrastructure.
 
 ## Local Validation
 Run from repository root:


### PR DESCRIPTION
## Summary
Adds a bounded snapshot export/restore benchmark lane to keep persistence/recovery coverage fast and cost-effective in CI while preserving deterministic behavior checks.

Closes #501.

## Changes
- `crates/kamn-core/tests/task_operation_snapshot.rs`: added `task_operation_snapshot_bounded_roundtrip_benchmark_is_fast_for_ci` for 128-task snapshot export+restore budget validation.
- `crates/kamn-core/tests/task_swarm_dag_docs.rs`: added docs contract test requiring snapshot benchmark guidance.
- `docs/foundation/task-operations.md`: documented snapshot roundtrip benchmark lane under bounded graph benchmark section.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed benchmark and docs contract alignment for deterministic/cost-effective lane.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | benchmark helper + docs assertion pass |
| Functional  | ✅     | snapshot export->restore flow already exercised in `task_operation_snapshot` |
| Integration | ✅     | `cargo test -p kamn-core` green with runtime/payment interoperability suites |
| Regression  | ✅     | existing tampered snapshot rejection regression remains green |
