### PR TITLE
ci(scope): route deploy-only diffs to preflight fast lane (#507)

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -53,6 +53,10 @@ jobs:
         if: steps.scope.outputs.docs_only != 'true'
         run: bash scripts/ci/test_ci_tools.sh
 
+      - name: Run deploy preflight tests
+        if: steps.scope.outputs.run_deploy_preflight_tests == 'true'
+        run: bash scripts/deploy/test_preflight_topology.sh
+
       - name: Set up Rust toolchain
         if: steps.scope.outputs.run_rust == 'true'
         uses: dtolnay/rust-toolchain@stable

--- a/docs/foundation/ci-caching-parallelism.md
+++ b/docs/foundation/ci-caching-parallelism.md
@@ -14,6 +14,7 @@ This document captures the first implementation slice for CI runtime/cost optimi
 - Added CI regression checks for workflow cache policy and deep-lane parallel harness configuration.
 - Added deterministic fast-lane target selection fallback safety:
   - Critical CI paths (`.github/workflows/*`, `scripts/ci/*`) escalate to full Rust validation scope.
+  - Deployment script paths (`scripts/deploy/*`) now route to a dedicated deploy preflight scope instead of full Rust.
   - Unknown non-doc paths escalate to full Rust validation scope.
   - duplicate/unknown matrix drift is guarded by selector regression tests (`Regression: #419`).
 - Added narrow-diff telemetry summary metrics for CI budget artifact rollups:
@@ -28,6 +29,7 @@ This document captures the first implementation slice for CI runtime/cost optimi
 - Cost control:
   - Keep cache saves on main only unless there is a measured need to populate PR-branch-specific caches.
   - Keep harness parallelism bounded (current limit: 2 in deep lane) to avoid unstable load spikes.
+  - Route deploy-only diffs to `scripts/deploy/test_preflight_topology.sh` so fast-gate avoids Rust toolchain startup.
   - Prefer targeted crate scopes for known Rust module edits, but keep strict full-scope fallback for critical/unknown paths.
 - Troubleshooting:
   - If deep invariant lane becomes unstable, temporarily reduce to `--parallelism 1` and compare budget telemetry.
@@ -40,4 +42,5 @@ Run from repository root:
 ```bash
 bash scripts/ci/test_ci_tools.sh
 bash scripts/ci/run_invariant_harness.sh --mode deep --parallelism 2 --dry-run
+bash scripts/deploy/test_preflight_topology.sh
 ```

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -26,6 +26,7 @@ append_summary() {
     echo "- Changed files: ${CHANGED_COUNT}"
     echo "- Docs only: ${DOCS_ONLY}"
     echo "- Run Rust checks: ${RUN_RUST}"
+    echo "- Run deploy preflight checks: ${RUN_DEPLOY_PREFLIGHT_TESTS}"
     echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
     echo "- Critical path fallback: ${CRITICAL_PATH_CHANGED}"
@@ -110,6 +111,7 @@ CHANGED_COUNT="${#CHANGED_FILES[@]}"
 DOCS_ONLY=true
 RUST_CHANGED=false
 CI_INFRA_CHANGED=false
+DEPLOY_SCRIPT_CHANGED=false
 CRITICAL_PATH_CHANGED=false
 UNKNOWN_RISK_CHANGED=false
 FULL_SUITE=false
@@ -147,6 +149,13 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
+    scripts/deploy/*)
+      DEPLOY_SCRIPT_CHANGED=true
+      classified=true
+      ;;
+  esac
+
+  case "$file" in
     crates/kamn-core/src/invariants.rs|crates/kamn-core/src/transaction.rs|crates/kamn-core/src/smoke.rs|crates/kamn-core/tests/invariant_*|crates/kamn-core/tests/transaction_guards.rs|docs/foundation/invariants.md|docs/foundation/transaction-guards.md|scripts/ci/run_invariant_harness.sh|scripts/ci/test_run_invariant_harness.sh)
       INVARIANT_RELATED_CHANGED=true
       ;;
@@ -172,6 +181,7 @@ if [ "$CRITICAL_PATH_CHANGED" = true ] || [ "$UNKNOWN_RISK_CHANGED" = true ]; th
 fi
 
 RUN_RUST=false
+RUN_DEPLOY_PREFLIGHT_TESTS=false
 FMT_CMD=":"
 CLIPPY_CMD=":"
 TEST_CMD=":"
@@ -217,8 +227,14 @@ if [ "$RUN_RUST" = true ] && { [ "$INVARIANT_RELATED_CHANGED" = true ] || [ "$FU
   RUN_INVARIANT_HARNESS=true
 fi
 
+if [ "$RUN_RUST" != true ] && [ "$DEPLOY_SCRIPT_CHANGED" = true ]; then
+  RUN_DEPLOY_PREFLIGHT_TESTS=true
+  TEST_SCOPE="deploy"
+fi
+
 write_output "docs_only" "$DOCS_ONLY"
 write_output "run_rust" "$RUN_RUST"
+write_output "run_deploy_preflight_tests" "$RUN_DEPLOY_PREFLIGHT_TESTS"
 write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"
 write_output "critical_path_changed" "$CRITICAL_PATH_CHANGED"

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -15,5 +15,6 @@ bash "$ROOT_DIR/scripts/ci/test_post_flaky_report_comment.sh"
 bash "$ROOT_DIR/scripts/ci/test_sync_flaky_registry_issues.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_retry_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_cache_policy.sh"
+bash "$ROOT_DIR/scripts/ci/test_workflow_scope_policy.sh"
 
 echo "All CI tool regression tests passed."

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -33,6 +33,12 @@ assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selec
 assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only should not run rust"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
 
+deploy_output="$(run_selector $'scripts/deploy/preflight_topology.sh')"
+assert_eq "$(extract_output "$deploy_output" "docs_only")" "false" "deploy-only change must not be docs-only"
+assert_eq "$(extract_output "$deploy_output" "run_rust")" "false" "deploy-only changes should avoid rust lane"
+assert_eq "$(extract_output "$deploy_output" "run_deploy_preflight_tests")" "true" "deploy-only changes must run deploy preflight tests"
+assert_eq "$(extract_output "$deploy_output" "test_scope")" "deploy" "deploy-only changes must use deploy scope"
+
 # Regression: #463
 runner_output_file="$(mktemp)"
 runner_docs_output="$(GITHUB_OUTPUT="$runner_output_file" run_selector $'docs/foundation/ci-caching-parallelism.md')"
@@ -44,6 +50,7 @@ assert_eq "$(extract_output "$critical_output" "run_rust")" "true" "workflow cha
 assert_eq "$(extract_output "$critical_output" "test_scope")" "full" "workflow changes must use full scope"
 
 unknown_output="$(run_selector $'config/runtime-policy.json')"
+# Regression: #505
 assert_eq "$(extract_output "$unknown_output" "run_rust")" "true" "unknown paths must run rust fallback"
 assert_eq "$(extract_output "$unknown_output" "test_scope")" "full" "unknown paths must use full fallback"
 

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAST_WORKFLOW="$ROOT_DIR/.github/workflows/ci-fast-gate.yml"
+
+if ! grep -Fq "steps.scope.outputs.run_deploy_preflight_tests == 'true'" "$FAST_WORKFLOW"; then
+  echo "expected deploy preflight scope condition in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/deploy/test_preflight_topology.sh" "$FAST_WORKFLOW"; then
+  echo "expected deploy preflight topology tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+echo "workflow scope policy tests passed."


### PR DESCRIPTION
## Summary
Adds deploy-path-aware CI scope selection so `scripts/deploy/*` changes run a bounded deploy preflight lane instead of the full Rust fast-gate lane. This keeps CI faster and cheaper for deployment-script-only diffs while preserving strict unknown-path fallback behavior.

## Linked Issues
- Closes #507
- Closes #508
- Closes #513

## Changes
- `.github/workflows/ci-fast-gate.yml`: added deploy preflight step gated by `run_deploy_preflight_tests` selector output.
- `scripts/ci/select_targets.sh`: added deploy path classification/output (`run_deploy_preflight_tests`, `test_scope=deploy`) and summary field.
- `scripts/ci/test_select_targets.sh`: added deploy-only selector assertions and preserved unknown fallback regression (`Regression: #505`).
- `scripts/ci/test_workflow_scope_policy.sh`: added workflow policy regression checks for deploy-scope wiring.
- `scripts/ci/test_ci_tools.sh`: wired new workflow policy test into CI tool regression suite.
- `docs/foundation/ci-caching-parallelism.md`: documented deploy-only fast-lane routing and validation commands.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Failing output:
```text
deploy-only changes should avoid rust lane: expected 'false', got 'true'
```

Command:
```bash
bash scripts/ci/test_ci_tools.sh
```
Failing output:
```text
expected deploy preflight scope condition in ci-fast-gate.yml
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_tools.sh
bash scripts/deploy/test_preflight_topology.sh
```
Passing summary:
- `select_targets matrix regression tests passed.`
- `workflow scope policy tests passed.`
- `All CI tool regression tests passed.`
- `deployment preflight topology tests passed.`

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
bash scripts/ci/test_ci_tools.sh
bash scripts/deploy/test_preflight_topology.sh
```
Passing summary:
- formatting/lint clean
- CI tool + deploy preflight regression suites clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Shell workflow/selector policy change; behavior validated at functional/integration layer |
| Functional   | ✅     | `scripts/ci/test_select_targets.sh` deploy-only matrix case | |
| Integration  | ✅     | `scripts/ci/test_workflow_scope_policy.sh` + `scripts/ci/test_ci_tools.sh` wiring | |
| Regression   | ✅     | unknown-path fallback retained in selector regression (`Regression: #505`) | |
| Performance  | ✅     | deploy-only scope avoids Rust toolchain lane in fast-gate | |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore previous full-fallback behavior for deploy-path diffs.

## Documentation Updates
- `docs/foundation/ci-caching-parallelism.md`: deploy-only scope semantics and local validation lane updated.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: `.github/workflows/ci-fast-gate.yml`
Expected runtime delta: deploy-only diffs run shell-based preflight tests instead of Rust lane; overall fast-gate time should decrease for deploy-only changes.
Expected runner-minute delta: lower runner minutes on deploy-only PRs due to skipping Rust toolchain/cache/test startup.
Rollback plan if CI cost/runtime regresses: revert PR #514 to restore prior selector/workflow behavior and investigate scope classifier outputs.
