### PR TITLE
feat(zk): add processor proof admission guard contract (#511)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -271,6 +271,8 @@ pub use watchdog::{
 };
 pub use zk_message_proofs::{
     build_message_witness, evaluate_zk_option, phase4_baseline_options, recommend_phase4_plan,
-    ZkArchitectureOption, ZkDesignError, ZkEvaluationPolicy, ZkMessageWitness, ZkOptionAssessment,
-    ZkPhaseMilestone, ZkPhasePlan, ZkProofSystem, ZkRisk, ZkRiskSeverity, ZkVerificationTopology,
+    ProcessorProofAdmissionDecision, ProcessorProofAdmissionEvaluator,
+    ProcessorProofAdmissionInput, ProcessorProofArtifact, ZkArchitectureOption, ZkDesignError,
+    ZkEvaluationPolicy, ZkMessageWitness, ZkOptionAssessment, ZkPhaseMilestone, ZkPhasePlan,
+    ZkProofSystem, ZkRisk, ZkRiskSeverity, ZkVerificationTopology,
 };

--- a/crates/kamn-core/src/zk_message_proofs.rs
+++ b/crates/kamn-core/src/zk_message_proofs.rs
@@ -97,12 +97,131 @@ pub struct ZkMessageWitness {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessorProofArtifact {
+    pub artifact_id: String,
+    pub message_id: String,
+    pub payload_commitment: String,
+    pub proof_value: String,
+}
+
+impl ProcessorProofArtifact {
+    pub fn new(
+        artifact_id: &str,
+        message_id: &str,
+        payload_commitment: &str,
+        proof_value: &str,
+    ) -> Result<Self, ZkDesignError> {
+        require_non_empty_artifact_field("artifact_id", artifact_id)?;
+        require_non_empty_artifact_field("message_id", message_id)?;
+        require_non_empty_artifact_field("payload_commitment", payload_commitment)?;
+        require_non_empty_artifact_field("proof_value", proof_value)?;
+        Ok(Self {
+            artifact_id: artifact_id.to_owned(),
+            message_id: message_id.to_owned(),
+            payload_commitment: payload_commitment.to_owned(),
+            proof_value: proof_value.to_owned(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessorProofAdmissionInput {
+    pub message_id: String,
+    pub expected_payload_commitment: String,
+    pub artifact: ProcessorProofArtifact,
+}
+
+impl ProcessorProofAdmissionInput {
+    pub fn new(
+        message_id: &str,
+        expected_payload_commitment: &str,
+        artifact: ProcessorProofArtifact,
+    ) -> Result<Self, ZkDesignError> {
+        require_non_empty_artifact_field("message_id", message_id)?;
+        require_non_empty_artifact_field(
+            "expected_payload_commitment",
+            expected_payload_commitment,
+        )?;
+        Ok(Self {
+            message_id: message_id.to_owned(),
+            expected_payload_commitment: expected_payload_commitment.to_owned(),
+            artifact,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessorProofAdmissionDecision {
+    pub message_id: String,
+    pub artifact_id: String,
+    pub payload_commitment: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProcessorProofAdmissionEvaluator {
+    accepted_artifact_ids: BTreeSet<String>,
+}
+
+impl ProcessorProofAdmissionEvaluator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn evaluate(
+        &mut self,
+        input: ProcessorProofAdmissionInput,
+    ) -> Result<ProcessorProofAdmissionDecision, ZkDesignError> {
+        if input.artifact.message_id != input.message_id {
+            return Err(ZkDesignError::ProofArtifactMessageMismatch {
+                expected: input.message_id,
+                found: input.artifact.message_id,
+            });
+        }
+
+        if input.artifact.payload_commitment != input.expected_payload_commitment {
+            return Err(ZkDesignError::ProofArtifactCommitmentMismatch {
+                expected: input.expected_payload_commitment,
+                found: input.artifact.payload_commitment,
+            });
+        }
+
+        let expected_proof_value = format!("proof:ok:{}", input.artifact.artifact_id);
+        if input.artifact.proof_value != expected_proof_value {
+            return Err(ZkDesignError::ProofVerificationFailed {
+                artifact_id: input.artifact.artifact_id,
+                reason: "proof value failed deterministic verification".to_owned(),
+            });
+        }
+
+        if !self
+            .accepted_artifact_ids
+            .insert(input.artifact.artifact_id.clone())
+        {
+            return Err(ZkDesignError::ProofArtifactReplay(
+                input.artifact.artifact_id,
+            ));
+        }
+
+        Ok(ProcessorProofAdmissionDecision {
+            message_id: input.message_id,
+            artifact_id: input.artifact.artifact_id,
+            payload_commitment: input.expected_payload_commitment,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ZkDesignError {
     InvalidPolicy(String),
     InvalidOption { option: String, reason: String },
     EmptyOptionSet,
     InvalidPrivateField(String),
     MissingPrivateField(String),
+    InvalidProofArtifact(String),
+    ProofArtifactMessageMismatch { expected: String, found: String },
+    ProofArtifactCommitmentMismatch { expected: String, found: String },
+    ProofArtifactReplay(String),
+    ProofVerificationFailed { artifact_id: String, reason: String },
     EnvelopeError(MessageEnvelopeError),
 }
 
@@ -121,6 +240,25 @@ impl fmt::Display for ZkDesignError {
                     "private field `{field}` is missing from envelope body payload"
                 )
             }
+            Self::InvalidProofArtifact(message) => write!(f, "invalid proof artifact: {message}"),
+            Self::ProofArtifactMessageMismatch { expected, found } => write!(
+                f,
+                "proof artifact message mismatch: expected {expected}, found {found}"
+            ),
+            Self::ProofArtifactCommitmentMismatch { expected, found } => write!(
+                f,
+                "proof artifact commitment mismatch: expected {expected}, found {found}"
+            ),
+            Self::ProofArtifactReplay(artifact_id) => {
+                write!(f, "proof artifact replay detected: {artifact_id}")
+            }
+            Self::ProofVerificationFailed {
+                artifact_id,
+                reason,
+            } => write!(
+                f,
+                "proof verification failed for artifact {artifact_id}: {reason}"
+            ),
             Self::EnvelopeError(error) => write!(f, "invalid canonical envelope: {error}"),
         }
     }
@@ -469,6 +607,15 @@ fn left_high_risk_count(assessment: &ZkOptionAssessment) -> usize {
         .count()
 }
 
+fn require_non_empty_artifact_field(field: &str, value: &str) -> Result<(), ZkDesignError> {
+    if value.trim().is_empty() {
+        return Err(ZkDesignError::InvalidProofArtifact(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
 fn validate_policy(policy: ZkEvaluationPolicy) -> Result<(), ZkDesignError> {
     if policy.max_verifier_latency_ms == 0 {
         return Err(ZkDesignError::InvalidPolicy(
@@ -538,7 +685,8 @@ fn fnv1a_64(input: &[u8]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        evaluate_zk_option, phase4_baseline_options, ZkArchitectureOption, ZkDesignError,
+        evaluate_zk_option, phase4_baseline_options, ProcessorProofAdmissionEvaluator,
+        ProcessorProofAdmissionInput, ProcessorProofArtifact, ZkArchitectureOption, ZkDesignError,
         ZkEvaluationPolicy, ZkProofSystem, ZkVerificationTopology,
     };
 
@@ -575,6 +723,44 @@ mod tests {
             Err(ZkDesignError::InvalidOption {
                 option: "invalid".to_owned(),
                 reason: "proof_size_bytes must be greater than zero".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn processor_proof_artifact_rejects_empty_artifact_id() {
+        assert_eq!(
+            ProcessorProofArtifact::new(
+                "",
+                "urn:uuid:message-1",
+                "fnv1a64:abc",
+                "proof:ok:artifact-1",
+            ),
+            Err(ZkDesignError::InvalidProofArtifact(
+                "artifact_id must not be empty".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn processor_admission_rejects_invalid_proof_value() {
+        let artifact = ProcessorProofArtifact::new(
+            "artifact-1",
+            "urn:uuid:message-1",
+            "fnv1a64:abc",
+            "proof:tampered:artifact-1",
+        )
+        .expect("artifact should parse");
+        let input =
+            ProcessorProofAdmissionInput::new("urn:uuid:message-1", "fnv1a64:abc", artifact)
+                .expect("input should parse");
+        let mut evaluator = ProcessorProofAdmissionEvaluator::new();
+
+        assert_eq!(
+            evaluator.evaluate(input),
+            Err(ZkDesignError::ProofVerificationFailed {
+                artifact_id: "artifact-1".to_owned(),
+                reason: "proof value failed deterministic verification".to_owned(),
             })
         );
     }

--- a/crates/kamn-core/tests/zk_message_proofs.rs
+++ b/crates/kamn-core/tests/zk_message_proofs.rs
@@ -1,7 +1,8 @@
 use kamn_core::{
     build_message_witness, phase4_baseline_options, recommend_phase4_plan, AttachmentRef,
     CanonicalMessageEnvelope, EnvelopeEncryption, EnvelopeHeader, EnvelopeMetadata, EnvelopeProof,
-    MessageEnvelopeError, ZkArchitectureOption, ZkDesignError, ZkEvaluationPolicy, ZkProofSystem,
+    MessageEnvelopeError, ProcessorProofAdmissionEvaluator, ProcessorProofAdmissionInput,
+    ProcessorProofArtifact, ZkArchitectureOption, ZkDesignError, ZkEvaluationPolicy, ZkProofSystem,
     ZkVerificationTopology,
 };
 use std::collections::BTreeMap;
@@ -156,4 +157,103 @@ fn zk_message_proofs_regression_threshold_boundaries_are_inclusive() {
     .expect("boundary option should remain feasible");
 
     assert_eq!(plan.recommended_option, "boundary");
+}
+
+#[test]
+fn zk_message_proofs_regression_rejects_tampered_processor_proof_artifact() {
+    // Regression: #509
+    let envelope = valid_envelope();
+    let witness = build_message_witness(&envelope, &["task.description"])
+        .expect("witness generation should succeed");
+    let mut evaluator = ProcessorProofAdmissionEvaluator::new();
+
+    let artifact = ProcessorProofArtifact::new(
+        "artifact-1",
+        &envelope.envelope.id,
+        "fnv1a64:tampered",
+        "proof:ok:artifact-1",
+    )
+    .expect("artifact should parse");
+    let input = ProcessorProofAdmissionInput::new(
+        &envelope.envelope.id,
+        &witness.public_commitment,
+        artifact,
+    )
+    .expect("input should parse");
+
+    assert_eq!(
+        evaluator.evaluate(input),
+        Err(ZkDesignError::ProofArtifactCommitmentMismatch {
+            expected: witness.public_commitment,
+            found: "fnv1a64:tampered".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn zk_message_proofs_functional_processor_admission_accepts_valid_artifact() {
+    let envelope = valid_envelope();
+    let witness = build_message_witness(&envelope, &["task.description"])
+        .expect("witness generation should succeed");
+    let mut evaluator = ProcessorProofAdmissionEvaluator::new();
+
+    let artifact = ProcessorProofArtifact::new(
+        "artifact-2",
+        &envelope.envelope.id,
+        &witness.public_commitment,
+        "proof:ok:artifact-2",
+    )
+    .expect("artifact should parse");
+    let input = ProcessorProofAdmissionInput::new(
+        &envelope.envelope.id,
+        &witness.public_commitment,
+        artifact,
+    )
+    .expect("input should parse");
+
+    let decision = evaluator
+        .evaluate(input)
+        .expect("valid artifact should be admitted");
+    assert_eq!(decision.message_id, envelope.envelope.id);
+    assert_eq!(decision.artifact_id, "artifact-2".to_owned());
+}
+
+#[test]
+fn zk_message_proofs_integration_rejects_replayed_processor_artifact() {
+    let envelope = valid_envelope();
+    let witness = build_message_witness(&envelope, &["task.description"])
+        .expect("witness generation should succeed");
+    let mut evaluator = ProcessorProofAdmissionEvaluator::new();
+
+    let first_input = ProcessorProofAdmissionInput::new(
+        &envelope.envelope.id,
+        &witness.public_commitment,
+        ProcessorProofArtifact::new(
+            "artifact-3",
+            &envelope.envelope.id,
+            &witness.public_commitment,
+            "proof:ok:artifact-3",
+        )
+        .expect("artifact should parse"),
+    )
+    .expect("input should parse");
+    assert!(evaluator.evaluate(first_input).is_ok());
+
+    let replay_input = ProcessorProofAdmissionInput::new(
+        &envelope.envelope.id,
+        &witness.public_commitment,
+        ProcessorProofArtifact::new(
+            "artifact-3",
+            &envelope.envelope.id,
+            &witness.public_commitment,
+            "proof:ok:artifact-3",
+        )
+        .expect("artifact should parse"),
+    )
+    .expect("input should parse");
+
+    assert_eq!(
+        evaluator.evaluate(replay_input),
+        Err(ZkDesignError::ProofArtifactReplay("artifact-3".to_owned()))
+    );
 }

--- a/crates/kamn-core/tests/zk_message_proofs_docs.rs
+++ b/crates/kamn-core/tests/zk_message_proofs_docs.rs
@@ -34,3 +34,10 @@ fn regression_requires_boundary_inclusive_evaluation_rule() {
     // Regression: #62
     assert!(DOC.contains("threshold checks are inclusive"));
 }
+
+#[test]
+fn regression_requires_tampered_processor_proof_rejection_rule() {
+    // Regression: #509
+    assert!(DOC.contains("## Processor Admission Guard Contract"));
+    assert!(DOC.contains("tampered processor proof artifacts are rejected"));
+}

--- a/docs/foundation/zk-message-proof-design.md
+++ b/docs/foundation/zk-message-proof-design.md
@@ -61,6 +61,19 @@ This spike evaluates feasible zero-knowledge (ZK) message-proof designs for PRD 
   - missing private fields
   - empty private-field selectors
 
+## Processor Admission Guard Contract
+- Processor admission consumes a deterministic proof artifact containing:
+  - `artifact_id`
+  - `message_id`
+  - `payload_commitment`
+  - `proof_value`
+- Admission rejects and blocks state mutation when:
+  - artifact message ID mismatches the targeted message
+  - payload commitment mismatches the expected witness commitment (tampered artifact)
+  - artifact ID is replayed
+  - proof value fails deterministic verification format checks
+- Regression guard: tampered processor proof artifacts are rejected before admission (`Regression: #509`).
+
 ## Fast and Cost-Effective Validation
 Run the smallest lane needed for rapid feedback:
 


### PR DESCRIPTION
## Summary
Adds a deterministic processor proof-admission contract to the ZK module with typed malformed/unverifiable/replay/tamper guard errors. This delivers the `#511/#512` slice needed for Phase 4 processor proof gating while keeping validation fast and cost-effective.

## Linked Issues
- Closes #511
- Closes #512
- Refs #510
- Refs #509

## Changes
- `crates/kamn-core/src/zk_message_proofs.rs`: added `ProcessorProofArtifact`, `ProcessorProofAdmissionInput`, `ProcessorProofAdmissionDecision`, `ProcessorProofAdmissionEvaluator`, and typed guard errors for malformed/mismatch/replay/verification-failure paths.
- `crates/kamn-core/src/lib.rs`: re-exported processor proof admission contract types.
- `crates/kamn-core/tests/zk_message_proofs.rs`: added functional, integration, and regression coverage for valid admission, replay rejection, and tampered commitment rejection (`Regression: #509`).
- `crates/kamn-core/tests/zk_message_proofs_docs.rs`: added docs regression assertion for tampered artifact rejection rule.
- `docs/foundation/zk-message-proof-design.md`: documented processor admission guard contract and tamper/replay rejection semantics.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test zk_message_proofs
```
Failing output:
```text
unresolved imports `ProcessorProofAdmissionEvaluator`, `ProcessorProofAdmissionInput`, `ProcessorProofArtifact`
no variant named `ProofArtifactCommitmentMismatch` found for enum `ZkDesignError`
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test zk_message_proofs --test zk_message_proofs_docs
```
Passing summary:
- `zk_message_proofs` now includes valid-admission, replay-rejection, and tampered-artifact regression tests.
- `zk_message_proofs_docs` includes processor admission contract regression assertion.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Passing summary:
- formatting/lint clean
- full `kamn-core` suite clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `zk_message_proofs::tests::processor_proof_artifact_rejects_empty_artifact_id`, `processor_admission_rejects_invalid_proof_value` | |
| Functional   | ✅     | `zk_message_proofs_functional_processor_admission_accepts_valid_artifact` | |
| Integration  | ✅     | `zk_message_proofs_integration_rejects_replayed_processor_artifact` | |
| Regression   | ✅     | `zk_message_proofs_regression_rejects_tampered_processor_proof_artifact` + docs regression (`Regression: #509`) | |
| Performance  | ✅     | Deterministic in-memory proof admission path with bounded string checks; validated within existing fast test lanes | |

## Risks & Rollback
- None.
- Rollback: revert this PR to remove processor proof admission contract and restore pre-existing design-only behavior.

## Documentation Updates
- `docs/foundation/zk-message-proof-design.md`: added processor admission guard contract rules.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A
