### PR TITLE
fix: harden validator transition proof replay and self-approval safeguards

### DIFF
--- a/crates/kamn-core/src/validator_lifecycle.rs
+++ b/crates/kamn-core/src/validator_lifecycle.rs
@@ -40,6 +40,7 @@ pub struct ValidatorLifecycleManager {
     quorum_threshold: usize,
     updated_at_unix: u64,
     transitions: Vec<ValidatorTransitionRecord>,
+    consumed_transition_proofs: BTreeSet<String>,
 }
 
 impl ValidatorLifecycleManager {
@@ -65,6 +66,7 @@ impl ValidatorLifecycleManager {
             quorum_threshold,
             updated_at_unix: 0,
             transitions: Vec::new(),
+            consumed_transition_proofs: BTreeSet::new(),
         })
     }
 
@@ -77,6 +79,8 @@ impl ValidatorLifecycleManager {
         validate_timestamp("requested_at_unix", requested_at_unix)?;
         validate_did(validator_did)?;
         validate_transition_proof(proof, self.quorum_threshold)?;
+        reject_onboarding_self_approval(validator_did, proof)?;
+        self.ensure_transition_proof_not_replayed(proof)?;
         if self.validator_dids.contains(validator_did) {
             return Err(ValidatorLifecycleError::DuplicateValidator(
                 validator_did.to_owned(),
@@ -95,6 +99,7 @@ impl ValidatorLifecycleManager {
             proof: proof.clone(),
             requested_at_unix,
         });
+        self.consume_transition_proof(proof);
         Ok(())
     }
 
@@ -107,6 +112,7 @@ impl ValidatorLifecycleManager {
         validate_timestamp("requested_at_unix", requested_at_unix)?;
         validate_did(validator_did)?;
         validate_transition_proof(proof, self.quorum_threshold)?;
+        self.ensure_transition_proof_not_replayed(proof)?;
         if !self.validator_dids.contains(validator_did) {
             return Err(ValidatorLifecycleError::ValidatorNotFound(
                 validator_did.to_owned(),
@@ -133,6 +139,7 @@ impl ValidatorLifecycleManager {
             proof: proof.clone(),
             requested_at_unix,
         });
+        self.consume_transition_proof(proof);
         Ok(())
     }
 
@@ -144,6 +151,7 @@ impl ValidatorLifecycleManager {
     ) -> Result<(), ValidatorLifecycleError> {
         validate_timestamp("requested_at_unix", requested_at_unix)?;
         validate_transition_proof(proof, self.quorum_threshold)?;
+        self.ensure_transition_proof_not_replayed(proof)?;
         validate_quorum_threshold(new_quorum_threshold, self.validator_dids.len())?;
 
         let previous_snapshot = self.snapshot();
@@ -158,6 +166,7 @@ impl ValidatorLifecycleManager {
             proof: proof.clone(),
             requested_at_unix,
         });
+        self.consume_transition_proof(proof);
         Ok(())
     }
 
@@ -211,6 +220,27 @@ impl ValidatorLifecycleManager {
     pub fn transition_history(&self) -> Vec<ValidatorTransitionRecord> {
         self.transitions.clone()
     }
+
+    fn ensure_transition_proof_not_replayed(
+        &self,
+        proof: &ValidatorTransitionProof,
+    ) -> Result<(), ValidatorLifecycleError> {
+        if self
+            .consumed_transition_proofs
+            .contains(&transition_proof_fingerprint(proof))
+        {
+            return Err(ValidatorLifecycleError::TransitionProofReplay {
+                proposal_id: proof.proposal_id.clone(),
+                proof_hash: proof.proof_hash.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn consume_transition_proof(&mut self, proof: &ValidatorTransitionProof) {
+        self.consumed_transition_proofs
+            .insert(transition_proof_fingerprint(proof));
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -233,6 +263,13 @@ pub enum ValidatorLifecycleError {
     InsufficientTransitionApprovals {
         required: usize,
         provided: usize,
+    },
+    TransitionProofReplay {
+        proposal_id: String,
+        proof_hash: String,
+    },
+    OnboardingSelfApproval {
+        validator_did: String,
     },
     NoTransitionToRollback,
 }
@@ -266,6 +303,17 @@ impl fmt::Display for ValidatorLifecycleError {
             Self::InsufficientTransitionApprovals { required, provided } => write!(
                 f,
                 "insufficient transition approvals: required {required}, provided {provided}"
+            ),
+            Self::TransitionProofReplay {
+                proposal_id,
+                proof_hash,
+            } => write!(
+                f,
+                "transition proof replay detected: proposal_id={proposal_id}, proof_hash={proof_hash}"
+            ),
+            Self::OnboardingSelfApproval { validator_did } => write!(
+                f,
+                "onboarding transition proof cannot include candidate self-approval: {validator_did}"
             ),
             Self::NoTransitionToRollback => write!(f, "no validator transition to rollback"),
         }
@@ -301,6 +349,26 @@ fn validate_transition_proof(
     }
 
     Ok(())
+}
+
+fn reject_onboarding_self_approval(
+    validator_did: &str,
+    proof: &ValidatorTransitionProof,
+) -> Result<(), ValidatorLifecycleError> {
+    if proof
+        .approver_dids
+        .iter()
+        .any(|approver| approver == validator_did)
+    {
+        return Err(ValidatorLifecycleError::OnboardingSelfApproval {
+            validator_did: validator_did.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn transition_proof_fingerprint(proof: &ValidatorTransitionProof) -> String {
+    format!("{}|{}", proof.proposal_id, proof.proof_hash)
 }
 
 fn validate_quorum_threshold(

--- a/crates/kamn-core/tests/validator_lifecycle.rs
+++ b/crates/kamn-core/tests/validator_lifecycle.rs
@@ -199,3 +199,59 @@ fn validator_lifecycle_regression_blocks_offboarding_that_breaks_quorum() {
         })
     );
 }
+
+#[test]
+fn validator_lifecycle_regression_rejects_replayed_transition_proof() {
+    // Regression: #523
+    let mut manager = ValidatorLifecycleManager::new(
+        vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+        ],
+        2,
+    )
+    .expect("manager should initialize");
+    let replayed_proof = proof(
+        "gov-proposal-replay",
+        &["kamn:did:agent:validator-1", "kamn:did:agent:validator-2"],
+    );
+
+    manager
+        .onboard_validator("kamn:did:agent:validator-3", &replayed_proof, 1_716_403_100)
+        .expect("first transition with proof should pass");
+
+    assert_eq!(
+        manager.reconfigure_quorum(2, &replayed_proof, 1_716_403_200),
+        Err(ValidatorLifecycleError::TransitionProofReplay {
+            proposal_id: "gov-proposal-replay".to_owned(),
+            proof_hash: "proof-hash-gov-proposal-replay".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn validator_lifecycle_regression_rejects_onboarding_self_approval() {
+    // Regression: #523
+    let mut manager = ValidatorLifecycleManager::new(
+        vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+        ],
+        2,
+    )
+    .expect("manager should initialize");
+
+    assert_eq!(
+        manager.onboard_validator(
+            "kamn:did:agent:validator-3",
+            &proof(
+                "gov-proposal-self-approval",
+                &["kamn:did:agent:validator-1", "kamn:did:agent:validator-3",],
+            ),
+            1_716_404_100,
+        ),
+        Err(ValidatorLifecycleError::OnboardingSelfApproval {
+            validator_did: "kamn:did:agent:validator-3".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/validator_lifecycle_docs.rs
+++ b/crates/kamn-core/tests/validator_lifecycle_docs.rs
@@ -14,6 +14,8 @@ fn doc_contains_transition_proof_and_quorum_safety_rules() {
     assert!(DOC.contains("## Transition Proof and Validation Rules"));
     assert!(DOC.contains("## Quorum Safety and Rollback Rules"));
     assert!(DOC.contains("Offboarding is blocked when resulting validator count would fall below current quorum threshold."));
+    assert!(DOC.contains("Transition proof fingerprint (`proposal_id` + `proof_hash`) is one-time-use and replay attempts are rejected."));
+    assert!(DOC.contains("Onboarding proof approver sets cannot include the candidate validator DID (self-approval rejection)."));
 }
 
 #[test]
@@ -27,4 +29,11 @@ fn doc_contains_fast_and_cost_effective_validation_lane() {
 fn regression_requires_quorum_breaking_offboard_block_rule() {
     // Regression: #195
     assert!(DOC.contains("Offboarding is blocked when resulting validator count would fall below current quorum threshold."));
+}
+
+#[test]
+fn regression_requires_replay_and_self_approval_rejection_rules() {
+    // Regression: #523
+    assert!(DOC.contains("transition proof replay is rejected (`Regression: #523`)."));
+    assert!(DOC.contains("onboarding self-approval is rejected (`Regression: #523`)."));
 }

--- a/docs/foundation/validator-lifecycle-quorum-reconfiguration.md
+++ b/docs/foundation/validator-lifecycle-quorum-reconfiguration.md
@@ -1,4 +1,4 @@
-# Validator Lifecycle and Quorum Reconfiguration (Issues #194 / #195)
+# Validator Lifecycle and Quorum Reconfiguration (Issues #194 / #195 / #523)
 
 This document captures the first implementation slice for validator onboarding, offboarding, and quorum updates.
 
@@ -28,6 +28,11 @@ This document captures the first implementation slice for validator onboarding, 
   - valid DID format for each approver.
 - Proof approvals must satisfy the current quorum threshold.
 - Duplicate validator DIDs are rejected.
+- Transition proof fingerprint (`proposal_id` + `proof_hash`) is one-time-use and replay attempts are rejected.
+- Onboarding proof approver sets cannot include the candidate validator DID (self-approval rejection).
+- Regression guards:
+  - transition proof replay is rejected (`Regression: #523`).
+  - onboarding self-approval is rejected (`Regression: #523`).
 
 ## Quorum Safety and Rollback Rules
 - Quorum threshold must be in `1..=validator_count`.


### PR DESCRIPTION
## Summary
Adds deterministic validator lifecycle safeguards that block replayed transition proofs and onboarding self-approval evidence. This hardens decentralized validator admission paths and closes a governance safety gap in transition-proof handling.

## Changes
- `crates/kamn-core/src/validator_lifecycle.rs`: added transition-proof replay tracking, onboarding self-approval rejection, and typed errors (`TransitionProofReplay`, `OnboardingSelfApproval`).
- `crates/kamn-core/tests/validator_lifecycle.rs`: added regression tests for replayed transition proof rejection and onboarding self-approval rejection.
- `docs/foundation/validator-lifecycle-quorum-reconfiguration.md`: documented replay/self-approval guard rules and regression markers.
- `crates/kamn-core/tests/validator_lifecycle_docs.rs`: added doc assertions for replay/self-approval rules.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: replay and self-approval paths return deterministic typed errors and do not mutate validator state.

## Test Matrix Evidence
| Category     | Status | Notes          |
|-------------|--------|----------------|
| Unit        | ✅     | Validation helpers and typed error surfaces exercised via `validator_lifecycle` and module unit lanes. |
| Functional  | ✅     | Existing onboard/reconfigure/offboard flow remains green with unique proofs. |
| Integration | ✅     | `validator_lifecycle_integration_requires_approved_governance_proposal_reference` and full `cargo test -p kamn-core`. |
| Regression  | ✅     | `validator_lifecycle_regression_rejects_replayed_transition_proof` and `validator_lifecycle_regression_rejects_onboarding_self_approval` (`Regression: #523`). |

Closes #526
Closes #525
Closes #524
Closes #523
