### PR TITLE
fix: enforce activation timelock for agent-driven upgrades

### DIFF
--- a/crates/kamn-core/src/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/src/agent_upgrade_workflow.rs
@@ -12,6 +12,7 @@ pub struct AgentUpgradeWorkflowConfig {
     pub allowed_agent_proposers: Vec<String>,
     pub required_human_reviews: usize,
     pub required_validator_quorum: usize,
+    pub min_activation_delay_secs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,6 +44,7 @@ pub struct AgentUpgradeProposalRecord {
     pub human_reviewers: BTreeSet<String>,
     pub state: AgentUpgradeProposalState,
     pub governance_status: GovernanceProposalStatus,
+    pub governance_approved_at_unix: Option<u64>,
     pub activated_at_unix: Option<u64>,
     pub operation_hash: Option<String>,
 }
@@ -71,6 +73,7 @@ pub struct AgentDrivenUpgradeWorkflow {
     allowed_agent_proposers: BTreeSet<String>,
     required_human_reviews: usize,
     required_validator_quorum: usize,
+    min_activation_delay_secs: u64,
     governance: GovernanceWorkflow,
     orchestrator: VersionUpgradeOrchestrator,
     proposals: BTreeMap<String, AgentUpgradeProposalRecord>,
@@ -84,6 +87,9 @@ impl AgentDrivenUpgradeWorkflow {
         }
         if config.required_validator_quorum == 0 {
             return Err(AgentUpgradeWorkflowError::InvalidRequiredValidatorQuorum(0));
+        }
+        if config.min_activation_delay_secs == 0 {
+            return Err(AgentUpgradeWorkflowError::InvalidMinActivationDelaySecs(0));
         }
         if config.allowed_agent_proposers.is_empty() {
             return Err(AgentUpgradeWorkflowError::MissingAllowedAgentProposers);
@@ -102,6 +108,7 @@ impl AgentDrivenUpgradeWorkflow {
             allowed_agent_proposers,
             required_human_reviews: config.required_human_reviews,
             required_validator_quorum: config.required_validator_quorum,
+            min_activation_delay_secs: config.min_activation_delay_secs,
             governance: GovernanceWorkflow::new(),
             orchestrator,
             proposals: BTreeMap::new(),
@@ -156,6 +163,7 @@ impl AgentDrivenUpgradeWorkflow {
                 human_reviewers: BTreeSet::new(),
                 state: AgentUpgradeProposalState::PendingHumanReview,
                 governance_status: GovernanceProposalStatus::Voting,
+                governance_approved_at_unix: None,
                 activated_at_unix: None,
                 operation_hash: None,
             },
@@ -245,6 +253,7 @@ impl AgentDrivenUpgradeWorkflow {
 
         proposal.state = AgentUpgradeProposalState::GovernanceVoting;
         proposal.governance_status = GovernanceProposalStatus::Voting;
+        proposal.governance_approved_at_unix = None;
         self.proposals.insert(proposal_id.to_owned(), proposal);
         self.events.push(AgentUpgradeAuditEvent {
             proposal_id: proposal_id.to_owned(),
@@ -274,6 +283,9 @@ impl AgentDrivenUpgradeWorkflow {
             record.governance_status = status;
             if status == GovernanceProposalStatus::Approved {
                 record.state = AgentUpgradeProposalState::GovernanceApproved;
+                if record.governance_approved_at_unix.is_none() {
+                    record.governance_approved_at_unix = Some(cast_at_unix);
+                }
                 self.events.push(AgentUpgradeAuditEvent {
                     proposal_id: proposal_id.to_owned(),
                     actor_did: validator_did.to_owned(),
@@ -309,6 +321,21 @@ impl AgentDrivenUpgradeWorkflow {
             return Err(AgentUpgradeWorkflowError::GovernanceStatusNotApproved {
                 proposal_id: proposal_id.to_owned(),
                 status: governance_status,
+            });
+        }
+        let governance_approved_at_unix =
+            proposal.governance_approved_at_unix.ok_or_else(|| {
+                AgentUpgradeWorkflowError::MissingGovernanceApprovalTimestamp(
+                    proposal_id.to_owned(),
+                )
+            })?;
+        let earliest_activation_unix =
+            governance_approved_at_unix.saturating_add(self.min_activation_delay_secs);
+        if executed_at_unix < earliest_activation_unix {
+            return Err(AgentUpgradeWorkflowError::ActivationDelayNotElapsed {
+                proposal_id: proposal_id.to_owned(),
+                earliest_activation_unix,
+                attempted_activation_unix: executed_at_unix,
             });
         }
 
@@ -404,6 +431,7 @@ pub enum AgentUpgradeWorkflowError {
     },
     InvalidRequiredHumanReviews(usize),
     InvalidRequiredValidatorQuorum(usize),
+    InvalidMinActivationDelaySecs(u64),
     MissingAllowedAgentProposers,
     UnauthorizedAgentProposer(String),
     ProposalAlreadyExists(String),
@@ -423,6 +451,12 @@ pub enum AgentUpgradeWorkflowError {
     GovernanceStatusNotApproved {
         proposal_id: String,
         status: GovernanceProposalStatus,
+    },
+    MissingGovernanceApprovalTimestamp(String),
+    ActivationDelayNotElapsed {
+        proposal_id: String,
+        earliest_activation_unix: u64,
+        attempted_activation_unix: u64,
     },
     GovernanceWorkflow(GovernanceWorkflowError),
     UpgradeOrchestration(UpgradeOrchestrationError),
@@ -446,6 +480,9 @@ impl fmt::Display for AgentUpgradeWorkflowError {
             }
             Self::InvalidRequiredValidatorQuorum(value) => {
                 write!(f, "invalid required validator quorum: {value}")
+            }
+            Self::InvalidMinActivationDelaySecs(value) => {
+                write!(f, "invalid minimum activation delay seconds: {value}")
             }
             Self::MissingAllowedAgentProposers => {
                 write!(f, "allowed agent proposer set must not be empty")
@@ -478,6 +515,18 @@ impl fmt::Display for AgentUpgradeWorkflowError {
             } => write!(
                 f,
                 "governance status is not approved: proposal={proposal_id}, status={status:?}"
+            ),
+            Self::MissingGovernanceApprovalTimestamp(proposal_id) => write!(
+                f,
+                "governance approval timestamp is missing for proposal: {proposal_id}"
+            ),
+            Self::ActivationDelayNotElapsed {
+                proposal_id,
+                earliest_activation_unix,
+                attempted_activation_unix,
+            } => write!(
+                f,
+                "activation delay not elapsed: proposal={proposal_id}, earliest_activation_unix={earliest_activation_unix}, attempted_activation_unix={attempted_activation_unix}"
             ),
             Self::GovernanceWorkflow(error) => write!(f, "{error}"),
             Self::UpgradeOrchestration(error) => write!(f, "{error}"),
@@ -522,8 +571,23 @@ mod tests {
                 allowed_agent_proposers: Vec::new(),
                 required_human_reviews: 1,
                 required_validator_quorum: 2,
+                min_activation_delay_secs: 60,
             }),
             Err(AgentUpgradeWorkflowError::MissingAllowedAgentProposers)
+        );
+    }
+
+    #[test]
+    fn constructor_rejects_zero_activation_delay() {
+        assert_eq!(
+            AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+                current_version: "v0.1.0".to_owned(),
+                allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+                required_human_reviews: 1,
+                required_validator_quorum: 2,
+                min_activation_delay_secs: 0,
+            }),
+            Err(AgentUpgradeWorkflowError::InvalidMinActivationDelaySecs(0))
         );
     }
 
@@ -534,6 +598,7 @@ mod tests {
             allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
             required_human_reviews: 1,
             required_validator_quorum: 2,
+            min_activation_delay_secs: 60,
         })
         .expect("workflow should initialize");
         workflow

--- a/crates/kamn-core/tests/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow.rs
@@ -11,6 +11,7 @@ fn agent_upgrade_workflow_rejects_unallowlisted_agent_proposer() {
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
         required_human_reviews: 1,
         required_validator_quorum: 2,
+        min_activation_delay_secs: 60,
     })
     .expect("workflow should initialize");
 
@@ -36,6 +37,7 @@ fn agent_upgrade_workflow_functional_human_review_governance_activation_flow() {
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
         required_human_reviews: 2,
         required_validator_quorum: 2,
+        min_activation_delay_secs: 60,
     })
     .expect("workflow should initialize");
     workflow
@@ -108,6 +110,7 @@ fn agent_upgrade_workflow_integration_records_governance_and_upgrade_audit_trace
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
         required_human_reviews: 1,
         required_validator_quorum: 2,
+        min_activation_delay_secs: 60,
     })
     .expect("workflow should initialize");
     workflow
@@ -183,6 +186,7 @@ fn agent_upgrade_workflow_regression_blocks_governance_submission_without_human_
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
         required_human_reviews: 2,
         required_validator_quorum: 2,
+        min_activation_delay_secs: 60,
     })
     .expect("workflow should initialize");
     workflow
@@ -208,6 +212,69 @@ fn agent_upgrade_workflow_regression_blocks_governance_submission_without_human_
         Err(AgentUpgradeWorkflowError::InsufficientHumanReviews {
             required: 2,
             provided: 1,
+        })
+    );
+}
+
+#[test]
+fn agent_upgrade_workflow_regression_rejects_early_activation_before_delay() {
+    // Regression: #528
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v0.8.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        required_human_reviews: 1,
+        required_validator_quorum: 2,
+        min_activation_delay_secs: 120,
+    })
+    .expect("workflow should initialize");
+    workflow
+        .submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-5".to_owned(),
+            target_version: "v0.9.0".to_owned(),
+            agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+            rationale: "timelock regression".to_owned(),
+            created_at_unix: 1_716_614_000,
+            voting_deadline_unix: 1_716_614_700,
+        })
+        .expect("proposal should register");
+    workflow
+        .approve_human_review(
+            "pilot-upgrade-5",
+            "kamn:did:agent:validator-1",
+            1_716_614_050,
+        )
+        .expect("review should pass");
+    workflow
+        .submit_to_governance("pilot-upgrade-5", 1_716_614_100)
+        .expect("governance submission should pass");
+    workflow
+        .cast_validator_vote(
+            "pilot-upgrade-5",
+            "kamn:did:agent:validator-1",
+            GovernanceVoteChoice::Yes,
+            1_716_614_120,
+        )
+        .expect("yes vote should pass");
+    workflow
+        .cast_validator_vote(
+            "pilot-upgrade-5",
+            "kamn:did:agent:validator-2",
+            GovernanceVoteChoice::Yes,
+            1_716_614_130,
+        )
+        .expect("yes vote should pass");
+
+    assert_eq!(
+        workflow.finalize_upgrade(
+            "pilot-upgrade-5",
+            "kamn:did:agent:validator-1",
+            1_716_614_200,
+            "op-hash-pilot-upgrade-5-early",
+        ),
+        Err(AgentUpgradeWorkflowError::ActivationDelayNotElapsed {
+            proposal_id: "pilot-upgrade-5".to_owned(),
+            earliest_activation_unix: 1_716_614_250,
+            attempted_activation_unix: 1_716_614_200,
         })
     );
 }

--- a/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
@@ -14,6 +14,9 @@ fn doc_contains_workflow_safeguards_and_audit_rules() {
     assert!(DOC.contains("## Workflow Safeguards"));
     assert!(DOC.contains("## Governance and Audit Rules"));
     assert!(DOC.contains("Governance submission requires:"));
+    assert!(DOC.contains(
+        "configured minimum activation delay elapsed since governance approval timestamp."
+    ));
 }
 
 #[test]
@@ -27,4 +30,12 @@ fn doc_contains_fast_and_cost_effective_validation_lane() {
 fn regression_requires_human_review_quorum_gating_rule() {
     // Regression: #235
     assert!(DOC.contains("sufficient unique human reviewer approvals"));
+}
+
+#[test]
+fn regression_requires_activation_delay_rejection_rule() {
+    // Regression: #528
+    assert!(
+        DOC.contains("early activation before required delay is rejected (`Regression: #528`).")
+    );
 }

--- a/docs/foundation/agent-driven-upgrade-proposal-workflow.md
+++ b/docs/foundation/agent-driven-upgrade-proposal-workflow.md
@@ -1,4 +1,4 @@
-# Agent-Driven Protocol Upgrade Proposal Workflow (Issues #234 / #235)
+# Agent-Driven Protocol Upgrade Proposal Workflow (Issues #234 / #235 / #528)
 
 This document captures the first implementation slice for a pilot agent-driven protocol upgrade workflow with mandatory human and validator safeguards.
 
@@ -31,6 +31,7 @@ This document captures the first implementation slice for a pilot agent-driven p
   - pending-human-review proposal state.
 - Upgrade finalization requires:
   - governance status `Approved`.
+  - configured minimum activation delay elapsed since governance approval timestamp.
   - governance execution recording.
   - application of validator `Yes` votes as upgrade approvals before activation.
 
@@ -45,6 +46,8 @@ This document captures the first implementation slice for a pilot agent-driven p
   - `proposal(...)`
   - `upgrade_audit_view(...)`
   - `agent_audit_log(...)`
+- Regression guard:
+  - early activation before required delay is rejected (`Regression: #528`).
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:


### PR DESCRIPTION
## Summary
Adds deterministic activation-timelock safeguards to the agent-driven upgrade workflow. Finalization now requires a configured minimum delay after governance approval, blocking early activation while preserving existing approval and audit flows.

## Changes
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: added `min_activation_delay_secs` config, governance approval timestamp tracking, finalize-time delay gate, and typed delay errors.
- `crates/kamn-core/tests/agent_upgrade_workflow.rs`: added regression for early activation rejection and updated workflow configs for timelock-aware paths.
- `docs/foundation/agent-driven-upgrade-proposal-workflow.md`: documented activation delay safeguard and regression rule.
- `crates/kamn-core/tests/agent_upgrade_workflow_docs.rs`: added doc assertions for delay safeguard and regression marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: finalize path rejects attempts before `governance_approved_at_unix + min_activation_delay_secs` and succeeds after threshold.

## Test Matrix Evidence
| Category     | Status | Notes          |
|-------------|--------|----------------|
| Unit        | ✅     | Added constructor delay validation and typed error coverage in workflow unit tests. |
| Functional  | ✅     | Existing human-review + governance + activation flow passes under delay boundary. |
| Integration | ✅     | `agent_upgrade_workflow_integration_records_governance_and_upgrade_audit_traces` and full `cargo test -p kamn-core`. |
| Regression  | ✅     | `agent_upgrade_workflow_regression_rejects_early_activation_before_delay` (`Regression: #528`). |

Closes #531
Closes #530
Closes #529
Closes #528
