### PR TITLE
fix(governance): allowlist validator voters for upgrade votes (#536)

### DIFF
--- a/crates/kamn-core/src/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/src/agent_upgrade_workflow.rs
@@ -10,6 +10,7 @@ use std::fmt;
 pub struct AgentUpgradeWorkflowConfig {
     pub current_version: String,
     pub allowed_agent_proposers: Vec<String>,
+    pub allowed_validator_voters: Vec<String>,
     pub required_human_reviews: usize,
     pub required_validator_quorum: usize,
     pub min_activation_delay_secs: u64,
@@ -71,6 +72,7 @@ pub struct AgentUpgradeAuditEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentDrivenUpgradeWorkflow {
     allowed_agent_proposers: BTreeSet<String>,
+    allowed_validator_voters: BTreeSet<String>,
     required_human_reviews: usize,
     required_validator_quorum: usize,
     min_activation_delay_secs: u64,
@@ -94,11 +96,19 @@ impl AgentDrivenUpgradeWorkflow {
         if config.allowed_agent_proposers.is_empty() {
             return Err(AgentUpgradeWorkflowError::MissingAllowedAgentProposers);
         }
+        if config.allowed_validator_voters.is_empty() {
+            return Err(AgentUpgradeWorkflowError::MissingAllowedValidatorVoters);
+        }
 
         let mut allowed_agent_proposers = BTreeSet::new();
         for proposer in config.allowed_agent_proposers {
             validate_did(&proposer)?;
             allowed_agent_proposers.insert(proposer);
+        }
+        let mut allowed_validator_voters = BTreeSet::new();
+        for validator in config.allowed_validator_voters {
+            validate_did(&validator)?;
+            allowed_validator_voters.insert(validator);
         }
 
         let orchestrator =
@@ -106,6 +116,7 @@ impl AgentDrivenUpgradeWorkflow {
 
         Ok(Self {
             allowed_agent_proposers,
+            allowed_validator_voters,
             required_human_reviews: config.required_human_reviews,
             required_validator_quorum: config.required_validator_quorum,
             min_activation_delay_secs: config.min_activation_delay_secs,
@@ -272,6 +283,12 @@ impl AgentDrivenUpgradeWorkflow {
         choice: GovernanceVoteChoice,
         cast_at_unix: u64,
     ) -> Result<(), AgentUpgradeWorkflowError> {
+        validate_did(validator_did)?;
+        if !self.allowed_validator_voters.contains(validator_did) {
+            return Err(AgentUpgradeWorkflowError::UnauthorizedValidatorVoter(
+                validator_did.to_owned(),
+            ));
+        }
         self.governance
             .cast_vote(proposal_id, validator_did, choice, cast_at_unix)
             .map_err(Self::map_governance)?;
@@ -433,7 +450,9 @@ pub enum AgentUpgradeWorkflowError {
     InvalidRequiredValidatorQuorum(usize),
     InvalidMinActivationDelaySecs(u64),
     MissingAllowedAgentProposers,
+    MissingAllowedValidatorVoters,
     UnauthorizedAgentProposer(String),
+    UnauthorizedValidatorVoter(String),
     ProposalAlreadyExists(String),
     ProposalNotFound(String),
     DuplicateHumanReview {
@@ -487,8 +506,14 @@ impl fmt::Display for AgentUpgradeWorkflowError {
             Self::MissingAllowedAgentProposers => {
                 write!(f, "allowed agent proposer set must not be empty")
             }
+            Self::MissingAllowedValidatorVoters => {
+                write!(f, "allowed validator voter set must not be empty")
+            }
             Self::UnauthorizedAgentProposer(agent_did) => {
                 write!(f, "unauthorized agent proposer: {agent_did}")
+            }
+            Self::UnauthorizedValidatorVoter(validator_did) => {
+                write!(f, "unauthorized validator voter: {validator_did}")
             }
             Self::ProposalAlreadyExists(proposal_id) => {
                 write!(f, "proposal already exists: {proposal_id}")
@@ -562,6 +587,7 @@ mod tests {
         AgentDrivenUpgradeWorkflow, AgentUpgradeProposalDraft, AgentUpgradeProposalState,
         AgentUpgradeWorkflowConfig, AgentUpgradeWorkflowError,
     };
+    use crate::GovernanceVoteChoice;
 
     #[test]
     fn constructor_requires_allowlisted_agent_set() {
@@ -569,6 +595,7 @@ mod tests {
             AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
                 current_version: "v0.1.0".to_owned(),
                 allowed_agent_proposers: Vec::new(),
+                allowed_validator_voters: vec!["kamn:did:agent:validator-1".to_owned()],
                 required_human_reviews: 1,
                 required_validator_quorum: 2,
                 min_activation_delay_secs: 60,
@@ -578,11 +605,27 @@ mod tests {
     }
 
     #[test]
+    fn constructor_requires_allowlisted_validator_set() {
+        assert_eq!(
+            AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+                current_version: "v0.1.0".to_owned(),
+                allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+                allowed_validator_voters: Vec::new(),
+                required_human_reviews: 1,
+                required_validator_quorum: 2,
+                min_activation_delay_secs: 60,
+            }),
+            Err(AgentUpgradeWorkflowError::MissingAllowedValidatorVoters)
+        );
+    }
+
+    #[test]
     fn constructor_rejects_zero_activation_delay() {
         assert_eq!(
             AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
                 current_version: "v0.1.0".to_owned(),
                 allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+                allowed_validator_voters: vec!["kamn:did:agent:validator-1".to_owned()],
                 required_human_reviews: 1,
                 required_validator_quorum: 2,
                 min_activation_delay_secs: 0,
@@ -596,6 +639,7 @@ mod tests {
         let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
             current_version: "v0.1.0".to_owned(),
             allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+            allowed_validator_voters: vec!["kamn:did:agent:validator-1".to_owned()],
             required_human_reviews: 1,
             required_validator_quorum: 2,
             min_activation_delay_secs: 60,
@@ -627,5 +671,46 @@ mod tests {
             .proposal("agent-upgrade-a")
             .expect("proposal should exist");
         assert_eq!(record.state, AgentUpgradeProposalState::PendingHumanReview);
+    }
+
+    #[test]
+    fn cast_validator_vote_rejects_non_allowlisted_validator() {
+        let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+            current_version: "v0.1.0".to_owned(),
+            allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+            allowed_validator_voters: vec!["kamn:did:agent:validator-1".to_owned()],
+            required_human_reviews: 1,
+            required_validator_quorum: 1,
+            min_activation_delay_secs: 60,
+        })
+        .expect("workflow should initialize");
+        workflow
+            .submit_agent_proposal(AgentUpgradeProposalDraft {
+                proposal_id: "agent-upgrade-b".to_owned(),
+                target_version: "v0.2.0".to_owned(),
+                agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+                rationale: "validator-vote-allowlist".to_owned(),
+                created_at_unix: 100,
+                voting_deadline_unix: 200,
+            })
+            .expect("proposal should register");
+        workflow
+            .approve_human_review("agent-upgrade-b", "kamn:did:agent:validator-1", 110)
+            .expect("review should pass");
+        workflow
+            .submit_to_governance("agent-upgrade-b", 120)
+            .expect("governance submission should pass");
+
+        assert_eq!(
+            workflow.cast_validator_vote(
+                "agent-upgrade-b",
+                "kamn:did:agent:validator-rogue",
+                GovernanceVoteChoice::Yes,
+                130,
+            ),
+            Err(AgentUpgradeWorkflowError::UnauthorizedValidatorVoter(
+                "kamn:did:agent:validator-rogue".to_owned()
+            ))
+        );
     }
 }

--- a/crates/kamn-core/tests/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow.rs
@@ -9,6 +9,11 @@ fn agent_upgrade_workflow_rejects_unallowlisted_agent_proposer() {
     let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
         current_version: "v0.5.0".to_owned(),
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+            "kamn:did:agent:validator-3".to_owned(),
+        ],
         required_human_reviews: 1,
         required_validator_quorum: 2,
         min_activation_delay_secs: 60,
@@ -35,6 +40,11 @@ fn agent_upgrade_workflow_functional_human_review_governance_activation_flow() {
     let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
         current_version: "v0.5.0".to_owned(),
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+            "kamn:did:agent:validator-3".to_owned(),
+        ],
         required_human_reviews: 2,
         required_validator_quorum: 2,
         min_activation_delay_secs: 60,
@@ -108,6 +118,11 @@ fn agent_upgrade_workflow_integration_records_governance_and_upgrade_audit_trace
     let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
         current_version: "v0.6.0".to_owned(),
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+            "kamn:did:agent:validator-3".to_owned(),
+        ],
         required_human_reviews: 1,
         required_validator_quorum: 2,
         min_activation_delay_secs: 60,
@@ -184,6 +199,11 @@ fn agent_upgrade_workflow_regression_blocks_governance_submission_without_human_
     let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
         current_version: "v0.7.0".to_owned(),
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+            "kamn:did:agent:validator-3".to_owned(),
+        ],
         required_human_reviews: 2,
         required_validator_quorum: 2,
         min_activation_delay_secs: 60,
@@ -222,6 +242,11 @@ fn agent_upgrade_workflow_regression_rejects_early_activation_before_delay() {
     let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
         current_version: "v0.8.0".to_owned(),
         allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+            "kamn:did:agent:validator-3".to_owned(),
+        ],
         required_human_reviews: 1,
         required_validator_quorum: 2,
         min_activation_delay_secs: 120,
@@ -276,5 +301,54 @@ fn agent_upgrade_workflow_regression_rejects_early_activation_before_delay() {
             earliest_activation_unix: 1_716_614_250,
             attempted_activation_unix: 1_716_614_200,
         })
+    );
+}
+
+#[test]
+fn agent_upgrade_workflow_regression_rejects_non_allowlisted_validator_vote() {
+    // Regression: #533
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v0.9.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+        ],
+        required_human_reviews: 1,
+        required_validator_quorum: 2,
+        min_activation_delay_secs: 120,
+    })
+    .expect("workflow should initialize");
+    workflow
+        .submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-6".to_owned(),
+            target_version: "v1.0.0".to_owned(),
+            agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+            rationale: "validator allowlist regression".to_owned(),
+            created_at_unix: 1_716_615_000,
+            voting_deadline_unix: 1_716_615_700,
+        })
+        .expect("proposal should register");
+    workflow
+        .approve_human_review(
+            "pilot-upgrade-6",
+            "kamn:did:agent:validator-1",
+            1_716_615_050,
+        )
+        .expect("review should pass");
+    workflow
+        .submit_to_governance("pilot-upgrade-6", 1_716_615_100)
+        .expect("governance submission should pass");
+
+    assert_eq!(
+        workflow.cast_validator_vote(
+            "pilot-upgrade-6",
+            "kamn:did:agent:validator-rogue",
+            GovernanceVoteChoice::Yes,
+            1_716_615_120,
+        ),
+        Err(AgentUpgradeWorkflowError::UnauthorizedValidatorVoter(
+            "kamn:did:agent:validator-rogue".to_owned()
+        ))
     );
 }

--- a/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
@@ -17,6 +17,7 @@ fn doc_contains_workflow_safeguards_and_audit_rules() {
     assert!(DOC.contains(
         "configured minimum activation delay elapsed since governance approval timestamp."
     ));
+    assert!(DOC.contains("allowlisted validator voter DID"));
 }
 
 #[test]
@@ -38,4 +39,10 @@ fn regression_requires_activation_delay_rejection_rule() {
     assert!(
         DOC.contains("early activation before required delay is rejected (`Regression: #528`).")
     );
+}
+
+#[test]
+fn regression_requires_unauthorized_validator_vote_rejection_rule() {
+    // Regression: #533
+    assert!(DOC.contains("unauthorized validator vote is rejected (`Regression: #533`)."));
 }

--- a/docs/foundation/agent-driven-upgrade-proposal-workflow.md
+++ b/docs/foundation/agent-driven-upgrade-proposal-workflow.md
@@ -26,6 +26,8 @@ This document captures the first implementation slice for a pilot agent-driven p
   - allowlisted proposer DID.
   - non-empty proposal id and rationale.
   - valid timestamps with deadline strictly after creation.
+- Validator governance voting requires:
+  - allowlisted validator voter DID.
 - Governance submission requires:
   - sufficient unique human reviewer approvals.
   - pending-human-review proposal state.
@@ -48,6 +50,7 @@ This document captures the first implementation slice for a pilot agent-driven p
   - `agent_audit_log(...)`
 - Regression guard:
   - early activation before required delay is rejected (`Regression: #528`).
+  - unauthorized validator vote is rejected (`Regression: #533`).
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:


### PR DESCRIPTION
## Summary
Adds validator voter allowlist enforcement to the agent-driven upgrade workflow so only approved validator DIDs can cast governance votes on upgrade proposals.
Also extends regression and documentation coverage to lock this behavior.

Closes #536
Closes #535
Closes #534
Closes #533

## Changes
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: add `allowed_validator_voters` config/state, constructor guards, and unauthorized voter rejection in `cast_validator_vote`
- `crates/kamn-core/tests/agent_upgrade_workflow.rs`: add regression coverage for non-allowlisted validator vote rejection and update workflow config fixtures
- `docs/foundation/agent-driven-upgrade-proposal-workflow.md`: document validator voter allowlist safeguard and regression marker
- `crates/kamn-core/tests/agent_upgrade_workflow_docs.rs`: assert new safeguard and regression marker are present in docs

## Risks & Compatibility
- Breaking change: `AgentUpgradeWorkflowConfig` now requires `allowed_validator_voters`; all call sites must provide an allowlist.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised full upgrade workflow and verified non-allowlisted validator vote is rejected while allowlisted votes continue to satisfy quorum

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Constructor + vote authorization guards in module tests |
| Functional  | ✅     | Agent upgrade lifecycle remains valid with authorized voters |
| Integration | ✅     | `cargo test -p kamn-core` includes cross-module workflow coverage |
| Regression  | ✅     | Added explicit rogue-validator vote rejection test |