### PR TITLE
fix(governance): reject non-allowlisted human reviewers (#540)

### DIFF
--- a/crates/kamn-core/src/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/src/agent_upgrade_workflow.rs
@@ -197,6 +197,11 @@ impl AgentDrivenUpgradeWorkflow {
     ) -> Result<(), AgentUpgradeWorkflowError> {
         validate_did(reviewer_did)?;
         validate_timestamp("reviewed_at_unix", reviewed_at_unix)?;
+        if !self.allowed_validator_voters.contains(reviewer_did) {
+            return Err(AgentUpgradeWorkflowError::UnauthorizedHumanReviewer(
+                reviewer_did.to_owned(),
+            ));
+        }
         let proposal = self
             .proposals
             .get_mut(proposal_id)
@@ -452,6 +457,7 @@ pub enum AgentUpgradeWorkflowError {
     MissingAllowedAgentProposers,
     MissingAllowedValidatorVoters,
     UnauthorizedAgentProposer(String),
+    UnauthorizedHumanReviewer(String),
     UnauthorizedValidatorVoter(String),
     ProposalAlreadyExists(String),
     ProposalNotFound(String),
@@ -511,6 +517,9 @@ impl fmt::Display for AgentUpgradeWorkflowError {
             }
             Self::UnauthorizedAgentProposer(agent_did) => {
                 write!(f, "unauthorized agent proposer: {agent_did}")
+            }
+            Self::UnauthorizedHumanReviewer(reviewer_did) => {
+                write!(f, "unauthorized human reviewer: {reviewer_did}")
             }
             Self::UnauthorizedValidatorVoter(validator_did) => {
                 write!(f, "unauthorized validator voter: {validator_did}")
@@ -709,6 +718,37 @@ mod tests {
                 130,
             ),
             Err(AgentUpgradeWorkflowError::UnauthorizedValidatorVoter(
+                "kamn:did:agent:validator-rogue".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn approve_human_review_rejects_non_allowlisted_reviewer() {
+        let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+            current_version: "v0.1.0".to_owned(),
+            allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+            allowed_validator_voters: vec!["kamn:did:agent:validator-1".to_owned()],
+            required_human_reviews: 1,
+            required_validator_quorum: 1,
+            min_activation_delay_secs: 60,
+        })
+        .expect("workflow should initialize");
+        workflow
+            .submit_agent_proposal(AgentUpgradeProposalDraft {
+                proposal_id: "agent-upgrade-c".to_owned(),
+                target_version: "v0.2.0".to_owned(),
+                agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+                rationale: "reviewer-allowlist".to_owned(),
+                created_at_unix: 100,
+                voting_deadline_unix: 200,
+            })
+            .expect("proposal should register");
+
+        assert_eq!(
+            workflow
+                .approve_human_review("agent-upgrade-c", "kamn:did:agent:validator-rogue", 110,),
+            Err(AgentUpgradeWorkflowError::UnauthorizedHumanReviewer(
                 "kamn:did:agent:validator-rogue".to_owned()
             ))
         );

--- a/crates/kamn-core/tests/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow.rs
@@ -352,3 +352,41 @@ fn agent_upgrade_workflow_regression_rejects_non_allowlisted_validator_vote() {
         ))
     );
 }
+
+#[test]
+fn agent_upgrade_workflow_regression_rejects_non_allowlisted_human_reviewer() {
+    // Regression: #538
+    let mut workflow = AgentDrivenUpgradeWorkflow::new(AgentUpgradeWorkflowConfig {
+        current_version: "v1.0.0".to_owned(),
+        allowed_agent_proposers: vec!["kamn:did:agent:upgrade-bot".to_owned()],
+        allowed_validator_voters: vec![
+            "kamn:did:agent:validator-1".to_owned(),
+            "kamn:did:agent:validator-2".to_owned(),
+        ],
+        required_human_reviews: 1,
+        required_validator_quorum: 2,
+        min_activation_delay_secs: 120,
+    })
+    .expect("workflow should initialize");
+    workflow
+        .submit_agent_proposal(AgentUpgradeProposalDraft {
+            proposal_id: "pilot-upgrade-7".to_owned(),
+            target_version: "v1.1.0".to_owned(),
+            agent_did: "kamn:did:agent:upgrade-bot".to_owned(),
+            rationale: "human reviewer allowlist regression".to_owned(),
+            created_at_unix: 1_716_616_000,
+            voting_deadline_unix: 1_716_616_700,
+        })
+        .expect("proposal should register");
+
+    assert_eq!(
+        workflow.approve_human_review(
+            "pilot-upgrade-7",
+            "kamn:did:agent:validator-rogue",
+            1_716_616_050,
+        ),
+        Err(AgentUpgradeWorkflowError::UnauthorizedHumanReviewer(
+            "kamn:did:agent:validator-rogue".to_owned()
+        ))
+    );
+}

--- a/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
+++ b/crates/kamn-core/tests/agent_upgrade_workflow_docs.rs
@@ -18,6 +18,7 @@ fn doc_contains_workflow_safeguards_and_audit_rules() {
         "configured minimum activation delay elapsed since governance approval timestamp."
     ));
     assert!(DOC.contains("allowlisted validator voter DID"));
+    assert!(DOC.contains("allowlisted validator reviewer DID"));
 }
 
 #[test]
@@ -45,4 +46,10 @@ fn regression_requires_activation_delay_rejection_rule() {
 fn regression_requires_unauthorized_validator_vote_rejection_rule() {
     // Regression: #533
     assert!(DOC.contains("unauthorized validator vote is rejected (`Regression: #533`)."));
+}
+
+#[test]
+fn regression_requires_unauthorized_human_reviewer_rejection_rule() {
+    // Regression: #538
+    assert!(DOC.contains("unauthorized human reviewer approval is rejected (`Regression: #538`)."));
 }

--- a/docs/foundation/agent-driven-upgrade-proposal-workflow.md
+++ b/docs/foundation/agent-driven-upgrade-proposal-workflow.md
@@ -1,4 +1,4 @@
-# Agent-Driven Protocol Upgrade Proposal Workflow (Issues #234 / #235 / #528)
+# Agent-Driven Protocol Upgrade Proposal Workflow (Issues #234 / #235 / #528 / #533 / #538)
 
 This document captures the first implementation slice for a pilot agent-driven protocol upgrade workflow with mandatory human and validator safeguards.
 
@@ -28,6 +28,8 @@ This document captures the first implementation slice for a pilot agent-driven p
   - valid timestamps with deadline strictly after creation.
 - Validator governance voting requires:
   - allowlisted validator voter DID.
+- Human review approvals require:
+  - allowlisted validator reviewer DID.
 - Governance submission requires:
   - sufficient unique human reviewer approvals.
   - pending-human-review proposal state.
@@ -51,6 +53,7 @@ This document captures the first implementation slice for a pilot agent-driven p
 - Regression guard:
   - early activation before required delay is rejected (`Regression: #528`).
   - unauthorized validator vote is rejected (`Regression: #533`).
+  - unauthorized human reviewer approval is rejected (`Regression: #538`).
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:


### PR DESCRIPTION
## Summary
Enforces reviewer authorization in `approve_human_review` so only allowlisted validator DIDs can satisfy human-review quorum for agent-driven upgrades.
Adds regression coverage and documentation safeguards to lock the policy and prevent silent governance bypass.

Closes #541
Closes #540
Closes #539
Closes #538

## Changes
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: add `UnauthorizedHumanReviewer` error and enforce allowlist membership in `approve_human_review`.
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: add unit test `approve_human_review_rejects_non_allowlisted_reviewer`.
- `crates/kamn-core/tests/agent_upgrade_workflow.rs`: add regression `agent_upgrade_workflow_regression_rejects_non_allowlisted_human_reviewer`.
- `docs/foundation/agent-driven-upgrade-proposal-workflow.md`: document reviewer allowlist safeguard and regression marker.
- `crates/kamn-core/tests/agent_upgrade_workflow_docs.rs`: add doc assertion for reviewer allowlist guard and regression rule.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test agent_upgrade_workflow
```
Observed failure (before implementation):
```text
error[E0599]: no variant or associated item named `UnauthorizedHumanReviewer` found for enum `AgentUpgradeWorkflowError`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test agent_upgrade_workflow --test agent_upgrade_workflow_docs
```
Observed pass summary:
```text
running 7 tests
... ok

test result: ok. 7 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Observed pass summary:
```text
test result: ok. 231 passed; 0 failed (unit tests)
... all integration/doc tests passed in `kamn-core`
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | `approve_human_review_rejects_non_allowlisted_reviewer`                              |                      |
| Functional   | ✅     | `agent_upgrade_workflow_functional_human_review_governance_activation_flow` (green)  |                      |
| Integration  | ✅     | `agent_upgrade_workflow_regression_rejects_non_allowlisted_human_reviewer`           |                      |
| Regression   | ✅     | Added `Regression: #538` unauthorized human reviewer rejection coverage               |                      |
| Performance  | N/A    | No new throughput-sensitive path; constant-time set-membership authorization check    | In-memory guard only |

## Risks & Rollback
- Behavioral tightening: previously accepted unauthorized reviewer approvals are now rejected with typed errors.
- Rollback plan: revert PR #550 commit to restore prior behavior if policy conflicts with downstream assumptions.

## Documentation Updates
- `docs/foundation/agent-driven-upgrade-proposal-workflow.md`
- `crates/kamn-core/tests/agent_upgrade_workflow_docs.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
