### PR TITLE
feat(economics): add timeout-conditioned escrow refunds (#544)

### DIFF
--- a/crates/kamn-core/src/escrow.rs
+++ b/crates/kamn-core/src/escrow.rs
@@ -107,6 +107,20 @@ impl EscrowLifecycle {
         Ok(())
     }
 
+    pub fn refund_after_timeout(
+        &mut self,
+        current_unix: u64,
+        timeout_unix: u64,
+    ) -> Result<(), EscrowLifecycleError> {
+        if current_unix < timeout_unix {
+            return Err(EscrowLifecycleError::TimeoutNotElapsed {
+                current_unix,
+                timeout_unix,
+            });
+        }
+        self.refund_remaining()
+    }
+
     pub fn dispute(&mut self) -> Result<(), EscrowLifecycleError> {
         match self.status {
             EscrowStatus::Funded | EscrowStatus::PartiallyReleased { .. } => {
@@ -176,6 +190,10 @@ pub enum EscrowLifecycleError {
         expected_remaining: u128,
         actual_split: u128,
     },
+    TimeoutNotElapsed {
+        current_unix: u64,
+        timeout_unix: u64,
+    },
     AmountOverflow,
 }
 
@@ -206,6 +224,13 @@ impl fmt::Display for EscrowLifecycleError {
             } => write!(
                 f,
                 "resolution split must equal remaining, expected {expected_remaining}, got {actual_split}"
+            ),
+            Self::TimeoutNotElapsed {
+                current_unix,
+                timeout_unix,
+            } => write!(
+                f,
+                "timeout not elapsed: current_unix {current_unix}, timeout_unix {timeout_unix}"
             ),
             Self::AmountOverflow => write!(f, "escrow amount overflow"),
         }
@@ -248,5 +273,31 @@ mod tests {
         }
         assert_eq!(escrow.status(), EscrowStatus::Refunded);
         assert_eq!(escrow.refunded_amount(), 10);
+    }
+
+    #[test]
+    fn regression_premature_timeout_refund_is_rejected() {
+        // Regression: #542
+        let mut escrow = EscrowLifecycle::new(50).expect("escrow should initialize");
+        assert_eq!(
+            escrow.refund_after_timeout(1_716_620_050, 1_716_620_100),
+            Err(EscrowLifecycleError::TimeoutNotElapsed {
+                current_unix: 1_716_620_050,
+                timeout_unix: 1_716_620_100,
+            })
+        );
+    }
+
+    #[test]
+    fn timeout_refund_at_deadline_refunds_remaining_balance() {
+        let mut escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+        escrow.release(35).expect("release should succeed");
+        escrow
+            .refund_after_timeout(1_716_620_100, 1_716_620_100)
+            .expect("refund at timeout boundary should succeed");
+
+        assert_eq!(escrow.status(), EscrowStatus::Refunded);
+        assert_eq!(escrow.released_amount(), 35);
+        assert_eq!(escrow.refunded_amount(), 65);
     }
 }

--- a/crates/kamn-core/tests/task_payment_workflow.rs
+++ b/crates/kamn-core/tests/task_payment_workflow.rs
@@ -164,3 +164,41 @@ fn regression_duplicate_confirm_is_rejected() {
         Err(TaskPaymentError::DuplicateConfirm("task-pay-4".to_owned()))
     );
 }
+
+#[test]
+fn integration_timeout_refund_recovers_remaining_escrow_after_confirm() {
+    let mut workflow = TaskPaymentWorkflow::new();
+    let tasks = completed_task_engine("task-pay-5");
+    let mut escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+
+    workflow
+        .submit_offer(
+            PaymentOffer {
+                task_id: "task-pay-5".to_owned(),
+                escrow_id: "escrow-5".to_owned(),
+                payer_did: "kamn:did:agent:requester-1".to_owned(),
+                payee_did: "kamn:did:agent:worker-1".to_owned(),
+                amount: 60,
+            },
+            &tasks,
+            &escrow,
+        )
+        .expect("offer should be accepted");
+    workflow
+        .confirm_offer(
+            PaymentConfirm {
+                task_id: "task-pay-5".to_owned(),
+                escrow_id: "escrow-5".to_owned(),
+                confirmer_did: "kamn:did:agent:requester-1".to_owned(),
+            },
+            &mut escrow,
+        )
+        .expect("confirmation should release escrow");
+    escrow
+        .refund_after_timeout(1_716_620_500, 1_716_620_100)
+        .expect("timeout refund should recover remaining funds");
+
+    assert_eq!(escrow.status(), EscrowStatus::Refunded);
+    assert_eq!(escrow.released_amount(), 60);
+    assert_eq!(escrow.refunded_amount(), 40);
+}

--- a/crates/kamn-core/tests/task_payment_workflow_docs.rs
+++ b/crates/kamn-core/tests/task_payment_workflow_docs.rs
@@ -15,11 +15,19 @@ fn doc_contains_completion_and_escrow_validation_rules() {
     assert!(DOC.contains("target task in `Completed` state."));
     assert!(DOC.contains("offered amount less than or equal to escrow remaining balance."));
     assert!(DOC.contains("single-use confirmation (duplicates are rejected)."));
+    assert!(DOC.contains("current_unix >= timeout_unix"));
     assert!(DOC.contains("## Escrow Release Behavior"));
+    assert!(DOC.contains("EscrowLifecycle::refund_after_timeout(current_unix, timeout_unix)"));
 }
 
 #[test]
 fn regression_requires_duplicate_confirm_rejection_rule() {
     // Regression: #216
     assert!(DOC.contains("duplicates are rejected"));
+}
+
+#[test]
+fn regression_requires_premature_timeout_refund_rejection_rule() {
+    // Regression: #542
+    assert!(DOC.contains("premature timeout refund attempts are rejected (`Regression: #542`)."));
 }

--- a/docs/foundation/task-payment-workflow.md
+++ b/docs/foundation/task-payment-workflow.md
@@ -1,4 +1,4 @@
-# Task Payment Offer/Confirm Workflow (Issue #216)
+# Task Payment Offer/Confirm Workflow (Issues #216 / #542)
 
 This document captures the first implementation slice for integrating `PaymentOffer` and `PaymentConfirm` with task completion and escrow release flow.
 
@@ -20,9 +20,13 @@ This document captures the first implementation slice for integrating `PaymentOf
   - matching task and escrow references for an existing offer.
   - confirmer DID equal to offer payer DID.
   - single-use confirmation (duplicates are rejected).
+- Timeout refunds require:
+  - `current_unix >= timeout_unix` before invoking timeout-conditioned escrow refund.
+  - premature timeout refund attempts are rejected (`Regression: #542`).
 
 ## Escrow Release Behavior
 - Successful `PaymentConfirm` calls `EscrowLifecycle::release(amount)` using the previously accepted offer amount.
+- Timeout-based recovery calls `EscrowLifecycle::refund_after_timeout(current_unix, timeout_unix)` to return the remaining balance once the deadline is reached.
 - Escrow transition and amount validation errors are surfaced as typed workflow errors.
 
 ## Local Validation


### PR DESCRIPTION
## Summary
Adds timeout-conditioned refund support to `EscrowLifecycle` so remaining escrow funds can be recovered only after a configured timeout boundary.
Also adds regression, integration, and documentation guards to keep timeout behavior deterministic and CI-friendly.

Closes #545
Closes #544
Closes #543
Closes #542

## Changes
- `crates/kamn-core/src/escrow.rs`: add `refund_after_timeout(current_unix, timeout_unix)` and typed `TimeoutNotElapsed` error.
- `crates/kamn-core/src/escrow.rs`: add regression and functional tests for timeout rejection/boundary success.
- `crates/kamn-core/tests/task_payment_workflow.rs`: add integration coverage for timeout recovery of remaining escrow after payment confirmation.
- `docs/foundation/task-payment-workflow.md`: document timeout refund preconditions and regression marker.
- `crates/kamn-core/tests/task_payment_workflow_docs.rs`: add doc assertions for timeout rule and regression policy.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core regression_premature_timeout_refund_is_rejected
```
Observed failure (before implementation):
```text
error[E0599]: no method named `refund_after_timeout` found for struct `EscrowLifecycle`
error[E0599]: no variant named `TimeoutNotElapsed` found for enum `EscrowLifecycleError`
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core regression_premature_timeout_refund_is_rejected
cargo test -p kamn-core --test task_payment_workflow --test task_payment_workflow_docs
```
Observed pass summary:
```text
escrow::tests::regression_premature_timeout_refund_is_rejected ... ok

running 5 tests (task_payment_workflow) ... ok
running 4 tests (task_payment_workflow_docs) ... ok
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Observed pass summary:
```text
test result: ok. 233 passed; 0 failed (unit tests)
... full `kamn-core` integration/doc suite passed
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | `regression_premature_timeout_refund_is_rejected`, `timeout_refund_at_deadline_refunds_remaining_balance` |
| Functional   | ✅     | Escrow timeout transition behavior in `escrow.rs` tests                              |                      |
| Integration  | ✅     | `integration_timeout_refund_recovers_remaining_escrow_after_confirm`                 |                      |
| Regression   | ✅     | `Regression: #542` rejection of premature timeout refunds                            |                      |
| Performance  | N/A    | No throughput-sensitive path change; constant-time timestamp comparison only          | In-memory check only |

## Risks & Rollback
- Behavioral tightening: timeout-conditioned refunds now require deadline satisfaction and return typed errors pre-deadline.
- Rollback plan: revert PR #551 commit if downstream callers require interim compatibility while migration is coordinated.

## Documentation Updates
- `docs/foundation/task-payment-workflow.md`
- `crates/kamn-core/tests/task_payment_workflow_docs.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
