### PR TITLE
fix(networking): reject stale inbound bridge events (#548)

### DIFF
--- a/crates/kamn-core/src/bridge_adapter.rs
+++ b/crates/kamn-core/src/bridge_adapter.rs
@@ -7,6 +7,8 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+const DEFAULT_MAX_INBOUND_AGE_SECS: u64 = 300;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BridgePlatform {
     Telegram,
@@ -44,6 +46,7 @@ pub struct BridgeInboundEnvelope {
     pub target_agent_did: String,
     pub body: String,
     pub received_at: String,
+    pub received_at_unix: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,6 +57,7 @@ pub struct NormalizedInboundMessage {
     pub target_agent_did: String,
     pub body: String,
     pub received_at: String,
+    pub received_at_unix: u64,
     pub platform: BridgePlatform,
 }
 
@@ -165,6 +169,7 @@ impl BridgeAdapter for PassThroughBridgeAdapter {
             target_agent_did: inbound.target_agent_did.clone(),
             body: inbound.body.clone(),
             received_at: inbound.received_at.clone(),
+            received_at_unix: inbound.received_at_unix,
             platform: self.platform(),
         })
     }
@@ -192,6 +197,7 @@ impl BridgeAdapter for PassThroughBridgeAdapter {
 pub struct BridgeAdapterEngine<A, P> {
     adapter: A,
     policy: P,
+    max_inbound_age_secs: u64,
     seen_inbound_message_ids: RefCell<BTreeSet<String>>,
     seen_outbound_request_ids: RefCell<BTreeSet<String>>,
 }
@@ -202,9 +208,14 @@ where
     P: BridgePolicyHook,
 {
     pub fn new(adapter: A, policy: P) -> Self {
+        Self::with_inbound_freshness_window(adapter, policy, DEFAULT_MAX_INBOUND_AGE_SECS)
+    }
+
+    pub fn with_inbound_freshness_window(adapter: A, policy: P, max_inbound_age_secs: u64) -> Self {
         Self {
             adapter,
             policy,
+            max_inbound_age_secs,
             seen_inbound_message_ids: RefCell::new(BTreeSet::new()),
             seen_outbound_request_ids: RefCell::new(BTreeSet::new()),
         }
@@ -213,12 +224,23 @@ where
     pub fn process_inbound(
         &self,
         inbound: &BridgeInboundEnvelope,
+        observed_at_unix: u64,
     ) -> Result<NormalizedInboundMessage, BridgeAdapterError> {
         validate_did(self.adapter.bridge_agent_did())?;
         validate_inbound_envelope(inbound)?;
+        validate_timestamp("observed_at_unix", observed_at_unix)?;
         let normalized = self.adapter.normalize_inbound(inbound)?;
         validate_normalized_inbound(&normalized)?;
         self.policy.authorize_inbound(&normalized)?;
+        let age_secs = observed_at_unix.saturating_sub(normalized.received_at_unix);
+        if age_secs > self.max_inbound_age_secs {
+            return Err(BridgeAdapterError::StaleInboundMessage {
+                bridge_message_id: normalized.bridge_message_id.clone(),
+                received_at_unix: normalized.received_at_unix,
+                observed_at_unix,
+                max_age_secs: self.max_inbound_age_secs,
+            });
+        }
         let bridge_message_id = normalized.bridge_message_id.clone();
         if !self
             .seen_inbound_message_ids
@@ -265,6 +287,7 @@ where
     pub fn process_inbound_to_envelope(
         &self,
         inbound: &BridgeInboundEnvelope,
+        observed_at_unix: u64,
         recipient_keys: Vec<String>,
         expires: &str,
         nonce: u64,
@@ -280,7 +303,7 @@ where
             return Err(BridgeAdapterError::InvalidNonce(nonce));
         }
 
-        let normalized = self.process_inbound(inbound)?;
+        let normalized = self.process_inbound(inbound, observed_at_unix)?;
 
         let mut body = BTreeMap::new();
         body.insert("message".to_owned(), normalized.body.clone());
@@ -338,7 +361,14 @@ pub enum BridgeAdapterError {
     DuplicateOutboundRequestId(String),
     EmptyField(&'static str),
     InvalidDid(String),
+    InvalidTimestamp(&'static str),
     InvalidNonce(u64),
+    StaleInboundMessage {
+        bridge_message_id: String,
+        received_at_unix: u64,
+        observed_at_unix: u64,
+        max_age_secs: u64,
+    },
     PolicyDenied {
         direction: BridgeDirection,
         reason: String,
@@ -361,7 +391,17 @@ impl fmt::Display for BridgeAdapterError {
             }
             Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
             Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidTimestamp(field) => write!(f, "timestamp must be > 0: {field}"),
             Self::InvalidNonce(value) => write!(f, "nonce must be greater than zero: {value}"),
+            Self::StaleInboundMessage {
+                bridge_message_id,
+                received_at_unix,
+                observed_at_unix,
+                max_age_secs,
+            } => write!(
+                f,
+                "stale inbound message: id={bridge_message_id}, received_at_unix={received_at_unix}, observed_at_unix={observed_at_unix}, max_age_secs={max_age_secs}"
+            ),
             Self::PolicyDenied { direction, reason } => {
                 write!(f, "policy denied {direction:?} traffic: {reason}")
             }
@@ -392,6 +432,10 @@ fn validate_inbound_envelope(inbound: &BridgeInboundEnvelope) -> Result<(), Brid
     validate_did(&inbound.target_agent_did)?;
     validate_non_empty("bridge_inbound_envelope.body", &inbound.body)?;
     validate_non_empty("bridge_inbound_envelope.received_at", &inbound.received_at)?;
+    validate_timestamp(
+        "bridge_inbound_envelope.received_at_unix",
+        inbound.received_at_unix,
+    )?;
     Ok(())
 }
 
@@ -415,6 +459,10 @@ fn validate_normalized_inbound(
     validate_non_empty(
         "normalized_inbound_message.received_at",
         &normalized.received_at,
+    )?;
+    validate_timestamp(
+        "normalized_inbound_message.received_at_unix",
+        normalized.received_at_unix,
     )?;
     if normalized.platform.label().is_empty() {
         return Err(BridgeAdapterError::EmptyField(
@@ -445,6 +493,13 @@ fn validate_non_empty(field: &'static str, value: &str) -> Result<(), BridgeAdap
 
 fn validate_did(value: &str) -> Result<(), BridgeAdapterError> {
     AgentDid::parse(value).map_err(|error| BridgeAdapterError::InvalidDid(error.to_string()))?;
+    Ok(())
+}
+
+fn validate_timestamp(field: &'static str, value: u64) -> Result<(), BridgeAdapterError> {
+    if value == 0 {
+        return Err(BridgeAdapterError::InvalidTimestamp(field));
+    }
     Ok(())
 }
 
@@ -506,6 +561,7 @@ mod tests {
                     target_agent_did: inbound.target_agent_did.clone(),
                     body: inbound.body.clone(),
                     received_at: inbound.received_at.clone(),
+                    received_at_unix: inbound.received_at_unix,
                     platform: self.platform(),
                 })
             }
@@ -556,10 +612,17 @@ mod tests {
             target_agent_did: "kamn:did:agent:planner-1".to_owned(),
             body: "hello".to_owned(),
             received_at: "2026-02-08T09:00:00Z".to_owned(),
+            received_at_unix: 1_707_383_600,
         };
 
         assert_eq!(
-            engine.process_inbound_to_envelope(&inbound, Vec::new(), "2026-02-08T10:00:00Z", 1),
+            engine.process_inbound_to_envelope(
+                &inbound,
+                1_707_383_600,
+                Vec::new(),
+                "2026-02-08T10:00:00Z",
+                1,
+            ),
             Err(BridgeAdapterError::EmptyField("recipient_keys"))
         );
     }
@@ -579,11 +642,12 @@ mod tests {
             target_agent_did: "kamn:did:agent:planner-1".to_owned(),
             body: "hello".to_owned(),
             received_at: "2026-02-08T09:00:00Z".to_owned(),
+            received_at_unix: 1_707_383_600,
         };
 
-        assert!(engine.process_inbound(&inbound).is_ok());
+        assert!(engine.process_inbound(&inbound, 1_707_383_700).is_ok());
         assert_eq!(
-            engine.process_inbound(&inbound),
+            engine.process_inbound(&inbound, 1_707_383_700),
             Err(BridgeAdapterError::DuplicateInboundMessageId(
                 "discord:ext-9".to_owned()
             ))

--- a/crates/kamn-core/src/cross_chain_bridge.rs
+++ b/crates/kamn-core/src/cross_chain_bridge.rs
@@ -34,6 +34,7 @@ pub struct CrossChainBridgeConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainInboundRequest {
     pub listener_did: String,
+    pub observed_at_unix: u64,
     pub chain: CrossChainNetwork,
     pub inbound: BridgeInboundEnvelope,
 }
@@ -133,7 +134,7 @@ impl CrossChainBridgeEngine {
     ) -> Result<NormalizedInboundMessage, CrossChainBridgeError> {
         self.validate_inbound_request(request)?;
         self.bridge_engine(request.chain)
-            .process_inbound(&request.inbound)
+            .process_inbound(&request.inbound, request.observed_at_unix)
             .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
     }
 
@@ -146,7 +147,13 @@ impl CrossChainBridgeEngine {
     ) -> Result<CanonicalMessageEnvelope, CrossChainBridgeError> {
         self.validate_inbound_request(request)?;
         self.bridge_engine(request.chain)
-            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .process_inbound_to_envelope(
+                &request.inbound,
+                request.observed_at_unix,
+                recipient_keys,
+                expires,
+                nonce,
+            )
             .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
     }
 

--- a/crates/kamn-core/src/discord_bridge.rs
+++ b/crates/kamn-core/src/discord_bridge.rs
@@ -18,6 +18,7 @@ pub struct DiscordBridgeConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordInboundRequest {
     pub listener_did: String,
+    pub observed_at_unix: u64,
     pub inbound: BridgeInboundEnvelope,
 }
 
@@ -87,7 +88,7 @@ impl DiscordBridgeEngine {
         self.validate_inbound_request(request)?;
 
         self.bridge
-            .process_inbound(&request.inbound)
+            .process_inbound(&request.inbound, request.observed_at_unix)
             .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
     }
 
@@ -100,7 +101,13 @@ impl DiscordBridgeEngine {
     ) -> Result<CanonicalMessageEnvelope, DiscordBridgeError> {
         self.validate_inbound_request(request)?;
         self.bridge
-            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .process_inbound_to_envelope(
+                &request.inbound,
+                request.observed_at_unix,
+                recipient_keys,
+                expires,
+                nonce,
+            )
             .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
     }
 

--- a/crates/kamn-core/src/telegram_bridge.rs
+++ b/crates/kamn-core/src/telegram_bridge.rs
@@ -15,6 +15,7 @@ pub struct TelegramBridgeConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelegramInboundRequest {
     pub listener_did: String,
+    pub observed_at_unix: u64,
     pub inbound: BridgeInboundEnvelope,
 }
 
@@ -56,7 +57,7 @@ impl TelegramBridgeEngine {
         self.validate_inbound_request(request)?;
 
         self.bridge
-            .process_inbound(&request.inbound)
+            .process_inbound(&request.inbound, request.observed_at_unix)
             .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
     }
 
@@ -69,7 +70,13 @@ impl TelegramBridgeEngine {
     ) -> Result<CanonicalMessageEnvelope, TelegramBridgeError> {
         self.validate_inbound_request(request)?;
         self.bridge
-            .process_inbound_to_envelope(&request.inbound, recipient_keys, expires, nonce)
+            .process_inbound_to_envelope(
+                &request.inbound,
+                request.observed_at_unix,
+                recipient_keys,
+                expires,
+                nonce,
+            )
             .map_err(|error| TelegramBridgeError::Bridge(error.to_string()))
     }
 

--- a/crates/kamn-core/tests/bridge_adapter.rs
+++ b/crates/kamn-core/tests/bridge_adapter.rs
@@ -12,6 +12,7 @@ fn inbound_sample() -> BridgeInboundEnvelope {
         target_agent_did: "kamn:did:agent:planner-1".to_owned(),
         body: "Need a sprint plan".to_owned(),
         received_at: "2026-02-08T10:00:00Z".to_owned(),
+        received_at_unix: 1_716_620_000,
     }
 }
 
@@ -33,7 +34,7 @@ fn inbound_is_normalized_deterministically() {
     let engine = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
 
     let normalized = engine
-        .process_inbound(&inbound_sample())
+        .process_inbound(&inbound_sample(), 1_716_620_100)
         .expect("inbound should normalize");
 
     assert_eq!(normalized.bridge_message_id, "discord:ext-42");
@@ -68,6 +69,7 @@ fn inbound_can_be_projected_to_canonical_envelope() {
     let envelope = engine
         .process_inbound_to_envelope(
             &inbound_sample(),
+            1_716_620_100,
             vec!["recipient-key-1".to_owned()],
             "2026-02-08T11:00:00Z",
             91,
@@ -127,6 +129,7 @@ impl BridgeAdapter for MismatchedOutboundAdapter {
             target_agent_did: inbound.target_agent_did.clone(),
             body: inbound.body.clone(),
             received_at: inbound.received_at.clone(),
+            received_at_unix: inbound.received_at_unix,
             platform: self.platform(),
         })
     }
@@ -182,10 +185,10 @@ fn regression_rejects_duplicate_inbound_event_replay() {
     let engine = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
 
     engine
-        .process_inbound(&inbound_sample())
+        .process_inbound(&inbound_sample(), 1_716_620_100)
         .expect("first inbound event should normalize");
     assert_eq!(
-        engine.process_inbound(&inbound_sample()),
+        engine.process_inbound(&inbound_sample(), 1_716_620_100),
         Err(BridgeAdapterError::DuplicateInboundMessageId(
             "discord:ext-42".to_owned()
         ))
@@ -209,5 +212,24 @@ fn regression_rejects_duplicate_outbound_request_replay() {
     assert_eq!(
         replay_error.to_string(),
         "duplicate outbound request id: req-7"
+    );
+}
+
+#[test]
+fn regression_rejects_stale_inbound_event() {
+    // Regression: #546
+    let adapter =
+        PassThroughBridgeAdapter::new(BridgePlatform::Discord, "kamn:did:agent:bridge-discord-1")
+            .expect("adapter should build");
+    let engine = BridgeAdapterEngine::new(adapter, AllowAllBridgePolicy::new());
+
+    assert_eq!(
+        engine.process_inbound(&inbound_sample(), 1_716_621_000),
+        Err(BridgeAdapterError::StaleInboundMessage {
+            bridge_message_id: "discord:ext-42".to_owned(),
+            received_at_unix: 1_716_620_000,
+            observed_at_unix: 1_716_621_000,
+            max_age_secs: 300,
+        })
     );
 }

--- a/crates/kamn-core/tests/bridge_adapter_docs.rs
+++ b/crates/kamn-core/tests/bridge_adapter_docs.rs
@@ -22,6 +22,14 @@ fn regression_requires_duplicate_outbound_replay_rejection_rule() {
 }
 
 #[test]
+fn regression_requires_stale_inbound_rejection_rule() {
+    // Regression: #546
+    assert!(DOC.contains("StaleInboundMessage"));
+    assert!(DOC
+        .contains("stale inbound event beyond freshness window is rejected (`Regression: #546`)"));
+}
+
+#[test]
 fn regression_requires_single_pass_projection_rule() {
     // Regression: #438
     assert!(DOC.contains("single-pass inbound projection"));

--- a/crates/kamn-core/tests/cross_chain_bridge.rs
+++ b/crates/kamn-core/tests/cross_chain_bridge.rs
@@ -43,6 +43,7 @@ fn eth_inbound(target: &str) -> BridgeInboundEnvelope {
         target_agent_did: target.to_owned(),
         body: "event:PaymentOffer".to_owned(),
         received_at: "2026-02-08T09:00:00Z".to_owned(),
+        received_at_unix: 1_707_383_200,
     }
 }
 
@@ -54,6 +55,7 @@ fn solana_inbound(target: &str) -> BridgeInboundEnvelope {
         target_agent_did: target.to_owned(),
         body: "event:TaskStateChanged".to_owned(),
         received_at: "2026-02-08T09:05:00Z".to_owned(),
+        received_at_unix: 1_707_383_500,
     }
 }
 
@@ -74,6 +76,7 @@ fn ethereum_listener_can_process_inbound() {
     let normalized = engine
         .process_inbound(&CrossChainInboundRequest {
             listener_did: "kamn:did:agent:listener-1".to_owned(),
+            observed_at_unix: 1_707_383_260,
             chain: CrossChainNetwork::Ethereum,
             inbound: eth_inbound("kamn:did:agent:listener-target-eth"),
         })
@@ -137,6 +140,7 @@ fn integration_projects_solana_inbound_to_envelope() {
         .process_inbound_to_envelope(
             &CrossChainInboundRequest {
                 listener_did: "kamn:did:agent:listener-1".to_owned(),
+                observed_at_unix: 1_707_383_560,
                 chain: CrossChainNetwork::Solana,
                 inbound: solana_inbound("kamn:did:agent:listener-target-sol"),
             },
@@ -162,6 +166,7 @@ fn regression_rejects_replayed_solana_inbound_projection_event() {
     let engine = CrossChainBridgeEngine::new(config()).expect("engine should build");
     let request = CrossChainInboundRequest {
         listener_did: "kamn:did:agent:listener-1".to_owned(),
+        observed_at_unix: 1_707_383_560,
         chain: CrossChainNetwork::Solana,
         inbound: solana_inbound("kamn:did:agent:listener-target-sol"),
     };
@@ -195,6 +200,7 @@ fn regression_unknown_ethereum_route_is_rejected() {
     assert_eq!(
         engine.process_inbound(&CrossChainInboundRequest {
             listener_did: "kamn:did:agent:listener-1".to_owned(),
+            observed_at_unix: 1_707_383_260,
             chain: CrossChainNetwork::Ethereum,
             inbound: BridgeInboundEnvelope {
                 external_channel_id: "ethereum:sepolia:contract:unknown".to_owned(),

--- a/crates/kamn-core/tests/discord_bridge.rs
+++ b/crates/kamn-core/tests/discord_bridge.rs
@@ -36,6 +36,7 @@ fn inbound(target: &str) -> BridgeInboundEnvelope {
         target_agent_did: target.to_owned(),
         body: "run diagnostics".to_owned(),
         received_at: "2026-02-08T04:00:00Z".to_owned(),
+        received_at_unix: 1_707_365_600,
     }
 }
 
@@ -111,6 +112,7 @@ fn integration_processes_discord_inbound_to_envelope() {
         .process_inbound_to_envelope(
             &DiscordInboundRequest {
                 listener_did: "kamn:did:agent:listener-1".to_owned(),
+                observed_at_unix: 1_707_365_700,
                 inbound: inbound("kamn:did:agent:listener-target-1"),
             },
             vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
@@ -135,6 +137,7 @@ fn regression_rejects_replayed_discord_inbound_projection_event() {
     let engine = DiscordBridgeEngine::new(config()).expect("engine should build");
     let request = DiscordInboundRequest {
         listener_did: "kamn:did:agent:listener-1".to_owned(),
+        observed_at_unix: 1_707_365_700,
         inbound: inbound("kamn:did:agent:listener-target-1"),
     };
 

--- a/crates/kamn-core/tests/telegram_bridge.rs
+++ b/crates/kamn-core/tests/telegram_bridge.rs
@@ -28,6 +28,7 @@ fn inbound(target: &str) -> BridgeInboundEnvelope {
         target_agent_did: target.to_owned(),
         body: "run diagnostics".to_owned(),
         received_at: "2026-02-07T21:00:00Z".to_owned(),
+        received_at_unix: 1_707_340_800,
     }
 }
 
@@ -38,6 +39,7 @@ fn authorized_listener_can_process_inbound() {
     let normalized = engine
         .process_inbound(&TelegramInboundRequest {
             listener_did: "kamn:did:agent:listener-1".to_owned(),
+            observed_at_unix: 1_707_340_900,
             inbound: inbound("kamn:did:agent:listener-target-1"),
         })
         .expect("inbound should process");
@@ -57,6 +59,7 @@ fn integration_processes_inbound_to_canonical_envelope() {
         .process_inbound_to_envelope(
             &TelegramInboundRequest {
                 listener_did: "kamn:did:agent:listener-1".to_owned(),
+                observed_at_unix: 1_707_340_900,
                 inbound: inbound("kamn:did:agent:listener-target-1"),
             },
             vec!["kamn:did:agent:listener-target-1#key-agreement-1".to_owned()],
@@ -81,6 +84,7 @@ fn regression_rejects_replayed_telegram_inbound_projection_event() {
     let engine = TelegramBridgeEngine::new(config()).expect("engine should build");
     let request = TelegramInboundRequest {
         listener_did: "kamn:did:agent:listener-1".to_owned(),
+        observed_at_unix: 1_707_340_900,
         inbound: inbound("kamn:did:agent:listener-target-1"),
     };
 
@@ -112,6 +116,7 @@ fn route_target_mismatch_is_rejected() {
     assert_eq!(
         engine.process_inbound(&TelegramInboundRequest {
             listener_did: "kamn:did:agent:listener-1".to_owned(),
+            observed_at_unix: 1_707_340_900,
             inbound: inbound("kamn:did:agent:different-target"),
         }),
         Err(TelegramBridgeError::RouteTargetMismatch {
@@ -130,6 +135,7 @@ fn regression_unauthorized_listener_is_rejected() {
     assert_eq!(
         engine.process_inbound(&TelegramInboundRequest {
             listener_did: "kamn:did:agent:listener-x".to_owned(),
+            observed_at_unix: 1_707_340_900,
             inbound: inbound("kamn:did:agent:listener-target-1"),
         }),
         Err(TelegramBridgeError::UnauthorizedListener(

--- a/docs/foundation/bridge-adapter-abstraction.md
+++ b/docs/foundation/bridge-adapter-abstraction.md
@@ -1,4 +1,4 @@
-# Bridge Adapter Abstraction (Issues #130, #131)
+# Bridge Adapter Abstraction (Issues #130, #131, #546)
 
 This document describes the first implementation slice for bridge adapter abstraction aligned to PRD section 10.1 and story #34.
 
@@ -21,9 +21,11 @@ This document describes the first implementation slice for bridge adapter abstra
 ## Design Notes
 - Inbound flow:
   - Validate external envelope fields and target DID.
+  - Enforce timestamp freshness by requiring `observed_at_unix - received_at_unix <= max_inbound_age_secs`.
   - Normalize external payload into deterministic `bridge_message_id` (`<platform>:<external_message_id>`).
   - Apply policy hook before returning normalized message.
   - Duplicate inbound message IDs are rejected with `DuplicateInboundMessageId`.
+  - Stale inbound messages are rejected with `StaleInboundMessage`.
 - Outbound flow:
   - Validate request fields and sender DID.
   - Apply policy hook before translation.
@@ -48,5 +50,6 @@ cargo test -p kamn-core
 - Replace static allow-all policy with channel and capability-aware policy implementations.
 - duplicate inbound event is rejected (`Regression: #423`).
 - duplicate outbound request is rejected (`Regression: #433`).
+- stale inbound event beyond freshness window is rejected (`Regression: #546`).
 - first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`).
 - cross-chain inbound projection also preserves single-pass replay safety (`Regression: #443`).


### PR DESCRIPTION
## Summary
Adds deterministic freshness-window enforcement for inbound bridge events so stale messages are rejected before replay registration and envelope projection.
Propagates observed-time metadata through bridge wrapper request types and updates tests/docs to lock regression behavior.

Closes #549
Closes #548
Closes #547
Closes #546

## Changes
- `crates/kamn-core/src/bridge_adapter.rs`: add `received_at_unix` model fields, freshness-window config (`DEFAULT_MAX_INBOUND_AGE_SECS`), observed-time-aware `process_inbound`/`process_inbound_to_envelope`, and `StaleInboundMessage` error.
- `crates/kamn-core/src/telegram_bridge.rs`, `crates/kamn-core/src/discord_bridge.rs`, `crates/kamn-core/src/cross_chain_bridge.rs`: add `observed_at_unix` to inbound request models and pass through to bridge adapter engine.
- `crates/kamn-core/tests/bridge_adapter.rs`: add stale inbound regression (`Regression: #546`) and adapt call signatures.
- `crates/kamn-core/tests/telegram_bridge.rs`, `crates/kamn-core/tests/discord_bridge.rs`, `crates/kamn-core/tests/cross_chain_bridge.rs`: update inbound fixtures and requests with deterministic unix timestamps.
- `docs/foundation/bridge-adapter-abstraction.md` + `crates/kamn-core/tests/bridge_adapter_docs.rs`: document/assert stale event rejection rule.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test bridge_adapter
```
Observed failure (before implementation):
```text
error[E0061]: this method takes 1 argument but 2 arguments were supplied
error[E0599]: no variant named `StaleInboundMessage` found for enum `BridgeAdapterError`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test bridge_adapter --test bridge_adapter_docs --test telegram_bridge --test discord_bridge --test cross_chain_bridge
```
Observed pass summary:
```text
bridge_adapter: 8 passed
bridge_adapter_docs: 6 passed
telegram_bridge: 5 passed
discord_bridge: 6 passed
cross_chain_bridge: 6 passed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Observed pass summary:
```text
test result: ok. 233 passed; 0 failed (unit tests)
... full `kamn-core` integration/doc suite passed
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | Bridge adapter internal validation paths and error surfaces in module tests           |                      |
| Functional   | ✅     | `inbound_is_normalized_deterministically`, wrapper inbound acceptance paths           |                      |
| Integration  | ✅     | Bridge wrapper tests (`telegram_bridge`, `discord_bridge`, `cross_chain_bridge`)      |                      |
| Regression   | ✅     | `regression_rejects_stale_inbound_event` (`Regression: #546`)                         |                      |
| Performance  | N/A    | Constant-time timestamp age check; no new I/O or expensive cryptographic path         | In-memory guard only |

## Risks & Rollback
- API change: inbound request models now require `observed_at_unix`; bridge callers must supply deterministic observed timestamps.
- Rollback plan: revert PR #552 commit if downstream callers need temporary compatibility while request-shape migration is coordinated.

## Documentation Updates
- `docs/foundation/bridge-adapter-abstraction.md`
- `crates/kamn-core/tests/bridge_adapter_docs.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
