### PR TITLE
fix(security): reject empty instruction signatures (#555)

### DIFF
--- a/crates/kamn-core/src/instruction_verify.rs
+++ b/crates/kamn-core/src/instruction_verify.rs
@@ -75,6 +75,8 @@ pub enum VerificationFailure {
         actual: String,
     },
     PayloadMismatch,
+    MissingClaimSignature,
+    MissingRecordSignature,
     SignatureMismatch,
     InclusionProofMismatch {
         expected: String,
@@ -131,6 +133,12 @@ impl InstructionVerifier {
         }
         if record.payload_hash != claim.payload_hash {
             return VerificationOutcome::Rejected(VerificationFailure::PayloadMismatch);
+        }
+        if claim.signature.trim().is_empty() {
+            return VerificationOutcome::Rejected(VerificationFailure::MissingClaimSignature);
+        }
+        if record.signature.trim().is_empty() {
+            return VerificationOutcome::Rejected(VerificationFailure::MissingRecordSignature);
         }
         if record.signature != claim.signature {
             return VerificationOutcome::Rejected(VerificationFailure::SignatureMismatch);
@@ -319,6 +327,58 @@ mod tests {
         assert_eq!(
             InstructionVerifier::verify(&claim, &context),
             VerificationOutcome::Rejected(VerificationFailure::MissingInclusionProofReference)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_claim_signature() {
+        let context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "kamn:did:agent:alpha".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: "sig".to_owned(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            })
+            .with_authorized_sender("kamn:did:agent:alpha");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "kamn:did:agent:alpha".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: String::new(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify(&claim, &context),
+            VerificationOutcome::Rejected(VerificationFailure::MissingClaimSignature)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_record_signature() {
+        let context = VerificationContext::new(100)
+            .with_instruction(InstructionRecord {
+                id: "ins_1".to_owned(),
+                from_did: "kamn:did:agent:alpha".to_owned(),
+                payload_hash: "hash_a".to_owned(),
+                signature: String::new(),
+                inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            })
+            .with_authorized_sender("kamn:did:agent:alpha");
+        let claim = InstructionClaim {
+            instruction_id: "ins_1".to_owned(),
+            from_did: "kamn:did:agent:alpha".to_owned(),
+            payload_hash: "hash_a".to_owned(),
+            signature: "sig".to_owned(),
+            inclusion_proof_ref: "proof:chain:tx-1".to_owned(),
+            expires_at_unix: 120,
+        };
+
+        assert_eq!(
+            InstructionVerifier::verify(&claim, &context),
+            VerificationOutcome::Rejected(VerificationFailure::MissingRecordSignature)
         );
     }
 

--- a/crates/kamn-core/tests/instruction_verification.rs
+++ b/crates/kamn-core/tests/instruction_verification.rs
@@ -208,3 +208,35 @@ fn regression_rejects_invalid_record_sender_did() {
         ))
     );
 }
+
+#[test]
+fn regression_rejects_empty_claim_signature() {
+    // Regression: #553
+    let record = sample_record();
+    let mut claim = sample_claim();
+    claim.signature.clear();
+    let context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("kamn:did:agent:alpha");
+
+    assert_eq!(
+        InstructionVerifier::verify(&claim, &context),
+        VerificationOutcome::Rejected(VerificationFailure::MissingClaimSignature)
+    );
+}
+
+#[test]
+fn regression_rejects_empty_record_signature() {
+    // Regression: #553
+    let mut record = sample_record();
+    record.signature.clear();
+    let claim = sample_claim();
+    let context = VerificationContext::new(100)
+        .with_instruction(record)
+        .with_authorized_sender("kamn:did:agent:alpha");
+
+    assert_eq!(
+        InstructionVerifier::verify(&claim, &context),
+        VerificationOutcome::Rejected(VerificationFailure::MissingRecordSignature)
+    );
+}

--- a/crates/kamn-core/tests/instruction_verification_docs.rs
+++ b/crates/kamn-core/tests/instruction_verification_docs.rs
@@ -42,3 +42,12 @@ fn regression_requires_sender_did_validation_rules() {
     assert!(DOC.contains("InvalidRecordSenderDid"));
     assert!(DOC.contains("malformed claim or record sender DID is rejected (`Regression: #453`)"));
 }
+
+#[test]
+fn regression_requires_non_empty_signature_rules() {
+    // Regression: #553
+    assert!(DOC.contains("Claim and on-chain signatures must be non-empty."));
+    assert!(DOC.contains("MissingClaimSignature"));
+    assert!(DOC.contains("MissingRecordSignature"));
+    assert!(DOC.contains("empty claim or record signatures are rejected (`Regression: #553`)."));
+}

--- a/docs/foundation/instruction-verification.md
+++ b/docs/foundation/instruction-verification.md
@@ -1,4 +1,4 @@
-# Instruction Verification Pipeline (Issues #144, #145)
+# Instruction Verification Pipeline (Issues #144, #145, #553)
 
 This document captures the first implementation slice of anti-hallucination instruction verification controls.
 
@@ -16,17 +16,20 @@ This document captures the first implementation slice of anti-hallucination inst
 2. sender DID format validation: claim sender DID and on-chain sender DID are syntactically valid.
 3. Claim sender matches on-chain sender.
 4. Claim payload hash matches on-chain payload hash.
-5. Claim signature matches on-chain signature.
-6. Sender is explicitly authorized.
-7. Claim is not expired relative to deterministic current time.
-8. bounded claim validity window is enforced against context policy.
-9. one-time claim consumption is enforced on replay-aware verification path.
-10. inclusion proof reference must be present and match the on-chain record.
+5. Claim and on-chain signatures must be non-empty.
+6. Claim signature matches on-chain signature.
+7. Sender is explicitly authorized.
+8. Claim is not expired relative to deterministic current time.
+9. bounded claim validity window is enforced against context policy.
+10. one-time claim consumption is enforced on replay-aware verification path.
+11. inclusion proof reference must be present and match the on-chain record.
 
 ## Rejection Outcomes
 - `MissingInstruction`
 - `SenderMismatch`
 - `PayloadMismatch`
+- `MissingClaimSignature`
+- `MissingRecordSignature`
 - `SignatureMismatch`
 - `InvalidClaimSenderDid`
 - `InvalidRecordSenderDid`
@@ -40,6 +43,7 @@ This document captures the first implementation slice of anti-hallucination inst
 - replayed claim is rejected (`Regression: #414`).
 - mismatched or missing inclusion proof reference is rejected (`Regression: #448`).
 - malformed claim or record sender DID is rejected (`Regression: #453`).
+- empty claim or record signatures are rejected (`Regression: #553`).
 
 ## Local Validation
 Run from repository root:


### PR DESCRIPTION
## Summary
Hardens instruction verification by requiring non-empty claim and record signatures before signature comparison.
Adds typed failure outcomes, regression coverage, and documentation updates to prevent empty-signature bypasses.

Closes #556
Closes #555
Closes #554
Closes #553

## Changes
- `crates/kamn-core/src/instruction_verify.rs`: add `MissingClaimSignature` and `MissingRecordSignature` failure variants and enforce non-empty signature checks in verifier flow.
- `crates/kamn-core/src/instruction_verify.rs`: add module tests for missing claim/record signatures.
- `crates/kamn-core/tests/instruction_verification.rs`: add regression tests for empty claim and record signatures (`Regression: #553`).
- `docs/foundation/instruction-verification.md`: document signature-presence requirement and regression marker.
- `crates/kamn-core/tests/instruction_verification_docs.rs`: add doc assertions for new signature guard rules.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test instruction_verification
```
Observed failure (before implementation):
```text
error[E0599]: no variant or associated item named `MissingClaimSignature` found for enum `VerificationFailure`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test instruction_verification --test instruction_verification_docs
```
Observed pass summary:
```text
instruction_verification: 13 passed
instruction_verification_docs: 6 passed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test -p kamn-core
```
Observed pass summary:
```text
test result: ok. 235 passed; 0 failed (unit tests)
... full `kamn-core` integration/doc suite passed
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | `rejects_missing_claim_signature`, `rejects_missing_record_signature`                 |                      |
| Functional   | ✅     | Existing valid claim verification path remains `VerificationOutcome::Valid`           |                      |
| Integration  | ✅     | `instruction_verification` target includes claim/record empty-signature scenarios     |                      |
| Regression   | ✅     | `regression_rejects_empty_claim_signature`, `regression_rejects_empty_record_signature` (`Regression: #553`) |
| Performance  | N/A    | Constant-time string presence checks only                                             | No new heavy path    |

## Risks & Rollback
- Behavioral tightening: unsigned/empty-signature instructions are now rejected with explicit typed failures.
- Rollback plan: revert PR #553 commit if downstream consumers require temporary compatibility while adapting to the new failure variants.

## Documentation Updates
- `docs/foundation/instruction-verification.md`
- `crates/kamn-core/tests/instruction_verification_docs.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
