### PR TITLE
fix(payments): enforce task participant binding in offers (#560)

### DIFF
--- a/crates/kamn-core/src/task_payment.rs
+++ b/crates/kamn-core/src/task_payment.rs
@@ -61,6 +61,7 @@ impl TaskPaymentWorkflow {
                 state,
             });
         }
+        validate_offer_participants(&offer, &task.requester, task.assignee.as_deref())?;
 
         let remaining = escrow.remaining_amount();
         if offer.amount > remaining {
@@ -130,8 +131,11 @@ pub enum TaskPaymentError {
     EscrowMismatch { expected: String, found: String },
     InvalidDid(String),
     InvalidOfferAmount(u128),
+    PayerRequesterMismatch { expected: String, found: String },
+    PayeeAssigneeMismatch { expected: String, found: String },
     OfferExceedsEscrow { offered: u128, remaining: u128 },
     TaskLookup(String),
+    TaskMissingAssignee(String),
     TaskNotCompleted { task_id: String, state: TaskState },
     UnauthorizedConfirmer { expected: String, found: String },
     UnknownOffer(String),
@@ -156,11 +160,22 @@ impl fmt::Display for TaskPaymentError {
             Self::InvalidOfferAmount(amount) => {
                 write!(f, "offer amount must be greater than zero, found {amount}")
             }
+            Self::PayerRequesterMismatch { expected, found } => write!(
+                f,
+                "payer DID must match task requester, expected {expected}, found {found}"
+            ),
+            Self::PayeeAssigneeMismatch { expected, found } => write!(
+                f,
+                "payee DID must match task assignee, expected {expected}, found {found}"
+            ),
             Self::OfferExceedsEscrow { offered, remaining } => write!(
                 f,
                 "offer amount exceeds escrow remaining balance, offered {offered}, remaining {remaining}"
             ),
             Self::TaskLookup(error) => write!(f, "task lookup failed: {error}"),
+            Self::TaskMissingAssignee(task_id) => {
+                write!(f, "task {task_id} has no assignee for payment offer")
+            }
             Self::TaskNotCompleted { task_id, state } => {
                 write!(
                     f,
@@ -196,6 +211,30 @@ fn validate_did(value: &str) -> Result<(), TaskPaymentError> {
     Ok(())
 }
 
+fn validate_offer_participants(
+    offer: &PaymentOffer,
+    task_requester: &str,
+    task_assignee: Option<&str>,
+) -> Result<(), TaskPaymentError> {
+    if offer.payer_did != task_requester {
+        return Err(TaskPaymentError::PayerRequesterMismatch {
+            expected: task_requester.to_owned(),
+            found: offer.payer_did.clone(),
+        });
+    }
+
+    let assignee = task_assignee
+        .ok_or_else(|| TaskPaymentError::TaskMissingAssignee(offer.task_id.clone()))?;
+    if offer.payee_did != assignee {
+        return Err(TaskPaymentError::PayeeAssigneeMismatch {
+            expected: assignee.to_owned(),
+            found: offer.payee_did.clone(),
+        });
+    }
+
+    Ok(())
+}
+
 impl From<TaskOperationError> for TaskPaymentError {
     fn from(error: TaskOperationError) -> Self {
         Self::TaskLookup(error.to_string())
@@ -205,5 +244,64 @@ impl From<TaskOperationError> for TaskPaymentError {
 impl From<EscrowLifecycleError> for TaskPaymentError {
     fn from(error: EscrowLifecycleError) -> Self {
         Self::Escrow(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_offer_participants, PaymentOffer, TaskPaymentError};
+
+    fn offer(payer: &str, payee: &str) -> PaymentOffer {
+        PaymentOffer {
+            task_id: "task-pay-unit".to_owned(),
+            escrow_id: "escrow-unit".to_owned(),
+            payer_did: payer.to_owned(),
+            payee_did: payee.to_owned(),
+            amount: 10,
+        }
+    }
+
+    #[test]
+    fn participant_check_rejects_payer_requester_mismatch() {
+        assert_eq!(
+            validate_offer_participants(
+                &offer("kamn:did:agent:observer-9", "kamn:did:agent:worker-1"),
+                "kamn:did:agent:requester-1",
+                Some("kamn:did:agent:worker-1")
+            ),
+            Err(TaskPaymentError::PayerRequesterMismatch {
+                expected: "kamn:did:agent:requester-1".to_owned(),
+                found: "kamn:did:agent:observer-9".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn participant_check_rejects_payee_assignee_mismatch() {
+        assert_eq!(
+            validate_offer_participants(
+                &offer("kamn:did:agent:requester-1", "kamn:did:agent:observer-9"),
+                "kamn:did:agent:requester-1",
+                Some("kamn:did:agent:worker-1")
+            ),
+            Err(TaskPaymentError::PayeeAssigneeMismatch {
+                expected: "kamn:did:agent:worker-1".to_owned(),
+                found: "kamn:did:agent:observer-9".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn participant_check_requires_task_assignee() {
+        assert_eq!(
+            validate_offer_participants(
+                &offer("kamn:did:agent:requester-1", "kamn:did:agent:worker-1"),
+                "kamn:did:agent:requester-1",
+                None
+            ),
+            Err(TaskPaymentError::TaskMissingAssignee(
+                "task-pay-unit".to_owned()
+            ))
+        );
     }
 }

--- a/crates/kamn-core/tests/task_payment_workflow.rs
+++ b/crates/kamn-core/tests/task_payment_workflow.rs
@@ -94,6 +94,62 @@ fn completed_task_offer_confirm_releases_escrow() {
 }
 
 #[test]
+fn regression_rejects_offer_with_payer_mismatch() {
+    // Regression: #558
+    let mut workflow = TaskPaymentWorkflow::new();
+    let tasks = completed_task_engine("task-pay-payer-mismatch");
+    let escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+
+    let result = workflow.submit_offer(
+        PaymentOffer {
+            task_id: "task-pay-payer-mismatch".to_owned(),
+            escrow_id: "escrow-payer-mismatch".to_owned(),
+            payer_did: "kamn:did:agent:observer-9".to_owned(),
+            payee_did: "kamn:did:agent:worker-1".to_owned(),
+            amount: 60,
+        },
+        &tasks,
+        &escrow,
+    );
+
+    assert_eq!(
+        result,
+        Err(TaskPaymentError::PayerRequesterMismatch {
+            expected: "kamn:did:agent:requester-1".to_owned(),
+            found: "kamn:did:agent:observer-9".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_rejects_offer_with_payee_mismatch() {
+    // Regression: #558
+    let mut workflow = TaskPaymentWorkflow::new();
+    let tasks = completed_task_engine("task-pay-payee-mismatch");
+    let escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+
+    let result = workflow.submit_offer(
+        PaymentOffer {
+            task_id: "task-pay-payee-mismatch".to_owned(),
+            escrow_id: "escrow-payee-mismatch".to_owned(),
+            payer_did: "kamn:did:agent:requester-1".to_owned(),
+            payee_did: "kamn:did:agent:observer-9".to_owned(),
+            amount: 60,
+        },
+        &tasks,
+        &escrow,
+    );
+
+    assert_eq!(
+        result,
+        Err(TaskPaymentError::PayeeAssigneeMismatch {
+            expected: "kamn:did:agent:worker-1".to_owned(),
+            found: "kamn:did:agent:observer-9".to_owned(),
+        })
+    );
+}
+
+#[test]
 fn confirm_rejects_unauthorized_confirmer() {
     let mut workflow = TaskPaymentWorkflow::new();
     let tasks = completed_task_engine("task-pay-3");

--- a/crates/kamn-core/tests/task_payment_workflow_docs.rs
+++ b/crates/kamn-core/tests/task_payment_workflow_docs.rs
@@ -13,6 +13,8 @@ fn doc_contains_payment_offer_confirm_models_and_workflow_contract() {
 fn doc_contains_completion_and_escrow_validation_rules() {
     assert!(DOC.contains("## Deterministic Validation Rules"));
     assert!(DOC.contains("target task in `Completed` state."));
+    assert!(DOC.contains("`payer_did` equal to task requester DID."));
+    assert!(DOC.contains("`payee_did` equal to task assignee DID."));
     assert!(DOC.contains("offered amount less than or equal to escrow remaining balance."));
     assert!(DOC.contains("single-use confirmation (duplicates are rejected)."));
     assert!(DOC.contains("current_unix >= timeout_unix"));
@@ -30,4 +32,11 @@ fn regression_requires_duplicate_confirm_rejection_rule() {
 fn regression_requires_premature_timeout_refund_rejection_rule() {
     // Regression: #542
     assert!(DOC.contains("premature timeout refund attempts are rejected (`Regression: #542`)."));
+}
+
+#[test]
+fn regression_requires_participant_binding_rules() {
+    // Regression: #558
+    assert!(DOC.contains("`payer_did` equal to task requester DID."));
+    assert!(DOC.contains("`payee_did` equal to task assignee DID."));
 }

--- a/docs/foundation/task-payment-workflow.md
+++ b/docs/foundation/task-payment-workflow.md
@@ -1,4 +1,4 @@
-# Task Payment Offer/Confirm Workflow (Issues #216 / #542)
+# Task Payment Offer/Confirm Workflow (Issues #216 / #542 / #558)
 
 This document captures the first implementation slice for integrating `PaymentOffer` and `PaymentConfirm` with task completion and escrow release flow.
 
@@ -15,6 +15,8 @@ This document captures the first implementation slice for integrating `PaymentOf
   - positive payment amount.
   - valid payer/payee DIDs.
   - target task in `Completed` state.
+  - `payer_did` equal to task requester DID.
+  - `payee_did` equal to task assignee DID.
   - offered amount less than or equal to escrow remaining balance.
 - Payment confirms require:
   - matching task and escrow references for an existing offer.


### PR DESCRIPTION
## Summary
Enforced task participant binding during payment offer submission so payer/payee identities must match the task requester/assignee. Added typed mismatch failures, regression coverage, and documentation updates to lock the behavior.

## Changes
- `crates/kamn-core/src/task_payment.rs`: enforce requester/assignee binding in `submit_offer`, add typed mismatch errors, and add unit tests for participant validation paths.
- `crates/kamn-core/tests/task_payment_workflow.rs`: add `Regression: #558` coverage for payer and payee mismatch rejection.
- `crates/kamn-core/tests/task_payment_workflow_docs.rs`: assert participant binding rules are documented (`Regression: #558`).
- `docs/foundation/task-payment-workflow.md`: document payer/requester and payee/assignee binding requirements.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed red-phase mismatch regressions failed before implementation and pass after implementation

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `task_payment::tests::participant_check_*` |
| Functional  | ✅     | `completed_task_offer_confirm_releases_escrow` remains green |
| Integration | ✅     | `cargo test -p kamn-core --test task_payment_workflow` |
| Regression  | ✅     | mismatch rejection tests marked `Regression: #558` |

Closes #560
Closes #561
