### PR TITLE
feat(messages): add TTL expiry APIs for lifecycle store (#565)

### DIFF
--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -124,26 +124,61 @@ impl MessageLifecycleStore {
         message_id: &str,
         to: MessageStatus,
     ) -> Result<(), MessageLifecycleError> {
-        let record = self
+        let from = self
             .records
-            .get_mut(message_id)
+            .get(message_id)
+            .map(|record| record.status)
             .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
-        let from = record.status;
         if !is_valid_transition(from, to) {
             return Err(MessageLifecycleError::InvalidTransition { from, to });
         }
 
-        record.status = to;
-        record.history.push(to);
-
-        if let Some(ids) = self.ids_by_status.get_mut(&from) {
-            ids.remove(message_id);
-        }
-        self.ids_by_status
-            .entry(to)
-            .or_default()
-            .insert(message_id.to_owned());
+        self.apply_status(message_id, to)?;
         Ok(())
+    }
+
+    pub fn expire_message_if_overdue(
+        &mut self,
+        message_id: &str,
+        observed_at: &str,
+    ) -> Result<bool, MessageLifecycleError> {
+        if observed_at.trim().is_empty() {
+            return Err(MessageLifecycleError::EmptyTimestamp("observed_at"));
+        }
+        let record = self
+            .records
+            .get(message_id)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
+        if !is_active_status(record.status) || observed_at <= record.expires.as_str() {
+            return Ok(false);
+        }
+
+        self.apply_status(message_id, MessageStatus::Expired)?;
+        Ok(true)
+    }
+
+    pub fn expire_overdue_messages(
+        &mut self,
+        observed_at: &str,
+    ) -> Result<Vec<String>, MessageLifecycleError> {
+        if observed_at.trim().is_empty() {
+            return Err(MessageLifecycleError::EmptyTimestamp("observed_at"));
+        }
+        let overdue_ids: Vec<String> = self
+            .records
+            .iter()
+            .filter_map(|(message_id, record)| {
+                if is_active_status(record.status) && observed_at > record.expires.as_str() {
+                    Some(message_id.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for message_id in &overdue_ids {
+            self.apply_status(message_id, MessageStatus::Expired)?;
+        }
+        Ok(overdue_ids)
     }
 
     pub fn ids_by_status(&self, status: MessageStatus) -> Vec<String> {
@@ -195,6 +230,32 @@ impl MessageLifecycleStore {
             .get(message_id)
             .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
         Ok((&record.sender, &record.recipients))
+    }
+
+    fn apply_status(
+        &mut self,
+        message_id: &str,
+        to: MessageStatus,
+    ) -> Result<(), MessageLifecycleError> {
+        let record = self
+            .records
+            .get_mut(message_id)
+            .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))?;
+        let from = record.status;
+        if from == to {
+            return Ok(());
+        }
+        record.status = to;
+        record.history.push(to);
+
+        if let Some(ids) = self.ids_by_status.get_mut(&from) {
+            ids.remove(message_id);
+        }
+        self.ids_by_status
+            .entry(to)
+            .or_default()
+            .insert(message_id.to_owned());
+        Ok(())
     }
 
     pub fn validate_with_processor_proof(
@@ -304,6 +365,17 @@ fn is_valid_transition(from: MessageStatus, to: MessageStatus) -> bool {
     )
 }
 
+fn is_active_status(status: MessageStatus) -> bool {
+    matches!(
+        status,
+        MessageStatus::Created
+            | MessageStatus::Signed
+            | MessageStatus::Broadcast
+            | MessageStatus::Included
+            | MessageStatus::Delivered
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -358,6 +430,82 @@ mod tests {
         assert_eq!(
             store.ids_by_status(MessageStatus::Signed),
             vec!["urn:uuid:msg-2".to_owned()]
+        );
+    }
+
+    #[test]
+    fn expire_message_if_overdue_rejects_empty_observed_timestamp() {
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg-2a",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+
+        assert_eq!(
+            store.expire_message_if_overdue("urn:uuid:msg-2a", " "),
+            Err(MessageLifecycleError::EmptyTimestamp("observed_at"))
+        );
+    }
+
+    #[test]
+    fn expire_overdue_messages_expires_active_records_only() {
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg-2b",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+        store
+            .register(
+                "urn:uuid:msg-2c",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+        store
+            .transition("urn:uuid:msg-2c", MessageStatus::Signed)
+            .expect("created->signed should succeed");
+        store
+            .transition("urn:uuid:msg-2c", MessageStatus::Broadcast)
+            .expect("signed->broadcast should succeed");
+        store
+            .transition("urn:uuid:msg-2c", MessageStatus::Included)
+            .expect("broadcast->included should succeed");
+        store
+            .transition("urn:uuid:msg-2c", MessageStatus::Delivered)
+            .expect("included->delivered should succeed");
+        store
+            .transition("urn:uuid:msg-2c", MessageStatus::Validated)
+            .expect("delivered->validated should succeed");
+
+        assert_eq!(
+            store
+                .expire_overdue_messages("2026-02-07T20:50:30.123Z")
+                .expect("sweep should succeed"),
+            vec!["urn:uuid:msg-2b".to_owned()]
+        );
+        assert_eq!(
+            store
+                .status("urn:uuid:msg-2b")
+                .expect("status should exist"),
+            MessageStatus::Expired
+        );
+        assert_eq!(
+            store
+                .status("urn:uuid:msg-2c")
+                .expect("status should exist"),
+            MessageStatus::Validated
         );
     }
 

--- a/crates/kamn-core/tests/message_lifecycle_docs.rs
+++ b/crates/kamn-core/tests/message_lifecycle_docs.rs
@@ -1,10 +1,36 @@
 const DOC: &str = include_str!("../../../docs/foundation/message-lifecycle.md");
 
 #[test]
+fn doc_contains_lifecycle_chain_and_core_indexes() {
+    assert!(DOC.contains("## Lifecycle State Machine"));
+    assert!(DOC.contains(
+        "Created -> Signed -> Broadcast -> Included -> Delivered -> Validated -> Rejected -> Expired"
+    ));
+    assert!(DOC.contains("ids_by_status(status)"));
+    assert!(DOC.contains("ids_by_sender(sender)"));
+    assert!(DOC.contains("ids_by_recipient(recipient)"));
+}
+
+#[test]
+fn doc_contains_ttl_expiry_apis_and_rules() {
+    assert!(DOC.contains("expire_message_if_overdue(message_id, observed_at)"));
+    assert!(DOC.contains("expire_overdue_messages(observed_at)"));
+    assert!(DOC.contains("observed_at > expires"));
+    assert!(DOC.contains("`observed_at` passed to expiry APIs must be non-empty."));
+}
+
+#[test]
 fn doc_contains_processor_proof_gated_validation_rules() {
     assert!(DOC.contains("## Processor Proof-Gated Validation"));
     assert!(DOC.contains("validate_with_processor_proof"));
     assert!(DOC.contains("Delivered -> Validated"));
+}
+
+#[test]
+fn regression_requires_active_record_ttl_expiry_rule() {
+    // Regression: #563
+    assert!(DOC.contains("Expiry APIs only transition active records"));
+    assert!(DOC.contains("`Included`, `Delivered`) to `Expired`."));
 }
 
 #[test]

--- a/crates/kamn-core/tests/message_lifecycle_queries.rs
+++ b/crates/kamn-core/tests/message_lifecycle_queries.rs
@@ -121,3 +121,50 @@ fn expired_message_cannot_reenter_pipeline() {
         })
     );
 }
+
+#[test]
+fn regression_expire_message_if_overdue_marks_active_record_expired() {
+    // Regression: #563
+    let mut store = MessageLifecycleStore::new();
+    register_baseline(&mut store, "urn:uuid:msg-5");
+
+    let changed = store
+        .expire_message_if_overdue("urn:uuid:msg-5", "2026-02-07T20:50:30.123Z")
+        .expect("expiry check should succeed");
+    assert!(changed, "message should expire once observed past TTL");
+    assert_eq!(
+        store.status("urn:uuid:msg-5").expect("status should exist"),
+        MessageStatus::Expired
+    );
+}
+
+#[test]
+fn integration_expire_overdue_messages_sweeps_active_records_deterministically() {
+    let mut store = MessageLifecycleStore::new();
+    register_baseline(&mut store, "urn:uuid:msg-6");
+    register_baseline(&mut store, "urn:uuid:msg-7");
+    store
+        .transition("urn:uuid:msg-7", MessageStatus::Signed)
+        .expect("created->signed should succeed");
+    store
+        .transition("urn:uuid:msg-7", MessageStatus::Broadcast)
+        .expect("signed->broadcast should succeed");
+    store
+        .transition("urn:uuid:msg-7", MessageStatus::Included)
+        .expect("broadcast->included should succeed");
+    store
+        .transition("urn:uuid:msg-7", MessageStatus::Delivered)
+        .expect("included->delivered should succeed");
+    store
+        .transition("urn:uuid:msg-7", MessageStatus::Validated)
+        .expect("delivered->validated should succeed");
+
+    let expired = store
+        .expire_overdue_messages("2026-02-07T20:50:30.123Z")
+        .expect("sweep should succeed");
+    assert_eq!(expired, vec!["urn:uuid:msg-6".to_owned()]);
+    assert_eq!(
+        store.ids_by_status(MessageStatus::Expired),
+        vec!["urn:uuid:msg-6".to_owned()]
+    );
+}

--- a/docs/foundation/message-lifecycle.md
+++ b/docs/foundation/message-lifecycle.md
@@ -1,4 +1,4 @@
-# Message Lifecycle and Index Queries (Issue #114)
+# Message Lifecycle and Index Queries (Issue #114 / #563)
 
 This document defines the first implementation slice for message lifecycle
 state transitions and deterministic index query APIs.
@@ -15,6 +15,10 @@ state transitions and deterministic index query APIs.
   applies legal state transitions and updates indexes.
 - `status(message_id)`:
   returns current lifecycle status.
+- `expire_message_if_overdue(message_id, observed_at)`:
+  expires an active message deterministically when `observed_at > expires`.
+- `expire_overdue_messages(observed_at)`:
+  sweeps active records and returns deterministically ordered expired message IDs.
 - `ids_by_status(status)`:
   returns deterministic message IDs for a lifecycle stage.
 - `ids_by_sender(sender)`:
@@ -27,7 +31,10 @@ state transitions and deterministic index query APIs.
 - `sender` and each recipient must be valid `kamn:did:agent:*` DIDs.
 - Recipients must be non-empty.
 - `created` and `expires` timestamps must be non-empty, with `expires > created`.
+- `observed_at` passed to expiry APIs must be non-empty.
 - Unknown message IDs return `MessageLifecycleError::NotFound`.
+- Expiry APIs only transition active records (`Created`, `Signed`, `Broadcast`,
+  `Included`, `Delivered`) to `Expired`.
 
 ## Processor Proof-Gated Validation
 - `validate_with_processor_proof(message_id, expected_payload_commitment, artifact, evaluator)` gates lifecycle validation on deterministic processor proof admission.


### PR DESCRIPTION
## Summary
Implemented deterministic TTL-expiry APIs for `MessageLifecycleStore` so overdue active messages can be expired by observed time without manual terminal transition choreography. Added regression coverage and documentation updates for the new per-message and sweep flows.

## Changes
- `crates/kamn-core/src/message_lifecycle.rs`: added `expire_message_if_overdue` and `expire_overdue_messages`, factored status/index update path via `apply_status`, and added unit tests for observed timestamp validation + active-only expiry behavior.
- `crates/kamn-core/tests/message_lifecycle_queries.rs`: added regression + integration tests for per-message and sweep expiry (`Regression: #563`).
- `crates/kamn-core/tests/message_lifecycle_docs.rs`: added/updated doc assertions for TTL-expiry APIs while preserving processor-proof regression checks.
- `docs/foundation/message-lifecycle.md`: documented TTL-expiry APIs and deterministic active-status expiry rules.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: red-phase captured missing method failures before implementation, followed by green targeted and full-suite runs

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `message_lifecycle::tests::expire_*` cases for observed timestamp and active-only expiry |
| Functional  | ✅     | `regression_expire_message_if_overdue_marks_active_record_expired` |
| Integration | ✅     | `integration_expire_overdue_messages_sweeps_active_records_deterministically` |
| Regression  | ✅     | `Regression: #563` tests in lifecycle queries and docs |

Closes #565
Closes #566
