### PR TITLE
ci(fast-gate): scope CI-tool checks to CI-sensitive diffs (#570)

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -38,7 +38,7 @@ jobs:
         run: bash scripts/ci/check_markdown.sh
 
       - name: Validate CI scripts syntax
-        if: steps.scope.outputs.docs_only != 'true'
+        if: steps.scope.outputs.run_ci_tool_checks == 'true'
         run: bash -n scripts/ci/*.sh
 
       - name: Validate flaky registry
@@ -46,11 +46,11 @@ jobs:
         run: bash scripts/ci/check_flaky_registry.sh
 
       - name: Validate PR CI impact declaration
-        if: steps.scope.outputs.docs_only != 'true'
+        if: steps.scope.outputs.run_ci_tool_checks == 'true'
         run: bash scripts/ci/check_pr_ci_declaration.sh
 
       - name: Run CI tool regression tests
-        if: steps.scope.outputs.docs_only != 'true'
+        if: steps.scope.outputs.run_ci_tool_checks == 'true'
         run: bash scripts/ci/test_ci_tools.sh
 
       - name: Run deploy preflight tests

--- a/docs/foundation/ci-caching-parallelism.md
+++ b/docs/foundation/ci-caching-parallelism.md
@@ -1,4 +1,4 @@
-# CI Caching and Parallelism Slice (Issues #182, #183)
+# CI Caching and Parallelism Slice (Issues #182, #183, #568)
 
 This document captures the first implementation slice for CI runtime/cost optimization in story #68.
 
@@ -12,6 +12,9 @@ This document captures the first implementation slice for CI runtime/cost optimi
   - `scripts/ci/run_invariant_harness.sh --parallelism <n>`
   - Deep validation lane now uses `--parallelism 2`.
 - Added CI regression checks for workflow cache policy and deep-lane parallel harness configuration.
+- Added selector-driven CI-tool-check gating in fast-gate:
+  - `run_ci_tool_checks` is true only for CI-sensitive diffs (`.github/workflows/*`, `scripts/ci/*`).
+  - CI syntax, CI impact declaration, and CI tool regression steps are skipped for non-CI PR paths.
 - Added deterministic fast-lane target selection fallback safety:
   - Critical CI paths (`.github/workflows/*`, `scripts/ci/*`) escalate to full Rust validation scope.
   - Deployment script paths (`scripts/deploy/*`) now route to a dedicated deploy preflight scope instead of full Rust.
@@ -30,6 +33,7 @@ This document captures the first implementation slice for CI runtime/cost optimi
   - Keep cache saves on main only unless there is a measured need to populate PR-branch-specific caches.
   - Keep harness parallelism bounded (current limit: 2 in deep lane) to avoid unstable load spikes.
   - Route deploy-only diffs to `scripts/deploy/test_preflight_topology.sh` so fast-gate avoids Rust toolchain startup.
+  - Keep CI-tool-check steps scoped to CI-sensitive diffs to reduce unnecessary runner time (`Regression: #568`).
   - Prefer targeted crate scopes for known Rust module edits, but keep strict full-scope fallback for critical/unknown paths.
 - Troubleshooting:
   - If deep invariant lane becomes unstable, temporarily reduce to `--parallelism 1` and compare budget telemetry.

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -26,6 +26,7 @@ append_summary() {
     echo "- Changed files: ${CHANGED_COUNT}"
     echo "- Docs only: ${DOCS_ONLY}"
     echo "- Run Rust checks: ${RUN_RUST}"
+    echo "- Run CI tool checks: ${RUN_CI_TOOL_CHECKS}"
     echo "- Run deploy preflight checks: ${RUN_DEPLOY_PREFLIGHT_TESTS}"
     echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
@@ -181,6 +182,7 @@ if [ "$CRITICAL_PATH_CHANGED" = true ] || [ "$UNKNOWN_RISK_CHANGED" = true ]; th
 fi
 
 RUN_RUST=false
+RUN_CI_TOOL_CHECKS=false
 RUN_DEPLOY_PREFLIGHT_TESTS=false
 FMT_CMD=":"
 CLIPPY_CMD=":"
@@ -232,8 +234,13 @@ if [ "$RUN_RUST" != true ] && [ "$DEPLOY_SCRIPT_CHANGED" = true ]; then
   TEST_SCOPE="deploy"
 fi
 
+if [ "$CI_INFRA_CHANGED" = true ]; then
+  RUN_CI_TOOL_CHECKS=true
+fi
+
 write_output "docs_only" "$DOCS_ONLY"
 write_output "run_rust" "$RUN_RUST"
+write_output "run_ci_tool_checks" "$RUN_CI_TOOL_CHECKS"
 write_output "run_deploy_preflight_tests" "$RUN_DEPLOY_PREFLIGHT_TESTS"
 write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -31,6 +31,7 @@ run_selector() {
 docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
 assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selection mismatch"
 assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only should not run rust"
+assert_eq "$(extract_output "$docs_output" "run_ci_tool_checks")" "false" "docs_only should not run CI tool checks"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
 
 deploy_output="$(run_selector $'scripts/deploy/preflight_topology.sh')"
@@ -47,6 +48,7 @@ assert_eq "$(extract_output "$runner_docs_output" "docs_only")" "true" "runner o
 
 critical_output="$(run_selector $'.github/workflows/ci-fast-gate.yml')"
 assert_eq "$(extract_output "$critical_output" "run_rust")" "true" "workflow changes must run rust"
+assert_eq "$(extract_output "$critical_output" "run_ci_tool_checks")" "true" "workflow changes must run CI tool checks"
 assert_eq "$(extract_output "$critical_output" "test_scope")" "full" "workflow changes must use full scope"
 
 unknown_output="$(run_selector $'config/runtime-policy.json')"
@@ -56,6 +58,7 @@ assert_eq "$(extract_output "$unknown_output" "test_scope")" "full" "unknown pat
 
 targeted_output="$(run_selector $'crates/kamn-core/src/bridge_adapter.rs')"
 assert_eq "$(extract_output "$targeted_output" "run_rust")" "true" "rust path should run rust"
+assert_eq "$(extract_output "$targeted_output" "run_ci_tool_checks")" "false" "Regression: #568 non-CI paths should skip CI tool checks"
 assert_eq "$(extract_output "$targeted_output" "test_scope")" "targeted" "crate path should be targeted"
 
 test_cmd="$(extract_output "$targeted_output" "test_cmd")"

--- a/scripts/ci/test_workflow_cache_policy.sh
+++ b/scripts/ci/test_workflow_cache_policy.sh
@@ -22,4 +22,10 @@ if ! grep -q "run_invariant_harness.sh --mode deep --parallelism 2" "$DEEP_WORKF
   exit 1
 fi
 
+# Regression: #568
+if ! grep -Fq "if: steps.scope.outputs.run_ci_tool_checks == 'true'" "$FAST_WORKFLOW"; then
+  echo "expected ci-fast-gate CI tool checks to be gated by run_ci_tool_checks output" >&2
+  exit 1
+fi
+
 echo "workflow cache policy tests passed."


### PR DESCRIPTION
## Summary
Reduced fast-gate CI overhead by introducing a dedicated selector output (`run_ci_tool_checks`) and using it to run CI-tool check steps only when CI-sensitive files change. This keeps normal backend/docs PRs faster while preserving CI safety checks for workflow/script edits.

## Changes
- `.github/workflows/ci-fast-gate.yml`: gate CI script syntax validation, PR CI-impact declaration check, and CI tool regression tests on `steps.scope.outputs.run_ci_tool_checks == 'true'`.
- `scripts/ci/select_targets.sh`: emit `run_ci_tool_checks` output (true only for `.github/workflows/*` and `scripts/ci/*` changes) and include it in scope summary.
- `scripts/ci/test_select_targets.sh`: add regression assertions for `run_ci_tool_checks` behavior (`Regression: #568`).
- `scripts/ci/test_workflow_cache_policy.sh`: enforce workflow gate condition (`Regression: #568`).
- `docs/foundation/ci-caching-parallelism.md`: document selector-driven CI-tool-check gating.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: red-phase script tests failed before implementation; green after selector/workflow wiring

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `bash scripts/ci/test_select_targets.sh` |
| Functional  | ✅     | `bash scripts/ci/test_workflow_cache_policy.sh` gate assertion |
| Integration | ✅     | `bash scripts/ci/test_ci_tools.sh` |
| Regression  | ✅     | `Regression: #568` assertions in selector/workflow script tests |

Closes #570
Closes #571
