### PR TITLE
feat(tasks): add InputRequired state and task request_input operation

### DIFF
--- a/crates/kamn-core/src/operator_dashboard_ui.rs
+++ b/crates/kamn-core/src/operator_dashboard_ui.rs
@@ -356,7 +356,9 @@ fn validate_rate(
 fn task_attention(state: TaskState) -> DashboardAttentionLevel {
     match state {
         TaskState::Blocked | TaskState::Failed => DashboardAttentionLevel::Critical,
-        TaskState::Cancelled | TaskState::Delegated => DashboardAttentionLevel::Warning,
+        TaskState::Cancelled | TaskState::Delegated | TaskState::InputRequired => {
+            DashboardAttentionLevel::Warning
+        }
         TaskState::Completed => DashboardAttentionLevel::Success,
         TaskState::Submitted | TaskState::Accepted | TaskState::InProgress => {
             DashboardAttentionLevel::Info

--- a/crates/kamn-core/src/task_lifecycle.rs
+++ b/crates/kamn-core/src/task_lifecycle.rs
@@ -6,6 +6,7 @@ pub enum TaskState {
     Accepted,
     Delegated,
     InProgress,
+    InputRequired,
     Blocked,
     Completed,
     Failed,
@@ -17,6 +18,7 @@ pub enum TaskTransition {
     Accept,
     Delegate,
     StartWork,
+    RequestInput,
     Block,
     Complete,
     Fail,
@@ -71,9 +73,14 @@ impl TaskLifecycle {
             (TaskState::Delegated, TaskTransition::Cancel) => TaskState::Cancelled,
 
             (TaskState::InProgress, TaskTransition::Block) => TaskState::Blocked,
+            (TaskState::InProgress, TaskTransition::RequestInput) => TaskState::InputRequired,
             (TaskState::InProgress, TaskTransition::Complete) => TaskState::Completed,
             (TaskState::InProgress, TaskTransition::Fail) => TaskState::Failed,
             (TaskState::InProgress, TaskTransition::Cancel) => TaskState::Cancelled,
+
+            (TaskState::InputRequired, TaskTransition::StartWork) => TaskState::InProgress,
+            (TaskState::InputRequired, TaskTransition::Fail) => TaskState::Failed,
+            (TaskState::InputRequired, TaskTransition::Cancel) => TaskState::Cancelled,
 
             (TaskState::Blocked, TaskTransition::StartWork) => TaskState::InProgress,
             (TaskState::Blocked, TaskTransition::Fail) => TaskState::Failed,
@@ -168,9 +175,14 @@ fn transition_between(from: TaskState, to: TaskState) -> Option<TaskTransition> 
         (TaskState::Delegated, TaskState::Cancelled) => Some(TaskTransition::Cancel),
 
         (TaskState::InProgress, TaskState::Blocked) => Some(TaskTransition::Block),
+        (TaskState::InProgress, TaskState::InputRequired) => Some(TaskTransition::RequestInput),
         (TaskState::InProgress, TaskState::Completed) => Some(TaskTransition::Complete),
         (TaskState::InProgress, TaskState::Failed) => Some(TaskTransition::Fail),
         (TaskState::InProgress, TaskState::Cancelled) => Some(TaskTransition::Cancel),
+
+        (TaskState::InputRequired, TaskState::InProgress) => Some(TaskTransition::StartWork),
+        (TaskState::InputRequired, TaskState::Failed) => Some(TaskTransition::Fail),
+        (TaskState::InputRequired, TaskState::Cancelled) => Some(TaskTransition::Cancel),
 
         (TaskState::Blocked, TaskState::InProgress) => Some(TaskTransition::StartWork),
         (TaskState::Blocked, TaskState::Failed) => Some(TaskTransition::Fail),
@@ -205,6 +217,19 @@ mod tests {
         assert!(lifecycle.transition(TaskTransition::Accept).is_ok());
         assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
         assert!(lifecycle.transition(TaskTransition::Block).is_ok());
+        assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
+        assert_eq!(lifecycle.state(), TaskState::InProgress);
+    }
+
+    #[test]
+    fn input_required_can_return_to_in_progress() {
+        let mut lifecycle = match TaskLifecycle::new("task-2") {
+            Ok(value) => value,
+            Err(error) => panic!("init failed: {error}"),
+        };
+        assert!(lifecycle.transition(TaskTransition::Accept).is_ok());
+        assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
+        assert!(lifecycle.transition(TaskTransition::RequestInput).is_ok());
         assert!(lifecycle.transition(TaskTransition::StartWork).is_ok());
         assert_eq!(lifecycle.state(), TaskState::InProgress);
     }

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -8,6 +8,7 @@ pub enum TaskOperationNoticeKind {
     Accepted,
     Delegated,
     Started,
+    InputRequired,
     Blocked,
     Completed,
     Failed,
@@ -238,6 +239,26 @@ impl TaskOperationEngine {
             .transition(TaskTransition::Block)
             .map_err(lifecycle_error)?;
         self.push_notice(task_id, TaskOperationNoticeKind::Blocked);
+        Ok(())
+    }
+
+    pub fn request_input(
+        &mut self,
+        task_id: &str,
+        actor: &str,
+        reason: &str,
+    ) -> Result<(), TaskOperationError> {
+        validate_did(actor)?;
+        if reason.trim().is_empty() {
+            return Err(TaskOperationError::EmptyReason("request_input"));
+        }
+        let record = self.task_mut(task_id)?;
+        Self::require_assignee(record, actor)?;
+        record
+            .lifecycle
+            .transition(TaskTransition::RequestInput)
+            .map_err(lifecycle_error)?;
+        self.push_notice(task_id, TaskOperationNoticeKind::InputRequired);
         Ok(())
     }
 
@@ -655,7 +676,11 @@ fn detect_cycle_task_id(graph: &BTreeMap<String, BTreeSet<String>>) -> Option<St
 fn requires_completed_dependencies(state: TaskState) -> bool {
     matches!(
         state,
-        TaskState::InProgress | TaskState::Blocked | TaskState::Completed | TaskState::Failed
+        TaskState::InProgress
+            | TaskState::InputRequired
+            | TaskState::Blocked
+            | TaskState::Completed
+            | TaskState::Failed
     )
 }
 

--- a/crates/kamn-core/tests/task_operations.rs
+++ b/crates/kamn-core/tests/task_operations.rs
@@ -113,3 +113,72 @@ fn cancelled_task_cannot_be_accepted_again() {
         ))
     );
 }
+
+#[test]
+fn request_input_then_resume_emits_notices_and_allows_completion() {
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit(
+            "task-op-6",
+            "kamn:did:agent:requester-1",
+            "Review specification",
+        )
+        .expect("submit should succeed");
+    engine
+        .accept("task-op-6", "kamn:did:agent:worker-1")
+        .expect("accept should succeed");
+    engine
+        .start_work("task-op-6", "kamn:did:agent:worker-1")
+        .expect("start should succeed");
+    engine
+        .request_input(
+            "task-op-6",
+            "kamn:did:agent:worker-1",
+            "Need clarification on section 4",
+        )
+        .expect("request input should succeed");
+    engine
+        .start_work("task-op-6", "kamn:did:agent:worker-1")
+        .expect("resume should succeed");
+    engine
+        .complete("task-op-6", "kamn:did:agent:worker-1")
+        .expect("complete should succeed");
+
+    let task = engine.task("task-op-6").expect("task should exist");
+    assert_eq!(task.lifecycle.state(), TaskState::Completed);
+    assert_eq!(
+        engine.notices("task-op-6"),
+        vec![
+            TaskOperationNoticeKind::Submitted,
+            TaskOperationNoticeKind::Accepted,
+            TaskOperationNoticeKind::Started,
+            TaskOperationNoticeKind::InputRequired,
+            TaskOperationNoticeKind::Started,
+            TaskOperationNoticeKind::Completed,
+        ]
+    );
+}
+
+#[test]
+fn regression_request_input_requires_non_empty_reason() {
+    // Regression: #573
+    let mut engine = TaskOperationEngine::new();
+    engine
+        .submit(
+            "task-op-7",
+            "kamn:did:agent:requester-1",
+            "Confirm assumptions",
+        )
+        .expect("submit should succeed");
+    engine
+        .accept("task-op-7", "kamn:did:agent:worker-1")
+        .expect("accept should succeed");
+    engine
+        .start_work("task-op-7", "kamn:did:agent:worker-1")
+        .expect("start should succeed");
+
+    assert_eq!(
+        engine.request_input("task-op-7", "kamn:did:agent:worker-1", " "),
+        Err(TaskOperationError::EmptyReason("request_input"))
+    );
+}

--- a/crates/kamn-core/tests/task_state_machine.rs
+++ b/crates/kamn-core/tests/task_state_machine.rs
@@ -88,3 +88,48 @@ fn cancelled_task_cannot_be_completed() {
         Err(TaskLifecycleError::TerminalState(TaskState::Cancelled))
     );
 }
+
+#[test]
+fn input_required_can_resume_to_in_progress_before_completion() {
+    let mut lifecycle = TaskLifecycle::new("task-6").expect("task lifecycle should initialize");
+    lifecycle
+        .transition(TaskTransition::Accept)
+        .expect("accept should succeed");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("start should succeed");
+    lifecycle
+        .transition(TaskTransition::RequestInput)
+        .expect("in_progress->input_required should succeed");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("input_required->in_progress should succeed");
+    lifecycle
+        .transition(TaskTransition::Complete)
+        .expect("in_progress->complete should succeed");
+
+    assert_eq!(lifecycle.state(), TaskState::Completed);
+}
+
+#[test]
+fn regression_input_required_cannot_complete_without_resume() {
+    // Regression: #573
+    let mut lifecycle = TaskLifecycle::new("task-7").expect("task lifecycle should initialize");
+    lifecycle
+        .transition(TaskTransition::Accept)
+        .expect("accept should succeed");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("start should succeed");
+    lifecycle
+        .transition(TaskTransition::RequestInput)
+        .expect("request input should succeed");
+
+    assert_eq!(
+        lifecycle.transition(TaskTransition::Complete),
+        Err(TaskLifecycleError::InvalidTransition {
+            from: TaskState::InputRequired,
+            transition: TaskTransition::Complete,
+        })
+    );
+}

--- a/crates/kamn-core/tests/task_swarm_dag_docs.rs
+++ b/crates/kamn-core/tests/task_swarm_dag_docs.rs
@@ -15,6 +15,8 @@ fn docs_define_dependency_aware_transition_gates() {
     assert!(STATE_MACHINE_DOC.contains("TaskOperationEngine::start_work"));
     assert!(STATE_MACHINE_DOC
         .contains("all declared dependencies must already be in `Completed` state."));
+    assert!(STATE_MACHINE_DOC.contains("`InputRequired`"));
+    assert!(STATE_MACHINE_DOC.contains("InputRequired -> InProgress | Failed | Cancelled"));
 }
 
 #[test]
@@ -49,4 +51,11 @@ fn regression_requires_tampered_snapshot_rejection_rule() {
 fn docs_define_snapshot_roundtrip_benchmark_lane() {
     assert!(OPERATIONS_DOC.contains("snapshot roundtrip benchmark"));
     assert!(OPERATIONS_DOC.contains("cargo test -p kamn-core --test task_operation_snapshot"));
+}
+
+#[test]
+fn regression_requires_input_required_operation_surface() {
+    // Regression: #573
+    assert!(OPERATIONS_DOC.contains("request_input(task_id, actor, reason)"));
+    assert!(OPERATIONS_DOC.contains("emits `InputRequired` notice."));
 }

--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -1,8 +1,8 @@
-# Task Operations Command Surface (Issue #128 / #472)
+# Task Operations Command Surface (Issue #128 / #472 / #573)
 
 This document defines the first implementation slice for task operation command
 handling across `submit`, `accept`, `delegate`, `block`, `complete`, `fail`,
-and `cancel`.
+`request_input`, and `cancel`.
 
 ## Core Types
 - `TaskOperationEngine`: deterministic in-memory task operations handler.
@@ -17,6 +17,7 @@ and `cancel`.
   - `Accepted`
   - `Delegated`
   - `Started`
+  - `InputRequired`
   - `Blocked`
   - `Completed`
   - `Failed`
@@ -48,6 +49,10 @@ and `cancel`.
   - assignee-only with non-empty reason.
   - transitions via `Block`.
   - emits `Blocked` notice.
+- `request_input(task_id, actor, reason)`:
+  - assignee-only with non-empty reason.
+  - transitions via `RequestInput`.
+  - emits `InputRequired` notice.
 - `complete(task_id, actor)`:
   - assignee-only.
   - transitions via `Complete`.

--- a/docs/foundation/task-state-machine.md
+++ b/docs/foundation/task-state-machine.md
@@ -1,4 +1,4 @@
-# Task State Machine and Transition Validator (Issue #126 / #472)
+# Task State Machine and Transition Validator (Issue #126 / #472 / #573)
 
 This document defines the first implementation slice for deterministic task
 state transitions and legal transition validation.
@@ -8,6 +8,7 @@ state transitions and legal transition validation.
 - `Accepted`
 - `Delegated`
 - `InProgress`
+- `InputRequired`
 - `Blocked`
 - `Completed` (terminal)
 - `Failed` (terminal)
@@ -17,7 +18,8 @@ state transitions and legal transition validation.
 - `Submitted -> Accepted | Cancelled`
 - `Accepted -> Delegated | InProgress | Cancelled`
 - `Delegated -> InProgress | Cancelled`
-- `InProgress -> Blocked | Completed | Failed | Cancelled`
+- `InProgress -> InputRequired | Blocked | Completed | Failed | Cancelled`
+- `InputRequired -> InProgress | Failed | Cancelled`
 - `Blocked -> InProgress | Failed | Cancelled`
 
 Any transition outside this map is rejected.


### PR DESCRIPTION
## Summary
Adds explicit `InputRequired` task lifecycle support and operation-surface command handling so assignees can pause work pending requester clarification and deterministically resume. The change preserves typed transition validation and updates docs/tests to keep behavior auditable.

Closes #573
Closes #574
Closes #575
Closes #576

## Changes
- `crates/kamn-core/src/task_lifecycle.rs`: added `TaskState::InputRequired`, `TaskTransition::RequestInput`, legal transitions, replay mapping, and unit coverage.
- `crates/kamn-core/src/task_operations.rs`: added `request_input(task_id, actor, reason)`, `InputRequired` notice kind, and dependency-state gating updates.
- `crates/kamn-core/src/operator_dashboard_ui.rs`: mapped `InputRequired` to warning attention level.
- `crates/kamn-core/tests/task_state_machine.rs`: added functional and regression coverage for input-required resume/completion constraints.
- `crates/kamn-core/tests/task_operations.rs`: added functional and regression coverage for request-input flow and non-empty reason enforcement.
- `crates/kamn-core/tests/task_swarm_dag_docs.rs`: added regression checks for docs alignment to operation surface.
- `docs/foundation/task-state-machine.md`: documented `InputRequired` state and legal transitions.
- `docs/foundation/task-operations.md`: documented `request_input` command and emitted notice.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command:
  - `cargo test -p kamn-core --test task_state_machine input_required_can_resume_to_in_progress_before_completion`
- Failing output excerpt:
  - missing `TaskTransition::RequestInput`
  - missing `TaskState::InputRequired`
- Command:
  - `cargo test -p kamn-core --test task_operations request_input_then_resume_emits_notices_and_allows_completion`
- Failing output excerpt:
  - missing `TaskOperationEngine::request_input`
  - missing `TaskOperationNoticeKind::InputRequired`

### 🟢 Green Phase
- `cargo test -p kamn-core --test task_state_machine`
- `cargo test -p kamn-core --test task_operations`
- `cargo test -p kamn-core --test task_swarm_dag_docs`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core`

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `task_lifecycle` unit + `tests/task_state_machine.rs` transition validations | |
| Functional   | ✅ | `request_input_then_resume_emits_notices_and_allows_completion` | |
| Integration  | ✅ | `cargo test -p kamn-core` (cross-module suite remains green) | |
| Regression   | ✅ | `regression_input_required_cannot_complete_without_resume`, `regression_request_input_requires_non_empty_reason`, docs regression assertion | |
| Performance  | N/A | None | In-memory deterministic state transitions only; no throughput/path-length change |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: Revert commit `dd930e0` to restore previous lifecycle/operation behavior.

## Documentation Updates
- `docs/foundation/task-state-machine.md`
- `docs/foundation/task-operations.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
