### PR TITLE
feat(deploy): support bundle-based triadic topology preflight

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -55,7 +55,9 @@ jobs:
 
       - name: Run deploy preflight tests
         if: steps.scope.outputs.run_deploy_preflight_tests == 'true'
-        run: bash scripts/deploy/test_preflight_topology.sh
+        run: |
+          bash scripts/deploy/test_preflight_topology.sh
+          bash scripts/deploy/test_generate_bundle.sh
 
       - name: Set up Rust toolchain
         if: steps.scope.outputs.run_rust == 'true'

--- a/crates/kamn-core/tests/failover_runbook_docs.rs
+++ b/crates/kamn-core/tests/failover_runbook_docs.rs
@@ -23,3 +23,11 @@ fn runbook_contains_verification_checklist() {
     assert!(RUNBOOK.contains("State hash continuity confirmed"));
     assert!(RUNBOOK.contains("No duplicate block production"));
 }
+
+#[test]
+fn regression_requires_topology_bundle_command_surface() {
+    // Regression: #579
+    assert!(RUNBOOK.contains("## Topology Bundle Command Surface"));
+    assert!(RUNBOOK.contains("scripts/deploy/generate_bundle.sh"));
+    assert!(RUNBOOK.contains("scripts/deploy/preflight_topology.sh --bundle-file"));
+}

--- a/docs/foundation/multi-az-failover-runbook.md
+++ b/docs/foundation/multi-az-failover-runbook.md
@@ -1,6 +1,16 @@
-# Multi-AZ Topology and Processor Failover Runbook (Issues #140, #141)
+# Multi-AZ Topology and Processor Failover Runbook (Issues #140, #141, #579)
 
 This runbook defines the minimal multi-AZ deployment shape and deterministic failover process for Processor continuity.
+
+## Topology Bundle Command Surface
+- Generate deterministic bundle:
+  - `bash scripts/deploy/generate_bundle.sh --output-file deploy/topology.env --processors 3 --listeners 3 --approvers 3 --required-approvals 2`
+- Validate explicit topology args:
+  - `bash scripts/deploy/preflight_topology.sh --processors 3 --listeners 3 --approvers 3 --required-approvals 2`
+- Validate generated bundle:
+  - `bash scripts/deploy/preflight_topology.sh --bundle-file deploy/topology.env`
+
+Malformed bundles (missing fields, non-integer values, invalid quorum thresholds) must fail deterministically with explicit error messages.
 
 ## Multi-AZ Topology
 

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -19,5 +19,7 @@ bash "$ROOT_DIR/scripts/ci/test_workflow_retry_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_cache_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_scope_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_performance_policy.sh"
+bash "$ROOT_DIR/scripts/deploy/test_preflight_topology.sh"
+bash "$ROOT_DIR/scripts/deploy/test_generate_bundle.sh"
 
 echo "All CI tool regression tests passed."

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -14,4 +14,9 @@ if ! grep -Fq "bash scripts/deploy/test_preflight_topology.sh" "$FAST_WORKFLOW";
   exit 1
 fi
 
+if ! grep -Fq "bash scripts/deploy/test_generate_bundle.sh" "$FAST_WORKFLOW"; then
+  echo "expected deploy bundle generator tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 echo "workflow scope policy tests passed."

--- a/scripts/deploy/generate_bundle.sh
+++ b/scripts/deploy/generate_bundle.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/deploy/generate_bundle.sh \
+    --output-file <path> \
+    --processors <n> \
+    --listeners <n> \
+    --approvers <n> \
+    --required-approvals <n>
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREFLIGHT_SCRIPT="$ROOT_DIR/scripts/deploy/preflight_topology.sh"
+
+output_file=""
+processors=""
+listeners=""
+approvers=""
+required_approvals=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --processors)
+      processors="${2:-}"
+      shift 2
+      ;;
+    --listeners)
+      listeners="${2:-}"
+      shift 2
+      ;;
+    --approvers)
+      approvers="${2:-}"
+      shift 2
+      ;;
+    --required-approvals)
+      required_approvals="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$processors" || -z "$listeners" || -z "$approvers" || -z "$required_approvals" ]]; then
+  usage
+  fail "all generator arguments are required"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+
+# Reuse preflight checks so generation and validation cannot drift.
+bash "$PREFLIGHT_SCRIPT" \
+  --processors "$processors" \
+  --listeners "$listeners" \
+  --approvers "$approvers" \
+  --required-approvals "$required_approvals" >/dev/null
+
+cat >"$output_file" <<EOF
+PROCESSORS=$processors
+LISTENERS=$listeners
+APPROVERS=$approvers
+REQUIRED_APPROVALS=$required_approvals
+EOF
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"

--- a/scripts/deploy/preflight_topology.sh
+++ b/scripts/deploy/preflight_topology.sh
@@ -5,6 +5,11 @@ usage() {
   cat <<'EOF'
 Usage:
   bash scripts/deploy/preflight_topology.sh \
+    --bundle-file <path>
+
+Or:
+
+  bash scripts/deploy/preflight_topology.sh \
     --processors <n> \
     --listeners <n> \
     --approvers <n> \
@@ -30,6 +35,7 @@ processors=""
 listeners=""
 approvers=""
 required_approvals=""
+bundle_file=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -49,6 +55,10 @@ while [[ $# -gt 0 ]]; do
       required_approvals="${2:-}"
       shift 2
       ;;
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -59,7 +69,59 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$processors" || -z "$listeners" || -z "$approvers" || -z "$required_approvals" ]]; then
+trim_whitespace() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+if [[ -n "$bundle_file" ]]; then
+  if [[ -n "$processors" || -n "$listeners" || -n "$approvers" || -n "$required_approvals" ]]; then
+    fail "cannot mix --bundle-file with explicit topology arguments"
+  fi
+
+  if [[ ! -f "$bundle_file" ]]; then
+    fail "bundle file not found: $bundle_file"
+  fi
+
+  while IFS='=' read -r raw_key raw_value; do
+    key="$(trim_whitespace "${raw_key:-}")"
+    value="$(trim_whitespace "${raw_value:-}")"
+
+    if [[ -z "$key" || "${key:0:1}" == "#" ]]; then
+      continue
+    fi
+
+    case "$key" in
+      PROCESSORS)
+        processors="$value"
+        ;;
+      LISTENERS)
+        listeners="$value"
+        ;;
+      APPROVERS)
+        approvers="$value"
+        ;;
+      REQUIRED_APPROVALS)
+        required_approvals="$value"
+        ;;
+    esac
+  done <"$bundle_file"
+
+  if [[ -z "$processors" ]]; then
+    fail "missing bundle field: PROCESSORS"
+  fi
+  if [[ -z "$listeners" ]]; then
+    fail "missing bundle field: LISTENERS"
+  fi
+  if [[ -z "$approvers" ]]; then
+    fail "missing bundle field: APPROVERS"
+  fi
+  if [[ -z "$required_approvals" ]]; then
+    fail "missing bundle field: REQUIRED_APPROVALS"
+  fi
+elif [[ -z "$processors" || -z "$listeners" || -z "$approvers" || -z "$required_approvals" ]]; then
   usage
   fail "all topology arguments are required"
 fi
@@ -87,3 +149,6 @@ printf 'processors=%s\n' "$processors"
 printf 'listeners=%s\n' "$listeners"
 printf 'approvers=%s\n' "$approvers"
 printf 'required_approvals=%s\n' "$required_approvals"
+if [[ -n "$bundle_file" ]]; then
+  printf 'bundle_file=%s\n' "$bundle_file"
+fi

--- a/scripts/deploy/test_generate_bundle.sh
+++ b/scripts/deploy/test_generate_bundle.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/deploy/generate_bundle.sh"
+PREFLIGHT="$ROOT_DIR/scripts/deploy/preflight_topology.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+BUNDLE_FILE="$TMP_DIR/topology.bundle.env"
+
+generated_output="$(
+  bash "$GENERATOR" \
+    --output-file "$BUNDLE_FILE" \
+    --processors 3 \
+    --listeners 3 \
+    --approvers 3 \
+    --required-approvals 2
+)"
+
+if ! printf '%s\n' "$generated_output" | grep -q "status=generated"; then
+  echo "expected generated status output from bundle generator" >&2
+  exit 1
+fi
+
+if [ ! -f "$BUNDLE_FILE" ]; then
+  echo "expected generated bundle file to exist" >&2
+  exit 1
+fi
+
+if ! grep -q "^PROCESSORS=3$" "$BUNDLE_FILE"; then
+  echo "expected generated bundle to include processor count" >&2
+  exit 1
+fi
+
+bundle_preflight_output="$(bash "$PREFLIGHT" --bundle-file "$BUNDLE_FILE")"
+if ! printf '%s\n' "$bundle_preflight_output" | grep -q "^status=ok$"; then
+  echo "expected generated bundle to pass preflight validation" >&2
+  exit 1
+fi
+
+set +e
+invalid_output="$(
+  bash "$GENERATOR" \
+    --output-file "$TMP_DIR/invalid.bundle.env" \
+    --processors 1 \
+    --listeners 1 \
+    --approvers 2 \
+    --required-approvals 3 2>&1
+)"
+invalid_code=$?
+set -e
+
+if [ "$invalid_code" -eq 0 ]; then
+  echo "expected generator to fail invalid quorum topology" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_output" | grep -q "required-approvals must be between 1 and approvers"; then
+  echo "expected quorum validation error to bubble from preflight" >&2
+  exit 1
+fi
+
+echo "deployment bundle generator tests passed."

--- a/scripts/deploy/test_preflight_topology.sh
+++ b/scripts/deploy/test_preflight_topology.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/deploy/preflight_topology.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 extract_value() {
   local output="$1"
@@ -64,6 +66,58 @@ if [ "$invalid_quorum_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$invalid_quorum_output" | grep -q "required-approvals must be between 1 and approvers"; then
   echo "missing quorum validation error output" >&2
+  exit 1
+fi
+
+valid_bundle="$TMP_DIR/valid.bundle.env"
+cat >"$valid_bundle" <<'EOF'
+PROCESSORS=3
+LISTENERS=3
+APPROVERS=3
+REQUIRED_APPROVALS=2
+EOF
+
+bundle_output="$(bash "$SCRIPT" --bundle-file "$valid_bundle")"
+assert_eq "$(extract_value "$bundle_output" "status")" "ok" "valid bundle topology must pass"
+
+missing_required_bundle="$TMP_DIR/missing_required.bundle.env"
+cat >"$missing_required_bundle" <<'EOF'
+PROCESSORS=3
+LISTENERS=3
+APPROVERS=3
+EOF
+
+set +e
+missing_required_output="$(bash "$SCRIPT" --bundle-file "$missing_required_bundle" 2>&1)"
+missing_required_code=$?
+set -e
+if [ "$missing_required_code" -eq 0 ]; then
+  echo "bundle with missing required fields should fail" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_required_output" | grep -q "missing bundle field: REQUIRED_APPROVALS"; then
+  echo "missing required field error output for bundle topology" >&2
+  exit 1
+fi
+
+non_integer_bundle="$TMP_DIR/non_integer.bundle.env"
+cat >"$non_integer_bundle" <<'EOF'
+PROCESSORS=x
+LISTENERS=3
+APPROVERS=3
+REQUIRED_APPROVALS=2
+EOF
+
+set +e
+non_integer_output="$(bash "$SCRIPT" --bundle-file "$non_integer_bundle" 2>&1)"
+non_integer_code=$?
+set -e
+if [ "$non_integer_code" -eq 0 ]; then
+  echo "bundle with non-integer processor count should fail" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$non_integer_output" | grep -q "processors must be an integer"; then
+  echo "missing non-integer processor validation error output for bundle topology" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Adds deterministic deployment bundle generation and bundle-based topology preflight validation for triadic role configurations. This closes malformed-bundle rejection gaps while keeping deploy-only CI checks fast and low-cost.

Closes #579
Closes #580
Closes #581
Closes #582

## Changes
- `scripts/deploy/preflight_topology.sh`: added `--bundle-file` support, bundle field parsing, malformed bundle rejection, and mixed-argument guard.
- `scripts/deploy/generate_bundle.sh`: added deterministic deployment bundle generator with preflight-backed validation.
- `scripts/deploy/test_preflight_topology.sh`: added failing/green bundle-path coverage for missing fields and non-integer values.
- `scripts/deploy/test_generate_bundle.sh`: added generator functional coverage and invalid quorum rejection checks.
- `.github/workflows/ci-fast-gate.yml`: deploy lane now runs both preflight and generator tests.
- `scripts/ci/test_workflow_scope_policy.sh`: added workflow policy assertion for generator tests.
- `scripts/ci/test_ci_tools.sh`: included deploy preflight + generator tests in CI regression aggregation.
- `docs/foundation/multi-az-failover-runbook.md`: documented bundle command surface.
- `crates/kamn-core/tests/failover_runbook_docs.rs`: added regression assertion for bundle command surface.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/deploy/test_preflight_topology.sh`
  - Failed: `unknown argument: --bundle-file`

### 🟢 Green Phase
- `bash scripts/deploy/test_preflight_topology.sh`
- `bash scripts/deploy/test_generate_bundle.sh`
- `cargo test -p kamn-core --test failover_runbook_docs`

### 🔁 Regression
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core`

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/deploy/test_preflight_topology.sh` bundle field + type validation guards | |
| Functional   | ✅ | `scripts/deploy/test_generate_bundle.sh` deterministic bundle generation + validation flow | |
| Integration  | ✅ | `.github/workflows/ci-fast-gate.yml` deploy lane + `scripts/ci/test_workflow_scope_policy.sh` | |
| Regression   | ✅ | `crates/kamn-core/tests/failover_runbook_docs.rs` (`Regression: #579`) | |
| Performance  | ✅ | Deploy-only lane remains script-only (no Rust build), preserving low-cost PR runtime | |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `7c09836`.

## Documentation Updates
- `docs/foundation/multi-az-failover-runbook.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
