### PR TITLE
feat(ci): route sdk diffs into targeted parity matrix lane

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -60,16 +60,20 @@ jobs:
           bash scripts/deploy/test_generate_bundle.sh
 
       - name: Set up Rust toolchain
-        if: steps.scope.outputs.run_rust == 'true'
+        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_sdk_parity_matrix == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
         id: rust_cache
-        if: steps.scope.outputs.run_rust == 'true'
+        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_sdk_parity_matrix == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: kamn-rust-ci-v1
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run SDK parity matrix
+        if: steps.scope.outputs.run_sdk_parity_matrix == 'true'
+        run: bash scripts/sdk/run_sdk_parity_matrix.sh --fixture fixtures/sdk_parity/register_validation_cases.json --output-json sdk-parity-report.json
 
       - name: Format check
         if: steps.scope.outputs.run_rust == 'true'

--- a/crates/kamn-core/tests/ci_caching_parallelism_docs.rs
+++ b/crates/kamn-core/tests/ci_caching_parallelism_docs.rs
@@ -5,6 +5,7 @@ fn doc_contains_selector_scope_and_cache_guidance() {
     assert!(DOC.contains("shared-key: kamn-rust-ci-v1"));
     assert!(DOC.contains("run_ci_tool_checks"));
     assert!(DOC.contains("scripts/deploy/test_preflight_topology.sh"));
+    assert!(DOC.contains("run_sdk_parity_matrix"));
 }
 
 #[test]
@@ -13,4 +14,12 @@ fn regression_requires_performance_threshold_gate_commands() {
     assert!(DOC.contains("generate_performance_smoke_report.sh --lane smoke|deep"));
     assert!(DOC.contains("check_performance_thresholds.sh --lane smoke|deep"));
     assert!(DOC.contains(".ci/performance-targets.env"));
+}
+
+#[test]
+fn regression_requires_sdk_parity_lane_guidance() {
+    // Regression: #583
+    assert!(DOC.contains("scripts/sdk/run_sdk_parity_matrix.sh"));
+    assert!(DOC.contains("test_scope=sdk"));
+    assert!(DOC.contains("Regression: #583"));
 }

--- a/docs/foundation/ci-caching-parallelism.md
+++ b/docs/foundation/ci-caching-parallelism.md
@@ -1,4 +1,4 @@
-# CI Caching and Parallelism Slice (Issues #182, #183, #568, #595)
+# CI Caching and Parallelism Slice (Issues #182, #183, #568, #595, #603, #604)
 
 This document captures the first implementation slice for CI runtime/cost optimization in story #68.
 
@@ -28,6 +28,10 @@ This document captures the first implementation slice for CI runtime/cost optimi
   - `scripts/ci/generate_performance_smoke_report.sh --lane smoke|deep`
   - `scripts/ci/check_performance_thresholds.sh --lane smoke|deep --profile-file .ci/performance-targets.env`
   - PR fast-gate runs smoke lane only; deep-validate runs deep lane on schedule/manual to keep PR cost low.
+- Added SDK parity matrix routing for SDK-related diffs:
+  - `run_sdk_parity_matrix` is true for SDK paths (`kamn_sdk.py`, `packages/kamn-sdk/*`, `crates/kamn-sdk/*`, `scripts/sdk/*`, `fixtures/sdk_parity/*`).
+  - SDK-only diffs use `test_scope=sdk` and skip broad Rust lint/test lanes to control cost.
+  - Fast-gate executes `scripts/sdk/run_sdk_parity_matrix.sh` with the canonical fixture corpus when routed.
 
 ## Operational Guidance
 - Cache invalidation:
@@ -38,6 +42,7 @@ This document captures the first implementation slice for CI runtime/cost optimi
   - Keep harness parallelism bounded (current limit: 2 in deep lane) to avoid unstable load spikes.
   - Route deploy-only diffs to `scripts/deploy/test_preflight_topology.sh` so fast-gate avoids Rust toolchain startup.
   - Keep CI-tool-check steps scoped to CI-sensitive diffs to reduce unnecessary runner time (`Regression: #568`).
+  - Keep SDK parity checks targeted to SDK paths to avoid full-suite fallback for non-Rust SDK edits (`Regression: #583`).
   - Keep performance threshold checks deterministic and fixture-based in PR lanes; reserve heavy replay/load suites for deferred deep lanes.
   - Prefer targeted crate scopes for known Rust module edits, but keep strict full-scope fallback for critical/unknown paths.
 - Troubleshooting:
@@ -54,4 +59,5 @@ bash scripts/ci/run_invariant_harness.sh --mode deep --parallelism 2 --dry-run
 bash scripts/ci/generate_performance_smoke_report.sh --lane smoke --output-json /tmp/perf-smoke.json
 bash scripts/ci/check_performance_thresholds.sh --lane smoke --report-json /tmp/perf-smoke.json --profile-file .ci/performance-targets.env
 bash scripts/deploy/test_preflight_topology.sh
+bash scripts/sdk/run_sdk_parity_matrix.sh --fixture fixtures/sdk_parity/register_validation_cases.json --output-json /tmp/sdk-parity-report.json
 ```

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -28,6 +28,7 @@ append_summary() {
     echo "- Run Rust checks: ${RUN_RUST}"
     echo "- Run CI tool checks: ${RUN_CI_TOOL_CHECKS}"
     echo "- Run deploy preflight checks: ${RUN_DEPLOY_PREFLIGHT_TESTS}"
+    echo "- Run SDK parity matrix: ${RUN_SDK_PARITY_MATRIX}"
     echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
     echo "- Critical path fallback: ${CRITICAL_PATH_CHANGED}"
@@ -113,6 +114,7 @@ DOCS_ONLY=true
 RUST_CHANGED=false
 CI_INFRA_CHANGED=false
 DEPLOY_SCRIPT_CHANGED=false
+SDK_RELATED_CHANGED=false
 CRITICAL_PATH_CHANGED=false
 UNKNOWN_RISK_CHANGED=false
 FULL_SUITE=false
@@ -157,6 +159,13 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
+    kamn_sdk.py|packages/kamn-sdk/*|crates/kamn-sdk/*|scripts/sdk/*|fixtures/sdk_parity/*|tests/python/test_sdk.py)
+      SDK_RELATED_CHANGED=true
+      classified=true
+      ;;
+  esac
+
+  case "$file" in
     crates/kamn-core/src/invariants.rs|crates/kamn-core/src/transaction.rs|crates/kamn-core/src/smoke.rs|crates/kamn-core/tests/invariant_*|crates/kamn-core/tests/transaction_guards.rs|docs/foundation/invariants.md|docs/foundation/transaction-guards.md|scripts/ci/run_invariant_harness.sh|scripts/ci/test_run_invariant_harness.sh)
       INVARIANT_RELATED_CHANGED=true
       ;;
@@ -184,6 +193,7 @@ fi
 RUN_RUST=false
 RUN_CI_TOOL_CHECKS=false
 RUN_DEPLOY_PREFLIGHT_TESTS=false
+RUN_SDK_PARITY_MATRIX=false
 FMT_CMD=":"
 CLIPPY_CMD=":"
 TEST_CMD=":"
@@ -234,6 +244,13 @@ if [ "$RUN_RUST" != true ] && [ "$DEPLOY_SCRIPT_CHANGED" = true ]; then
   TEST_SCOPE="deploy"
 fi
 
+if [ "$SDK_RELATED_CHANGED" = true ]; then
+  RUN_SDK_PARITY_MATRIX=true
+  if [ "$RUN_RUST" != true ]; then
+    TEST_SCOPE="sdk"
+  fi
+fi
+
 if [ "$CI_INFRA_CHANGED" = true ]; then
   RUN_CI_TOOL_CHECKS=true
 fi
@@ -242,6 +259,7 @@ write_output "docs_only" "$DOCS_ONLY"
 write_output "run_rust" "$RUN_RUST"
 write_output "run_ci_tool_checks" "$RUN_CI_TOOL_CHECKS"
 write_output "run_deploy_preflight_tests" "$RUN_DEPLOY_PREFLIGHT_TESTS"
+write_output "run_sdk_parity_matrix" "$RUN_SDK_PARITY_MATRIX"
 write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"
 write_output "critical_path_changed" "$CRITICAL_PATH_CHANGED"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -32,12 +32,14 @@ docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
 assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selection mismatch"
 assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only should not run rust"
 assert_eq "$(extract_output "$docs_output" "run_ci_tool_checks")" "false" "docs_only should not run CI tool checks"
+assert_eq "$(extract_output "$docs_output" "run_sdk_parity_matrix")" "false" "docs_only should not run sdk parity matrix"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
 
 deploy_output="$(run_selector $'scripts/deploy/preflight_topology.sh')"
 assert_eq "$(extract_output "$deploy_output" "docs_only")" "false" "deploy-only change must not be docs-only"
 assert_eq "$(extract_output "$deploy_output" "run_rust")" "false" "deploy-only changes should avoid rust lane"
 assert_eq "$(extract_output "$deploy_output" "run_deploy_preflight_tests")" "true" "deploy-only changes must run deploy preflight tests"
+assert_eq "$(extract_output "$deploy_output" "run_sdk_parity_matrix")" "false" "deploy-only changes should skip sdk parity matrix"
 assert_eq "$(extract_output "$deploy_output" "test_scope")" "deploy" "deploy-only changes must use deploy scope"
 
 # Regression: #463
@@ -54,11 +56,13 @@ assert_eq "$(extract_output "$critical_output" "test_scope")" "full" "workflow c
 unknown_output="$(run_selector $'config/runtime-policy.json')"
 # Regression: #505
 assert_eq "$(extract_output "$unknown_output" "run_rust")" "true" "unknown paths must run rust fallback"
+assert_eq "$(extract_output "$unknown_output" "run_sdk_parity_matrix")" "false" "unknown paths should not trigger sdk parity matrix"
 assert_eq "$(extract_output "$unknown_output" "test_scope")" "full" "unknown paths must use full fallback"
 
 targeted_output="$(run_selector $'crates/kamn-core/src/bridge_adapter.rs')"
 assert_eq "$(extract_output "$targeted_output" "run_rust")" "true" "rust path should run rust"
 assert_eq "$(extract_output "$targeted_output" "run_ci_tool_checks")" "false" "Regression: #568 non-CI paths should skip CI tool checks"
+assert_eq "$(extract_output "$targeted_output" "run_sdk_parity_matrix")" "false" "non-sdk rust paths should skip sdk parity matrix"
 assert_eq "$(extract_output "$targeted_output" "test_scope")" "targeted" "crate path should be targeted"
 
 test_cmd="$(extract_output "$targeted_output" "test_cmd")"
@@ -66,5 +70,20 @@ if ! printf '%s\n' "$test_cmd" | grep -q "run_cargo_test_with_quarantine.sh"; th
   echo "targeted test command must use quarantine wrapper" >&2
   exit 1
 fi
+
+python_sdk_output="$(run_selector $'kamn_sdk.py')"
+assert_eq "$(extract_output "$python_sdk_output" "run_rust")" "false" "python sdk-only changes should avoid rust lane"
+assert_eq "$(extract_output "$python_sdk_output" "run_sdk_parity_matrix")" "true" "python sdk-only changes must run sdk parity matrix"
+assert_eq "$(extract_output "$python_sdk_output" "test_scope")" "sdk" "python sdk-only changes should set sdk scope"
+
+typescript_sdk_output="$(run_selector $'packages/kamn-sdk/src/memory_client.ts')"
+assert_eq "$(extract_output "$typescript_sdk_output" "run_rust")" "false" "typescript sdk-only changes should avoid rust lane"
+assert_eq "$(extract_output "$typescript_sdk_output" "run_sdk_parity_matrix")" "true" "typescript sdk-only changes must run sdk parity matrix"
+assert_eq "$(extract_output "$typescript_sdk_output" "test_scope")" "sdk" "typescript sdk-only changes should set sdk scope"
+
+rust_sdk_output="$(run_selector $'crates/kamn-sdk/src/lib.rs')"
+assert_eq "$(extract_output "$rust_sdk_output" "run_rust")" "true" "rust sdk changes should run rust lane"
+# Regression: #583
+assert_eq "$(extract_output "$rust_sdk_output" "run_sdk_parity_matrix")" "true" "rust sdk changes must also run sdk parity matrix"
 
 echo "select_targets matrix regression tests passed."

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -19,4 +19,15 @@ if ! grep -Fq "bash scripts/deploy/test_generate_bundle.sh" "$FAST_WORKFLOW"; th
   exit 1
 fi
 
+# Regression: #583
+if ! grep -Fq "if: steps.scope.outputs.run_sdk_parity_matrix == 'true'" "$FAST_WORKFLOW"; then
+  echo "expected sdk parity matrix scope condition in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/sdk/run_sdk_parity_matrix.sh --fixture fixtures/sdk_parity/register_validation_cases.json --output-json sdk-parity-report.json" "$FAST_WORKFLOW"; then
+  echo "expected sdk parity matrix command in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 echo "workflow scope policy tests passed."


### PR DESCRIPTION
## Summary
Route SDK-related diffs into a targeted SDK parity matrix lane in fast-gate CI so cross-language drift is detected without forcing broad Rust validation for non-Rust SDK edits. This keeps PR validation coverage high while controlling runtime and cost.

Closes #604
Refs #603
Refs #583

## Changes
- `scripts/ci/select_targets.sh`: add deterministic `run_sdk_parity_matrix` output, SDK path classification, and `test_scope=sdk` for SDK-only diffs.
- `.github/workflows/ci-fast-gate.yml`: wire SDK parity matrix step gated by selector output and ensure Rust toolchain/cache are available for parity lane execution.
- `scripts/ci/test_select_targets.sh`: add selector regression coverage for SDK and non-SDK paths (`Regression: #583`).
- `scripts/ci/test_workflow_scope_policy.sh`: add workflow policy regression guard for SDK matrix gate and command (`Regression: #583`).
- `docs/foundation/ci-caching-parallelism.md`: document SDK parity lane routing and cost-control guidance.
- `crates/kamn-core/tests/ci_caching_parallelism_docs.rs`: add doc regression assertions for SDK parity lane guidance.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`

Output:
- `docs_only should not run sdk parity matrix: expected 'false', got ''`
- `expected sdk parity matrix scope condition in ci-fast-gate.yml`

### 🟢 Green Phase
Commands:
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`

Output:
- `select_targets matrix regression tests passed.`
- `workflow scope policy tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/sdk/test_run_sdk_parity_matrix.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo test -p kamn-core --test ci_caching_parallelism_docs`
- `python3 -m unittest tests/python/test_sdk.py`
- `npm --prefix packages/kamn-sdk test`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core`

Result:
- All commands passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/ci/test_select_targets.sh` | |
| Functional   | ✅     | `scripts/sdk/test_run_sdk_parity_matrix.sh` | |
| Integration  | ✅     | `scripts/ci/test_workflow_scope_policy.sh` | |
| Regression   | ✅     | `scripts/ci/test_select_targets.sh`, `scripts/ci/test_workflow_scope_policy.sh`, `crates/kamn-core/tests/ci_caching_parallelism_docs.rs` | |
| Performance  | ✅     | Selector routing keeps SDK-only diffs on `test_scope=sdk` lane | |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert this PR to restore previous CI scope selection behavior and remove SDK parity gate.

## Documentation Updates
- `docs/foundation/ci-caching-parallelism.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
