### PR TITLE
feat(bridges): add replay fixture matrix and targeted CI bridge lane

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -60,16 +60,20 @@ jobs:
           bash scripts/deploy/test_generate_bundle.sh
 
       - name: Set up Rust toolchain
-        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_sdk_parity_matrix == 'true'
+        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_bridge_replay_harness == 'true' || steps.scope.outputs.run_sdk_parity_matrix == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
         id: rust_cache
-        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_sdk_parity_matrix == 'true'
+        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_bridge_replay_harness == 'true' || steps.scope.outputs.run_sdk_parity_matrix == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: kamn-rust-ci-v1
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run bridge replay fixture harness
+        if: steps.scope.outputs.run_bridge_replay_harness == 'true'
+        run: bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json bridge-replay-report.json
 
       - name: Run SDK parity matrix
         if: steps.scope.outputs.run_sdk_parity_matrix == 'true'

--- a/crates/kamn-core/tests/bridge_adapter_docs.rs
+++ b/crates/kamn-core/tests/bridge_adapter_docs.rs
@@ -5,6 +5,7 @@ fn doc_contains_bridge_adapter_core_contracts() {
     assert!(DOC.contains("# Bridge Adapter Abstraction"));
     assert!(DOC.contains("BridgeAdapterEngine"));
     assert!(DOC.contains("process_inbound_to_envelope(...)"));
+    assert!(DOC.contains("run_bridge_replay_harness"));
 }
 
 #[test]
@@ -44,4 +45,12 @@ fn regression_requires_cross_chain_single_pass_projection_rule() {
     assert!(DOC.contains(
         "cross-chain inbound projection also preserves single-pass replay safety (`Regression: #443`)"
     ));
+}
+
+#[test]
+fn regression_requires_bridge_fixture_matrix_guard() {
+    // Regression: #587
+    assert!(DOC.contains("fixtures/bridge_replay/replay_validation_cases.json"));
+    assert!(DOC.contains("scripts/bridge/run_bridge_replay_matrix.sh"));
+    assert!(DOC.contains("Regression: #587"));
 }

--- a/docs/foundation/bridge-adapter-abstraction.md
+++ b/docs/foundation/bridge-adapter-abstraction.md
@@ -1,4 +1,4 @@
-# Bridge Adapter Abstraction (Issues #130, #131, #546)
+# Bridge Adapter Abstraction (Issues #130, #131, #546, #587, #589, #590)
 
 This document describes the first implementation slice for bridge adapter abstraction aligned to PRD section 10.1 and story #34.
 
@@ -17,6 +17,13 @@ This document describes the first implementation slice for bridge adapter abstra
   - `AllowAllBridgePolicy`
 - Added inbound-to-canonical-envelope projection path so bridge ingress can be validated using existing `CanonicalMessageEnvelope` schema checks.
 - Added integration tests covering deterministic behavior, policy denial, and regression guard for outbound request ID mutation.
+- Added shared bridge replay fixture corpus and matrix harness:
+  - `fixtures/bridge_replay/replay_validation_cases.json`
+  - `scripts/bridge/run_bridge_replay_case.sh`
+  - `scripts/bridge/run_bridge_replay_matrix.sh`
+- Added CI scope routing for bridge-only diffs:
+  - selector output `run_bridge_replay_harness`
+  - fast-gate bridge harness command runs only for bridge-related path changes.
 
 ## Design Notes
 - Inbound flow:
@@ -34,12 +41,17 @@ This document describes the first implementation slice for bridge adapter abstra
 - Cross-module integration:
   - `process_inbound_to_envelope(...)` maps normalized bridge ingress into `CanonicalMessageEnvelope` and runs envelope validation before returning.
   - Bridge engine wrappers apply route/listener checks while keeping single-pass inbound projection so replay guards run exactly once per logical projection flow.
+- Replay fixture coverage classes:
+  - duplicate replay: Telegram, Discord, and cross-chain inbound projection replay rejections.
+  - stale ingress: stale bridge inbound message rejection.
+  - malformed ingress: route-target mismatch and unknown route rejection paths.
 
 ## Local Validation
 Run from repository root:
 
 ```bash
 cargo test -p kamn-core --test bridge_adapter
+bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json /tmp/bridge-replay-report.json
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core
@@ -53,3 +65,4 @@ cargo test -p kamn-core
 - stale inbound event beyond freshness window is rejected (`Regression: #546`).
 - first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`).
 - cross-chain inbound projection also preserves single-pass replay safety (`Regression: #443`).
+- bridge replay fixture matrix guards duplicate/stale/malformed replay behavior across adapters (`Regression: #587`).

--- a/fixtures/bridge_replay/replay_validation_cases.json
+++ b/fixtures/bridge_replay/replay_validation_cases.json
@@ -1,0 +1,59 @@
+{
+  "version": "1",
+  "cases": [
+    {
+      "id": "telegram-duplicate-inbound-replay",
+      "suite": "telegram_bridge",
+      "test_name": "regression_rejects_replayed_telegram_inbound_projection_event",
+      "class": "duplicate",
+      "expected": {
+        "status": "pass"
+      }
+    },
+    {
+      "id": "discord-duplicate-inbound-replay",
+      "suite": "discord_bridge",
+      "test_name": "regression_rejects_replayed_discord_inbound_projection_event",
+      "class": "duplicate",
+      "expected": {
+        "status": "pass"
+      }
+    },
+    {
+      "id": "cross-chain-duplicate-inbound-replay",
+      "suite": "cross_chain_bridge",
+      "test_name": "regression_rejects_replayed_solana_inbound_projection_event",
+      "class": "duplicate",
+      "expected": {
+        "status": "pass"
+      }
+    },
+    {
+      "id": "bridge-adapter-stale-inbound",
+      "suite": "bridge_adapter",
+      "test_name": "regression_rejects_stale_inbound_event",
+      "class": "stale",
+      "expected": {
+        "status": "pass"
+      }
+    },
+    {
+      "id": "telegram-route-target-mismatch",
+      "suite": "telegram_bridge",
+      "test_name": "route_target_mismatch_is_rejected",
+      "class": "malformed",
+      "expected": {
+        "status": "pass"
+      }
+    },
+    {
+      "id": "cross-chain-unknown-route",
+      "suite": "cross_chain_bridge",
+      "test_name": "regression_unknown_ethereum_route_is_rejected",
+      "class": "malformed",
+      "expected": {
+        "status": "pass"
+      }
+    }
+  ]
+}

--- a/scripts/bridge/run_bridge_replay_case.sh
+++ b/scripts/bridge/run_bridge_replay_case.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  echo "usage: run_bridge_replay_case.sh --suite <bridge_adapter|telegram_bridge|discord_bridge|cross_chain_bridge> --test-name <test>" >&2
+  exit 2
+}
+
+suite=""
+test_name=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --suite)
+      shift
+      [ "$#" -gt 0 ] || usage
+      suite="$1"
+      ;;
+    --test-name)
+      shift
+      [ "$#" -gt 0 ] || usage
+      test_name="$1"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+  shift
+done
+
+[ -n "$suite" ] || usage
+[ -n "$test_name" ] || usage
+
+case "$suite" in
+  bridge_adapter|telegram_bridge|discord_bridge|cross_chain_bridge)
+    ;;
+  *)
+    echo "status=error"
+    echo "suite=$suite"
+    echo "test_name=$test_name"
+    echo "error=unknown suite"
+    exit 2
+    ;;
+esac
+
+set +e
+command_output="$(cargo test -p kamn-core --test "$suite" -- "$test_name" --exact 2>&1)"
+command_code=$?
+set -e
+
+if [ "$command_code" -eq 0 ]; then
+  if printf '%s\n' "$command_output" | grep -q "running 0 tests"; then
+    echo "status=fail"
+    echo "suite=$suite"
+    echo "test_name=$test_name"
+    echo "error=test-not-found"
+    exit 1
+  fi
+
+  echo "status=pass"
+  echo "suite=$suite"
+  echo "test_name=$test_name"
+  exit 0
+fi
+
+message="$(printf '%s' "$command_output" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^ //; s/ $//')"
+
+echo "status=fail"
+echo "suite=$suite"
+echo "test_name=$test_name"
+echo "error=$message"
+exit 1

--- a/scripts/bridge/run_bridge_replay_matrix.py
+++ b/scripts/bridge/run_bridge_replay_matrix.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fixture",
+        default=str(ROOT_DIR / "fixtures/bridge_replay/replay_validation_cases.json"),
+    )
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def parse_key_values(stdout: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+def run_case(case: Dict[str, Any]) -> Dict[str, str]:
+    command = [
+        "bash",
+        str(ROOT_DIR / "scripts/bridge/run_bridge_replay_case.sh"),
+        "--suite",
+        str(case.get("suite", "")),
+        "--test-name",
+        str(case.get("test_name", "")),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        text=True,
+        capture_output=True,
+    )
+
+    values = parse_key_values(completed.stdout)
+    status = values.get("status", "error")
+    error = values.get("error", "")
+
+    if completed.returncode == 2 and status == "error":
+        return {"status": "error", "error": error or "runner configuration error"}
+
+    if completed.returncode not in (0, 1):
+        message = (completed.stderr.strip() or completed.stdout.strip() or "runner failed").replace(
+            "\n", " "
+        )
+        return {"status": "error", "error": message}
+
+    return {"status": status, "error": error}
+
+
+def evaluate_case(case: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+    expected = case.get("expected", {})
+    expected_status = str(expected.get("status", "pass")) if isinstance(expected, dict) else "pass"
+
+    result = run_case(case)
+    actual_status = result.get("status", "error")
+
+    mismatches: List[str] = []
+    if actual_status != expected_status:
+        mismatches.append(f"status expected {expected_status} got {actual_status}")
+
+    passed = len(mismatches) == 0
+    record: Dict[str, Any] = {
+        "id": case.get("id", "unknown"),
+        "suite": case.get("suite", ""),
+        "test_name": case.get("test_name", ""),
+        "class": case.get("class", ""),
+        "expected_status": expected_status,
+        "actual_status": actual_status,
+        "error": result.get("error", ""),
+        "passed": passed,
+    }
+    if mismatches:
+        record["mismatches"] = mismatches
+    return record, passed
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        print(f"status=fail; reason=fixture-not-found; fixture={fixture_path}")
+        return 2
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    cases = fixture.get("cases", [])
+    if not isinstance(cases, list):
+        print("status=fail; reason=invalid-fixture-cases")
+        return 2
+
+    report_cases: List[Dict[str, Any]] = []
+    failed_ids: List[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            failed_ids.append("invalid-case")
+            continue
+        record, passed = evaluate_case(case)
+        report_cases.append(record)
+        if not passed:
+            failed_ids.append(str(case.get("id", "unknown")))
+
+    status = "pass" if not failed_ids else "fail"
+    report = {
+        "status": status,
+        "fixture": str(fixture_path),
+        "case_count": len(cases),
+        "failed_count": len(failed_ids),
+        "failed_case_ids": failed_ids,
+        "cases": report_cases,
+    }
+
+    if args.output_json:
+        Path(args.output_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if status == "pass":
+        print(f"status=pass; cases={len(cases)}; failed=0")
+        return 0
+
+    print(
+        "status=fail; "
+        f"cases={len(cases)}; failed={len(failed_ids)}; "
+        f"failed_ids={','.join(failed_ids)}"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bridge/run_bridge_replay_matrix.sh
+++ b/scripts/bridge/run_bridge_replay_matrix.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 scripts/bridge/run_bridge_replay_matrix.py "$@"

--- a/scripts/bridge/test_run_bridge_replay_matrix.sh
+++ b/scripts/bridge/test_run_bridge_replay_matrix.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_replay_matrix.sh"
+FIXTURE="$ROOT_DIR/fixtures/bridge_replay/replay_validation_cases.json"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS_REPORT="$TMP_DIR/pass-report.json"
+bash "$SCRIPT" --fixture "$FIXTURE" --output-json "$PASS_REPORT" >"$TMP_DIR/pass.out"
+grep -q '"status": "pass"' "$PASS_REPORT"
+
+INVALID_FIXTURE="$TMP_DIR/invalid.json"
+cat >"$INVALID_FIXTURE" <<'JSON'
+{
+  "cases": {}
+}
+JSON
+
+set +e
+bash "$SCRIPT" --fixture "$INVALID_FIXTURE" --output-json "$TMP_DIR/invalid-report.json" >"$TMP_DIR/invalid.out" 2>&1
+invalid_code=$?
+set -e
+
+if [ "$invalid_code" -eq 0 ]; then
+  echo "expected bridge replay matrix to fail for invalid fixture schema" >&2
+  exit 1
+fi
+
+if ! grep -q "status=fail; reason=invalid-fixture-cases" "$TMP_DIR/invalid.out"; then
+  echo "expected invalid fixture schema failure status output" >&2
+  exit 1
+fi
+
+MISMATCH_FIXTURE="$TMP_DIR/mismatch.json"
+cat >"$MISMATCH_FIXTURE" <<'JSON'
+{
+  "cases": [
+    {
+      "id": "replay-nonexistent-test",
+      "suite": "telegram_bridge",
+      "test_name": "does_not_exist",
+      "class": "duplicate",
+      "expected": {
+        "status": "pass"
+      }
+    }
+  ]
+}
+JSON
+
+set +e
+bash "$SCRIPT" --fixture "$MISMATCH_FIXTURE" --output-json "$TMP_DIR/fail-report.json" >"$TMP_DIR/fail.out" 2>&1
+fail_code=$?
+set -e
+
+if [ "$fail_code" -eq 0 ]; then
+  echo "expected bridge replay matrix to fail for mismatch fixture" >&2
+  exit 1
+fi
+
+# Regression: #587
+if ! grep -q "status=fail" "$TMP_DIR/fail.out"; then
+  echo "expected mismatch failure status output" >&2
+  exit 1
+fi
+
+echo "bridge replay matrix tests passed."

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -28,6 +28,7 @@ append_summary() {
     echo "- Run Rust checks: ${RUN_RUST}"
     echo "- Run CI tool checks: ${RUN_CI_TOOL_CHECKS}"
     echo "- Run deploy preflight checks: ${RUN_DEPLOY_PREFLIGHT_TESTS}"
+    echo "- Run bridge replay harness: ${RUN_BRIDGE_REPLAY_HARNESS}"
     echo "- Run SDK parity matrix: ${RUN_SDK_PARITY_MATRIX}"
     echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
@@ -114,6 +115,7 @@ DOCS_ONLY=true
 RUST_CHANGED=false
 CI_INFRA_CHANGED=false
 DEPLOY_SCRIPT_CHANGED=false
+BRIDGE_REPLAY_RELATED_CHANGED=false
 SDK_RELATED_CHANGED=false
 CRITICAL_PATH_CHANGED=false
 UNKNOWN_RISK_CHANGED=false
@@ -159,6 +161,13 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
+    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/src/telegram_bridge.rs|crates/kamn-core/src/discord_bridge.rs|crates/kamn-core/src/cross_chain_bridge.rs|crates/kamn-core/tests/bridge_adapter.rs|crates/kamn-core/tests/telegram_bridge.rs|crates/kamn-core/tests/discord_bridge.rs|crates/kamn-core/tests/cross_chain_bridge.rs|docs/foundation/bridge-adapter-abstraction.md|scripts/bridge/*|fixtures/bridge_replay/*)
+      BRIDGE_REPLAY_RELATED_CHANGED=true
+      classified=true
+      ;;
+  esac
+
+  case "$file" in
     kamn_sdk.py|packages/kamn-sdk/*|crates/kamn-sdk/*|scripts/sdk/*|fixtures/sdk_parity/*|tests/python/test_sdk.py)
       SDK_RELATED_CHANGED=true
       classified=true
@@ -193,6 +202,7 @@ fi
 RUN_RUST=false
 RUN_CI_TOOL_CHECKS=false
 RUN_DEPLOY_PREFLIGHT_TESTS=false
+RUN_BRIDGE_REPLAY_HARNESS=false
 RUN_SDK_PARITY_MATRIX=false
 FMT_CMD=":"
 CLIPPY_CMD=":"
@@ -244,6 +254,13 @@ if [ "$RUN_RUST" != true ] && [ "$DEPLOY_SCRIPT_CHANGED" = true ]; then
   TEST_SCOPE="deploy"
 fi
 
+if [ "$BRIDGE_REPLAY_RELATED_CHANGED" = true ]; then
+  RUN_BRIDGE_REPLAY_HARNESS=true
+  if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
+    TEST_SCOPE="bridge"
+  fi
+fi
+
 if [ "$SDK_RELATED_CHANGED" = true ]; then
   RUN_SDK_PARITY_MATRIX=true
   if [ "$RUN_RUST" != true ]; then
@@ -259,6 +276,7 @@ write_output "docs_only" "$DOCS_ONLY"
 write_output "run_rust" "$RUN_RUST"
 write_output "run_ci_tool_checks" "$RUN_CI_TOOL_CHECKS"
 write_output "run_deploy_preflight_tests" "$RUN_DEPLOY_PREFLIGHT_TESTS"
+write_output "run_bridge_replay_harness" "$RUN_BRIDGE_REPLAY_HARNESS"
 write_output "run_sdk_parity_matrix" "$RUN_SDK_PARITY_MATRIX"
 write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -19,6 +19,7 @@ bash "$ROOT_DIR/scripts/ci/test_workflow_retry_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_cache_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_scope_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_workflow_performance_policy.sh"
+bash "$ROOT_DIR/scripts/bridge/test_run_bridge_replay_matrix.sh"
 bash "$ROOT_DIR/scripts/deploy/test_preflight_topology.sh"
 bash "$ROOT_DIR/scripts/deploy/test_generate_bundle.sh"
 

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -32,6 +32,7 @@ docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
 assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selection mismatch"
 assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only should not run rust"
 assert_eq "$(extract_output "$docs_output" "run_ci_tool_checks")" "false" "docs_only should not run CI tool checks"
+assert_eq "$(extract_output "$docs_output" "run_bridge_replay_harness")" "false" "docs_only should not run bridge replay harness"
 assert_eq "$(extract_output "$docs_output" "run_sdk_parity_matrix")" "false" "docs_only should not run sdk parity matrix"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
 
@@ -39,6 +40,7 @@ deploy_output="$(run_selector $'scripts/deploy/preflight_topology.sh')"
 assert_eq "$(extract_output "$deploy_output" "docs_only")" "false" "deploy-only change must not be docs-only"
 assert_eq "$(extract_output "$deploy_output" "run_rust")" "false" "deploy-only changes should avoid rust lane"
 assert_eq "$(extract_output "$deploy_output" "run_deploy_preflight_tests")" "true" "deploy-only changes must run deploy preflight tests"
+assert_eq "$(extract_output "$deploy_output" "run_bridge_replay_harness")" "false" "deploy-only changes should skip bridge replay harness"
 assert_eq "$(extract_output "$deploy_output" "run_sdk_parity_matrix")" "false" "deploy-only changes should skip sdk parity matrix"
 assert_eq "$(extract_output "$deploy_output" "test_scope")" "deploy" "deploy-only changes must use deploy scope"
 
@@ -56,12 +58,14 @@ assert_eq "$(extract_output "$critical_output" "test_scope")" "full" "workflow c
 unknown_output="$(run_selector $'config/runtime-policy.json')"
 # Regression: #505
 assert_eq "$(extract_output "$unknown_output" "run_rust")" "true" "unknown paths must run rust fallback"
+assert_eq "$(extract_output "$unknown_output" "run_bridge_replay_harness")" "false" "unknown paths should not trigger bridge replay harness"
 assert_eq "$(extract_output "$unknown_output" "run_sdk_parity_matrix")" "false" "unknown paths should not trigger sdk parity matrix"
 assert_eq "$(extract_output "$unknown_output" "test_scope")" "full" "unknown paths must use full fallback"
 
 targeted_output="$(run_selector $'crates/kamn-core/src/bridge_adapter.rs')"
 assert_eq "$(extract_output "$targeted_output" "run_rust")" "true" "rust path should run rust"
 assert_eq "$(extract_output "$targeted_output" "run_ci_tool_checks")" "false" "Regression: #568 non-CI paths should skip CI tool checks"
+assert_eq "$(extract_output "$targeted_output" "run_bridge_replay_harness")" "true" "bridge adapter rust paths should run bridge replay harness"
 assert_eq "$(extract_output "$targeted_output" "run_sdk_parity_matrix")" "false" "non-sdk rust paths should skip sdk parity matrix"
 assert_eq "$(extract_output "$targeted_output" "test_scope")" "targeted" "crate path should be targeted"
 
@@ -85,5 +89,11 @@ rust_sdk_output="$(run_selector $'crates/kamn-sdk/src/lib.rs')"
 assert_eq "$(extract_output "$rust_sdk_output" "run_rust")" "true" "rust sdk changes should run rust lane"
 # Regression: #583
 assert_eq "$(extract_output "$rust_sdk_output" "run_sdk_parity_matrix")" "true" "rust sdk changes must also run sdk parity matrix"
+assert_eq "$(extract_output "$rust_sdk_output" "run_bridge_replay_harness")" "false" "sdk-only paths should skip bridge replay harness"
+
+bridge_script_output="$(run_selector $'scripts/bridge/run_bridge_replay_matrix.sh')"
+assert_eq "$(extract_output "$bridge_script_output" "run_rust")" "false" "bridge script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$bridge_script_output" "run_bridge_replay_harness")" "true" "bridge script-only changes must run bridge replay harness"
+assert_eq "$(extract_output "$bridge_script_output" "test_scope")" "bridge" "bridge script-only changes should set bridge scope"
 
 echo "select_targets matrix regression tests passed."

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -19,6 +19,17 @@ if ! grep -Fq "bash scripts/deploy/test_generate_bundle.sh" "$FAST_WORKFLOW"; th
   exit 1
 fi
 
+# Regression: #587
+if ! grep -Fq "if: steps.scope.outputs.run_bridge_replay_harness == 'true'" "$FAST_WORKFLOW"; then
+  echo "expected bridge replay harness scope condition in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json bridge-replay-report.json" "$FAST_WORKFLOW"; then
+  echo "expected bridge replay harness command in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 # Regression: #583
 if ! grep -Fq "if: steps.scope.outputs.run_sdk_parity_matrix == 'true'" "$FAST_WORKFLOW"; then
   echo "expected sdk parity matrix scope condition in ci-fast-gate.yml" >&2


### PR DESCRIPTION
## Summary
Implement a shared bridge replay fixture matrix with adapter case runner hooks and route bridge-related diffs into a targeted fast-gate CI harness lane. This delivers deterministic duplicate/stale/malformed replay validation while keeping CI scope cost-efficient.

Closes #589
Closes #590
Refs #588
Refs #587

## Changes
- `fixtures/bridge_replay/replay_validation_cases.json`: add canonical duplicate/stale/malformed bridge replay fixture corpus.
- `scripts/bridge/run_bridge_replay_case.sh`: add suite/test adapter hook runner with deterministic pass/fail output and test-not-found detection.
- `scripts/bridge/run_bridge_replay_matrix.py` + `scripts/bridge/run_bridge_replay_matrix.sh`: add fixture-driven bridge replay matrix harness and JSON reporting.
- `scripts/bridge/test_run_bridge_replay_matrix.sh`: add fixture harness regression tests (pass, invalid fixture schema, mismatch fixture) (`Regression: #587`).
- `scripts/ci/select_targets.sh`: add `run_bridge_replay_harness` selector output and bridge-only `test_scope=bridge` routing.
- `.github/workflows/ci-fast-gate.yml`: wire bridge replay matrix step gated by selector output.
- `scripts/ci/test_select_targets.sh` + `scripts/ci/test_workflow_scope_policy.sh`: add CI routing/policy regression guards for bridge harness gate (`Regression: #587`).
- `scripts/ci/test_ci_tools.sh`: include bridge replay matrix script tests in CI tool regression suite.
- `docs/foundation/bridge-adapter-abstraction.md` + `crates/kamn-core/tests/bridge_adapter_docs.rs`: document and enforce bridge replay fixture matrix guidance.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
- `bash scripts/bridge/test_run_bridge_replay_matrix.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`

Output:
- `bash: /home/n/Code/kamn/scripts/bridge/run_bridge_replay_matrix.sh: No such file or directory`
- `docs_only should not run bridge replay harness: expected 'false', got ''`
- `expected bridge replay harness scope condition in ci-fast-gate.yml`

### 🟢 Green Phase
Commands:
- `bash scripts/bridge/test_run_bridge_replay_matrix.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`

Output:
- `bridge replay matrix tests passed.`
- `select_targets matrix regression tests passed.`
- `workflow scope policy tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json /tmp/bridge-replay-report.json`
- `bash scripts/bridge/test_run_bridge_replay_matrix.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo test -p kamn-core --test bridge_adapter_docs`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core`

Result:
- All commands passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/bridge/test_run_bridge_replay_matrix.sh` (fixture schema + mismatch detection) | |
| Functional   | ✅     | `scripts/bridge/run_bridge_replay_matrix.sh` over canonical fixture cases | |
| Integration  | ✅     | `scripts/ci/test_workflow_scope_policy.sh`, `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | `scripts/bridge/test_run_bridge_replay_matrix.sh`, `scripts/ci/test_select_targets.sh`, `scripts/ci/test_workflow_scope_policy.sh`, `crates/kamn-core/tests/bridge_adapter_docs.rs` | |
| Performance  | ✅     | bridge-only diffs route to targeted bridge harness lane (`test_scope=bridge`) | |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert this PR to restore previous CI routing and remove bridge replay fixture harness lane.

## Documentation Updates
- `docs/foundation/bridge-adapter-abstraction.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
