### PR TITLE
feat(ci): add bridge subset routing and signature-failure fixtures

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run bridge replay fixture harness
         if: steps.scope.outputs.run_bridge_replay_harness == 'true'
-        run: bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json bridge-replay-report.json
+        run: bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites "${{ steps.scope.outputs.bridge_replay_suites }}" --output-json bridge-replay-report.json
 
       - name: Run SDK parity matrix
         if: steps.scope.outputs.run_sdk_parity_matrix == 'true'

--- a/crates/kamn-core/tests/bridge_adapter_docs.rs
+++ b/crates/kamn-core/tests/bridge_adapter_docs.rs
@@ -6,6 +6,7 @@ fn doc_contains_bridge_adapter_core_contracts() {
     assert!(DOC.contains("BridgeAdapterEngine"));
     assert!(DOC.contains("process_inbound_to_envelope(...)"));
     assert!(DOC.contains("run_bridge_replay_harness"));
+    assert!(DOC.contains("bridge_replay_suites"));
 }
 
 #[test]
@@ -52,5 +53,7 @@ fn regression_requires_bridge_fixture_matrix_guard() {
     // Regression: #587
     assert!(DOC.contains("fixtures/bridge_replay/replay_validation_cases.json"));
     assert!(DOC.contains("scripts/bridge/run_bridge_replay_matrix.sh"));
+    assert!(DOC.contains("signature-failure"));
+    assert!(DOC.contains("adapter subset execution"));
     assert!(DOC.contains("Regression: #587"));
 }

--- a/crates/kamn-core/tests/bridge_quorum_runtime_docs.rs
+++ b/crates/kamn-core/tests/bridge_quorum_runtime_docs.rs
@@ -17,6 +17,8 @@ fn doc_contains_bridge_quorum_fast_lane_commands() {
     assert!(DOC.contains("cargo test -p kamn-core --test bridge_quorum_runtime_docs"));
     assert!(DOC.contains("cargo test -p kamn-core --test runtime_network_docs"));
     assert!(DOC.contains("cargo test -p kamn-core approver_quorum"));
+    assert!(DOC.contains("bridge_replay_matrix.sh"));
+    assert!(DOC.contains("--suites bridge_adapter,discord_bridge"));
     assert!(DOC.contains("cargo fmt --check"));
     assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
 }
@@ -28,4 +30,6 @@ fn regression_requires_listener_and_approver_quorum_guard_rules() {
     assert!(DOC.contains("Replayed or out-of-order listener event sequences are rejected."));
     assert!(DOC.contains("Outbound under-quorum approval sets are rejected."));
     assert!(DOC.contains("Malformed approver attestation payload is rejected."));
+    assert!(DOC.contains("unauthorized approver signature-failure rejection"));
+    assert!(DOC.contains("Regression: #587"));
 }

--- a/docs/foundation/bridge-adapter-abstraction.md
+++ b/docs/foundation/bridge-adapter-abstraction.md
@@ -1,4 +1,4 @@
-# Bridge Adapter Abstraction (Issues #130, #131, #546, #587, #589, #590)
+# Bridge Adapter Abstraction (Issues #130, #131, #546, #587, #589, #590, #612)
 
 This document describes the first implementation slice for bridge adapter abstraction aligned to PRD section 10.1 and story #34.
 
@@ -23,7 +23,8 @@ This document describes the first implementation slice for bridge adapter abstra
   - `scripts/bridge/run_bridge_replay_matrix.sh`
 - Added CI scope routing for bridge-only diffs:
   - selector output `run_bridge_replay_harness`
-  - fast-gate bridge harness command runs only for bridge-related path changes.
+  - selector output `bridge_replay_suites` to run changed adapter subsets.
+  - fast-gate bridge harness command runs only for bridge-related path changes and passes selected suites.
 
 ## Design Notes
 - Inbound flow:
@@ -45,13 +46,14 @@ This document describes the first implementation slice for bridge adapter abstra
   - duplicate replay: Telegram, Discord, and cross-chain inbound projection replay rejections.
   - stale ingress: stale bridge inbound message rejection.
   - malformed ingress: route-target mismatch and unknown route rejection paths.
+  - signature-failure: unauthorized approver signatures are rejected for Discord and cross-chain outbound quorum flows.
 
 ## Local Validation
 Run from repository root:
 
 ```bash
 cargo test -p kamn-core --test bridge_adapter
-bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json /tmp/bridge-replay-report.json
+bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites bridge_adapter,telegram_bridge --output-json /tmp/bridge-replay-report.json
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core
@@ -66,3 +68,4 @@ cargo test -p kamn-core
 - first inbound-to-envelope projection does not self-trigger duplicate replay rejection (`Regression: #438`).
 - cross-chain inbound projection also preserves single-pass replay safety (`Regression: #443`).
 - bridge replay fixture matrix guards duplicate/stale/malformed replay behavior across adapters (`Regression: #587`).
+- bridge replay fixture matrix includes signature-failure class coverage and adapter subset execution (`Regression: #587`).

--- a/docs/foundation/bridge-quorum-runtime.md
+++ b/docs/foundation/bridge-quorum-runtime.md
@@ -20,6 +20,10 @@ This document captures deterministic bridge quorum runtime contracts for listene
   - `ApproverQuorumDecision`
   - `ApproverQuorumError`
   - `authorize_daemon_outbound_action`
+- Added bridge replay fixture mapping for approver signature-failure coverage:
+  - `discord_bridge::outbound_rejects_unauthorized_approver`
+  - `cross_chain_bridge::outbound_rejects_unauthorized_approver`
+- Added bridge replay subset command example for low-cost fast-gate execution.
 
 ## Listener Quorum Workflow Rules
 - Inbound bridge decisions require canonical listener attestation normalization before threshold evaluation.
@@ -43,6 +47,7 @@ This document captures deterministic bridge quorum runtime contracts for listene
   - listener event sequence replay rejection (`Regression: #371`)
   - malformed approver payload rejection (`Regression: #372`)
   - outbound under-quorum rejection (`Regression: #372`)
+  - unauthorized approver signature-failure rejection in bridge replay fixtures (`Regression: #587`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
@@ -51,6 +56,7 @@ Run targeted checks first:
 cargo test -p kamn-core --test bridge_quorum_runtime_docs
 cargo test -p kamn-core --test runtime_network_docs
 cargo test -p kamn-core approver_quorum
+bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites bridge_adapter,discord_bridge --output-json /tmp/bridge-replay-quorum-report.json
 cargo fmt --check
 cargo clippy -p kamn-core -- -D warnings
 ```

--- a/fixtures/bridge_replay/replay_validation_cases.json
+++ b/fixtures/bridge_replay/replay_validation_cases.json
@@ -54,6 +54,24 @@
       "expected": {
         "status": "pass"
       }
+    },
+    {
+      "id": "discord-unauthorized-approver-signature-failure",
+      "suite": "discord_bridge",
+      "test_name": "outbound_rejects_unauthorized_approver",
+      "class": "signature-failure",
+      "expected": {
+        "status": "pass"
+      }
+    },
+    {
+      "id": "cross-chain-unauthorized-approver-signature-failure",
+      "suite": "cross_chain_bridge",
+      "test_name": "outbound_rejects_unauthorized_approver",
+      "class": "signature-failure",
+      "expected": {
+        "status": "pass"
+      }
     }
   ]
 }

--- a/scripts/bridge/run_bridge_replay_matrix.py
+++ b/scripts/bridge/run_bridge_replay_matrix.py
@@ -17,6 +17,11 @@ def parse_args() -> argparse.Namespace:
         "--fixture",
         default=str(ROOT_DIR / "fixtures/bridge_replay/replay_validation_cases.json"),
     )
+    parser.add_argument(
+        "--suites",
+        default="",
+        help="Comma-separated suite names to include (for example: telegram_bridge,bridge_adapter)",
+    )
     parser.add_argument("--output-json", default="")
     return parser.parse_args()
 
@@ -30,6 +35,20 @@ def parse_key_values(stdout: str) -> Dict[str, str]:
         key, value = line.split("=", 1)
         values[key] = value
     return values
+
+
+def parse_requested_suites(raw: str) -> List[str]:
+    requested: List[str] = []
+    seen = set()
+    for part in raw.split(","):
+        suite = part.strip()
+        if not suite:
+            continue
+        if suite in seen:
+            continue
+        seen.add(suite)
+        requested.append(suite)
+    return requested
 
 
 def run_case(case: Dict[str, Any]) -> Dict[str, str]:
@@ -104,9 +123,27 @@ def main() -> int:
         print("status=fail; reason=invalid-fixture-cases")
         return 2
 
+    requested_suites = parse_requested_suites(args.suites)
+    if requested_suites:
+        requested_set = set(requested_suites)
+        selected_cases = [
+            case
+            for case in cases
+            if isinstance(case, dict) and str(case.get("suite", "")) in requested_set
+        ]
+        if not selected_cases:
+            print(
+                "status=fail; "
+                "reason=no-selected-cases; "
+                f"requested_suites={','.join(requested_suites)}"
+            )
+            return 2
+    else:
+        selected_cases = cases
+
     report_cases: List[Dict[str, Any]] = []
     failed_ids: List[str] = []
-    for case in cases:
+    for case in selected_cases:
         if not isinstance(case, dict):
             failed_ids.append("invalid-case")
             continue
@@ -119,9 +156,10 @@ def main() -> int:
     report = {
         "status": status,
         "fixture": str(fixture_path),
-        "case_count": len(cases),
+        "case_count": len(selected_cases),
         "failed_count": len(failed_ids),
         "failed_case_ids": failed_ids,
+        "requested_suites": requested_suites,
         "cases": report_cases,
     }
 
@@ -129,12 +167,15 @@ def main() -> int:
         Path(args.output_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     if status == "pass":
-        print(f"status=pass; cases={len(cases)}; failed=0")
+        print(
+            f"status=pass; cases={len(selected_cases)}; failed=0; "
+            f"suites={','.join(requested_suites) if requested_suites else 'all'}"
+        )
         return 0
 
     print(
         "status=fail; "
-        f"cases={len(cases)}; failed={len(failed_ids)}; "
+        f"cases={len(selected_cases)}; failed={len(failed_ids)}; "
         f"failed_ids={','.join(failed_ids)}"
     )
     return 1

--- a/scripts/bridge/test_run_bridge_replay_matrix.sh
+++ b/scripts/bridge/test_run_bridge_replay_matrix.sh
@@ -11,6 +11,30 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 PASS_REPORT="$TMP_DIR/pass-report.json"
 bash "$SCRIPT" --fixture "$FIXTURE" --output-json "$PASS_REPORT" >"$TMP_DIR/pass.out"
 grep -q '"status": "pass"' "$PASS_REPORT"
+grep -q '"class": "signature-failure"' "$PASS_REPORT"
+
+TELEGRAM_REPORT="$TMP_DIR/telegram-report.json"
+bash "$SCRIPT" --fixture "$FIXTURE" --suites "telegram_bridge" --output-json "$TELEGRAM_REPORT" >"$TMP_DIR/telegram.out"
+grep -q '"suite": "telegram_bridge"' "$TELEGRAM_REPORT"
+if grep -q '"suite": "discord_bridge"' "$TELEGRAM_REPORT"; then
+  echo "expected suite-filtered report to exclude discord cases" >&2
+  exit 1
+fi
+
+set +e
+bash "$SCRIPT" --fixture "$FIXTURE" --suites "unknown_suite" --output-json "$TMP_DIR/unknown-suite.json" >"$TMP_DIR/unknown-suite.out" 2>&1
+unknown_suite_code=$?
+set -e
+
+if [ "$unknown_suite_code" -eq 0 ]; then
+  echo "expected bridge replay matrix to fail for unknown suite filter" >&2
+  exit 1
+fi
+
+if ! grep -q "reason=no-selected-cases" "$TMP_DIR/unknown-suite.out"; then
+  echo "expected unknown suite filter failure status output" >&2
+  exit 1
+fi
 
 INVALID_FIXTURE="$TMP_DIR/invalid.json"
 cat >"$INVALID_FIXTURE" <<'JSON'

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -30,6 +30,7 @@ append_summary() {
     echo "- Run deploy preflight checks: ${RUN_DEPLOY_PREFLIGHT_TESTS}"
     echo "- Run frontend dashboard tests: ${RUN_FRONTEND_DASHBOARD_TESTS}"
     echo "- Run bridge replay harness: ${RUN_BRIDGE_REPLAY_HARNESS}"
+    echo "- Bridge replay suites: ${BRIDGE_REPLAY_SUITES}"
     echo "- Run SDK parity matrix: ${RUN_SDK_PARITY_MATRIX}"
     echo "- Run invariant harness: ${RUN_INVARIANT_HARNESS}"
     echo "- Test scope: ${TEST_SCOPE}"
@@ -118,6 +119,10 @@ CI_INFRA_CHANGED=false
 DEPLOY_SCRIPT_CHANGED=false
 FRONTEND_DASHBOARD_CHANGED=false
 BRIDGE_REPLAY_RELATED_CHANGED=false
+BRIDGE_SUITE_ADAPTER=false
+BRIDGE_SUITE_TELEGRAM=false
+BRIDGE_SUITE_DISCORD=false
+BRIDGE_SUITE_CROSS_CHAIN=false
 SDK_RELATED_CHANGED=false
 CRITICAL_PATH_CHANGED=false
 UNKNOWN_RISK_CHANGED=false
@@ -170,8 +175,30 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/src/telegram_bridge.rs|crates/kamn-core/src/discord_bridge.rs|crates/kamn-core/src/cross_chain_bridge.rs|crates/kamn-core/tests/bridge_adapter.rs|crates/kamn-core/tests/telegram_bridge.rs|crates/kamn-core/tests/discord_bridge.rs|crates/kamn-core/tests/cross_chain_bridge.rs|docs/foundation/bridge-adapter-abstraction.md|scripts/bridge/*|fixtures/bridge_replay/*)
+    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/tests/bridge_adapter.rs|docs/foundation/bridge-adapter-abstraction.md|scripts/bridge/*|fixtures/bridge_replay/*)
       BRIDGE_REPLAY_RELATED_CHANGED=true
+      BRIDGE_SUITE_ADAPTER=true
+      BRIDGE_SUITE_TELEGRAM=true
+      BRIDGE_SUITE_DISCORD=true
+      BRIDGE_SUITE_CROSS_CHAIN=true
+      classified=true
+      ;;
+    crates/kamn-core/src/telegram_bridge.rs|crates/kamn-core/tests/telegram_bridge.rs)
+      BRIDGE_REPLAY_RELATED_CHANGED=true
+      BRIDGE_SUITE_ADAPTER=true
+      BRIDGE_SUITE_TELEGRAM=true
+      classified=true
+      ;;
+    crates/kamn-core/src/discord_bridge.rs|crates/kamn-core/tests/discord_bridge.rs)
+      BRIDGE_REPLAY_RELATED_CHANGED=true
+      BRIDGE_SUITE_ADAPTER=true
+      BRIDGE_SUITE_DISCORD=true
+      classified=true
+      ;;
+    crates/kamn-core/src/cross_chain_bridge.rs|crates/kamn-core/tests/cross_chain_bridge.rs)
+      BRIDGE_REPLAY_RELATED_CHANGED=true
+      BRIDGE_SUITE_ADAPTER=true
+      BRIDGE_SUITE_CROSS_CHAIN=true
       classified=true
       ;;
   esac
@@ -220,6 +247,7 @@ TEST_CMD=":"
 TEST_SCOPE="none"
 CHANGED_MANIFESTS=""
 RUN_INVARIANT_HARNESS=false
+BRIDGE_REPLAY_SUITES=""
 
 if [ "$REPO_HAS_RUST" = true ] && { [ "$RUST_CHANGED" = true ] || [ "$CI_INFRA_CHANGED" = true ] || [ "$FULL_SUITE" = true ]; }; then
   RUN_RUST=true
@@ -273,6 +301,28 @@ fi
 
 if [ "$BRIDGE_REPLAY_RELATED_CHANGED" = true ]; then
   RUN_BRIDGE_REPLAY_HARNESS=true
+  bridge_suite_parts=()
+  if [ "$BRIDGE_SUITE_ADAPTER" = true ]; then
+    bridge_suite_parts+=("bridge_adapter")
+  fi
+  if [ "$BRIDGE_SUITE_TELEGRAM" = true ]; then
+    bridge_suite_parts+=("telegram_bridge")
+  fi
+  if [ "$BRIDGE_SUITE_DISCORD" = true ]; then
+    bridge_suite_parts+=("discord_bridge")
+  fi
+  if [ "$BRIDGE_SUITE_CROSS_CHAIN" = true ]; then
+    bridge_suite_parts+=("cross_chain_bridge")
+  fi
+  if [ "${#bridge_suite_parts[@]}" -eq 0 ]; then
+    bridge_suite_parts=(
+      "bridge_adapter"
+      "telegram_bridge"
+      "discord_bridge"
+      "cross_chain_bridge"
+    )
+  fi
+  BRIDGE_REPLAY_SUITES="$(printf '%s,' "${bridge_suite_parts[@]}" | sed 's/,$//')"
   if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
     TEST_SCOPE="bridge"
   fi
@@ -295,6 +345,7 @@ write_output "run_ci_tool_checks" "$RUN_CI_TOOL_CHECKS"
 write_output "run_deploy_preflight_tests" "$RUN_DEPLOY_PREFLIGHT_TESTS"
 write_output "run_frontend_dashboard_tests" "$RUN_FRONTEND_DASHBOARD_TESTS"
 write_output "run_bridge_replay_harness" "$RUN_BRIDGE_REPLAY_HARNESS"
+write_output "bridge_replay_suites" "$BRIDGE_REPLAY_SUITES"
 write_output "run_sdk_parity_matrix" "$RUN_SDK_PARITY_MATRIX"
 write_output "run_invariant_harness" "$RUN_INVARIANT_HARNESS"
 write_output "test_scope" "$TEST_SCOPE"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -34,6 +34,7 @@ assert_eq "$(extract_output "$docs_output" "run_rust")" "false" "docs_only shoul
 assert_eq "$(extract_output "$docs_output" "run_ci_tool_checks")" "false" "docs_only should not run CI tool checks"
 assert_eq "$(extract_output "$docs_output" "run_frontend_dashboard_tests")" "false" "docs_only should not run frontend dashboard tests"
 assert_eq "$(extract_output "$docs_output" "run_bridge_replay_harness")" "false" "docs_only should not run bridge replay harness"
+assert_eq "$(extract_output "$docs_output" "bridge_replay_suites")" "" "docs_only should not select bridge replay suites"
 assert_eq "$(extract_output "$docs_output" "run_sdk_parity_matrix")" "false" "docs_only should not run sdk parity matrix"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
 
@@ -43,6 +44,7 @@ assert_eq "$(extract_output "$deploy_output" "run_rust")" "false" "deploy-only c
 assert_eq "$(extract_output "$deploy_output" "run_deploy_preflight_tests")" "true" "deploy-only changes must run deploy preflight tests"
 assert_eq "$(extract_output "$deploy_output" "run_frontend_dashboard_tests")" "false" "deploy-only changes should skip frontend dashboard tests"
 assert_eq "$(extract_output "$deploy_output" "run_bridge_replay_harness")" "false" "deploy-only changes should skip bridge replay harness"
+assert_eq "$(extract_output "$deploy_output" "bridge_replay_suites")" "" "deploy-only changes should not select bridge replay suites"
 assert_eq "$(extract_output "$deploy_output" "run_sdk_parity_matrix")" "false" "deploy-only changes should skip sdk parity matrix"
 assert_eq "$(extract_output "$deploy_output" "test_scope")" "deploy" "deploy-only changes must use deploy scope"
 
@@ -62,6 +64,7 @@ unknown_output="$(run_selector $'config/runtime-policy.json')"
 assert_eq "$(extract_output "$unknown_output" "run_rust")" "true" "unknown paths must run rust fallback"
 assert_eq "$(extract_output "$unknown_output" "run_frontend_dashboard_tests")" "false" "unknown paths should not trigger frontend dashboard tests"
 assert_eq "$(extract_output "$unknown_output" "run_bridge_replay_harness")" "false" "unknown paths should not trigger bridge replay harness"
+assert_eq "$(extract_output "$unknown_output" "bridge_replay_suites")" "" "unknown paths should not select bridge replay suites"
 assert_eq "$(extract_output "$unknown_output" "run_sdk_parity_matrix")" "false" "unknown paths should not trigger sdk parity matrix"
 assert_eq "$(extract_output "$unknown_output" "test_scope")" "full" "unknown paths must use full fallback"
 
@@ -70,6 +73,7 @@ assert_eq "$(extract_output "$targeted_output" "run_rust")" "true" "rust path sh
 assert_eq "$(extract_output "$targeted_output" "run_ci_tool_checks")" "false" "Regression: #568 non-CI paths should skip CI tool checks"
 assert_eq "$(extract_output "$targeted_output" "run_frontend_dashboard_tests")" "false" "bridge adapter rust paths should skip frontend dashboard tests"
 assert_eq "$(extract_output "$targeted_output" "run_bridge_replay_harness")" "true" "bridge adapter rust paths should run bridge replay harness"
+assert_eq "$(extract_output "$targeted_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge,discord_bridge,cross_chain_bridge" "bridge adapter path should select all bridge suites"
 assert_eq "$(extract_output "$targeted_output" "run_sdk_parity_matrix")" "false" "non-sdk rust paths should skip sdk parity matrix"
 assert_eq "$(extract_output "$targeted_output" "test_scope")" "targeted" "crate path should be targeted"
 
@@ -100,7 +104,20 @@ bridge_script_output="$(run_selector $'scripts/bridge/run_bridge_replay_matrix.s
 assert_eq "$(extract_output "$bridge_script_output" "run_rust")" "false" "bridge script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$bridge_script_output" "run_frontend_dashboard_tests")" "false" "bridge script-only changes should skip frontend dashboard tests"
 assert_eq "$(extract_output "$bridge_script_output" "run_bridge_replay_harness")" "true" "bridge script-only changes must run bridge replay harness"
+assert_eq "$(extract_output "$bridge_script_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge,discord_bridge,cross_chain_bridge" "bridge script-only changes should select all bridge suites"
 assert_eq "$(extract_output "$bridge_script_output" "test_scope")" "bridge" "bridge script-only changes should set bridge scope"
+
+telegram_bridge_output="$(run_selector $'crates/kamn-core/src/telegram_bridge.rs')"
+assert_eq "$(extract_output "$telegram_bridge_output" "run_bridge_replay_harness")" "true" "telegram bridge changes must run bridge replay harness"
+assert_eq "$(extract_output "$telegram_bridge_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge" "telegram bridge changes should select telegram subset plus bridge adapter suite"
+
+discord_bridge_output="$(run_selector $'crates/kamn-core/src/discord_bridge.rs')"
+assert_eq "$(extract_output "$discord_bridge_output" "run_bridge_replay_harness")" "true" "discord bridge changes must run bridge replay harness"
+assert_eq "$(extract_output "$discord_bridge_output" "bridge_replay_suites")" "bridge_adapter,discord_bridge" "discord bridge changes should select discord subset plus bridge adapter suite"
+
+cross_chain_bridge_output="$(run_selector $'crates/kamn-core/src/cross_chain_bridge.rs')"
+assert_eq "$(extract_output "$cross_chain_bridge_output" "run_bridge_replay_harness")" "true" "cross-chain bridge changes must run bridge replay harness"
+assert_eq "$(extract_output "$cross_chain_bridge_output" "bridge_replay_suites")" "bridge_adapter,cross_chain_bridge" "cross-chain bridge changes should select cross-chain subset plus bridge adapter suite"
 
 frontend_output="$(run_selector $'packages/kamn-dashboard/tests/dashboard.test.ts')"
 assert_eq "$(extract_output "$frontend_output" "run_rust")" "false" "frontend-only changes should avoid rust lane"

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -35,7 +35,7 @@ if ! grep -Fq "if: steps.scope.outputs.run_bridge_replay_harness == 'true'" "$FA
   exit 1
 fi
 
-if ! grep -Fq "bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --output-json bridge-replay-report.json" "$FAST_WORKFLOW"; then
+if ! grep -Fq "bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites \"\${{ steps.scope.outputs.bridge_replay_suites }}\" --output-json bridge-replay-report.json" "$FAST_WORKFLOW"; then
   echo "expected bridge replay harness command in ci-fast-gate.yml" >&2
   exit 1
 fi


### PR DESCRIPTION
Closes #612

## Summary
Adds adapter-subset routing for bridge replay CI execution and extends bridge replay fixtures with signature-failure coverage. This keeps fast-gate bridge validation lower cost for bridge-only diffs while preserving deterministic regression coverage.

## Changes
- `scripts/bridge/run_bridge_replay_matrix.py`: adds `--suites` filtering, deterministic suite parsing, and explicit `no-selected-cases` failure output.
- `scripts/ci/select_targets.sh`: emits `bridge_replay_suites` and computes adapter-aware bridge suite subsets from changed files.
- `.github/workflows/ci-fast-gate.yml`: bridge harness step now passes `--suites "${{ steps.scope.outputs.bridge_replay_suites }}"`.
- `fixtures/bridge_replay/replay_validation_cases.json`: adds `signature-failure` class cases for unauthorized approver rejection in Discord and cross-chain suites.
- `scripts/bridge/test_run_bridge_replay_matrix.sh`: adds suite-filter and unknown-suite regression checks plus signature-failure fixture assertion.
- `scripts/ci/test_select_targets.sh`: adds selector regression checks for `bridge_replay_suites` and adapter-specific subsets.
- `scripts/ci/test_workflow_scope_policy.sh`: verifies fast-gate bridge harness uses selector-provided suites.
- `docs/foundation/bridge-adapter-abstraction.md`: documents `bridge_replay_suites`, adapter subset execution, and signature-failure fixture class.
- `docs/foundation/bridge-quorum-runtime.md`: documents signature-failure fixture mapping and subset command usage.
- `crates/kamn-core/tests/bridge_adapter_docs.rs`: adds docs assertions for suite output and signature-failure/subset coverage.
- `crates/kamn-core/tests/bridge_quorum_runtime_docs.rs`: adds docs assertions for subset command and signature-failure regression references.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated suite-filtered harness behavior, selector outputs, workflow scope wiring, CI tool regression suite, and full `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `scripts/bridge/test_run_bridge_replay_matrix.sh`; docs assertions in `bridge_adapter_docs.rs` and `bridge_quorum_runtime_docs.rs` |
| Functional  | ✅     | Suite-filtered bridge matrix run (`--suites telegram_bridge`) and fixture execution outcomes |
| Integration | ✅     | `scripts/ci/test_select_targets.sh`; `scripts/ci/test_workflow_scope_policy.sh`; `scripts/ci/test_ci_tools.sh` |
| Regression  | ✅     | Unknown suite `reason=no-selected-cases`; signature-failure fixture entries tied to `Regression: #587` references |
