### PR TITLE
docs(bridge): align Telegram/Discord replay hardening contracts

### DIFF
--- a/crates/kamn-core/tests/discord_bridge_approver_docs.rs
+++ b/crates/kamn-core/tests/discord_bridge_approver_docs.rs
@@ -1,0 +1,23 @@
+const DOC: &str = include_str!("../../../docs/foundation/discord-bridge-approver-gating.md");
+
+#[test]
+fn doc_contains_discord_bridge_scope_and_quorum_contracts() {
+    assert!(DOC.contains("# Discord Bridge Approver-Gated Outbound Flow"));
+    assert!(DOC.contains("DiscordBridgeConfig"));
+    assert!(DOC.contains("process_outbound_with_approvals(...)"));
+    assert!(DOC.contains("approver quorum"));
+}
+
+#[test]
+fn doc_contains_bridge_replay_subset_validation_lane() {
+    assert!(DOC.contains("scripts/bridge/run_bridge_replay_matrix.sh"));
+    assert!(DOC.contains("--suites bridge_adapter,discord_bridge"));
+    assert!(DOC.contains("bridge_replay_suites"));
+}
+
+#[test]
+fn regression_requires_signature_failure_fixture_reference() {
+    // Regression: #587
+    assert!(DOC.contains("signature-failure"));
+    assert!(DOC.contains("Regression: #587"));
+}

--- a/crates/kamn-core/tests/telegram_bridge_listener_docs.rs
+++ b/crates/kamn-core/tests/telegram_bridge_listener_docs.rs
@@ -1,0 +1,23 @@
+const DOC: &str = include_str!("../../../docs/foundation/telegram-bridge-listener-validation.md");
+
+#[test]
+fn doc_contains_telegram_bridge_scope_and_listener_contracts() {
+    assert!(DOC.contains("# Telegram Bridge Listener-Validated Inbound Flow"));
+    assert!(DOC.contains("TelegramBridgeConfig"));
+    assert!(DOC.contains("process_inbound_to_envelope(...)"));
+    assert!(DOC.contains("listener DID must be authorized"));
+}
+
+#[test]
+fn doc_contains_bridge_replay_subset_validation_lane() {
+    assert!(DOC.contains("scripts/bridge/run_bridge_replay_matrix.sh"));
+    assert!(DOC.contains("--suites bridge_adapter,telegram_bridge"));
+    assert!(DOC.contains("bridge_replay_suites"));
+}
+
+#[test]
+fn regression_requires_replay_fixture_reference() {
+    // Regression: #587
+    assert!(DOC.contains("duplicate replay"));
+    assert!(DOC.contains("Regression: #587"));
+}

--- a/docs/foundation/discord-bridge-approver-gating.md
+++ b/docs/foundation/discord-bridge-approver-gating.md
@@ -1,4 +1,4 @@
-# Discord Bridge Approver-Gated Outbound Flow (Issues #220, #221)
+# Discord Bridge Approver-Gated Outbound Flow (Issues #220, #221, #587, #614)
 
 This document captures the first implementation slice for Discord bridge processing with approver quorum gating on outbound actions.
 
@@ -10,6 +10,10 @@ This document captures the first implementation slice for Discord bridge process
   - `DiscordOutboundApproval` and `DiscordOutboundDispatch` to preserve deterministic approval metadata for auditing.
   - typed error handling via `DiscordBridgeError`.
 - Added integration tests in `crates/kamn-core/tests/discord_bridge.rs`.
+- Added bridge replay fixture hardening references for low-cost CI coverage:
+  - `fixtures/bridge_replay/replay_validation_cases.json`
+  - suite subset execution via `scripts/bridge/run_bridge_replay_matrix.sh`
+  - changed-adapter selector output `bridge_replay_suites`
 
 ## Validation Rules
 - Bridge/listener/approver DIDs must parse as `kamn:did:agent:*`.
@@ -21,6 +25,14 @@ This document captures the first implementation slice for Discord bridge process
   - approver set contains no duplicates.
   - all approvers are authorized.
   - provided approvals satisfy quorum threshold.
+  - unauthorized approver signatures are treated as signature-failure fixture class outcomes.
+
+## Replay Fixture Hardening
+- Bridge replay harness validates Discord replay contracts without requiring full bridge suite execution for every diff.
+- Fast-gate bridge lane consumes `bridge_replay_suites` and runs adapter subsets first.
+- Discord-focused bridge diffs should run:
+  - `--suites bridge_adapter,discord_bridge`
+- Replay fixture coverage includes signature-failure class checks for unauthorized approver rejection (`Regression: #587`).
 
 ## Processing Flow
 - `process_inbound(...)`:
@@ -39,6 +51,7 @@ Run from repository root:
 
 ```bash
 cargo test -p kamn-core --test discord_bridge
+bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites bridge_adapter,discord_bridge --output-json /tmp/discord-bridge-replay-report.json
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core

--- a/docs/foundation/telegram-bridge-listener-validation.md
+++ b/docs/foundation/telegram-bridge-listener-validation.md
@@ -1,4 +1,4 @@
-# Telegram Bridge Listener-Validated Inbound Flow (Issues #222, #223)
+# Telegram Bridge Listener-Validated Inbound Flow (Issues #222, #223, #587, #614)
 
 This document captures the first implementation slice for Telegram bridge inbound processing with listener validation.
 
@@ -9,6 +9,10 @@ This document captures the first implementation slice for Telegram bridge inboun
   - `TelegramBridgeEngine` wrapper over generic bridge adapter flow.
   - typed errors via `TelegramBridgeError`.
 - Added integration tests in `crates/kamn-core/tests/telegram_bridge.rs`.
+- Added bridge replay fixture hardening references for low-cost CI coverage:
+  - `fixtures/bridge_replay/replay_validation_cases.json`
+  - suite subset execution via `scripts/bridge/run_bridge_replay_matrix.sh`
+  - changed-adapter selector output `bridge_replay_suites`
 
 ## Validation Rules
 - Bridge agent DID and listener DIDs must parse as `kamn:did:agent:*`.
@@ -19,6 +23,14 @@ This document captures the first implementation slice for Telegram bridge inboun
   - listener DID must be authorized.
   - inbound `external_channel_id` must exist in route map.
   - inbound `target_agent_did` must match mapped route target.
+  - duplicate replay ingress is rejected deterministically by adapter replay guards.
+
+## Replay Fixture Hardening
+- Bridge replay harness validates Telegram replay contracts without running all adapter suites for every bridge diff.
+- Fast-gate bridge lane consumes `bridge_replay_suites` and executes changed-adapter subsets first.
+- Telegram-focused bridge diffs should run:
+  - `--suites bridge_adapter,telegram_bridge`
+- Replay fixture corpus includes duplicate replay and malformed ingress classes (`Regression: #587`).
 
 ## Processing Flow
 - `process_inbound(...)`:
@@ -33,6 +45,7 @@ Run from repository root:
 
 ```bash
 cargo test -p kamn-core --test telegram_bridge
+bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites bridge_adapter,telegram_bridge --output-json /tmp/telegram-bridge-replay-report.json
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core


### PR DESCRIPTION
Closes #614

## Summary
Aligns Telegram and Discord bridge documentation with replay fixture hardening contracts required by epic #587. Adds doc tests to lock in subset-lane CI guidance and regression marker coverage.

## Changes
- `docs/foundation/discord-bridge-approver-gating.md`: adds replay fixture hardening section, `bridge_replay_suites` subset routing guidance, signature-failure fixture references, and targeted replay command.
- `docs/foundation/telegram-bridge-listener-validation.md`: adds replay fixture hardening section, `bridge_replay_suites` subset routing guidance, duplicate replay fixture references, and targeted replay command.
- `crates/kamn-core/tests/discord_bridge_approver_docs.rs`: new docs contract test coverage for replay subset lane and regression markers.
- `crates/kamn-core/tests/telegram_bridge_listener_docs.rs`: new docs contract test coverage for replay subset lane and regression markers.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed red/green docs tests for both files and reran selector/workflow policy plus full `cargo test -p kamn-core`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test discord_bridge_approver_docs`; `cargo test -p kamn-core --test telegram_bridge_listener_docs` |
| Functional  | ✅     | Docs now include deterministic replay subset command examples for Telegram/Discord |
| Integration | ✅     | `bash scripts/ci/test_select_targets.sh`; `bash scripts/ci/test_workflow_scope_policy.sh` |
| Regression  | ✅     | Explicit `Regression: #587` markers in both docs and enforced by tests |
