### PR TITLE
feat(frontend): replace mock-only dashboard path with live backend adapter

### DIFF
--- a/crates/kamn-core/tests/operator_dashboard_ui_docs.rs
+++ b/crates/kamn-core/tests/operator_dashboard_ui_docs.rs
@@ -7,6 +7,8 @@ fn doc_contains_ui_scope_and_composer_contract() {
     assert!(DOC.contains("DashboardSummary"));
     assert!(DOC.contains("OperatorDashboardUiError"));
     assert!(DOC.contains("packages/kamn-dashboard"));
+    assert!(DOC.contains("src/live_api.ts"));
+    assert!(DOC.contains("buildDashboardShellFromBackend(...)"));
 }
 
 #[test]
@@ -40,4 +42,12 @@ fn regression_requires_critical_badge_with_stale_banner_rule() {
     assert!(DOC.contains("stale-data-banner"));
     assert!(DOC.contains("severity-critical"));
     assert!(DOC.contains("Regression: #591"));
+}
+
+#[test]
+fn regression_requires_live_backend_error_shell_rule() {
+    // Regression: #639
+    assert!(DOC.contains("fetchDashboardSnapshotFromBackend(...)"));
+    assert!(DOC.contains("dashboard-error"));
+    assert!(DOC.contains("Regression: #639"));
 }

--- a/docs/foundation/operator-dashboard-ui-mvp.md
+++ b/docs/foundation/operator-dashboard-ui-mvp.md
@@ -1,4 +1,4 @@
-# Operator Dashboard UI MVP Composition (Issues #200, #201, #591, #593, #594)
+# Operator Dashboard UI MVP Composition (Issues #200, #201, #591, #593, #594, #639)
 
 This document captures the first implementation slice for the operator dashboard UI presentation model.
 
@@ -17,7 +17,9 @@ This document captures the first implementation slice for the operator dashboard
 - Added integration and regression tests in `crates/kamn-core/tests/operator_dashboard_ui.rs`.
 - Added frontend MVP package `packages/kamn-dashboard` with:
   - deterministic mock snapshot adapter (`src/mock_api.ts`),
+  - live backend snapshot client (`src/live_api.ts`),
   - UI mapping and rendering logic (`src/dashboard.ts`),
+  - async backend-backed shell rendering (`buildDashboardShellFromBackend(...)`),
   - exported package surface (`src/index.ts`),
   - frontend unit/functional/integration/regression tests (`tests/dashboard.test.ts`).
 
@@ -37,6 +39,10 @@ This document captures the first implementation slice for the operator dashboard
   - loading: `dashboard-loading` section with status semantics.
   - error: `dashboard-error` section with deterministic message surface.
   - empty: `dashboard-empty` section when no rows are available.
+- Frontend live backend behavior:
+  - backend snapshot fetch uses `fetchDashboardSnapshotFromBackend(...)`.
+  - successful live fetch maps to deterministic ready shell rendering.
+  - non-2xx backend responses map to deterministic `dashboard-error` rendering with status detail.
 
 ## Audit Trace Rules
 - Audit traces are projected from `OperatorActionAuditRecord`.
@@ -62,3 +68,4 @@ cargo test -p kamn-core
 
 ## Regression Guards
 - critical severity badge and stale banner render together for degraded snapshots (`Regression: #591`).
+- live backend HTTP failures render deterministic error shell output (`Regression: #639`).

--- a/packages/kamn-dashboard/src/dashboard.ts
+++ b/packages/kamn-dashboard/src/dashboard.ts
@@ -1,4 +1,8 @@
 import { fetchMockDashboardSnapshot } from "./mock_api.ts";
+import {
+  fetchDashboardSnapshotFromBackend,
+  type DashboardBackendClientOptions,
+} from "./live_api.ts";
 import type {
   DashboardDomainSample,
   DashboardModel,
@@ -219,4 +223,21 @@ export function buildDashboardShell(
     state: "ready",
     model,
   });
+}
+
+export async function buildDashboardShellFromBackend(
+  nowUnix: number,
+  backendOptions: DashboardBackendClientOptions,
+): Promise<string> {
+  try {
+    const snapshot = await fetchDashboardSnapshotFromBackend(backendOptions);
+    return buildDashboardShell(nowUnix, snapshot);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "dashboard backend request failed";
+    return renderDashboardState({
+      state: "error",
+      message,
+    });
+  }
 }

--- a/packages/kamn-dashboard/src/index.ts
+++ b/packages/kamn-dashboard/src/index.ts
@@ -1,6 +1,13 @@
 export { fetchMockDashboardSnapshot } from "./mock_api.ts";
 export {
+  DashboardBackendError,
+  fetchDashboardSnapshotFromBackend,
+  type DashboardBackendClientOptions,
+  type DashboardFetchLike,
+} from "./live_api.ts";
+export {
   buildDashboardShell,
+  buildDashboardShellFromBackend,
   mapSeverityLevel,
   mapSnapshotToDashboardModel,
   renderDashboardHtml,

--- a/packages/kamn-dashboard/src/live_api.ts
+++ b/packages/kamn-dashboard/src/live_api.ts
@@ -1,0 +1,145 @@
+import type { DashboardDomainSample, DashboardSnapshot } from "./types.ts";
+
+type JsonResponse = {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+};
+
+export type DashboardFetchLike = (
+  url: string,
+  init?: {
+    headers?: Record<string, string>;
+  },
+) => Promise<JsonResponse>;
+
+export type DashboardBackendClientOptions = {
+  baseUrl: string;
+  snapshotPath?: string;
+  headers?: Record<string, string>;
+  fetchImpl?: DashboardFetchLike;
+};
+
+export class DashboardBackendError extends Error {
+  readonly code: "network" | "http" | "invalid-response";
+  readonly status?: number;
+
+  constructor(code: "network" | "http" | "invalid-response", message: string, status?: number) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseDomain(value: unknown): DashboardDomainSample {
+  if (!isRecord(value)) {
+    throw new DashboardBackendError("invalid-response", "dashboard domain row is not an object");
+  }
+
+  const domain = value.domain;
+  const latency = value.latency_p99_ms;
+  const errorRate = value.error_rate;
+  const availability = value.availability;
+
+  if (typeof domain !== "string" || domain.length === 0) {
+    throw new DashboardBackendError("invalid-response", "dashboard domain name is invalid");
+  }
+  if (typeof latency !== "number" || !Number.isFinite(latency)) {
+    throw new DashboardBackendError("invalid-response", "dashboard latency value is invalid");
+  }
+  if (typeof errorRate !== "number" || !Number.isFinite(errorRate)) {
+    throw new DashboardBackendError("invalid-response", "dashboard error rate value is invalid");
+  }
+  if (typeof availability !== "number" || !Number.isFinite(availability)) {
+    throw new DashboardBackendError("invalid-response", "dashboard availability value is invalid");
+  }
+
+  return {
+    domain,
+    latency_p99_ms: latency,
+    error_rate: errorRate,
+    availability,
+  };
+}
+
+function parseSnapshot(value: unknown): DashboardSnapshot {
+  if (!isRecord(value)) {
+    throw new DashboardBackendError("invalid-response", "dashboard snapshot payload is not an object");
+  }
+
+  const generatedAt = value.generated_at_unix;
+  const domains = value.domains;
+  if (!Number.isFinite(generatedAt)) {
+    throw new DashboardBackendError("invalid-response", "dashboard snapshot timestamp is invalid");
+  }
+  if (!Array.isArray(domains)) {
+    throw new DashboardBackendError("invalid-response", "dashboard snapshot domains field is invalid");
+  }
+
+  return {
+    generated_at_unix: generatedAt,
+    domains: domains.map(parseDomain),
+  };
+}
+
+function buildSnapshotUrl(baseUrl: string, snapshotPath = "/api/dashboard/snapshot"): string {
+  try {
+    return new URL(snapshotPath, baseUrl).toString();
+  } catch (_error) {
+    throw new DashboardBackendError("invalid-response", "dashboard backend base URL is invalid");
+  }
+}
+
+export async function fetchDashboardSnapshotFromBackend(
+  options: DashboardBackendClientOptions,
+): Promise<DashboardSnapshot> {
+  const url = buildSnapshotUrl(options.baseUrl, options.snapshotPath);
+
+  const defaultFetch: DashboardFetchLike | undefined = globalThis.fetch
+    ? async (targetUrl, init) => {
+        const response = await globalThis.fetch(targetUrl, init);
+        return response as JsonResponse;
+      }
+    : undefined;
+  const fetchImpl = options.fetchImpl ?? defaultFetch;
+  if (!fetchImpl) {
+    throw new DashboardBackendError(
+      "network",
+      "dashboard backend fetch implementation is not available",
+    );
+  }
+
+  let response: JsonResponse;
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        Accept: "application/json",
+        ...(options.headers ?? {}),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown network error";
+    throw new DashboardBackendError("network", `dashboard backend request failed: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new DashboardBackendError(
+      "http",
+      `dashboard backend responded with status ${response.status}`,
+      response.status,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (_error) {
+    throw new DashboardBackendError("invalid-response", "dashboard backend returned invalid JSON");
+  }
+
+  return parseSnapshot(payload);
+}

--- a/packages/kamn-dashboard/tests/dashboard.test.ts
+++ b/packages/kamn-dashboard/tests/dashboard.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import {
   buildDashboardShell,
+  buildDashboardShellFromBackend,
+  fetchDashboardSnapshotFromBackend,
   mapSnapshotToDashboardModel,
   mapSeverityLevel,
   renderDashboardHtml,
@@ -128,4 +130,70 @@ test("regression renders critical badge and stale banner together", () => {
 
   assert.match(html, /stale-data-banner/);
   assert.match(html, /severity-critical/);
+});
+
+test("unit fetches dashboard snapshot from live backend client", async () => {
+  const snapshot = await fetchDashboardSnapshotFromBackend({
+    baseUrl: "https://dashboard.internal",
+    fetchImpl: async (url) => {
+      assert.equal(url, "https://dashboard.internal/api/dashboard/snapshot");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          generated_at_unix: 1_700_002_000,
+          domains: [
+            {
+              domain: "messaging",
+              latency_p99_ms: 470,
+              error_rate: 0.012,
+              availability: 0.998,
+            },
+          ],
+        }),
+      };
+    },
+  });
+
+  assert.equal(snapshot.generated_at_unix, 1_700_002_000);
+  assert.equal(snapshot.domains[0]?.domain, "messaging");
+});
+
+test("functional builds dashboard shell from live backend snapshot", async () => {
+  const html = await buildDashboardShellFromBackend(1_700_002_200, {
+    baseUrl: "https://dashboard.internal",
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        generated_at_unix: 1_700_002_000,
+        domains: [
+          {
+            domain: "messaging",
+            latency_p99_ms: 470,
+            error_rate: 0.012,
+            availability: 0.998,
+          },
+        ],
+      }),
+    }),
+  });
+
+  assert.match(html, /summary-grid/);
+  assert.match(html, /messaging/);
+});
+
+test("regression renders error shell when live backend request fails", async () => {
+  // Regression: #622
+  const html = await buildDashboardShellFromBackend(1_700_002_200, {
+    baseUrl: "https://dashboard.internal",
+    fetchImpl: async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }),
+  });
+
+  assert.match(html, /dashboard-error/);
+  assert.match(html, /503/);
 });


### PR DESCRIPTION
Closes #639

## Summary
Adds a live backend snapshot client to `packages/kamn-dashboard` and wires an async backend-backed shell rendering path while preserving deterministic mock-mode behavior for low-cost local/test flows.

## Changes
- `packages/kamn-dashboard/src/live_api.ts`: adds backend fetch client with runtime payload validation and typed `DashboardBackendError` failure modes.
- `packages/kamn-dashboard/src/dashboard.ts`: adds `buildDashboardShellFromBackend(...)` for async backend-backed shell rendering.
- `packages/kamn-dashboard/src/index.ts`: exports live backend client types/functions.
- `packages/kamn-dashboard/tests/dashboard.test.ts`: adds unit/functional/regression tests for live backend fetch success/error rendering behavior.
- `docs/foundation/operator-dashboard-ui-mvp.md`: documents live backend adapter and error-shell contract.
- `crates/kamn-core/tests/operator_dashboard_ui_docs.rs`: adds docs regression assertions for live backend error contract (`Regression: #639`).

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed frontend package tests, frontend CI wrapper, targeted docs tests, and full `kamn-core` test suite.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `unit fetches dashboard snapshot from live backend client` |
| Functional  | ✅     | `functional builds dashboard shell from live backend snapshot` |
| Integration | ✅     | `npm --prefix packages/kamn-dashboard test`; `bash scripts/frontend/test_dashboard_package.sh`; `cargo test -p kamn-core --test operator_dashboard_ui_docs` |
| Regression  | ✅     | `regression renders error shell when live backend request fails` + docs `Regression: #639` assertions |
