### PR TITLE
feat(frontend): add dashboard operator session and role gates

### DIFF
--- a/crates/kamn-core/tests/operator_dashboard_api_docs.rs
+++ b/crates/kamn-core/tests/operator_dashboard_api_docs.rs
@@ -37,3 +37,12 @@ fn regression_requires_frontend_state_mapping_contract_rules() {
     assert!(DOC.contains("dashboard-error"));
     assert!(DOC.contains("dashboard-empty"));
 }
+
+#[test]
+fn regression_requires_live_session_authorization_contract_rules() {
+    // Regression: #640
+    assert!(DOC.contains("operator session token is required"));
+    assert!(DOC.contains("expired sessions are rejected"));
+    assert!(DOC.contains("Authorization: Bearer <token>"));
+    assert!(DOC.contains("Regression: #640"));
+}

--- a/crates/kamn-core/tests/operator_dashboard_ui_docs.rs
+++ b/crates/kamn-core/tests/operator_dashboard_ui_docs.rs
@@ -51,3 +51,10 @@ fn regression_requires_live_backend_error_shell_rule() {
     assert!(DOC.contains("dashboard-error"));
     assert!(DOC.contains("Regression: #639"));
 }
+
+#[test]
+fn regression_requires_live_session_gate_rule() {
+    // Regression: #640
+    assert!(DOC.contains("missing/expired/unauthorized operator sessions"));
+    assert!(DOC.contains("Regression: #640"));
+}

--- a/docs/foundation/operator-dashboard-backend-apis.md
+++ b/docs/foundation/operator-dashboard-backend-apis.md
@@ -1,4 +1,4 @@
-# Operator Dashboard Backend APIs (Issues #202, #203, #591, #610)
+# Operator Dashboard Backend APIs (Issues #202, #203, #591, #610, #640)
 
 This document captures the first implementation slice for backend read APIs that power human-operator dashboard visibility.
 
@@ -18,6 +18,7 @@ This document captures the first implementation slice for backend read APIs that
 - Added explicit frontend consumer contract mapping for `packages/kamn-dashboard`:
   - backend snapshot shape maps to deterministic frontend shell state projections.
   - backend absence/failure semantics map to deterministic loading/error/empty frontend states.
+  - live backend fetch path requires operator session token + allowed role gates.
 
 ## Pagination and Filter Rules
 - Page limit must be positive.
@@ -38,6 +39,12 @@ This document captures the first implementation slice for backend read APIs that
 - Backend fetch-in-flight maps to frontend `dashboard-loading` state.
 - Backend fetch failures map to frontend `dashboard-error` state.
 - Empty backend snapshot sets map to frontend `dashboard-empty` state.
+- Live backend session policy:
+  - operator session token is required before backend fetch.
+  - expired sessions are rejected before backend fetch.
+  - allowed roles default to `operator` and `admin`.
+  - role mismatches map to deterministic `dashboard-error` output.
+  - backend requests carry `Authorization: Bearer <token>` and `X-KAMN-Role` headers.
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
@@ -54,3 +61,8 @@ Then run crate regression:
 ```bash
 cargo test -p kamn-core
 ```
+
+## Regression Guards
+- tampered pagination cursor tokens are rejected (`Regression: #203`).
+- dashboard shell state mapping remains deterministic for loading/error/empty (`Regression: #591`).
+- missing/expired/unauthorized operator sessions are rejected in live backend fetch path (`Regression: #640`).

--- a/docs/foundation/operator-dashboard-ui-mvp.md
+++ b/docs/foundation/operator-dashboard-ui-mvp.md
@@ -43,6 +43,7 @@ This document captures the first implementation slice for the operator dashboard
   - backend snapshot fetch uses `fetchDashboardSnapshotFromBackend(...)`.
   - successful live fetch maps to deterministic ready shell rendering.
   - non-2xx backend responses map to deterministic `dashboard-error` rendering with status detail.
+  - missing/expired/unauthorized operator sessions map to deterministic `dashboard-error` rendering.
 
 ## Audit Trace Rules
 - Audit traces are projected from `OperatorActionAuditRecord`.
@@ -69,3 +70,4 @@ cargo test -p kamn-core
 ## Regression Guards
 - critical severity badge and stale banner render together for degraded snapshots (`Regression: #591`).
 - live backend HTTP failures render deterministic error shell output (`Regression: #639`).
+- live backend operator session gate rejects missing/expired/unauthorized access (`Regression: #640`).

--- a/packages/kamn-dashboard/src/index.ts
+++ b/packages/kamn-dashboard/src/index.ts
@@ -17,6 +17,8 @@ export type {
   DashboardDomainRow,
   DashboardDomainSample,
   DashboardModel,
+  DashboardOperatorRole,
+  DashboardOperatorSession,
   DashboardRenderState,
   DashboardSnapshot,
   DashboardSummaryCard,

--- a/packages/kamn-dashboard/src/live_api.ts
+++ b/packages/kamn-dashboard/src/live_api.ts
@@ -1,4 +1,9 @@
-import type { DashboardDomainSample, DashboardSnapshot } from "./types.ts";
+import type {
+  DashboardDomainSample,
+  DashboardOperatorRole,
+  DashboardOperatorSession,
+  DashboardSnapshot,
+} from "./types.ts";
 
 type JsonResponse = {
   ok: boolean;
@@ -17,14 +22,21 @@ export type DashboardBackendClientOptions = {
   baseUrl: string;
   snapshotPath?: string;
   headers?: Record<string, string>;
+  session?: DashboardOperatorSession;
+  allowedRoles?: DashboardOperatorRole[];
+  sessionNowUnix?: number;
   fetchImpl?: DashboardFetchLike;
 };
 
 export class DashboardBackendError extends Error {
-  readonly code: "network" | "http" | "invalid-response";
+  readonly code: "network" | "http" | "invalid-response" | "unauthorized";
   readonly status?: number;
 
-  constructor(code: "network" | "http" | "invalid-response", message: string, status?: number) {
+  constructor(
+    code: "network" | "http" | "invalid-response" | "unauthorized",
+    message: string,
+    status?: number,
+  ) {
     super(message);
     this.code = code;
     this.status = status;
@@ -94,10 +106,43 @@ function buildSnapshotUrl(baseUrl: string, snapshotPath = "/api/dashboard/snapsh
   }
 }
 
+function validateSession(options: DashboardBackendClientOptions): DashboardOperatorSession {
+  const session = options.session;
+  if (!session) {
+    throw new DashboardBackendError(
+      "unauthorized",
+      "operator session is required for dashboard backend access",
+    );
+  }
+
+  if (typeof session.accessToken !== "string" || session.accessToken.trim().length === 0) {
+    throw new DashboardBackendError("unauthorized", "operator session token is invalid");
+  }
+
+  const nowUnix = options.sessionNowUnix ?? Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(session.expiresAtUnix) || session.expiresAtUnix <= nowUnix) {
+    throw new DashboardBackendError(
+      "unauthorized",
+      `operator session expired at ${session.expiresAtUnix}`,
+    );
+  }
+
+  const allowedRoles = options.allowedRoles ?? ["operator", "admin"];
+  if (!allowedRoles.includes(session.role)) {
+    throw new DashboardBackendError(
+      "unauthorized",
+      `operator session role not allowed: ${session.role}`,
+    );
+  }
+
+  return session;
+}
+
 export async function fetchDashboardSnapshotFromBackend(
   options: DashboardBackendClientOptions,
 ): Promise<DashboardSnapshot> {
   const url = buildSnapshotUrl(options.baseUrl, options.snapshotPath);
+  const session = validateSession(options);
 
   const defaultFetch: DashboardFetchLike | undefined = globalThis.fetch
     ? async (targetUrl, init) => {
@@ -118,6 +163,8 @@ export async function fetchDashboardSnapshotFromBackend(
     response = await fetchImpl(url, {
       headers: {
         Accept: "application/json",
+        Authorization: `Bearer ${session.accessToken}`,
+        "X-KAMN-Role": session.role,
         ...(options.headers ?? {}),
       },
     });

--- a/packages/kamn-dashboard/src/types.ts
+++ b/packages/kamn-dashboard/src/types.ts
@@ -19,6 +19,14 @@ export type DashboardSnapshot = {
   domains: DashboardDomainSample[];
 };
 
+export type DashboardOperatorRole = "viewer" | "operator" | "admin";
+
+export type DashboardOperatorSession = {
+  accessToken: string;
+  role: DashboardOperatorRole;
+  expiresAtUnix: number;
+};
+
 export type DashboardSummaryCard = {
   id: string;
   label: string;

--- a/packages/kamn-dashboard/tests/dashboard.test.ts
+++ b/packages/kamn-dashboard/tests/dashboard.test.ts
@@ -11,6 +11,12 @@ import {
   renderDashboardState,
 } from "../src/index.ts";
 
+const ACTIVE_SESSION = {
+  accessToken: "token-ops-1",
+  role: "operator",
+  expiresAtUnix: 1_700_003_000,
+} as const;
+
 test("unit maps severity to critical when error rate exceeds critical threshold", () => {
   const severity = mapSeverityLevel({
     value: 0.09,
@@ -135,8 +141,12 @@ test("regression renders critical badge and stale banner together", () => {
 test("unit fetches dashboard snapshot from live backend client", async () => {
   const snapshot = await fetchDashboardSnapshotFromBackend({
     baseUrl: "https://dashboard.internal",
-    fetchImpl: async (url) => {
+    session: ACTIVE_SESSION,
+    sessionNowUnix: 1_700_002_200,
+    fetchImpl: async (url, init) => {
       assert.equal(url, "https://dashboard.internal/api/dashboard/snapshot");
+      assert.equal(init?.headers?.Authorization, "Bearer token-ops-1");
+      assert.equal(init?.headers?.["X-KAMN-Role"], "operator");
       return {
         ok: true,
         status: 200,
@@ -162,6 +172,8 @@ test("unit fetches dashboard snapshot from live backend client", async () => {
 test("functional builds dashboard shell from live backend snapshot", async () => {
   const html = await buildDashboardShellFromBackend(1_700_002_200, {
     baseUrl: "https://dashboard.internal",
+    session: ACTIVE_SESSION,
+    sessionNowUnix: 1_700_002_200,
     fetchImpl: async () => ({
       ok: true,
       status: 200,
@@ -184,9 +196,11 @@ test("functional builds dashboard shell from live backend snapshot", async () =>
 });
 
 test("regression renders error shell when live backend request fails", async () => {
-  // Regression: #622
+  // Regression: #639
   const html = await buildDashboardShellFromBackend(1_700_002_200, {
     baseUrl: "https://dashboard.internal",
+    session: ACTIVE_SESSION,
+    sessionNowUnix: 1_700_002_200,
     fetchImpl: async () => ({
       ok: false,
       status: 503,
@@ -196,4 +210,49 @@ test("regression renders error shell when live backend request fails", async () 
 
   assert.match(html, /dashboard-error/);
   assert.match(html, /503/);
+});
+
+test("regression rejects live backend access without operator session", async () => {
+  // Regression: #640
+  const html = await buildDashboardShellFromBackend(1_700_002_200, {
+    baseUrl: "https://dashboard.internal",
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called without session");
+    },
+  });
+
+  assert.match(html, /dashboard-error/);
+  assert.match(html, /operator session is required/i);
+});
+
+test("regression rejects expired or unauthorized session role", async () => {
+  // Regression: #640
+  const expiredHtml = await buildDashboardShellFromBackend(1_700_002_200, {
+    baseUrl: "https://dashboard.internal",
+    session: {
+      accessToken: "token-expired",
+      role: "operator",
+      expiresAtUnix: 1_700_002_100,
+    },
+    sessionNowUnix: 1_700_002_200,
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called with expired session");
+    },
+  });
+  assert.match(expiredHtml, /session expired/i);
+
+  const unauthorizedRoleHtml = await buildDashboardShellFromBackend(1_700_002_200, {
+    baseUrl: "https://dashboard.internal",
+    session: {
+      accessToken: "token-viewer",
+      role: "viewer",
+      expiresAtUnix: 1_700_003_000,
+    },
+    sessionNowUnix: 1_700_002_200,
+    allowedRoles: ["operator", "admin"],
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called with unauthorized role");
+    },
+  });
+  assert.match(unauthorizedRoleHtml, /session role not allowed/i);
 });


### PR DESCRIPTION
Closes #640

## Summary
Adds explicit operator session and role-based access gates to the live dashboard backend client path. Live backend fetches now require a valid session token, non-expired session, and allowed role before issuing requests.

## Changes
- `packages/kamn-dashboard/src/live_api.ts`: adds session validation (required token, expiry check, role allowlist) and propagates auth headers (`Authorization`, `X-KAMN-Role`) for backend requests.
- `packages/kamn-dashboard/src/types.ts`: adds `DashboardOperatorRole` and `DashboardOperatorSession` types.
- `packages/kamn-dashboard/src/index.ts`: exports new dashboard session types.
- `packages/kamn-dashboard/tests/dashboard.test.ts`: adds regression tests for missing session, expired session, unauthorized role, and auth-header wiring.
- `docs/foundation/operator-dashboard-backend-apis.md`: documents live session policy and regression guards.
- `docs/foundation/operator-dashboard-ui-mvp.md`: documents session-gate behavior for live dashboard rendering.
- `crates/kamn-core/tests/operator_dashboard_api_docs.rs`: adds `Regression: #640` docs assertions.
- `crates/kamn-core/tests/operator_dashboard_ui_docs.rs`: adds `Regression: #640` docs assertions.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: frontend tests, frontend CI wrapper, targeted docs tests, and full `kamn-core` suite all passed.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | session validation and auth-header assertions in `packages/kamn-dashboard/tests/dashboard.test.ts` |
| Functional  | ✅     | backend shell rendering with valid operator session |
| Integration | ✅     | `npm --prefix packages/kamn-dashboard test`; `bash scripts/frontend/test_dashboard_package.sh`; docs tests |
| Regression  | ✅     | missing/expired/unauthorized session rejection (`Regression: #640`) in tests and docs contracts |
