### PR TITLE
feat(runtime): add deterministic network fault simulation harness

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -215,10 +215,11 @@ pub use retention_engine::{
     RetentionPolicyEngine, RetentionPolicyError, RetentionRecord, RetentionStatus,
 };
 pub use runtime::{
-    BoundedRuntimeQueue, DeterministicProposalPlanner, PeerLifecycle, PeerLifecycleEvent,
-    PeerLifecycleState, ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError,
-    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeLifecycleError, RuntimeQueueError,
-    RuntimeWiring,
+    simulate_daemon_network_fault, BoundedRuntimeQueue, DeterministicNetworkFaultSimulator,
+    DeterministicProposalPlanner, NetworkFaultSimulationError, NetworkFaultSimulationInput,
+    NetworkFaultSimulationReport, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
+    ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError, RecoveryRejoinGuard,
+    RecoveryStatus, RejoinAttempt, RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
 };
 pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -1726,6 +1726,182 @@ pub fn evaluate_daemon_watchdog_anomaly(
     evaluator.evaluate(input)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkFaultSimulationInput {
+    sample_id: String,
+    peer_id: String,
+    expected_deliveries: u32,
+    delivered_deliveries: u32,
+    active_peers: u32,
+    healthy_peers: u32,
+    sample_window_secs: u64,
+    targeted_peer_count: u32,
+    queue_capacity: usize,
+    queued_events: usize,
+}
+
+impl NetworkFaultSimulationInput {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        sample_id: &str,
+        peer_id: &str,
+        expected_deliveries: u32,
+        delivered_deliveries: u32,
+        active_peers: u32,
+        healthy_peers: u32,
+        sample_window_secs: u64,
+        targeted_peer_count: u32,
+        queue_capacity: usize,
+        queued_events: usize,
+    ) -> Result<Self, NetworkFaultSimulationError> {
+        if sample_id.trim().is_empty() {
+            return Err(NetworkFaultSimulationError::InvalidSampleId);
+        }
+        if peer_id.trim().is_empty() {
+            return Err(NetworkFaultSimulationError::InvalidPeerId);
+        }
+        if queue_capacity == 0 {
+            return Err(NetworkFaultSimulationError::InvalidQueueCapacity { capacity: 0 });
+        }
+        WatchdogAnomalyWatchInput::new(
+            sample_id,
+            expected_deliveries,
+            delivered_deliveries,
+            active_peers,
+            healthy_peers,
+            sample_window_secs,
+            targeted_peer_count,
+        )
+        .map_err(NetworkFaultSimulationError::Watchdog)?;
+
+        Ok(Self {
+            sample_id: sample_id.to_owned(),
+            peer_id: peer_id.to_owned(),
+            expected_deliveries,
+            delivered_deliveries,
+            active_peers,
+            healthy_peers,
+            sample_window_secs,
+            targeted_peer_count,
+            queue_capacity,
+            queued_events,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkFaultSimulationReport {
+    pub sample_id: String,
+    pub final_lifecycle_state: PeerLifecycleState,
+    pub queue_capacity: usize,
+    pub queued_events: usize,
+    pub queue_overflow_attempts: usize,
+    pub watchdog_kind: WatchdogAnomalyKind,
+    pub watchdog_severity: WatchdogAnomalySeverity,
+    pub watchdog_delivery_ratio_per_mille: u16,
+    pub watchdog_liveness_ratio_per_mille: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkFaultSimulationError {
+    InvalidSampleId,
+    InvalidPeerId,
+    InvalidQueueCapacity { capacity: usize },
+    Lifecycle(RuntimeLifecycleError),
+    Watchdog(WatchdogAnomalyError),
+}
+
+impl Display for NetworkFaultSimulationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidSampleId => {
+                write!(f, "network fault simulation sample id cannot be empty")
+            }
+            Self::InvalidPeerId => write!(f, "network fault simulation peer id cannot be empty"),
+            Self::InvalidQueueCapacity { capacity } => write!(
+                f,
+                "network fault simulation queue capacity must be positive, found {capacity}"
+            ),
+            Self::Lifecycle(error) => write!(f, "{error}"),
+            Self::Watchdog(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl Error for NetworkFaultSimulationError {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DeterministicNetworkFaultSimulator {
+    anomaly_evaluator: WatchdogAnomalyEvaluator,
+}
+
+impl DeterministicNetworkFaultSimulator {
+    pub fn simulate(
+        &self,
+        input: NetworkFaultSimulationInput,
+    ) -> Result<NetworkFaultSimulationReport, NetworkFaultSimulationError> {
+        let mut lifecycle =
+            PeerLifecycle::new(&input.peer_id).map_err(NetworkFaultSimulationError::Lifecycle)?;
+        lifecycle
+            .transition(PeerLifecycleEvent::StartConnect)
+            .map_err(NetworkFaultSimulationError::Lifecycle)?;
+        lifecycle
+            .transition(PeerLifecycleEvent::HandshakeSucceeded)
+            .map_err(NetworkFaultSimulationError::Lifecycle)?;
+        if input.healthy_peers < input.active_peers {
+            lifecycle
+                .transition(PeerLifecycleEvent::HeartbeatMissed)
+                .map_err(NetworkFaultSimulationError::Lifecycle)?;
+        }
+
+        let mut queue = BoundedRuntimeQueue::new(input.queue_capacity).map_err(|_| {
+            NetworkFaultSimulationError::InvalidQueueCapacity {
+                capacity: input.queue_capacity,
+            }
+        })?;
+        let mut queue_overflow_attempts = 0usize;
+        for event_index in 0..input.queued_events {
+            if queue.enqueue(format!("fault-event-{event_index}")).is_err() {
+                queue_overflow_attempts += 1;
+            }
+        }
+
+        let watchdog_input = WatchdogAnomalyWatchInput::new(
+            &input.sample_id,
+            input.expected_deliveries,
+            input.delivered_deliveries,
+            input.active_peers,
+            input.healthy_peers,
+            input.sample_window_secs,
+            input.targeted_peer_count,
+        )
+        .map_err(NetworkFaultSimulationError::Watchdog)?;
+        let watchdog_report = self
+            .anomaly_evaluator
+            .evaluate(watchdog_input)
+            .map_err(NetworkFaultSimulationError::Watchdog)?;
+
+        Ok(NetworkFaultSimulationReport {
+            sample_id: input.sample_id,
+            final_lifecycle_state: lifecycle.state(),
+            queue_capacity: input.queue_capacity,
+            queued_events: input.queued_events,
+            queue_overflow_attempts,
+            watchdog_kind: watchdog_report.kind,
+            watchdog_severity: watchdog_report.severity,
+            watchdog_delivery_ratio_per_mille: watchdog_report.delivery_ratio_per_mille,
+            watchdog_liveness_ratio_per_mille: watchdog_report.liveness_ratio_per_mille,
+        })
+    }
+}
+
+pub fn simulate_daemon_network_fault(
+    simulator: &DeterministicNetworkFaultSimulator,
+    input: NetworkFaultSimulationInput,
+) -> Result<NetworkFaultSimulationReport, NetworkFaultSimulationError> {
+    simulator.simulate(input)
+}
+
 fn is_valid_listener_did(value: &str) -> bool {
     is_valid_kamn_did(value)
 }
@@ -1876,9 +2052,10 @@ mod tests {
         authorize_daemon_outbound_action, build_runtime_wiring, evaluate_daemon_state_divergence,
         evaluate_daemon_watchdog_anomaly, execute_processor_daemon_tick, ApproverAttestation,
         ApproverQuorumError, ApproverQuorumEvaluator, ApproverQuorumInput, BoundedRuntimeQueue,
-        ConstructLockError, ConstructLockGuard, DeterministicProposalPlanner,
-        FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore, ListenerAttestation,
-        ListenerQuorumError, ListenerQuorumEvaluator, ListenerQuorumInput, PeerLifecycle,
+        ConstructLockError, ConstructLockGuard, DeterministicNetworkFaultSimulator,
+        DeterministicProposalPlanner, FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore,
+        ListenerAttestation, ListenerQuorumError, ListenerQuorumEvaluator, ListenerQuorumInput,
+        NetworkFaultSimulationError, NetworkFaultSimulationInput, PeerLifecycle,
         PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
         RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
         RuntimeLifecycleError, RuntimeQueueError, RuntimeSnapshot, RuntimeSnapshotStore,
@@ -2774,6 +2951,156 @@ mod tests {
             .expect("edge censorship signal should be classified");
         assert_eq!(report.kind, WatchdogAnomalyKind::CensorshipSignal);
         assert_eq!(report.severity, WatchdogAnomalySeverity::Critical);
+    }
+
+    #[test]
+    fn unit_network_fault_simulation_rejects_zero_queue_capacity() {
+        let input = NetworkFaultSimulationInput::new(
+            "fault-sample-invalid",
+            "peer-sim-a",
+            100,
+            99,
+            6,
+            6,
+            30,
+            1,
+            0,
+            2,
+        );
+        assert_eq!(
+            input,
+            Err(NetworkFaultSimulationError::InvalidQueueCapacity { capacity: 0 })
+        );
+    }
+
+    #[test]
+    fn functional_network_fault_simulation_classifies_targeted_packet_loss_as_critical() {
+        let simulator = DeterministicNetworkFaultSimulator::default();
+        let input = NetworkFaultSimulationInput::new(
+            "fault-sample-censorship",
+            "peer-sim-a",
+            100,
+            45,
+            8,
+            8,
+            60,
+            3,
+            8,
+            8,
+        )
+        .expect("valid simulation input");
+        let report = simulator
+            .simulate(input)
+            .expect("simulation should classify targeted packet loss");
+
+        assert_eq!(report.watchdog_kind, WatchdogAnomalyKind::CensorshipSignal);
+        assert_eq!(report.watchdog_severity, WatchdogAnomalySeverity::Critical);
+        assert_eq!(report.final_lifecycle_state, PeerLifecycleState::Active);
+        assert_eq!(report.queue_overflow_attempts, 0);
+    }
+
+    #[test]
+    fn integration_daemon_network_fault_simulation_reports_overflow_and_degradation() {
+        let simulator = DeterministicNetworkFaultSimulator::default();
+        let input = NetworkFaultSimulationInput::new(
+            "fault-sample-overflow",
+            "peer-sim-b",
+            120,
+            110,
+            6,
+            4,
+            30,
+            1,
+            2,
+            5,
+        )
+        .expect("valid simulation input");
+        let report = super::simulate_daemon_network_fault(&simulator, input)
+            .expect("simulation should pass");
+
+        assert_eq!(report.final_lifecycle_state, PeerLifecycleState::Degraded);
+        assert_eq!(report.queue_overflow_attempts, 3);
+        assert_eq!(
+            report.watchdog_kind,
+            WatchdogAnomalyKind::LivenessDegradation
+        );
+    }
+
+    #[test]
+    fn regression_network_fault_simulation_keeps_censorship_critical_boundary() {
+        // Regression: #618
+        let simulator = DeterministicNetworkFaultSimulator::default();
+        let input = NetworkFaultSimulationInput::new(
+            "fault-sample-regression",
+            "peer-sim-c",
+            200,
+            100,
+            12,
+            12,
+            60,
+            2,
+            4,
+            4,
+        )
+        .expect("valid simulation input");
+        let report = simulator
+            .simulate(input)
+            .expect("simulation should classify censorship boundary");
+
+        assert_eq!(report.watchdog_kind, WatchdogAnomalyKind::CensorshipSignal);
+        assert_eq!(report.watchdog_severity, WatchdogAnomalySeverity::Critical);
+    }
+
+    #[test]
+    fn performance_network_fault_simulation_pr_lane_stays_within_budget() {
+        let simulator = DeterministicNetworkFaultSimulator::default();
+        let start = Instant::now();
+        for sample_index in 0..256 {
+            let input = NetworkFaultSimulationInput::new(
+                &format!("fault-sample-perf-{sample_index}"),
+                "peer-sim-perf",
+                100,
+                98,
+                16,
+                16,
+                30,
+                1,
+                8,
+                8,
+            )
+            .expect("valid simulation input");
+            assert!(simulator.simulate(input).is_ok());
+        }
+        let elapsed_millis = start.elapsed().as_millis();
+        assert!(
+            elapsed_millis < 250,
+            "network fault simulation PR lane exceeded budget: {elapsed_millis}ms"
+        );
+    }
+
+    #[test]
+    #[ignore = "scheduled chaos lane"]
+    fn performance_network_fault_simulation_chaos_lane_stress() {
+        let simulator = DeterministicNetworkFaultSimulator::default();
+        for sample_index in 0..5000 {
+            let targeted_peer_count = if sample_index % 4 == 0 { 3 } else { 1 };
+            let delivered = if targeted_peer_count == 3 { 45 } else { 99 };
+            let healthy_peers = if sample_index % 3 == 0 { 8 } else { 10 };
+            let input = NetworkFaultSimulationInput::new(
+                &format!("fault-sample-chaos-{sample_index}"),
+                "peer-sim-chaos",
+                100,
+                delivered,
+                10,
+                healthy_peers,
+                30,
+                targeted_peer_count,
+                16,
+                24,
+            )
+            .expect("valid simulation input");
+            assert!(simulator.simulate(input).is_ok());
+        }
     }
 
     #[test]

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -6,9 +6,13 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("## Node CLI Recovery-Check Mapping"));
     assert!(DOC.contains("## Node CLI Daemon Lifecycle Mapping"));
     assert!(DOC.contains("## Bridge Quorum Runtime Mapping"));
+    assert!(DOC.contains("## Deterministic Fault Simulation Harness Rules"));
     assert!(DOC.contains("PeerLifecycle"));
     assert!(DOC.contains("BoundedRuntimeQueue<T>"));
     assert!(DOC.contains("RuntimeLifecycleError"));
+    assert!(DOC.contains("NetworkFaultSimulationInput"));
+    assert!(DOC.contains("DeterministicNetworkFaultSimulator"));
+    assert!(DOC.contains("simulate_daemon_network_fault(...)"));
 }
 
 #[test]
@@ -25,6 +29,15 @@ fn doc_contains_peer_lifecycle_and_queue_rules() {
 }
 
 #[test]
+fn doc_contains_network_fault_simulation_rules() {
+    assert!(DOC.contains("queue_overflow_attempts"));
+    assert!(DOC.contains("watchdog-compatible delivery/peer sample values"));
+    assert!(
+        DOC.contains("daemon network-fault simulation with queue-overflow/degradation reporting")
+    );
+}
+
+#[test]
 fn doc_contains_recovery_check_cli_command_example() {
     assert!(DOC.contains("`kamn-node --role processor --runtime-mode recovery-check`"));
 }
@@ -33,10 +46,14 @@ fn doc_contains_recovery_check_cli_command_example() {
 fn doc_contains_fast_and_cost_effective_validation_lane() {
     assert!(DOC.contains("## Fast and Cost-Effective Validation"));
     assert!(DOC.contains("cargo test -p kamn-core runtime::tests::"));
+    assert!(DOC.contains("cargo test -p kamn-core network_fault_simulation"));
     assert!(DOC.contains("cargo test -p kamn-core --test bridge_quorum_runtime_docs"));
     assert!(DOC.contains("cargo test -p kamn-node --test node_runtime_cli_docs"));
     assert!(DOC.contains(
         "cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core performance_network_fault_simulation_chaos_lane_stress -- --ignored"
     ));
     assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
 }
@@ -54,4 +71,7 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
     assert!(DOC.contains("daemon lifecycle invalid transition rejection"));
     assert!(DOC.contains("listener attestation replay rejection (`Regression: #371`)"));
     assert!(DOC.contains("outbound under-quorum rejection (`Regression: #372`)"));
+    assert!(DOC.contains(
+        "network fault simulation censorship critical-boundary guard (`Regression: #618`)"
+    ));
 }

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -21,6 +21,12 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `RecoveryRejoinGuard`
   - `RecoveryStatus`
   - `RecoveryGuardError`
+- Added deterministic fault simulation primitives in `crates/kamn-core/src/runtime.rs`:
+  - `NetworkFaultSimulationInput`
+  - `NetworkFaultSimulationReport`
+  - `NetworkFaultSimulationError`
+  - `DeterministicNetworkFaultSimulator`
+  - `simulate_daemon_network_fault(...)`
 - Kept runtime role wiring behavior unchanged and covered by existing tests.
 
 ## Node CLI Recovery-Check Mapping
@@ -113,6 +119,25 @@ This document captures the initial runtime-network foundation slice for peer lif
   - replayed resume tokens are rejected (`ReplayResumeToken`)
   - matching version/hash with unique resume token is accepted (`RejoinAccepted`)
 
+## Deterministic Fault Simulation Harness Rules
+- `NetworkFaultSimulationInput` requires:
+  - non-empty `sample_id`
+  - non-empty `peer_id`
+  - queue capacity greater than zero
+  - watchdog-compatible delivery/peer sample values
+- `DeterministicNetworkFaultSimulator` executes deterministic simulation flow:
+  - lifecycle bootstrap: `StartConnect` -> `HandshakeSucceeded`
+  - degraded lifecycle projection when `healthy_peers < active_peers`
+  - bounded queue saturation accounting via `queue_overflow_attempts`
+  - watchdog anomaly classification via `WatchdogAnomalyEvaluator`
+- `simulate_daemon_network_fault(...)` provides daemon wrapper parity for simulator execution.
+- Output contract fields:
+  - `final_lifecycle_state`
+  - `queue_overflow_attempts`
+  - `watchdog_kind`
+  - `watchdog_severity`
+  - delivery/liveness per-mille ratios
+
 ## Test Coverage Mapping
 - Unit:
   - invalid transition checks
@@ -127,6 +152,7 @@ This document captures the initial runtime-network foundation slice for peer lif
   - bounded FIFO queue behavior under capacity
   - queue-drain to planner ordering preservation
   - lagging-node catch-up guidance output
+  - daemon network-fault simulation with queue-overflow/degradation reporting
 - Regression:
   - rejoin without disconnect is rejected (`Regression: #324`)
   - queue overflow rejects new event (`Regression: #324`)
@@ -138,16 +164,27 @@ This document captures the initial runtime-network foundation slice for peer lif
   - daemon lifecycle invalid transition rejection (`Regression: #349`)
   - listener attestation replay rejection (`Regression: #371`)
   - outbound under-quorum rejection (`Regression: #372`)
+  - network fault simulation censorship critical-boundary guard (`Regression: #618`)
+- Performance:
+  - bounded PR-lane deterministic fault simulation budget check
+  - scheduled chaos lane stress hook (`--ignored`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
 
 ```bash
 cargo test -p kamn-core runtime::tests::
+cargo test -p kamn-core network_fault_simulation
 cargo test -p kamn-core --test runtime_network_docs
 cargo test -p kamn-core --test bridge_quorum_runtime_docs
 cargo test -p kamn-node --test node_runtime_cli_docs
 cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
+```
+
+Scheduled deep-lane command:
+
+```bash
+cargo test -p kamn-core performance_network_fault_simulation_chaos_lane_stress -- --ignored
 ```
 
 Then run strict lint/format gates:


### PR DESCRIPTION
## Summary
Introduces a deterministic runtime network-fault simulation harness that composes lifecycle, queue backpressure, and watchdog anomaly classification into a typed report surface. Adds low-cost PR-lane checks and an explicit ignored deep-lane chaos entrypoint while keeping CI cost bounded.

Closes #629
Refs #618
Refs #616

## Changes
- `crates/kamn-core/src/runtime.rs`: added `NetworkFaultSimulationInput`, `NetworkFaultSimulationReport`, `NetworkFaultSimulationError`, `DeterministicNetworkFaultSimulator`, and `simulate_daemon_network_fault(...)`; added unit/functional/integration/regression/performance tests plus ignored chaos-lane stress test.
- `crates/kamn-core/src/lib.rs`: re-exported network-fault simulation API surface.
- `docs/foundation/runtime-network.md`: documented deterministic fault-simulation rules and fast/deep validation entrypoints.
- `crates/kamn-core/tests/runtime_network_docs.rs`: extended docs contract assertions for the new fault-simulation surface and validation lanes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core network_fault_simulation -- --nocapture
```
Failure excerpt (before implementation):
```text
error[E0432]: unresolved imports `super::DeterministicNetworkFaultSimulator`, `super::NetworkFaultSimulationError`, `super::NetworkFaultSimulationInput`
error[E0425]: cannot find function `simulate_daemon_network_fault` in module `super`
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core network_fault_simulation -- --nocapture
cargo test -p kamn-core --test runtime_network_docs
```
Pass summary:
```text
network_fault_simulation: 5 passed, 1 ignored
runtime_network_docs: 6 passed
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core performance_network_fault_simulation_chaos_lane_stress -- --ignored
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
Pass summary:
```text
chaos deep lane: 1 passed
workspace regression suite: all tests passed
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `runtime::tests::unit_network_fault_simulation_rejects_zero_queue_capacity` | |
| Functional   | ✅ | `runtime::tests::functional_network_fault_simulation_classifies_targeted_packet_loss_as_critical` | |
| Integration  | ✅ | `runtime::tests::integration_daemon_network_fault_simulation_reports_overflow_and_degradation` | |
| Regression   | ✅ | `runtime::tests::regression_network_fault_simulation_keeps_censorship_critical_boundary` (`Regression: #618`) | |
| Performance  | ✅ | `runtime::tests::performance_network_fault_simulation_pr_lane_stays_within_budget`; deep lane `runtime::tests::performance_network_fault_simulation_chaos_lane_stress` | |

## Risks & Rollback
- Adds new API surface only; no existing behavior was removed.
- Rollback: revert commit `032d31c` to remove new simulator surface/tests/docs.

## Documentation Updates
- `docs/foundation/runtime-network.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
