### PR TITLE
feat(core): add secure signer provider adapter routing

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -229,8 +229,8 @@ pub use signature_profile::{
     baseline_signature_for_fields, baseline_signature_profile_id, BASELINE_SIGNATURE_PROFILE_ID,
 };
 pub use signer_backend::{
-    BackendSignature, LocalSignerBackend, SecureSignerBackend, SignerBackend, SignerBackendError,
-    SignerBackendRouter, SigningRequest,
+    BackendSignature, LocalSignerBackend, SecureSignerBackend, SecureSignerProvider, SignerBackend,
+    SignerBackendError, SignerBackendRouter, SigningRequest,
 };
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{

--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -2,7 +2,8 @@ use crate::signature_profile::baseline_signature_for_fields;
 use crate::transaction::BaselineTransaction;
 
 const LOCAL_BACKEND_NAME: &str = "local-software";
-const SECURE_BACKEND_NAME: &str = "secure-mock";
+const SECURE_MOCK_BACKEND_NAME: &str = "secure-mock";
+const SECURE_AWS_KMS_BACKEND_NAME: &str = "secure-aws-kms-emulator";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SigningRequest {
@@ -67,6 +68,80 @@ pub struct BackendSignature {
     pub signature: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecureSignerProvider {
+    Mock,
+    AwsKmsEmulator,
+}
+
+impl SecureSignerProvider {
+    pub fn from_key_id(key_id: &str) -> Result<Self, SignerBackendError> {
+        Ok(SecureKeyReference::parse(key_id)?.provider)
+    }
+
+    pub fn backend_name(self) -> &'static str {
+        match self {
+            Self::Mock => SECURE_MOCK_BACKEND_NAME,
+            Self::AwsKmsEmulator => SECURE_AWS_KMS_BACKEND_NAME,
+        }
+    }
+
+    fn from_label(label: &str, key_id: &str) -> Result<Self, SignerBackendError> {
+        match label {
+            "mock" => Ok(Self::Mock),
+            "aws-kms" => Ok(Self::AwsKmsEmulator),
+            _ => Err(SignerBackendError::UnsupportedSecureProvider {
+                backend: SECURE_MOCK_BACKEND_NAME.to_owned(),
+                provider: label.to_owned(),
+                key_id: key_id.to_owned(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SecureKeyReference {
+    provider: SecureSignerProvider,
+    _provider_key_id: String,
+}
+
+impl SecureKeyReference {
+    fn parse(key_id: &str) -> Result<Self, SignerBackendError> {
+        if !key_id.starts_with("secure:") {
+            return Err(SignerBackendError::UnsupportedKeyReference {
+                backend: SECURE_MOCK_BACKEND_NAME.to_owned(),
+                key_id: key_id.to_owned(),
+            });
+        }
+
+        let suffix = &key_id["secure:".len()..];
+        if suffix.trim().is_empty() {
+            return Err(SignerBackendError::MalformedSecureKeyReference {
+                key_id: key_id.to_owned(),
+            });
+        }
+
+        if let Some((provider_label, provider_key_id)) = suffix.split_once(':') {
+            if provider_label.trim().is_empty() || provider_key_id.trim().is_empty() {
+                return Err(SignerBackendError::MalformedSecureKeyReference {
+                    key_id: key_id.to_owned(),
+                });
+            }
+            let normalized_provider_label = provider_label.trim().to_ascii_lowercase();
+            let provider = SecureSignerProvider::from_label(&normalized_provider_label, key_id)?;
+            return Ok(Self {
+                provider,
+                _provider_key_id: provider_key_id.to_owned(),
+            });
+        }
+
+        Ok(Self {
+            provider: SecureSignerProvider::Mock,
+            _provider_key_id: suffix.to_owned(),
+        })
+    }
+}
+
 pub trait SignerBackend {
     fn backend_name(&self) -> &'static str;
     fn sign(&self, request: &SigningRequest) -> Result<String, SignerBackendError>;
@@ -108,46 +183,65 @@ impl SecureSignerBackend {
     pub fn new(available: bool) -> Self {
         Self { available }
     }
+
+    fn sign_with_backend(
+        &self,
+        request: &SigningRequest,
+    ) -> Result<BackendSignature, SignerBackendError> {
+        let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        if !self.available {
+            return Err(SignerBackendError::ProviderUnavailable {
+                backend: secure_key.provider.backend_name().to_owned(),
+            });
+        }
+
+        Ok(BackendSignature {
+            backend: secure_key.provider.backend_name().to_owned(),
+            signature: request.expected_signature(),
+        })
+    }
+
+    fn verify_with_backend_name(
+        &self,
+        backend: &str,
+        request: &SigningRequest,
+        signature: &str,
+    ) -> Result<(), SignerBackendError> {
+        let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        let expected_backend = secure_key.provider.backend_name();
+        if backend != expected_backend {
+            return Err(SignerBackendError::SecureProviderBackendMismatch {
+                expected_backend: expected_backend.to_owned(),
+                provided_backend: backend.to_owned(),
+                key_id: request.key_id.clone(),
+            });
+        }
+
+        self.verify(request, signature)
+    }
 }
 
 impl SignerBackend for SecureSignerBackend {
     fn backend_name(&self) -> &'static str {
-        SECURE_BACKEND_NAME
+        SECURE_MOCK_BACKEND_NAME
     }
 
     fn sign(&self, request: &SigningRequest) -> Result<String, SignerBackendError> {
-        if !self.available {
-            return Err(SignerBackendError::ProviderUnavailable {
-                backend: self.backend_name().to_owned(),
-            });
-        }
-        if !request.key_id.starts_with("secure:") {
-            return Err(SignerBackendError::UnsupportedKeyReference {
-                backend: self.backend_name().to_owned(),
-                key_id: request.key_id.clone(),
-            });
-        }
-
-        Ok(request.expected_signature())
+        Ok(self.sign_with_backend(request)?.signature)
     }
 
     fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
+        let secure_key = SecureKeyReference::parse(&request.key_id)?;
         if !self.available {
             return Err(SignerBackendError::ProviderUnavailable {
-                backend: self.backend_name().to_owned(),
-            });
-        }
-        if !request.key_id.starts_with("secure:") {
-            return Err(SignerBackendError::UnsupportedKeyReference {
-                backend: self.backend_name().to_owned(),
-                key_id: request.key_id.clone(),
+                backend: secure_key.provider.backend_name().to_owned(),
             });
         }
 
         let expected = request.expected_signature();
         if expected != signature {
             return Err(SignerBackendError::SignatureMismatch {
-                backend: self.backend_name().to_owned(),
+                backend: secure_key.provider.backend_name().to_owned(),
                 expected,
                 found: signature.to_owned(),
             });
@@ -175,11 +269,8 @@ impl SignerBackendRouter {
         &self,
         request: &SigningRequest,
     ) -> Result<BackendSignature, SignerBackendError> {
-        match self.secure.sign(request) {
-            Ok(signature) => Ok(BackendSignature {
-                backend: self.secure.backend_name().to_owned(),
-                signature,
-            }),
+        match self.secure.sign_with_backend(request) {
+            Ok(signature) => Ok(signature),
             Err(SignerBackendError::ProviderUnavailable { .. }) => {
                 let signature = self.local.sign(request)?;
                 Ok(BackendSignature {
@@ -199,7 +290,9 @@ impl SignerBackendRouter {
     ) -> Result<(), SignerBackendError> {
         match backend {
             LOCAL_BACKEND_NAME => self.local.verify(request, signature),
-            SECURE_BACKEND_NAME => self.secure.verify(request, signature),
+            SECURE_MOCK_BACKEND_NAME | SECURE_AWS_KMS_BACKEND_NAME => self
+                .secure
+                .verify_with_backend_name(backend, request, signature),
             _ => Err(SignerBackendError::UnknownBackend(backend.to_owned())),
         }
     }
@@ -215,8 +308,16 @@ impl Default for SignerBackendRouter {
 pub enum SignerBackendError {
     EmptyField(&'static str),
     InvalidNonce,
+    MalformedSecureKeyReference {
+        key_id: String,
+    },
     ProviderUnavailable {
         backend: String,
+    },
+    SecureProviderBackendMismatch {
+        expected_backend: String,
+        provided_backend: String,
+        key_id: String,
     },
     SignatureMismatch {
         backend: String,
@@ -224,6 +325,11 @@ pub enum SignerBackendError {
         found: String,
     },
     UnknownBackend(String),
+    UnsupportedSecureProvider {
+        backend: String,
+        provider: String,
+        key_id: String,
+    },
     UnsupportedKeyReference {
         backend: String,
         key_id: String,
@@ -235,9 +341,20 @@ impl std::fmt::Display for SignerBackendError {
         match self {
             Self::EmptyField(field) => write!(f, "{field} must not be empty"),
             Self::InvalidNonce => write!(f, "nonce must be positive"),
+            Self::MalformedSecureKeyReference { key_id } => {
+                write!(f, "malformed secure key reference: {key_id}")
+            }
             Self::ProviderUnavailable { backend } => {
                 write!(f, "signer backend unavailable: {backend}")
             }
+            Self::SecureProviderBackendMismatch {
+                expected_backend,
+                provided_backend,
+                key_id,
+            } => write!(
+                f,
+                "secure provider backend mismatch for key {key_id}; expected {expected_backend}, found {provided_backend}"
+            ),
             Self::SignatureMismatch {
                 backend,
                 expected,
@@ -247,6 +364,14 @@ impl std::fmt::Display for SignerBackendError {
                 "signature mismatch for backend {backend}; expected {expected}, found {found}"
             ),
             Self::UnknownBackend(backend) => write!(f, "unknown signer backend: {backend}"),
+            Self::UnsupportedSecureProvider {
+                backend,
+                provider,
+                key_id,
+            } => write!(
+                f,
+                "unsupported secure signer provider for backend {backend}: {provider} ({key_id})"
+            ),
             Self::UnsupportedKeyReference { backend, key_id } => {
                 write!(
                     f,
@@ -261,7 +386,7 @@ impl std::error::Error for SignerBackendError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{SignerBackendError, SigningRequest};
+    use super::{SecureSignerProvider, SignerBackendError, SigningRequest};
 
     #[test]
     fn signing_request_rejects_invalid_fields() {
@@ -272,6 +397,40 @@ mod tests {
         assert_eq!(
             SigningRequest::new("secure:key-1", "agent-a", 0, "payload", "state:genesis"),
             Err(SignerBackendError::InvalidNonce)
+        );
+    }
+
+    #[test]
+    fn secure_provider_parser_accepts_legacy_and_explicit_key_formats() {
+        assert_eq!(
+            SecureSignerProvider::from_key_id("secure:key-legacy-1"),
+            Ok(SecureSignerProvider::Mock)
+        );
+        assert_eq!(
+            SecureSignerProvider::from_key_id("secure:mock:key-legacy-2"),
+            Ok(SecureSignerProvider::Mock)
+        );
+        assert_eq!(
+            SecureSignerProvider::from_key_id("secure:aws-kms:key-prod-1"),
+            Ok(SecureSignerProvider::AwsKmsEmulator)
+        );
+    }
+
+    #[test]
+    fn secure_provider_parser_rejects_unknown_and_malformed_key_references() {
+        assert_eq!(
+            SecureSignerProvider::from_key_id("secure:gcp-kms:key-prod-1"),
+            Err(SignerBackendError::UnsupportedSecureProvider {
+                backend: "secure-mock".to_owned(),
+                provider: "gcp-kms".to_owned(),
+                key_id: "secure:gcp-kms:key-prod-1".to_owned(),
+            })
+        );
+        assert_eq!(
+            SecureSignerProvider::from_key_id("secure:"),
+            Err(SignerBackendError::MalformedSecureKeyReference {
+                key_id: "secure:".to_owned(),
+            })
         );
     }
 }

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -27,6 +27,28 @@ fn functional_secure_backend_signs_and_verifies_when_available() {
 }
 
 #[test]
+fn functional_aws_kms_provider_routes_to_production_adapter_backend() {
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:aws-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("secure backend should sign");
+    assert_eq!(signed.backend, "secure-aws-kms-emulator");
+
+    router
+        .verify_with_backend(&signed.backend, &request, &signed.signature)
+        .expect("signature should verify");
+}
+
+#[test]
 fn functional_secure_unavailable_falls_back_to_local_backend() {
     let router = SignerBackendRouter::with_secure_availability(false);
     let request = SigningRequest::new(
@@ -73,6 +95,31 @@ fn integration_router_signed_transaction_passes_transaction_guards() {
 }
 
 #[test]
+fn integration_aws_kms_signed_transaction_passes_transaction_guards() {
+    let router = SignerBackendRouter::default();
+    let mut guards = TransactionGuards::new();
+    let mut tx = BaselineTransaction::signed(
+        "tx-sign-aws-1",
+        "agent-a",
+        1,
+        "payload-sign-1",
+        guards.expected_state_hash(),
+    );
+
+    let request = SigningRequest::for_transaction("secure:aws-kms:key-ops-2", &tx)
+        .expect("request should map from transaction");
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("signing should succeed");
+    assert_eq!(signed.backend, "secure-aws-kms-emulator");
+    tx.signature = signed.signature;
+
+    guards
+        .validate_and_record(&tx)
+        .expect("signed transaction should validate");
+}
+
+#[test]
 fn regression_unsupported_secure_key_reference_does_not_fallback() {
     // Regression: #160
     let router = SignerBackendRouter::default();
@@ -84,6 +131,55 @@ fn regression_unsupported_secure_key_reference_does_not_fallback() {
         Err(SignerBackendError::UnsupportedKeyReference {
             backend: "secure-mock".to_owned(),
             key_id: "local:key-1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_unknown_secure_provider_is_rejected_without_fallback() {
+    // Regression: #619
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:gcp-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    assert_eq!(
+        router.sign_with_secure_fallback(&request),
+        Err(SignerBackendError::UnsupportedSecureProvider {
+            backend: "secure-mock".to_owned(),
+            provider: "gcp-kms".to_owned(),
+            key_id: "secure:gcp-kms:key-ops-1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_secure_provider_backend_mismatch_is_rejected() {
+    // Regression: #619
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:aws-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("signing should succeed");
+
+    assert_eq!(
+        router.verify_with_backend("secure-mock", &request, &signed.signature),
+        Err(SignerBackendError::SecureProviderBackendMismatch {
+            expected_backend: "secure-aws-kms-emulator".to_owned(),
+            provided_backend: "secure-mock".to_owned(),
+            key_id: "secure:aws-kms:key-ops-1".to_owned(),
         })
     );
 }
@@ -150,8 +246,13 @@ fn performance_signer_emulator_contract_lane_stays_within_budget() {
     let start = Instant::now();
 
     for nonce in 1..=256 {
+        let key_id = if nonce % 2 == 0 {
+            "secure:key-ops-perf"
+        } else {
+            "secure:aws-kms:key-ops-perf"
+        };
         let request = SigningRequest::new(
-            "secure:key-ops-perf",
+            key_id,
             "agent-a",
             nonce,
             &format!("payload-perf-{nonce}"),
@@ -161,7 +262,12 @@ fn performance_signer_emulator_contract_lane_stays_within_budget() {
         let signed = router
             .sign_with_secure_fallback(&request)
             .expect("signature should be produced");
-        assert_eq!(signed.backend, "secure-mock");
+        let expected_backend = if nonce % 2 == 0 {
+            "secure-mock"
+        } else {
+            "secure-aws-kms-emulator"
+        };
+        assert_eq!(signed.backend, expected_backend);
     }
 
     let elapsed_millis = start.elapsed().as_millis();

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -29,10 +29,19 @@ fn doc_contains_signer_emulator_contract_lane_policy() {
 }
 
 #[test]
+fn doc_contains_production_style_secure_provider_adapter_rules() {
+    assert!(DOC.contains("secure-aws-kms-emulator"));
+    assert!(DOC.contains("secure:aws-kms:<key-ref>"));
+    assert!(DOC.contains("UnsupportedSecureProvider"));
+    assert!(DOC.contains("MalformedSecureKeyReference"));
+}
+
+#[test]
 fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
     // Regression: #160
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("canonical signature-profile helper consumed by both paths"));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)"));
     assert!(DOC.contains("Contract lane guards remain required for signer provider compatibility (`Regression: #619`)."));
+    assert!(DOC.contains("SecureProviderBackendMismatch"));
 }

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -14,12 +14,20 @@ This document captures the first implementation slice for signer backend abstrac
 ## Backend Compatibility Rules
 - `local-software` backend:
   - signs and verifies deterministic signatures for valid requests.
-- `secure-mock` backend:
-  - requires key IDs with `secure:` prefix.
-  - returns explicit `ProviderUnavailable` when disabled/unavailable.
+- secure provider adapters:
+  - `secure-mock` for deterministic mock custody.
+  - `secure-aws-kms-emulator` for production-style provider adapter coverage.
+  - key references:
+    - legacy mock: `secure:<key-ref>`
+    - explicit mock: `secure:mock:<key-ref>`
+    - production-style adapter: `secure:aws-kms:<key-ref>`
+  - unknown provider labels are rejected with typed `UnsupportedSecureProvider`.
+  - malformed secure key references are rejected with typed `MalformedSecureKeyReference`.
+  - `ProviderUnavailable` reports the provider-specific backend when the secure path is disabled.
 - Router fallback:
   - falls back from secure to local only for `ProviderUnavailable`.
   - does not fallback on hard request errors (for example, unsupported secure key references).
+  - verification rejects backend/provider mismatches via `SecureProviderBackendMismatch` (`Regression: #619`).
 
 ## Transaction Path Integration
 - `SigningRequest::for_transaction(...)` maps `BaselineTransaction` fields into signer requests.


### PR DESCRIPTION
Closes #630

## Summary
Adds explicit secure signer provider adapter routing with a production-style `aws-kms` emulator path while preserving deterministic mock compatibility. Tightens typed error contracts so unknown/malformed secure provider references are rejected without unsafe fallback.

## Changes
- `crates/kamn-core/src/signer_backend.rs`: add `SecureSignerProvider` contract, secure key parsing, provider-aware backend routing, and new typed errors (`UnsupportedSecureProvider`, `MalformedSecureKeyReference`, `SecureProviderBackendMismatch`).
- `crates/kamn-core/src/lib.rs`: export `SecureSignerProvider` for consumer contracts.
- `crates/kamn-core/tests/signer_backend.rs`: add functional/integration/regression/performance coverage for `secure:aws-kms:<key-ref>` routing and provider mismatch safety.
- `crates/kamn-core/tests/signer_backend_docs.rs`: assert provider adapter and typed error contract docs.
- `docs/foundation/signer-backend-abstraction.md`: document production-style provider adapter path, key formats, and rejection/fallback policy.

## Risks & Compatibility
- Low risk; legacy `secure:<key-ref>` remains supported as `secure-mock`.
- New stricter behavior: unknown provider labels in `secure:<provider>:<key-ref>` now fail with typed `UnsupportedSecureProvider`.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: signer fast/deep lane scripts and CI tooling regression suite are green

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core secure_provider_parser` |
| Functional  | ✅ | `cargo test -p kamn-core --test signer_backend` (`functional_aws_kms_provider_routes_to_production_adapter_backend`) |
| Integration | ✅ | `cargo test -p kamn-core --test signer_backend` (`integration_aws_kms_signed_transaction_passes_transaction_guards`) |
| Regression  | ✅ | `cargo test -p kamn-core --test signer_backend` (`regression_unknown_secure_provider_is_rejected_without_fallback`, `regression_secure_provider_backend_mismatch_is_rejected`) |
