### PR TITLE
feat(core): enforce signer fallback role policy

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -230,7 +230,7 @@ pub use signature_profile::{
 };
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SecureSignerProvider, SignerBackend,
-    SignerBackendError, SignerBackendRouter, SigningRequest,
+    SignerBackendError, SignerBackendRouter, SignerKeyRole, SigningRequest,
 };
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{

--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -99,9 +99,89 @@ impl SecureSignerProvider {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignerKeyRole {
+    Operator,
+    Admin,
+    Treasury,
+    Auditor,
+}
+
+impl SignerKeyRole {
+    pub fn from_key_id(key_id: &str) -> Result<Self, SignerBackendError> {
+        Ok(SecureKeyReference::parse(key_id)?.key_role)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Operator => "operator",
+            Self::Admin => "admin",
+            Self::Treasury => "treasury",
+            Self::Auditor => "auditor",
+        }
+    }
+
+    fn allows_secure_fallback(self) -> bool {
+        matches!(self, Self::Operator)
+    }
+
+    fn from_sender(sender: &str) -> Self {
+        let normalized_sender = sender.trim().to_ascii_lowercase();
+        if normalized_sender.starts_with("admin-") || normalized_sender.starts_with("admin:") {
+            return Self::Admin;
+        }
+        if normalized_sender.starts_with("treasury-") || normalized_sender.starts_with("treasury:")
+        {
+            return Self::Treasury;
+        }
+        if normalized_sender.starts_with("auditor-")
+            || normalized_sender.starts_with("auditor:")
+            || normalized_sender.starts_with("audit-")
+            || normalized_sender.starts_with("audit:")
+        {
+            return Self::Auditor;
+        }
+
+        Self::Operator
+    }
+
+    fn from_provider_key_id(
+        provider_key_id: &str,
+        key_id: &str,
+    ) -> Result<Self, SignerBackendError> {
+        let Some(role_suffix) = provider_key_id.strip_prefix("role-") else {
+            return Ok(Self::Operator);
+        };
+
+        let Some((role_label, role_key_id)) = role_suffix.split_once('/') else {
+            return Err(SignerBackendError::MalformedSecureKeyReference {
+                key_id: key_id.to_owned(),
+            });
+        };
+        if role_label.trim().is_empty() || role_key_id.trim().is_empty() {
+            return Err(SignerBackendError::MalformedSecureKeyReference {
+                key_id: key_id.to_owned(),
+            });
+        }
+
+        let normalized_role_label = role_label.trim().to_ascii_lowercase();
+        match normalized_role_label.as_str() {
+            "operator" => Ok(Self::Operator),
+            "admin" => Ok(Self::Admin),
+            "treasury" => Ok(Self::Treasury),
+            "auditor" => Ok(Self::Auditor),
+            _ => Err(SignerBackendError::UnsupportedSignerKeyRole {
+                role: normalized_role_label,
+                key_id: key_id.to_owned(),
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SecureKeyReference {
     provider: SecureSignerProvider,
+    key_role: SignerKeyRole,
     _provider_key_id: String,
 }
 
@@ -129,14 +209,17 @@ impl SecureKeyReference {
             }
             let normalized_provider_label = provider_label.trim().to_ascii_lowercase();
             let provider = SecureSignerProvider::from_label(&normalized_provider_label, key_id)?;
+            let key_role = SignerKeyRole::from_provider_key_id(provider_key_id, key_id)?;
             return Ok(Self {
                 provider,
+                key_role,
                 _provider_key_id: provider_key_id.to_owned(),
             });
         }
 
         Ok(Self {
             provider: SecureSignerProvider::Mock,
+            key_role: SignerKeyRole::Operator,
             _provider_key_id: suffix.to_owned(),
         })
     }
@@ -184,11 +267,30 @@ impl SecureSignerBackend {
         Self { available }
     }
 
+    fn enforce_key_role_segregation(
+        &self,
+        request: &SigningRequest,
+        secure_key: &SecureKeyReference,
+    ) -> Result<(), SignerBackendError> {
+        let sender_role = SignerKeyRole::from_sender(&request.sender);
+        if sender_role != secure_key.key_role {
+            return Err(SignerBackendError::KeyRoleMismatch {
+                key_role: secure_key.key_role.label().to_owned(),
+                sender_role: sender_role.label().to_owned(),
+                sender: request.sender.clone(),
+                key_id: request.key_id.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
     fn sign_with_backend(
         &self,
         request: &SigningRequest,
     ) -> Result<BackendSignature, SignerBackendError> {
         let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        self.enforce_key_role_segregation(request, &secure_key)?;
         if !self.available {
             return Err(SignerBackendError::ProviderUnavailable {
                 backend: secure_key.provider.backend_name().to_owned(),
@@ -232,6 +334,7 @@ impl SignerBackend for SecureSignerBackend {
 
     fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
         let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        self.enforce_key_role_segregation(request, &secure_key)?;
         if !self.available {
             return Err(SignerBackendError::ProviderUnavailable {
                 backend: secure_key.provider.backend_name().to_owned(),
@@ -272,6 +375,13 @@ impl SignerBackendRouter {
         match self.secure.sign_with_backend(request) {
             Ok(signature) => Ok(signature),
             Err(SignerBackendError::ProviderUnavailable { .. }) => {
+                let key_role = SignerKeyRole::from_key_id(&request.key_id)?;
+                if !key_role.allows_secure_fallback() {
+                    return Err(SignerBackendError::FallbackDeniedByRolePolicy {
+                        key_role: key_role.label().to_owned(),
+                        key_id: request.key_id.clone(),
+                    });
+                }
                 let signature = self.local.sign(request)?;
                 Ok(BackendSignature {
                     backend: self.local.backend_name().to_owned(),
@@ -307,7 +417,17 @@ impl Default for SignerBackendRouter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SignerBackendError {
     EmptyField(&'static str),
+    FallbackDeniedByRolePolicy {
+        key_role: String,
+        key_id: String,
+    },
     InvalidNonce,
+    KeyRoleMismatch {
+        key_role: String,
+        sender_role: String,
+        sender: String,
+        key_id: String,
+    },
     MalformedSecureKeyReference {
         key_id: String,
     },
@@ -330,6 +450,10 @@ pub enum SignerBackendError {
         provider: String,
         key_id: String,
     },
+    UnsupportedSignerKeyRole {
+        role: String,
+        key_id: String,
+    },
     UnsupportedKeyReference {
         backend: String,
         key_id: String,
@@ -340,7 +464,20 @@ impl std::fmt::Display for SignerBackendError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyField(field) => write!(f, "{field} must not be empty"),
+            Self::FallbackDeniedByRolePolicy { key_role, key_id } => write!(
+                f,
+                "secure fallback denied for key role {key_role} ({key_id})"
+            ),
             Self::InvalidNonce => write!(f, "nonce must be positive"),
+            Self::KeyRoleMismatch {
+                key_role,
+                sender_role,
+                sender,
+                key_id,
+            } => write!(
+                f,
+                "key role mismatch for {key_id}; key role {key_role}, sender role {sender_role}, sender {sender}"
+            ),
             Self::MalformedSecureKeyReference { key_id } => {
                 write!(f, "malformed secure key reference: {key_id}")
             }
@@ -372,6 +509,9 @@ impl std::fmt::Display for SignerBackendError {
                 f,
                 "unsupported secure signer provider for backend {backend}: {provider} ({key_id})"
             ),
+            Self::UnsupportedSignerKeyRole { role, key_id } => {
+                write!(f, "unsupported signer key role {role} for key reference {key_id}")
+            }
             Self::UnsupportedKeyReference { backend, key_id } => {
                 write!(
                     f,
@@ -386,7 +526,7 @@ impl std::error::Error for SignerBackendError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{SecureSignerProvider, SignerBackendError, SigningRequest};
+    use super::{SecureSignerProvider, SignerBackendError, SignerKeyRole, SigningRequest};
 
     #[test]
     fn signing_request_rejects_invalid_fields() {
@@ -430,6 +570,33 @@ mod tests {
             SecureSignerProvider::from_key_id("secure:"),
             Err(SignerBackendError::MalformedSecureKeyReference {
                 key_id: "secure:".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn signer_key_role_parser_supports_role_prefixes_and_legacy_defaults() {
+        assert_eq!(
+            SignerKeyRole::from_key_id("secure:key-legacy-1"),
+            Ok(SignerKeyRole::Operator)
+        );
+        assert_eq!(
+            SignerKeyRole::from_key_id("secure:aws-kms:role-admin/key-prod-1"),
+            Ok(SignerKeyRole::Admin)
+        );
+        assert_eq!(
+            SignerKeyRole::from_key_id("secure:aws-kms:role-treasury/key-prod-2"),
+            Ok(SignerKeyRole::Treasury)
+        );
+    }
+
+    #[test]
+    fn signer_key_role_parser_rejects_unsupported_role_labels() {
+        assert_eq!(
+            SignerKeyRole::from_key_id("secure:aws-kms:role-root/key-prod-3"),
+            Err(SignerBackendError::UnsupportedSignerKeyRole {
+                role: "root".to_owned(),
+                key_id: "secure:aws-kms:role-root/key-prod-3".to_owned(),
             })
         );
     }

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -120,6 +120,74 @@ fn integration_aws_kms_signed_transaction_passes_transaction_guards() {
 }
 
 #[test]
+fn functional_admin_role_key_signs_when_sender_role_matches() {
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:aws-kms:role-admin/key-ops-1",
+        "admin-agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("signing should succeed");
+    assert_eq!(signed.backend, "secure-aws-kms-emulator");
+
+    router
+        .verify_with_backend(&signed.backend, &request, &signed.signature)
+        .expect("signature should verify");
+}
+
+#[test]
+fn regression_role_mismatch_signing_request_is_rejected() {
+    // Regression: #619
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:aws-kms:role-admin/key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    assert_eq!(
+        router.sign_with_secure_fallback(&request),
+        Err(SignerBackendError::KeyRoleMismatch {
+            key_role: "admin".to_owned(),
+            sender_role: "operator".to_owned(),
+            sender: "agent-a".to_owned(),
+            key_id: "secure:aws-kms:role-admin/key-ops-1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_admin_key_does_not_fallback_when_secure_provider_unavailable() {
+    // Regression: #619
+    let router = SignerBackendRouter::with_secure_availability(false);
+    let request = SigningRequest::new(
+        "secure:aws-kms:role-admin/key-ops-1",
+        "admin-agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    assert_eq!(
+        router.sign_with_secure_fallback(&request),
+        Err(SignerBackendError::FallbackDeniedByRolePolicy {
+            key_role: "admin".to_owned(),
+            key_id: "secure:aws-kms:role-admin/key-ops-1".to_owned(),
+        })
+    );
+}
+
+#[test]
 fn regression_unsupported_secure_key_reference_does_not_fallback() {
     // Regression: #160
     let router = SignerBackendRouter::default();

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -13,7 +13,9 @@ fn doc_contains_signer_backend_contract_and_router_rules() {
 #[test]
 fn doc_contains_fallback_semantics_and_transaction_integration() {
     assert!(DOC.contains("## Backend Compatibility Rules"));
-    assert!(DOC.contains("falls back from secure to local only for `ProviderUnavailable`."));
+    assert!(DOC.contains(
+        "falls back from secure to local only for `ProviderUnavailable` and `operator` role keys."
+    ));
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("## Transaction Path Integration"));
     assert!(DOC.contains("SigningRequest::for_transaction(...)"));
@@ -32,7 +34,11 @@ fn doc_contains_signer_emulator_contract_lane_policy() {
 fn doc_contains_production_style_secure_provider_adapter_rules() {
     assert!(DOC.contains("secure-aws-kms-emulator"));
     assert!(DOC.contains("secure:aws-kms:<key-ref>"));
+    assert!(DOC.contains("role-scoped production keys"));
+    assert!(DOC.contains("KeyRoleMismatch"));
+    assert!(DOC.contains("FallbackDeniedByRolePolicy"));
     assert!(DOC.contains("UnsupportedSecureProvider"));
+    assert!(DOC.contains("UnsupportedSignerKeyRole"));
     assert!(DOC.contains("MalformedSecureKeyReference"));
 }
 

--- a/crates/kamn-core/tests/transaction_guards_docs.rs
+++ b/crates/kamn-core/tests/transaction_guards_docs.rs
@@ -17,10 +17,23 @@ fn doc_contains_canonical_signature_profile_contract() {
 }
 
 #[test]
+fn doc_contains_signer_fallback_policy_integration_rules() {
+    assert!(DOC.contains("## Signer Fallback Policy Integration"));
+    assert!(DOC.contains("secure:aws-kms:role-<operator|admin|treasury|auditor>/<key-ref>"));
+    assert!(DOC.contains("KeyRoleMismatch"));
+    assert!(DOC.contains("FallbackDeniedByRolePolicy"));
+}
+
+#[test]
 fn regression_requires_signature_profile_drift_guard_rule() {
     // Regression: #400
     assert!(DOC.contains(
         "signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).",
     ));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)."));
+    assert!(
+        DOC.contains(
+            "privileged roles (`admin`, `treasury`, `auditor`) reject fallback via `FallbackDeniedByRolePolicy` (`Regression: #619`).",
+        ),
+    );
 }

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -21,11 +21,16 @@ This document captures the first implementation slice for signer backend abstrac
     - legacy mock: `secure:<key-ref>`
     - explicit mock: `secure:mock:<key-ref>`
     - production-style adapter: `secure:aws-kms:<key-ref>`
+    - role-scoped production keys: `secure:aws-kms:role-<operator|admin|treasury|auditor>/<key-ref>`
+  - sender role prefixes map to signer roles (`admin-*`, `treasury-*`, `auditor-*`; default is `operator`).
+  - key-role mismatch is rejected with typed `KeyRoleMismatch`.
   - unknown provider labels are rejected with typed `UnsupportedSecureProvider`.
+  - unknown role labels are rejected with typed `UnsupportedSignerKeyRole`.
   - malformed secure key references are rejected with typed `MalformedSecureKeyReference`.
   - `ProviderUnavailable` reports the provider-specific backend when the secure path is disabled.
 - Router fallback:
-  - falls back from secure to local only for `ProviderUnavailable`.
+  - falls back from secure to local only for `ProviderUnavailable` and `operator` role keys.
+  - fallback is denied for privileged roles with typed `FallbackDeniedByRolePolicy`.
   - does not fallback on hard request errors (for example, unsupported secure key references).
   - verification rejects backend/provider mismatches via `SecureProviderBackendMismatch` (`Regression: #619`).
 

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -24,6 +24,13 @@ This document defines the baseline deterministic transaction guards implemented 
 - signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).
 - non-versioned signature profile is rejected (`Regression: #404`).
 
+## Signer Fallback Policy Integration
+- signer keys support role-scoped secure references: `secure:aws-kms:role-<operator|admin|treasury|auditor>/<key-ref>`.
+- sender role prefixes map to signing roles and are validated against key role before signing.
+- role mismatch is rejected through typed `KeyRoleMismatch`.
+- secure fallback to local signing is permitted only for `operator` role keys.
+- privileged roles (`admin`, `treasury`, `auditor`) reject fallback via `FallbackDeniedByRolePolicy` (`Regression: #619`).
+
 ## Validation
 Run from repository root:
 


### PR DESCRIPTION
Closes #631

## Summary
Enforces signer key-role segregation and privileged fallback policy gates on top of the secure provider adapter contract. Role-scoped secure keys now require sender-role alignment, and local fallback is denied for privileged key roles when secure providers are unavailable.

## Changes
- `crates/kamn-core/src/signer_backend.rs`: add `SignerKeyRole` contract, role parsing from secure key references, sender-role derivation, key-role mismatch enforcement, and restricted fallback policy (`FallbackDeniedByRolePolicy`).
- `crates/kamn-core/src/signer_backend.rs`: add typed errors for role violations (`KeyRoleMismatch`, `UnsupportedSignerKeyRole`) and fallback denial.
- `crates/kamn-core/src/lib.rs`: export `SignerKeyRole`.
- `crates/kamn-core/tests/signer_backend.rs`: add functional/regression coverage for role-matched admin keys, role mismatch rejection, and privileged fallback denial.
- `docs/foundation/signer-backend-abstraction.md`: document role-scoped key formats, sender-role mapping, and fallback constraints.
- `docs/foundation/transaction-guards.md`: document signer fallback policy integration and regression contract.
- `crates/kamn-core/tests/signer_backend_docs.rs` and `crates/kamn-core/tests/transaction_guards_docs.rs`: add doc contract assertions.

## Risks & Compatibility
- Low to medium risk: introduces stricter policy behavior for role-scoped secure keys.
- Backward compatibility preserved for legacy non-role key IDs (`secure:<key-ref>`) as `operator` role.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: signer fast/deep lanes and CI tooling suite pass with role-policy changes

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core signer_key_role_parser` |
| Functional  | ✅ | `cargo test -p kamn-core --test signer_backend` (`functional_admin_role_key_signs_when_sender_role_matches`) |
| Integration | ✅ | `cargo test -p kamn-core --test signer_backend` + `bash scripts/signer/run_signer_provider_deep_lane.sh` |
| Regression  | ✅ | `cargo test -p kamn-core --test signer_backend` (`regression_role_mismatch_signing_request_is_rejected`, `regression_admin_key_does_not_fallback_when_secure_provider_unavailable`) |
