### PR TITLE
feat(deploy): add DR evidence and release SLO gate policy checks

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -62,6 +62,8 @@ jobs:
           bash scripts/deploy/test_run_gonogo_evidence_contract_lane.sh
           bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
           bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
+          bash scripts/deploy/test_generate_dr_evidence_bundle.sh
+          bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
 
       - name: Run frontend dashboard tests
         if: steps.scope.outputs.run_frontend_dashboard_tests == 'true'

--- a/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
+++ b/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
@@ -46,6 +46,15 @@ fn runbook_contains_watchdog_incident_response_flow() {
 }
 
 #[test]
+fn runbook_contains_dr_evidence_and_slo_gate_contract() {
+    assert!(RUNBOOK.contains("## DR Drill Evidence and Release SLO Gate Contract"));
+    assert!(RUNBOOK.contains("generate_dr_evidence_bundle.sh"));
+    assert!(RUNBOOK.contains("check_release_slo_gates.sh"));
+    assert!(RUNBOOK.contains("run_dr_evidence_contract_lane.sh"));
+    assert!(RUNBOOK.contains("run_dr_evidence_deep_lane.sh"));
+}
+
+#[test]
 fn regression_requires_watchdog_evidence_capture_and_fast_lane() {
     // Regression: #383
     assert!(RUNBOOK.contains(
@@ -54,4 +63,12 @@ fn regression_requires_watchdog_evidence_capture_and_fast_lane() {
     assert!(RUNBOOK.contains("## Fast and Cost-Effective Watchdog Validation Lane"));
     assert!(RUNBOOK.contains("cargo test -p kamn-core --test runtime_watchdog_attestation_docs"));
     assert!(RUNBOOK.contains("cargo test -p kamn-core --test upgrade_rollback_runbook_docs"));
+}
+
+#[test]
+fn regression_requires_dr_evidence_and_slo_gate_guard() {
+    // Regression: #623
+    assert!(RUNBOOK.contains(
+        "missing/incomplete DR evidence and SLO threshold violations force `NO-GO` (`Regression: #623`)."
+    ));
 }

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -41,6 +41,20 @@ For semantic versioning policy and compatibility rules, see `docs/foundation/ver
 
 Capture incident evidence payload with expected/observed state hash, quorum sample, and censorship delivery ratios before rollback action.
 
+## DR Drill Evidence and Release SLO Gate Contract (Issue #660)
+Release promotion requires machine-validated DR drill evidence and SLO gate checks.
+
+- DR evidence bundle generator:
+  - `bash scripts/deploy/generate_dr_evidence_bundle.sh --output-file /tmp/dr-evidence.json --drill-id dr-2026-02-08-a --recovery-rto-seconds 240 --recovery-rpo-seconds 90 --max-rto-seconds 300 --max-rpo-seconds 120 --rollback-restored true --evidence-complete true --ci-fast-gate PASS`
+- SLO gate policy checker:
+  - `bash scripts/deploy/check_release_slo_gates.sh --bundle-file /tmp/dr-evidence.json`
+- Fast contract lane:
+  - `bash scripts/deploy/run_dr_evidence_contract_lane.sh`
+- Scheduled deep lane entrypoint:
+  - `bash scripts/deploy/run_dr_evidence_deep_lane.sh`
+- Regression policy:
+  - missing/incomplete DR evidence and SLO threshold violations force `NO-GO` (`Regression: #623`).
+
 ## Fast and Cost-Effective Watchdog Validation Lane
 Run from repository root:
 
@@ -56,6 +70,8 @@ cargo clippy -p kamn-core -- -D warnings
 Run from repository root:
 
 ```bash
+bash scripts/deploy/test_generate_dr_evidence_bundle.sh
+bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
 cargo test -p kamn-core --test upgrade_rollback_runbook_docs
 cargo fmt --check
 cargo clippy -- -D warnings

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -33,5 +33,7 @@ bash "$ROOT_DIR/scripts/deploy/test_generate_gonogo_evidence_bundle.sh"
 bash "$ROOT_DIR/scripts/deploy/test_run_gonogo_evidence_contract_lane.sh"
 bash "$ROOT_DIR/scripts/deploy/test_generate_staging_rehearsal_bundle.sh"
 bash "$ROOT_DIR/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh"
+bash "$ROOT_DIR/scripts/deploy/test_generate_dr_evidence_bundle.sh"
+bash "$ROOT_DIR/scripts/deploy/test_run_dr_evidence_contract_lane.sh"
 
 echo "All CI tool regression tests passed."

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -39,6 +39,16 @@ if ! grep -Fq "bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh" 
   exit 1
 fi
 
+if ! grep -Fq "bash scripts/deploy/test_generate_dr_evidence_bundle.sh" "$FAST_WORKFLOW"; then
+  echo "expected DR evidence bundle tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/deploy/test_run_dr_evidence_contract_lane.sh" "$FAST_WORKFLOW"; then
+  echo "expected DR evidence contract lane script tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 if ! grep -Fq "if: steps.scope.outputs.run_frontend_dashboard_tests == 'true'" "$FAST_WORKFLOW"; then
   echo "expected frontend dashboard scope condition in ci-fast-gate.yml" >&2
   exit 1

--- a/scripts/deploy/check_release_slo_gates.sh
+++ b/scripts/deploy/check_release_slo_gates.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/deploy/check_release_slo_gates.sh \
+    --bundle-file <path>
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "drill_id",
+    "dr_evidence",
+    "decision_reasons",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+dr_evidence = payload["dr_evidence"]
+if not isinstance(dr_evidence, dict):
+    fail("bundle field 'dr_evidence' must be an object")
+
+for field in (
+    "recovery_rto_seconds",
+    "recovery_rpo_seconds",
+    "max_rto_seconds",
+    "max_rpo_seconds",
+    "rollback_restored",
+    "evidence_complete",
+    "ci_fast_gate",
+):
+    if field not in dr_evidence:
+        fail(f"missing dr_evidence field: {field}")
+
+for numeric_field in (
+    "recovery_rto_seconds",
+    "recovery_rpo_seconds",
+    "max_rto_seconds",
+    "max_rpo_seconds",
+):
+    if not isinstance(dr_evidence[numeric_field], int):
+        fail(f"dr_evidence.{numeric_field} must be an integer")
+
+if dr_evidence["max_rto_seconds"] < 1:
+    fail("dr_evidence.max_rto_seconds must be >= 1")
+if dr_evidence["max_rpo_seconds"] < 1:
+    fail("dr_evidence.max_rpo_seconds must be >= 1")
+
+if not isinstance(dr_evidence["rollback_restored"], bool):
+    fail("dr_evidence.rollback_restored must be a boolean")
+if not isinstance(dr_evidence["evidence_complete"], bool):
+    fail("dr_evidence.evidence_complete must be a boolean")
+if dr_evidence["ci_fast_gate"] not in {"PASS", "FAIL"}:
+    fail("dr_evidence.ci_fast_gate must be PASS or FAIL")
+
+decision_reasons = []
+if dr_evidence["recovery_rto_seconds"] > dr_evidence["max_rto_seconds"]:
+    decision_reasons.append("rto threshold exceeded")
+if dr_evidence["recovery_rpo_seconds"] > dr_evidence["max_rpo_seconds"]:
+    decision_reasons.append("rpo threshold exceeded")
+if not dr_evidence["rollback_restored"]:
+    decision_reasons.append("rollback not restored")
+if not dr_evidence["evidence_complete"]:
+    decision_reasons.append("incomplete drill evidence")
+if dr_evidence["ci_fast_gate"] != "PASS":
+    decision_reasons.append("ci-fast-gate-failed")
+
+expected_decision = "GO" if not decision_reasons else "NO-GO"
+actual_decision = payload["final_decision"]
+if actual_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+
+if actual_decision != expected_decision:
+    reasons = ", ".join(decision_reasons) if decision_reasons else "all dr evidence gates satisfied"
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {actual_decision}; reasons={reasons}"
+    )
+
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"final_decision={actual_decision}")
+print(f"recovery_rto_seconds={dr_evidence['recovery_rto_seconds']}")
+print(f"recovery_rpo_seconds={dr_evidence['recovery_rpo_seconds']}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/deploy/generate_dr_evidence_bundle.sh
+++ b/scripts/deploy/generate_dr_evidence_bundle.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/deploy/generate_dr_evidence_bundle.sh \
+    --output-file <path> \
+    --drill-id <value> \
+    --recovery-rto-seconds <n> \
+    --recovery-rpo-seconds <n> \
+    --max-rto-seconds <n> \
+    --max-rpo-seconds <n> \
+    --rollback-restored true|false \
+    --evidence-complete true|false \
+    --ci-fast-gate PASS|FAIL
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+require_int() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fail "${name} must be an integer"
+  fi
+}
+
+output_file=""
+drill_id=""
+recovery_rto_seconds=""
+recovery_rpo_seconds=""
+max_rto_seconds=""
+max_rpo_seconds=""
+rollback_restored=""
+evidence_complete=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --drill-id)
+      drill_id="${2:-}"
+      shift 2
+      ;;
+    --recovery-rto-seconds)
+      recovery_rto_seconds="${2:-}"
+      shift 2
+      ;;
+    --recovery-rpo-seconds)
+      recovery_rpo_seconds="${2:-}"
+      shift 2
+      ;;
+    --max-rto-seconds)
+      max_rto_seconds="${2:-}"
+      shift 2
+      ;;
+    --max-rpo-seconds)
+      max_rpo_seconds="${2:-}"
+      shift 2
+      ;;
+    --rollback-restored)
+      rollback_restored="${2:-}"
+      shift 2
+      ;;
+    --evidence-complete)
+      evidence_complete="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$drill_id" || -z "$recovery_rto_seconds" || -z "$recovery_rpo_seconds" || -z "$max_rto_seconds" || -z "$max_rpo_seconds" || -z "$rollback_restored" || -z "$evidence_complete" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all DR evidence bundle arguments are required"
+fi
+
+require_int "recovery-rto-seconds" "$recovery_rto_seconds"
+require_int "recovery-rpo-seconds" "$recovery_rpo_seconds"
+require_int "max-rto-seconds" "$max_rto_seconds"
+require_int "max-rpo-seconds" "$max_rpo_seconds"
+
+if (( max_rto_seconds < 1 )); then
+  fail "max-rto-seconds must be >= 1"
+fi
+if (( max_rpo_seconds < 1 )); then
+  fail "max-rpo-seconds must be >= 1"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$drill_id" "$recovery_rto_seconds" "$recovery_rpo_seconds" "$max_rto_seconds" "$max_rpo_seconds" "$rollback_restored" "$evidence_complete" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+(
+    output_file,
+    generated_at,
+    drill_id,
+    recovery_rto_raw,
+    recovery_rpo_raw,
+    max_rto_raw,
+    max_rpo_raw,
+    rollback_restored_raw,
+    evidence_complete_raw,
+    ci_fast_gate,
+) = sys.argv[1:]
+
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci-fast-gate must be PASS or FAIL")
+
+if rollback_restored_raw not in {"true", "false"}:
+    fail("rollback-restored must be true or false")
+if evidence_complete_raw not in {"true", "false"}:
+    fail("evidence-complete must be true or false")
+
+rollback_restored = rollback_restored_raw == "true"
+evidence_complete = evidence_complete_raw == "true"
+
+recovery_rto = int(recovery_rto_raw)
+recovery_rpo = int(recovery_rpo_raw)
+max_rto = int(max_rto_raw)
+max_rpo = int(max_rpo_raw)
+
+decision_reasons = []
+if recovery_rto > max_rto:
+    decision_reasons.append("rto threshold exceeded")
+if recovery_rpo > max_rpo:
+    decision_reasons.append("rpo threshold exceeded")
+if not rollback_restored:
+    decision_reasons.append("rollback not restored")
+if not evidence_complete:
+    decision_reasons.append("incomplete drill evidence")
+if ci_fast_gate != "PASS":
+    decision_reasons.append("ci-fast-gate-failed")
+
+final_decision = "GO" if not decision_reasons else "NO-GO"
+if not decision_reasons:
+    decision_reasons.append("all dr evidence gates satisfied")
+
+payload = {
+    "schema_version": "kamn.release.dr-evidence.v1",
+    "generated_at": generated_at,
+    "drill_id": drill_id,
+    "dr_evidence": {
+        "recovery_rto_seconds": recovery_rto,
+        "recovery_rpo_seconds": recovery_rpo,
+        "max_rto_seconds": max_rto,
+        "max_rpo_seconds": max_rpo,
+        "rollback_restored": rollback_restored,
+        "evidence_complete": evidence_complete,
+        "ci_fast_gate": ci_fast_gate,
+    },
+    "decision_reasons": decision_reasons,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/deploy/run_dr_evidence_contract_lane.sh
+++ b/scripts/deploy/run_dr_evidence_contract_lane.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/deploy/generate_dr_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/deploy/check_release_slo_gates.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DR_EVIDENCE_REPORT="$TMP_DIR/dr-evidence-report.json"
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$DR_EVIDENCE_REPORT" \
+    --drill-id "dr-contract-2026-02-08" \
+    --recovery-rto-seconds 210 \
+    --recovery-rpo-seconds 75 \
+    --max-rto-seconds 300 \
+    --max-rpo-seconds 120 \
+    --rollback-restored true \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
+  echo "expected DR evidence contract lane decision to be GO" >&2
+  exit 1
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$DR_EVIDENCE_REPORT")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
+  echo "expected DR evidence policy check decision to be GO" >&2
+  exit 1
+fi
+
+echo "dr evidence contract lane tests passed."

--- a/scripts/deploy/run_dr_evidence_deep_lane.sh
+++ b/scripts/deploy/run_dr_evidence_deep_lane.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/deploy/generate_dr_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/deploy/check_release_slo_gates.sh"
+CONTRACT_LANE="$ROOT_DIR/scripts/deploy/run_dr_evidence_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DR_EVIDENCE_REPORT="$TMP_DIR/dr-evidence-report.json"
+
+bash "$CONTRACT_LANE"
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$DR_EVIDENCE_REPORT" \
+    --drill-id "dr-deep-2026-02-08" \
+    --recovery-rto-seconds 390 \
+    --recovery-rpo-seconds 130 \
+    --max-rto-seconds 300 \
+    --max-rpo-seconds 120 \
+    --rollback-restored true \
+    --evidence-complete false \
+    --ci-fast-gate PASS
+)"
+
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=NO-GO$"; then
+  echo "expected DR deep-lane failure scenario decision to be NO-GO" >&2
+  exit 1
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$DR_EVIDENCE_REPORT")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=NO-GO$"; then
+  echo "expected DR deep-lane policy check decision to be NO-GO" >&2
+  exit 1
+fi
+
+echo "dr evidence deep lane tests passed."

--- a/scripts/deploy/test_generate_dr_evidence_bundle.sh
+++ b/scripts/deploy/test_generate_dr_evidence_bundle.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/deploy/generate_dr_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/deploy/check_release_slo_gates.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected dr evidence bundle generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected release SLO gate policy checker to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/dr-go.json"
+go_generate_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --drill-id "dr-2026-02-08-a" \
+    --recovery-rto-seconds 240 \
+    --recovery-rpo-seconds 90 \
+    --max-rto-seconds 300 \
+    --max-rpo-seconds 120 \
+    --rollback-restored true \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_generate_output" "status")" "generated" "expected GO DR bundle generation to succeed"
+assert_eq "$(extract_value "$go_generate_output" "final_decision")" "GO" "expected DR generator to derive GO decision"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO DR policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO DR policy decision"
+
+no_go_bundle="$TMP_DIR/dr-no-go.json"
+no_go_generate_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --drill-id "dr-2026-02-08-b" \
+    --recovery-rto-seconds 360 \
+    --recovery-rpo-seconds 90 \
+    --max-rto-seconds 300 \
+    --max-rpo-seconds 120 \
+    --rollback-restored true \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$no_go_generate_output" "final_decision")" "NO-GO" "expected SLO threshold breach to force NO-GO"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO DR policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO DR policy decision"
+
+tampered_bundle="$TMP_DIR/dr-tampered.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered DR decision bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit final-decision mismatch error from DR policy checker" >&2
+  exit 1
+fi
+
+# Regression: #623
+if ! printf '%s\n' "$tampered_output" | grep -q "rto threshold exceeded"; then
+  echo "expected rto threshold regression guard to be enforced" >&2
+  exit 1
+fi
+
+echo "dr evidence bundle tests passed."

--- a/scripts/deploy/test_run_dr_evidence_contract_lane.sh
+++ b/scripts/deploy/test_run_dr_evidence_contract_lane.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAST_SCRIPT="$ROOT_DIR/scripts/deploy/run_dr_evidence_contract_lane.sh"
+DEEP_SCRIPT="$ROOT_DIR/scripts/deploy/run_dr_evidence_deep_lane.sh"
+
+if [ ! -x "$FAST_SCRIPT" ]; then
+  echo "expected DR evidence fast-lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_SCRIPT" ]; then
+  echo "expected DR evidence deep-lane runner to be executable" >&2
+  exit 1
+fi
+
+TMP_OUT="$(mktemp)"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+bash "$FAST_SCRIPT" >"$TMP_OUT"
+if ! grep -q "dr evidence contract lane tests passed." "$TMP_OUT"; then
+  echo "expected DR evidence contract lane success marker" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_dr_evidence_contract_lane.sh" "$DEEP_SCRIPT"; then
+  echo "expected deep-lane script to execute fast-lane DR checks first" >&2
+  exit 1
+fi
+
+if ! grep -q "dr-evidence-report.json" "$DEEP_SCRIPT"; then
+  echo "expected deep-lane script to emit DR evidence report artifact" >&2
+  exit 1
+fi
+
+echo "dr evidence contract lane script tests passed."


### PR DESCRIPTION
## Summary
Implements issue #660 by adding deterministic disaster-recovery drill evidence bundles and release SLO gate policy checks with fast/deep lane entrypoints. Deploy fast-gate now validates DR evidence/SLO contracts for deploy-path diffs.

Closes #660

## Changes
- `scripts/deploy/generate_dr_evidence_bundle.sh`: machine-readable DR drill evidence bundle generator with typed SLO/rollback/evidence gates.
- `scripts/deploy/check_release_slo_gates.sh`: policy validator enforcing DR SLO thresholds and decision consistency.
- `scripts/deploy/run_dr_evidence_contract_lane.sh`: fast-lane DR evidence contract runner.
- `scripts/deploy/run_dr_evidence_deep_lane.sh`: deep-lane DR evidence entrypoint with failure scenario enforcement.
- `scripts/deploy/test_generate_dr_evidence_bundle.sh`: unit/functional/regression coverage for DR evidence + SLO policy checks (`Regression: #623`).
- `scripts/deploy/test_run_dr_evidence_contract_lane.sh`: integration coverage for lane wiring and deep-lane artifact contract.
- `.github/workflows/ci-fast-gate.yml`: deploy step now runs DR evidence contract tests.
- `scripts/ci/test_workflow_scope_policy.sh`: workflow policy assertions updated for DR evidence commands.
- `scripts/ci/test_ci_tools.sh`: CI tool regression suite includes DR evidence tests.
- `docs/foundation/upgrade-rollback-runbook.md`: documented DR evidence/SLO gate contracts and deep-lane guidance.
- `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs`: doc contract assertions for new DR evidence section and regression guard.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ bash scripts/deploy/test_generate_dr_evidence_bundle.sh
expected dr evidence bundle generator to be executable
```

### 🟢 Green Phase
```bash
$ bash scripts/deploy/test_generate_dr_evidence_bundle.sh
dr evidence bundle tests passed.

$ bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
dr evidence contract lane script tests passed.
```

### 🔁 Regression
```bash
$ bash scripts/deploy/run_dr_evidence_deep_lane.sh
dr evidence contract lane tests passed.
dr evidence deep lane tests passed.

$ bash scripts/ci/test_select_targets.sh
select_targets matrix regression tests passed.

$ bash scripts/ci/test_workflow_scope_policy.sh
workflow scope policy tests passed.

$ bash scripts/ci/test_ci_tools.sh
All CI tool regression tests passed.

$ cargo test -p kamn-core --test upgrade_rollback_runbook_docs
# 8 passed

$ cargo fmt --check
# clean

$ cargo clippy -- -D warnings
# clean
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/deploy/test_generate_dr_evidence_bundle.sh` | |
| Functional   | ✅ | `scripts/deploy/test_generate_dr_evidence_bundle.sh`; `scripts/deploy/run_dr_evidence_contract_lane.sh` | |
| Integration  | ✅ | `scripts/deploy/test_run_dr_evidence_contract_lane.sh`; workflow deploy wiring in `scripts/ci/test_workflow_scope_policy.sh` | |
| Regression   | ✅ | `scripts/deploy/test_generate_dr_evidence_bundle.sh` tampered decision + threshold guard (`Regression: #623`) | |
| Performance  | ✅ | DR checks remain deploy-path scoped in fast lane; deep drill scenarios deferred to `run_dr_evidence_deep_lane.sh` | |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove DR evidence scripts and workflow wiring.

## Documentation Updates
- `docs/foundation/upgrade-rollback-runbook.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
