### PR TITLE
feat(runtime): deterministic queue backpressure and stale-peer guards (#674)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -225,11 +225,13 @@ pub use retention_engine::{
 };
 pub use runtime::{
     simulate_daemon_network_fault, AuthenticatedPeerFrame, AuthenticatedPeerFrameError,
-    BoundedRuntimeQueue, DeterministicNetworkFaultSimulator, DeterministicProposalPlanner,
-    NetworkFaultSimulationError, NetworkFaultSimulationInput, NetworkFaultSimulationReport,
-    PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
-    ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError, RecoveryRejoinGuard,
-    RecoveryStatus, RejoinAttempt, RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
+    BoundedRuntimeQueue, DeterministicBackpressureController, DeterministicNetworkFaultSimulator,
+    DeterministicProposalPlanner, NetworkFaultSimulationError, NetworkFaultSimulationInput,
+    NetworkFaultSimulationReport, PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent,
+    PeerLifecycleState, ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError,
+    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeBackpressureAction,
+    RuntimeBackpressureDecision, RuntimeBackpressureError, RuntimeBackpressureInput,
+    RuntimeBackpressurePolicy, RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
 };
 pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -195,6 +195,218 @@ impl<T> BoundedRuntimeQueue<T> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeBackpressureAction {
+    Accept,
+    SlowProducer,
+    RejectNewEnqueue,
+    PurgeStalePeerQueue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackpressureDecision {
+    pub action: RuntimeBackpressureAction,
+    pub queue_utilization_per_mille: u16,
+    pub stale_peer_queue: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackpressurePolicy {
+    slow_threshold_per_mille: u16,
+    reject_threshold_per_mille: u16,
+    purge_disconnected_with_pending_queue: bool,
+}
+
+impl RuntimeBackpressurePolicy {
+    pub fn new(
+        slow_threshold_per_mille: u16,
+        reject_threshold_per_mille: u16,
+        purge_disconnected_with_pending_queue: bool,
+    ) -> Result<Self, RuntimeBackpressureError> {
+        if slow_threshold_per_mille == 0 || slow_threshold_per_mille > 1000 {
+            return Err(RuntimeBackpressureError::InvalidThresholdRange {
+                field: "slow_threshold_per_mille",
+                found: slow_threshold_per_mille,
+            });
+        }
+        if reject_threshold_per_mille == 0 || reject_threshold_per_mille > 1000 {
+            return Err(RuntimeBackpressureError::InvalidThresholdRange {
+                field: "reject_threshold_per_mille",
+                found: reject_threshold_per_mille,
+            });
+        }
+        if slow_threshold_per_mille >= reject_threshold_per_mille {
+            return Err(RuntimeBackpressureError::InvalidThresholdOrder {
+                slow_threshold_per_mille,
+                reject_threshold_per_mille,
+            });
+        }
+
+        Ok(Self {
+            slow_threshold_per_mille,
+            reject_threshold_per_mille,
+            purge_disconnected_with_pending_queue,
+        })
+    }
+
+    pub fn slow_threshold_per_mille(&self) -> u16 {
+        self.slow_threshold_per_mille
+    }
+
+    pub fn reject_threshold_per_mille(&self) -> u16 {
+        self.reject_threshold_per_mille
+    }
+
+    pub fn purge_disconnected_with_pending_queue(&self) -> bool {
+        self.purge_disconnected_with_pending_queue
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackpressureInput {
+    peer_id: String,
+    queue_depth: usize,
+    queue_capacity: usize,
+    lifecycle_state: PeerLifecycleState,
+}
+
+impl RuntimeBackpressureInput {
+    pub fn new(
+        peer_id: &str,
+        queue_depth: usize,
+        queue_capacity: usize,
+        lifecycle_state: PeerLifecycleState,
+    ) -> Result<Self, RuntimeBackpressureError> {
+        if !is_valid_kamn_did(peer_id) {
+            return Err(RuntimeBackpressureError::InvalidPeerId);
+        }
+        if queue_capacity == 0 {
+            return Err(RuntimeBackpressureError::InvalidQueueCapacity {
+                capacity: queue_capacity,
+            });
+        }
+        if queue_depth > queue_capacity {
+            return Err(RuntimeBackpressureError::QueueDepthExceedsCapacity {
+                depth: queue_depth,
+                capacity: queue_capacity,
+            });
+        }
+
+        Ok(Self {
+            peer_id: peer_id.to_owned(),
+            queue_depth,
+            queue_capacity,
+            lifecycle_state,
+        })
+    }
+
+    pub fn peer_id(&self) -> &str {
+        &self.peer_id
+    }
+
+    pub fn queue_depth(&self) -> usize {
+        self.queue_depth
+    }
+
+    pub fn queue_capacity(&self) -> usize {
+        self.queue_capacity
+    }
+
+    pub fn lifecycle_state(&self) -> PeerLifecycleState {
+        self.lifecycle_state
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeBackpressureError {
+    InvalidThresholdRange {
+        field: &'static str,
+        found: u16,
+    },
+    InvalidThresholdOrder {
+        slow_threshold_per_mille: u16,
+        reject_threshold_per_mille: u16,
+    },
+    InvalidPeerId,
+    InvalidQueueCapacity {
+        capacity: usize,
+    },
+    QueueDepthExceedsCapacity {
+        depth: usize,
+        capacity: usize,
+    },
+}
+
+impl Display for RuntimeBackpressureError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidThresholdRange { field, found } => write!(
+                f,
+                "runtime backpressure threshold {field} must be in 1..=1000 (got {found})"
+            ),
+            Self::InvalidThresholdOrder {
+                slow_threshold_per_mille,
+                reject_threshold_per_mille,
+            } => write!(
+                f,
+                "runtime backpressure threshold order is invalid: slow {slow_threshold_per_mille}, reject {reject_threshold_per_mille}"
+            ),
+            Self::InvalidPeerId => write!(f, "runtime backpressure peer id must be a valid DID"),
+            Self::InvalidQueueCapacity { capacity } => write!(
+                f,
+                "runtime backpressure queue capacity must be at least 1 (got {capacity})"
+            ),
+            Self::QueueDepthExceedsCapacity { depth, capacity } => write!(
+                f,
+                "runtime backpressure queue depth exceeds capacity: depth {depth}, capacity {capacity}"
+            ),
+        }
+    }
+}
+
+impl Error for RuntimeBackpressureError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeterministicBackpressureController {
+    policy: RuntimeBackpressurePolicy,
+}
+
+impl DeterministicBackpressureController {
+    pub fn new(policy: RuntimeBackpressurePolicy) -> Self {
+        Self { policy }
+    }
+
+    pub fn evaluate(
+        &self,
+        input: RuntimeBackpressureInput,
+    ) -> Result<RuntimeBackpressureDecision, RuntimeBackpressureError> {
+        let utilization = queue_utilization_per_mille(input.queue_depth, input.queue_capacity);
+        let stale_peer_queue = input.lifecycle_state == PeerLifecycleState::Disconnected
+            && input.queue_depth > 0
+            && self.policy.purge_disconnected_with_pending_queue;
+
+        let action = if stale_peer_queue {
+            RuntimeBackpressureAction::PurgeStalePeerQueue
+        } else if utilization >= self.policy.reject_threshold_per_mille {
+            RuntimeBackpressureAction::RejectNewEnqueue
+        } else if utilization >= self.policy.slow_threshold_per_mille {
+            RuntimeBackpressureAction::SlowProducer
+        } else {
+            RuntimeBackpressureAction::Accept
+        };
+
+        Ok(RuntimeBackpressureDecision {
+            action,
+            queue_utilization_per_mille: utilization,
+            stale_peer_queue,
+        })
+    }
+}
+
+fn queue_utilization_per_mille(queue_depth: usize, queue_capacity: usize) -> u16 {
+    ((queue_depth as u128) * 1000 / queue_capacity as u128) as u16
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthenticatedPeerFrameError {
     InvalidFrameId,
@@ -2570,12 +2782,14 @@ mod tests {
         evaluate_daemon_watchdog_anomaly, execute_processor_daemon_tick, ApproverAttestation,
         ApproverQuorumError, ApproverQuorumEvaluator, ApproverQuorumInput, AuthenticatedPeerFrame,
         AuthenticatedPeerFrameError, BoundedRuntimeQueue, ConstructLockError, ConstructLockGuard,
-        DeterministicNetworkFaultSimulator, DeterministicProposalPlanner, FileRuntimeSnapshotStore,
-        InMemoryRuntimeSnapshotStore, ListenerAttestation, ListenerQuorumError,
-        ListenerQuorumEvaluator, ListenerQuorumInput, NetworkFaultSimulationError,
-        NetworkFaultSimulationInput, PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent,
-        PeerLifecycleState, ProposalCandidate, ProposalPlannerError, RecoveryGuardError,
-        RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeLifecycleError,
+        DeterministicBackpressureController, DeterministicNetworkFaultSimulator,
+        DeterministicProposalPlanner, FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore,
+        ListenerAttestation, ListenerQuorumError, ListenerQuorumEvaluator, ListenerQuorumInput,
+        NetworkFaultSimulationError, NetworkFaultSimulationInput, PeerFrameAuthenticator,
+        PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate,
+        ProposalPlannerError, RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus,
+        RejoinAttempt, RuntimeBackpressureAction, RuntimeBackpressureError,
+        RuntimeBackpressureInput, RuntimeBackpressurePolicy, RuntimeLifecycleError,
         RuntimeQueueError, RuntimeSnapshot, RuntimeSnapshotStore, SnapshotRestoreError,
         SnapshotRestoreGuard, SnapshotStoreError, StateDivergenceError, StateDivergenceEvaluator,
         StateDivergenceSeverity, StateDivergenceStatus, StateDivergenceWatchInput,
@@ -2720,6 +2934,94 @@ mod tests {
         assert_eq!(
             BoundedRuntimeQueue::<String>::new(0),
             Err(RuntimeQueueError::InvalidCapacity { capacity: 0 })
+        );
+    }
+
+    #[test]
+    fn unit_runtime_backpressure_policy_rejects_invalid_threshold_order() {
+        assert_eq!(
+            RuntimeBackpressurePolicy::new(900, 900, true),
+            Err(RuntimeBackpressureError::InvalidThresholdOrder {
+                slow_threshold_per_mille: 900,
+                reject_threshold_per_mille: 900
+            })
+        );
+    }
+
+    #[test]
+    fn functional_runtime_backpressure_classifies_queue_saturation() {
+        let policy = RuntimeBackpressurePolicy::new(700, 900, true).expect("valid policy");
+        let controller = DeterministicBackpressureController::new(policy);
+        let input = RuntimeBackpressureInput::new(
+            "kamn:did:agent:peer-a",
+            8,
+            10,
+            PeerLifecycleState::Active,
+        )
+        .expect("valid input");
+        let decision = controller.evaluate(input).expect("evaluation should pass");
+        assert_eq!(decision.action, RuntimeBackpressureAction::SlowProducer);
+        assert_eq!(decision.queue_utilization_per_mille, 800);
+    }
+
+    #[test]
+    fn integration_runtime_backpressure_purges_stale_disconnected_peer_queue() {
+        let policy = RuntimeBackpressurePolicy::new(700, 900, true).expect("valid policy");
+        let controller = DeterministicBackpressureController::new(policy);
+        let input = RuntimeBackpressureInput::new(
+            "kamn:did:agent:peer-b",
+            3,
+            10,
+            PeerLifecycleState::Disconnected,
+        )
+        .expect("valid input");
+        let decision = controller.evaluate(input).expect("evaluation should pass");
+        assert_eq!(
+            decision.action,
+            RuntimeBackpressureAction::PurgeStalePeerQueue
+        );
+    }
+
+    #[test]
+    fn regression_runtime_backpressure_rejects_capacity_overflow_sample() {
+        // Regression: #618
+        assert_eq!(
+            RuntimeBackpressureInput::new(
+                "kamn:did:agent:peer-a",
+                11,
+                10,
+                PeerLifecycleState::Active
+            ),
+            Err(RuntimeBackpressureError::QueueDepthExceedsCapacity {
+                depth: 11,
+                capacity: 10
+            })
+        );
+    }
+
+    #[test]
+    fn performance_runtime_backpressure_evaluation_stays_within_ci_budget() {
+        let policy = RuntimeBackpressurePolicy::new(700, 900, true).expect("valid policy");
+        let controller = DeterministicBackpressureController::new(policy);
+        let started = Instant::now();
+        for sample_index in 0..2000 {
+            let queue_depth = (sample_index % 10) + 1;
+            let state = if sample_index % 7 == 0 {
+                PeerLifecycleState::Disconnected
+            } else {
+                PeerLifecycleState::Active
+            };
+            let input =
+                RuntimeBackpressureInput::new("kamn:did:agent:peer-perf", queue_depth, 10, state)
+                    .expect("input should be valid");
+            let _ = controller
+                .evaluate(input)
+                .expect("evaluation should remain bounded");
+        }
+        let elapsed_millis = started.elapsed().as_millis();
+        assert!(
+            elapsed_millis < 200,
+            "runtime backpressure evaluation exceeded CI budget: {elapsed_millis}ms"
         );
     }
 

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -11,6 +11,8 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("PeerLifecycle"));
     assert!(DOC.contains("AuthenticatedPeerFrame"));
     assert!(DOC.contains("PeerFrameAuthenticator"));
+    assert!(DOC.contains("RuntimeBackpressurePolicy"));
+    assert!(DOC.contains("DeterministicBackpressureController"));
     assert!(DOC.contains("BoundedRuntimeQueue<T>"));
     assert!(DOC.contains("RuntimeLifecycleError"));
     assert!(DOC.contains("NetworkFaultSimulationInput"));
@@ -26,6 +28,7 @@ fn doc_contains_peer_lifecycle_and_queue_rules() {
     assert!(DOC.contains("## Peer Lifecycle Rules"));
     assert!(DOC.contains("## Authenticated Peer Transport Framing Rules"));
     assert!(DOC.contains("## Queue Guard Rules"));
+    assert!(DOC.contains("## Deterministic Backpressure and Stale-Peer Queue Rules"));
     assert!(DOC.contains("## Scheduler Determinism Rules"));
     assert!(DOC.contains("## Recovery and Rejoin Guard Rules"));
     assert!(DOC.contains("version/hash/cursor"));
@@ -39,6 +42,8 @@ fn doc_contains_peer_lifecycle_and_queue_rules() {
         "frame|<frame_id>|<sender_peer_did>|<recipient_peer_did>|<nonce>|<payload>|<signature>"
     ));
     assert!(DOC.contains("monotonic sender nonce progression"));
+    assert!(DOC.contains("queue depth less than or equal to queue capacity"));
+    assert!(DOC.contains("PurgeStalePeerQueue"));
 }
 
 #[test]
@@ -59,6 +64,12 @@ fn doc_contains_recovery_check_cli_command_example() {
 fn doc_contains_fast_and_cost_effective_validation_lane() {
     assert!(DOC.contains("## Fast and Cost-Effective Validation"));
     assert!(DOC.contains("cargo test -p kamn-core runtime::tests::"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifies_queue_saturation"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core runtime::tests::regression_runtime_backpressure_rejects_capacity_overflow_sample"
+    ));
     assert!(DOC.contains(
         "cargo test -p kamn-core runtime::tests::functional_authenticated_peer_frame_roundtrips_wire_and_signature"
     ));
@@ -98,6 +109,10 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
     ));
     assert!(DOC.contains("forged or unauthorized peer frame rejection (`Regression: #618`)"));
     assert!(DOC.contains("replayed peer-frame nonce rejection (`Regression: #618`)"));
+    assert!(DOC.contains("queue depth above capacity is rejected (`Regression: #618`)"));
+    assert!(DOC.contains(
+        "stale disconnected peer queue purge decision remains deterministic (`Regression: #618`)"
+    ));
     assert!(DOC.contains("snapshot stale metadata rejection (`Regression: #617`)"));
     assert!(DOC.contains("snapshot restore cursor mismatch rejection (`Regression: #617`)"));
 }

--- a/crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs
+++ b/crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs
@@ -18,6 +18,11 @@ fn doc_contains_watchdog_attestation_scope_and_models() {
     assert!(DOC.contains("WatchdogAnomalyReport"));
     assert!(DOC.contains("WatchdogAnomalyError"));
     assert!(DOC.contains("evaluate_daemon_watchdog_anomaly"));
+    assert!(DOC.contains("RuntimeBackpressurePolicy"));
+    assert!(DOC.contains("RuntimeBackpressureInput"));
+    assert!(DOC.contains("RuntimeBackpressureDecision"));
+    assert!(DOC.contains("RuntimeBackpressureAction"));
+    assert!(DOC.contains("DeterministicBackpressureController"));
     assert!(DOC.contains("ValidatorProofConsensusEvaluator"));
     assert!(DOC.contains("ValidatorProofConsensusDecision"));
     assert!(DOC.contains("ProofWatchdogProjector"));
@@ -34,6 +39,9 @@ fn doc_contains_incident_response_mapping_and_fast_lane() {
     assert!(DOC.contains("cargo test -p kamn-core --test upgrade_rollback_runbook_docs"));
     assert!(DOC.contains("cargo test -p kamn-core divergence_watchdog"));
     assert!(DOC.contains("cargo test -p kamn-core watchdog_anomaly"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifies_queue_saturation"
+    ));
     assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
 }
 
@@ -51,6 +59,12 @@ fn regression_requires_divergence_and_censorship_guard_rules() {
     assert!(DOC.contains("hash mismatch false-negative is rejected (`Regression: #381`)."));
     assert!(DOC.contains(
         "censorship edge-signal remains critical when targeted peers are at least two and delivery ratio is 500 per-mille or lower (`Regression: #382`)."
+    ));
+    assert!(DOC.contains(
+        "backpressure overflow sample validation rejects queue depth above capacity (`Regression: #618`)."
+    ));
+    assert!(DOC.contains(
+        "stale disconnected peer queue purge mapping remains deterministic (`Regression: #618`)."
     ));
     assert!(DOC.contains("proof consensus alignment (`ConsensusValid`) projects `info` severity."));
     assert!(DOC.contains(

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -15,6 +15,13 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Added bounded FIFO queue primitives in `crates/kamn-core/src/runtime.rs`:
   - `BoundedRuntimeQueue<T>`
   - `RuntimeQueueError`
+- Added deterministic queue backpressure primitives in `crates/kamn-core/src/runtime.rs`:
+  - `RuntimeBackpressurePolicy`
+  - `RuntimeBackpressureInput`
+  - `RuntimeBackpressureDecision`
+  - `RuntimeBackpressureAction`
+  - `RuntimeBackpressureError`
+  - `DeterministicBackpressureController`
 - Added deterministic proposal-planner primitives in `crates/kamn-core/src/runtime.rs`:
   - `ProposalCandidate`
   - `DeterministicProposalPlanner`
@@ -127,6 +134,28 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Zero-capacity queues fail with:
   - `RuntimeQueueError::InvalidCapacity { capacity: 0 }`
 
+## Deterministic Backpressure and Stale-Peer Queue Rules
+- `RuntimeBackpressurePolicy` thresholds are bounded and ordered:
+  - `slow_threshold_per_mille` must be in `1..=1000`
+  - `reject_threshold_per_mille` must be in `1..=1000`
+  - slow threshold must be strictly lower than reject threshold
+- `RuntimeBackpressureInput` requires:
+  - valid `kamn:did:*` peer identifier
+  - queue capacity greater than zero
+  - queue depth less than or equal to queue capacity
+- `DeterministicBackpressureController` decisions are deterministic for identical inputs:
+  - `Accept`
+  - `SlowProducer`
+  - `RejectNewEnqueue`
+  - `PurgeStalePeerQueue`
+- Backpressure action mapping:
+  - disconnected peers with pending queue entries can be forced to `PurgeStalePeerQueue` when policy enables stale-peer purge.
+  - utilization above reject threshold yields `RejectNewEnqueue`.
+  - utilization above slow threshold yields `SlowProducer`.
+- Regression contract:
+  - queue depth above capacity is rejected (`Regression: #618`)
+  - stale disconnected peer queue must purge deterministically (`Regression: #618`)
+
 ## Scheduler Determinism Rules
 - `ProposalCandidate` requires non-empty:
   - candidate ID
@@ -201,18 +230,21 @@ This document captures the initial runtime-network foundation slice for peer lif
   - empty peer ID and zero-capacity queue rejection
   - invalid peer-frame wire payload and delimiter rejection
   - deterministic signature mismatch rejection
+  - invalid backpressure threshold ordering and queue-depth validation rejection
   - empty proposal candidate ID rejection
   - empty resume-token rejoin attempt rejection
   - snapshot cursor/hash validation and continuity regression checks
 - Functional:
   - peer lifecycle connect/degrade/recover/disconnect flow
   - authenticated peer-frame wire roundtrip and signature verification
+  - deterministic queue saturation backpressure classification
   - planner deterministic ordering contract
   - rejoin acceptance with matching snapshot
   - snapshot recovery truncation with stale metadata suffix
 - Integration:
   - bounded FIFO queue behavior under capacity
   - inbound peer-frame authenticator monotonic nonce acceptance flow
+  - stale disconnected peer queue purge decision mapping
   - queue-drain to planner ordering preservation
   - lagging-node catch-up guidance output
   - daemon network-fault simulation with queue-overflow/degradation reporting
@@ -231,9 +263,12 @@ This document captures the initial runtime-network foundation slice for peer lif
   - network fault simulation censorship critical-boundary guard (`Regression: #618`)
   - forged or unauthorized peer frame rejection (`Regression: #618`)
   - replayed peer-frame nonce rejection (`Regression: #618`)
+  - queue depth above capacity is rejected (`Regression: #618`)
+  - stale disconnected peer queue purge decision remains deterministic (`Regression: #618`)
   - snapshot stale metadata rejection (`Regression: #617`)
   - snapshot restore cursor mismatch rejection (`Regression: #617`)
 - Performance:
+  - bounded PR-lane runtime backpressure evaluation budget check
   - bounded PR-lane authenticated peer-frame validation budget check
   - bounded PR-lane deterministic fault simulation budget check
   - bounded PR-lane snapshot recovery budget check
@@ -245,6 +280,8 @@ Run targeted checks first:
 
 ```bash
 cargo test -p kamn-core runtime::tests::
+cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifies_queue_saturation
+cargo test -p kamn-core runtime::tests::regression_runtime_backpressure_rejects_capacity_overflow_sample
 cargo test -p kamn-core runtime::tests::functional_authenticated_peer_frame_roundtrips_wire_and_signature
 cargo test -p kamn-core runtime::tests::regression_forged_or_unauthorized_peer_frame_is_rejected
 cargo test -p kamn-core network_fault_simulation

--- a/docs/foundation/runtime-watchdog-attestation.md
+++ b/docs/foundation/runtime-watchdog-attestation.md
@@ -6,6 +6,7 @@ It complements `docs/foundation/watchdog-node-prototype.md` with runtime-facing 
 ## Scope Delivered
 - Runtime watchdog attestation payload structure for state-divergence and liveness/censorship anomalies.
 - Deterministic severity mapping and evidence field requirements for operator workflows.
+- Deterministic runtime backpressure incident mapping for queue saturation and stale-peer queue purge signals.
 - Explicit incident response mapping to `docs/foundation/upgrade-rollback-runbook.md`.
 - Fast and cost-effective validation commands for docs contract changes.
 
@@ -37,6 +38,12 @@ It complements `docs/foundation/watchdog-node-prototype.md` with runtime-facing 
   - `WatchdogAnomalyReport`
   - `WatchdogAnomalyError`
   - `evaluate_daemon_watchdog_anomaly`
+- Runtime backpressure evaluator references:
+  - `RuntimeBackpressurePolicy`
+  - `RuntimeBackpressureInput`
+  - `RuntimeBackpressureDecision`
+  - `RuntimeBackpressureAction`
+  - `DeterministicBackpressureController`
 - Proof outcome mismatch projection references:
   - `ValidatorProofConsensusEvaluator`
   - `ValidatorProofConsensusDecision`
@@ -48,11 +55,15 @@ It complements `docs/foundation/watchdog-node-prototype.md` with runtime-facing 
 - Quorum anomaly severity is `critical` when observed quorum is below configured safety floor.
 - single-recipient deliveries are excluded from censorship classification.
 - Censorship classification must use bounded sample windows to avoid stale evidence amplification.
+- queue saturation incidents should include utilization and threshold evidence for deterministic response routing.
+- stale disconnected peer queue incidents should include peer identifier and pending queue depth evidence.
 - proof consensus alignment (`ConsensusValid`) projects `info` severity.
 - proof consensus invalid/replay/mismatch projects `critical` severity with deterministic fingerprint fields.
 - attestation replay for the same incident fingerprint is rejected (`Regression: #383`).
 - hash mismatch false-negative is rejected (`Regression: #381`).
 - censorship edge-signal remains critical when targeted peers are at least two and delivery ratio is 500 per-mille or lower (`Regression: #382`).
+- backpressure overflow sample validation rejects queue depth above capacity (`Regression: #618`).
+- stale disconnected peer queue purge mapping remains deterministic (`Regression: #618`).
 
 ## Incident Response Mapping
 - Runtime watchdog output is triaged with `WatchdogSeverity` and `incident_fingerprint`.
@@ -69,6 +80,7 @@ cargo test -p kamn-core --test watchdog_node_docs
 cargo test -p kamn-core --test upgrade_rollback_runbook_docs
 cargo test -p kamn-core divergence_watchdog
 cargo test -p kamn-core watchdog_anomaly
+cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifies_queue_saturation
 cargo fmt --check
 cargo clippy -p kamn-core -- -D warnings
 ```

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -209,7 +209,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    docs/foundation/runtime-network.md|crates/kamn-core/tests/runtime_network_docs.rs|scripts/runtime/*)
+    docs/foundation/runtime-network.md|docs/foundation/runtime-watchdog-attestation.md|crates/kamn-core/tests/runtime_network_docs.rs|crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs|scripts/runtime/*)
       RUNTIME_SNAPSHOT_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -219,6 +219,11 @@ assert_eq "$(extract_output "$runtime_contract_docs_output" "run_rust")" "false"
 assert_eq "$(extract_output "$runtime_contract_docs_output" "run_runtime_snapshot_contract_tests")" "true" "runtime contract docs must run runtime snapshot contract lane"
 assert_eq "$(extract_output "$runtime_contract_docs_output" "test_scope")" "runtime-contract" "runtime contract docs should set runtime-contract scope"
 
+runtime_watchdog_contract_docs_output="$(run_selector $'docs/foundation/runtime-watchdog-attestation.md')"
+assert_eq "$(extract_output "$runtime_watchdog_contract_docs_output" "run_rust")" "false" "runtime watchdog contract docs should avoid rust lane"
+assert_eq "$(extract_output "$runtime_watchdog_contract_docs_output" "run_runtime_snapshot_contract_tests")" "true" "runtime watchdog contract docs must run runtime snapshot contract lane"
+assert_eq "$(extract_output "$runtime_watchdog_contract_docs_output" "test_scope")" "runtime-contract" "runtime watchdog contract docs should set runtime-contract scope"
+
 runtime_contract_script_output="$(run_selector $'scripts/runtime/run_runtime_snapshot_contract_lane.sh')"
 assert_eq "$(extract_output "$runtime_contract_script_output" "run_rust")" "false" "runtime contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$runtime_contract_script_output" "run_runtime_snapshot_contract_tests")" "true" "runtime contract script changes must run runtime snapshot contract lane"

--- a/scripts/runtime/run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/run_runtime_snapshot_contract_lane.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifies_queue_saturation >/dev/null
+cargo test -p kamn-core runtime::tests::regression_runtime_backpressure_rejects_capacity_overflow_sample >/dev/null
 cargo test -p kamn-core runtime::tests::functional_authenticated_peer_frame_roundtrips_wire_and_signature >/dev/null
 cargo test -p kamn-core runtime::tests::regression_forged_or_unauthorized_peer_frame_is_rejected >/dev/null
 cargo test -p kamn-core runtime::tests::regression_replayed_peer_frame_nonce_is_rejected >/dev/null
@@ -8,5 +10,6 @@ cargo test -p kamn-core runtime::tests::functional_file_snapshot_store_recovery_
 cargo test -p kamn-core runtime::tests::regression_file_snapshot_store_rejects_cursor_regression_metadata >/dev/null
 cargo test -p kamn-core runtime::tests::regression_snapshot_restore_cursor_mismatch_is_rejected >/dev/null
 cargo test -p kamn-core --test runtime_network_docs >/dev/null
+cargo test -p kamn-core --test runtime_watchdog_attestation_docs >/dev/null
 
 echo "runtime snapshot contract lane tests passed."

--- a/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
@@ -24,6 +24,16 @@ if ! grep -q "runtime snapshot contract lane tests passed." "$TMP_OUT"; then
   exit 1
 fi
 
+if ! grep -q "functional_runtime_backpressure_classifies_queue_saturation" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include backpressure saturation functional coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "regression_runtime_backpressure_rejects_capacity_overflow_sample" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include backpressure overflow regression coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "functional_authenticated_peer_frame_roundtrips_wire_and_signature" "$FAST_SCRIPT"; then
   echo "expected runtime snapshot contract lane to include authenticated peer frame roundtrip coverage" >&2
   exit 1
@@ -36,6 +46,11 @@ fi
 
 if ! grep -q "regression_replayed_peer_frame_nonce_is_rejected" "$FAST_SCRIPT"; then
   echo "expected runtime snapshot contract lane to include replay nonce regression coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_watchdog_attestation_docs" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include runtime watchdog attestation docs coverage" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This PR adds deterministic runtime queue backpressure primitives and stale-peer queue guard behavior in `kamn-core`, then wires those contracts into docs and fast runtime-contract CI selection. It also extends targeted runtime lane scripts so validation remains fast and focused while covering the new regression boundaries.

## Linked Issues
Closes #674

## Changes
- `crates/kamn-core/src/runtime.rs`: added `RuntimeBackpressurePolicy`, `RuntimeBackpressureInput`, `RuntimeBackpressureDecision`, `RuntimeBackpressureAction`, `RuntimeBackpressureError`, and `DeterministicBackpressureController`; added unit/functional/integration/regression/performance tests.
- `crates/kamn-core/src/lib.rs`: exported runtime backpressure types.
- `docs/foundation/runtime-network.md`: documented deterministic backpressure rules, stale-peer purge mapping, and Regression `#618` guardrails.
- `docs/foundation/runtime-watchdog-attestation.md`: documented backpressure incident mapping and runtime watchdog coupling.
- `crates/kamn-core/tests/runtime_network_docs.rs`: expanded doc contract assertions for backpressure rules and commands.
- `crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs`: expanded doc contract assertions for backpressure references and regression statements.
- `scripts/runtime/run_runtime_snapshot_contract_lane.sh`: added backpressure functional/regression checks and watchdog-docs contract test.
- `scripts/runtime/test_run_runtime_snapshot_contract_lane.sh`: added assertions for the new runtime fast-lane coverage.
- `scripts/ci/select_targets.sh`: routed watchdog runtime docs changes to runtime-contract fast lane.
- `scripts/ci/test_select_targets.sh`: added selector regression for watchdog runtime docs routing.

## Risks & Compatibility
None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed runtime/doc/CI lane diffs for deterministic behavior and scope hygiene

Commands executed:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core runtime::tests::`
- `cargo test -p kamn-core --test runtime_network_docs`
- `cargo test -p kamn-core --test runtime_watchdog_attestation_docs`
- `bash scripts/runtime/test_run_runtime_snapshot_contract_lane.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `runtime::tests` includes backpressure policy/input validation |
| Functional  | ✅     | queue saturation classification + docs contract checks |
| Integration | ✅     | stale disconnected peer queue purge mapping |
| Regression  | ✅     | queue depth overflow rejection (`Regression: #618`) |

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: runtime contract lane selection via `scripts/ci/select_targets.sh`; runtime snapshot fast lane via `scripts/runtime/run_runtime_snapshot_contract_lane.sh`.
- Expected runtime delta: negligible to slight increase for runtime-contract lane due to two targeted tests + one doc contract test.
- Expected runner-minute delta: low single-digit percentage in runtime-contract scoped runs; no change to broad rust lanes for unaffected scopes.
- Rollback plan if CI cost/runtime regresses: revert the three added lane invocations and selector routing additions, keeping core backpressure logic/tests intact.
