### PR TITLE
feat(signer): add provider handshake matrix and targeted fast-lane checks (#681)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -242,7 +242,8 @@ pub use signature_profile::{
 };
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SecureSignerProvider, SignerBackend,
-    SignerBackendError, SignerBackendRouter, SignerKeyRole, SigningRequest,
+    SignerBackendError, SignerBackendRouter, SignerKeyRole, SignerProviderHandshakeMatrix,
+    SignerProviderHandshakeStatus, SigningRequest,
 };
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
 pub use state::{

--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -100,6 +100,47 @@ impl SecureSignerProvider {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignerProviderHandshakeStatus {
+    Available,
+    Unavailable,
+    PolicyBlocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignerProviderHandshakeMatrix {
+    mock_status: SignerProviderHandshakeStatus,
+    aws_kms_status: SignerProviderHandshakeStatus,
+}
+
+impl SignerProviderHandshakeMatrix {
+    pub fn with_uniform_availability(available: bool) -> Self {
+        let status = if available {
+            SignerProviderHandshakeStatus::Available
+        } else {
+            SignerProviderHandshakeStatus::Unavailable
+        };
+        Self::with_statuses(status, status)
+    }
+
+    pub fn with_statuses(
+        mock_status: SignerProviderHandshakeStatus,
+        aws_kms_status: SignerProviderHandshakeStatus,
+    ) -> Self {
+        Self {
+            mock_status,
+            aws_kms_status,
+        }
+    }
+
+    fn status_for_provider(&self, provider: SecureSignerProvider) -> SignerProviderHandshakeStatus {
+        match provider {
+            SecureSignerProvider::Mock => self.mock_status,
+            SecureSignerProvider::AwsKmsEmulator => self.aws_kms_status,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SignerKeyRole {
     Operator,
     Admin,
@@ -259,12 +300,22 @@ impl SignerBackend for LocalSignerBackend {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecureSignerBackend {
-    available: bool,
+    provider_handshake_matrix: SignerProviderHandshakeMatrix,
 }
 
 impl SecureSignerBackend {
     pub fn new(available: bool) -> Self {
-        Self { available }
+        Self::with_provider_handshake_matrix(
+            SignerProviderHandshakeMatrix::with_uniform_availability(available),
+        )
+    }
+
+    pub fn with_provider_handshake_matrix(
+        provider_handshake_matrix: SignerProviderHandshakeMatrix,
+    ) -> Self {
+        Self {
+            provider_handshake_matrix,
+        }
     }
 
     fn enforce_key_role_segregation(
@@ -285,17 +336,32 @@ impl SecureSignerBackend {
         Ok(())
     }
 
+    fn enforce_provider_handshake(
+        &self,
+        provider: SecureSignerProvider,
+    ) -> Result<(), SignerBackendError> {
+        let backend = provider.backend_name().to_owned();
+        match self.provider_handshake_matrix.status_for_provider(provider) {
+            SignerProviderHandshakeStatus::Available => Ok(()),
+            SignerProviderHandshakeStatus::Unavailable => {
+                Err(SignerBackendError::ProviderUnavailable { backend })
+            }
+            SignerProviderHandshakeStatus::PolicyBlocked => {
+                Err(SignerBackendError::ProviderHandshakeRejected {
+                    backend,
+                    failure_class: "policy-blocked".to_owned(),
+                })
+            }
+        }
+    }
+
     fn sign_with_backend(
         &self,
         request: &SigningRequest,
     ) -> Result<BackendSignature, SignerBackendError> {
         let secure_key = SecureKeyReference::parse(&request.key_id)?;
         self.enforce_key_role_segregation(request, &secure_key)?;
-        if !self.available {
-            return Err(SignerBackendError::ProviderUnavailable {
-                backend: secure_key.provider.backend_name().to_owned(),
-            });
-        }
+        self.enforce_provider_handshake(secure_key.provider)?;
 
         Ok(BackendSignature {
             backend: secure_key.provider.backend_name().to_owned(),
@@ -335,11 +401,7 @@ impl SignerBackend for SecureSignerBackend {
     fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
         let secure_key = SecureKeyReference::parse(&request.key_id)?;
         self.enforce_key_role_segregation(request, &secure_key)?;
-        if !self.available {
-            return Err(SignerBackendError::ProviderUnavailable {
-                backend: secure_key.provider.backend_name().to_owned(),
-            });
-        }
+        self.enforce_provider_handshake(secure_key.provider)?;
 
         let expected = request.expected_signature();
         if expected != signature {
@@ -362,9 +424,17 @@ pub struct SignerBackendRouter {
 
 impl SignerBackendRouter {
     pub fn with_secure_availability(secure_available: bool) -> Self {
+        Self::with_provider_handshake_matrix(
+            SignerProviderHandshakeMatrix::with_uniform_availability(secure_available),
+        )
+    }
+
+    pub fn with_provider_handshake_matrix(
+        provider_handshake_matrix: SignerProviderHandshakeMatrix,
+    ) -> Self {
         Self {
             local: LocalSignerBackend,
-            secure: SecureSignerBackend::new(secure_available),
+            secure: SecureSignerBackend::with_provider_handshake_matrix(provider_handshake_matrix),
         }
     }
 
@@ -431,6 +501,10 @@ pub enum SignerBackendError {
     MalformedSecureKeyReference {
         key_id: String,
     },
+    ProviderHandshakeRejected {
+        backend: String,
+        failure_class: String,
+    },
     ProviderUnavailable {
         backend: String,
     },
@@ -481,6 +555,13 @@ impl std::fmt::Display for SignerBackendError {
             Self::MalformedSecureKeyReference { key_id } => {
                 write!(f, "malformed secure key reference: {key_id}")
             }
+            Self::ProviderHandshakeRejected {
+                backend,
+                failure_class,
+            } => write!(
+                f,
+                "signer provider handshake rejected for backend {backend}: {failure_class}"
+            ),
             Self::ProviderUnavailable { backend } => {
                 write!(f, "signer backend unavailable: {backend}")
             }
@@ -526,7 +607,11 @@ impl std::error::Error for SignerBackendError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{SecureSignerProvider, SignerBackendError, SignerKeyRole, SigningRequest};
+    use super::{
+        SecureSignerBackend, SecureSignerProvider, SignerBackend, SignerBackendError,
+        SignerKeyRole, SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus,
+        SigningRequest,
+    };
 
     #[test]
     fn signing_request_rejects_invalid_fields() {
@@ -597,6 +682,48 @@ mod tests {
             Err(SignerBackendError::UnsupportedSignerKeyRole {
                 role: "root".to_owned(),
                 key_id: "secure:aws-kms:role-root/key-prod-3".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn handshake_matrix_maps_provider_statuses() {
+        let matrix = SignerProviderHandshakeMatrix::with_statuses(
+            SignerProviderHandshakeStatus::Available,
+            SignerProviderHandshakeStatus::PolicyBlocked,
+        );
+        assert_eq!(
+            matrix.status_for_provider(SecureSignerProvider::Mock),
+            SignerProviderHandshakeStatus::Available
+        );
+        assert_eq!(
+            matrix.status_for_provider(SecureSignerProvider::AwsKmsEmulator),
+            SignerProviderHandshakeStatus::PolicyBlocked
+        );
+    }
+
+    #[test]
+    fn secure_backend_rejects_policy_blocked_provider_handshake() {
+        let backend = SecureSignerBackend::with_provider_handshake_matrix(
+            SignerProviderHandshakeMatrix::with_statuses(
+                SignerProviderHandshakeStatus::Available,
+                SignerProviderHandshakeStatus::PolicyBlocked,
+            ),
+        );
+        let request = SigningRequest::new(
+            "secure:aws-kms:key-prod-1",
+            "agent-a",
+            1,
+            "payload-1",
+            "state:genesis",
+        )
+        .expect("request should be valid");
+
+        assert_eq!(
+            backend.sign(&request),
+            Err(SignerBackendError::ProviderHandshakeRejected {
+                backend: "secure-aws-kms-emulator".to_owned(),
+                failure_class: "policy-blocked".to_owned(),
             })
         );
     }

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -1,6 +1,7 @@
 use kamn_core::{
     baseline_signature_for_fields, BaselineTransaction, SignerBackendError, SignerBackendRouter,
-    SigningRequest, TransactionGuards, GENESIS_STATE_HASH,
+    SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus, SigningRequest,
+    TransactionGuards, GENESIS_STATE_HASH,
 };
 use std::time::Instant;
 
@@ -68,6 +69,29 @@ fn functional_secure_unavailable_falls_back_to_local_backend() {
     router
         .verify_with_backend(&signed.backend, &request, &signed.signature)
         .expect("fallback signature should verify");
+}
+
+#[test]
+fn functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider() {
+    let router = SignerBackendRouter::with_provider_handshake_matrix(
+        SignerProviderHandshakeMatrix::with_statuses(
+            SignerProviderHandshakeStatus::Available,
+            SignerProviderHandshakeStatus::Unavailable,
+        ),
+    );
+    let request = SigningRequest::new(
+        "secure:aws-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("operator fallback should sign when provider is unavailable");
+    assert_eq!(signed.backend, "local-software");
 }
 
 #[test]
@@ -222,6 +246,33 @@ fn regression_unknown_secure_provider_is_rejected_without_fallback() {
             backend: "secure-mock".to_owned(),
             provider: "gcp-kms".to_owned(),
             key_id: "secure:gcp-kms:key-ops-1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_provider_handshake_policy_block_rejects_without_fallback() {
+    // Regression: #677
+    let router = SignerBackendRouter::with_provider_handshake_matrix(
+        SignerProviderHandshakeMatrix::with_statuses(
+            SignerProviderHandshakeStatus::Available,
+            SignerProviderHandshakeStatus::PolicyBlocked,
+        ),
+    );
+    let request = SigningRequest::new(
+        "secure:aws-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    assert_eq!(
+        router.sign_with_secure_fallback(&request),
+        Err(SignerBackendError::ProviderHandshakeRejected {
+            backend: "secure-aws-kms-emulator".to_owned(),
+            failure_class: "policy-blocked".to_owned(),
         })
     );
 }

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -13,8 +13,13 @@ fn doc_contains_signer_backend_contract_and_router_rules() {
 #[test]
 fn doc_contains_fallback_semantics_and_transaction_integration() {
     assert!(DOC.contains("## Backend Compatibility Rules"));
+    assert!(DOC.contains("provider handshake matrix statuses"));
+    assert!(DOC.contains("ProviderHandshakeRejected"));
     assert!(DOC.contains(
         "falls back from secure to local only for `ProviderUnavailable` and `operator` role keys."
+    ));
+    assert!(DOC.contains(
+        "fallback is denied for handshake policy blocks (`ProviderHandshakeRejected`) (`Regression: #677`)."
     ));
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("## Transaction Path Integration"));
@@ -28,6 +33,10 @@ fn doc_contains_signer_emulator_contract_lane_policy() {
     assert!(DOC.contains("## Signer Emulator Contract Lanes"));
     assert!(DOC.contains("bash scripts/signer/run_signer_emulator_contract_lane.sh"));
     assert!(DOC.contains("bash scripts/signer/run_signer_provider_deep_lane.sh"));
+    assert!(DOC.contains(
+        "functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider"
+    ));
+    assert!(DOC.contains("regression_provider_handshake_policy_block_rejects_without_fallback"));
 }
 
 #[test]
@@ -49,5 +58,8 @@ fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
     assert!(DOC.contains("canonical signature-profile helper consumed by both paths"));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)"));
     assert!(DOC.contains("Contract lane guards remain required for signer provider compatibility (`Regression: #619`)."));
+    assert!(DOC.contains(
+        "fallback is denied for handshake policy blocks (`ProviderHandshakeRejected`) (`Regression: #677`)."
+    ));
     assert!(DOC.contains("SecureProviderBackendMismatch"));
 }

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -17,6 +17,10 @@ This document captures the first implementation slice for signer backend abstrac
 - secure provider adapters:
   - `secure-mock` for deterministic mock custody.
   - `secure-aws-kms-emulator` for production-style provider adapter coverage.
+  - provider handshake matrix statuses:
+    - `Available`
+    - `Unavailable`
+    - `PolicyBlocked`
   - key references:
     - legacy mock: `secure:<key-ref>`
     - explicit mock: `secure:mock:<key-ref>`
@@ -27,10 +31,12 @@ This document captures the first implementation slice for signer backend abstrac
   - unknown provider labels are rejected with typed `UnsupportedSecureProvider`.
   - unknown role labels are rejected with typed `UnsupportedSignerKeyRole`.
   - malformed secure key references are rejected with typed `MalformedSecureKeyReference`.
+  - provider handshake policy blocks are rejected with typed `ProviderHandshakeRejected`.
   - `ProviderUnavailable` reports the provider-specific backend when the secure path is disabled.
 - Router fallback:
   - falls back from secure to local only for `ProviderUnavailable` and `operator` role keys.
   - fallback is denied for privileged roles with typed `FallbackDeniedByRolePolicy`.
+  - fallback is denied for handshake policy blocks (`ProviderHandshakeRejected`) (`Regression: #677`).
   - does not fallback on hard request errors (for example, unsupported secure key references).
   - verification rejects backend/provider mismatches via `SecureProviderBackendMismatch` (`Regression: #619`).
 
@@ -44,6 +50,9 @@ This document captures the first implementation slice for signer backend abstrac
 ## Signer Emulator Contract Lanes
 - Fast PR lane (low-cost):
   - `bash scripts/signer/run_signer_emulator_contract_lane.sh`
+  - includes provider handshake matrix functional + regression checks:
+    - `cargo test -p kamn-core --test signer_backend functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider`
+    - `cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback`
 - Scheduled provider-integration deep lane:
   - `bash scripts/signer/run_signer_provider_deep_lane.sh`
 - Contract lane guards remain required for signer provider compatibility (`Regression: #619`).

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -214,6 +214,11 @@ assert_eq "$(extract_output "$signer_rust_output" "run_rust")" "true" "signer ba
 assert_eq "$(extract_output "$signer_rust_output" "run_signer_emulator_contract_tests")" "true" "signer backend rust changes must run signer emulator contract lane"
 assert_eq "$(extract_output "$signer_rust_output" "test_scope")" "targeted" "signer backend rust changes should stay targeted"
 
+signer_contract_script_output="$(run_selector $'scripts/signer/run_signer_emulator_contract_lane.sh')"
+assert_eq "$(extract_output "$signer_contract_script_output" "run_rust")" "false" "signer contract script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$signer_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer contract script changes must run signer emulator contract lane"
+assert_eq "$(extract_output "$signer_contract_script_output" "test_scope")" "signer-contract" "signer contract script changes should set signer-contract scope"
+
 runtime_contract_docs_output="$(run_selector $'docs/foundation/runtime-network.md')"
 assert_eq "$(extract_output "$runtime_contract_docs_output" "run_rust")" "false" "runtime contract docs should avoid rust lane"
 assert_eq "$(extract_output "$runtime_contract_docs_output" "run_runtime_snapshot_contract_tests")" "true" "runtime contract docs must run runtime snapshot contract lane"

--- a/scripts/signer/run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/run_signer_emulator_contract_lane.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_secure_provider_backend_mismatch_is_rejected
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_contract_lane_stays_within_budget
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend_docs
 
 if ! grep -Fq "## Signer Emulator Contract Lanes" docs/foundation/signer-backend-abstraction.md; then

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -24,6 +24,16 @@ if ! grep -q "signer emulator contract lane tests passed." "$TMP_OUT"; then
   exit 1
 fi
 
+if ! grep -q "functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to include provider handshake fallback functional coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "regression_provider_handshake_policy_block_rejects_without_fallback" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to include provider handshake policy-block regression coverage" >&2
+  exit 1
+fi
+
 if ! grep -Fq "performance_signer_emulator_bulk_signing_deep_lane -- --ignored" "$DEEP_SCRIPT"; then
   echo "expected deep-lane script to execute ignored signer provider stress test" >&2
   exit 1


### PR DESCRIPTION
## Summary
This PR adds an explicit signer provider-handshake matrix to `kamn-core` and uses it to model deterministic provider availability vs policy-block failure classes. It also tightens the signer emulator fast lane to targeted handshake/regression checks so PR validation stays cheap while preserving critical coverage.

## Linked Issues
Closes #681

## Changes
- `crates/kamn-core/src/signer_backend.rs`: added `SignerProviderHandshakeStatus` + `SignerProviderHandshakeMatrix`; added `ProviderHandshakeRejected` error path; routed secure sign/verify through provider handshake evaluation; added router constructor for explicit handshake matrix.
- `crates/kamn-core/src/lib.rs`: exported new handshake matrix/status contracts.
- `crates/kamn-core/tests/signer_backend.rs`: added functional/regression tests for handshake matrix fallback and policy-block rejection.
- `docs/foundation/signer-backend-abstraction.md`: documented handshake statuses, policy-block behavior, and fast-lane matrix coverage.
- `crates/kamn-core/tests/signer_backend_docs.rs`: expanded docs contract assertions for handshake matrix and regression statements.
- `scripts/signer/run_signer_emulator_contract_lane.sh`: switched to targeted signer test set (functional/regression/perf + docs test).
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`: added script assertions for new targeted handshake matrix tests.
- `scripts/ci/test_select_targets.sh`: added regression for signer script-only path routing to signer-contract scope without rust lane.

## Risks & Compatibility
- `SignerBackendRouter::with_provider_handshake_matrix(...)` is additive.
- `ProviderHandshakeRejected` is a new error variant surfaced by secure signer flows when provider policy blocks the handshake.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed signer/docs/CI lane routing diffs for deterministic behavior and scope hygiene

Commands executed:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core --test signer_backend`
- `cargo test -p kamn-core --test signer_backend_docs`
- `bash scripts/signer/test_run_signer_emulator_contract_lane.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | handshake matrix status mapping + policy-block rejection path |
| Functional  | ✅     | operator fallback behavior when provider unavailable |
| Integration | ✅     | signer router secure/local routing through handshake matrix |
| Regression  | ✅     | policy-block no-fallback + backend mismatch safety checks |

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: signer emulator contract lane script behavior; signer select-targets regression coverage.
- Expected runtime delta: neutral to slightly improved for signer contract lane due targeted signer test invocations.
- Expected runner-minute delta: low single-digit reduction for signer-contract scoped runs.
- Rollback plan if CI cost/runtime regresses: revert targeted signer lane command changes in `scripts/signer/run_signer_emulator_contract_lane.sh` and matching script assertions.
