### PR TITLE
feat(crypto): add signature profile fixture matrix parity checks (#683)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -238,7 +238,11 @@ pub use service_marketplace::{
     ServiceMarketplaceError,
 };
 pub use signature_profile::{
-    baseline_signature_for_fields, baseline_signature_profile_id, BASELINE_SIGNATURE_PROFILE_ID,
+    baseline_signature_for_fields, baseline_signature_profile_id, legacy_signature_for_fields,
+    signature_matches_supported_profile_for_fields,
+    signature_profile_compatibility_fixtures_for_fields, unknown_signature_profile_for_fields,
+    SignatureProfileCompatibilityFixture, BASELINE_SIGNATURE_PROFILE_ID,
+    LEGACY_SIGNATURE_PROFILE_ID,
 };
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SecureSignerProvider, SignerBackend,

--- a/crates/kamn-core/src/signature_profile.rs
+++ b/crates/kamn-core/src/signature_profile.rs
@@ -1,4 +1,5 @@
 pub const BASELINE_SIGNATURE_PROFILE_ID: &str = "baseline-v1";
+pub const LEGACY_SIGNATURE_PROFILE_ID: &str = "legacy-unversioned";
 
 pub fn baseline_signature_profile_id() -> &'static str {
     BASELINE_SIGNATURE_PROFILE_ID
@@ -20,10 +21,79 @@ pub fn baseline_signature_for_fields(
     )
 }
 
+pub fn legacy_signature_for_fields(
+    sender: &str,
+    nonce: u64,
+    state_hash: &str,
+    payload: &str,
+) -> String {
+    format!("sig:{}:{}:{}:{}", sender, nonce, state_hash, payload.len())
+}
+
+pub fn unknown_signature_profile_for_fields(
+    sender: &str,
+    nonce: u64,
+    state_hash: &str,
+    payload: &str,
+) -> String {
+    format!(
+        "sig:baseline-v0:{}:{}:{}:{}",
+        sender,
+        nonce,
+        state_hash,
+        payload.len()
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureProfileCompatibilityFixture {
+    pub fixture_id: &'static str,
+    pub signature: String,
+    pub should_verify: bool,
+}
+
+pub fn signature_profile_compatibility_fixtures_for_fields(
+    sender: &str,
+    nonce: u64,
+    state_hash: &str,
+    payload: &str,
+) -> Vec<SignatureProfileCompatibilityFixture> {
+    vec![
+        SignatureProfileCompatibilityFixture {
+            fixture_id: BASELINE_SIGNATURE_PROFILE_ID,
+            signature: baseline_signature_for_fields(sender, nonce, state_hash, payload),
+            should_verify: true,
+        },
+        SignatureProfileCompatibilityFixture {
+            fixture_id: LEGACY_SIGNATURE_PROFILE_ID,
+            signature: legacy_signature_for_fields(sender, nonce, state_hash, payload),
+            should_verify: false,
+        },
+        SignatureProfileCompatibilityFixture {
+            fixture_id: "baseline-v0",
+            signature: unknown_signature_profile_for_fields(sender, nonce, state_hash, payload),
+            should_verify: false,
+        },
+    ]
+}
+
+pub fn signature_matches_supported_profile_for_fields(
+    signature: &str,
+    sender: &str,
+    nonce: u64,
+    state_hash: &str,
+    payload: &str,
+) -> bool {
+    signature == baseline_signature_for_fields(sender, nonce, state_hash, payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        baseline_signature_for_fields, baseline_signature_profile_id, BASELINE_SIGNATURE_PROFILE_ID,
+        baseline_signature_for_fields, baseline_signature_profile_id, legacy_signature_for_fields,
+        signature_matches_supported_profile_for_fields,
+        signature_profile_compatibility_fixtures_for_fields, BASELINE_SIGNATURE_PROFILE_ID,
+        LEGACY_SIGNATURE_PROFILE_ID,
     };
 
     #[test]
@@ -45,5 +115,52 @@ mod tests {
             baseline_signature_profile_id(),
             BASELINE_SIGNATURE_PROFILE_ID
         );
+    }
+
+    #[test]
+    fn legacy_signature_profile_fixture_is_non_versioned() {
+        let signature = legacy_signature_for_fields("agent-a", 9, "state:x", "abcdef");
+        assert_eq!(signature, "sig:agent-a:9:state:x:6");
+    }
+
+    #[test]
+    fn signature_profile_fixture_matrix_marks_only_baseline_v1_as_supported() {
+        let fixtures = signature_profile_compatibility_fixtures_for_fields(
+            "agent-a",
+            1,
+            "state:genesis",
+            "payload-1",
+        );
+        assert_eq!(fixtures.len(), 3);
+        assert_eq!(fixtures[0].fixture_id, BASELINE_SIGNATURE_PROFILE_ID);
+        assert_eq!(fixtures[1].fixture_id, LEGACY_SIGNATURE_PROFILE_ID);
+        assert_eq!(fixtures[2].fixture_id, "baseline-v0");
+        assert!(fixtures[0].should_verify);
+        assert!(!fixtures[1].should_verify);
+        assert!(!fixtures[2].should_verify);
+    }
+
+    #[test]
+    fn signature_profile_matcher_accepts_baseline_and_rejects_migration_fixtures() {
+        let fixtures = signature_profile_compatibility_fixtures_for_fields(
+            "agent-a",
+            1,
+            "state:genesis",
+            "payload-1",
+        );
+        for fixture in fixtures {
+            assert_eq!(
+                signature_matches_supported_profile_for_fields(
+                    &fixture.signature,
+                    "agent-a",
+                    1,
+                    "state:genesis",
+                    "payload-1"
+                ),
+                fixture.should_verify,
+                "fixture {} should map to deterministic compatibility expectation",
+                fixture.fixture_id
+            );
+        }
     }
 }

--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -1,4 +1,6 @@
-use crate::signature_profile::baseline_signature_for_fields;
+use crate::signature_profile::{
+    baseline_signature_for_fields, signature_matches_supported_profile_for_fields,
+};
 use crate::transaction::BaselineTransaction;
 
 const LOCAL_BACKEND_NAME: &str = "local-software";
@@ -286,7 +288,13 @@ impl SignerBackend for LocalSignerBackend {
 
     fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
         let expected = request.expected_signature();
-        if expected != signature {
+        if !signature_matches_supported_profile_for_fields(
+            signature,
+            &request.sender,
+            request.nonce,
+            &request.state_hash,
+            &request.payload,
+        ) {
             return Err(SignerBackendError::SignatureMismatch {
                 backend: self.backend_name().to_owned(),
                 expected,
@@ -404,7 +412,13 @@ impl SignerBackend for SecureSignerBackend {
         self.enforce_provider_handshake(secure_key.provider)?;
 
         let expected = request.expected_signature();
-        if expected != signature {
+        if !signature_matches_supported_profile_for_fields(
+            signature,
+            &request.sender,
+            request.nonce,
+            &request.state_hash,
+            &request.payload,
+        ) {
             return Err(SignerBackendError::SignatureMismatch {
                 backend: secure_key.provider.backend_name().to_owned(),
                 expected,

--- a/crates/kamn-core/src/transaction.rs
+++ b/crates/kamn-core/src/transaction.rs
@@ -1,4 +1,6 @@
-use crate::signature_profile::baseline_signature_for_fields;
+use crate::signature_profile::{
+    baseline_signature_for_fields, signature_matches_supported_profile_for_fields,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
@@ -94,7 +96,13 @@ impl TransactionGuards {
             });
         }
 
-        if tx.signature != tx.expected_signature() {
+        if !signature_matches_supported_profile_for_fields(
+            &tx.signature,
+            &tx.sender,
+            tx.nonce,
+            &tx.state_hash,
+            &tx.payload,
+        ) {
             return Err(TransactionGuardError::InvalidSignature {
                 tx_id: tx.id.clone(),
                 expected: tx.expected_signature(),

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -1,5 +1,6 @@
 use kamn_core::{
-    baseline_signature_for_fields, BaselineTransaction, SignerBackendError, SignerBackendRouter,
+    baseline_signature_for_fields, signature_profile_compatibility_fixtures_for_fields,
+    BaselineTransaction, RoleSmokeNetwork, SignerBackendError, SignerBackendRouter,
     SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus, SigningRequest,
     TransactionGuards, GENESIS_STATE_HASH,
 };
@@ -275,6 +276,59 @@ fn regression_provider_handshake_policy_block_rejects_without_fallback() {
             failure_class: "policy-blocked".to_owned(),
         })
     );
+}
+
+#[test]
+fn integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards() {
+    let router = SignerBackendRouter::default();
+    let request = SigningRequest::new(
+        "secure:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let fixtures = signature_profile_compatibility_fixtures_for_fields(
+        "agent-a",
+        1,
+        GENESIS_STATE_HASH,
+        "payload-1",
+    );
+
+    for fixture in fixtures {
+        let signer_accepts = router
+            .verify_with_backend("secure-mock", &request, &fixture.signature)
+            .is_ok();
+
+        let mut tx_network = RoleSmokeNetwork::new(true);
+        let mut tx = BaselineTransaction::signed(
+            "tx-profile-fixture",
+            "agent-a",
+            1,
+            "payload-1",
+            GENESIS_STATE_HASH,
+        );
+        tx.signature = fixture.signature.clone();
+        let transaction_accepts = tx_network.submit_transaction(tx).is_ok();
+
+        assert_eq!(
+            signer_accepts, fixture.should_verify,
+            "signer compatibility fixture {} should remain deterministic",
+            fixture.fixture_id
+        );
+        assert_eq!(
+            transaction_accepts, fixture.should_verify,
+            "transaction compatibility fixture {} should remain deterministic",
+            fixture.fixture_id
+        );
+        assert_eq!(
+            signer_accepts, transaction_accepts,
+            "signer and transaction compatibility decisions must stay aligned for fixture {}",
+            fixture.fixture_id
+        );
+    }
 }
 
 #[test]

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -25,6 +25,9 @@ fn doc_contains_fallback_semantics_and_transaction_integration() {
     assert!(DOC.contains("## Transaction Path Integration"));
     assert!(DOC.contains("SigningRequest::for_transaction(...)"));
     assert!(DOC.contains("baseline_signature_for_fields(...)"));
+    assert!(DOC.contains("signature_profile_compatibility_fixtures_for_fields(...)"));
+    assert!(DOC.contains("legacy-unversioned"));
+    assert!(DOC.contains("baseline-v0"));
     assert!(DOC.contains("baseline signature profile id: `baseline-v1`"));
 }
 
@@ -37,6 +40,9 @@ fn doc_contains_signer_emulator_contract_lane_policy() {
         "functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider"
     ));
     assert!(DOC.contains("regression_provider_handshake_policy_block_rejects_without_fallback"));
+    assert!(DOC.contains(
+        "integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards"
+    ));
 }
 
 #[test]
@@ -57,6 +63,9 @@ fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("canonical signature-profile helper consumed by both paths"));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)"));
+    assert!(DOC.contains(
+        "signer and transaction compatibility fixture matrix decisions stay aligned (`Regression: #677`)."
+    ));
     assert!(DOC.contains("Contract lane guards remain required for signer provider compatibility (`Regression: #619`)."));
     assert!(DOC.contains(
         "fallback is denied for handshake policy blocks (`ProviderHandshakeRejected`) (`Regression: #677`)."

--- a/crates/kamn-core/tests/transaction_guards.rs
+++ b/crates/kamn-core/tests/transaction_guards.rs
@@ -1,6 +1,7 @@
 use kamn_core::{
-    baseline_signature_for_fields, BaselineTransaction, RoleSmokeNetwork, SmokeError,
-    TransactionGuardError, GENESIS_STATE_HASH,
+    baseline_signature_for_fields, legacy_signature_for_fields,
+    signature_profile_compatibility_fixtures_for_fields, BaselineTransaction, RoleSmokeNetwork,
+    SmokeError, TransactionGuardError, GENESIS_STATE_HASH,
 };
 
 fn signed_tx(
@@ -108,7 +109,7 @@ fn regression_non_versioned_signature_profile_is_rejected() {
     let mut network = RoleSmokeNetwork::new(true);
     let mut tx =
         BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-tx-1", GENESIS_STATE_HASH);
-    tx.signature = "sig:agent-a:1:state:genesis:12".to_owned();
+    tx.signature = legacy_signature_for_fields("agent-a", 1, GENESIS_STATE_HASH, "payload-tx-1");
 
     assert!(matches!(
         network.submit_transaction(tx),
@@ -116,4 +117,28 @@ fn regression_non_versioned_signature_profile_is_rejected() {
             TransactionGuardError::InvalidSignature { .. }
         ))
     ));
+}
+
+#[test]
+fn regression_signature_profile_fixture_matrix_matches_transaction_guard_expectations() {
+    // Regression: #677
+    let fixtures = signature_profile_compatibility_fixtures_for_fields(
+        "agent-a",
+        1,
+        GENESIS_STATE_HASH,
+        "payload-tx-1",
+    );
+
+    for fixture in fixtures {
+        let mut network = RoleSmokeNetwork::new(true);
+        let mut tx =
+            BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-tx-1", GENESIS_STATE_HASH);
+        tx.signature = fixture.signature.clone();
+        let accepted = network.submit_transaction(tx).is_ok();
+        assert_eq!(
+            accepted, fixture.should_verify,
+            "transaction guard compatibility fixture {} should remain deterministic",
+            fixture.fixture_id
+        );
+    }
 }

--- a/crates/kamn-core/tests/transaction_guards_docs.rs
+++ b/crates/kamn-core/tests/transaction_guards_docs.rs
@@ -12,6 +12,9 @@ fn doc_contains_transaction_guard_scope_and_components() {
 fn doc_contains_canonical_signature_profile_contract() {
     assert!(DOC.contains("## Canonical Signature Profile"));
     assert!(DOC.contains("baseline_signature_for_fields(...)"));
+    assert!(DOC.contains("signature_profile_compatibility_fixtures_for_fields(...)"));
+    assert!(DOC.contains("legacy-unversioned"));
+    assert!(DOC.contains("baseline-v0"));
     assert!(DOC.contains("shared between `transaction` and `signer_backend` paths"));
     assert!(DOC.contains("baseline signature profile id: `baseline-v1`"));
 }
@@ -31,6 +34,9 @@ fn regression_requires_signature_profile_drift_guard_rule() {
         "signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).",
     ));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)."));
+    assert!(DOC.contains(
+        "compatibility fixture matrix remains aligned between signer and transaction verification (`Regression: #677`)."
+    ));
     assert!(
         DOC.contains(
             "privileged roles (`admin`, `treasury`, `auditor`) reject fallback via `FallbackDeniedByRolePolicy` (`Regression: #619`).",

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -44,8 +44,12 @@ This document captures the first implementation slice for signer backend abstrac
 - `SigningRequest::for_transaction(...)` maps `BaselineTransaction` fields into signer requests.
 - Signed output remains compatible with `TransactionGuards::validate_and_record(...)`.
 - `baseline_signature_for_fields(...)` provides the canonical signature-profile helper consumed by both paths.
+- `signature_profile_compatibility_fixtures_for_fields(...)` defines migration fixtures for signer/transaction parity:
+  - `baseline-v1` fixture is accepted.
+  - `legacy-unversioned` and `baseline-v0` fixtures are rejected.
 - baseline signature profile id: `baseline-v1`.
 - non-versioned signature profile is rejected (`Regression: #404`).
+- signer and transaction compatibility fixture matrix decisions stay aligned (`Regression: #677`).
 
 ## Signer Emulator Contract Lanes
 - Fast PR lane (low-cost):
@@ -53,6 +57,7 @@ This document captures the first implementation slice for signer backend abstrac
   - includes provider handshake matrix functional + regression checks:
     - `cargo test -p kamn-core --test signer_backend functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider`
     - `cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback`
+    - `cargo test -p kamn-core --test signer_backend integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards`
 - Scheduled provider-integration deep lane:
   - `bash scripts/signer/run_signer_provider_deep_lane.sh`
 - Contract lane guards remain required for signer provider compatibility (`Regression: #619`).

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -21,8 +21,14 @@ This document defines the baseline deterministic transaction guards implemented 
 - `baseline_signature_for_fields(...)` is the canonical baseline signing profile helper.
 - Signature profile is shared between `transaction` and `signer_backend` paths.
 - baseline signature profile id: `baseline-v1`.
+- migration fixture matrix helper:
+  - `signature_profile_compatibility_fixtures_for_fields(...)`
+  - baseline fixture (`baseline-v1`) is accepted.
+  - legacy unversioned fixture (`legacy-unversioned`) is rejected.
+  - unknown profile fixture (`baseline-v0`) is rejected.
 - signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).
 - non-versioned signature profile is rejected (`Regression: #404`).
+- compatibility fixture matrix remains aligned between signer and transaction verification (`Regression: #677`).
 
 ## Signer Fallback Policy Integration
 - signer keys support role-scoped secure references: `secure:aws-kms:role-<operator|admin|treasury|auditor>/<key-ref>`.

--- a/scripts/signer/run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/run_signer_emulator_contract_lane.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_secure_provider_backend_mismatch_is_rejected
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_contract_lane_stays_within_budget
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend_docs

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -34,6 +34,11 @@ if ! grep -q "regression_provider_handshake_policy_block_rejects_without_fallbac
   exit 1
 fi
 
+if ! grep -q "integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to include signature profile compatibility matrix integration coverage" >&2
+  exit 1
+fi
+
 if ! grep -Fq "performance_signer_emulator_bulk_signing_deep_lane -- --ignored" "$DEEP_SCRIPT"; then
   echo "expected deep-lane script to execute ignored signer provider stress test" >&2
   exit 1


### PR DESCRIPTION
## Summary
This PR adds deterministic signature-profile migration fixtures and uses them to enforce compatibility parity between signer verification and transaction guards. It centralizes signature profile matching logic and extends low-cost signer fast-lane checks with a targeted compatibility-matrix integration assertion.

## Linked Issues
Closes #683

## Changes
- `crates/kamn-core/src/signature_profile.rs`: added legacy/unknown profile fixture builders, compatibility fixture model, and shared `signature_matches_supported_profile_for_fields(...)` matcher.
- `crates/kamn-core/src/transaction.rs`: switched signature validation to shared compatibility matcher.
- `crates/kamn-core/src/signer_backend.rs`: switched signer verification paths to shared compatibility matcher.
- `crates/kamn-core/src/lib.rs`: exported new signature profile compatibility contracts.
- `crates/kamn-core/tests/transaction_guards.rs`: added fixture-matrix regression coverage and switched non-versioned regression to deterministic legacy fixture helper.
- `crates/kamn-core/tests/signer_backend.rs`: added signer-vs-transaction fixture matrix parity integration regression.
- `docs/foundation/transaction-guards.md`: documented compatibility fixture matrix contract and regression marker.
- `docs/foundation/signer-backend-abstraction.md`: documented fixture matrix parity contract and fast-lane command coverage.
- `crates/kamn-core/tests/transaction_guards_docs.rs`: expanded docs contract checks for fixture matrix rules.
- `crates/kamn-core/tests/signer_backend_docs.rs`: expanded docs contract checks for fixture matrix parity and lane command.
- `scripts/signer/run_signer_emulator_contract_lane.sh`: added targeted fixture-matrix integration test invocation.
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`: added assertion that fast signer lane includes fixture-matrix integration coverage.

## Risks & Compatibility
- Additive API surface in `signature_profile` exports.
- Verification behavior remains intentionally strict (only baseline-v1 accepted), now through a shared matcher used by both signer and transaction guards.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed fixture matrix parity and docs/fast-lane scope updates

Commands executed:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -p kamn-core --test signer_backend`
- `cargo test -p kamn-core --test transaction_guards`
- `cargo test -p kamn-core --test signer_backend_docs`
- `cargo test -p kamn-core --test transaction_guards_docs`
- `bash scripts/signer/test_run_signer_emulator_contract_lane.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | fixture/matcher behavior in `signature_profile` |
| Functional  | ✅     | deterministic acceptance/rejection over profile fixtures |
| Integration | ✅     | signer-vs-transaction compatibility matrix parity test |
| Regression  | ✅     | legacy/non-versioned + unknown-profile rejection and parity (`Regression: #677`) |

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: signer emulator fast-lane script command set and script regression assertions.
- Expected runtime delta: slight increase in signer-contract scoped runs due one extra targeted integration test.
- Expected runner-minute delta: low single-digit increase in signer-contract scope only.
- Rollback plan if CI cost/runtime regresses: remove the additional fixture-matrix integration test invocation/assertion from signer fast-lane scripts while keeping core compatibility logic/tests.
