### PR TITLE
feat(crypto): enforce algorithm-tagged signature profile verification

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -238,11 +238,13 @@ pub use service_marketplace::{
     ServiceMarketplaceError,
 };
 pub use signature_profile::{
-    baseline_signature_for_fields, baseline_signature_profile_id, legacy_signature_for_fields,
+    baseline_signature_algorithm, baseline_signature_for_fields, baseline_signature_profile_id,
+    legacy_signature_for_fields, parse_signature_profile_metadata,
     signature_matches_supported_profile_for_fields,
-    signature_profile_compatibility_fixtures_for_fields, unknown_signature_profile_for_fields,
-    SignatureProfileCompatibilityFixture, BASELINE_SIGNATURE_PROFILE_ID,
-    LEGACY_SIGNATURE_PROFILE_ID,
+    signature_profile_compatibility_fixtures_for_fields, unknown_signature_algorithm_for_fields,
+    unknown_signature_profile_for_fields, SignatureProfileCompatibilityFixture,
+    SignatureProfileMetadata, BASELINE_SIGNATURE_ALGORITHM, BASELINE_SIGNATURE_PROFILE_ID,
+    LEGACY_SIGNATURE_PROFILE_ID, UNKNOWN_SIGNATURE_ALGORITHM_ID,
 };
 pub use signer_backend::{
     BackendSignature, LocalSignerBackend, SecureSignerBackend, SecureSignerProvider, SignerBackend,

--- a/crates/kamn-core/src/signature_profile.rs
+++ b/crates/kamn-core/src/signature_profile.rs
@@ -1,8 +1,37 @@
+pub const BASELINE_SIGNATURE_ALGORITHM: &str = "ed25519";
 pub const BASELINE_SIGNATURE_PROFILE_ID: &str = "baseline-v1";
 pub const LEGACY_SIGNATURE_PROFILE_ID: &str = "legacy-unversioned";
+pub const UNKNOWN_SIGNATURE_ALGORITHM_ID: &str = "secp256k1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureProfileMetadata {
+    pub algorithm: String,
+    pub profile_id: String,
+}
+
+pub fn baseline_signature_algorithm() -> &'static str {
+    BASELINE_SIGNATURE_ALGORITHM
+}
 
 pub fn baseline_signature_profile_id() -> &'static str {
     BASELINE_SIGNATURE_PROFILE_ID
+}
+
+pub fn parse_signature_profile_metadata(signature: &str) -> Option<SignatureProfileMetadata> {
+    let suffix = signature.strip_prefix("sig:")?;
+    let mut segments = suffix.splitn(3, ':');
+    let algorithm = segments.next()?.trim();
+    let profile_id = segments.next()?.trim();
+    let payload_segments = segments.next()?.trim();
+
+    if algorithm.is_empty() || profile_id.is_empty() || payload_segments.is_empty() {
+        return None;
+    }
+
+    Some(SignatureProfileMetadata {
+        algorithm: algorithm.to_owned(),
+        profile_id: profile_id.to_owned(),
+    })
 }
 
 pub fn baseline_signature_for_fields(
@@ -12,7 +41,8 @@ pub fn baseline_signature_for_fields(
     payload: &str,
 ) -> String {
     format!(
-        "sig:{}:{}:{}:{}:{}",
+        "sig:{}:{}:{}:{}:{}:{}",
+        baseline_signature_algorithm(),
         baseline_signature_profile_id(),
         sender,
         nonce,
@@ -37,7 +67,25 @@ pub fn unknown_signature_profile_for_fields(
     payload: &str,
 ) -> String {
     format!(
-        "sig:baseline-v0:{}:{}:{}:{}",
+        "sig:{}:baseline-v0:{}:{}:{}:{}",
+        baseline_signature_algorithm(),
+        sender,
+        nonce,
+        state_hash,
+        payload.len()
+    )
+}
+
+pub fn unknown_signature_algorithm_for_fields(
+    sender: &str,
+    nonce: u64,
+    state_hash: &str,
+    payload: &str,
+) -> String {
+    format!(
+        "sig:{}:{}:{}:{}:{}:{}",
+        UNKNOWN_SIGNATURE_ALGORITHM_ID,
+        baseline_signature_profile_id(),
         sender,
         nonce,
         state_hash,
@@ -74,6 +122,11 @@ pub fn signature_profile_compatibility_fixtures_for_fields(
             signature: unknown_signature_profile_for_fields(sender, nonce, state_hash, payload),
             should_verify: false,
         },
+        SignatureProfileCompatibilityFixture {
+            fixture_id: "secp256k1+baseline-v1",
+            signature: unknown_signature_algorithm_for_fields(sender, nonce, state_hash, payload),
+            should_verify: false,
+        },
     ]
 }
 
@@ -84,16 +137,27 @@ pub fn signature_matches_supported_profile_for_fields(
     state_hash: &str,
     payload: &str,
 ) -> bool {
+    let Some(metadata) = parse_signature_profile_metadata(signature) else {
+        return false;
+    };
+    if metadata.algorithm != baseline_signature_algorithm() {
+        return false;
+    }
+    if metadata.profile_id != baseline_signature_profile_id() {
+        return false;
+    }
+
     signature == baseline_signature_for_fields(sender, nonce, state_hash, payload)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        baseline_signature_for_fields, baseline_signature_profile_id, legacy_signature_for_fields,
+        baseline_signature_algorithm, baseline_signature_for_fields, baseline_signature_profile_id,
+        legacy_signature_for_fields, parse_signature_profile_metadata,
         signature_matches_supported_profile_for_fields,
         signature_profile_compatibility_fixtures_for_fields, BASELINE_SIGNATURE_PROFILE_ID,
-        LEGACY_SIGNATURE_PROFILE_ID,
+        LEGACY_SIGNATURE_PROFILE_ID, UNKNOWN_SIGNATURE_ALGORITHM_ID,
     };
 
     #[test]
@@ -106,7 +170,7 @@ mod tests {
     #[test]
     fn baseline_signature_profile_includes_nonce_and_payload_length() {
         let signature = baseline_signature_for_fields("agent-a", 9, "state:x", "abcdef");
-        assert_eq!(signature, "sig:baseline-v1:agent-a:9:state:x:6");
+        assert_eq!(signature, "sig:ed25519:baseline-v1:agent-a:9:state:x:6");
     }
 
     #[test]
@@ -131,13 +195,68 @@ mod tests {
             "state:genesis",
             "payload-1",
         );
-        assert_eq!(fixtures.len(), 3);
+        assert_eq!(fixtures.len(), 4);
         assert_eq!(fixtures[0].fixture_id, BASELINE_SIGNATURE_PROFILE_ID);
         assert_eq!(fixtures[1].fixture_id, LEGACY_SIGNATURE_PROFILE_ID);
         assert_eq!(fixtures[2].fixture_id, "baseline-v0");
+        assert_eq!(fixtures[3].fixture_id, "secp256k1+baseline-v1");
         assert!(fixtures[0].should_verify);
         assert!(!fixtures[1].should_verify);
         assert!(!fixtures[2].should_verify);
+        assert!(!fixtures[3].should_verify);
+    }
+
+    #[test]
+    fn baseline_signature_profile_algorithm_helper_matches_constant() {
+        assert_eq!(baseline_signature_algorithm(), "ed25519");
+    }
+
+    #[test]
+    fn parse_signature_profile_metadata_extracts_algorithm_and_profile() {
+        let signature = baseline_signature_for_fields("agent-a", 1, "state:genesis", "payload-1");
+        assert_eq!(
+            parse_signature_profile_metadata(&signature),
+            Some(super::SignatureProfileMetadata {
+                algorithm: "ed25519".to_owned(),
+                profile_id: BASELINE_SIGNATURE_PROFILE_ID.to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_signature_profile_metadata_extracts_legacy_tags_and_rejects_malformed_signatures() {
+        assert_eq!(
+            parse_signature_profile_metadata("sig:agent-a:1:state:genesis:9"),
+            Some(super::SignatureProfileMetadata {
+                algorithm: "agent-a".to_owned(),
+                profile_id: "1".to_owned(),
+            })
+        );
+        assert_eq!(
+            parse_signature_profile_metadata("sig:ed25519:baseline-v1"),
+            None
+        );
+        assert_eq!(parse_signature_profile_metadata("bad"), None);
+    }
+
+    #[test]
+    fn signature_profile_matcher_rejects_unknown_algorithm_fixture() {
+        let signature = format!(
+            "sig:{}:{}:{}:{}:{}:{}",
+            UNKNOWN_SIGNATURE_ALGORITHM_ID,
+            BASELINE_SIGNATURE_PROFILE_ID,
+            "agent-a",
+            1,
+            "state:genesis",
+            "payload-1".len()
+        );
+        assert!(!signature_matches_supported_profile_for_fields(
+            &signature,
+            "agent-a",
+            1,
+            "state:genesis",
+            "payload-1"
+        ));
     }
 
     #[test]

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -410,7 +410,7 @@ fn regression_signatures_include_profile_identifier_segment() {
     let signed = router
         .sign_with_secure_fallback(&request)
         .expect("signature should be produced");
-    assert!(signed.signature.starts_with("sig:baseline-v1:"));
+    assert!(signed.signature.starts_with("sig:ed25519:baseline-v1:"));
 }
 
 #[test]

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -28,7 +28,10 @@ fn doc_contains_fallback_semantics_and_transaction_integration() {
     assert!(DOC.contains("signature_profile_compatibility_fixtures_for_fields(...)"));
     assert!(DOC.contains("legacy-unversioned"));
     assert!(DOC.contains("baseline-v0"));
+    assert!(DOC.contains("secp256k1+baseline-v1"));
+    assert!(DOC.contains("baseline signature algorithm: `ed25519`."));
     assert!(DOC.contains("baseline signature profile id: `baseline-v1`"));
+    assert!(DOC.contains("parse_signature_profile_metadata(...)"));
 }
 
 #[test]
@@ -63,6 +66,7 @@ fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
     assert!(DOC.contains("does not fallback on hard request errors"));
     assert!(DOC.contains("canonical signature-profile helper consumed by both paths"));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)"));
+    assert!(DOC.contains("algorithm/profile drift is rejected (`Regression: #677`)."));
     assert!(DOC.contains(
         "signer and transaction compatibility fixture matrix decisions stay aligned (`Regression: #677`)."
     ));

--- a/crates/kamn-core/tests/threat_control_matrix_docs.rs
+++ b/crates/kamn-core/tests/threat_control_matrix_docs.rs
@@ -13,6 +13,7 @@ fn matrix_contains_core_threat_entries() {
     assert!(CONTROL_MATRIX.contains("TM-002"));
     assert!(CONTROL_MATRIX.contains("TM-003"));
     assert!(CONTROL_MATRIX.contains("TM-004"));
+    assert!(CONTROL_MATRIX.contains("TM-005"));
 }
 
 #[test]
@@ -20,4 +21,7 @@ fn matrix_maps_controls_to_tests() {
     assert!(CONTROL_MATRIX.contains("verify_instruction_signature_path"));
     assert!(CONTROL_MATRIX.contains("reject_out_of_sequence_nonce_per_sender"));
     assert!(CONTROL_MATRIX.contains("escrow_lifecycle_illegal_transition_rejected"));
+    assert!(CONTROL_MATRIX.contains(
+        "integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards"
+    ));
 }

--- a/crates/kamn-core/tests/transaction_guards_docs.rs
+++ b/crates/kamn-core/tests/transaction_guards_docs.rs
@@ -15,7 +15,9 @@ fn doc_contains_canonical_signature_profile_contract() {
     assert!(DOC.contains("signature_profile_compatibility_fixtures_for_fields(...)"));
     assert!(DOC.contains("legacy-unversioned"));
     assert!(DOC.contains("baseline-v0"));
+    assert!(DOC.contains("secp256k1+baseline-v1"));
     assert!(DOC.contains("shared between `transaction` and `signer_backend` paths"));
+    assert!(DOC.contains("baseline signature algorithm: `ed25519`."));
     assert!(DOC.contains("baseline signature profile id: `baseline-v1`"));
 }
 
@@ -34,6 +36,9 @@ fn regression_requires_signature_profile_drift_guard_rule() {
         "signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).",
     ));
     assert!(DOC.contains("non-versioned signature profile is rejected (`Regression: #404`)."));
+    assert!(DOC.contains(
+        "algorithm/profile metadata drift or downgrade is rejected (`Regression: #677`)."
+    ));
     assert!(DOC.contains(
         "compatibility fixture matrix remains aligned between signer and transaction verification (`Regression: #677`)."
     ));

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -44,11 +44,15 @@ This document captures the first implementation slice for signer backend abstrac
 - `SigningRequest::for_transaction(...)` maps `BaselineTransaction` fields into signer requests.
 - Signed output remains compatible with `TransactionGuards::validate_and_record(...)`.
 - `baseline_signature_for_fields(...)` provides the canonical signature-profile helper consumed by both paths.
+- baseline signatures carry explicit metadata prefix: `sig:ed25519:baseline-v1:<sender>:<nonce>:<state_hash>:<payload_len>`.
 - `signature_profile_compatibility_fixtures_for_fields(...)` defines migration fixtures for signer/transaction parity:
   - `baseline-v1` fixture is accepted.
-  - `legacy-unversioned` and `baseline-v0` fixtures are rejected.
+  - `legacy-unversioned`, `baseline-v0`, and `secp256k1+baseline-v1` fixtures are rejected.
+- parsed signature metadata is enforced through shared profile verification (`parse_signature_profile_metadata(...)`).
+- baseline signature algorithm: `ed25519`.
 - baseline signature profile id: `baseline-v1`.
 - non-versioned signature profile is rejected (`Regression: #404`).
+- algorithm/profile drift is rejected (`Regression: #677`).
 - signer and transaction compatibility fixture matrix decisions stay aligned (`Regression: #677`).
 
 ## Signer Emulator Contract Lanes

--- a/docs/foundation/threat-control-matrix.md
+++ b/docs/foundation/threat-control-matrix.md
@@ -10,6 +10,7 @@ This matrix translates PRD threat model concerns into enforceable controls, owne
 | TM-002 | Replay and nonce reuse | Enforce per-sender nonce monotonicity and stale state hash rejection | Transaction guard validation | Backend | `reject_out_of_sequence_nonce_per_sender` |
 | TM-003 | Unauthorized escrow state mutation | Escrow lifecycle state machine blocks illegal transitions and invalid release amounts | Escrow lifecycle engine | Economics + Backend | `escrow_lifecycle_illegal_transition_rejected` |
 | TM-004 | Invalid failover action during degraded quorum | Require listener/approver quorum checks before processor promotion | Failover runbook execution gate | DevOps + Governance | `failover_runbook_contains_failover_steps` |
+| TM-005 | Signature metadata downgrade or algorithm drift | Enforce explicit signature algorithm/profile parsing and reject unsupported metadata pairs | Shared signer + transaction profile verification | Security + Backend | `integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards` |
 
 ## Ownership and Review Cadence
 - Security owner reviews this matrix each milestone and when new threat classes are introduced.

--- a/docs/foundation/transaction-guards.md
+++ b/docs/foundation/transaction-guards.md
@@ -7,7 +7,7 @@ This document defines the baseline deterministic transaction guards implemented 
 - Positive nonce values.
 - Per-sender nonce sequencing (first nonce `1`, then increment by `1`).
 - State-hash match against the currently expected chain/app state hash.
-- Deterministic signature integrity check (baseline placeholder scheme).
+- Deterministic signature integrity check (explicit algorithm/profile metadata contract).
 - Duplicate transaction ID rejection.
 
 ## Components
@@ -20,14 +20,18 @@ This document defines the baseline deterministic transaction guards implemented 
 ## Canonical Signature Profile
 - `baseline_signature_for_fields(...)` is the canonical baseline signing profile helper.
 - Signature profile is shared between `transaction` and `signer_backend` paths.
+- baseline signature algorithm: `ed25519`.
 - baseline signature profile id: `baseline-v1`.
+- baseline signatures include explicit metadata prefix: `sig:ed25519:baseline-v1:<sender>:<nonce>:<state_hash>:<payload_len>`.
 - migration fixture matrix helper:
   - `signature_profile_compatibility_fixtures_for_fields(...)`
   - baseline fixture (`baseline-v1`) is accepted.
   - legacy unversioned fixture (`legacy-unversioned`) is rejected.
   - unknown profile fixture (`baseline-v0`) is rejected.
+  - unknown algorithm fixture (`secp256k1+baseline-v1`) is rejected.
 - signature-profile drift between transaction and signer paths is rejected (`Regression: #400`).
 - non-versioned signature profile is rejected (`Regression: #404`).
+- algorithm/profile metadata drift or downgrade is rejected (`Regression: #677`).
 - compatibility fixture matrix remains aligned between signer and transaction verification (`Regression: #677`).
 
 ## Signer Fallback Policy Integration


### PR DESCRIPTION
## Summary
Introduces explicit algorithm-tagged signature profile metadata and a shared profile parser/verifier so signer and transaction guard paths enforce the same migration-safe compatibility policy. This closes the remaining #682 hardening scope for deterministic algorithm/profile drift rejection.

Closes #694
Refs #682
Refs #677

## Changes
- `crates/kamn-core/src/signature_profile.rs`: added explicit baseline algorithm constant (`ed25519`), metadata parser (`parse_signature_profile_metadata`), unknown-algorithm fixture support, and shared verifier gate enforcing algorithm + profile compatibility before canonical signature match.
- `crates/kamn-core/src/lib.rs`: exported new signature metadata/parsing APIs/constants for shared consumption.
- `crates/kamn-core/tests/signer_backend.rs`: updated regression assertion to expect algorithm-tagged signature prefix.
- `crates/kamn-core/tests/signer_backend_docs.rs`: updated doc contract assertions for algorithm metadata and unknown-algorithm fixture coverage.
- `crates/kamn-core/tests/transaction_guards_docs.rs`: updated doc contract assertions for algorithm metadata drift rejection coverage.
- `crates/kamn-core/tests/threat_control_matrix_docs.rs`: added TM-005 row assertions for signature metadata drift control mapping.
- `docs/foundation/signer-backend-abstraction.md`: documented explicit algorithm/profile signature format and shared metadata parsing policy.
- `docs/foundation/transaction-guards.md`: documented explicit algorithm-tagged canonical profile and unknown-algorithm rejection fixture.
- `docs/foundation/threat-control-matrix.md`: added TM-005 threat/control row for metadata downgrade/drift rejection.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core signature_profile::tests -- --nocapture
```
Failing evidence before implementation:
- `assertion left == right failed` for canonical format:
  - left: `sig:baseline-v1:agent-a:9:state:x:6`
  - right: `sig:ed25519:baseline-v1:agent-a:9:state:x:6`
- `assertion left == right failed` for compatibility fixture count:
  - left: `3`
  - right: `4`

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core signature_profile::tests -- --nocapture
```
Passing evidence after implementation:
- `test result: ok. 10 passed; 0 failed`

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test signer_backend
cargo test -p kamn-core --test transaction_guards
cargo test -p kamn-core --test signer_backend_docs
cargo test -p kamn-core --test transaction_guards_docs
cargo test -p kamn-core --test threat_control_matrix_docs
cargo fmt --check
cargo clippy -- -D warnings
bash scripts/signer/test_run_signer_emulator_contract_lane.sh
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_tools.sh
```
Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `signature_profile::tests::*` metadata/parser/compatibility assertions | |
| Functional   | ✅     | signer backend canonical signature prefix regression check | |
| Integration  | ✅     | existing signer/transaction compatibility fixture parity remains green | |
| Regression   | ✅     | `Regression: #677` coverage now includes unknown-algorithm drift rejection and TM-005 docs contract mapping | |
| Performance  | ✅     | signer emulator contract budget lane remains enforced (`performance_signer_emulator_contract_lane_stays_within_budget`) | |

## Risks & Rollback
- Breaking change risk: baseline signatures now require explicit algorithm segment in canonical form.
- Rollback plan: revert commit `a71ca04` to restore previous signature contract if downstream consumers require temporary compatibility window.

## Documentation Updates
- `docs/foundation/signer-backend-abstraction.md`
- `docs/foundation/transaction-guards.md`
- `docs/foundation/threat-control-matrix.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
