### PR TITLE
feat(escrow): add receipt finality settlement adapter

### DIFF
--- a/crates/kamn-core/src/escrow.rs
+++ b/crates/kamn-core/src/escrow.rs
@@ -16,6 +16,46 @@ pub enum EscrowStatus {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EscrowReceiptFinality {
+    Final,
+    Pending,
+    Failed,
+}
+
+impl EscrowReceiptFinality {
+    pub fn parse(value: &str) -> Result<Self, EscrowLifecycleError> {
+        let normalized = value.trim().to_ascii_uppercase();
+        match normalized.as_str() {
+            "FINAL" => Ok(Self::Final),
+            "PENDING" => Ok(Self::Pending),
+            "FAILED" => Ok(Self::Failed),
+            _ => Err(EscrowLifecycleError::InvalidReceiptFinality {
+                found: value.to_owned(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EscrowSettlementAction {
+    Release {
+        amount: u128,
+    },
+    RefundRemaining,
+    TimeoutRefund {
+        current_unix: u64,
+        timeout_unix: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EscrowSettlementOutcome {
+    Settled { status: EscrowStatus },
+    Pending { reason: &'static str },
+    Rejected { reason: &'static str },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EscrowLifecycle {
     total_amount: u128,
@@ -166,6 +206,40 @@ impl EscrowLifecycle {
         Ok(())
     }
 
+    pub fn reconcile_receipt_finality(
+        &mut self,
+        receipt_id: &str,
+        finality: EscrowReceiptFinality,
+        action: EscrowSettlementAction,
+    ) -> Result<EscrowSettlementOutcome, EscrowLifecycleError> {
+        if receipt_id.trim().is_empty() {
+            return Err(EscrowLifecycleError::MissingReceiptEvidence);
+        }
+
+        match finality {
+            EscrowReceiptFinality::Pending => Ok(EscrowSettlementOutcome::Pending {
+                reason: "receipt finality pending",
+            }),
+            EscrowReceiptFinality::Failed => Ok(EscrowSettlementOutcome::Rejected {
+                reason: "receipt finality failed",
+            }),
+            EscrowReceiptFinality::Final => {
+                match action {
+                    EscrowSettlementAction::Release { amount } => self.release(amount)?,
+                    EscrowSettlementAction::RefundRemaining => self.refund_remaining()?,
+                    EscrowSettlementAction::TimeoutRefund {
+                        current_unix,
+                        timeout_unix,
+                    } => self.refund_after_timeout(current_unix, timeout_unix)?,
+                }
+
+                Ok(EscrowSettlementOutcome::Settled {
+                    status: self.status(),
+                })
+            }
+        }
+    }
+
     fn invalid_transition(&self, action: &'static str) -> EscrowLifecycleError {
         EscrowLifecycleError::InvalidTransition {
             from: self.status(),
@@ -177,6 +251,10 @@ impl EscrowLifecycle {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowLifecycleError {
     ZeroAmount,
+    MissingReceiptEvidence,
+    InvalidReceiptFinality {
+        found: String,
+    },
     InvalidAmount {
         action: &'static str,
         amount: u128,
@@ -201,6 +279,10 @@ impl fmt::Display for EscrowLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ZeroAmount => write!(f, "amount must be greater than zero"),
+            Self::MissingReceiptEvidence => write!(f, "missing receipt evidence"),
+            Self::InvalidReceiptFinality { found } => {
+                write!(f, "invalid receipt finality state: {found}")
+            }
             Self::InvalidAmount {
                 action,
                 amount,

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -146,7 +146,10 @@ pub use durable_guard_store::{
     DurableGuardSnapshotBundle, DurableGuardSnapshotStoreError, FileDurableGuardSnapshotStore,
     InMemoryDurableGuardSnapshotStore, DURABLE_GUARD_BUNDLE_SCHEMA_VERSION,
 };
-pub use escrow::{EscrowLifecycle, EscrowLifecycleError, EscrowStatus};
+pub use escrow::{
+    EscrowLifecycle, EscrowLifecycleError, EscrowReceiptFinality, EscrowSettlementAction,
+    EscrowSettlementOutcome, EscrowStatus,
+};
 pub use governance_workflow::{
     GovernanceExecutionRecord, GovernanceParameterChangeDraft, GovernanceProposalDraft,
     GovernanceProposalRecord, GovernanceProposalStatus, GovernanceVoteChoice, GovernanceVoteRecord,

--- a/crates/kamn-core/tests/escrow_lifecycle_docs.rs
+++ b/crates/kamn-core/tests/escrow_lifecycle_docs.rs
@@ -17,6 +17,15 @@ fn doc_contains_settlement_reconciliation_evidence_contract() {
 }
 
 #[test]
+fn doc_contains_chain_receipt_finality_adapter_contract() {
+    assert!(DOC.contains("## Chain Receipt Finality Adapter Contract"));
+    assert!(DOC.contains("EscrowReceiptFinality::{Final, Pending, Failed}"));
+    assert!(DOC.contains("reconcile_receipt_finality(receipt_id, finality, action)"));
+    assert!(DOC.contains("EscrowSettlementOutcome::{Settled, Pending, Rejected}"));
+    assert!(DOC.contains("EscrowReceiptFinality::parse(...)"));
+}
+
+#[test]
 fn regression_requires_missing_receipt_evidence_guard_marker() {
     // Regression: #678
     assert!(DOC.contains(

--- a/crates/kamn-core/tests/escrow_receipt_finality.rs
+++ b/crates/kamn-core/tests/escrow_receipt_finality.rs
@@ -1,0 +1,88 @@
+use kamn_core::{
+    EscrowLifecycle, EscrowLifecycleError, EscrowReceiptFinality, EscrowSettlementAction,
+    EscrowSettlementOutcome, EscrowStatus,
+};
+
+#[test]
+fn unit_receipt_finality_parser_rejects_unknown_value() {
+    assert_eq!(
+        EscrowReceiptFinality::parse("UNKNOWN_FINALITY"),
+        Err(EscrowLifecycleError::InvalidReceiptFinality {
+            found: "UNKNOWN_FINALITY".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn functional_pending_finality_defers_settlement_action() {
+    let mut escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+    let outcome = escrow
+        .reconcile_receipt_finality(
+            "receipt-pending-001",
+            EscrowReceiptFinality::Pending,
+            EscrowSettlementAction::Release { amount: 40 },
+        )
+        .expect("pending finality should not hard-fail");
+
+    assert_eq!(
+        outcome,
+        EscrowSettlementOutcome::Pending {
+            reason: "receipt finality pending",
+        }
+    );
+    assert_eq!(escrow.status(), EscrowStatus::Funded);
+}
+
+#[test]
+fn functional_failed_finality_rejects_settlement_action() {
+    let mut escrow = EscrowLifecycle::new(90).expect("escrow should initialize");
+    let outcome = escrow
+        .reconcile_receipt_finality(
+            "receipt-failed-001",
+            EscrowReceiptFinality::Failed,
+            EscrowSettlementAction::Release { amount: 25 },
+        )
+        .expect("failed finality should surface typed rejection");
+
+    assert_eq!(
+        outcome,
+        EscrowSettlementOutcome::Rejected {
+            reason: "receipt finality failed",
+        }
+    );
+    assert_eq!(escrow.status(), EscrowStatus::Funded);
+}
+
+#[test]
+fn integration_final_finality_applies_release_transition() {
+    let mut escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+    let outcome = escrow
+        .reconcile_receipt_finality(
+            "receipt-final-001",
+            EscrowReceiptFinality::Final,
+            EscrowSettlementAction::Release { amount: 100 },
+        )
+        .expect("final receipt should allow release");
+
+    assert_eq!(
+        outcome,
+        EscrowSettlementOutcome::Settled {
+            status: EscrowStatus::Released,
+        }
+    );
+    assert_eq!(escrow.status(), EscrowStatus::Released);
+}
+
+#[test]
+fn regression_missing_receipt_id_is_rejected() {
+    // Regression: #678
+    let mut escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+    assert_eq!(
+        escrow.reconcile_receipt_finality(
+            "   ",
+            EscrowReceiptFinality::Final,
+            EscrowSettlementAction::RefundRemaining,
+        ),
+        Err(EscrowLifecycleError::MissingReceiptEvidence)
+    );
+}

--- a/docs/foundation/escrow-lifecycle.md
+++ b/docs/foundation/escrow-lifecycle.md
@@ -37,6 +37,18 @@ Settlement reconciliation evidence is captured as machine-readable JSON so relea
 - Regression policy:
   - missing or invalid chain receipt evidence forces `NO-GO` (`Regression: #678`).
 
+## Chain Receipt Finality Adapter Contract (Issue #718)
+Escrow settlement transitions must map chain receipt finality to deterministic typed outcomes.
+
+- Core adapter API:
+  - `EscrowReceiptFinality::{Final, Pending, Failed}`
+  - `EscrowLifecycle::reconcile_receipt_finality(receipt_id, finality, action)`
+  - `EscrowSettlementOutcome::{Settled, Pending, Rejected}`
+- Fail-closed policy:
+  - unknown finality values are rejected by `EscrowReceiptFinality::parse(...)`.
+  - pending/failed finality never mutates escrow state.
+  - missing receipt evidence returns an explicit typed error.
+
 ## Local Validation
 Run from repository root:
 


### PR DESCRIPTION
## Summary
Added a typed escrow receipt-finality reconciliation adapter so settlement actions are gated by chain receipt finality and fail closed when evidence is missing or invalid. This implements the #718 scope under the open escrow reconciliation story while keeping behavior deterministic and auditable.

## Changes
- `crates/kamn-core/src/escrow.rs`
  - Added `EscrowReceiptFinality` with parser (`FINAL|PENDING|FAILED`).
  - Added `EscrowSettlementAction` and `EscrowSettlementOutcome` typed enums.
  - Added `EscrowLifecycle::reconcile_receipt_finality(...)` to map receipt finality to settlement behavior.
  - Added typed errors `MissingReceiptEvidence` and `InvalidReceiptFinality`.
- `crates/kamn-core/src/lib.rs`
  - Exported new escrow receipt/finality adapter types.
- `crates/kamn-core/tests/escrow_receipt_finality.rs`
  - Added unit/functional/integration/regression test matrix for finality mapping.
- `docs/foundation/escrow-lifecycle.md`
  - Documented chain receipt finality adapter contract and fail-closed behavior.
- `crates/kamn-core/tests/escrow_lifecycle_docs.rs`
  - Added docs contract checks for the new adapter section/API markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test escrow_receipt_finality
# failures before implementation:
# - unresolved imports: EscrowReceiptFinality, EscrowSettlementAction, EscrowSettlementOutcome
# - missing EscrowLifecycle::reconcile_receipt_finality
# - missing EscrowLifecycleError variants InvalidReceiptFinality and MissingReceiptEvidence
```

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test escrow_receipt_finality
# 5 passed

cargo test -p kamn-core --test escrow_lifecycle_docs
# 4 passed

cargo test -p kamn-core --test escrow_lifecycle
# 5 passed
```

### 🔁 Regression
```bash
cargo fmt --check
cargo clippy -- -D warnings
# clean
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `unit_receipt_finality_parser_rejects_unknown_value` | |
| Functional   | ✅ | `functional_pending_finality_defers_settlement_action`, `functional_failed_finality_rejects_settlement_action` | |
| Integration  | ✅ | `integration_final_finality_applies_release_transition` | |
| Regression   | ✅ | `regression_missing_receipt_id_is_rejected` (`Regression: #678`) | |
| Performance  | N/A | | No new runtime-heavy path introduced; existing scoped fast-lane budget controls remain unchanged in this task. |

## Risks & Rollback
- Risks: low-to-medium behavior change in escrow settlement gating when adapter path is used.
- Rollback plan: revert this PR commit to restore prior escrow behavior.

## Documentation Updates
- `docs/foundation/escrow-lifecycle.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant escrow/docs targets)
- [x] Docs updated (or justified why not)

Closes #718
Refs #686
Refs #678
Refs #676
