### PR TITLE
feat(bridges): add ethereum/near receipt finality normalization contract

### DIFF
--- a/crates/kamn-core/src/cross_chain_receipt.rs
+++ b/crates/kamn-core/src/cross_chain_receipt.rs
@@ -1,0 +1,224 @@
+use std::fmt;
+
+pub const ETHEREUM_FINAL_CONFIRMATION_THRESHOLD: u64 = 12;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CrossChainReceiptNetwork {
+    Ethereum,
+    Near,
+}
+
+impl CrossChainReceiptNetwork {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ethereum => "ethereum",
+            Self::Near => "near",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossChainReceiptStatus {
+    Success,
+    Pending,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossChainReceiptProof {
+    pub network: CrossChainReceiptNetwork,
+    pub receipt_id: String,
+    pub block_reference: String,
+    pub finality_label: String,
+    pub confirmation_count: u64,
+    pub status: CrossChainReceiptStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossChainReceiptFinality {
+    Final,
+    Pending,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedCrossChainReceipt {
+    pub network: CrossChainReceiptNetwork,
+    pub receipt_id: String,
+    pub block_reference: String,
+    pub finality: CrossChainReceiptFinality,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrossChainReceiptNormalizationError {
+    EmptyField(&'static str),
+    UnsupportedFinalityLabel {
+        network: CrossChainReceiptNetwork,
+        label: String,
+    },
+}
+
+impl fmt::Display for CrossChainReceiptNormalizationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::UnsupportedFinalityLabel { network, label } => {
+                write!(f, "unsupported {} finality label: {label}", network.label())
+            }
+        }
+    }
+}
+
+impl std::error::Error for CrossChainReceiptNormalizationError {}
+
+pub fn normalize_cross_chain_receipt(
+    proof: &CrossChainReceiptProof,
+) -> Result<NormalizedCrossChainReceipt, CrossChainReceiptNormalizationError> {
+    validate_non_empty("receipt_id", &proof.receipt_id)?;
+    validate_non_empty("block_reference", &proof.block_reference)?;
+    validate_non_empty("finality_label", &proof.finality_label)?;
+
+    let finality = match proof.status {
+        CrossChainReceiptStatus::Failed => CrossChainReceiptFinality::Failed,
+        CrossChainReceiptStatus::Pending => CrossChainReceiptFinality::Pending,
+        CrossChainReceiptStatus::Success => normalize_success_finality(
+            proof.network,
+            &proof.finality_label,
+            proof.confirmation_count,
+        )?,
+    };
+
+    Ok(NormalizedCrossChainReceipt {
+        network: proof.network,
+        receipt_id: proof.receipt_id.clone(),
+        block_reference: proof.block_reference.clone(),
+        finality,
+    })
+}
+
+fn normalize_success_finality(
+    network: CrossChainReceiptNetwork,
+    finality_label: &str,
+    confirmation_count: u64,
+) -> Result<CrossChainReceiptFinality, CrossChainReceiptNormalizationError> {
+    let label = finality_label.trim().to_ascii_lowercase();
+
+    match network {
+        CrossChainReceiptNetwork::Ethereum => match label.as_str() {
+            "finalized" | "safe" if confirmation_count >= ETHEREUM_FINAL_CONFIRMATION_THRESHOLD => {
+                Ok(CrossChainReceiptFinality::Final)
+            }
+            "finalized" | "safe" | "latest" => Ok(CrossChainReceiptFinality::Pending),
+            _ => Err(
+                CrossChainReceiptNormalizationError::UnsupportedFinalityLabel { network, label },
+            ),
+        },
+        CrossChainReceiptNetwork::Near => match label.as_str() {
+            "final" => Ok(CrossChainReceiptFinality::Final),
+            "optimistic" | "none" => Ok(CrossChainReceiptFinality::Pending),
+            _ => Err(
+                CrossChainReceiptNormalizationError::UnsupportedFinalityLabel { network, label },
+            ),
+        },
+    }
+}
+
+fn validate_non_empty(
+    field: &'static str,
+    value: &str,
+) -> Result<(), CrossChainReceiptNormalizationError> {
+    if value.trim().is_empty() {
+        return Err(CrossChainReceiptNormalizationError::EmptyField(field));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        normalize_cross_chain_receipt, CrossChainReceiptFinality, CrossChainReceiptNetwork,
+        CrossChainReceiptNormalizationError, CrossChainReceiptProof, CrossChainReceiptStatus,
+    };
+
+    fn proof(
+        network: CrossChainReceiptNetwork,
+        finality_label: &str,
+        confirmation_count: u64,
+        status: CrossChainReceiptStatus,
+    ) -> CrossChainReceiptProof {
+        CrossChainReceiptProof {
+            network,
+            receipt_id: "receipt-1".to_owned(),
+            block_reference: "block-1".to_owned(),
+            finality_label: finality_label.to_owned(),
+            confirmation_count,
+            status,
+        }
+    }
+
+    #[test]
+    fn ethereum_safe_with_threshold_confirmations_is_final() {
+        let normalized = normalize_cross_chain_receipt(&proof(
+            CrossChainReceiptNetwork::Ethereum,
+            "safe",
+            12,
+            CrossChainReceiptStatus::Success,
+        ))
+        .expect("ethereum proof should normalize");
+        assert_eq!(normalized.finality, CrossChainReceiptFinality::Final);
+    }
+
+    #[test]
+    fn ethereum_safe_below_threshold_is_pending() {
+        let normalized = normalize_cross_chain_receipt(&proof(
+            CrossChainReceiptNetwork::Ethereum,
+            "safe",
+            11,
+            CrossChainReceiptStatus::Success,
+        ))
+        .expect("ethereum proof should normalize");
+        assert_eq!(normalized.finality, CrossChainReceiptFinality::Pending);
+    }
+
+    #[test]
+    fn near_final_is_final() {
+        let normalized = normalize_cross_chain_receipt(&proof(
+            CrossChainReceiptNetwork::Near,
+            "final",
+            0,
+            CrossChainReceiptStatus::Success,
+        ))
+        .expect("near proof should normalize");
+        assert_eq!(normalized.finality, CrossChainReceiptFinality::Final);
+    }
+
+    #[test]
+    fn failed_status_is_failed_regardless_of_chain_label() {
+        let normalized = normalize_cross_chain_receipt(&proof(
+            CrossChainReceiptNetwork::Near,
+            "unsupported-label",
+            0,
+            CrossChainReceiptStatus::Failed,
+        ))
+        .expect("failed status should normalize");
+        assert_eq!(normalized.finality, CrossChainReceiptFinality::Failed);
+    }
+
+    #[test]
+    fn rejects_unknown_near_finality_label_when_successful() {
+        assert_eq!(
+            normalize_cross_chain_receipt(&proof(
+                CrossChainReceiptNetwork::Near,
+                "unsafe",
+                0,
+                CrossChainReceiptStatus::Success,
+            )),
+            Err(
+                CrossChainReceiptNormalizationError::UnsupportedFinalityLabel {
+                    network: CrossChainReceiptNetwork::Near,
+                    label: "unsafe".to_owned(),
+                }
+            )
+        );
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod content_replication;
 pub mod content_retrieval;
 pub mod content_storage;
 pub mod cross_chain_bridge;
+pub mod cross_chain_receipt;
 pub mod data_classification;
 pub mod did;
 pub mod did_registry;
@@ -111,6 +112,11 @@ pub use cross_chain_bridge::{
     CrossChainBridgeConfig, CrossChainBridgeEngine, CrossChainBridgeError,
     CrossChainInboundRequest, CrossChainNetwork, CrossChainOutboundApproval,
     CrossChainOutboundDispatch,
+};
+pub use cross_chain_receipt::{
+    normalize_cross_chain_receipt, CrossChainReceiptFinality, CrossChainReceiptNetwork,
+    CrossChainReceiptNormalizationError, CrossChainReceiptProof, CrossChainReceiptStatus,
+    NormalizedCrossChainReceipt, ETHEREUM_FINAL_CONFIRMATION_THRESHOLD,
 };
 pub use data_classification::{
     ClassificationPolicy, ClassificationStatus, DataClassificationEngine, DataClassificationError,

--- a/crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs
+++ b/crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs
@@ -1,0 +1,20 @@
+const DOC: &str = include_str!("../../../docs/foundation/cross-chain-bridge-adapters.md");
+
+#[test]
+fn doc_covers_adapter_and_receipt_normalization_scopes() {
+    assert!(DOC.contains("# Cross-Chain Bridge Adapters"));
+    assert!(DOC.contains("CrossChainBridgeEngine"));
+    assert!(DOC.contains("normalize_cross_chain_receipt(...)"));
+}
+
+#[test]
+fn doc_lists_ethereum_and_near_finality_rules() {
+    assert!(DOC.contains("## Receipt Finality Normalization Rules (Ethereum / Near)"));
+    assert!(DOC.contains("finalized` or `safe` with at least `12` confirmations"));
+    assert!(DOC.contains("`final` -> `Final`"));
+}
+
+#[test]
+fn doc_includes_cross_chain_receipt_finality_test_command() {
+    assert!(DOC.contains("cargo test -p kamn-core --test cross_chain_receipt_finality"));
+}

--- a/crates/kamn-core/tests/cross_chain_receipt_finality.rs
+++ b/crates/kamn-core/tests/cross_chain_receipt_finality.rs
@@ -1,0 +1,90 @@
+use kamn_core::{
+    normalize_cross_chain_receipt, CrossChainReceiptFinality, CrossChainReceiptNetwork,
+    CrossChainReceiptNormalizationError, CrossChainReceiptProof, CrossChainReceiptStatus,
+};
+
+fn ethereum_proof(
+    finality_label: &str,
+    confirmations: u64,
+    status: CrossChainReceiptStatus,
+) -> CrossChainReceiptProof {
+    CrossChainReceiptProof {
+        network: CrossChainReceiptNetwork::Ethereum,
+        receipt_id: "0xabc123:7".to_owned(),
+        block_reference: "0xblock-88".to_owned(),
+        finality_label: finality_label.to_owned(),
+        confirmation_count: confirmations,
+        status,
+    }
+}
+
+fn near_proof(finality_label: &str, status: CrossChainReceiptStatus) -> CrossChainReceiptProof {
+    CrossChainReceiptProof {
+        network: CrossChainReceiptNetwork::Near,
+        receipt_id: "near:receipt:991".to_owned(),
+        block_reference: "near:block:2201".to_owned(),
+        finality_label: finality_label.to_owned(),
+        confirmation_count: 0,
+        status,
+    }
+}
+
+#[test]
+fn ethereum_finalized_receipt_normalizes_to_final() {
+    let normalized = normalize_cross_chain_receipt(&ethereum_proof(
+        "finalized",
+        18,
+        CrossChainReceiptStatus::Success,
+    ))
+    .expect("ethereum finalized receipt should normalize");
+    assert_eq!(normalized.finality, CrossChainReceiptFinality::Final);
+}
+
+#[test]
+fn ethereum_latest_receipt_with_low_confirmations_normalizes_to_pending() {
+    let normalized = normalize_cross_chain_receipt(&ethereum_proof(
+        "latest",
+        2,
+        CrossChainReceiptStatus::Success,
+    ))
+    .expect("ethereum latest receipt should normalize");
+    assert_eq!(normalized.finality, CrossChainReceiptFinality::Pending);
+}
+
+#[test]
+fn near_final_receipt_normalizes_to_final() {
+    let normalized =
+        normalize_cross_chain_receipt(&near_proof("final", CrossChainReceiptStatus::Success))
+            .expect("near final receipt should normalize");
+    assert_eq!(normalized.finality, CrossChainReceiptFinality::Final);
+}
+
+#[test]
+fn near_optimistic_receipt_normalizes_to_pending() {
+    let normalized =
+        normalize_cross_chain_receipt(&near_proof("optimistic", CrossChainReceiptStatus::Success))
+            .expect("near optimistic receipt should normalize");
+    assert_eq!(normalized.finality, CrossChainReceiptFinality::Pending);
+}
+
+#[test]
+fn near_failed_receipt_normalizes_to_failed() {
+    let normalized =
+        normalize_cross_chain_receipt(&near_proof("final", CrossChainReceiptStatus::Failed))
+            .expect("failed receipt should normalize");
+    assert_eq!(normalized.finality, CrossChainReceiptFinality::Failed);
+}
+
+#[test]
+fn regression_rejects_unknown_near_finality_label() {
+    // Regression: #740
+    assert_eq!(
+        normalize_cross_chain_receipt(&near_proof("unsafe", CrossChainReceiptStatus::Success)),
+        Err(
+            CrossChainReceiptNormalizationError::UnsupportedFinalityLabel {
+                network: CrossChainReceiptNetwork::Near,
+                label: "unsafe".to_owned(),
+            }
+        )
+    );
+}

--- a/docs/foundation/cross-chain-bridge-adapters.md
+++ b/docs/foundation/cross-chain-bridge-adapters.md
@@ -1,6 +1,6 @@
-# Cross-Chain Bridge Adapters (Ethereum and Solana) (Issues #232, #233)
+# Cross-Chain Bridge Adapters (Ethereum and Solana) (Issues #232, #233, #740)
 
-This document captures the first implementation slice for cross-chain bridge adapters covering Ethereum and Solana inbound/outbound pathways.
+This document captures cross-chain adapter and receipt-finality normalization slices for Ethereum, Solana, and Near pathways.
 
 ## Scope Delivered
 - Added `crates/kamn-core/src/cross_chain_bridge.rs` with:
@@ -11,6 +11,12 @@ This document captures the first implementation slice for cross-chain bridge ada
   - `process_outbound_with_approvals(...)` with approver quorum enforcement and deterministic approval metadata.
   - typed error handling via `CrossChainBridgeError`.
 - Added integration tests in `crates/kamn-core/tests/cross_chain_bridge.rs`.
+- Added `crates/kamn-core/src/cross_chain_receipt.rs` with deterministic Ethereum/Near receipt-finality normalization:
+  - `CrossChainReceiptNetwork` enum (`Ethereum`, `Near`).
+  - `CrossChainReceiptProof` and `NormalizedCrossChainReceipt` contract structures.
+  - `normalize_cross_chain_receipt(...)` with strict chain-specific finality rules.
+  - typed errors via `CrossChainReceiptNormalizationError`.
+- Added integration tests in `crates/kamn-core/tests/cross_chain_receipt_finality.rs`.
 
 ## Validation Rules
 - Bridge/listener/approver DIDs must parse as `kamn:did:agent:*`.
@@ -25,6 +31,21 @@ This document captures the first implementation slice for cross-chain bridge ada
   - destination channel present in chain-specific route map.
   - authorized approver set with no duplicates.
   - provided approvals satisfy quorum threshold.
+
+## Receipt Finality Normalization Rules (Ethereum / Near)
+- Shared input validation:
+  - `receipt_id`, `block_reference`, and `finality_label` must be non-empty.
+- Ethereum success normalization:
+  - `finalized` or `safe` with at least `12` confirmations -> `Final`.
+  - `finalized`, `safe`, or `latest` below threshold -> `Pending`.
+  - unknown labels are rejected.
+- Near success normalization:
+  - `final` -> `Final`.
+  - `optimistic` or `none` -> `Pending`.
+  - unknown labels are rejected.
+- Status override behavior:
+  - `Failed` status always normalizes to `Failed`.
+  - `Pending` status always normalizes to `Pending`.
 
 ## Processing Flow
 - `process_inbound(...)`:
@@ -43,6 +64,7 @@ Run from repository root:
 
 ```bash
 cargo test -p kamn-core --test cross_chain_bridge
+cargo test -p kamn-core --test cross_chain_receipt_finality
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core


### PR DESCRIPTION
## Summary
Implements a deterministic Ethereum/Near receipt-finality normalization contract for cross-chain proof handling, plus regression-focused tests and docs updates. This closes task #740 under story #739 and provides a low-cost fast-lane validation path.

Closes #740
Refs #739
Refs #731

## Changes
- `crates/kamn-core/src/cross_chain_receipt.rs`: added normalization contract, typed models, deterministic chain-specific finality mapping, and unit coverage.
- `crates/kamn-core/src/lib.rs`: exported receipt normalization API/types.
- `crates/kamn-core/tests/cross_chain_receipt_finality.rs`: added integration/functional/regression tests for Ethereum/Near outcomes.
- `crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs`: added docs contract checks for the new finality rules and validation command.
- `docs/foundation/cross-chain-bridge-adapters.md`: documented Ethereum/Near finality normalization policy and local validation command.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test cross_chain_receipt_finality
```
Failure excerpt:
```text
error[E0432]: unresolved imports `kamn_core::normalize_cross_chain_receipt`, ...
no `CrossChainReceiptNetwork` in the root
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test cross_chain_receipt_finality
```
Passing excerpt:
```text
running 6 tests
... ok

 test result: ok. 6 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
Result: all commands passed.

## Test Matrix (Mandatory)
| Category      | Status   | Tests Added/Modified                                  | Justification if N/A |
|--------------|----------|--------------------------------------------------------|----------------------|
| Unit         | ✅       | `cross_chain_receipt` module tests                     |                      |
| Functional   | ✅       | `cross_chain_receipt_finality.rs` success/pending/fail paths |                      |
| Integration  | ✅       | `cross_chain_receipt_finality.rs`, `cross_chain_bridge.rs`, docs contract test |                      |
| Regression   | ✅       | unknown Near finality label rejection (`Regression: #740`) |                      |
| Performance  | N/A      |                                                        | Deterministic O(1) mapping only; no measurable throughput path introduced in this slice. |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert this PR commit to remove the new module/export/tests/docs if downstream behavior diverges.

## Documentation Updates
- `docs/foundation/cross-chain-bridge-adapters.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
