### PR TITLE
feat(bridge): add outbound intent attestation and idempotent retry lane (#742)

### DIFF
--- a/.github/workflows/ci-deep-validate.yml
+++ b/.github/workflows/ci-deep-validate.yml
@@ -137,6 +137,18 @@ jobs:
           path: post-cutover-slo-report.json
           if-no-files-found: error
 
+      - name: Run bridge credentialed deep lane
+        if: steps.detect.outputs.run_rust == 'true'
+        run: bash scripts/bridge/run_bridge_credentialed_deep_lane.sh --output-json bridge-credentialed-deep-report.json
+
+      - name: Upload bridge credentialed deep report
+        if: always() && hashFiles('bridge-credentialed-deep-report.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: bridge-credentialed-deep-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: bridge-credentialed-deep-report.json
+          if-no-files-found: error
+
       - name: Run SDK parity matrix (scheduled only)
         if: steps.detect.outputs.run_rust == 'true'
         run: bash scripts/sdk/run_sdk_parity_matrix.sh --fixture fixtures/sdk_parity/register_validation_cases.json --output-json sdk-parity-report.json

--- a/crates/kamn-core/tests/bridge_quorum_runtime_docs.rs
+++ b/crates/kamn-core/tests/bridge_quorum_runtime_docs.rs
@@ -19,6 +19,7 @@ fn doc_contains_bridge_quorum_fast_lane_commands() {
     assert!(DOC.contains("cargo test -p kamn-core approver_quorum"));
     assert!(DOC.contains("bridge_replay_matrix.sh"));
     assert!(DOC.contains("--suites bridge_adapter,discord_bridge"));
+    assert!(DOC.contains("run_cross_chain_outbound_intent_contract_lane.sh"));
     assert!(DOC.contains("cargo fmt --check"));
     assert!(DOC.contains("cargo clippy -p kamn-core -- -D warnings"));
 }
@@ -30,6 +31,9 @@ fn regression_requires_listener_and_approver_quorum_guard_rules() {
     assert!(DOC.contains("Replayed or out-of-order listener event sequences are rejected."));
     assert!(DOC.contains("Outbound under-quorum approval sets are rejected."));
     assert!(DOC.contains("Malformed approver attestation payload is rejected."));
+    assert!(DOC.contains("idempotency-key and payload-hash consistency across attempts"));
+    assert!(DOC.contains("Duplicate outbound replay requests are rejected"));
     assert!(DOC.contains("unauthorized approver signature-failure rejection"));
     assert!(DOC.contains("Regression: #587"));
+    assert!(DOC.contains("Regression: #742"));
 }

--- a/crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs
+++ b/crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs
@@ -15,6 +15,16 @@ fn doc_lists_ethereum_and_near_finality_rules() {
 }
 
 #[test]
+fn doc_contains_outbound_intent_attestation_and_idempotency_rules() {
+    assert!(DOC.contains("## Outbound Intent Attestation and Retry Idempotency Rules"));
+    assert!(DOC.contains("idempotency key must be `idemp:<value>`"));
+    assert!(DOC.contains("duplicate request flag forces deterministic `NO-GO`"));
+    assert!(DOC.contains("Regression: #742"));
+}
+
+#[test]
 fn doc_includes_cross_chain_receipt_finality_test_command() {
     assert!(DOC.contains("cargo test -p kamn-core --test cross_chain_receipt_finality"));
+    assert!(DOC.contains("test_generate_cross_chain_outbound_intent_evidence_bundle.sh"));
+    assert!(DOC.contains("test_run_cross_chain_outbound_intent_contract_lane.sh"));
 }

--- a/docs/foundation/bridge-quorum-runtime.md
+++ b/docs/foundation/bridge-quorum-runtime.md
@@ -1,4 +1,4 @@
-# Bridge Quorum Runtime Contracts (Issues #364 / #367 / #370 / #373)
+# Bridge Quorum Runtime Contracts (Issues #364 / #367 / #370 / #373 / #742)
 
 This document captures deterministic bridge quorum runtime contracts for listener-confirmed inbound events and approver-gated outbound actions.
 
@@ -36,6 +36,8 @@ This document captures deterministic bridge quorum runtime contracts for listene
 - Outbound bridge actions require canonical approver attestation set evaluation against configured quorum thresholds.
 - Outbound under-quorum approval sets are rejected.
 - Malformed approver attestation payload is rejected.
+- Cross-chain outbound retries require idempotency-key and payload-hash consistency across attempts.
+- Duplicate outbound replay requests are rejected with deterministic `NO-GO` policy evidence.
 - Outbound authorization decisions emit deterministic typed rejection reasons when quorum requirements are unmet.
 
 ## Test Coverage Mapping
@@ -48,6 +50,7 @@ This document captures deterministic bridge quorum runtime contracts for listene
   - malformed approver payload rejection (`Regression: #372`)
   - outbound under-quorum rejection (`Regression: #372`)
   - unauthorized approver signature-failure rejection in bridge replay fixtures (`Regression: #587`)
+  - outbound retry payload-drift and tampered final-decision rejection (`Regression: #742`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
@@ -57,6 +60,7 @@ cargo test -p kamn-core --test bridge_quorum_runtime_docs
 cargo test -p kamn-core --test runtime_network_docs
 cargo test -p kamn-core approver_quorum
 bash scripts/bridge/run_bridge_replay_matrix.sh --fixture fixtures/bridge_replay/replay_validation_cases.json --suites bridge_adapter,discord_bridge --output-json /tmp/bridge-replay-quorum-report.json
+bash scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh
 cargo fmt --check
 cargo clippy -p kamn-core -- -D warnings
 ```

--- a/docs/foundation/cross-chain-bridge-adapters.md
+++ b/docs/foundation/cross-chain-bridge-adapters.md
@@ -1,4 +1,4 @@
-# Cross-Chain Bridge Adapters (Ethereum and Solana) (Issues #232, #233, #740)
+# Cross-Chain Bridge Adapters (Ethereum and Solana) (Issues #232, #233, #740, #742)
 
 This document captures cross-chain adapter and receipt-finality normalization slices for Ethereum, Solana, and Near pathways.
 
@@ -17,6 +17,13 @@ This document captures cross-chain adapter and receipt-finality normalization sl
   - `normalize_cross_chain_receipt(...)` with strict chain-specific finality rules.
   - typed errors via `CrossChainReceiptNormalizationError`.
 - Added integration tests in `crates/kamn-core/tests/cross_chain_receipt_finality.rs`.
+- Added outbound cross-chain intent evidence scripts:
+  - `scripts/bridge/generate_cross_chain_outbound_intent_evidence_bundle.sh`
+  - `scripts/bridge/check_cross_chain_outbound_intent_policy.sh`
+  - `scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh`
+  - `scripts/bridge/run_cross_chain_outbound_intent_deep_lane.sh`
+  - `scripts/bridge/run_cross_chain_outbound_intent_matrix.py`
+  - fixture matrix: `fixtures/bridge_outbound_intent/approval_retry_cases.json`
 
 ## Validation Rules
 - Bridge/listener/approver DIDs must parse as `kamn:did:agent:*`.
@@ -47,6 +54,20 @@ This document captures cross-chain adapter and receipt-finality normalization sl
   - `Failed` status always normalizes to `Failed`.
   - `Pending` status always normalizes to `Pending`.
 
+## Outbound Intent Attestation and Retry Idempotency Rules
+- Outbound intent evidence requires:
+  - chain (`ethereum` or `near`) and destination channel prefix alignment.
+  - quorum evidence (`required` approvals met by `received` approvals).
+  - non-empty `approval_quorum_hash` (`sha256:...`).
+- Retry/idempotency constraints:
+  - idempotency key must be `idemp:<value>`.
+  - attempt number must be at least `1`.
+  - retry attempts (`attempt_number > 1`) must preserve payload hash equality.
+  - duplicate request flag forces deterministic `NO-GO`.
+- Policy checker behavior:
+  - recomputes expected final decision from bundle fields.
+  - rejects tampered `final_decision` mismatches fail closed (`Regression: #742`).
+
 ## Processing Flow
 - `process_inbound(...)`:
   - validates listener and chain route mapping.
@@ -65,6 +86,8 @@ Run from repository root:
 ```bash
 cargo test -p kamn-core --test cross_chain_bridge
 cargo test -p kamn-core --test cross_chain_receipt_finality
+bash scripts/bridge/test_generate_cross_chain_outbound_intent_evidence_bundle.sh
+bash scripts/bridge/test_run_cross_chain_outbound_intent_contract_lane.sh
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core

--- a/fixtures/bridge_outbound_intent/approval_retry_cases.json
+++ b/fixtures/bridge_outbound_intent/approval_retry_cases.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "kamn.bridge.cross-chain-outbound-intent.fixture.v1",
+  "cases": [
+    {
+      "case_id": "go-ethereum-first-attempt-approved",
+      "chain": "ethereum",
+      "request_id": "intent-go-001",
+      "destination_channel": "ethereum:sepolia:contract:escrow-v1",
+      "required_approvals": 2,
+      "received_approvals": 2,
+      "approval_quorum_hash": "sha256:intent-go-approvals-001",
+      "idempotency_key": "idemp:intent-go-001",
+      "attempt_number": 1,
+      "payload_hash": "sha256:payload-go-001",
+      "previous_payload_hash": "sha256:payload-go-001",
+      "duplicate_request": false,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "GO"
+    },
+    {
+      "case_id": "no-go-near-under-quorum",
+      "chain": "near",
+      "request_id": "intent-no-go-approvals",
+      "destination_channel": "near:testnet:contract:escrow-v1",
+      "required_approvals": 3,
+      "received_approvals": 2,
+      "approval_quorum_hash": "sha256:intent-no-go-approvals-001",
+      "idempotency_key": "idemp:intent-no-go-approvals",
+      "attempt_number": 1,
+      "payload_hash": "sha256:payload-no-go-approvals-001",
+      "previous_payload_hash": "sha256:payload-no-go-approvals-001",
+      "duplicate_request": false,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    },
+    {
+      "case_id": "no-go-retry-payload-drift",
+      "chain": "ethereum",
+      "request_id": "intent-no-go-retry-drift",
+      "destination_channel": "ethereum:sepolia:contract:escrow-v1",
+      "required_approvals": 2,
+      "received_approvals": 2,
+      "approval_quorum_hash": "sha256:intent-no-go-retry-drift-001",
+      "idempotency_key": "idemp:intent-no-go-retry-drift",
+      "attempt_number": 2,
+      "payload_hash": "sha256:payload-drift-new-001",
+      "previous_payload_hash": "sha256:payload-drift-old-001",
+      "duplicate_request": false,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    },
+    {
+      "case_id": "no-go-duplicate-request",
+      "chain": "near",
+      "request_id": "intent-no-go-duplicate",
+      "destination_channel": "near:testnet:contract:escrow-v1",
+      "required_approvals": 2,
+      "received_approvals": 2,
+      "approval_quorum_hash": "sha256:intent-no-go-duplicate-001",
+      "idempotency_key": "idemp:intent-no-go-duplicate",
+      "attempt_number": 1,
+      "payload_hash": "sha256:payload-duplicate-001",
+      "previous_payload_hash": "sha256:payload-duplicate-001",
+      "duplicate_request": true,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    }
+  ]
+}

--- a/scripts/bridge/check_cross_chain_outbound_intent_policy.sh
+++ b/scripts/bridge/check_cross_chain_outbound_intent_policy.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/bridge/check_cross_chain_outbound_intent_policy.sh \
+    --bundle-file <path>
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "chain",
+    "request_id",
+    "destination_channel",
+    "approvals",
+    "retry",
+    "ci_fast_gate",
+    "decision_reasons",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+if payload["schema_version"] != "kamn.bridge.cross-chain-outbound-intent.v1":
+    fail("unexpected schema_version for cross-chain outbound intent evidence bundle")
+
+chain = payload["chain"]
+if chain not in {"ethereum", "near"}:
+    fail("chain must be ethereum or near")
+
+request_id = payload["request_id"]
+if not isinstance(request_id, str) or not request_id.strip():
+    fail("request_id must be a non-empty string")
+
+destination_channel = payload["destination_channel"]
+if not isinstance(destination_channel, str):
+    fail("destination_channel must be a string")
+if not destination_channel.startswith(f"{chain}:"):
+    fail("destination channel must match selected chain prefix")
+
+approvals = payload["approvals"]
+if not isinstance(approvals, dict):
+    fail("approvals must be an object")
+for key in ("required", "received", "approval_quorum_hash"):
+    if key not in approvals:
+        fail(f"approvals missing field: {key}")
+if not isinstance(approvals["required"], int) or approvals["required"] < 0:
+    fail("approvals.required must be a non-negative integer")
+if not isinstance(approvals["received"], int) or approvals["received"] < 0:
+    fail("approvals.received must be a non-negative integer")
+if not isinstance(approvals["approval_quorum_hash"], str):
+    fail("approvals.approval_quorum_hash must be a string")
+
+retry = payload["retry"]
+if not isinstance(retry, dict):
+    fail("retry must be an object")
+for key in (
+    "idempotency_key",
+    "attempt_number",
+    "payload_hash",
+    "previous_payload_hash",
+    "duplicate_request",
+):
+    if key not in retry:
+        fail(f"retry missing field: {key}")
+if not isinstance(retry["idempotency_key"], str):
+    fail("retry.idempotency_key must be a string")
+if not isinstance(retry["attempt_number"], int):
+    fail("retry.attempt_number must be an integer")
+if not isinstance(retry["payload_hash"], str):
+    fail("retry.payload_hash must be a string")
+if not isinstance(retry["previous_payload_hash"], str):
+    fail("retry.previous_payload_hash must be a string")
+if not isinstance(retry["duplicate_request"], bool):
+    fail("retry.duplicate_request must be a boolean")
+
+if payload["ci_fast_gate"] not in {"PASS", "FAIL"}:
+    fail("ci_fast_gate must be PASS or FAIL")
+
+if not isinstance(payload["decision_reasons"], list) or not all(
+    isinstance(item, str) for item in payload["decision_reasons"]
+):
+    fail("decision_reasons must be an array of strings")
+
+expected_go = True
+if approvals["required"] <= 0:
+    expected_go = False
+if approvals["received"] < approvals["required"]:
+    expected_go = False
+if not approvals["approval_quorum_hash"].startswith("sha256:") or len(
+    approvals["approval_quorum_hash"]
+) <= len("sha256:"):
+    expected_go = False
+if not retry["idempotency_key"].startswith("idemp:") or len(retry["idempotency_key"]) <= len(
+    "idemp:"
+):
+    expected_go = False
+if retry["attempt_number"] < 1:
+    expected_go = False
+for hash_field in ("payload_hash", "previous_payload_hash"):
+    hash_value = retry[hash_field]
+    if not hash_value.startswith("sha256:") or len(hash_value) <= len("sha256:"):
+        expected_go = False
+if retry["attempt_number"] > 1 and retry["payload_hash"] != retry["previous_payload_hash"]:
+    expected_go = False
+if retry["duplicate_request"]:
+    expected_go = False
+if payload["ci_fast_gate"] != "PASS":
+    expected_go = False
+
+expected_decision = "GO" if expected_go else "NO-GO"
+actual_decision = payload["final_decision"]
+if actual_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+if actual_decision != expected_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {actual_decision}"
+    )
+
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"final_decision={actual_decision}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/bridge/generate_cross_chain_outbound_intent_evidence_bundle.sh
+++ b/scripts/bridge/generate_cross_chain_outbound_intent_evidence_bundle.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/bridge/generate_cross_chain_outbound_intent_evidence_bundle.sh \
+    --output-file <path> \
+    --chain ethereum|near \
+    --request-id <value> \
+    --destination-channel <value> \
+    --required-approvals <n> \
+    --received-approvals <n> \
+    --approval-quorum-hash <sha256:...> \
+    --idempotency-key <idemp:...> \
+    --attempt-number <n> \
+    --payload-hash <sha256:...> \
+    --previous-payload-hash <sha256:...> \
+    --duplicate-request true|false \
+    --ci-fast-gate PASS|FAIL
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+require_int() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fail "${name} must be an integer"
+  fi
+}
+
+output_file=""
+chain=""
+request_id=""
+destination_channel=""
+required_approvals=""
+received_approvals=""
+approval_quorum_hash=""
+idempotency_key=""
+attempt_number=""
+payload_hash=""
+previous_payload_hash=""
+duplicate_request=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --chain)
+      chain="${2:-}"
+      shift 2
+      ;;
+    --request-id)
+      request_id="${2:-}"
+      shift 2
+      ;;
+    --destination-channel)
+      destination_channel="${2:-}"
+      shift 2
+      ;;
+    --required-approvals)
+      required_approvals="${2:-}"
+      shift 2
+      ;;
+    --received-approvals)
+      received_approvals="${2:-}"
+      shift 2
+      ;;
+    --approval-quorum-hash)
+      approval_quorum_hash="${2:-}"
+      shift 2
+      ;;
+    --idempotency-key)
+      idempotency_key="${2:-}"
+      shift 2
+      ;;
+    --attempt-number)
+      attempt_number="${2:-}"
+      shift 2
+      ;;
+    --payload-hash)
+      payload_hash="${2:-}"
+      shift 2
+      ;;
+    --previous-payload-hash)
+      previous_payload_hash="${2:-}"
+      shift 2
+      ;;
+    --duplicate-request)
+      duplicate_request="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$chain" || -z "$request_id" || -z "$destination_channel" || -z "$required_approvals" || -z "$received_approvals" || -z "$approval_quorum_hash" || -z "$idempotency_key" || -z "$attempt_number" || -z "$payload_hash" || -z "$previous_payload_hash" || -z "$duplicate_request" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all cross-chain outbound intent evidence arguments are required"
+fi
+
+require_int "required-approvals" "$required_approvals"
+require_int "received-approvals" "$received_approvals"
+require_int "attempt-number" "$attempt_number"
+
+mkdir -p "$(dirname "$output_file")"
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$chain" "$request_id" "$destination_channel" "$required_approvals" "$received_approvals" "$approval_quorum_hash" "$idempotency_key" "$attempt_number" "$payload_hash" "$previous_payload_hash" "$duplicate_request" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+(
+    output_file,
+    generated_at,
+    chain,
+    request_id,
+    destination_channel,
+    required_approvals_raw,
+    received_approvals_raw,
+    approval_quorum_hash,
+    idempotency_key,
+    attempt_number_raw,
+    payload_hash,
+    previous_payload_hash,
+    duplicate_request_raw,
+    ci_fast_gate,
+) = sys.argv[1:]
+
+if chain not in {"ethereum", "near"}:
+    fail("chain must be ethereum or near")
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci-fast-gate must be PASS or FAIL")
+if duplicate_request_raw not in {"true", "false"}:
+    fail("duplicate-request must be true or false")
+
+required_approvals = int(required_approvals_raw)
+received_approvals = int(received_approvals_raw)
+attempt_number = int(attempt_number_raw)
+duplicate_request = duplicate_request_raw == "true"
+
+decision_reasons: list[str] = []
+
+if not request_id.strip():
+    decision_reasons.append("request_id must not be empty")
+if not destination_channel.startswith(f"{chain}:"):
+    decision_reasons.append("destination channel must match selected chain prefix")
+if required_approvals <= 0:
+    decision_reasons.append("required approvals must be greater than zero")
+if received_approvals < required_approvals:
+    decision_reasons.append("received approvals are below required approvals")
+if not approval_quorum_hash.startswith("sha256:") or len(approval_quorum_hash) <= len("sha256:"):
+    decision_reasons.append("approval quorum hash must be a non-empty sha256 digest")
+if not idempotency_key.startswith("idemp:") or len(idempotency_key) <= len("idemp:"):
+    decision_reasons.append("idempotency key must use idemp:<value> format")
+if attempt_number < 1:
+    decision_reasons.append("attempt number must be at least 1")
+
+for field_name, field_value in (
+    ("payload_hash", payload_hash),
+    ("previous_payload_hash", previous_payload_hash),
+):
+    if not field_value.startswith("sha256:") or len(field_value) <= len("sha256:"):
+        decision_reasons.append(f"{field_name} must be a non-empty sha256 digest")
+
+if attempt_number > 1 and payload_hash != previous_payload_hash:
+    decision_reasons.append("retry payload hash drift detected")
+if duplicate_request:
+    decision_reasons.append("duplicate request replay detected")
+if ci_fast_gate != "PASS":
+    decision_reasons.append("ci-fast-gate-failed")
+
+final_decision = "GO" if not decision_reasons else "NO-GO"
+if not decision_reasons:
+    decision_reasons.append("all outbound intent approval/idempotency gates satisfied")
+
+payload = {
+    "schema_version": "kamn.bridge.cross-chain-outbound-intent.v1",
+    "generated_at": generated_at,
+    "chain": chain,
+    "request_id": request_id,
+    "destination_channel": destination_channel,
+    "approvals": {
+        "required": required_approvals,
+        "received": received_approvals,
+        "approval_quorum_hash": approval_quorum_hash,
+    },
+    "retry": {
+        "idempotency_key": idempotency_key,
+        "attempt_number": attempt_number,
+        "payload_hash": payload_hash,
+        "previous_payload_hash": previous_payload_hash,
+        "duplicate_request": duplicate_request,
+    },
+    "ci_fast_gate": ci_fast_gate,
+    "decision_reasons": decision_reasons,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/bridge/run_bridge_credentialed_contract_lane.sh
+++ b/scripts/bridge/run_bridge_credentialed_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPLAY_FIXTURE="$ROOT_DIR/fixtures/bridge_replay/replay_validation_cases.json"
 REPLAY_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_replay_matrix.sh"
 REDACTION_CHECK_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_credential_redaction_check.py"
+OUTBOUND_INTENT_CONTRACT_SCRIPT="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh"
 
 skip_replay=false
 while [[ $# -gt 0 ]]; do
@@ -33,6 +34,8 @@ if [ "$skip_replay" != true ]; then
     --suites "bridge_adapter,discord_bridge,cross_chain_bridge" \
     --output-json "$BRIDGE_REPLAY_REPORT" >/dev/null
 fi
+
+bash "$OUTBOUND_INTENT_CONTRACT_SCRIPT" >/dev/null
 
 TELEGRAM_TOKEN="telegram_contract_token_q7h3n5m1v9x2"
 DISCORD_TOKEN="discord_contract_token_z6k4d8r2p1w5"

--- a/scripts/bridge/run_bridge_credentialed_deep_lane.sh
+++ b/scripts/bridge/run_bridge_credentialed_deep_lane.sh
@@ -6,6 +6,22 @@ REPLAY_FIXTURE="$ROOT_DIR/fixtures/bridge_replay/replay_validation_cases.json"
 REPLAY_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_replay_matrix.sh"
 CONTRACT_LANE="$ROOT_DIR/scripts/bridge/run_bridge_credentialed_contract_lane.sh"
 REDACTION_CHECK_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_credential_redaction_check.py"
+OUTBOUND_INTENT_DEEP_SCRIPT="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_deep_lane.sh"
+
+output_json=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -13,8 +29,10 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 BRIDGE_REPLAY_DEEP_REPORT="$TMP_DIR/bridge-replay-deep-report.json"
 BRIDGE_CREDENTIAL_REDACTION_DEEP_REPORT="$TMP_DIR/bridge-credential-redaction-report.json"
 BRIDGE_DEEP_STDOUT="$TMP_DIR/bridge-redaction-deep.out"
+BRIDGE_OUTBOUND_INTENT_DEEP_REPORT="$TMP_DIR/bridge-outbound-intent-deep-report.json"
 
 bash "$CONTRACT_LANE"
+bash "$OUTBOUND_INTENT_DEEP_SCRIPT" --output-json "$BRIDGE_OUTBOUND_INTENT_DEEP_REPORT" >/dev/null
 
 bash "$REPLAY_SCRIPT" \
   --fixture "$REPLAY_FIXTURE" \
@@ -40,6 +58,10 @@ fi
 if ! grep -q '"sample_count": 128' "$BRIDGE_CREDENTIAL_REDACTION_DEEP_REPORT"; then
   echo "expected deep-lane redaction report to include sample-count contract" >&2
   exit 1
+fi
+
+if [[ -n "$output_json" ]]; then
+  cp "$BRIDGE_OUTBOUND_INTENT_DEEP_REPORT" "$output_json"
 fi
 
 echo "bridge credentialed deep lane tests passed."

--- a/scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh
+++ b/scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/bridge_outbound_intent/approval_retry_cases.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  echo "expected outbound intent matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected outbound intent fixture file to exist" >&2
+  exit 1
+fi
+
+start_epoch="$(date +%s)"
+report_file="$TMP_DIR/bridge-outbound-intent-contract-report.json"
+
+matrix_output="$(
+  python3 "$MATRIX_SCRIPT" \
+    --fixture "$FIXTURE_FILE" \
+    --max-cases 2 \
+    --output-json "$report_file"
+)"
+if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
+  echo "expected outbound intent contract matrix to pass" >&2
+  exit 1
+fi
+
+cargo test -p kamn-core --test cross_chain_bridge -- outbound_rejects_unauthorized_approver --exact >/dev/null
+cargo test -p kamn-core --test cross_chain_receipt_finality >/dev/null
+cargo test -p kamn-core --test cross_chain_bridge_adapters_docs >/dev/null
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt 120 ]; then
+  echo "cross-chain outbound intent contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+echo "cross-chain outbound intent contract lane tests passed."

--- a/scripts/bridge/run_cross_chain_outbound_intent_deep_lane.sh
+++ b/scripts/bridge/run_cross_chain_outbound_intent_deep_lane.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/bridge_outbound_intent/approval_retry_cases.json"
+REPLAY_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_replay_matrix.sh"
+REPLAY_FIXTURE="$ROOT_DIR/fixtures/bridge_replay/replay_validation_cases.json"
+
+output_json=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$output_json" ]]; then
+  output_json="$ROOT_DIR/bridge-outbound-intent-deep-report.json"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+bash "$CONTRACT_LANE" >/dev/null
+
+matrix_output="$(
+  python3 "$MATRIX_SCRIPT" \
+    --fixture "$FIXTURE_FILE" \
+    --output-json "$output_json"
+)"
+if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
+  echo "expected outbound intent deep matrix to pass" >&2
+  exit 1
+fi
+
+bash "$REPLAY_SCRIPT" \
+  --fixture "$REPLAY_FIXTURE" \
+  --suites "discord_bridge,cross_chain_bridge" \
+  --output-json "$TMP_DIR/bridge-outbound-intent-replay-report.json" >/dev/null
+
+echo "cross-chain outbound intent deep lane tests passed."

--- a/scripts/bridge/run_cross_chain_outbound_intent_matrix.py
+++ b/scripts/bridge/run_cross_chain_outbound_intent_matrix.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+GENERATOR = ROOT_DIR / "scripts/bridge/generate_cross_chain_outbound_intent_evidence_bundle.sh"
+POLICY_CHECKER = ROOT_DIR / "scripts/bridge/check_cross_chain_outbound_intent_policy.sh"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fixture",
+        default=str(ROOT_DIR / "fixtures/bridge_outbound_intent/approval_retry_cases.json"),
+    )
+    parser.add_argument("--output-json", default="")
+    parser.add_argument(
+        "--max-cases",
+        type=int,
+        default=0,
+        help="Optional cap for first N cases to evaluate.",
+    )
+    return parser.parse_args()
+
+
+def parse_key_values(stdout: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for line in stdout.splitlines():
+        raw = line.strip()
+        if not raw or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        values[key] = value
+    return values
+
+
+def run_generator(case: Dict[str, Any], bundle_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(GENERATOR),
+        "--output-file",
+        str(bundle_path),
+        "--chain",
+        str(case["chain"]),
+        "--request-id",
+        str(case["request_id"]),
+        "--destination-channel",
+        str(case["destination_channel"]),
+        "--required-approvals",
+        str(case["required_approvals"]),
+        "--received-approvals",
+        str(case["received_approvals"]),
+        "--approval-quorum-hash",
+        str(case["approval_quorum_hash"]),
+        "--idempotency-key",
+        str(case["idempotency_key"]),
+        "--attempt-number",
+        str(case["attempt_number"]),
+        "--payload-hash",
+        str(case["payload_hash"]),
+        "--previous-payload-hash",
+        str(case["previous_payload_hash"]),
+        "--duplicate-request",
+        "true" if case["duplicate_request"] else "false",
+        "--ci-fast-gate",
+        str(case["ci_fast_gate"]),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def run_policy_checker(bundle_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(POLICY_CHECKER),
+        "--bundle-file",
+        str(bundle_path),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        print(f"status=fail; reason=fixture-not-found; fixture={fixture_path}")
+        return 2
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    cases = fixture.get("cases")
+    if not isinstance(cases, list):
+        print("status=fail; reason=invalid-fixture-cases")
+        return 2
+
+    selected_cases = cases[: args.max_cases] if args.max_cases > 0 else cases
+    tmp_dir = Path(
+        subprocess.check_output(
+            ["mktemp", "-d"], text=True, cwd=ROOT_DIR
+        ).strip()
+    )
+    try:
+        failed_case_ids: List[str] = []
+        report_cases: List[Dict[str, Any]] = []
+
+        for index, case in enumerate(selected_cases):
+            if not isinstance(case, dict):
+                failed_case_ids.append(f"invalid-case-{index}")
+                report_cases.append(
+                    {
+                        "case_id": f"invalid-case-{index}",
+                        "passed": False,
+                        "error": "case payload is not an object",
+                    }
+                )
+                continue
+
+            case_id = str(case.get("case_id", f"case-{index}"))
+            bundle_path = tmp_dir / f"{case_id}.json"
+            expected = str(case.get("expected_final_decision", "GO"))
+
+            generated = run_generator(case, bundle_path)
+            if generated.returncode != 0:
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_final_decision": expected,
+                        "passed": False,
+                        "stage": "generate",
+                        "error": (generated.stderr.strip() or generated.stdout.strip()),
+                    }
+                )
+                continue
+
+            generated_values = parse_key_values(generated.stdout)
+            generated_decision = generated_values.get("final_decision", "")
+
+            checked = run_policy_checker(bundle_path)
+            if checked.returncode != 0:
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_final_decision": expected,
+                        "generated_final_decision": generated_decision,
+                        "passed": False,
+                        "stage": "policy-check",
+                        "error": (checked.stderr.strip() or checked.stdout.strip()),
+                    }
+                )
+                continue
+
+            checked_values = parse_key_values(checked.stdout)
+            checked_decision = checked_values.get("final_decision", "")
+
+            passed = generated_decision == expected and checked_decision == expected
+            if not passed:
+                failed_case_ids.append(case_id)
+
+            report_cases.append(
+                {
+                    "case_id": case_id,
+                    "expected_final_decision": expected,
+                    "generated_final_decision": generated_decision,
+                    "checked_final_decision": checked_decision,
+                    "passed": passed,
+                }
+            )
+
+        status = "pass" if not failed_case_ids else "fail"
+        report = {
+            "status": status,
+            "fixture": str(fixture_path),
+            "case_count": len(selected_cases),
+            "failed_count": len(failed_case_ids),
+            "failed_case_ids": failed_case_ids,
+            "cases": report_cases,
+        }
+
+        if args.output_json:
+            Path(args.output_json).write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+
+        if status == "pass":
+            print(f"status=pass; cases={len(selected_cases)}; failed=0")
+            return 0
+
+        print(
+            "status=fail; "
+            f"cases={len(selected_cases)}; failed={len(failed_case_ids)}; "
+            f"failed_ids={','.join(failed_case_ids)}"
+        )
+        return 1
+    finally:
+        subprocess.run(["rm", "-rf", str(tmp_dir)], check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bridge/test_generate_cross_chain_outbound_intent_evidence_bundle.sh
+++ b/scripts/bridge/test_generate_cross_chain_outbound_intent_evidence_bundle.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/bridge/generate_cross_chain_outbound_intent_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/bridge/check_cross_chain_outbound_intent_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected outbound intent evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected outbound intent policy checker to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/outbound-intent-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --chain ethereum \
+    --request-id "intent-go-001" \
+    --destination-channel "ethereum:sepolia:contract:escrow-v1" \
+    --required-approvals 2 \
+    --received-approvals 2 \
+    --approval-quorum-hash "sha256:intent-go-approvals-001" \
+    --idempotency-key "idemp:intent-go-001" \
+    --attempt-number 1 \
+    --payload-hash "sha256:payload-go-001" \
+    --previous-payload-hash "sha256:payload-go-001" \
+    --duplicate-request false \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO bundle generation to pass"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO policy decision"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO bundle policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO policy checker decision"
+
+no_go_bundle="$TMP_DIR/outbound-intent-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --chain near \
+    --request-id "intent-no-go-001" \
+    --destination-channel "near:testnet:contract:escrow-v1" \
+    --required-approvals 3 \
+    --received-approvals 2 \
+    --approval-quorum-hash "sha256:intent-no-go-approvals-001" \
+    --idempotency-key "idemp:intent-no-go-001" \
+    --attempt-number 2 \
+    --payload-hash "sha256:payload-no-go-001" \
+    --previous-payload-hash "sha256:payload-no-go-999" \
+    --duplicate-request true \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO policy decision"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO bundle policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO checker decision"
+
+tampered_bundle="$TMP_DIR/outbound-intent-tampered.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered outbound intent bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch error for tampered outbound intent bundle" >&2
+  exit 1
+fi
+
+# Regression: #742
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO decision mismatch in tampered regression path" >&2
+  exit 1
+fi
+
+echo "cross-chain outbound intent evidence bundle tests passed."

--- a/scripts/bridge/test_run_bridge_credentialed_contract_lane.sh
+++ b/scripts/bridge/test_run_bridge_credentialed_contract_lane.sh
@@ -29,8 +29,18 @@ if ! grep -Fq "run_bridge_credentialed_contract_lane.sh" "$DEEP_SCRIPT"; then
   exit 1
 fi
 
+if ! grep -q "run_cross_chain_outbound_intent_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected bridge credentialed fast-lane script to execute outbound intent contract lane" >&2
+  exit 1
+fi
+
 if ! grep -q "bridge-credential-redaction-report.json" "$DEEP_SCRIPT"; then
   echo "expected deep-lane script to emit bridge credential redaction report" >&2
+  exit 1
+fi
+
+if ! grep -q "bridge-outbound-intent-deep-report.json" "$DEEP_SCRIPT"; then
+  echo "expected deep-lane script to emit outbound intent deep report" >&2
   exit 1
 fi
 

--- a/scripts/bridge/test_run_cross_chain_outbound_intent_contract_lane.sh
+++ b/scripts/bridge/test_run_cross_chain_outbound_intent_contract_lane.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_contract_lane.sh"
+DEEP_LANE="$ROOT_DIR/scripts/bridge/run_cross_chain_outbound_intent_deep_lane.sh"
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected outbound intent contract lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_LANE" ]; then
+  echo "expected outbound intent deep lane script to be executable" >&2
+  exit 1
+fi
+
+lane_output="$(bash "$CONTRACT_LANE")"
+if ! printf '%s\n' "$lane_output" | grep -q "cross-chain outbound intent contract lane tests passed."; then
+  echo "expected outbound intent contract lane success marker" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_cross_chain_outbound_intent_contract_lane.sh" "$DEEP_LANE"; then
+  echo "expected deep lane script to invoke outbound intent contract lane baseline checks first" >&2
+  exit 1
+fi
+
+if ! grep -q "bridge-outbound-intent-deep-report.json" "$DEEP_LANE"; then
+  echo "expected deep lane script to emit outbound intent deep report artifact" >&2
+  exit 1
+fi
+
+echo "cross-chain outbound intent contract lane script tests passed."

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -302,7 +302,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/tests/bridge_adapter.rs|docs/foundation/bridge-adapter-abstraction.md|scripts/bridge/*|fixtures/bridge_replay/*)
+    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/tests/bridge_adapter.rs|crates/kamn-core/src/cross_chain_receipt.rs|crates/kamn-core/tests/cross_chain_receipt_finality.rs|crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs|docs/foundation/bridge-adapter-abstraction.md|docs/foundation/cross-chain-bridge-adapters.md|docs/foundation/bridge-quorum-runtime.md|scripts/bridge/*|fixtures/bridge_replay/*|fixtures/bridge_outbound_intent/*)
       BRIDGE_REPLAY_RELATED_CHANGED=true
       BRIDGE_SUITE_ADAPTER=true
       BRIDGE_SUITE_TELEGRAM=true

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -239,6 +239,12 @@ cross_chain_bridge_output="$(run_selector $'crates/kamn-core/src/cross_chain_bri
 assert_eq "$(extract_output "$cross_chain_bridge_output" "run_bridge_replay_harness")" "true" "cross-chain bridge changes must run bridge replay harness"
 assert_eq "$(extract_output "$cross_chain_bridge_output" "bridge_replay_suites")" "bridge_adapter,cross_chain_bridge" "cross-chain bridge changes should select cross-chain subset plus bridge adapter suite"
 
+bridge_outbound_fixture_output="$(run_selector $'fixtures/bridge_outbound_intent/approval_retry_cases.json')"
+assert_eq "$(extract_output "$bridge_outbound_fixture_output" "run_rust")" "false" "bridge outbound fixture-only changes should avoid rust lane"
+assert_eq "$(extract_output "$bridge_outbound_fixture_output" "run_bridge_replay_harness")" "true" "bridge outbound fixture-only changes must run bridge replay harness"
+assert_eq "$(extract_output "$bridge_outbound_fixture_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge,discord_bridge,cross_chain_bridge" "bridge outbound fixture-only changes should select all bridge suites"
+assert_eq "$(extract_output "$bridge_outbound_fixture_output" "test_scope")" "bridge" "bridge outbound fixture-only changes should set bridge scope"
+
 frontend_output="$(run_selector $'packages/kamn-dashboard/tests/dashboard.test.ts')"
 assert_eq "$(extract_output "$frontend_output" "run_rust")" "false" "frontend-only changes should avoid rust lane"
 assert_eq "$(extract_output "$frontend_output" "run_frontend_dashboard_tests")" "true" "frontend-only changes must run dashboard tests"

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -342,6 +342,16 @@ if ! grep -Fq "post-cutover-slo-report-\${{ github.run_id }}-\${{ github.run_att
   exit 1
 fi
 
+if ! grep -Fq "bash scripts/bridge/run_bridge_credentialed_deep_lane.sh --output-json bridge-credentialed-deep-report.json" "$DEEP_WORKFLOW"; then
+  echo "expected bridge credentialed deep lane command in ci-deep-validate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bridge-credentialed-deep-report-\${{ github.run_id }}-\${{ github.run_attempt }}" "$DEEP_WORKFLOW"; then
+  echo "expected bridge credentialed deep report artifact upload in ci-deep-validate.yml" >&2
+  exit 1
+fi
+
 if ! grep -Fq "bash scripts/sdk/run_sdk_parity_matrix.sh --fixture fixtures/sdk_parity/register_validation_cases.json --output-json sdk-parity-report.json" "$DEEP_WORKFLOW"; then
   echo "expected sdk parity matrix command in ci-deep-validate.yml" >&2
   exit 1


### PR DESCRIPTION
Closes #742

## Summary
Adds a deterministic outbound cross-chain intent evidence + policy lane with idempotent retry regression checks. Wires the new lane into bridge credentialed contract/deep flows and CI deep validation so failures are isolated early with low-cost targeted execution.

## Changes
- scripts/bridge: added outbound intent evidence bundle generator, policy checker, matrix runner, contract/deep lane runners, and dedicated script tests.
- scripts/bridge/run_bridge_credentialed_contract_lane.sh: executes outbound intent contract lane.
- scripts/bridge/run_bridge_credentialed_deep_lane.sh: added --output-json and outbound deep report wiring.
- scripts/ci/select_targets.sh and scripts/ci/test_select_targets.sh: bridge scope and regression assertions for outbound intent fixture/docs/tests.
- .github/workflows/ci-deep-validate.yml and scripts/ci/test_workflow_scope_policy.sh: bridge deep lane execution + artifact upload and workflow assertions.
- docs/foundation/cross-chain-bridge-adapters.md and docs/foundation/bridge-quorum-runtime.md: outbound attestation, idempotency/replay rules, and command references.
- crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs and crates/kamn-core/tests/bridge_quorum_runtime_docs.rs: docs assertions for new rules/commands.

## Risks & Compatibility
- None.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (changed scope)
- [x] Manual verification: Executed outbound intent contract/deep lanes and validated JSON reports/artifacts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Script unit/regression tests and docs assertion tests green for changed scope |
| Functional  | ✅     | Contract/deep outbound intent lanes pass with expected status |
| Integration | ✅     | Bridge credentialed deep lane includes outbound intent lane and emits report artifact |
| Regression  | ✅     | Target selection and workflow scope policy regressions added and passing |

## Commands Run
- bash scripts/bridge/test_generate_cross_chain_outbound_intent_evidence_bundle.sh
- bash scripts/bridge/test_run_cross_chain_outbound_intent_contract_lane.sh
- bash scripts/bridge/test_run_bridge_credentialed_contract_lane.sh
- bash scripts/ci/test_select_targets.sh
- bash scripts/ci/test_workflow_scope_policy.sh
- bash scripts/bridge/run_cross_chain_outbound_intent_deep_lane.sh --output-json /tmp/bridge-outbound-intent-deep-report.json
- bash scripts/bridge/run_bridge_credentialed_deep_lane.sh --output-json /tmp/bridge-credentialed-deep-report.json
- cargo test -p kamn-core --test cross_chain_bridge_adapters_docs
- cargo test -p kamn-core --test bridge_quorum_runtime_docs
- cargo test -p kamn-core --test cross_chain_bridge
- cargo fmt --check
- cargo clippy -- -D warnings

## Note
A full cargo test run currently fails on unrelated pre-existing assertion in task_swarm_dag_docs::docs_define_bounded_graph_benchmark_lane; this change does not modify that scope.
