### PR TITLE
test(reputation): add trust-score invariant matrix and stale-history guard

### DIFF
--- a/crates/kamn-core/src/trust_score.rs
+++ b/crates/kamn-core/src/trust_score.rs
@@ -123,7 +123,6 @@ fn calculate_decay_multiplier_bps(agent: &AgentReputation) -> u16 {
     } else {
         let mut recent = 0usize;
         let mut mid = 0usize;
-        let mut stale = 0usize;
         for snapshot in &agent.score_history {
             let age = agent
                 .last_updated_block
@@ -132,12 +131,10 @@ fn calculate_decay_multiplier_bps(agent: &AgentReputation) -> u16 {
                 recent += 1;
             } else if age <= DECAY_WINDOW_MID_BLOCKS {
                 mid += 1;
-            } else {
-                stale += 1;
             }
         }
 
-        550 + (recent.min(3) as i32 * 120) + (mid.min(4) as i32 * 40) + (stale.min(8) as i32 * 10)
+        550 + (recent.min(3) as i32 * 120) + (mid.min(4) as i32 * 40)
     };
 
     let total_activity = agent.tasks_completed + agent.tasks_failed + agent.tasks_delegated;

--- a/crates/kamn-core/tests/trust_score_engine_docs.rs
+++ b/crates/kamn-core/tests/trust_score_engine_docs.rs
@@ -51,3 +51,11 @@ fn regression_requires_weighted_decay_abuse_guard_marker() {
         "replayed reciprocity/burst/churn abuse fixtures remain penalized (`Regression: #730`)."
     ));
 }
+
+#[test]
+fn regression_requires_stale_history_decay_guard_marker() {
+    // Regression: #768
+    assert!(
+        DOC.contains("stale-only history does not improve decay multiplier (`Regression: #768`).")
+    );
+}

--- a/crates/kamn-core/tests/trust_score_property_invariants.rs
+++ b/crates/kamn-core/tests/trust_score_property_invariants.rs
@@ -1,0 +1,127 @@
+use kamn_core::{
+    AgentReputation, CapabilityVerification, DisputeRecord, Endorsement, ScoreSnapshot,
+};
+
+fn generated_reputation() -> AgentReputation {
+    AgentReputation {
+        agent_did: "kamn:did:agent:generated".to_owned(),
+        trust_score: 500,
+        delivery_rate: 0.5,
+        response_time_avg_ms: 5_000,
+        dispute_rate: 0.0,
+        tasks_completed: 0,
+        tasks_failed: 0,
+        tasks_delegated: 0,
+        total_earned: 0,
+        total_spent: 0,
+        endorsements: Vec::new(),
+        disputes: Vec::new(),
+        verified_capabilities: vec![CapabilityVerification {
+            capability: "analysis".to_owned(),
+            verifier_did: "kamn:did:agent:verifier-1".to_owned(),
+            proof_ref: "ipfs://proof".to_owned(),
+            block_height: 10,
+        }],
+        last_updated_block: 1_000,
+        score_history: Vec::new(),
+    }
+}
+
+fn build_endorsements(count: usize) -> Vec<Endorsement> {
+    (0..count)
+        .map(|index| Endorsement {
+            endorsement_id: format!("endorsement-{index}"),
+            from_agent_did: format!("kamn:did:agent:endorser-{index}"),
+            note: "generated".to_owned(),
+            block_height: 20 + index as u64,
+        })
+        .collect()
+}
+
+#[test]
+fn trust_score_property_generated_inputs_stay_within_bounds() {
+    let delivery_rates = [0.0, 0.25, 0.5, 0.75, 1.0];
+    let dispute_rates = [0.0, 0.1, 0.3, 0.6, 1.0];
+    let response_buckets = [500_u64, 1_000, 1_001, 5_000, 5_001, 30_000, 60_000];
+    let completion_counts = [0_u64, 1, 10, 25, 100, 500, 1_000, 2_000];
+    let endorsement_counts = [0_usize, 1, 5, 25, 50, 75];
+
+    for delivery_rate in delivery_rates {
+        for dispute_rate in dispute_rates {
+            for response_time in response_buckets {
+                for tasks_completed in completion_counts {
+                    for endorsements in endorsement_counts {
+                        let mut reputation = generated_reputation();
+                        reputation.delivery_rate = delivery_rate;
+                        reputation.dispute_rate = dispute_rate;
+                        reputation.response_time_avg_ms = response_time;
+                        reputation.tasks_completed = tasks_completed;
+                        reputation.endorsements = build_endorsements(endorsements);
+
+                        let breakdown = kamn_core::calculate_trust_score(&reputation)
+                            .expect("generated case should calculate");
+                        assert!(breakdown.final_score <= 1_000);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn trust_score_property_dispute_rate_is_non_increasing() {
+    let dispute_rates = [0.0, 0.05, 0.1, 0.2, 0.3, 0.5, 0.8, 1.0];
+    let mut previous_score = u32::MAX;
+
+    for dispute_rate in dispute_rates {
+        let mut reputation = generated_reputation();
+        reputation.delivery_rate = 0.9;
+        reputation.response_time_avg_ms = 1_000;
+        reputation.tasks_completed = 120;
+        reputation.endorsements = build_endorsements(5);
+        reputation.dispute_rate = dispute_rate;
+
+        let breakdown = kamn_core::calculate_trust_score(&reputation)
+            .expect("dispute-rate property case should calculate");
+        assert!(
+            breakdown.final_score <= previous_score,
+            "score must not increase as dispute rate rises: {previous_score} -> {}",
+            breakdown.final_score
+        );
+        previous_score = breakdown.final_score;
+    }
+}
+
+#[test]
+fn trust_score_regression_stale_only_history_must_not_improve_decay_multiplier() {
+    // Regression: #768
+    let mut previous_multiplier = u16::MAX;
+
+    for stale_count in 1_u64..=8 {
+        let mut reputation = generated_reputation();
+        reputation.tasks_completed = 100;
+        reputation.score_history = (0..stale_count)
+            .map(|index| ScoreSnapshot {
+                trust_score: 500,
+                block_height: 100 - index,
+            })
+            .collect::<Vec<_>>();
+        reputation.disputes = (0..stale_count.min(5))
+            .map(|index| DisputeRecord {
+                dispute_id: format!("dispute-{index}"),
+                opened_by: "kamn:did:agent:requester".to_owned(),
+                reason: "generated".to_owned(),
+                block_height: 300 + index,
+            })
+            .collect::<Vec<_>>();
+
+        let breakdown = kamn_core::calculate_trust_score(&reputation)
+            .expect("stale-history property case should calculate");
+        assert!(
+            breakdown.decay_multiplier_bps <= previous_multiplier,
+            "stale-only snapshots must not increase decay multiplier: {previous_multiplier} -> {}",
+            breakdown.decay_multiplier_bps
+        );
+        previous_multiplier = breakdown.decay_multiplier_bps;
+    }
+}

--- a/docs/foundation/trust-score-engine.md
+++ b/docs/foundation/trust-score-engine.md
@@ -24,6 +24,7 @@ Engine constants and core components:
 - Weighted decay applies a deterministic `decay_multiplier_bps` to `volume_bonus` and `endorsement_bonus`:
   - `decayed_volume_bonus = volume_bonus * decay_multiplier_bps / 1000`
   - `decayed_endorsement_bonus = endorsement_bonus * decay_multiplier_bps / 1000`
+- Stale-only history entries do not increase `decay_multiplier_bps`; only recent and mid windows can lift the multiplier.
 - Abuse-threshold penalties map to typed outcomes:
   - `ReciprocityRing` when delegation ratio breaches threshold
   - `BurstSpam` when failure-burst ratio breaches threshold
@@ -42,6 +43,7 @@ Engine constants and core components:
 Regression guards:
 - `1000ms` remains in the highest response bucket.
 - replayed reciprocity/burst/churn abuse fixtures remain penalized (`Regression: #730`).
+- stale-only history does not improve decay multiplier (`Regression: #768`).
 
 ## Weighted Decay and Anti-Gaming Fixture Lanes (Issue #736)
 - Compact PR lane entrypoint:


### PR DESCRIPTION
## Summary
Adds deterministic generated invariant tests for trust-score behavior and fixes a stale-history decay issue where stale-only snapshots could increase the decay multiplier. Also updates trust-score docs/contracts with a regression marker.

Closes #768

## Changes
- `crates/kamn-core/tests/trust_score_property_invariants.rs`: new generated invariant suite for bounds, dispute-rate monotonicity, and stale-history regression.
- `crates/kamn-core/src/trust_score.rs`: decay multiplier updated so stale-only history no longer increases multiplier; only recent/mid windows provide positive lift.
- `docs/foundation/trust-score-engine.md`: documented stale-history decay guard (`Regression: #768`).
- `crates/kamn-core/tests/trust_score_engine_docs.rs`: added docs-contract regression assertion for stale-history guard text.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command (with pre-fix trust-score logic replayed):
```bash
git checkout HEAD^ -- crates/kamn-core/src/trust_score.rs
cargo test -p kamn-core --test trust_score_property_invariants -- --nocapture
```
Output excerpt:
```text
stale-only snapshots must not increase decay multiplier: 560 -> 570
```

### 🟢 Green Phase
Commands:
```bash
git restore --source=HEAD --staged --worktree crates/kamn-core/src/trust_score.rs
cargo test -p kamn-core --test trust_score_property_invariants
cargo test -p kamn-core --test trust_score_engine --test trust_score_engine_docs
```
Result summary: all commands passed.

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_select_targets.sh
bash scripts/sdk/test_run_local_e2e_demo.sh
cargo fmt --check
cargo clippy -- -D warnings
bash scripts/ci/test_ci_tools.sh
```
Result summary: passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Generated invariant tests in `trust_score_property_invariants.rs` | |
| Functional   | ✅     | Dispute-rate monotonicity + bounds invariants over generated input matrix | |
| Integration  | ✅     | Trust-score engine + docs contract tests run together (`trust_score_engine`, `trust_score_engine_docs`) | |
| Regression   | ✅     | `trust_score_regression_stale_only_history_must_not_improve_decay_multiplier` (`Regression: #768`) | |
| Performance  | ✅     | Deterministic generated tests only; no heavy lane/dependency added | |

## Risks & Rollback
- Behavior change: stale-only score history no longer lifts decay multiplier.
- Rollback: revert commit `c88bfe7` if this decay rule change is not desired.

## Documentation Updates
- Updated `docs/foundation/trust-score-engine.md` with stale-history decay guard note and regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
