### PR TITLE
feat(networking): add federated DID handshake contract/deep lanes (#752)

### DIFF
--- a/.github/workflows/ci-deep-validate.yml
+++ b/.github/workflows/ci-deep-validate.yml
@@ -113,6 +113,18 @@ jobs:
           path: dsar-legal-hold-report.json
           if-no-files-found: error
 
+      - name: Run federated DID handshake deep lane
+        if: steps.detect.outputs.run_rust == 'true'
+        run: bash scripts/did/run_federated_did_handshake_deep_lane.sh --output-json federated-did-handshake-report.json
+
+      - name: Upload federated DID handshake deep report
+        if: always() && hashFiles('federated-did-handshake-report.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: federated-did-handshake-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: federated-did-handshake-report.json
+          if-no-files-found: error
+
       - name: Run governance simulation deep lane
         if: steps.detect.outputs.run_rust == 'true'
         run: bash scripts/governance/run_governance_simulation_deep_lane.sh --output-json governance-simulation-report.json

--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -82,12 +82,12 @@ jobs:
         run: npm --prefix packages/kamn-sdk test
 
       - name: Set up Rust toolchain
-        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_bridge_replay_harness == 'true' || steps.scope.outputs.run_signer_emulator_contract_tests == 'true' || steps.scope.outputs.run_did_registry_contract_tests == 'true' || steps.scope.outputs.run_runtime_snapshot_contract_tests == 'true' || steps.scope.outputs.run_message_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_channel_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_task_operation_snapshot_contract_tests == 'true' || steps.scope.outputs.run_durable_guard_recovery_contract_tests == 'true' || steps.scope.outputs.run_settlement_reconciliation_contract_tests == 'true' || steps.scope.outputs.run_token_launch_contract_tests == 'true' || steps.scope.outputs.run_treasury_disbursement_contract_tests == 'true' || steps.scope.outputs.run_reputation_decay_contract_tests == 'true' || steps.scope.outputs.run_rust_live_transport_contract_tests == 'true' || steps.scope.outputs.run_live_transport_parity_rust_contract_tests == 'true'
+        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_bridge_replay_harness == 'true' || steps.scope.outputs.run_signer_emulator_contract_tests == 'true' || steps.scope.outputs.run_did_registry_contract_tests == 'true' || steps.scope.outputs.run_federated_did_handshake_contract_tests == 'true' || steps.scope.outputs.run_runtime_snapshot_contract_tests == 'true' || steps.scope.outputs.run_message_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_channel_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_task_operation_snapshot_contract_tests == 'true' || steps.scope.outputs.run_durable_guard_recovery_contract_tests == 'true' || steps.scope.outputs.run_settlement_reconciliation_contract_tests == 'true' || steps.scope.outputs.run_token_launch_contract_tests == 'true' || steps.scope.outputs.run_treasury_disbursement_contract_tests == 'true' || steps.scope.outputs.run_reputation_decay_contract_tests == 'true' || steps.scope.outputs.run_rust_live_transport_contract_tests == 'true' || steps.scope.outputs.run_live_transport_parity_rust_contract_tests == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
         id: rust_cache
-        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_bridge_replay_harness == 'true' || steps.scope.outputs.run_signer_emulator_contract_tests == 'true' || steps.scope.outputs.run_did_registry_contract_tests == 'true' || steps.scope.outputs.run_runtime_snapshot_contract_tests == 'true' || steps.scope.outputs.run_message_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_channel_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_task_operation_snapshot_contract_tests == 'true' || steps.scope.outputs.run_durable_guard_recovery_contract_tests == 'true' || steps.scope.outputs.run_settlement_reconciliation_contract_tests == 'true' || steps.scope.outputs.run_token_launch_contract_tests == 'true' || steps.scope.outputs.run_treasury_disbursement_contract_tests == 'true' || steps.scope.outputs.run_reputation_decay_contract_tests == 'true' || steps.scope.outputs.run_rust_live_transport_contract_tests == 'true' || steps.scope.outputs.run_live_transport_parity_rust_contract_tests == 'true'
+        if: steps.scope.outputs.run_rust == 'true' || steps.scope.outputs.run_bridge_replay_harness == 'true' || steps.scope.outputs.run_signer_emulator_contract_tests == 'true' || steps.scope.outputs.run_did_registry_contract_tests == 'true' || steps.scope.outputs.run_federated_did_handshake_contract_tests == 'true' || steps.scope.outputs.run_runtime_snapshot_contract_tests == 'true' || steps.scope.outputs.run_message_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_channel_lifecycle_contract_tests == 'true' || steps.scope.outputs.run_task_operation_snapshot_contract_tests == 'true' || steps.scope.outputs.run_durable_guard_recovery_contract_tests == 'true' || steps.scope.outputs.run_settlement_reconciliation_contract_tests == 'true' || steps.scope.outputs.run_token_launch_contract_tests == 'true' || steps.scope.outputs.run_treasury_disbursement_contract_tests == 'true' || steps.scope.outputs.run_reputation_decay_contract_tests == 'true' || steps.scope.outputs.run_rust_live_transport_contract_tests == 'true' || steps.scope.outputs.run_live_transport_parity_rust_contract_tests == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: kamn-rust-ci-v1
@@ -108,6 +108,14 @@ jobs:
       - name: Run DID registry contract lane
         if: steps.scope.outputs.run_did_registry_contract_tests == 'true'
         run: bash scripts/did/run_did_registry_contract_lane.sh
+
+      - name: Run federated DID handshake contract lane
+        if: steps.scope.outputs.run_federated_did_handshake_contract_tests == 'true'
+        run: |
+          bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
+          bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
+          bash scripts/did/test_run_federated_did_handshake_matrix.sh
+          bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
 
       - name: Run runtime snapshot contract lane
         if: steps.scope.outputs.run_runtime_snapshot_contract_tests == 'true'

--- a/crates/kamn-core/tests/did_method_docs.rs
+++ b/crates/kamn-core/tests/did_method_docs.rs
@@ -1,0 +1,26 @@
+const DID_METHOD_DOC: &str = include_str!("../../../docs/foundation/did-method.md");
+
+#[test]
+fn did_method_doc_contains_core_rules() {
+    assert!(DID_METHOD_DOC.contains("## DID Validation Rules"));
+    assert!(DID_METHOD_DOC.contains("DID must start with `kamn:did:agent:`."));
+    assert!(DID_METHOD_DOC.contains("## Canonical DID Document Rules"));
+}
+
+#[test]
+fn did_method_doc_contains_federated_handshake_contract() {
+    assert!(DID_METHOD_DOC.contains("## Federated DID Handshake Evidence Contract"));
+    assert!(DID_METHOD_DOC.contains("generate_federated_did_handshake_evidence_bundle.sh"));
+    assert!(DID_METHOD_DOC.contains("check_federated_did_handshake_policy.sh"));
+    assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_contract_lane.sh"));
+    assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_deep_lane.sh"));
+    assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_matrix.py"));
+    assert!(DID_METHOD_DOC.contains("fixtures/federated_did_handshake/partition_replay_cases.json"));
+}
+
+#[test]
+fn regression_requires_federated_handshake_replay_guard_marker() {
+    // Regression: #734
+    assert!(DID_METHOD_DOC
+        .contains("replay/downgrade/tamper attempts force `NO-GO` (`Regression: #734`)."));
+}

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -91,6 +91,17 @@ fn checklist_contains_dsar_legal_hold_evidence_contract() {
 }
 
 #[test]
+fn checklist_contains_federated_did_handshake_evidence_contract() {
+    assert!(CHECKLIST.contains("## Federated DID Handshake Evidence Contract"));
+    assert!(CHECKLIST.contains("generate_federated_did_handshake_evidence_bundle.sh"));
+    assert!(CHECKLIST.contains("check_federated_did_handshake_policy.sh"));
+    assert!(CHECKLIST.contains("run_federated_did_handshake_contract_lane.sh"));
+    assert!(CHECKLIST.contains("run_federated_did_handshake_deep_lane.sh"));
+    assert!(CHECKLIST.contains("run_federated_did_handshake_matrix.py"));
+    assert!(CHECKLIST.contains("fixtures/federated_did_handshake/partition_replay_cases.json"));
+}
+
+#[test]
 fn checklist_contains_governance_simulation_and_human_veto_evidence_contract() {
     assert!(CHECKLIST.contains("## Governance Simulation and Human-Veto Evidence Contract"));
     assert!(CHECKLIST.contains("generate_governance_simulation_evidence_bundle.sh"));
@@ -221,6 +232,14 @@ fn regression_requires_dsar_legal_hold_evidence_guard_marker() {
     // Regression: #732
     assert!(CHECKLIST.contains(
         "legal-hold bypass attempts and tampered DSAR evidence force `NO-GO` (`Regression: #732`)."
+    ));
+}
+
+#[test]
+fn regression_requires_federated_did_handshake_evidence_guard_marker() {
+    // Regression: #734
+    assert!(CHECKLIST.contains(
+        "replay/downgrade attempts, quorum shortfalls, and tampered final decisions force `NO-GO` (`Regression: #734`)."
     ));
 }
 

--- a/docs/foundation/did-method.md
+++ b/docs/foundation/did-method.md
@@ -27,10 +27,30 @@ For DID Core 1.1 conformance mapping of `kamn:did`, see `docs/foundation/did-cor
 - Default service endpoint: `kamn://messaging/<method-specific-id>`.
 - Public key and capability entries must be non-empty.
 
+## Federated DID Handshake Evidence Contract (Issue #752)
+Cross-network DID trust handshakes must emit deterministic evidence before release approval.
+
+- Evidence bundle generator:
+  - `bash scripts/did/generate_federated_did_handshake_evidence_bundle.sh --output-file /tmp/federated-did-handshake.json --handshake-id federated-go-001 --subject-did kamn:did:agent:federated-worker-1 --local-network kolme-mainnet-a --remote-network kolme-mainnet-b --resolver-cache-hit true --resolver-version resolver-v1 --signature-policy PASS --nonce-monotonic true --downgrade-detected false --partition-sequence-monotonic true --required-quorum 2 --received-quorum 2 --ci-fast-gate PASS`
+- Policy checker:
+  - `bash scripts/did/check_federated_did_handshake_policy.sh --bundle-file /tmp/federated-did-handshake.json`
+- PR fast contract lane:
+  - `bash scripts/did/run_federated_did_handshake_contract_lane.sh`
+- Scheduled deep lane entrypoint:
+  - `bash scripts/did/run_federated_did_handshake_deep_lane.sh --output-json federated-did-handshake-report.json`
+- Partition replay matrix runner:
+  - `python3 scripts/did/run_federated_did_handshake_matrix.py --fixture fixtures/federated_did_handshake/partition_replay_cases.json --output-json federated-did-handshake-report.json`
+- Regression policy:
+  - replay/downgrade/tamper attempts force `NO-GO` (`Regression: #734`).
+
 ## Local Validation
 Run from repository root:
 
 ```bash
+bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
+bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
+bash scripts/did/test_run_federated_did_handshake_matrix.sh
+bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
 cargo test -p kamn-core --test did_method
 cargo fmt --check
 cargo clippy -- -D warnings

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -121,6 +121,22 @@ GDPR data-subject workflows require deterministic legal-hold precedence evidence
 - Regression policy:
   - legal-hold bypass attempts and tampered DSAR evidence force `NO-GO` (`Regression: #732`).
 
+## Federated DID Handshake Evidence Contract (Issue #752)
+Federated DID trust handshakes require deterministic replay, downgrade, and quorum evidence before cross-network approval.
+
+- Evidence bundle generator:
+  - `bash scripts/did/generate_federated_did_handshake_evidence_bundle.sh --output-file /tmp/federated-did-handshake.json --handshake-id federated-go-001 --subject-did kamn:did:agent:federated-worker-1 --local-network kolme-mainnet-a --remote-network kolme-mainnet-b --resolver-cache-hit true --resolver-version resolver-v1 --signature-policy PASS --nonce-monotonic true --downgrade-detected false --partition-sequence-monotonic true --required-quorum 2 --received-quorum 2 --ci-fast-gate PASS`
+- Policy checker:
+  - `bash scripts/did/check_federated_did_handshake_policy.sh --bundle-file /tmp/federated-did-handshake.json`
+- PR fast contract lane:
+  - `bash scripts/did/run_federated_did_handshake_contract_lane.sh`
+- Scheduled deep lane entrypoint:
+  - `bash scripts/did/run_federated_did_handshake_deep_lane.sh --output-json federated-did-handshake-report.json`
+- Partition replay matrix runner:
+  - `python3 scripts/did/run_federated_did_handshake_matrix.py --fixture fixtures/federated_did_handshake/partition_replay_cases.json --output-json federated-did-handshake-report.json`
+- Regression policy:
+  - replay/downgrade attempts, quorum shortfalls, and tampered final decisions force `NO-GO` (`Regression: #734`).
+
 ## Governance Simulation and Human-Veto Evidence Contract (Issue #748)
 Governance activation requires deterministic simulation, veto, timelock, and approval evidence before GO decisions.
 
@@ -272,6 +288,10 @@ bash scripts/compliance/test_generate_dsar_legal_hold_evidence_bundle.sh
 bash scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh
 bash scripts/compliance/test_run_dsar_legal_hold_matrix.sh
 bash scripts/compliance/test_run_dsar_legal_hold_deep_lane.sh
+bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
+bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
+bash scripts/did/test_run_federated_did_handshake_matrix.sh
+bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
 bash scripts/governance/test_generate_governance_simulation_evidence_bundle.sh
 bash scripts/governance/test_run_governance_simulation_contract_lane.sh
 bash scripts/governance/test_run_governance_simulation_matrix.sh

--- a/fixtures/federated_did_handshake/partition_replay_cases.json
+++ b/fixtures/federated_did_handshake/partition_replay_cases.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "kamn.did.federated-handshake.partition-replay-cases.v1",
+  "cases": [
+    {
+      "case_id": "go_quorum_cache_hit",
+      "handshake_id": "federated-go-001",
+      "subject_did": "kamn:did:agent:federated-worker-1",
+      "local_network": "kolme-mainnet-a",
+      "remote_network": "kolme-mainnet-b",
+      "resolver_cache_hit": true,
+      "resolver_version": "resolver-v1",
+      "signature_policy": "PASS",
+      "nonce_monotonic": true,
+      "downgrade_detected": false,
+      "partition_sequence_monotonic": true,
+      "required_quorum": 2,
+      "received_quorum": 2,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "GO"
+    },
+    {
+      "case_id": "no_go_partition_replay",
+      "handshake_id": "federated-replay-001",
+      "subject_did": "kamn:did:agent:federated-worker-2",
+      "local_network": "kolme-mainnet-a",
+      "remote_network": "kolme-mainnet-b",
+      "resolver_cache_hit": false,
+      "resolver_version": "resolver-v1",
+      "signature_policy": "PASS",
+      "nonce_monotonic": false,
+      "downgrade_detected": false,
+      "partition_sequence_monotonic": false,
+      "required_quorum": 2,
+      "received_quorum": 2,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    },
+    {
+      "case_id": "no_go_downgrade_attack",
+      "handshake_id": "federated-downgrade-001",
+      "subject_did": "kamn:did:agent:federated-worker-3",
+      "local_network": "kolme-mainnet-a",
+      "remote_network": "kolme-mainnet-b",
+      "resolver_cache_hit": true,
+      "resolver_version": "resolver-v1",
+      "signature_policy": "PASS",
+      "nonce_monotonic": true,
+      "downgrade_detected": true,
+      "partition_sequence_monotonic": true,
+      "required_quorum": 2,
+      "received_quorum": 2,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    },
+    {
+      "case_id": "no_go_quorum_shortfall",
+      "handshake_id": "federated-quorum-001",
+      "subject_did": "kamn:did:agent:federated-worker-4",
+      "local_network": "kolme-mainnet-a",
+      "remote_network": "kolme-mainnet-b",
+      "resolver_cache_hit": true,
+      "resolver_version": "resolver-v1",
+      "signature_policy": "PASS",
+      "nonce_monotonic": true,
+      "downgrade_detected": false,
+      "partition_sequence_monotonic": true,
+      "required_quorum": 3,
+      "received_quorum": 2,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    }
+  ]
+}

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -32,6 +32,7 @@ append_summary() {
     echo "- Run dashboard contract tests: ${RUN_DASHBOARD_CONTRACT_TESTS}"
     echo "- Run signer emulator contract tests: ${RUN_SIGNER_EMULATOR_CONTRACT_TESTS}"
     echo "- Run DID registry contract tests: ${RUN_DID_REGISTRY_CONTRACT_TESTS}"
+    echo "- Run federated DID handshake contract tests: ${RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS}"
     echo "- Run runtime snapshot contract tests: ${RUN_RUNTIME_SNAPSHOT_CONTRACT_TESTS}"
     echo "- Run message lifecycle contract tests: ${RUN_MESSAGE_LIFECYCLE_CONTRACT_TESTS}"
     echo "- Run channel lifecycle contract tests: ${RUN_CHANNEL_LIFECYCLE_CONTRACT_TESTS}"
@@ -146,6 +147,7 @@ FRONTEND_DASHBOARD_CHANGED=false
 DASHBOARD_CONTRACT_CHANGED=false
 SIGNER_EMULATOR_CONTRACT_CHANGED=false
 DID_REGISTRY_CONTRACT_CHANGED=false
+FEDERATED_DID_HANDSHAKE_CONTRACT_CHANGED=false
 RUNTIME_SNAPSHOT_CONTRACT_CHANGED=false
 MESSAGE_LIFECYCLE_CONTRACT_CHANGED=false
 CHANNEL_LIFECYCLE_CONTRACT_CHANGED=false
@@ -237,8 +239,15 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/did_registry.rs|crates/kamn-core/tests/did_registry_transactions.rs|crates/kamn-core/tests/did_registry_transactions_docs.rs|docs/foundation/did-registry-transactions.md|scripts/did/*)
+    crates/kamn-core/src/did_registry.rs|crates/kamn-core/tests/did_registry_transactions.rs|crates/kamn-core/tests/did_registry_transactions_docs.rs|docs/foundation/did-registry-transactions.md|scripts/did/*did_registry*)
       DID_REGISTRY_CONTRACT_CHANGED=true
+      classified=true
+      ;;
+  esac
+
+  case "$file" in
+    docs/foundation/did-method.md|scripts/did/*federated_did_handshake*|fixtures/federated_did_handshake/*|crates/kamn-core/tests/did_method_docs.rs)
+      FEDERATED_DID_HANDSHAKE_CONTRACT_CHANGED=true
       classified=true
       ;;
   esac
@@ -439,6 +448,7 @@ RUN_FRONTEND_DASHBOARD_TESTS=false
 RUN_DASHBOARD_CONTRACT_TESTS=false
 RUN_SIGNER_EMULATOR_CONTRACT_TESTS=false
 RUN_DID_REGISTRY_CONTRACT_TESTS=false
+RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS=false
 RUN_RUNTIME_SNAPSHOT_CONTRACT_TESTS=false
 RUN_MESSAGE_LIFECYCLE_CONTRACT_TESTS=false
 RUN_CHANNEL_LIFECYCLE_CONTRACT_TESTS=false
@@ -539,6 +549,13 @@ if [ "$DID_REGISTRY_CONTRACT_CHANGED" = true ]; then
   RUN_DID_REGISTRY_CONTRACT_TESTS=true
   if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
     TEST_SCOPE="did-contract"
+  fi
+fi
+
+if [ "$FEDERATED_DID_HANDSHAKE_CONTRACT_CHANGED" = true ]; then
+  RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS=true
+  if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
+    TEST_SCOPE="federated-did-contract"
   fi
 fi
 
@@ -746,6 +763,7 @@ write_output "run_frontend_dashboard_tests" "$RUN_FRONTEND_DASHBOARD_TESTS"
 write_output "run_dashboard_contract_tests" "$RUN_DASHBOARD_CONTRACT_TESTS"
 write_output "run_signer_emulator_contract_tests" "$RUN_SIGNER_EMULATOR_CONTRACT_TESTS"
 write_output "run_did_registry_contract_tests" "$RUN_DID_REGISTRY_CONTRACT_TESTS"
+write_output "run_federated_did_handshake_contract_tests" "$RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS"
 write_output "run_runtime_snapshot_contract_tests" "$RUN_RUNTIME_SNAPSHOT_CONTRACT_TESTS"
 write_output "run_message_lifecycle_contract_tests" "$RUN_MESSAGE_LIFECYCLE_CONTRACT_TESTS"
 write_output "run_channel_lifecycle_contract_tests" "$RUN_CHANNEL_LIFECYCLE_CONTRACT_TESTS"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -310,17 +310,38 @@ assert_eq "$(extract_output "$signer_contract_script_output" "test_scope")" "sig
 did_contract_docs_output="$(run_selector $'docs/foundation/did-registry-transactions.md')"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_rust")" "false" "did contract docs should avoid rust lane"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_did_registry_contract_tests")" "true" "did contract docs must run did registry contract lane"
+assert_eq "$(extract_output "$did_contract_docs_output" "run_federated_did_handshake_contract_tests")" "false" "did registry docs should not run federated DID handshake lane"
 assert_eq "$(extract_output "$did_contract_docs_output" "test_scope")" "did-contract" "did contract docs should set did-contract scope"
 
 did_contract_rust_output="$(run_selector $'crates/kamn-core/src/did_registry.rs')"
 assert_eq "$(extract_output "$did_contract_rust_output" "run_rust")" "true" "did registry rust changes should run rust lane"
 assert_eq "$(extract_output "$did_contract_rust_output" "run_did_registry_contract_tests")" "true" "did registry rust changes must run did registry contract lane"
+assert_eq "$(extract_output "$did_contract_rust_output" "run_federated_did_handshake_contract_tests")" "false" "did registry rust changes should not run federated DID handshake lane"
 assert_eq "$(extract_output "$did_contract_rust_output" "test_scope")" "targeted" "did registry rust changes should stay targeted"
 
 did_contract_script_output="$(run_selector $'scripts/did/run_did_registry_contract_lane.sh')"
 assert_eq "$(extract_output "$did_contract_script_output" "run_rust")" "false" "did contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$did_contract_script_output" "run_did_registry_contract_tests")" "true" "did contract script changes must run did registry contract lane"
+assert_eq "$(extract_output "$did_contract_script_output" "run_federated_did_handshake_contract_tests")" "false" "did registry script changes should not run federated DID handshake lane"
 assert_eq "$(extract_output "$did_contract_script_output" "test_scope")" "did-contract" "did contract script changes should set did-contract scope"
+
+federated_did_contract_docs_output="$(run_selector $'docs/foundation/did-method.md')"
+assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_rust")" "false" "federated DID docs should avoid rust lane"
+assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_did_registry_contract_tests")" "false" "federated DID docs should not trigger did registry contract lane"
+assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID docs must run federated DID handshake contract lane"
+assert_eq "$(extract_output "$federated_did_contract_docs_output" "test_scope")" "federated-did-contract" "federated DID docs should set federated-did-contract scope"
+
+federated_did_contract_script_output="$(run_selector $'scripts/did/run_federated_did_handshake_contract_lane.sh')"
+assert_eq "$(extract_output "$federated_did_contract_script_output" "run_rust")" "false" "federated DID contract script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$federated_did_contract_script_output" "run_did_registry_contract_tests")" "false" "federated DID contract script changes should not trigger did registry lane"
+assert_eq "$(extract_output "$federated_did_contract_script_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID contract script changes must run federated DID handshake lane"
+assert_eq "$(extract_output "$federated_did_contract_script_output" "test_scope")" "federated-did-contract" "federated DID contract script changes should set federated-did-contract scope"
+
+federated_did_contract_fixture_output="$(run_selector $'fixtures/federated_did_handshake/partition_replay_cases.json')"
+assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_rust")" "false" "federated DID fixture-only changes should avoid rust lane"
+assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_did_registry_contract_tests")" "false" "federated DID fixture changes should not trigger did registry lane"
+assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID fixture changes must run federated DID handshake lane"
+assert_eq "$(extract_output "$federated_did_contract_fixture_output" "test_scope")" "federated-did-contract" "federated DID fixture changes should set federated-did-contract scope"
 
 runtime_contract_docs_output="$(run_selector $'docs/foundation/runtime-network.md')"
 assert_eq "$(extract_output "$runtime_contract_docs_output" "run_rust")" "false" "runtime contract docs should avoid rust lane"

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -135,6 +135,31 @@ if ! grep -Fq "bash scripts/did/run_did_registry_contract_lane.sh" "$FAST_WORKFL
   exit 1
 fi
 
+if ! grep -Fq "if: steps.scope.outputs.run_federated_did_handshake_contract_tests == 'true'" "$FAST_WORKFLOW"; then
+  echo "expected federated DID handshake contract scope condition in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh" "$FAST_WORKFLOW"; then
+  echo "expected federated DID handshake generator tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/did/test_run_federated_did_handshake_contract_lane.sh" "$FAST_WORKFLOW"; then
+  echo "expected federated DID handshake contract lane tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/did/test_run_federated_did_handshake_matrix.sh" "$FAST_WORKFLOW"; then
+  echo "expected federated DID handshake matrix tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/did/test_run_federated_did_handshake_deep_lane.sh" "$FAST_WORKFLOW"; then
+  echo "expected federated DID handshake deep lane tests in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 if ! grep -Fq "if: steps.scope.outputs.run_runtime_snapshot_contract_tests == 'true'" "$FAST_WORKFLOW"; then
   echo "expected runtime snapshot contract scope condition in ci-fast-gate.yml" >&2
   exit 1
@@ -429,6 +454,16 @@ fi
 
 if ! grep -Fq "dsar-legal-hold-report-\${{ github.run_id }}-\${{ github.run_attempt }}" "$DEEP_WORKFLOW"; then
   echo "expected DSAR legal-hold deep report artifact upload in ci-deep-validate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/did/run_federated_did_handshake_deep_lane.sh --output-json federated-did-handshake-report.json" "$DEEP_WORKFLOW"; then
+  echo "expected scheduled federated DID handshake deep lane command in ci-deep-validate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "federated-did-handshake-report-\${{ github.run_id }}-\${{ github.run_attempt }}" "$DEEP_WORKFLOW"; then
+  echo "expected federated DID handshake deep report artifact upload in ci-deep-validate.yml" >&2
   exit 1
 fi
 

--- a/scripts/did/check_federated_did_handshake_policy.sh
+++ b/scripts/did/check_federated_did_handshake_policy.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/did/check_federated_did_handshake_policy.sh \
+    --bundle-file <path>
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+from typing import List
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "handshake_id",
+    "subject_did",
+    "local_network",
+    "remote_network",
+    "resolver_cache_hit",
+    "resolver_version",
+    "signature_policy",
+    "nonce_monotonic",
+    "downgrade_detected",
+    "partition_sequence_monotonic",
+    "required_quorum",
+    "received_quorum",
+    "ci_fast_gate",
+    "policy_checks",
+    "reason_codes",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+if payload["schema_version"] != "kamn.did.federated-handshake.v1":
+    fail("unsupported schema_version for federated DID handshake bundle")
+
+for field in (
+    "resolver_cache_hit",
+    "nonce_monotonic",
+    "downgrade_detected",
+    "partition_sequence_monotonic",
+):
+    if not isinstance(payload[field], bool):
+        fail(f"{field} must be boolean")
+
+for field in ("required_quorum", "received_quorum"):
+    if not isinstance(payload[field], int):
+        fail(f"{field} must be integer")
+    if payload[field] < 0:
+        fail(f"{field} must be non-negative")
+
+if payload["required_quorum"] <= 0:
+    fail("required_quorum must be greater than zero")
+
+for field in ("signature_policy", "ci_fast_gate"):
+    if payload[field] not in {"PASS", "FAIL"}:
+        fail(f"{field} must be PASS or FAIL")
+
+policy_checks = payload["policy_checks"]
+if not isinstance(policy_checks, dict):
+    fail("policy_checks must be an object")
+
+required_policy_fields = (
+    "resolver_version_present",
+    "signature_policy_passed",
+    "quorum_satisfied",
+    "replay_guard_passed",
+    "downgrade_guard_passed",
+)
+for field in required_policy_fields:
+    if field not in policy_checks:
+        fail(f"missing policy_checks field: {field}")
+    if not isinstance(policy_checks[field], bool):
+        fail(f"policy_checks.{field} must be boolean")
+
+resolver_version_present = bool(str(payload["resolver_version"]).strip())
+signature_policy_passed = payload["signature_policy"] == "PASS"
+quorum_satisfied = payload["received_quorum"] >= payload["required_quorum"]
+replay_guard_passed = payload["nonce_monotonic"] and payload["partition_sequence_monotonic"]
+downgrade_guard_passed = not payload["downgrade_detected"]
+
+expected_checks = {
+    "resolver_version_present": resolver_version_present,
+    "signature_policy_passed": signature_policy_passed,
+    "quorum_satisfied": quorum_satisfied,
+    "replay_guard_passed": replay_guard_passed,
+    "downgrade_guard_passed": downgrade_guard_passed,
+}
+
+for key, expected_value in expected_checks.items():
+    if policy_checks[key] != expected_value:
+        fail(f"policy_checks.{key} does not match derived policy")
+
+expected_go = (
+    resolver_version_present
+    and signature_policy_passed
+    and quorum_satisfied
+    and replay_guard_passed
+    and downgrade_guard_passed
+    and payload["ci_fast_gate"] == "PASS"
+)
+expected_decision = "GO" if expected_go else "NO-GO"
+actual_decision = payload["final_decision"]
+
+if actual_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+
+if actual_decision != expected_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {actual_decision}"
+    )
+
+failed_checks: List[str] = []
+if not resolver_version_present:
+    failed_checks.append("resolver_version_missing")
+if not signature_policy_passed:
+    failed_checks.append("signature_policy_failed")
+if not quorum_satisfied:
+    failed_checks.append("quorum_shortfall")
+if not payload["nonce_monotonic"]:
+    failed_checks.append("nonce_replay_detected")
+if not payload["partition_sequence_monotonic"]:
+    failed_checks.append("partition_sequence_replayed")
+if payload["downgrade_detected"]:
+    failed_checks.append("downgrade_attack_detected")
+if payload["ci_fast_gate"] != "PASS":
+    failed_checks.append("ci_fast_gate_failed")
+
+failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"final_decision={actual_decision}")
+print(f"failed_checks={failed_checks_value}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/did/generate_federated_did_handshake_evidence_bundle.sh
+++ b/scripts/did/generate_federated_did_handshake_evidence_bundle.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/did/generate_federated_did_handshake_evidence_bundle.sh \
+    --output-file <path> \
+    --handshake-id <value> \
+    --subject-did <value> \
+    --local-network <value> \
+    --remote-network <value> \
+    --resolver-cache-hit true|false \
+    --resolver-version <value> \
+    --signature-policy PASS|FAIL \
+    --nonce-monotonic true|false \
+    --downgrade-detected true|false \
+    --partition-sequence-monotonic true|false \
+    --required-quorum <integer> \
+    --received-quorum <integer> \
+    --ci-fast-gate PASS|FAIL
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+normalize_bool() {
+  local input="$1"
+  case "$input" in
+    true|false)
+      printf '%s\n' "$input"
+      ;;
+    *)
+      fail "boolean fields must be true or false"
+      ;;
+  esac
+}
+
+require_positive_int() {
+  local value="$1"
+  local name="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fail "$name must be a non-negative integer"
+  fi
+}
+
+output_file=""
+handshake_id=""
+subject_did=""
+local_network=""
+remote_network=""
+resolver_cache_hit=""
+resolver_version=""
+signature_policy=""
+nonce_monotonic=""
+downgrade_detected=""
+partition_sequence_monotonic=""
+required_quorum=""
+received_quorum=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --handshake-id)
+      handshake_id="${2:-}"
+      shift 2
+      ;;
+    --subject-did)
+      subject_did="${2:-}"
+      shift 2
+      ;;
+    --local-network)
+      local_network="${2:-}"
+      shift 2
+      ;;
+    --remote-network)
+      remote_network="${2:-}"
+      shift 2
+      ;;
+    --resolver-cache-hit)
+      resolver_cache_hit="$(normalize_bool "${2:-}")"
+      shift 2
+      ;;
+    --resolver-version)
+      resolver_version="${2:-}"
+      shift 2
+      ;;
+    --signature-policy)
+      signature_policy="${2:-}"
+      shift 2
+      ;;
+    --nonce-monotonic)
+      nonce_monotonic="$(normalize_bool "${2:-}")"
+      shift 2
+      ;;
+    --downgrade-detected)
+      downgrade_detected="$(normalize_bool "${2:-}")"
+      shift 2
+      ;;
+    --partition-sequence-monotonic)
+      partition_sequence_monotonic="$(normalize_bool "${2:-}")"
+      shift 2
+      ;;
+    --required-quorum)
+      required_quorum="${2:-}"
+      shift 2
+      ;;
+    --received-quorum)
+      received_quorum="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$handshake_id" || -z "$subject_did" || -z "$local_network" || -z "$remote_network" || -z "$resolver_cache_hit" || -z "$resolver_version" || -z "$signature_policy" || -z "$nonce_monotonic" || -z "$downgrade_detected" || -z "$partition_sequence_monotonic" || -z "$required_quorum" || -z "$received_quorum" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all handshake bundle arguments are required"
+fi
+
+for status in "$signature_policy" "$ci_fast_gate"; do
+  if [[ "$status" != "PASS" && "$status" != "FAIL" ]]; then
+    fail "signature-policy and ci-fast-gate must be PASS or FAIL"
+  fi
+done
+
+require_positive_int "$required_quorum" "required-quorum"
+require_positive_int "$received_quorum" "received-quorum"
+
+if [[ "$required_quorum" -eq 0 ]]; then
+  fail "required-quorum must be greater than zero"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$handshake_id" "$subject_did" "$local_network" "$remote_network" "$resolver_cache_hit" "$resolver_version" "$signature_policy" "$nonce_monotonic" "$downgrade_detected" "$partition_sequence_monotonic" "$required_quorum" "$received_quorum" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import sys
+
+(
+    output_file,
+    generated_at,
+    handshake_id,
+    subject_did,
+    local_network,
+    remote_network,
+    resolver_cache_hit_raw,
+    resolver_version,
+    signature_policy,
+    nonce_monotonic_raw,
+    downgrade_detected_raw,
+    partition_sequence_monotonic_raw,
+    required_quorum_raw,
+    received_quorum_raw,
+    ci_fast_gate,
+) = sys.argv[1:]
+
+resolver_cache_hit = resolver_cache_hit_raw == "true"
+nonce_monotonic = nonce_monotonic_raw == "true"
+downgrade_detected = downgrade_detected_raw == "true"
+partition_sequence_monotonic = partition_sequence_monotonic_raw == "true"
+required_quorum = int(required_quorum_raw)
+received_quorum = int(received_quorum_raw)
+
+resolver_version_present = bool(resolver_version.strip())
+signature_policy_passed = signature_policy == "PASS"
+quorum_satisfied = received_quorum >= required_quorum
+replay_guard_passed = nonce_monotonic and partition_sequence_monotonic
+downgrade_guard_passed = not downgrade_detected
+
+is_go = (
+    resolver_version_present
+    and signature_policy_passed
+    and quorum_satisfied
+    and replay_guard_passed
+    and downgrade_guard_passed
+    and ci_fast_gate == "PASS"
+)
+
+reason_codes = []
+if not resolver_version_present:
+    reason_codes.append("resolver_version_missing")
+if not signature_policy_passed:
+    reason_codes.append("signature_policy_failed")
+if not quorum_satisfied:
+    reason_codes.append("quorum_shortfall")
+if not nonce_monotonic:
+    reason_codes.append("nonce_replay_detected")
+if not partition_sequence_monotonic:
+    reason_codes.append("partition_sequence_replayed")
+if downgrade_detected:
+    reason_codes.append("downgrade_attack_detected")
+if ci_fast_gate != "PASS":
+    reason_codes.append("ci_fast_gate_failed")
+
+final_decision = "GO" if is_go else "NO-GO"
+
+payload = {
+    "schema_version": "kamn.did.federated-handshake.v1",
+    "generated_at": generated_at,
+    "handshake_id": handshake_id,
+    "subject_did": subject_did,
+    "local_network": local_network,
+    "remote_network": remote_network,
+    "resolver_cache_hit": resolver_cache_hit,
+    "resolver_version": resolver_version,
+    "signature_policy": signature_policy,
+    "nonce_monotonic": nonce_monotonic,
+    "downgrade_detected": downgrade_detected,
+    "partition_sequence_monotonic": partition_sequence_monotonic,
+    "required_quorum": required_quorum,
+    "received_quorum": received_quorum,
+    "ci_fast_gate": ci_fast_gate,
+    "policy_checks": {
+        "resolver_version_present": resolver_version_present,
+        "signature_policy_passed": signature_policy_passed,
+        "quorum_satisfied": quorum_satisfied,
+        "replay_guard_passed": replay_guard_passed,
+        "downgrade_guard_passed": downgrade_guard_passed,
+    },
+    "reason_codes": reason_codes,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/did/run_federated_did_handshake_contract_lane.sh
+++ b/scripts/did/run_federated_did_handshake_contract_lane.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/did/run_federated_did_handshake_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/federated_did_handshake/partition_replay_cases.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  echo "expected federated DID handshake matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected federated DID handshake fixture file to exist" >&2
+  exit 1
+fi
+
+start_epoch="$(date +%s)"
+report_file="$TMP_DIR/federated-did-handshake-contract-report.json"
+
+matrix_output="$(
+  python3 "$MATRIX_SCRIPT" \
+    --fixture "$FIXTURE_FILE" \
+    --max-cases 2 \
+    --output-json "$report_file"
+)"
+if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
+  echo "expected federated DID handshake contract matrix to pass" >&2
+  exit 1
+fi
+
+cargo test -p kamn-core --test did_method >/dev/null
+cargo test -p kamn-core regression_replayed_peer_frame_nonce_is_rejected -- --exact >/dev/null
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt 120 ]; then
+  echo "federated DID handshake contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+echo "federated DID handshake contract lane tests passed."

--- a/scripts/did/run_federated_did_handshake_deep_lane.sh
+++ b/scripts/did/run_federated_did_handshake_deep_lane.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/did/run_federated_did_handshake_contract_lane.sh"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/did/run_federated_did_handshake_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/federated_did_handshake/partition_replay_cases.json"
+
+output_json=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$output_json" ]]; then
+  output_json="$ROOT_DIR/federated-did-handshake-report.json"
+fi
+
+mkdir -p "$(dirname "$output_json")"
+
+bash "$CONTRACT_LANE" >/dev/null
+
+matrix_output="$(
+  python3 "$MATRIX_SCRIPT" \
+    --fixture "$FIXTURE_FILE" \
+    --output-json "$output_json"
+)"
+
+if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
+  echo "expected federated DID handshake deep matrix to pass" >&2
+  exit 1
+fi
+
+echo "federated DID handshake deep lane tests passed."

--- a/scripts/did/run_federated_did_handshake_matrix.py
+++ b/scripts/did/run_federated_did_handshake_matrix.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+GENERATOR = ROOT_DIR / "scripts/did/generate_federated_did_handshake_evidence_bundle.sh"
+POLICY_CHECKER = ROOT_DIR / "scripts/did/check_federated_did_handshake_policy.sh"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fixture",
+        default=str(ROOT_DIR / "fixtures/federated_did_handshake/partition_replay_cases.json"),
+    )
+    parser.add_argument("--output-json", default="")
+    parser.add_argument(
+        "--max-cases",
+        type=int,
+        default=0,
+        help="Optional cap for first N cases to evaluate.",
+    )
+    return parser.parse_args()
+
+
+def parse_key_values(stdout: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for line in stdout.splitlines():
+        raw = line.strip()
+        if not raw or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        values[key] = value
+    return values
+
+
+def bool_value(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def run_generator(case: Dict[str, Any], bundle_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(GENERATOR),
+        "--output-file",
+        str(bundle_path),
+        "--handshake-id",
+        str(case["handshake_id"]),
+        "--subject-did",
+        str(case["subject_did"]),
+        "--local-network",
+        str(case["local_network"]),
+        "--remote-network",
+        str(case["remote_network"]),
+        "--resolver-cache-hit",
+        bool_value(case["resolver_cache_hit"]),
+        "--resolver-version",
+        str(case["resolver_version"]),
+        "--signature-policy",
+        str(case["signature_policy"]),
+        "--nonce-monotonic",
+        bool_value(case["nonce_monotonic"]),
+        "--downgrade-detected",
+        bool_value(case["downgrade_detected"]),
+        "--partition-sequence-monotonic",
+        bool_value(case["partition_sequence_monotonic"]),
+        "--required-quorum",
+        str(case["required_quorum"]),
+        "--received-quorum",
+        str(case["received_quorum"]),
+        "--ci-fast-gate",
+        str(case["ci_fast_gate"]),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def run_policy_checker(bundle_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(POLICY_CHECKER),
+        "--bundle-file",
+        str(bundle_path),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        print(f"status=fail; reason=fixture-not-found; fixture={fixture_path}")
+        return 2
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    cases = fixture.get("cases")
+    if not isinstance(cases, list):
+        print("status=fail; reason=invalid-fixture-cases")
+        return 2
+
+    selected_cases = cases[: args.max_cases] if args.max_cases > 0 else cases
+    tmp_dir = Path(subprocess.check_output(["mktemp", "-d"], text=True, cwd=ROOT_DIR).strip())
+    try:
+        failed_case_ids: List[str] = []
+        report_cases: List[Dict[str, Any]] = []
+
+        for index, case in enumerate(selected_cases):
+            if not isinstance(case, dict):
+                failed_case_ids.append(f"invalid-case-{index}")
+                report_cases.append(
+                    {
+                        "case_id": f"invalid-case-{index}",
+                        "passed": False,
+                        "error": "case payload is not an object",
+                    }
+                )
+                continue
+
+            case_id = str(case.get("case_id", f"case-{index}"))
+            bundle_path = tmp_dir / f"{case_id}.json"
+            expected = str(case.get("expected_final_decision", "GO"))
+
+            generated = run_generator(case, bundle_path)
+            if generated.returncode != 0:
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_final_decision": expected,
+                        "passed": False,
+                        "stage": "generate",
+                        "error": (generated.stderr.strip() or generated.stdout.strip()),
+                    }
+                )
+                continue
+
+            generated_values = parse_key_values(generated.stdout)
+            generated_decision = generated_values.get("final_decision", "")
+
+            checked = run_policy_checker(bundle_path)
+            if checked.returncode != 0:
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_final_decision": expected,
+                        "generated_final_decision": generated_decision,
+                        "passed": False,
+                        "stage": "policy-check",
+                        "error": (checked.stderr.strip() or checked.stdout.strip()),
+                    }
+                )
+                continue
+
+            checked_values = parse_key_values(checked.stdout)
+            checked_decision = checked_values.get("final_decision", "")
+            failed_checks = checked_values.get("failed_checks", "")
+
+            passed = generated_decision == expected and checked_decision == expected
+            if not passed:
+                failed_case_ids.append(case_id)
+
+            report_cases.append(
+                {
+                    "case_id": case_id,
+                    "expected_final_decision": expected,
+                    "generated_final_decision": generated_decision,
+                    "checked_final_decision": checked_decision,
+                    "failed_checks": failed_checks,
+                    "passed": passed,
+                }
+            )
+
+        status = "pass" if not failed_case_ids else "fail"
+        report = {
+            "schema_version": "kamn.did.federated-handshake.partition-replay-matrix.v1",
+            "status": status,
+            "fixture": str(fixture_path),
+            "case_count": len(selected_cases),
+            "failed_count": len(failed_case_ids),
+            "failed_case_ids": failed_case_ids,
+            "cases": report_cases,
+        }
+
+        if args.output_json:
+            Path(args.output_json).write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+
+        if status == "pass":
+            print(f"status=pass; cases={len(selected_cases)}; failed=0")
+            return 0
+
+        print(
+            "status=fail; "
+            f"cases={len(selected_cases)}; failed={len(failed_case_ids)}; "
+            f"failed_ids={','.join(failed_case_ids)}"
+        )
+        return 1
+    finally:
+        subprocess.run(["rm", "-rf", str(tmp_dir)], check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
+++ b/scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/did/generate_federated_did_handshake_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/did/check_federated_did_handshake_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected federated DID handshake evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected federated DID handshake policy checker to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/federated-handshake-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --handshake-id "federated-go-001" \
+    --subject-did "kamn:did:agent:federated-agent-go" \
+    --local-network "kolme-mainnet-a" \
+    --remote-network "kolme-mainnet-b" \
+    --resolver-cache-hit true \
+    --resolver-version "resolver-v1" \
+    --signature-policy PASS \
+    --nonce-monotonic true \
+    --downgrade-detected false \
+    --partition-sequence-monotonic true \
+    --required-quorum 2 \
+    --received-quorum 2 \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO handshake bundle generation to pass"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO handshake policy decision"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO handshake policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO handshake checker decision"
+
+no_go_bundle="$TMP_DIR/federated-handshake-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --handshake-id "federated-no-go-001" \
+    --subject-did "kamn:did:agent:federated-agent-no-go" \
+    --local-network "kolme-mainnet-a" \
+    --remote-network "kolme-mainnet-b" \
+    --resolver-cache-hit false \
+    --resolver-version "resolver-v1" \
+    --signature-policy PASS \
+    --nonce-monotonic false \
+    --downgrade-detected true \
+    --partition-sequence-monotonic false \
+    --required-quorum 2 \
+    --received-quorum 1 \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO handshake policy decision"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO handshake policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO checker decision"
+
+tampered_bundle="$TMP_DIR/federated-handshake-tampered.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered federated DID handshake bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch error for tampered federated DID handshake bundle" >&2
+  exit 1
+fi
+
+# Regression: #734
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO decision mismatch in tampered regression path" >&2
+  exit 1
+fi
+
+echo "federated DID handshake evidence bundle tests passed."

--- a/scripts/did/test_run_federated_did_handshake_contract_lane.sh
+++ b/scripts/did/test_run_federated_did_handshake_contract_lane.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/did/run_federated_did_handshake_contract_lane.sh"
+DEEP_LANE="$ROOT_DIR/scripts/did/run_federated_did_handshake_deep_lane.sh"
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected federated DID handshake contract lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_LANE" ]; then
+  echo "expected federated DID handshake deep lane script to be executable" >&2
+  exit 1
+fi
+
+lane_output="$(bash "$CONTRACT_LANE")"
+if ! printf '%s\n' "$lane_output" | grep -q "federated DID handshake contract lane tests passed."; then
+  echo "expected federated DID handshake contract lane success marker" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_federated_did_handshake_contract_lane.sh" "$DEEP_LANE"; then
+  echo "expected federated DID handshake deep lane script to invoke contract lane baseline checks first" >&2
+  exit 1
+fi
+
+if ! grep -q "federated-did-handshake-report.json" "$DEEP_LANE"; then
+  echo "expected federated DID handshake deep lane script to emit report artifact" >&2
+  exit 1
+fi
+
+echo "federated DID handshake contract lane script tests passed."

--- a/scripts/did/test_run_federated_did_handshake_deep_lane.sh
+++ b/scripts/did/test_run_federated_did_handshake_deep_lane.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEEP_LANE="$ROOT_DIR/scripts/did/run_federated_did_handshake_deep_lane.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$DEEP_LANE" ]; then
+  echo "expected federated DID handshake deep lane script to be executable" >&2
+  exit 1
+fi
+
+output="$(bash "$DEEP_LANE" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$output" | grep -q "federated DID handshake deep lane tests passed."; then
+  echo "expected federated DID handshake deep lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -s "$TMP_REPORT" ]; then
+  echo "expected federated DID handshake deep lane to produce non-empty report" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text())
+if report.get("schema_version") != "kamn.did.federated-handshake.partition-replay-matrix.v1":
+    raise SystemExit("unexpected federated DID handshake deep report schema version")
+if report.get("status") != "pass":
+    raise SystemExit("expected federated DID handshake deep report to pass")
+PY
+
+echo "federated DID handshake deep lane script tests passed."

--- a/scripts/did/test_run_federated_did_handshake_matrix.sh
+++ b/scripts/did/test_run_federated_did_handshake_matrix.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/did/run_federated_did_handshake_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/federated_did_handshake/partition_replay_cases.json"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  echo "expected federated DID handshake matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected federated DID handshake fixture file to exist" >&2
+  exit 1
+fi
+
+python3 "$MATRIX_SCRIPT" \
+  --fixture "$FIXTURE_FILE" \
+  --output-json "$TMP_REPORT" \
+  >/dev/null
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+report_path = pathlib.Path(sys.argv[1])
+payload = json.loads(report_path.read_text())
+
+if payload.get("schema_version") != "kamn.did.federated-handshake.partition-replay-matrix.v1":
+    raise SystemExit("unexpected federated DID handshake matrix schema version")
+
+cases = payload.get("cases", [])
+if not cases:
+    raise SystemExit("expected at least one federated DID handshake matrix case")
+
+if not any(case.get("case_id") == "no_go_partition_replay" for case in cases):
+    raise SystemExit("expected no_go_partition_replay case in federated DID handshake matrix report")
+PY
+
+echo "federated DID handshake matrix tests passed."


### PR DESCRIPTION
## Summary
Adds the federated DID handshake contract lane for issue #752: deterministic evidence bundle generation/checking, partition replay matrix validation, and CI fast/deep lane routing with cost-aware defaults. This closes the federation handshake policy gap by enforcing replay/downgrade/quorum fail-closed behavior.

Closes #752

## Changes
- `scripts/did/generate_federated_did_handshake_evidence_bundle.sh`: new evidence bundle generator for federated DID handshake policy signals.
- `scripts/did/check_federated_did_handshake_policy.sh`: new policy checker with deterministic derived-policy validation.
- `scripts/did/run_federated_did_handshake_matrix.py`: new replay/partition matrix runner and JSON report generation.
- `scripts/did/run_federated_did_handshake_contract_lane.sh`: fast contract lane with bounded matrix + replay regression guard command.
- `scripts/did/run_federated_did_handshake_deep_lane.sh`: scheduled deep lane runner and artifact output.
- `scripts/did/test_*federated_did_handshake*.sh`: new script-level contract/deep/matrix/generator tests.
- `fixtures/federated_did_handshake/partition_replay_cases.json`: new deterministic replay/downgrade/quorum fixture matrix.
- `scripts/ci/select_targets.sh`: new `run_federated_did_handshake_contract_tests` selector output and lane routing.
- `.github/workflows/ci-fast-gate.yml`: new federated DID handshake fast-lane test step.
- `.github/workflows/ci-deep-validate.yml`: new federated DID handshake deep-lane step + artifact upload.
- `scripts/ci/test_select_targets.sh` and `scripts/ci/test_workflow_scope_policy.sh`: selector/workflow regression coverage for the new lane.
- `docs/foundation/did-method.md` and `docs/foundation/release-gonogo-checklist.md`: new federated DID handshake evidence contract documentation.
- `crates/kamn-core/tests/did_method_docs.rs` and `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`: docs contract tests including regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
```
Output:
```text
expected federated DID handshake evidence generator to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
bash scripts/did/test_run_federated_did_handshake_matrix.sh
bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_workflow_scope_policy.sh
cargo test -p kamn-core --test did_method_docs
cargo test -p kamn-core --test release_gonogo_checklist_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
Result:
- All commands passed.

### 🔁 Regression
Command:
```bash
cargo test
```
Result:
- Failed in pre-existing docs lane not touched by this change:
  - `-p kamn-core --test task_swarm_dag_docs` (`docs_define_bounded_graph_benchmark_lane` assertion failure)
- Federated DID handshake regression paths in this PR are green, including replay/downgrade/tamper checks.

## Test Matrix (Mandatory)
| Category      | Status     | Tests Added/Modified | Justification if N/A |
|--------------|------------|----------------------|----------------------|
| Unit         | ✅ | Policy derivation and checker validation via new generator/checker + docs tests | |
| Functional   | ✅ | Contract lane GO/NO-GO handshake scenarios and matrix case outcomes | |
| Integration  | ✅ | CI selector/workflow routing + deep artifact wiring + docs contract coverage | |
| Regression   | ✅ | Replay/downgrade/tamper/quorum fail-closed checks (`Regression: #734`) | |
| Performance  | ✅ | Fast-lane runtime budget guard in contract lane; deep matrix scheduled | |

## Risks & Rollback
- No breaking API changes.
- Risk: CI lane surface expansion; mitigated by selector-scoped triggering and runtime budget guard.
- Rollback: revert this PR to remove federated DID lane scripts and selector/workflow hooks.

## Documentation Updates
- Updated: `docs/foundation/did-method.md`
- Updated: `docs/foundation/release-gonogo-checklist.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped run: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [ ] Full regression suite passing (`cargo test` currently fails in pre-existing `task_swarm_dag_docs`)
- [x] Docs updated (or justified why not)
