### PR TITLE
fix(docs): restore bounded graph benchmark command contract (#795)

### DIFF
--- a/docs/foundation/task-operations.md
+++ b/docs/foundation/task-operations.md
@@ -118,6 +118,8 @@ persistence/recovery contracts for the task operation registry.
 ## Bounded Graph Benchmark
 - A bounded graph benchmark keeps CI cost low while validating DAG guard performance characteristics.
 - The benchmark covers a 128-task linear DAG registration path and enforces a generous local CI budget.
+- Run bounded graph benchmark lane:
+  - `cargo test -p kamn-core --test swarm_task_dag`
 - A snapshot roundtrip benchmark validates export+restore overhead for a bounded 128-task DAG without requiring expensive integration infrastructure.
 - A bounded snapshot-store roundtrip benchmark validates write/read overhead in PR lanes.
 


### PR DESCRIPTION
## Summary
Restores the missing bounded graph benchmark command text in `docs/foundation/task-operations.md` so the docs contract test remains fail-closed and `main` stays green.

Closes #795

## Changes
- `docs/foundation/task-operations.md`: added explicit command line for bounded graph benchmark lane:
  - `cargo test -p kamn-core --test swarm_task_dag`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test task_swarm_dag_docs
```
Failure:
```text
docs_define_bounded_graph_benchmark_lane ... FAILED
assertion failed: OPERATIONS_DOC.contains("cargo test -p kamn-core --test swarm_task_dag")
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test task_swarm_dag_docs
cargo test
cargo fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
```
Summary:
- All commands passed locally.

### 🔁 Regression
Command:
```bash
cargo test
```
Summary:
- Full suite passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `crates/kamn-core/tests/task_swarm_dag_docs.rs` (existing assertion now satisfied) | |
| Functional   | ✅     | bounded graph benchmark command contract in docs | |
| Integration  | ✅     | full `cargo test` suite | |
| Regression   | ✅     | bounded graph command remains explicit and fail-closed | |
| Performance  | N/A    | docs-only change; no runtime behavior change | no performance path modified |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert this commit if docs command contract must be altered with corresponding test update.

## Documentation Updates
- `docs/foundation/task-operations.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
