### PR TITLE
chore(core): enforce phased missing_docs lint baseline (#797)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -1,63 +1,131 @@
+//! Core KAMN domain, protocol, and contract surfaces.
+//!
+//! This crate exports the public interfaces used by node, SDK, and contract-lane
+//! tooling. Missing-docs lint is enabled in phased mode: legacy exports are
+//! explicitly allow-listed while new public surfaces should carry docs by default.
+#![warn(missing_docs)]
+
+#[allow(missing_docs)]
 pub mod agent_key_hierarchy;
+#[allow(missing_docs)]
 pub mod agent_upgrade_workflow;
+#[allow(missing_docs)]
 pub mod anti_spam;
+#[allow(missing_docs)]
 pub mod audit_exports;
+#[allow(missing_docs)]
 pub mod bootstrap;
+#[allow(missing_docs)]
 pub mod bridge_adapter;
+#[allow(missing_docs)]
 pub mod channel_models;
+#[allow(missing_docs)]
 pub mod channel_policies;
+#[allow(missing_docs)]
 pub mod config;
+#[allow(missing_docs)]
 pub mod content_lifecycle;
+#[allow(missing_docs)]
 pub mod content_replication;
+#[allow(missing_docs)]
 pub mod content_retrieval;
+#[allow(missing_docs)]
 pub mod content_storage;
+#[allow(missing_docs)]
 pub mod cross_chain_bridge;
+#[allow(missing_docs)]
 pub mod cross_chain_receipt;
+#[allow(missing_docs)]
 pub mod data_classification;
+#[allow(missing_docs)]
 pub mod did;
+#[allow(missing_docs)]
 pub mod did_registry;
+#[allow(missing_docs)]
 pub mod direct_message_crypto;
+#[allow(missing_docs)]
 pub mod discord_bridge;
+#[allow(missing_docs)]
 pub mod durable_guard_store;
+#[allow(missing_docs)]
 pub mod escrow;
+#[allow(missing_docs)]
 pub mod governance_workflow;
+#[allow(missing_docs)]
 pub mod group_channel_crypto;
+#[allow(missing_docs)]
 pub mod instruction_verify;
+#[allow(missing_docs)]
 pub mod invariants;
+#[allow(missing_docs)]
 pub mod key_lifecycle;
+#[allow(missing_docs)]
 pub mod key_recovery;
+#[allow(missing_docs)]
 pub mod message_delivery_guards;
+#[allow(missing_docs)]
 pub mod message_envelope;
+#[allow(missing_docs)]
 pub mod message_lifecycle;
+#[allow(missing_docs)]
 pub mod migrations;
+#[allow(missing_docs)]
 pub mod namespaces;
+#[allow(missing_docs)]
 pub mod observability;
+#[allow(missing_docs)]
 pub mod operator_actions;
+#[allow(missing_docs)]
 pub mod operator_binding;
+#[allow(missing_docs)]
 pub mod operator_dashboard_api;
+#[allow(missing_docs)]
 pub mod operator_dashboard_ui;
+#[allow(missing_docs)]
 pub mod performance_targets;
+#[allow(missing_docs)]
 pub mod redaction_compliance;
+#[allow(missing_docs)]
 pub mod reputation_signals;
+#[allow(missing_docs)]
 pub mod reputation_state;
+#[allow(missing_docs)]
 pub mod retention_engine;
+#[allow(missing_docs)]
 pub mod runtime;
+#[allow(missing_docs)]
 pub mod service_marketplace;
+#[allow(missing_docs)]
 pub mod signature_profile;
+#[allow(missing_docs)]
 pub mod signer_backend;
+#[allow(missing_docs)]
 pub mod smoke;
+#[allow(missing_docs)]
 pub mod state;
+#[allow(missing_docs)]
 pub mod task_artifacts;
+#[allow(missing_docs)]
 pub mod task_lifecycle;
+#[allow(missing_docs)]
 pub mod task_operations;
+#[allow(missing_docs)]
 pub mod task_payment;
+#[allow(missing_docs)]
 pub mod telegram_bridge;
+#[allow(missing_docs)]
 pub mod token;
+#[allow(missing_docs)]
 pub mod transaction;
+#[allow(missing_docs)]
 pub mod trust_score;
+#[allow(missing_docs)]
 pub mod upgrade_orchestration;
+#[allow(missing_docs)]
 pub mod validator_lifecycle;
+#[allow(missing_docs)]
 pub mod watchdog;
+#[allow(missing_docs)]
 pub mod zk_message_proofs;
 
 pub use agent_key_hierarchy::{

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -1,0 +1,6 @@
+const CORE_LIB: &str = include_str!("../src/lib.rs");
+
+#[test]
+fn kamn_core_declares_missing_docs_warning_policy() {
+    assert!(CORE_LIB.contains("#![warn(missing_docs)]"));
+}


### PR DESCRIPTION
## Summary
Enables a phased `missing_docs` policy baseline in `kamn-core` so new public API additions are linted by default without breaking current legacy surfaces. Adds a policy test to lock this requirement in CI.

## Changes
- crates/kamn-core/src/lib.rs: add crate-level docs and `#![warn(missing_docs)]`, with phased module-level allowances for existing legacy modules.
- crates/kamn-core/tests/missing_docs_policy.rs: add regression test asserting the crate-level missing-docs warning policy remains present.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed `cargo rustc -p kamn-core --lib -- -W missing-docs` passes and policy test remains green.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test` |
| Functional  | ✅     | `cargo test` |
| Integration | ✅     | `cargo test` |
| Regression  | ✅     | `cargo test -p kamn-core --test missing_docs_policy` |

Closes #797
