### PR TITLE
test(core): add lifecycle property invariants for task escrow and peer states (#803)

### DIFF
--- a/crates/kamn-core/tests/escrow_lifecycle.rs
+++ b/crates/kamn-core/tests/escrow_lifecycle.rs
@@ -1,5 +1,139 @@
 use kamn_core::{EscrowLifecycle, EscrowLifecycleError, EscrowStatus};
 
+#[derive(Debug, Clone, Copy)]
+enum EscrowPropertyAction {
+    ReleaseOne,
+    ReleaseRemaining,
+    Dispute,
+    ResolveHalfSplit,
+    RefundRemaining,
+}
+
+const ESCROW_PROPERTY_ACTIONS: [EscrowPropertyAction; 5] = [
+    EscrowPropertyAction::ReleaseOne,
+    EscrowPropertyAction::ReleaseRemaining,
+    EscrowPropertyAction::Dispute,
+    EscrowPropertyAction::ResolveHalfSplit,
+    EscrowPropertyAction::RefundRemaining,
+];
+
+fn for_each_escrow_action_sequence(max_len: usize, mut f: impl FnMut(&[EscrowPropertyAction])) {
+    fn recurse(
+        target_len: usize,
+        current: &mut Vec<EscrowPropertyAction>,
+        f: &mut impl FnMut(&[EscrowPropertyAction]),
+    ) {
+        if current.len() == target_len {
+            f(current.as_slice());
+            return;
+        }
+
+        for action in ESCROW_PROPERTY_ACTIONS {
+            current.push(action);
+            recurse(target_len, current, f);
+            current.pop();
+        }
+    }
+
+    let mut current = Vec::new();
+    for len in 1..=max_len {
+        recurse(len, &mut current, &mut f);
+    }
+}
+
+fn assert_escrow_invariants(escrow: &EscrowLifecycle, total_amount: u128) {
+    let released = escrow.released_amount();
+    let refunded = escrow.refunded_amount();
+    let remaining = escrow.remaining_amount();
+    assert_eq!(released + refunded + remaining, total_amount);
+    assert!(released <= total_amount);
+    assert!(refunded <= total_amount);
+    assert!(remaining <= total_amount);
+
+    match escrow.status() {
+        EscrowStatus::Funded => {
+            assert_eq!(released, 0);
+            assert_eq!(refunded, 0);
+            assert_eq!(remaining, total_amount);
+        }
+        EscrowStatus::PartiallyReleased {
+            released: status_released,
+            remaining: status_remaining,
+        } => {
+            assert_eq!(status_released, released);
+            assert_eq!(status_remaining, remaining);
+            assert!(remaining > 0);
+        }
+        EscrowStatus::Released => {
+            assert_eq!(remaining, 0);
+            assert_eq!(refunded, 0);
+        }
+        EscrowStatus::Refunded => {
+            assert_eq!(remaining, 0);
+        }
+        EscrowStatus::Disputed => {}
+        EscrowStatus::Resolved {
+            released_total,
+            refunded_total,
+        } => {
+            assert_eq!(released_total, released);
+            assert_eq!(refunded_total, refunded);
+            assert_eq!(remaining, 0);
+        }
+    }
+}
+
+fn apply_escrow_action(
+    escrow: &mut EscrowLifecycle,
+    action: EscrowPropertyAction,
+) -> Result<(), EscrowLifecycleError> {
+    let remaining = escrow.remaining_amount();
+    match action {
+        EscrowPropertyAction::ReleaseOne => escrow.release(1),
+        EscrowPropertyAction::ReleaseRemaining => escrow.release(remaining.max(1)),
+        EscrowPropertyAction::Dispute => escrow.dispute(),
+        EscrowPropertyAction::ResolveHalfSplit => {
+            let release_to_payee = remaining / 2;
+            let refund_to_payer = remaining.saturating_sub(release_to_payee);
+            escrow.resolve(release_to_payee, refund_to_payer)
+        }
+        EscrowPropertyAction::RefundRemaining => escrow.refund_remaining(),
+    }
+}
+
+#[test]
+fn escrow_property_generated_action_sequences_preserve_amount_and_status_invariants() {
+    let totals = [1_u128, 2, 3, 5, 8, 21];
+
+    for total_amount in totals {
+        // Bound sequence depth to keep the property lane fast and CI-cost efficient.
+        for_each_escrow_action_sequence(4, |sequence| {
+            let mut escrow =
+                EscrowLifecycle::new(total_amount).expect("escrow property case should initialize");
+            assert_escrow_invariants(&escrow, total_amount);
+
+            for action in sequence {
+                let before_status = escrow.status();
+                let before_released = escrow.released_amount();
+                let before_refunded = escrow.refunded_amount();
+                let before_remaining = escrow.remaining_amount();
+
+                match apply_escrow_action(&mut escrow, *action) {
+                    Ok(()) => {
+                        assert_escrow_invariants(&escrow, total_amount);
+                    }
+                    Err(_error) => {
+                        assert_eq!(escrow.status(), before_status);
+                        assert_eq!(escrow.released_amount(), before_released);
+                        assert_eq!(escrow.refunded_amount(), before_refunded);
+                        assert_eq!(escrow.remaining_amount(), before_remaining);
+                    }
+                }
+            }
+        });
+    }
+}
+
 #[test]
 fn funded_to_partial_to_released_flow_is_valid() {
     let mut escrow = EscrowLifecycle::new(100).expect("escrow must initialize");

--- a/crates/kamn-core/tests/runtime_peer_lifecycle.rs
+++ b/crates/kamn-core/tests/runtime_peer_lifecycle.rs
@@ -1,0 +1,121 @@
+use kamn_core::{PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, RuntimeLifecycleError};
+
+const PEER_EVENTS: [PeerLifecycleEvent; 6] = [
+    PeerLifecycleEvent::StartConnect,
+    PeerLifecycleEvent::HandshakeSucceeded,
+    PeerLifecycleEvent::HeartbeatMissed,
+    PeerLifecycleEvent::HeartbeatRestored,
+    PeerLifecycleEvent::Disconnect,
+    PeerLifecycleEvent::Rejoin,
+];
+
+fn expected_next_state(
+    from: PeerLifecycleState,
+    event: PeerLifecycleEvent,
+) -> Option<PeerLifecycleState> {
+    match (from, event) {
+        (PeerLifecycleState::Disconnected, PeerLifecycleEvent::StartConnect)
+        | (PeerLifecycleState::Disconnected, PeerLifecycleEvent::Rejoin) => {
+            Some(PeerLifecycleState::Connecting)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::HandshakeSucceeded) => {
+            Some(PeerLifecycleState::Active)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Active, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Degraded, PeerLifecycleEvent::Disconnect) => {
+            Some(PeerLifecycleState::Disconnected)
+        }
+        (PeerLifecycleState::Active, PeerLifecycleEvent::HeartbeatMissed) => {
+            Some(PeerLifecycleState::Degraded)
+        }
+        (PeerLifecycleState::Degraded, PeerLifecycleEvent::HeartbeatRestored) => {
+            Some(PeerLifecycleState::Active)
+        }
+        _ => None,
+    }
+}
+
+fn for_each_peer_event_sequence(max_len: usize, mut f: impl FnMut(&[PeerLifecycleEvent])) {
+    fn recurse(
+        target_len: usize,
+        current: &mut Vec<PeerLifecycleEvent>,
+        f: &mut impl FnMut(&[PeerLifecycleEvent]),
+    ) {
+        if current.len() == target_len {
+            f(current.as_slice());
+            return;
+        }
+
+        for event in PEER_EVENTS {
+            current.push(event);
+            recurse(target_len, current, f);
+            current.pop();
+        }
+    }
+
+    let mut current = Vec::new();
+    for len in 1..=max_len {
+        recurse(len, &mut current, &mut f);
+    }
+}
+
+#[test]
+fn peer_lifecycle_property_generated_event_sequences_match_transition_contract() {
+    // Bound sequence depth for fast PR feedback while still exploring broad transition space.
+    for_each_peer_event_sequence(5, |sequence| {
+        let mut lifecycle =
+            PeerLifecycle::new("peer-property").expect("peer lifecycle should initialize");
+
+        for event in sequence {
+            let before_state = lifecycle.state();
+            let expected = expected_next_state(before_state, *event);
+            match (expected, lifecycle.transition(*event)) {
+                (Some(next_state), Ok(applied)) => {
+                    assert_eq!(applied, next_state);
+                    assert_eq!(lifecycle.state(), next_state);
+                }
+                (
+                    None,
+                    Err(RuntimeLifecycleError::InvalidTransition {
+                        from,
+                        event: rejected,
+                    }),
+                ) => {
+                    assert_eq!(from, before_state);
+                    assert_eq!(rejected, *event);
+                    assert_eq!(lifecycle.state(), before_state);
+                }
+                (Some(_), Err(error)) => panic!(
+                    "expected successful transition from {before_state:?} via {event:?}, got \
+                     error: {error:?}"
+                ),
+                (None, Ok(applied)) => panic!(
+                    "expected invalid transition from {before_state:?} via {event:?}, got state \
+                     {applied:?}"
+                ),
+                (None, Err(RuntimeLifecycleError::InvalidPeerId)) => {
+                    panic!("peer id is fixed and valid in this property lane");
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn peer_lifecycle_property_disconnected_state_accepts_only_connect_or_rejoin() {
+    for event in PEER_EVENTS {
+        let mut lifecycle =
+            PeerLifecycle::new("peer-disconnected-check").expect("peer should initialize");
+        let outcome = lifecycle.transition(event);
+        let should_succeed = matches!(
+            event,
+            PeerLifecycleEvent::StartConnect | PeerLifecycleEvent::Rejoin
+        );
+        assert_eq!(
+            outcome.is_ok(),
+            should_succeed,
+            "event {event:?} success mismatch in disconnected state"
+        );
+    }
+}

--- a/crates/kamn-core/tests/task_state_machine.rs
+++ b/crates/kamn-core/tests/task_state_machine.rs
@@ -1,5 +1,128 @@
 use kamn_core::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 
+const TASK_TRANSITIONS: [TaskTransition; 8] = [
+    TaskTransition::Accept,
+    TaskTransition::Delegate,
+    TaskTransition::StartWork,
+    TaskTransition::RequestInput,
+    TaskTransition::Block,
+    TaskTransition::Complete,
+    TaskTransition::Fail,
+    TaskTransition::Cancel,
+];
+
+fn is_terminal_task_state(state: TaskState) -> bool {
+    matches!(
+        state,
+        TaskState::Completed | TaskState::Failed | TaskState::Cancelled
+    )
+}
+
+fn is_legal_task_state_step(from: TaskState, to: TaskState) -> bool {
+    matches!(
+        (from, to),
+        (TaskState::Submitted, TaskState::Accepted)
+            | (TaskState::Submitted, TaskState::Cancelled)
+            | (TaskState::Accepted, TaskState::Delegated)
+            | (TaskState::Accepted, TaskState::InProgress)
+            | (TaskState::Accepted, TaskState::Cancelled)
+            | (TaskState::Delegated, TaskState::InProgress)
+            | (TaskState::Delegated, TaskState::Cancelled)
+            | (TaskState::InProgress, TaskState::Blocked)
+            | (TaskState::InProgress, TaskState::InputRequired)
+            | (TaskState::InProgress, TaskState::Completed)
+            | (TaskState::InProgress, TaskState::Failed)
+            | (TaskState::InProgress, TaskState::Cancelled)
+            | (TaskState::InputRequired, TaskState::InProgress)
+            | (TaskState::InputRequired, TaskState::Failed)
+            | (TaskState::InputRequired, TaskState::Cancelled)
+            | (TaskState::Blocked, TaskState::InProgress)
+            | (TaskState::Blocked, TaskState::Failed)
+            | (TaskState::Blocked, TaskState::Cancelled)
+    )
+}
+
+fn for_each_task_transition_sequence(max_len: usize, mut f: impl FnMut(&[TaskTransition])) {
+    fn recurse(
+        target_len: usize,
+        current: &mut Vec<TaskTransition>,
+        f: &mut impl FnMut(&[TaskTransition]),
+    ) {
+        if current.len() == target_len {
+            f(current.as_slice());
+            return;
+        }
+
+        for transition in TASK_TRANSITIONS {
+            current.push(transition);
+            recurse(target_len, current, f);
+            current.pop();
+        }
+    }
+
+    let mut current = Vec::new();
+    for len in 1..=max_len {
+        recurse(len, &mut current, &mut f);
+    }
+}
+
+#[test]
+fn task_lifecycle_property_generated_sequences_preserve_transition_contracts() {
+    // Keep sequence depth bounded for fast CI while still exploring broad transition permutations.
+    for_each_task_transition_sequence(4, |sequence| {
+        let mut lifecycle =
+            TaskLifecycle::new("task-property").expect("task lifecycle should initialize");
+        let mut successful_transitions = 0_usize;
+
+        for transition in sequence {
+            let before_state = lifecycle.state();
+            let before_history = lifecycle.history();
+            match lifecycle.transition(*transition) {
+                Ok(()) => {
+                    successful_transitions += 1;
+                    let after_state = lifecycle.state();
+                    assert!(
+                        is_legal_task_state_step(before_state, after_state),
+                        "successful transition must be legal from {before_state:?} via \
+                         {transition:?} to {after_state:?}"
+                    );
+                    assert_eq!(
+                        lifecycle.history().len(),
+                        before_history.len() + 1,
+                        "successful transition must append one state to history"
+                    );
+                }
+                Err(TaskLifecycleError::InvalidTransition {
+                    from,
+                    transition: rejected,
+                }) => {
+                    assert_eq!(from, before_state);
+                    assert_eq!(rejected, *transition);
+                    assert_eq!(lifecycle.state(), before_state);
+                    assert_eq!(lifecycle.history(), before_history);
+                }
+                Err(TaskLifecycleError::TerminalState(state)) => {
+                    assert!(is_terminal_task_state(state));
+                    assert_eq!(state, before_state);
+                    assert_eq!(lifecycle.state(), before_state);
+                    assert_eq!(lifecycle.history(), before_history);
+                }
+                Err(error) => panic!("unexpected task lifecycle error in property lane: {error:?}"),
+            }
+
+            let history = lifecycle.history();
+            assert_eq!(history.first(), Some(&TaskState::Submitted));
+            assert_eq!(history.last().copied(), Some(lifecycle.state()));
+        }
+
+        assert_eq!(
+            lifecycle.history().len(),
+            successful_transitions + 1,
+            "history length must equal initial submitted state plus successful transitions"
+        );
+    });
+}
+
 #[test]
 fn new_task_starts_submitted_with_history() {
     let lifecycle = TaskLifecycle::new("task-1").expect("task lifecycle should initialize");


### PR DESCRIPTION
## Summary
Adds deterministic property-style lifecycle invariants across task, escrow, and runtime peer state transitions to increase transition-safety confidence without adding new dependency overhead. The new tests are bounded for fast and cost-effective CI execution.

## Changes
- crates/kamn-core/tests/task_state_machine.rs: add generated transition-sequence property assertions for legality, history integrity, and terminal-state behavior.
- crates/kamn-core/tests/escrow_lifecycle.rs: add generated action-sequence invariants for amount conservation, status consistency, and mutation safety on rejected actions.
- crates/kamn-core/tests/runtime_peer_lifecycle.rs: add new peer lifecycle property target validating transition contract parity over generated event sequences.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed targeted lifecycle test targets and full `cargo test`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test task_state_machine`; `cargo test -p kamn-core --test escrow_lifecycle`; `cargo test -p kamn-core --test runtime_peer_lifecycle` |
| Functional  | ✅     | Deterministic generated-sequence lifecycle property tests in all three domains |
| Integration | ✅     | `cargo test` |
| Regression  | ✅     | Invariant checks enforce no-mutation-on-rejected-actions and transition contract parity |

Closes #803
