### PR TITLE
chore(dev): add fast make lanes (#808)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+SHELL := /bin/bash
+
+.PHONY: help check test demo
+
+help:
+	@echo "KAMN developer lanes"
+	@echo "  make check  - fast static verification (cargo fmt + strict clippy)"
+	@echo "  make test   - default bounded test lane (cargo test)"
+	@echo "  make demo   - two-process localhost signed-message demo"
+	@echo "Deep/scheduled lanes remain opt-in via scripts/sdk/run_rust_live_transport_deep_lane.sh and related scripts."
+
+check:
+	cargo fmt --check
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+test:
+	cargo test
+
+demo:
+	bash scripts/sdk/run_localhost_signed_demo.sh

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ cargo test
 bash scripts/ci/test_ci_tools.sh
 ```
 
+### Fast Make Lanes
+
+```bash
+# Fast static gates
+make check
+
+# Default bounded test lane
+make test
+
+# Two-process localhost signed-message demo
+make demo
+```
+
+Deep/scheduled lanes remain opt-in via scripts in `scripts/sdk/` and `scripts/ci/`.
+
 ### Run A Focused Core Slice
 
 ```bash


### PR DESCRIPTION
## Summary
Adds a repository-level Makefile with fast local lanes (`check`, `test`, `demo`) and documents those commands in README Quickstart.
This gives contributors a low-cost default CI-aligned path while keeping deep/scheduled lanes opt-in.

Closes #808

## Changes
- `Makefile`: adds `check`, `test`, `demo`, and `help` targets mapped to existing fast commands.
- `README.md`: adds a “Fast Make Lanes” section with command usage and scope notes.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `make check`, `make test`, and `make demo` locally.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Covered by `make test` |
| Functional  | ✅ | Covered by existing functional suites in `make test` |
| Integration | ✅ | Covered by existing integration suites in `make test` + localhost demo |
| Regression  | ✅ | Existing regression suites executed in `make test` |
