### PR TITLE
feat(sdk): add TCP handshake replay guard persistence (#823)

### DIFF
--- a/crates/kamn-sdk/src/tcp.rs
+++ b/crates/kamn-sdk/src/tcp.rs
@@ -1,12 +1,17 @@
 use crate::{AgentDid, SdkError};
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
 const DEFAULT_CONNECT_RETRIES: u32 = 20;
 const DEFAULT_RETRY_DELAY_MILLIS: u64 = 100;
 const DEFAULT_MAX_WIRE_BYTES: usize = 32 * 1024;
+const TCP_HANDSHAKE_VERSION: &str = "1";
+const TCP_HANDSHAKE_PROFILE: &str = "ed25519:baseline-v1";
+const TCP_FRAME_DELIMITER: &str = "\n\n";
 
 /// Deterministic signed envelope transported over TCP.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -231,6 +236,229 @@ pub fn signature_for_fields(from: &str, nonce: u64, state_hash: &str, body: &str
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TcpHandshakeFrame {
+    from: AgentDid,
+    to: AgentDid,
+    nonce: u64,
+    signature: String,
+}
+
+impl TcpHandshakeFrame {
+    fn from_envelope(envelope: &TcpSignedEnvelope) -> Self {
+        Self {
+            from: envelope.from.clone(),
+            to: envelope.to.clone(),
+            nonce: envelope.nonce,
+            signature: envelope.signature.clone(),
+        }
+    }
+
+    fn to_wire_payload(&self) -> String {
+        format!(
+            "frame=handshake\nversion={TCP_HANDSHAKE_VERSION}\nprofile={TCP_HANDSHAKE_PROFILE}\nfrom={}\nto={}\nnonce={}\nsignature={}\n",
+            self.from.as_str(),
+            self.to.as_str(),
+            self.nonce,
+            self.signature
+        )
+    }
+
+    fn parse_wire_payload(payload: &str) -> Result<Self, SdkError> {
+        let mut frame: Option<String> = None;
+        let mut version: Option<String> = None;
+        let mut profile: Option<String> = None;
+        let mut from: Option<String> = None;
+        let mut to: Option<String> = None;
+        let mut nonce: Option<u64> = None;
+        let mut signature: Option<String> = None;
+
+        for raw_line in payload.lines() {
+            if raw_line.trim().is_empty() {
+                continue;
+            }
+
+            let (key, raw_value) = raw_line.split_once('=').ok_or(SdkError::InvalidInput {
+                field: "handshake_frame",
+                reason: "line must contain key=value",
+            })?;
+            let value = raw_value.trim_end_matches('\r');
+
+            match key {
+                "frame" => {
+                    if frame.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: frame",
+                        });
+                    }
+                    frame = Some(value.to_owned());
+                }
+                "version" => {
+                    if version.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: version",
+                        });
+                    }
+                    version = Some(value.to_owned());
+                }
+                "profile" => {
+                    if profile.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: profile",
+                        });
+                    }
+                    profile = Some(value.to_owned());
+                }
+                "from" => {
+                    if from.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: from",
+                        });
+                    }
+                    from = Some(value.to_owned());
+                }
+                "to" => {
+                    if to.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: to",
+                        });
+                    }
+                    to = Some(value.to_owned());
+                }
+                "nonce" => {
+                    if nonce.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: nonce",
+                        });
+                    }
+                    nonce = Some(value.parse::<u64>().map_err(|_| SdkError::InvalidInput {
+                        field: "handshake.nonce",
+                        reason: "must be an unsigned integer",
+                    })?);
+                }
+                "signature" => {
+                    if signature.is_some() {
+                        return Err(SdkError::InvalidInput {
+                            field: "handshake_frame",
+                            reason: "duplicate key: signature",
+                        });
+                    }
+                    signature = Some(value.to_owned());
+                }
+                _ => {
+                    return Err(SdkError::InvalidInput {
+                        field: "handshake_frame",
+                        reason: "unknown key",
+                    });
+                }
+            }
+        }
+
+        if frame.ok_or(SdkError::InvalidInput {
+            field: "handshake.frame",
+            reason: "missing required key",
+        })? != "handshake"
+        {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.frame",
+                reason: "must equal handshake",
+            });
+        }
+        if version.ok_or(SdkError::InvalidInput {
+            field: "handshake.version",
+            reason: "missing required key",
+        })? != TCP_HANDSHAKE_VERSION
+        {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.version",
+                reason: "unsupported handshake version",
+            });
+        }
+        if profile.ok_or(SdkError::InvalidInput {
+            field: "handshake.profile",
+            reason: "missing required key",
+        })? != TCP_HANDSHAKE_PROFILE
+        {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.profile",
+                reason: "unsupported signature profile",
+            });
+        }
+
+        Ok(Self {
+            from: AgentDid::parse(from.ok_or(SdkError::InvalidInput {
+                field: "handshake.from",
+                reason: "missing required key",
+            })?)?,
+            to: AgentDid::parse(to.ok_or(SdkError::InvalidInput {
+                field: "handshake.to",
+                reason: "missing required key",
+            })?)?,
+            nonce: nonce.ok_or(SdkError::InvalidInput {
+                field: "handshake.nonce",
+                reason: "missing required key",
+            })?,
+            signature: signature.ok_or(SdkError::InvalidInput {
+                field: "handshake.signature",
+                reason: "missing required key",
+            })?,
+        })
+    }
+
+    fn verify_matches_envelope(&self, envelope: &TcpSignedEnvelope) -> Result<(), SdkError> {
+        if self.from != envelope.from {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.from",
+                reason: "does not match envelope sender",
+            });
+        }
+        if self.to != envelope.to {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.to",
+                reason: "does not match envelope recipient",
+            });
+        }
+        if self.nonce != envelope.nonce {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.nonce",
+                reason: "does not match envelope nonce",
+            });
+        }
+        if self.signature != envelope.signature {
+            return Err(SdkError::InvalidInput {
+                field: "handshake.signature",
+                reason: "does not match envelope signature",
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct TcpReplayGuardState {
+    highest_nonce_by_route: HashMap<String, u64>,
+}
+
+impl TcpReplayGuardState {
+    fn verify_and_record(&mut self, envelope: &TcpSignedEnvelope) -> Result<(), SdkError> {
+        let route_key = format!("{}=>{}", envelope.from.as_str(), envelope.to.as_str());
+        if let Some(highest_nonce) = self.highest_nonce_by_route.get(&route_key) {
+            if envelope.nonce <= *highest_nonce {
+                return Err(SdkError::Conflict("tcp handshake replay detected"));
+            }
+        }
+        self.highest_nonce_by_route
+            .insert(route_key, envelope.nonce);
+        Ok(())
+    }
+}
+
 /// TCP transport configuration for local relay flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TcpTransportConfig {
@@ -312,18 +540,23 @@ pub struct TcpReceivedEnvelope {
 #[derive(Debug, Clone)]
 pub struct TcpTransportAdapter {
     config: TcpTransportConfig,
+    replay_guard_state: Arc<Mutex<TcpReplayGuardState>>,
 }
 
 impl TcpTransportAdapter {
     /// Creates a new adapter for the provided transport config.
     pub fn new(config: TcpTransportConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            replay_guard_state: Arc::new(Mutex::new(TcpReplayGuardState::default())),
+        }
     }
 
     /// Sends a deterministic envelope to the configured TCP endpoint.
     pub fn send(&self, envelope: &TcpSignedEnvelope) -> Result<(), SdkError> {
         envelope.verify_integrity()?;
-        let payload = envelope.to_wire_payload();
+        let handshake = TcpHandshakeFrame::from_envelope(envelope);
+        let payload = serialize_transport_payload(&handshake, envelope);
 
         let mut stream = self.connect_with_retry()?;
         stream
@@ -383,6 +616,38 @@ impl TcpTransportAdapter {
             });
         }
 
-        TcpSignedEnvelope::parse_wire_payload(payload.as_str())
+        let (handshake_payload, envelope_payload) = split_transport_payload(payload.as_str())?;
+        let handshake = TcpHandshakeFrame::parse_wire_payload(handshake_payload)?;
+        let envelope = TcpSignedEnvelope::parse_wire_payload(envelope_payload)?;
+        handshake.verify_matches_envelope(&envelope)?;
+        self.verify_and_record_replay_guard(&envelope)?;
+        Ok(envelope)
     }
+
+    fn verify_and_record_replay_guard(&self, envelope: &TcpSignedEnvelope) -> Result<(), SdkError> {
+        let mut guard = self
+            .replay_guard_state
+            .lock()
+            .map_err(|_| SdkError::TransportFailure("tcp replay guard lock poisoned"))?;
+        guard.verify_and_record(envelope)
+    }
+}
+
+fn serialize_transport_payload(
+    handshake: &TcpHandshakeFrame,
+    envelope: &TcpSignedEnvelope,
+) -> String {
+    let mut payload = handshake.to_wire_payload();
+    payload.push('\n');
+    payload.push_str(&envelope.to_wire_payload());
+    payload
+}
+
+fn split_transport_payload(payload: &str) -> Result<(&str, &str), SdkError> {
+    payload
+        .split_once(TCP_FRAME_DELIMITER)
+        .ok_or(SdkError::InvalidInput {
+            field: "wire_payload",
+            reason: "missing handshake frame delimiter",
+        })
 }

--- a/crates/kamn-sdk/tests/rust_sdk_alpha_docs.rs
+++ b/crates/kamn-sdk/tests/rust_sdk_alpha_docs.rs
@@ -47,3 +47,11 @@ fn regression_requires_tcp_signed_relay_demo_marker_contract() {
     assert!(DOC.contains("tcp_signed_relay_listener"));
     assert!(DOC.contains("tcp_signed_relay_sender"));
 }
+
+#[test]
+fn regression_requires_tcp_handshake_replay_guard_contract() {
+    // Regression: #823
+    assert!(DOC.contains("`Regression: #823`"));
+    assert!(DOC.contains("Forged handshake frames are rejected"));
+    assert!(DOC.contains("conflict: tcp handshake replay detected"));
+}

--- a/crates/kamn-sdk/tests/tcp_transport_adapter.rs
+++ b/crates/kamn-sdk/tests/tcp_transport_adapter.rs
@@ -2,7 +2,8 @@ use kamn_sdk::{
     signature_for_fields, AgentDid, SdkError, TcpSignedEnvelope, TcpTransportAdapter,
     TcpTransportConfig,
 };
-use std::net::TcpListener;
+use std::io::Write;
+use std::net::{Shutdown, TcpListener, TcpStream};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -23,6 +24,27 @@ fn free_addr() -> String {
         Err(error) => panic!("failed to read allocated local address: {error}"),
     };
     addr.to_string()
+}
+
+fn send_raw_payload(addr: &str, payload: &str) {
+    for _attempt in 0..40 {
+        match TcpStream::connect(addr) {
+            Ok(mut stream) => {
+                if let Err(error) = stream.write_all(payload.as_bytes()) {
+                    panic!("failed to write raw payload: {error}");
+                }
+                if let Err(error) = stream.flush() {
+                    panic!("failed to flush raw payload: {error}");
+                }
+                if let Err(error) = stream.shutdown(Shutdown::Write) {
+                    panic!("failed to shutdown raw payload stream: {error}");
+                }
+                return;
+            }
+            Err(_) => thread::sleep(Duration::from_millis(10)),
+        }
+    }
+    panic!("failed to connect raw payload sender to {addr}");
 }
 
 #[test]
@@ -159,6 +181,144 @@ fn integration_tcp_adapter_rejects_oversized_wire_payload() {
 }
 
 #[test]
+fn functional_tcp_adapter_reconnect_preserves_nonce_replay_guard_state() {
+    let addr = free_addr();
+
+    let listener_config = match TcpTransportConfig::new(addr.as_str()) {
+        Ok(value) => value,
+        Err(error) => panic!("listener config failed: {error}"),
+    };
+    let sender_config = match TcpTransportConfig::new(addr.as_str()) {
+        Ok(value) => value,
+        Err(error) => panic!("sender config failed: {error}"),
+    };
+
+    let listener_adapter = TcpTransportAdapter::new(listener_config);
+    let sender_adapter = TcpTransportAdapter::new(sender_config);
+
+    let first = match TcpSignedEnvelope::new(
+        did("sender-reconnect"),
+        did("listener-reconnect"),
+        1,
+        "state:reconnect",
+        "first-connect",
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("first envelope build failed: {error}"),
+    };
+    let second = match TcpSignedEnvelope::new(
+        did("sender-reconnect"),
+        did("listener-reconnect"),
+        2,
+        "state:reconnect",
+        "second-connect",
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("second envelope build failed: {error}"),
+    };
+
+    let first_listener = listener_adapter.clone();
+    let first_thread = thread::spawn(move || first_listener.listen_once());
+    thread::sleep(Duration::from_millis(30));
+
+    if let Err(error) = sender_adapter.send(&first) {
+        panic!("first send failed: {error}");
+    }
+    let first_received = match first_thread.join() {
+        Ok(result) => match result {
+            Ok(value) => value,
+            Err(error) => panic!("first listen failed: {error}"),
+        },
+        Err(_) => panic!("first listener thread panicked"),
+    };
+    assert_eq!(first_received.envelope, first);
+
+    let second_listener = listener_adapter.clone();
+    let second_thread = thread::spawn(move || second_listener.listen_once());
+    thread::sleep(Duration::from_millis(30));
+
+    if let Err(error) = sender_adapter.send(&second) {
+        panic!("second send failed: {error}");
+    }
+    let second_received = match second_thread.join() {
+        Ok(result) => match result {
+            Ok(value) => value,
+            Err(error) => panic!("second listen failed: {error}"),
+        },
+        Err(_) => panic!("second listener thread panicked"),
+    };
+    assert_eq!(second_received.envelope, second);
+}
+
+#[test]
+fn integration_tcp_adapter_replay_nonce_is_rejected_across_reconnect() {
+    let addr = free_addr();
+
+    let listener_config = match TcpTransportConfig::new(addr.as_str()) {
+        Ok(value) => value,
+        Err(error) => panic!("listener config failed: {error}"),
+    };
+    let sender_config = match TcpTransportConfig::new(addr.as_str()) {
+        Ok(value) => value,
+        Err(error) => panic!("sender config failed: {error}"),
+    };
+
+    let listener_adapter = TcpTransportAdapter::new(listener_config);
+    let sender_adapter = TcpTransportAdapter::new(sender_config);
+
+    let first = match TcpSignedEnvelope::new(
+        did("sender-replay"),
+        did("listener-replay"),
+        9,
+        "state:replay",
+        "nonce-9-initial",
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("first envelope build failed: {error}"),
+    };
+    let replayed = match TcpSignedEnvelope::new(
+        did("sender-replay"),
+        did("listener-replay"),
+        9,
+        "state:replay",
+        "nonce-9-replayed",
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("replayed envelope build failed: {error}"),
+    };
+
+    let first_listener = listener_adapter.clone();
+    let first_thread = thread::spawn(move || first_listener.listen_once());
+    thread::sleep(Duration::from_millis(30));
+    if let Err(error) = sender_adapter.send(&first) {
+        panic!("first send failed: {error}");
+    }
+    match first_thread.join() {
+        Ok(result) => {
+            if let Err(error) = result {
+                panic!("first listen failed: {error}");
+            }
+        }
+        Err(_) => panic!("first listener thread panicked"),
+    }
+
+    let replay_listener = listener_adapter.clone();
+    let replay_thread = thread::spawn(move || replay_listener.listen_once());
+    thread::sleep(Duration::from_millis(30));
+    if let Err(error) = sender_adapter.send(&replayed) {
+        panic!("replay send failed: {error}");
+    }
+    let replay_result = match replay_thread.join() {
+        Ok(result) => result,
+        Err(_) => panic!("replay listener thread panicked"),
+    };
+    assert_eq!(
+        replay_result,
+        Err(SdkError::Conflict("tcp handshake replay detected"))
+    );
+}
+
+#[test]
 fn regression_tampered_tcp_envelope_signature_is_rejected() {
     // Regression: #822
     let signature = signature_for_fields(
@@ -181,6 +341,58 @@ signature={signature}\n"
         Err(SdkError::InvalidInput {
             field: "signature",
             reason: "does not match deterministic envelope fields",
+        })
+    );
+}
+
+#[test]
+fn regression_forged_handshake_frame_is_rejected() {
+    // Regression: #823
+    let addr = free_addr();
+    let listener_config = match TcpTransportConfig::new(addr.as_str()) {
+        Ok(value) => value,
+        Err(error) => panic!("listener config failed: {error}"),
+    };
+    let listener_adapter = TcpTransportAdapter::new(listener_config);
+
+    let envelope = match TcpSignedEnvelope::new(
+        did("sender-forged"),
+        did("listener-forged"),
+        5,
+        "state:forged",
+        "forged-handshake-frame",
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("envelope build failed: {error}"),
+    };
+
+    let forged_payload = format!(
+        "frame=handshake\n\
+version=1\n\
+profile=ed25519:baseline-v1\n\
+from={}\n\
+to={}\n\
+nonce={}\n\
+signature=sig:ed25519:baseline-v1:forged-signature\n\n{}",
+        envelope.from,
+        envelope.to,
+        envelope.nonce,
+        envelope.to_wire_payload()
+    );
+
+    let listener_thread = thread::spawn(move || listener_adapter.listen_once());
+    thread::sleep(Duration::from_millis(30));
+    send_raw_payload(addr.as_str(), forged_payload.as_str());
+
+    let listener_result = match listener_thread.join() {
+        Ok(result) => result,
+        Err(_) => panic!("listener thread panicked"),
+    };
+    assert_eq!(
+        listener_result,
+        Err(SdkError::InvalidInput {
+            field: "handshake.signature",
+            reason: "does not match envelope signature",
         })
     );
 }

--- a/docs/foundation/rust-sdk-alpha.md
+++ b/docs/foundation/rust-sdk-alpha.md
@@ -67,8 +67,16 @@ The SDK now includes a deterministic TCP relay adapter demo backed by reusable w
   - `verified=true`
   - `adapter=tcp`
   - `signature=sig:ed25519:baseline-v1:...`
+  - handshake profile validation uses `ed25519:baseline-v1`
+
+Security guard behavior now fails closed across reconnect cycles:
+
+- Forged handshake frames are rejected with explicit handshake field classification.
+- Replayed nonces for the same `(from, to)` route are rejected with:
+  - `conflict: tcp handshake replay detected`
 
 `Regression: #822` ensures deterministic envelope parsing rejects malformed payloads and preserves signed relay markers.
+`Regression: #823` ensures forged handshake frames and replayed nonces are rejected across reconnect.
 
 ## Local End-to-End Demo (Issue #770)
 The SDK now includes a deterministic one-command demo for first-run validation:


### PR DESCRIPTION
## Summary
Adds deterministic TCP handshake framing validation and nonce replay-guard persistence across reconnects in the Rust SDK TCP transport adapter. This ensures forged/replayed handshake traffic fails closed while preserving fast, low-cost CI coverage.

## Changes
- `crates/kamn-sdk/src/tcp.rs`: Added deterministic handshake frame encode/parse/verification, frame delimiter handling, and adapter-shared replay-guard state keyed by `(from,to)` nonce progression.
- `crates/kamn-sdk/tests/tcp_transport_adapter.rs`: Added reconnect nonce progression functional test, replay rejection integration test, and forged-handshake regression test (`Regression: #823`).
- `docs/foundation/rust-sdk-alpha.md`: Documented handshake profile checks and replay-guard fail-closed behavior for TCP relay adapter.
- `crates/kamn-sdk/tests/rust_sdk_alpha_docs.rs`: Added docs regression assertions for `#823` markers.

## Risks & Compatibility
- Low risk: transport wire payload now requires handshake frame + delimiter before envelope payload. Legacy envelope-only raw senders will fail closed by design.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-sdk -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `bash scripts/sdk/test_run_rust_live_transport_contract_lane.sh` and `bash scripts/sdk/test_run_tcp_signed_relay_demo.sh`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅  | deterministic envelope parser + duplicate-key checks |
| Functional  | ✅  | two-process relay and reconnect nonce progression tests |
| Integration | ✅  | oversized wire rejection + replay nonce rejection across reconnect |
| Regression  | ✅  | forged handshake frame fail-closed + docs contract markers (`Regression: #823`) |

Closes #823
