### PR TITLE
feat(bridges): add localhost demo evidence policy lane (#859)

### DIFF
--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -11,6 +11,9 @@ fn live_network_wave_doc_contains_smoke_commands_and_schema() {
     assert!(LIVE_NETWORK_WAVE_DOC.contains("run_bridge_replay_redaction_contract_lane.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("run_bridge_replay_redaction_deep_lane.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("check_bridge_replay_redaction_policy.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("run_localhost_bridge_demo_evidence_contract_lane.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("check_localhost_bridge_demo_policy.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("kamn.bridge.localhost-demo-evidence.v1"));
 }
 
 #[test]

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -30,10 +30,14 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
 
 - PR-fast bridge evidence lane (bounded):
   - `bash scripts/bridge/run_bridge_replay_redaction_contract_lane.sh --skip-replay --replay-report-file bridge-replay-report.json`
+- PR-fast localhost bridge demo evidence lane (bounded):
+  - `bash scripts/bridge/run_localhost_bridge_demo_evidence_contract_lane.sh`
 - Scheduled/manual bridge evidence lane (deep):
   - `bash scripts/bridge/run_bridge_replay_redaction_deep_lane.sh --output-json /tmp/bridge-replay-redaction-deep-report.json`
 - Bridge evidence bundle policy checker:
   - `bash scripts/bridge/check_bridge_replay_redaction_policy.sh --bundle-file /tmp/bridge-replay-redaction-deep-report.json`
+- Localhost bridge demo evidence policy checker:
+  - `bash scripts/bridge/check_localhost_bridge_demo_policy.sh --bundle-file /tmp/localhost-bridge-demo-evidence.json`
 
 ## Evidence Contract
 
@@ -41,6 +45,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `kamn.runtime.live-network-smoke-report.v1`
 - Pilot summary schema:
   - `kamn.runtime.live-network-pilot-artifact-summary.v1`
+- Localhost bridge demo evidence schema:
+  - `kamn.bridge.localhost-demo-evidence.v1`
 - Required smoke report fields:
   - `status`
   - `final_decision`
@@ -71,6 +77,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `run_live_network_pilot_deep_lane.sh` rejects non-`schedule` and non-`workflow_dispatch` events.
 - Bridge PR-fast budget:
   - `run_bridge_replay_redaction_contract_lane.sh` enforces a 120-second upper bound.
+- Localhost bridge demo evidence budget:
+  - `run_localhost_bridge_demo_evidence_contract_lane.sh` enforces a 120-second upper bound.
 - Bridge deep lane budget:
   - `run_bridge_replay_redaction_deep_lane.sh` enforces a 300-second upper bound.
 - Regression guard:

--- a/scripts/bridge/check_localhost_bridge_demo_policy.sh
+++ b/scripts/bridge/check_localhost_bridge_demo_policy.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/bridge/check_localhost_bridge_demo_policy.sh \
+    --bundle-file <path>
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "lane",
+    "relay",
+    "replay",
+    "ci_fast_gate",
+    "decision_reasons",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+if payload["schema_version"] != "kamn.bridge.localhost-demo-evidence.v1":
+    fail("unexpected schema_version for localhost bridge demo evidence bundle")
+
+lane = payload["lane"]
+if lane not in {"contract", "deep"}:
+    fail("lane must be contract or deep")
+
+if payload["ci_fast_gate"] not in {"PASS", "FAIL"}:
+    fail("ci_fast_gate must be PASS or FAIL")
+
+if not isinstance(payload["decision_reasons"], list) or not all(
+    isinstance(item, str) for item in payload["decision_reasons"]
+):
+    fail("decision_reasons must be an array of strings")
+
+relay = payload["relay"]
+if not isinstance(relay, dict):
+    fail("relay must be an object")
+for field in ("signed_transport", "relay_contracts", "completion_marker_present"):
+    if field not in relay:
+        fail(f"relay missing field: {field}")
+if not isinstance(relay["signed_transport"], str):
+    fail("relay.signed_transport must be a string")
+if not isinstance(relay["relay_contracts"], str):
+    fail("relay.relay_contracts must be a string")
+if not isinstance(relay["completion_marker_present"], bool):
+    fail("relay.completion_marker_present must be a boolean")
+
+replay = payload["replay"]
+if not isinstance(replay, dict):
+    fail("replay must be an object")
+for field in ("status", "case_count", "failed_count", "requested_suites", "failed_case_ids"):
+    if field not in replay:
+        fail(f"replay missing field: {field}")
+if replay["status"] not in {"pass", "fail"}:
+    fail("replay.status must be pass or fail")
+if not isinstance(replay["case_count"], int):
+    fail("replay.case_count must be an integer")
+if not isinstance(replay["failed_count"], int):
+    fail("replay.failed_count must be an integer")
+if not isinstance(replay["requested_suites"], list):
+    fail("replay.requested_suites must be an array")
+if not isinstance(replay["failed_case_ids"], list):
+    fail("replay.failed_case_ids must be an array")
+
+expected_go = True
+if relay["signed_transport"] != "pass":
+    expected_go = False
+if relay["relay_contracts"] != "pass":
+    expected_go = False
+if relay["completion_marker_present"] is not True:
+    expected_go = False
+if replay["status"] != "pass":
+    expected_go = False
+if replay["case_count"] <= 0:
+    expected_go = False
+if replay["failed_count"] > 0:
+    expected_go = False
+if lane == "contract" and payload["ci_fast_gate"] != "PASS":
+    expected_go = False
+
+expected_decision = "GO" if expected_go else "NO-GO"
+actual_decision = payload["final_decision"]
+if actual_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+if actual_decision != expected_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {actual_decision}"
+    )
+
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"final_decision={actual_decision}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/bridge/generate_localhost_bridge_demo_evidence_bundle.sh
+++ b/scripts/bridge/generate_localhost_bridge_demo_evidence_bundle.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/bridge/generate_localhost_bridge_demo_evidence_bundle.sh \
+    --output-file <path> \
+    --lane contract|deep \
+    --relay-lane-output-file <path> \
+    --replay-report-file <path> \
+    --ci-fast-gate PASS|FAIL
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+output_file=""
+lane=""
+relay_lane_output_file=""
+replay_report_file=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --lane)
+      lane="${2:-}"
+      shift 2
+      ;;
+    --relay-lane-output-file)
+      relay_lane_output_file="${2:-}"
+      shift 2
+      ;;
+    --replay-report-file)
+      replay_report_file="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$lane" || -z "$relay_lane_output_file" || -z "$replay_report_file" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all localhost bridge demo evidence bundle arguments are required"
+fi
+
+if [[ ! -f "$relay_lane_output_file" ]]; then
+  fail "relay lane output file not found: $relay_lane_output_file"
+fi
+
+if [[ ! -f "$replay_report_file" ]]; then
+  fail "replay report file not found: $replay_report_file"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$lane" "$relay_lane_output_file" "$replay_report_file" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def read_marker(output: str, key: str) -> str:
+    prefix = f"{key}="
+    for line in output.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    return "missing"
+
+
+(
+    output_file,
+    generated_at,
+    lane,
+    relay_lane_output_file,
+    replay_report_file,
+    ci_fast_gate,
+) = sys.argv[1:]
+
+if lane not in {"contract", "deep"}:
+    fail("lane must be contract or deep")
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci-fast-gate must be PASS or FAIL")
+
+relay_output = pathlib.Path(relay_lane_output_file).read_text()
+replay_payload = json.loads(pathlib.Path(replay_report_file).read_text())
+
+signed_transport = read_marker(relay_output, "bridge_demo_signed_transport")
+relay_contracts = read_marker(relay_output, "bridge_demo_relay_contracts")
+completion_marker_present = "localhost bridge relay demo contract lane tests passed." in relay_output
+
+replay_status = str(replay_payload.get("status", ""))
+case_count = int(replay_payload.get("case_count", 0))
+failed_count = int(replay_payload.get("failed_count", 0))
+requested_suites = replay_payload.get("requested_suites", [])
+failed_case_ids = replay_payload.get("failed_case_ids", [])
+
+if not isinstance(requested_suites, list):
+    fail("replay report requested_suites must be an array")
+if not isinstance(failed_case_ids, list):
+    fail("replay report failed_case_ids must be an array")
+
+decision_reasons: list[str] = []
+
+if signed_transport != "pass":
+    decision_reasons.append("localhost signed transport marker is not pass")
+if relay_contracts != "pass":
+    decision_reasons.append("localhost bridge relay contracts marker is not pass")
+if not completion_marker_present:
+    decision_reasons.append("localhost bridge relay completion marker is missing")
+if replay_status != "pass":
+    decision_reasons.append("bridge replay matrix status is not pass")
+if case_count <= 0:
+    decision_reasons.append("bridge replay matrix must include at least one case")
+if failed_count > 0:
+    decision_reasons.append("bridge replay matrix reported failed cases")
+if lane == "contract" and ci_fast_gate != "PASS":
+    decision_reasons.append("ci-fast-gate-failed")
+
+final_decision = "GO" if not decision_reasons else "NO-GO"
+if not decision_reasons:
+    decision_reasons.append("all localhost bridge demo evidence invariants satisfied")
+
+payload = {
+    "schema_version": "kamn.bridge.localhost-demo-evidence.v1",
+    "generated_at": generated_at,
+    "lane": lane,
+    "relay": {
+        "signed_transport": signed_transport,
+        "relay_contracts": relay_contracts,
+        "completion_marker_present": completion_marker_present,
+    },
+    "replay": {
+        "status": replay_status,
+        "case_count": case_count,
+        "failed_count": failed_count,
+        "requested_suites": requested_suites,
+        "failed_case_ids": failed_case_ids,
+    },
+    "ci_fast_gate": ci_fast_gate,
+    "decision_reasons": decision_reasons,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/bridge/run_localhost_bridge_demo_evidence_contract_lane.sh
+++ b/scripts/bridge/run_localhost_bridge_demo_evidence_contract_lane.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RELAY_LANE_SCRIPT="$ROOT_DIR/scripts/bridge/run_localhost_bridge_relay_demo_contract_lane.sh"
+REPLAY_FIXTURE="$ROOT_DIR/fixtures/bridge_replay/replay_validation_cases.json"
+REPLAY_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_replay_matrix.sh"
+EVIDENCE_GENERATOR="$ROOT_DIR/scripts/bridge/generate_localhost_bridge_demo_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/bridge/check_localhost_bridge_demo_policy.sh"
+
+skip_replay=false
+replay_report_file=""
+output_bundle=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-replay)
+      skip_replay=true
+      shift
+      ;;
+    --replay-report-file)
+      replay_report_file="${2:-}"
+      shift 2
+      ;;
+    --output-bundle)
+      output_bundle="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$skip_replay" = true ] && [[ -z "$replay_report_file" ]]; then
+  echo "--replay-report-file is required when --skip-replay is enabled" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+start_epoch="$(date +%s)"
+
+relay_lane_output_file="$TMP_DIR/localhost-bridge-relay-contract.out"
+bash "$RELAY_LANE_SCRIPT" >"$relay_lane_output_file"
+
+if ! grep -q '^bridge_demo_signed_transport=pass$' "$relay_lane_output_file"; then
+  echo "expected localhost bridge relay contract lane signed transport marker to pass" >&2
+  exit 1
+fi
+
+if ! grep -q '^bridge_demo_relay_contracts=pass$' "$relay_lane_output_file"; then
+  echo "expected localhost bridge relay contract lane relay contract marker to pass" >&2
+  exit 1
+fi
+
+if [ "$skip_replay" = true ]; then
+  if [ ! -f "$replay_report_file" ]; then
+    echo "replay report file not found: $replay_report_file" >&2
+    exit 1
+  fi
+else
+  replay_report_file="$TMP_DIR/localhost-bridge-replay-contract-report.json"
+  bash "$REPLAY_SCRIPT" \
+    --fixture "$REPLAY_FIXTURE" \
+    --suites "bridge_adapter" \
+    --output-json "$replay_report_file" >/dev/null
+fi
+
+bundle_file="$TMP_DIR/localhost-bridge-demo-evidence-contract.json"
+bundle_output="$(
+  bash "$EVIDENCE_GENERATOR" \
+    --output-file "$bundle_file" \
+    --lane contract \
+    --relay-lane-output-file "$relay_lane_output_file" \
+    --replay-report-file "$replay_report_file" \
+    --ci-fast-gate PASS
+)"
+
+if ! printf '%s\n' "$bundle_output" | grep -q '^status=generated$'; then
+  echo "expected localhost bridge demo evidence bundle generation to succeed" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$bundle_output" | grep -q '^final_decision=GO$'; then
+  echo "expected localhost bridge demo evidence bundle final decision to be GO" >&2
+  exit 1
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$bundle_file")"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected localhost bridge demo evidence policy check to pass" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected localhost bridge demo evidence policy final decision to be GO" >&2
+  exit 1
+fi
+
+if [[ -n "$output_bundle" ]]; then
+  cp "$bundle_file" "$output_bundle"
+fi
+
+echo "localhost_bridge_demo_evidence=generated"
+echo "localhost_bridge_demo_policy=ok"
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt 120 ]; then
+  echo "localhost bridge demo evidence contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+echo "localhost bridge demo evidence contract lane tests passed."

--- a/scripts/bridge/test_generate_localhost_bridge_demo_evidence_bundle.sh
+++ b/scripts/bridge/test_generate_localhost_bridge_demo_evidence_bundle.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/bridge/generate_localhost_bridge_demo_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/bridge/check_localhost_bridge_demo_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected localhost bridge demo evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected localhost bridge demo evidence policy checker to be executable" >&2
+  exit 1
+fi
+
+go_relay_output="$TMP_DIR/relay-go.out"
+cat >"$go_relay_output" <<'EOF_RELAY_GO'
+bridge_demo_signed_transport=pass
+bridge_demo_relay_contracts=pass
+localhost bridge relay demo contract lane tests passed.
+EOF_RELAY_GO
+
+go_replay_report="$TMP_DIR/replay-go.json"
+cat >"$go_replay_report" <<'EOF_REPLAY_GO'
+{
+  "status": "pass",
+  "case_count": 2,
+  "failed_count": 0,
+  "requested_suites": ["bridge_adapter"],
+  "failed_case_ids": []
+}
+EOF_REPLAY_GO
+
+go_bundle="$TMP_DIR/localhost-bridge-demo-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --lane contract \
+    --relay-lane-output-file "$go_relay_output" \
+    --replay-report-file "$go_replay_report" \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO evidence bundle generation to succeed"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO localhost bridge demo evidence decision"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO localhost bridge demo policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO localhost bridge demo policy decision"
+
+no_go_relay_output="$TMP_DIR/relay-no-go.out"
+cat >"$no_go_relay_output" <<'EOF_RELAY_NOGO'
+bridge_demo_signed_transport=pass
+bridge_demo_relay_contracts=pass
+localhost bridge relay demo contract lane tests passed.
+EOF_RELAY_NOGO
+
+no_go_replay_report="$TMP_DIR/replay-no-go.json"
+cat >"$no_go_replay_report" <<'EOF_REPLAY_NOGO'
+{
+  "status": "pass",
+  "case_count": 2,
+  "failed_count": 1,
+  "requested_suites": ["bridge_adapter"],
+  "failed_case_ids": ["bridge_adapter::outbound_rejects_unauthorized_approver"]
+}
+EOF_REPLAY_NOGO
+
+no_go_bundle="$TMP_DIR/localhost-bridge-demo-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --lane contract \
+    --relay-lane-output-file "$no_go_relay_output" \
+    --replay-report-file "$no_go_replay_report" \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$no_go_output" "status")" "generated" "expected NO-GO evidence bundle generation to succeed"
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO localhost bridge demo evidence decision"
+
+if ! grep -q '"bridge replay matrix reported failed cases"' "$no_go_bundle"; then
+  echo "expected replay drift reason marker in NO-GO localhost bridge demo evidence bundle" >&2
+  exit 1
+fi
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO localhost bridge demo policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO localhost bridge demo policy decision"
+
+tampered_bundle="$TMP_DIR/localhost-bridge-demo-tampered.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered localhost bridge demo evidence bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch error for tampered localhost bridge demo bundle" >&2
+  exit 1
+fi
+
+# Regression: #859
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO decision mismatch in localhost bridge demo regression path" >&2
+  exit 1
+fi
+
+echo "localhost bridge demo evidence bundle tests passed."

--- a/scripts/bridge/test_run_localhost_bridge_demo_evidence_contract_lane.sh
+++ b/scripts/bridge/test_run_localhost_bridge_demo_evidence_contract_lane.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/bridge/run_localhost_bridge_demo_evidence_contract_lane.sh"
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected localhost bridge demo evidence contract lane script to be executable" >&2
+  exit 1
+fi
+
+TMP_OUT="$(mktemp)"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+bash "$LANE_SCRIPT" >"$TMP_OUT"
+
+required_markers=(
+  "localhost_bridge_demo_evidence=generated"
+  "localhost_bridge_demo_policy=ok"
+  "localhost bridge demo evidence contract lane tests passed."
+)
+
+for marker in "${required_markers[@]}"; do
+  if ! grep -Fq -- "$marker" "$TMP_OUT"; then
+    echo "expected localhost bridge demo evidence lane output marker '$marker'" >&2
+    exit 1
+  fi
+done
+
+if ! grep -q "run_localhost_bridge_relay_demo_contract_lane.sh" "$LANE_SCRIPT"; then
+  echo "expected localhost bridge demo evidence lane to execute localhost relay contract baseline" >&2
+  exit 1
+fi
+
+if ! grep -q "run_bridge_replay_matrix.sh" "$LANE_SCRIPT"; then
+  echo "expected localhost bridge demo evidence lane to execute replay matrix evidence capture" >&2
+  exit 1
+fi
+
+if ! grep -q "generate_localhost_bridge_demo_evidence_bundle.sh" "$LANE_SCRIPT"; then
+  echo "expected localhost bridge demo evidence lane to generate evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q "check_localhost_bridge_demo_policy.sh" "$LANE_SCRIPT"; then
+  echo "expected localhost bridge demo evidence lane to enforce policy checker" >&2
+  exit 1
+fi
+
+echo "localhost bridge demo evidence contract lane script tests passed."

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -85,6 +85,8 @@ bash "$ROOT_DIR/scripts/bridge/test_generate_bridge_replay_redaction_evidence_bu
 bash "$ROOT_DIR/scripts/bridge/test_run_bridge_replay_redaction_contract_lane.sh"
 bash "$ROOT_DIR/scripts/bridge/test_run_bridge_replay_redaction_deep_lane.sh"
 bash "$ROOT_DIR/scripts/bridge/test_run_localhost_bridge_relay_demo_contract_lane.sh"
+bash "$ROOT_DIR/scripts/bridge/test_generate_localhost_bridge_demo_evidence_bundle.sh"
+bash "$ROOT_DIR/scripts/bridge/test_run_localhost_bridge_demo_evidence_contract_lane.sh"
 bash "$ROOT_DIR/scripts/deploy/test_preflight_topology.sh"
 bash "$ROOT_DIR/scripts/deploy/test_generate_bundle.sh"
 bash "$ROOT_DIR/scripts/deploy/test_generate_gonogo_evidence_bundle.sh"


### PR DESCRIPTION
## Summary
- Adds deterministic localhost bridge demo evidence bundling and policy validation so demo runs produce auditable GO/NO-GO artifacts.
- Introduces a bounded localhost bridge demo evidence contract lane with replay/tamper fail-closed checks.

## Linked Issues
- Closes #859

## Changes
- `scripts/bridge/generate_localhost_bridge_demo_evidence_bundle.sh`: new generator for schema `kamn.bridge.localhost-demo-evidence.v1` with deterministic decision reasons and GO/NO-GO output.
- `scripts/bridge/check_localhost_bridge_demo_policy.sh`: new policy checker that recomputes decision invariants and fails closed on mismatch.
- `scripts/bridge/run_localhost_bridge_demo_evidence_contract_lane.sh`: new bounded contract lane that executes relay baseline + replay subset + evidence/policy checks.
- `scripts/bridge/test_generate_localhost_bridge_demo_evidence_bundle.sh`: GO, NO-GO, replay-drift marker, and tampered-final-decision regression coverage.
- `scripts/bridge/test_run_localhost_bridge_demo_evidence_contract_lane.sh`: contract-lane marker and wiring assertions.
- `scripts/ci/test_ci_tools.sh`: adds new bridge evidence tests to CI tool regression harness.
- `docs/planning/live-network-wave.md` and `crates/kamn-core/tests/live_network_wave_docs.rs`: documents and verifies localhost bridge demo evidence lane commands/schema/policy references.

## Risks & Compatibility
- None

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed localhost bridge evidence generator and contract lane tests and confirmed deterministic markers plus fail-closed tamper handling.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: None directly; CI regression surface changed via `scripts/ci/test_ci_tools.sh`.
Expected runtime delta: low single-digit seconds added to CI tool regression script execution.
Expected runner-minute delta: near-zero incremental cost on bridge-related validation runs.
Rollback plan if CI cost/runtime regresses: remove the two new bridge evidence script-test invocations from `scripts/ci/test_ci_tools.sh` while preserving the scripts for manual/targeted execution.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Evidence schema/policy field contracts validated by generator/policy script tests. |
| Functional  | ✅     | GO and NO-GO localhost demo evidence generation and policy outcomes asserted. |
| Integration | ✅     | Contract lane + CI tool hook coverage validated through script tests and full ci-tools suite. |
| Regression  | ✅     | Tampered `final_decision` and replay drift NO-GO mismatch are fail-closed (`Regression: #859`). |
