### PR TITLE
fix(ci): pin fast-gate Node runtime for dashboard lanes (#867)

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -65,6 +65,12 @@ jobs:
           bash scripts/deploy/test_generate_dr_evidence_bundle.sh
           bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
 
+      - name: Set up Node.js runtime
+        if: steps.scope.outputs.run_frontend_dashboard_tests == 'true' || steps.scope.outputs.run_dashboard_contract_tests == 'true' || steps.scope.outputs.run_typescript_live_transport_contract_tests == 'true' || steps.scope.outputs.run_live_transport_parity_contract_tests == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Run frontend dashboard tests
         if: steps.scope.outputs.run_frontend_dashboard_tests == 'true'
         run: bash scripts/frontend/test_dashboard_package.sh

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ make demo
 ```
 
 Deep/scheduled lanes remain opt-in via scripts in `scripts/sdk/` and `scripts/ci/`.
+CI fast gate provisions Node.js 22 for frontend and TypeScript contract lanes.
 
 ### Run A Focused Core Slice
 

--- a/scripts/ci/test_readme_contract.sh
+++ b/scripts/ci/test_readme_contract.sh
@@ -35,6 +35,7 @@ required_snippets=(
   "run_localhost_bridge_demo_evidence_contract_lane.sh"
   "run_localhost_bridge_demo_evidence_deep_lane.sh"
   "kamn.bridge.localhost-demo-evidence.v1"
+  "Node.js 22"
   "AGENTS.md"
   "PRD.md"
 )

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -50,6 +50,21 @@ if ! grep -Fq "bash scripts/deploy/test_run_dr_evidence_contract_lane.sh" "$FAST
   exit 1
 fi
 
+if ! grep -Fq "uses: actions/setup-node@v4" "$FAST_WORKFLOW"; then
+  echo "expected Node.js runtime setup step in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "if: steps.scope.outputs.run_frontend_dashboard_tests == 'true' || steps.scope.outputs.run_dashboard_contract_tests == 'true' || steps.scope.outputs.run_typescript_live_transport_contract_tests == 'true' || steps.scope.outputs.run_live_transport_parity_contract_tests == 'true'" "$FAST_WORKFLOW"; then
+  echo "expected Node.js runtime setup scope condition in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "node-version: '22'" "$FAST_WORKFLOW"; then
+  echo "expected Node.js 22 runtime pin in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 if ! grep -Fq "if: steps.scope.outputs.run_frontend_dashboard_tests == 'true'" "$FAST_WORKFLOW"; then
   echo "expected frontend dashboard scope condition in ci-fast-gate.yml" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Pin fast-gate Node runtime setup for frontend and TypeScript dashboard contract lanes.
- Enforce the runtime wiring with workflow scope policy assertions.
- Update README contract expectations to keep docs and CI policy in sync.

## Linked Issues
- Closes #867

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Local checks:
- bash scripts/ci/test_workflow_scope_policy.sh
- bash scripts/ci/test_readme_contract.sh
- cargo fmt --check
- cargo clippy -- -D warnings
- bash scripts/ci/test_ci_tools.sh

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: .github/workflows/ci-fast-gate.yml
- Expected runtime delta: Near-zero; adds one setup-node step only when frontend/TypeScript lanes are selected.
- Expected runner-minute delta: Small bounded increase on affected lanes; no impact on unrelated lanes.
- Rollback plan if CI cost/runtime regresses: Revert commit 5751718 or disable the setup-node step conditionally and rerun workflow policy tests.

## Risks & Compatibility
- None expected; behavior is additive and scoped by existing lane selectors.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Workflow scope assertions in scripts/ci/test_workflow_scope_policy.sh |
| Functional  | ✅ | Frontend/TypeScript lane runtime setup conditioned by scope outputs |
| Integration | ✅ | scripts/ci/test_ci_tools.sh includes policy/contract lanes |
| Regression  | ✅ | Guards missing runtime setup for #867 |
