### PR TITLE
test(ci): add dashboard runtime compatibility regression contracts (#868)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ KAMN (Kolme AI Agent Messaging Network) is a privacy-first, auditable coordinati
 - Node.js/npm (only needed for dashboard/TypeScript lanes)
 - Dashboard package lane auto-falls back to `npx -y node@22` when local Node lacks `--experimental-strip-types`
 
+### Dashboard Runtime Compatibility (CI + Local)
+
+```bash
+# Runtime compatibility regression contract
+bash scripts/frontend/test_dashboard_package_runtime_compat.sh
+
+# Frontend/backend dashboard contract lane
+bash scripts/frontend/test_dashboard_contract_lane.sh
+```
+
+For hosts where the default `node` binary does not support `--experimental-strip-types`, run:
+
+```bash
+KAMN_DASHBOARD_NODE_BIN=node \
+KAMN_DASHBOARD_FALLBACK_NODE_CMD="npx -y node@22" \
+bash scripts/frontend/test_dashboard_package.sh
+```
+
 ### Validate Local Environment
 
 ```bash

--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -15,6 +15,8 @@ fn live_network_wave_doc_contains_smoke_commands_and_schema() {
     assert!(LIVE_NETWORK_WAVE_DOC.contains("run_localhost_bridge_demo_evidence_deep_lane.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("check_localhost_bridge_demo_policy.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("kamn.bridge.localhost-demo-evidence.v1"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("test_dashboard_package_runtime_compat.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("npx -y node@22"));
 }
 
 #[test]
@@ -24,6 +26,9 @@ fn regression_budget_guard_marker_is_documented() {
     assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #828`"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("120-second upper bound"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("300-second upper bound"));
+    // Regression: #868
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #868`"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("node@22"));
 }
 
 #[test]

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -85,7 +85,12 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `run_localhost_bridge_demo_evidence_deep_lane.sh` enforces a 300-second upper bound.
 - Bridge deep lane budget:
   - `run_bridge_replay_redaction_deep_lane.sh` enforces a 300-second upper bound.
+- Dashboard runtime compatibility guard:
+  - `bash scripts/frontend/test_dashboard_package_runtime_compat.sh` validates fallback behavior when local `node` lacks `--experimental-strip-types`.
+  - `scripts/frontend/test_dashboard_package.sh` defaults fallback execution to `npx -y node@22` in fail-closed mode.
 - Regression guard:
   - budget overflow remains fail-closed with explicit reason code `runtime_budget_exceeded` (`Regression: #828`).
 - Regression guard:
   - tampered pilot summary `final_decision` is rejected by policy checker (`Regression: #829`).
+- Regression guard:
+  - dashboard runtime fallback contract remains pinned to `node@22` with local reproduction guidance (`Regression: #868`).

--- a/scripts/ci/test_readme_contract.sh
+++ b/scripts/ci/test_readme_contract.sh
@@ -36,6 +36,9 @@ required_snippets=(
   "run_localhost_bridge_demo_evidence_deep_lane.sh"
   "kamn.bridge.localhost-demo-evidence.v1"
   "Node.js 22"
+  "bash scripts/frontend/test_dashboard_package_runtime_compat.sh"
+  "KAMN_DASHBOARD_NODE_BIN"
+  "KAMN_DASHBOARD_FALLBACK_NODE_CMD"
   "AGENTS.md"
   "PRD.md"
 )

--- a/scripts/frontend/test_dashboard_package_runtime_compat.sh
+++ b/scripts/frontend/test_dashboard_package_runtime_compat.sh
@@ -130,4 +130,44 @@ if ! printf '%s\n' "$failure_output" | grep -q "set KAMN_DASHBOARD_FALLBACK_NODE
   exit 1
 fi
 
+# Regression: #868
+: >"$marker_file"
+create_fake_node "$primary_binary" "reject" "$marker_file" "primary"
+
+cat >"$TMP_DIR/npx" <<'FAKE_NPX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+MARKER_FILE="${KAMN_DASHBOARD_RUNTIME_MARKER_FILE:?}"
+if [[ "${1:-}" != "-y" || "${2:-}" != "node@22" ]]; then
+  echo "expected default fallback command to invoke 'npx -y node@22'" >&2
+  exit 33
+fi
+
+if [[ "${3:-}" == "--experimental-strip-types" && "${4:-}" == "-e" ]]; then
+  exit 0
+fi
+
+if [[ "${3:-}" == "--experimental-strip-types" && "${4:-}" == "--test" ]]; then
+  printf '%s\n' "default-fallback" >>"$MARKER_FILE"
+  exit 0
+fi
+
+exit 0
+FAKE_NPX
+chmod +x "$TMP_DIR/npx"
+
+env -u KAMN_DASHBOARD_FALLBACK_NODE_CMD \
+  PATH="$TMP_DIR:$PATH" \
+  KAMN_DASHBOARD_RUNTIME_MARKER_FILE="$marker_file" \
+  KAMN_DASHBOARD_NODE_BIN="$primary_binary.wrapper" \
+  KAMN_DASHBOARD_TEST_TARGET_GLOB="./packages/kamn-dashboard/tests/dashboard.test.ts" \
+  bash "$SCRIPT_UNDER_TEST"
+
+assert_contains "$marker_file" "default-fallback" "expected dashboard package script to use default node@22 fallback when primary runtime probing fails"
+if grep -Fq "primary" "$marker_file"; then
+  echo "expected dashboard package script to avoid primary node execution when default fallback is selected" >&2
+  exit 1
+fi
+
 echo "dashboard package runtime compatibility tests passed."


### PR DESCRIPTION
## Summary
- Add a regression contract for the default dashboard fallback path so CI fails if `test_dashboard_package.sh` stops using `npx -y node@22` when primary Node probing fails.
- Expand README runtime compatibility guidance with explicit local reproduction commands/env vars.
- Extend docs contracts so live-network planning docs and README checks lock the new runtime guidance in place.

## Linked Issues
- Closes #868

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Local checks:
- bash scripts/ci/test_readme_contract.sh
- bash scripts/frontend/test_dashboard_package_runtime_compat.sh
- cargo test -p kamn-core --test live_network_wave_docs
- cargo fmt --check
- cargo clippy -- -D warnings
- bash scripts/ci/test_ci_tools.sh

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert commit 8cd33d3.

## Risks & Compatibility
- Low risk; changes are test/doc contracts and do not alter production runtime behavior.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | README/docs contract assertions updated |
| Functional  | ✅ | Dashboard fallback behavior verified with default `npx -y node@22` path |
| Integration | ✅ | CI tool regression suite includes updated contracts |
| Regression  | ✅ | Explicit `Regression: #868` guard for runtime fallback docs/contract |
