### PR TITLE
docs(runtime): add localhost transport demo entrypoint contracts (#877)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help check test smoke-live-network deep-live-network demo ci-tools
+.PHONY: help check test smoke-live-network deep-live-network demo demo-localhost-transport ci-tools
 
 help:
 	@echo "KAMN developer lanes"
@@ -9,6 +9,7 @@ help:
 	@echo "  make smoke-live-network - bounded pilot smoke lane + JSON report"
 	@echo "  make deep-live-network - scheduled/manual pilot deep lane summary report"
 	@echo "  make demo   - two-process localhost signed-message demo"
+	@echo "  make demo-localhost-transport - explicit localhost sender/listener transport demo"
 	@echo "  make ci-tools - CI helper regression suite"
 	@echo "Deep/scheduled lanes remain opt-in via scripts/sdk/run_rust_live_transport_deep_lane.sh and related scripts."
 
@@ -26,6 +27,9 @@ deep-live-network:
 	bash scripts/runtime/run_live_network_pilot_deep_lane.sh --event-name workflow_dispatch --output-json /tmp/live-network-pilot-report.json
 
 demo:
+	bash scripts/sdk/run_localhost_signed_demo.sh
+
+demo-localhost-transport:
 	bash scripts/sdk/run_localhost_signed_demo.sh
 
 ci-tools:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ make test
 
 # Two-process localhost signed-message demo
 make demo
+
+# Explicit localhost transport sender/listener demo
+make demo-localhost-transport
 ```
 
 Deep/scheduled lanes remain opt-in via scripts in `scripts/sdk/` and `scripts/ci/`.
@@ -81,6 +84,8 @@ bash scripts/ci/test_select_targets.sh
 
 ```bash
 bash scripts/sdk/run_local_e2e_demo.sh
+# localhost signed sender/listener transport
+bash scripts/sdk/run_localhost_signed_demo.sh
 ```
 
 ### Run Localhost Bridge Relay Demo Lane

--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -35,10 +35,18 @@ fn regression_budget_guard_marker_is_documented() {
 fn readme_and_makefile_expose_live_network_entrypoints() {
     assert!(README.contains("make smoke-live-network"));
     assert!(README.contains("make deep-live-network"));
+    assert!(README.contains("make demo-localhost-transport"));
     assert!(README.contains("run_localhost_bridge_demo_evidence_contract_lane.sh"));
     assert!(README.contains("run_localhost_bridge_demo_evidence_deep_lane.sh"));
     assert!(MAKEFILE.contains("smoke-live-network:"));
     assert!(MAKEFILE.contains("deep-live-network:"));
     assert!(MAKEFILE.contains("run_live_network_smoke_lane.sh"));
     assert!(MAKEFILE.contains("run_live_network_pilot_deep_lane.sh"));
+}
+
+#[test]
+fn regression_localhost_transport_demo_entrypoint_is_documented() {
+    // Regression: #877
+    assert!(README.contains("run_localhost_signed_demo.sh"));
+    assert!(MAKEFILE.contains("demo-localhost-transport:"));
 }

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -15,6 +15,7 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
 - Makefile developer entrypoints:
   - `make smoke-live-network`
   - `make deep-live-network`
+  - `make demo-localhost-transport`
 - Direct smoke runner:
   - `bash scripts/runtime/run_live_network_smoke_lane.sh --output-json /tmp/live-network-smoke-report.json`
 - Smoke contract lane:
@@ -25,6 +26,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `bash scripts/runtime/run_live_network_pilot_deep_contract_lane.sh`
 - Deep summary policy checker:
   - `bash scripts/runtime/check_live_network_pilot_artifact_summary_policy.sh --summary-file /tmp/live-network-pilot-report.json`
+- Localhost signed sender/listener transport demo:
+  - `bash scripts/sdk/run_localhost_signed_demo.sh`
 
 ## Bridge Replay/Redaction Lane Matrix
 

--- a/scripts/ci/test_readme_contract.sh
+++ b/scripts/ci/test_readme_contract.sh
@@ -32,6 +32,8 @@ required_snippets=(
   "live-network-smoke-report.json"
   "make deep-live-network"
   "live-network-pilot-report.json"
+  "make demo-localhost-transport"
+  "run_localhost_signed_demo.sh"
   "run_localhost_bridge_demo_evidence_contract_lane.sh"
   "run_localhost_bridge_demo_evidence_deep_lane.sh"
   "kamn.bridge.localhost-demo-evidence.v1"


### PR DESCRIPTION
## Summary
- Add an explicit `make demo-localhost-transport` developer entrypoint for the localhost signed sender/listener demo.
- Update README and live-network planning docs so the transport entrypoint is discoverable and reproducible.
- Add docs contract coverage and a regression marker to prevent entrypoint drift.

## Linked Issues
- Closes #877

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Local checks:
- bash scripts/ci/test_readme_contract.sh
- cargo test -p kamn-core --test live_network_wave_docs
- bash scripts/sdk/test_run_localhost_signed_demo.sh
- cargo fmt --check
- cargo clippy -- -D warnings
- bash scripts/ci/test_ci_tools.sh

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert commit b0cb7cc.

## Risks & Compatibility
- Low risk; this change is limited to developer entrypoints and documentation/contracts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | README/docs contract assertions |
| Functional  | ✅ | localhost demo script command verification |
| Integration | ✅ | ci-tools suite includes updated contract checks |
| Regression  | ✅ | `Regression: #877` docs drift guard |
