### PR TITLE
feat(sdk): add fail-closed localhost demo CLI args (#875)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ bash scripts/ci/test_select_targets.sh
 bash scripts/sdk/run_local_e2e_demo.sh
 # localhost signed sender/listener transport
 bash scripts/sdk/run_localhost_signed_demo.sh
+
+# inspect CLI/session arguments
+bash scripts/sdk/run_localhost_signed_demo.sh --help
+
+# explicit deterministic session arguments
+bash scripts/sdk/run_localhost_signed_demo.sh \
+  --addr 127.0.0.1:17879 \
+  --from kamn:did:agent:sender-1 \
+  --to kamn:did:agent:listener-1 \
+  --nonce 1 \
+  --timeout-seconds 15
 ```
 
 ### Run Localhost Bridge Relay Demo Lane

--- a/scripts/ci/test_readme_contract.sh
+++ b/scripts/ci/test_readme_contract.sh
@@ -34,6 +34,8 @@ required_snippets=(
   "live-network-pilot-report.json"
   "make demo-localhost-transport"
   "run_localhost_signed_demo.sh"
+  "run_localhost_signed_demo.sh --help"
+  "--timeout-seconds"
   "run_localhost_bridge_demo_evidence_contract_lane.sh"
   "run_localhost_bridge_demo_evidence_deep_lane.sh"
   "kamn.bridge.localhost-demo-evidence.v1"
@@ -46,7 +48,7 @@ required_snippets=(
 )
 
 for snippet in "${required_snippets[@]}"; do
-  if ! grep -Fq "$snippet" "$README_FILE"; then
+  if ! grep -Fq -- "$snippet" "$README_FILE"; then
     echo "README contract failed: missing snippet '$snippet'." >&2
     exit 1
   fi

--- a/scripts/sdk/run_localhost_signed_demo.sh
+++ b/scripts/sdk/run_localhost_signed_demo.sh
@@ -4,16 +4,160 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+usage() {
+  cat <<'EOF'
+Usage: run_localhost_signed_demo.sh [options]
+
+Options:
+  --addr <host:port>            Listener bind/connect address.
+  --from <did>                  Sender DID.
+  --to <did>                    Listener DID.
+  --state-hash <hash>           State hash attached to message envelope.
+  --body <text>                 Message body payload.
+  --nonce <n>                   Positive integer nonce.
+  --timeout-seconds <seconds>   Positive integer listener completion timeout.
+  --help                        Show this help output.
+
+Environment defaults:
+  KAMN_LOCALHOST_SIGNED_DEMO_ADDR
+  KAMN_LOCALHOST_SIGNED_DEMO_FROM
+  KAMN_LOCALHOST_SIGNED_DEMO_TO
+  KAMN_LOCALHOST_SIGNED_DEMO_STATE_HASH
+  KAMN_LOCALHOST_SIGNED_DEMO_BODY
+  KAMN_LOCALHOST_SIGNED_DEMO_NONCE
+  KAMN_LOCALHOST_SIGNED_DEMO_TIMEOUT_SECONDS
+EOF
+}
+
+require_arg_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [ -z "$value" ]; then
+    echo "missing value for $option" >&2
+    exit 1
+  fi
+}
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+validate_agent_did() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^kamn:did:agent:[[:alnum:]_.:-]+$ ]]; then
+    echo "$label must be a kamn agent DID (kamn:did:agent:<id>)" >&2
+    exit 1
+  fi
+}
+
 ADDR="${KAMN_LOCALHOST_SIGNED_DEMO_ADDR:-127.0.0.1:17879}"
 FROM_DID="${KAMN_LOCALHOST_SIGNED_DEMO_FROM:-kamn:did:agent:sender-1}"
 TO_DID="${KAMN_LOCALHOST_SIGNED_DEMO_TO:-kamn:did:agent:listener-1}"
 STATE_HASH="${KAMN_LOCALHOST_SIGNED_DEMO_STATE_HASH:-state:localhost-demo}"
 BODY="${KAMN_LOCALHOST_SIGNED_DEMO_BODY:-hello-from-localhost-demo}"
+NONCE="${KAMN_LOCALHOST_SIGNED_DEMO_NONCE:-1}"
+TIMEOUT_SECONDS="${KAMN_LOCALHOST_SIGNED_DEMO_TIMEOUT_SECONDS:-15}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --addr)
+      require_arg_value "$1" "${2:-}"
+      ADDR="$2"
+      shift 2
+      ;;
+    --from)
+      require_arg_value "$1" "${2:-}"
+      FROM_DID="$2"
+      shift 2
+      ;;
+    --to)
+      require_arg_value "$1" "${2:-}"
+      TO_DID="$2"
+      shift 2
+      ;;
+    --state-hash)
+      require_arg_value "$1" "${2:-}"
+      STATE_HASH="$2"
+      shift 2
+      ;;
+    --body)
+      require_arg_value "$1" "${2:-}"
+      BODY="$2"
+      shift 2
+      ;;
+    --nonce)
+      require_arg_value "$1" "${2:-}"
+      NONCE="$2"
+      shift 2
+      ;;
+    --timeout-seconds)
+      require_arg_value "$1" "${2:-}"
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$ADDR" ] || [[ "$ADDR" != *:* ]]; then
+  echo "addr must be in host:port form" >&2
+  exit 1
+fi
+
+validate_agent_did "from DID" "$FROM_DID"
+validate_agent_did "to DID" "$TO_DID"
+
+if ! is_positive_integer "$NONCE"; then
+  echo "nonce must be a positive integer" >&2
+  exit 1
+fi
+
+if ! is_positive_integer "$TIMEOUT_SECONDS"; then
+  echo "timeout-seconds must be a positive integer" >&2
+  exit 1
+fi
 
 TMP_DIR="$(mktemp -d)"
 LISTENER_OUT="$TMP_DIR/listener.out"
 SENDER_OUT="$TMP_DIR/sender.out"
-trap 'rm -rf "$TMP_DIR"' EXIT
+
+LISTENER_PID=""
+
+cleanup() {
+  if [ -n "$LISTENER_PID" ] && kill -0 "$LISTENER_PID" >/dev/null 2>&1; then
+    kill "$LISTENER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+wait_for_listener_completion() {
+  local pid="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+
+  while kill -0 "$pid" >/dev/null 2>&1; do
+    if [ "$elapsed" -ge "$timeout_seconds" ]; then
+      echo "listener did not complete within ${timeout_seconds}s" >&2
+      kill "$pid" >/dev/null 2>&1 || true
+      wait "$pid" >/dev/null 2>&1 || true
+      return 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  wait "$pid"
+}
 
 cargo run --quiet -p kamn-sdk --example localhost_signed_listener -- \
   --addr "$ADDR" \
@@ -22,22 +166,15 @@ cargo run --quiet -p kamn-sdk --example localhost_signed_listener -- \
   --state-hash "$STATE_HASH" >"$LISTENER_OUT" 2>&1 &
 LISTENER_PID=$!
 
-cleanup_listener() {
-  if kill -0 "$LISTENER_PID" >/dev/null 2>&1; then
-    kill "$LISTENER_PID" >/dev/null 2>&1 || true
-  fi
-}
-trap 'cleanup_listener; rm -rf "$TMP_DIR"' EXIT
-
 cargo run --quiet -p kamn-sdk --example localhost_signed_sender -- \
   --addr "$ADDR" \
   --from "$FROM_DID" \
   --to "$TO_DID" \
-  --nonce 1 \
+  --nonce "$NONCE" \
   --state-hash "$STATE_HASH" \
   --body "$BODY" >"$SENDER_OUT"
 
-wait "$LISTENER_PID"
+wait_for_listener_completion "$LISTENER_PID" "$TIMEOUT_SECONDS"
 
 echo "--- sender ---"
 cat "$SENDER_OUT"

--- a/scripts/sdk/test_run_localhost_signed_demo.sh
+++ b/scripts/sdk/test_run_localhost_signed_demo.sh
@@ -10,7 +10,37 @@ if [ ! -x "$DEMO_SCRIPT" ]; then
 fi
 
 TMP_OUT="$(mktemp)"
-trap 'rm -f "$TMP_OUT"' EXIT
+TMP_HELP="$(mktemp)"
+TMP_ERR="$(mktemp)"
+trap 'rm -f "$TMP_OUT" "$TMP_HELP" "$TMP_ERR"' EXIT
+
+bash "$DEMO_SCRIPT" --help >"$TMP_HELP"
+
+if ! grep -Fq -- "Usage: run_localhost_signed_demo.sh" "$TMP_HELP"; then
+  echo "expected localhost signed demo help usage banner" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "--timeout-seconds" "$TMP_HELP"; then
+  echo "expected localhost signed demo help to document --timeout-seconds" >&2
+  exit 1
+fi
+
+set +e
+bash "$DEMO_SCRIPT" --timeout-seconds 0 >"$TMP_ERR" 2>&1
+error_code=$?
+set -e
+
+if [ "$error_code" -eq 0 ]; then
+  echo "expected localhost signed demo script to reject invalid timeout argument" >&2
+  exit 1
+fi
+
+# Regression: #875
+if ! grep -Fq -- "timeout-seconds must be a positive integer" "$TMP_ERR"; then
+  echo "expected explicit timeout validation failure message" >&2
+  exit 1
+fi
 
 bash "$DEMO_SCRIPT" >"$TMP_OUT"
 


### PR DESCRIPTION
## Summary
- Add explicit CLI/session argument parsing to `scripts/sdk/run_localhost_signed_demo.sh` with fail-closed validation and bounded listener completion.
- Extend localhost demo tests with Red/Green regression coverage for help output and timeout validation (`Regression: #875`).
- Update README and README contract checks to document and enforce the new CLI usage.

## Linked Issues
- Closes #875

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Local checks:
- bash scripts/sdk/test_run_localhost_signed_demo.sh
- bash scripts/ci/test_readme_contract.sh
- cargo fmt --check
- cargo clippy -- -D warnings
- bash scripts/ci/test_ci_tools.sh

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert commit dfc562a.

## Risks & Compatibility
- Low to medium risk; script interface expanded, but defaults preserve previous behavior and test coverage guards critical paths.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | argument/help/validation assertions in script tests |
| Functional  | ✅ | localhost sender/listener demo still succeeds with defaults |
| Integration | ✅ | ci-tools regression suite remains green |
| Regression  | ✅ | explicit `Regression: #875` timeout-validation guard |
