### PR TITLE
test(sdk): enforce localhost integration evidence key contracts (#899)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh \
   --output-json /tmp/localhost-signed-integration-contract-report.json
 bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json
 # schema: kamn.sdk.localhost-signed.integration-contract.v1
+# deterministic keys:
+# contract_key=localhost_signed_integration_contract:v1
+# success_evidence_key=localhost_signed_integration:success:v1
+# signature_mismatch_evidence_key=localhost_signed_integration:signature-mismatch:v1
+# timeout_evidence_key=localhost_signed_integration:timeout:v1
 ```
 
 CI fast-gate routes this lane when selector output

--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -19,6 +19,10 @@ fn live_network_wave_doc_contains_smoke_commands_and_schema() {
     assert!(LIVE_NETWORK_WAVE_DOC.contains("run_localhost_signed_integration_contract_lane.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("check_localhost_signed_integration_evidence_policy.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("kamn.sdk.localhost-signed.integration-contract.v1"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("contract_key"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("success_evidence_key"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("signature_mismatch_evidence_key"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("timeout_evidence_key"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("test_dashboard_package_runtime_compat.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("npx -y node@22"));
 }
@@ -39,6 +43,9 @@ fn regression_budget_guard_marker_is_documented() {
     // Regression: #880
     assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #880`"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("policy checker preserves schema and reason-code"));
+    // Regression: #899
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #899`"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("deterministic evidence keys"));
     // Regression: #868
     assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #868`"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("node@22"));

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -196,3 +196,16 @@ fn doc_contains_invariant_fuzz_concurrency_contract_rules() {
     assert!(DOC.contains("check_invariant_fuzz_concurrency_policy.sh"));
     assert!(DOC.contains("kamn.runtime.invariant-fuzz-concurrency-contract-report.v1"));
 }
+
+#[test]
+fn doc_contains_localhost_signed_integration_evidence_key_contract_rules() {
+    assert!(DOC.contains("## Localhost Signed Integration Evidence Key Contract Rules"));
+    assert!(DOC.contains("run_localhost_signed_integration_harness.sh"));
+    assert!(DOC.contains("run_localhost_signed_integration_contract_lane.sh"));
+    assert!(DOC.contains("check_localhost_signed_integration_evidence_policy.sh"));
+    assert!(DOC.contains("localhost_signed_integration_contract:v1"));
+    assert!(DOC.contains("localhost_signed_integration:success:v1"));
+    assert!(DOC.contains("localhost_signed_integration:signature-mismatch:v1"));
+    assert!(DOC.contains("localhost_signed_integration:timeout:v1"));
+    assert!(DOC.contains("Regression: #899"));
+}

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -170,6 +170,23 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Regression policy:
   - reason-code policy remains fail-closed with stable `["none"]` success marker (`Regression: #897`).
 
+## Localhost Signed Integration Evidence Key Contract Rules
+- Harness command:
+  - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario success --output-json /tmp/localhost-signed-harness-success.json`
+- Contract lane command:
+  - `bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed-integration-contract-report.json`
+- Evidence policy checker:
+  - `bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json`
+- Contract report schema:
+  - `kamn.sdk.localhost-signed.integration-contract.v1`
+- Deterministic keys:
+  - `localhost_signed_integration_contract:v1`
+  - `localhost_signed_integration:success:v1`
+  - `localhost_signed_integration:signature-mismatch:v1`
+  - `localhost_signed_integration:timeout:v1`
+- Regression policy:
+  - deterministic evidence keys and reason keys remain fail-closed (`Regression: #899`).
+
 ## Queue Guard Rules
 - `BoundedRuntimeQueue<T>` is FIFO and preserves insertion order.
 - Capacity must be greater than zero.

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -64,11 +64,18 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `kamn.sdk.localhost-signed.integration-contract.v1`
 - Required localhost signed integration report fields:
   - `status`
+  - `contract_key`
   - `success_scenario_status`
   - `signature_mismatch_scenario_status`
   - `timeout_scenario_status`
+  - `success_evidence_key`
+  - `signature_mismatch_evidence_key`
+  - `timeout_evidence_key`
   - `signature_mismatch_reason_code`
   - `timeout_reason_code`
+  - `success_reason_key`
+  - `signature_mismatch_reason_key`
+  - `timeout_reason_key`
 - Required smoke report fields:
   - `status`
   - `final_decision`
@@ -120,5 +127,7 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - localhost signed integration contract lane preserves signature-mismatch/timeout reason codes in report schema (`Regression: #878`).
 - Regression guard:
   - localhost signed integration policy checker preserves schema and reason-code contracts (`Regression: #880`).
+- Regression guard:
+  - localhost signed integration harness and contract lane preserve deterministic evidence keys (`Regression: #899`).
 - Regression guard:
   - dashboard runtime fallback contract remains pinned to `node@22` with local reproduction guidance (`Regression: #868`).

--- a/scripts/sdk/check_localhost_signed_integration_evidence_policy.sh
+++ b/scripts/sdk/check_localhost_signed_integration_evidence_policy.sh
@@ -63,11 +63,18 @@ except json.JSONDecodeError as exc:
 required_fields = (
     "schema_version",
     "status",
+    "contract_key",
     "success_scenario_status",
     "signature_mismatch_scenario_status",
     "timeout_scenario_status",
+    "success_evidence_key",
+    "signature_mismatch_evidence_key",
+    "timeout_evidence_key",
     "signature_mismatch_reason_code",
     "timeout_reason_code",
+    "success_reason_key",
+    "signature_mismatch_reason_key",
+    "timeout_reason_key",
     "success_elapsed_seconds",
     "signature_mismatch_elapsed_seconds",
     "timeout_elapsed_seconds",
@@ -82,6 +89,9 @@ if payload["schema_version"] != "kamn.sdk.localhost-signed.integration-contract.
 status = payload["status"]
 if status not in {"pass", "fail"}:
     fail("status must be pass or fail")
+
+if payload["contract_key"] != "localhost_signed_integration_contract:v1":
+    fail("contract_key must be localhost_signed_integration_contract:v1")
 
 for field in (
     "success_scenario_status",
@@ -98,6 +108,48 @@ if payload["signature_mismatch_reason_code"] != "signature_mismatch_detected":
 
 if payload["timeout_reason_code"] != "listener_timeout_detected":
     fail("timeout_reason_code must be listener_timeout_detected")
+
+if payload["success_evidence_key"] != "localhost_signed_integration:success:v1":
+    fail("success_evidence_key must be localhost_signed_integration:success:v1")
+
+if (
+    payload["signature_mismatch_evidence_key"]
+    != "localhost_signed_integration:signature-mismatch:v1"
+):
+    fail(
+        "signature_mismatch_evidence_key must be "
+        "localhost_signed_integration:signature-mismatch:v1"
+    )
+
+if payload["timeout_evidence_key"] != "localhost_signed_integration:timeout:v1":
+    fail("timeout_evidence_key must be localhost_signed_integration:timeout:v1")
+
+if (
+    payload["success_reason_key"]
+    != "localhost_signed_integration_reason:none:v1"
+):
+    fail(
+        "success_reason_key must be "
+        "localhost_signed_integration_reason:none:v1"
+    )
+
+if (
+    payload["signature_mismatch_reason_key"]
+    != "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+):
+    fail(
+        "signature_mismatch_reason_key must be "
+        "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+    )
+
+if (
+    payload["timeout_reason_key"]
+    != "localhost_signed_integration_reason:listener_timeout_detected:v1"
+):
+    fail(
+        "timeout_reason_key must be "
+        "localhost_signed_integration_reason:listener_timeout_detected:v1"
+    )
 
 for field in (
     "success_elapsed_seconds",

--- a/scripts/sdk/run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/run_localhost_signed_integration_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HARNESS_RUNNER="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_harness.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/sdk/check_localhost_signed_integration_evidence_policy.sh"
 LIVE_NETWORK_DOC="$ROOT_DIR/docs/planning/live-network-wave.md"
+RUNTIME_NETWORK_DOC="$ROOT_DIR/docs/foundation/runtime-network.md"
 README_FILE="$ROOT_DIR/README.md"
 
 output_json=""
@@ -37,6 +38,11 @@ if [ ! -f "$LIVE_NETWORK_DOC" ]; then
   exit 1
 fi
 
+if [ ! -f "$RUNTIME_NETWORK_DOC" ]; then
+  echo "expected runtime-network foundation doc to exist" >&2
+  exit 1
+fi
+
 if [ ! -f "$README_FILE" ]; then
   echo "expected README.md to exist" >&2
   exit 1
@@ -58,8 +64,16 @@ success_output="$(
     --scenario success \
     --output-json "$success_report"
 )"
-if ! printf '%s\n' "$success_output" | grep -Fq "status=pass; scenario=success; reason_code=none;"; then
-  echo "expected localhost signed integration success scenario to pass" >&2
+if ! printf '%s\n' "$success_output" | grep -Fq "status=pass; scenario=success;"; then
+  echo "expected localhost signed integration success scenario status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$success_output" | grep -Fq "reason_code=none;"; then
+  echo "expected localhost signed integration success scenario reason code marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$success_output" | grep -Fq "evidence_key=localhost_signed_integration:success:v1;"; then
+  echo "expected localhost signed integration success scenario evidence key" >&2
   exit 1
 fi
 
@@ -69,8 +83,16 @@ signature_output="$(
     --scenario signature-mismatch \
     --output-json "$signature_report"
 )"
-if ! printf '%s\n' "$signature_output" | grep -Fq "status=pass; scenario=signature-mismatch; reason_code=signature_mismatch_detected;"; then
-  echo "expected localhost signed integration signature mismatch scenario to pass" >&2
+if ! printf '%s\n' "$signature_output" | grep -Fq "status=pass; scenario=signature-mismatch;"; then
+  echo "expected localhost signed integration signature mismatch scenario status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$signature_output" | grep -Fq "reason_code=signature_mismatch_detected;"; then
+  echo "expected localhost signed integration signature mismatch scenario reason code marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$signature_output" | grep -Fq "evidence_key=localhost_signed_integration:signature-mismatch:v1;"; then
+  echo "expected localhost signed integration signature mismatch scenario evidence key" >&2
   exit 1
 fi
 
@@ -81,8 +103,16 @@ timeout_output="$(
     --timeout-seconds 1 \
     --output-json "$timeout_report"
 )"
-if ! printf '%s\n' "$timeout_output" | grep -Fq "status=pass; scenario=timeout; reason_code=listener_timeout_detected;"; then
-  echo "expected localhost signed integration timeout scenario to pass" >&2
+if ! printf '%s\n' "$timeout_output" | grep -Fq "status=pass; scenario=timeout;"; then
+  echo "expected localhost signed integration timeout scenario status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$timeout_output" | grep -Fq "reason_code=listener_timeout_detected;"; then
+  echo "expected localhost signed integration timeout scenario reason code marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$timeout_output" | grep -Fq "evidence_key=localhost_signed_integration:timeout:v1;"; then
+  echo "expected localhost signed integration timeout scenario evidence key" >&2
   exit 1
 fi
 
@@ -100,11 +130,18 @@ output_file = pathlib.Path(sys.argv[4])
 summary = {
     "schema_version": "kamn.sdk.localhost-signed.integration-contract.v1",
     "status": "pass",
+    "contract_key": "localhost_signed_integration_contract:v1",
     "success_scenario_status": success["status"],
     "signature_mismatch_scenario_status": signature["status"],
     "timeout_scenario_status": timeout["status"],
+    "success_evidence_key": success["evidence_key"],
+    "signature_mismatch_evidence_key": signature["evidence_key"],
+    "timeout_evidence_key": timeout["evidence_key"],
     "signature_mismatch_reason_code": signature["reason_code"],
     "timeout_reason_code": timeout["reason_code"],
+    "success_reason_key": success["reason_key"],
+    "signature_mismatch_reason_key": signature["reason_key"],
+    "timeout_reason_key": timeout["reason_key"],
     "success_elapsed_seconds": success["elapsed_seconds"],
     "signature_mismatch_elapsed_seconds": signature["elapsed_seconds"],
     "timeout_elapsed_seconds": timeout["elapsed_seconds"],
@@ -145,6 +182,16 @@ fi
 
 if ! grep -Fq "/tmp/localhost-signed-integration-contract-report.json" "$README_FILE"; then
   echo "expected README to reference localhost signed integration report artifact path" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Localhost Signed Integration Evidence Key Contract Rules" "$RUNTIME_NETWORK_DOC"; then
+  echo "expected runtime-network doc to define localhost signed integration evidence key contract rules" >&2
+  exit 1
+fi
+
+if ! grep -Fq "localhost_signed_integration_contract:v1" "$RUNTIME_NETWORK_DOC"; then
+  echo "expected runtime-network doc to reference localhost signed integration contract key" >&2
   exit 1
 fi
 

--- a/scripts/sdk/run_localhost_signed_integration_harness.sh
+++ b/scripts/sdk/run_localhost_signed_integration_harness.sh
@@ -117,14 +117,18 @@ emit_report() {
   local status="$1"
   local reason_code="$2"
   local elapsed
+  local evidence_key
+  local reason_key
   elapsed="$(elapsed_seconds)"
+  evidence_key="localhost_signed_integration:${SCENARIO}:v1"
+  reason_key="localhost_signed_integration_reason:${reason_code}:v1"
 
-  echo "status=$status; scenario=$SCENARIO; reason_code=$reason_code; elapsed_seconds=$elapsed;"
+  echo "status=$status; scenario=$SCENARIO; evidence_key=$evidence_key; reason_code=$reason_code; reason_key=$reason_key; elapsed_seconds=$elapsed;"
 
   if [ -n "$OUTPUT_JSON" ]; then
     mkdir -p "$(dirname "$OUTPUT_JSON")"
     cat >"$OUTPUT_JSON" <<EOF
-{"schema_version":"kamn.sdk.localhost-signed.integration-harness.v1","status":"$status","scenario":"$SCENARIO","reason_code":"$reason_code","addr":"$ADDR","timeout_seconds":$TIMEOUT_SECONDS,"elapsed_seconds":$elapsed}
+{"schema_version":"kamn.sdk.localhost-signed.integration-harness.v1","status":"$status","scenario":"$SCENARIO","evidence_key":"$evidence_key","reason_code":"$reason_code","reason_key":"$reason_key","addr":"$ADDR","timeout_seconds":$TIMEOUT_SECONDS,"elapsed_seconds":$elapsed}
 EOF
   fi
 }

--- a/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
+++ b/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
@@ -35,7 +35,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["signature_mismatch_reason_code"] = "unexpected_reason_code"
+payload["signature_mismatch_evidence_key"] = "unexpected_evidence_key"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -49,14 +49,14 @@ if [ "$tampered_code" -eq 0 ]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$tampered_output" | grep -Fq "signature_mismatch_reason_code"; then
-  echo "expected explicit signature mismatch reason-code policy error" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "signature_mismatch_evidence_key"; then
+  echo "expected explicit signature mismatch evidence-key policy error" >&2
   exit 1
 fi
 
 # Regression: #880
-if ! printf '%s\n' "$tampered_output" | grep -Fq "signature_mismatch_detected"; then
-  echo "expected expected reason-code marker in localhost signed integration policy regression path" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "localhost_signed_integration:signature-mismatch:v1"; then
+  echo "expected expected evidence-key marker in localhost signed integration policy regression path" >&2
   exit 1
 fi
 

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -42,6 +42,22 @@ assert report["status"] == "pass"
 assert report["success_scenario_status"] == "pass"
 assert report["signature_mismatch_scenario_status"] == "pass"
 assert report["timeout_scenario_status"] == "pass"
+assert report["contract_key"] == "localhost_signed_integration_contract:v1"
+assert report["success_evidence_key"] == "localhost_signed_integration:success:v1"
+assert (
+    report["signature_mismatch_evidence_key"]
+    == "localhost_signed_integration:signature-mismatch:v1"
+)
+assert report["timeout_evidence_key"] == "localhost_signed_integration:timeout:v1"
+assert report["success_reason_key"] == "localhost_signed_integration_reason:none:v1"
+assert (
+    report["signature_mismatch_reason_key"]
+    == "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+)
+assert (
+    report["timeout_reason_key"]
+    == "localhost_signed_integration_reason:listener_timeout_detected:v1"
+)
 # Regression: #878
 assert report["signature_mismatch_reason_code"] == "signature_mismatch_detected"
 assert report["timeout_reason_code"] == "listener_timeout_detected"

--- a/scripts/sdk/test_run_localhost_signed_integration_harness.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_harness.sh
@@ -17,8 +17,16 @@ success_output="$(
     --scenario success \
     --output-json "$success_report"
 )"
-if ! printf '%s\n' "$success_output" | grep -Fq "status=pass; scenario=success; reason_code=none;"; then
-  echo "expected success scenario summary from localhost signed integration harness" >&2
+if ! printf '%s\n' "$success_output" | grep -Fq "status=pass; scenario=success;"; then
+  echo "expected success scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$success_output" | grep -Fq "reason_code=none;"; then
+  echo "expected success scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$success_output" | grep -Fq "evidence_key=localhost_signed_integration:success:v1;"; then
+  echo "expected success scenario evidence key from localhost signed integration harness" >&2
   exit 1
 fi
 
@@ -28,8 +36,16 @@ signature_output="$(
     --scenario signature-mismatch \
     --output-json "$signature_report"
 )"
-if ! printf '%s\n' "$signature_output" | grep -Fq "status=pass; scenario=signature-mismatch; reason_code=signature_mismatch_detected;"; then
-  echo "expected signature mismatch scenario summary from localhost signed integration harness" >&2
+if ! printf '%s\n' "$signature_output" | grep -Fq "status=pass; scenario=signature-mismatch;"; then
+  echo "expected signature mismatch scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$signature_output" | grep -Fq "reason_code=signature_mismatch_detected;"; then
+  echo "expected signature mismatch scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$signature_output" | grep -Fq "evidence_key=localhost_signed_integration:signature-mismatch:v1;"; then
+  echo "expected signature mismatch scenario evidence key from localhost signed integration harness" >&2
   exit 1
 fi
 
@@ -40,8 +56,16 @@ timeout_output="$(
     --timeout-seconds 1 \
     --output-json "$timeout_report"
 )"
-if ! printf '%s\n' "$timeout_output" | grep -Fq "status=pass; scenario=timeout; reason_code=listener_timeout_detected;"; then
-  echo "expected timeout scenario summary from localhost signed integration harness" >&2
+if ! printf '%s\n' "$timeout_output" | grep -Fq "status=pass; scenario=timeout;"; then
+  echo "expected timeout scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$timeout_output" | grep -Fq "reason_code=listener_timeout_detected;"; then
+  echo "expected timeout scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$timeout_output" | grep -Fq "evidence_key=localhost_signed_integration:timeout:v1;"; then
+  echo "expected timeout scenario evidence key from localhost signed integration harness" >&2
   exit 1
 fi
 
@@ -58,16 +82,31 @@ assert success_report["schema_version"] == "kamn.sdk.localhost-signed.integratio
 assert success_report["status"] == "pass"
 assert success_report["scenario"] == "success"
 assert success_report["reason_code"] == "none"
+assert success_report["evidence_key"] == "localhost_signed_integration:success:v1"
+assert success_report["reason_key"] == "localhost_signed_integration_reason:none:v1"
 assert success_report["elapsed_seconds"] >= 0
 
 assert signature_report["status"] == "pass"
 assert signature_report["scenario"] == "signature-mismatch"
 # Regression: #876
 assert signature_report["reason_code"] == "signature_mismatch_detected"
+assert (
+    signature_report["evidence_key"]
+    == "localhost_signed_integration:signature-mismatch:v1"
+)
+assert (
+    signature_report["reason_key"]
+    == "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+)
 
 assert timeout_report["status"] == "pass"
 assert timeout_report["scenario"] == "timeout"
 assert timeout_report["reason_code"] == "listener_timeout_detected"
+assert timeout_report["evidence_key"] == "localhost_signed_integration:timeout:v1"
+assert (
+    timeout_report["reason_key"]
+    == "localhost_signed_integration_reason:listener_timeout_detected:v1"
+)
 PY
 
 echo "localhost signed integration harness tests passed."


### PR DESCRIPTION
## Summary
This PR upgrades the localhost signed integration harness/contracts to include deterministic evidence keys and reason keys, then enforces those keys in the policy checker and docs contract surface. It closes the remaining #899 gap from “reason codes only” to “deterministic keys + reason codes” with fail-closed validation.

## Linked Issues
- Closes #899

## Changes
- `scripts/sdk/run_localhost_signed_integration_harness.sh`
  - emits deterministic `evidence_key` and `reason_key` per scenario in stdout and JSON report.
- `scripts/sdk/run_localhost_signed_integration_contract_lane.sh`
  - requires evidence-key markers from harness output.
  - emits `contract_key`, scenario evidence keys, and scenario reason keys in summary report.
  - enforces runtime-network docs contract references for localhost integration evidence keys.
- `scripts/sdk/check_localhost_signed_integration_evidence_policy.sh`
  - validates deterministic contract/evidence/reason keys fail-closed.
- `scripts/sdk/test_run_localhost_signed_integration_harness.sh`
  - adds assertions for deterministic evidence/reason keys.
- `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`
  - adds assertions for deterministic contract/evidence/reason keys.
- `scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh`
  - regression path now tampers `signature_mismatch_evidence_key` and expects fail-closed rejection.
- Docs updates:
  - `docs/foundation/runtime-network.md`
  - `docs/planning/live-network-wave.md`
  - `README.md`
- Docs tests updates:
  - `crates/kamn-core/tests/runtime_network_docs.rs`
  - `crates/kamn-core/tests/live_network_wave_docs.rs`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/sdk/test_run_localhost_signed_integration_harness.sh
# failed: KeyError: 'evidence_key'

bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
# failed: KeyError: 'contract_key'

bash scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
# failed: tampered evidence-key payload not rejected

cargo test -p kamn-core --test live_network_wave_docs regression_budget_guard_marker_is_documented -- --exact
# failed: missing `Regression: #899` marker

cargo test -p kamn-core --test runtime_network_docs doc_contains_localhost_signed_integration_evidence_key_contract_rules -- --exact
# failed: missing localhost integration evidence-key section
```

### 🟢 Green Phase
```bash
bash scripts/sdk/test_run_localhost_signed_integration_harness.sh
bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
bash scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
cargo test -p kamn-core --test live_network_wave_docs
cargo test -p kamn-core --test runtime_network_docs
```
All commands passed.

### 🔁 Regression
```bash
bash scripts/ci/test_ci_tools.sh
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
All commands passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Policy checker key/reason validations (`check_localhost_signed_integration_evidence_policy.sh`) | |
| Functional   | ✅     | Harness/lane output markers + deterministic key assertions | |
| Integration  | ✅     | Localhost contract lane + policy checker + docs contract wiring | |
| Regression   | ✅     | Evidence-key tamper rejection + `Regression: #899` docs contract marker | |
| Performance  | ✅     | Existing bounded contract-lane budget (`KAMN_LOCALHOST_SIGNED_INTEGRATION_CONTRACT_MAX_SECONDS`) preserved | |

## Risks & Rollback
- Risk: Low/Med. Main risk is false positives if deterministic key constants change without updating policy/docs contracts.
- Rollback plan: Revert this PR to restore previous localhost integration contract schema and checker behavior.

## Documentation Updates
- `docs/foundation/runtime-network.md`
- `docs/planning/live-network-wave.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: no workflow YAML changes; SDK runtime contract scripts/tests and docs contract tests changed.
- Expected runtime delta: near-neutral; deterministic key checks are constant-time validations.
- Expected runner-minute delta: near-neutral; no additional broad lanes were added.
- Rollback plan if CI cost/runtime regresses: revert this PR.
