### PR TITLE
test(crypto): add key lifecycle invariant contract lane

### DIFF
--- a/crates/kamn-core/tests/key_management_and_encryption_docs.rs
+++ b/crates/kamn-core/tests/key_management_and_encryption_docs.rs
@@ -1,0 +1,15 @@
+const DOC: &str = include_str!("../../../docs/foundation/key-management-and-encryption.md");
+
+#[test]
+fn doc_contains_key_lifecycle_contract_scope() {
+    assert!(DOC.contains("# Key Management and Encryption Contract Rules"));
+    assert!(DOC.contains("run_key_hierarchy_invariant_contract_lane.sh"));
+    assert!(DOC.contains("kamn.key-lifecycle.invariant-evidence.v1"));
+}
+
+#[test]
+fn regression_requires_replay_stale_activation_marker() {
+    // Regression: #931
+    assert!(DOC.contains("replay/stale key activation drift is rejected (`Regression: #931`)"));
+    assert!(DOC.contains("check_key_lifecycle_invariant_policy.sh"));
+}

--- a/docs/foundation/key-management-and-encryption.md
+++ b/docs/foundation/key-management-and-encryption.md
@@ -1,0 +1,39 @@
+# Key Management and Encryption Contract Rules
+
+This document defines deterministic contract checks for key hierarchy rotation,
+revocation invariants, and replay/stale-state rejection policies.
+
+## Contract Scope
+- Key role separation and rotation/revocation invariants.
+- Recovery replay nonce rejection and stale-generation activation checks.
+- Schema-validated evidence contract for key lifecycle policy drift detection.
+
+## Evidence Schema
+- `schema_version`: `kamn.key-lifecycle.invariant-evidence.v1`
+- `evidence_key`: `key_lifecycle_invariant:<lane>:v1`
+- `reason_key`: `key_lifecycle_invariant_reason:<final_decision>:v1`
+- `final_decision`: `GO|NO-GO`
+
+## Local Validation Commands
+Run from repository root:
+
+```bash
+bash scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh --help
+bash scripts/message/check_key_lifecycle_invariant_policy.sh --help
+bash scripts/message/run_key_hierarchy_invariant_contract_lane.sh
+bash scripts/message/test_generate_key_lifecycle_invariant_evidence_bundle.sh
+bash scripts/message/test_run_key_hierarchy_invariant_contract_lane.sh
+cargo test -p kamn-core --test agent_key_hierarchy
+cargo test -p kamn-core --test key_lifecycle
+cargo test -p kamn-core --test key_recovery
+cargo test -p kamn-core --test key_management_and_encryption_docs
+```
+
+## Policy Rules
+- Replay/stale/revocation drift must force `NO-GO`.
+- `report.reason_codes` must be sorted deterministic strings.
+- `final_decision` must match derived policy from report booleans.
+- `evidence_key` and `reason_key` must match deterministic lane/decision keys.
+
+## Regression Marker
+- replay/stale key activation drift is rejected (`Regression: #931`)

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -303,7 +303,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    docs/foundation/message-lifecycle.md|crates/kamn-core/tests/message_lifecycle_docs.rs|scripts/message/*)
+    docs/foundation/message-lifecycle.md|docs/foundation/key-management-and-encryption.md|crates/kamn-core/tests/message_lifecycle_docs.rs|crates/kamn-core/tests/key_management_and_encryption_docs.rs|scripts/message/*)
       MESSAGE_LIFECYCLE_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -57,6 +57,8 @@ bash "$ROOT_DIR/scripts/runtime/test_run_failover_sync_drill_preflight_contract_
 bash "$ROOT_DIR/scripts/runtime/test_run_failover_sync_drill_deep_lane.sh"
 bash "$ROOT_DIR/scripts/runtime/test_run_failover_sync_drill_suite.sh"
 bash "$ROOT_DIR/scripts/message/test_run_message_lifecycle_contract_lane.sh"
+bash "$ROOT_DIR/scripts/message/test_generate_key_lifecycle_invariant_evidence_bundle.sh"
+bash "$ROOT_DIR/scripts/message/test_run_key_hierarchy_invariant_contract_lane.sh"
 bash "$ROOT_DIR/scripts/channel/test_run_channel_lifecycle_contract_lane.sh"
 bash "$ROOT_DIR/scripts/channel/test_run_channel_policy_contract_lane.sh"
 bash "$ROOT_DIR/scripts/channel/test_generate_channel_retention_redaction_evidence_bundle.sh"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -666,10 +666,20 @@ assert_eq "$(extract_output "$message_contract_docs_output" "run_rust")" "false"
 assert_eq "$(extract_output "$message_contract_docs_output" "run_message_lifecycle_contract_tests")" "true" "message lifecycle contract docs must run message lifecycle contract lane"
 assert_eq "$(extract_output "$message_contract_docs_output" "test_scope")" "message-contract" "message lifecycle contract docs should set message-contract scope"
 
+key_management_contract_docs_output="$(run_selector $'docs/foundation/key-management-and-encryption.md')"
+assert_eq "$(extract_output "$key_management_contract_docs_output" "run_rust")" "false" "key management contract docs should avoid rust lane"
+assert_eq "$(extract_output "$key_management_contract_docs_output" "run_message_lifecycle_contract_tests")" "true" "key management contract docs must run message lifecycle contract lane"
+assert_eq "$(extract_output "$key_management_contract_docs_output" "test_scope")" "message-contract" "key management contract docs should set message-contract scope"
+
 message_contract_script_output="$(run_selector $'scripts/message/run_message_lifecycle_contract_lane.sh')"
 assert_eq "$(extract_output "$message_contract_script_output" "run_rust")" "false" "message lifecycle contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$message_contract_script_output" "run_message_lifecycle_contract_tests")" "true" "message lifecycle contract script changes must run message lifecycle contract lane"
 assert_eq "$(extract_output "$message_contract_script_output" "test_scope")" "message-contract" "message lifecycle contract script changes should set message-contract scope"
+
+key_lifecycle_invariant_contract_script_output="$(run_selector $'scripts/message/run_key_hierarchy_invariant_contract_lane.sh')"
+assert_eq "$(extract_output "$key_lifecycle_invariant_contract_script_output" "run_rust")" "false" "key hierarchy invariant contract script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$key_lifecycle_invariant_contract_script_output" "run_message_lifecycle_contract_tests")" "true" "key hierarchy invariant contract script changes must run message lifecycle contract lane"
+assert_eq "$(extract_output "$key_lifecycle_invariant_contract_script_output" "test_scope")" "message-contract" "key hierarchy invariant contract script changes should set message-contract scope"
 
 channel_contract_docs_output="$(run_selector $'docs/foundation/channel-models.md')"
 assert_eq "$(extract_output "$channel_contract_docs_output" "run_rust")" "false" "channel lifecycle contract docs should avoid rust lane"

--- a/scripts/message/check_key_lifecycle_invariant_policy.sh
+++ b/scripts/message/check_key_lifecycle_invariant_policy.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/message/check_key_lifecycle_invariant_policy.sh \
+    --bundle-file <path>
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "lane",
+    "evidence_key",
+    "reason_key",
+    "report",
+    "ci_fast_gate",
+    "decision_reasons",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+if payload["schema_version"] != "kamn.key-lifecycle.invariant-evidence.v1":
+    fail("unexpected schema_version for key lifecycle invariant evidence bundle")
+
+lane = payload["lane"]
+if lane not in {"contract", "deep"}:
+    fail("lane must be contract or deep")
+
+expected_evidence_key = f"key_lifecycle_invariant:{lane}:v1"
+if payload["evidence_key"] != expected_evidence_key:
+    fail(
+        "evidence_key mismatch: "
+        f"expected {expected_evidence_key}, found {payload['evidence_key']}"
+    )
+
+ci_fast_gate = payload["ci_fast_gate"]
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci_fast_gate must be PASS or FAIL")
+
+decision_reasons = payload["decision_reasons"]
+if not isinstance(decision_reasons, list) or not all(
+    isinstance(item, str) and item for item in decision_reasons
+):
+    fail("decision_reasons must be an array of non-empty strings")
+
+report = payload["report"]
+if not isinstance(report, dict):
+    fail("report must be an object")
+for field in (
+    "status",
+    "rotation_replay_detected",
+    "stale_generation_detected",
+    "revocation_bypass_detected",
+    "reason_codes",
+):
+    if field not in report:
+        fail(f"report missing field: {field}")
+
+if report["status"] not in {"pass", "fail"}:
+    fail("report.status must be pass or fail")
+if not isinstance(report["rotation_replay_detected"], bool):
+    fail("report.rotation_replay_detected must be a boolean")
+if not isinstance(report["stale_generation_detected"], bool):
+    fail("report.stale_generation_detected must be a boolean")
+if not isinstance(report["revocation_bypass_detected"], bool):
+    fail("report.revocation_bypass_detected must be a boolean")
+if not isinstance(report["reason_codes"], list) or not all(
+    isinstance(item, str) and item for item in report["reason_codes"]
+):
+    fail("report.reason_codes must be an array of non-empty strings")
+if report["reason_codes"] != sorted(report["reason_codes"]):
+    fail("report.reason_codes must be sorted and deterministic")
+
+expected_go = True
+if report["status"] != "pass":
+    expected_go = False
+if report["rotation_replay_detected"]:
+    expected_go = False
+if report["stale_generation_detected"]:
+    expected_go = False
+if report["revocation_bypass_detected"]:
+    expected_go = False
+if lane == "contract" and ci_fast_gate != "PASS":
+    expected_go = False
+if not report["reason_codes"]:
+    expected_go = False
+
+expected_decision = "GO" if expected_go else "NO-GO"
+actual_decision = payload["final_decision"]
+if actual_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+if actual_decision != expected_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {actual_decision}"
+    )
+
+expected_reason_key = f"key_lifecycle_invariant_reason:{actual_decision}:v1"
+if payload["reason_key"] != expected_reason_key:
+    fail(
+        "reason_key mismatch: "
+        f"expected {expected_reason_key}, found {payload['reason_key']}"
+    )
+
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"schema_version={payload['schema_version']}")
+print(f"evidence_key={payload['evidence_key']}")
+print(f"reason_key={payload['reason_key']}")
+print(f"final_decision={actual_decision}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh
+++ b/scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh \
+    --output-file <path> \
+    --lane contract|deep \
+    --report-file <path> \
+    --ci-fast-gate PASS|FAIL
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+output_file=""
+lane=""
+report_file=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --lane)
+      lane="${2:-}"
+      shift 2
+      ;;
+    --report-file)
+      report_file="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$lane" || -z "$report_file" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all key lifecycle invariant evidence bundle arguments are required"
+fi
+
+if [[ ! -f "$report_file" ]]; then
+  fail "report file not found: $report_file"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$lane" "$report_file" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+output_file, generated_at, lane, report_file, ci_fast_gate = sys.argv[1:]
+if lane not in {"contract", "deep"}:
+    fail("lane must be contract or deep")
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci-fast-gate must be PASS or FAIL")
+
+report = json.loads(pathlib.Path(report_file).read_text())
+status = str(report.get("status", ""))
+rotation_replay_detected = report.get("rotation_replay_detected")
+stale_generation_detected = report.get("stale_generation_detected")
+revocation_bypass_detected = report.get("revocation_bypass_detected")
+reason_codes = report.get("reason_codes", [])
+
+if status not in {"pass", "fail"}:
+    fail("report.status must be pass or fail")
+if not isinstance(rotation_replay_detected, bool):
+    fail("report.rotation_replay_detected must be a boolean")
+if not isinstance(stale_generation_detected, bool):
+    fail("report.stale_generation_detected must be a boolean")
+if not isinstance(revocation_bypass_detected, bool):
+    fail("report.revocation_bypass_detected must be a boolean")
+if not isinstance(reason_codes, list) or not all(
+    isinstance(item, str) and item for item in reason_codes
+):
+    fail("report.reason_codes must be an array of non-empty strings")
+
+reason_codes = sorted(reason_codes)
+
+decision_reasons: list[str] = []
+if status != "pass":
+    decision_reasons.append("lifecycle_status_not_pass")
+if rotation_replay_detected:
+    decision_reasons.append("rotation_replay_detected")
+if stale_generation_detected:
+    decision_reasons.append("stale_generation_activation_detected")
+if revocation_bypass_detected:
+    decision_reasons.append("revocation_bypass_detected")
+if lane == "contract" and ci_fast_gate != "PASS":
+    decision_reasons.append("ci_fast_gate_failed")
+if not reason_codes:
+    decision_reasons.append("reason_codes_missing")
+
+final_decision = "GO" if not decision_reasons else "NO-GO"
+if not decision_reasons:
+    decision_reasons.append("all key lifecycle invariant checks passed")
+
+evidence_key = f"key_lifecycle_invariant:{lane}:v1"
+reason_key = f"key_lifecycle_invariant_reason:{final_decision}:v1"
+
+payload = {
+    "schema_version": "kamn.key-lifecycle.invariant-evidence.v1",
+    "generated_at": generated_at,
+    "lane": lane,
+    "evidence_key": evidence_key,
+    "reason_key": reason_key,
+    "report": {
+        "status": status,
+        "rotation_replay_detected": rotation_replay_detected,
+        "stale_generation_detected": stale_generation_detected,
+        "revocation_bypass_detected": revocation_bypass_detected,
+        "reason_codes": reason_codes,
+    },
+    "ci_fast_gate": ci_fast_gate,
+    "decision_reasons": decision_reasons,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'schema_version=kamn.key-lifecycle.invariant-evidence.v1\n'
+printf 'evidence_key=key_lifecycle_invariant:%s:v1\n' "$lane"
+printf 'reason_key=key_lifecycle_invariant_reason:%s:v1\n' "$final_decision"
+printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/message/run_key_hierarchy_invariant_contract_lane.sh
+++ b/scripts/message/run_key_hierarchy_invariant_contract_lane.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/message/check_key_lifecycle_invariant_policy.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/message/run_key_hierarchy_invariant_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "key lifecycle invariant evidence generator is not executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "key lifecycle invariant policy checker is not executable"
+fi
+
+if [ "$skip_tests" != true ]; then
+  cargo test -p kamn-core --test agent_key_hierarchy >/dev/null
+  cargo test -p kamn-core --test key_lifecycle >/dev/null
+  cargo test -p kamn-core --test key_recovery >/dev/null
+  cargo test -p kamn-core --test key_management_and_encryption_docs >/dev/null
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+report_file="$tmp_dir/key-lifecycle-report.json"
+cat >"$report_file" <<'JSON'
+{
+  "status": "pass",
+  "rotation_replay_detected": false,
+  "stale_generation_detected": false,
+  "revocation_bypass_detected": false,
+  "reason_codes": ["revocation_state_consistent", "rotation_sequence_monotonic"]
+}
+JSON
+
+if [[ -z "$output_file" ]]; then
+  output_file="$tmp_dir/key-lifecycle-invariant-evidence.json"
+fi
+
+generation_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --lane contract \
+    --report-file "$report_file" \
+    --ci-fast-gate PASS
+)"
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'schema_version=%s\n' "$(extract_value "$policy_output" "schema_version")"
+printf 'evidence_key=%s\n' "$(extract_value "$generation_output" "evidence_key")"
+printf 'reason_key=%s\n' "$(extract_value "$generation_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
+echo "key hierarchy invariant contract lane tests passed."

--- a/scripts/message/run_message_lifecycle_contract_lane.sh
+++ b/scripts/message/run_message_lifecycle_contract_lane.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KEY_HIERARCHY_LANE="$ROOT_DIR/scripts/message/run_key_hierarchy_invariant_contract_lane.sh"
+
 cargo test -p kamn-core --lib message_lifecycle::tests:: >/dev/null
 cargo test -p kamn-core --test message_lifecycle_docs >/dev/null
+bash "$KEY_HIERARCHY_LANE" >/dev/null
 
 echo "message lifecycle snapshot contract lane tests passed."

--- a/scripts/message/test_generate_key_lifecycle_invariant_evidence_bundle.sh
+++ b/scripts/message/test_generate_key_lifecycle_invariant_evidence_bundle.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/message/check_key_lifecycle_invariant_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected key lifecycle invariant evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected key lifecycle invariant policy checker to be executable" >&2
+  exit 1
+fi
+
+go_report="$TMP_DIR/key-lifecycle-go.json"
+cat >"$go_report" <<'JSON'
+{
+  "status": "pass",
+  "rotation_replay_detected": false,
+  "stale_generation_detected": false,
+  "revocation_bypass_detected": false,
+  "reason_codes": ["rotation_sequence_monotonic", "revocation_state_consistent"]
+}
+JSON
+
+go_bundle="$TMP_DIR/key-lifecycle-go-bundle.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --lane contract \
+    --report-file "$go_report" \
+    --ci-fast-gate PASS
+)"
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO key lifecycle evidence generation to succeed"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO key lifecycle evidence decision"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO key lifecycle policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO key lifecycle policy decision"
+
+no_go_report="$TMP_DIR/key-lifecycle-no-go.json"
+cat >"$no_go_report" <<'JSON'
+{
+  "status": "fail",
+  "rotation_replay_detected": true,
+  "stale_generation_detected": true,
+  "revocation_bypass_detected": false,
+  "reason_codes": ["rotation_replay_detected", "stale_generation_activation_detected"]
+}
+JSON
+
+no_go_bundle="$TMP_DIR/key-lifecycle-no-go-bundle.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --lane contract \
+    --report-file "$no_go_report" \
+    --ci-fast-gate PASS
+)"
+assert_eq "$(extract_value "$no_go_output" "status")" "generated" "expected NO-GO key lifecycle evidence generation to succeed"
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO key lifecycle evidence decision"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO key lifecycle policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO key lifecycle policy decision"
+
+tampered_bundle="$TMP_DIR/key-lifecycle-tampered-bundle.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered key lifecycle evidence to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch for tampered key lifecycle evidence" >&2
+  exit 1
+fi
+
+# Regression: #931
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO mismatch in key lifecycle replay/stale regression path" >&2
+  exit 1
+fi
+
+echo "key lifecycle invariant evidence bundle tests passed."

--- a/scripts/message/test_run_key_hierarchy_invariant_contract_lane.sh
+++ b/scripts/message/test_run_key_hierarchy_invariant_contract_lane.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/message/run_key_hierarchy_invariant_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected key hierarchy invariant contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/key-lifecycle-invariant-bundle.json"
+lane_output="$(bash "$SCRIPT" --output-file "$bundle_file")"
+
+if ! printf '%s\n' "$lane_output" | grep -q "key hierarchy invariant contract lane tests passed."; then
+  echo "expected key hierarchy invariant contract lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected key hierarchy invariant contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.key-lifecycle.invariant-evidence.v1"' "$bundle_file"; then
+  echo "expected key lifecycle invariant evidence schema marker" >&2
+  exit 1
+fi
+
+echo "key hierarchy invariant contract lane script tests passed."

--- a/scripts/message/test_run_message_lifecycle_contract_lane.sh
+++ b/scripts/message/test_run_message_lifecycle_contract_lane.sh
@@ -24,6 +24,11 @@ if ! grep -q "message lifecycle snapshot contract lane tests passed." "$TMP_OUT"
   exit 1
 fi
 
+if ! grep -Fq "run_key_hierarchy_invariant_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected message lifecycle lane to execute key hierarchy invariant lane checks" >&2
+  exit 1
+fi
+
 if ! grep -Fq "run_message_lifecycle_contract_lane.sh" "$DEEP_SCRIPT"; then
   echo "expected deep-lane script to execute message lifecycle fast-lane checks first" >&2
   exit 1


### PR DESCRIPTION
Closes #931

## Summary
Adds deterministic key hierarchy lifecycle invariant contracts with schema-versioned evidence generation, fail-closed policy validation, and bounded lane integration into the existing message contract lane for low-cost CI routing.

## Changes
- `scripts/message/generate_key_lifecycle_invariant_evidence_bundle.sh`: emits deterministic key lifecycle evidence (`kamn.key-lifecycle.invariant-evidence.v1`) with stable evidence/reason keys.
- `scripts/message/check_key_lifecycle_invariant_policy.sh`: validates schema/type/sorted reason-code invariants and rejects decision drift fail-closed.
- `scripts/message/run_key_hierarchy_invariant_contract_lane.sh`: bounded lane for key hierarchy/lifecycle/recovery tests plus evidence generation and policy checks.
- `scripts/message/test_generate_key_lifecycle_invariant_evidence_bundle.sh`: GO/NO-GO/tamper regression coverage for generator+checker.
- `scripts/message/test_run_key_hierarchy_invariant_contract_lane.sh`: lane contract test with emitted evidence bundle checks.
- `scripts/message/run_message_lifecycle_contract_lane.sh`: now executes key hierarchy invariant lane.
- `scripts/message/test_run_message_lifecycle_contract_lane.sh`: asserts message lane includes key hierarchy lane.
- `docs/foundation/key-management-and-encryption.md`: new key lifecycle contract doc + `Regression: #931` marker.
- `crates/kamn-core/tests/key_management_and_encryption_docs.rs`: docs contract tests for commands/schema/marker.
- `scripts/ci/select_targets.sh`: routes key-management docs/docs-tests to scoped `message-contract` lane.
- `scripts/ci/test_select_targets.sh`: selector regressions for key-management docs and key-lane script changes.
- `scripts/ci/test_ci_tools.sh`: includes key lifecycle generator and lane regression tests.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: key lifecycle lane emits deterministic evidence and checker rejects tampered decisions

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | key state/recovery tests and docs contract checks |
| Functional  | ✅     | generator/checker behavior for GO/NO-GO/tamper scenarios |
| Integration | ✅     | message lane + key lane + selector + CI tool routing |
| Regression  | ✅     | explicit `Regression: #931` tamper mismatch marker and docs guard |

## Commands Run
- `bash scripts/message/test_generate_key_lifecycle_invariant_evidence_bundle.sh`
- `bash scripts/message/test_run_key_hierarchy_invariant_contract_lane.sh`
- `cargo test -p kamn-core --test key_management_and_encryption_docs`
- `bash scripts/message/test_run_message_lifecycle_contract_lane.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
