### PR TITLE
test(reputation): add weighted decay anti-gaming property lane (#933)

### DIFF
--- a/crates/kamn-core/tests/trust_score_engine_docs.rs
+++ b/crates/kamn-core/tests/trust_score_engine_docs.rs
@@ -26,9 +26,13 @@ fn doc_contains_bounds_and_versioning_controls() {
 fn doc_contains_weighted_decay_and_antigaming_fixture_lanes() {
     assert!(DOC.contains("## Weighted Decay and Anti-Gaming Fixture Lanes"));
     assert!(DOC.contains("run_weighted_decay_contract_lane.sh"));
+    assert!(DOC.contains("generate_weighted_decay_property_evidence_bundle.sh"));
+    assert!(DOC.contains("check_weighted_decay_property_policy.sh"));
     assert!(DOC.contains("run_weighted_decay_deep_lane.sh"));
     assert!(DOC.contains("run_weighted_decay_matrix.py"));
     assert!(DOC.contains("fixtures/reputation_decay/compact_cases.json"));
+    assert!(DOC.contains("fixtures/reputation_decay/adversarial_cases.json"));
+    assert!(DOC.contains("cargo test -p kamn-core --test trust_score_property_invariants"));
 }
 
 #[test]
@@ -58,4 +62,12 @@ fn regression_requires_stale_history_decay_guard_marker() {
     assert!(
         DOC.contains("stale-only history does not improve decay multiplier (`Regression: #768`).")
     );
+}
+
+#[test]
+fn regression_requires_weighted_decay_property_guard_marker() {
+    // Regression: #933
+    assert!(DOC.contains(
+        "reciprocity/burst/churn anti-gaming property drift is rejected (`Regression: #933`)."
+    ));
 }

--- a/docs/foundation/trust-score-engine.md
+++ b/docs/foundation/trust-score-engine.md
@@ -44,14 +44,24 @@ Regression guards:
 - `1000ms` remains in the highest response bucket.
 - replayed reciprocity/burst/churn abuse fixtures remain penalized (`Regression: #730`).
 - stale-only history does not improve decay multiplier (`Regression: #768`).
+- reciprocity/burst/churn anti-gaming property drift is rejected (`Regression: #933`).
 
-## Weighted Decay and Anti-Gaming Fixture Lanes (Issue #736)
+## Weighted Decay and Anti-Gaming Fixture Lanes (Issue #736 / #933)
 - Compact PR lane entrypoint:
-  - `bash scripts/reputation/run_weighted_decay_contract_lane.sh`
+  - `bash scripts/reputation/run_weighted_decay_contract_lane.sh --output-file reputation-weighted-decay-property-contract-bundle.json`
+- Compact/deep evidence generator:
+  - `bash scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh --help`
+- Compact/deep policy checker:
+  - `bash scripts/reputation/check_weighted_decay_property_policy.sh --help`
 - Scheduled deep lane entrypoint:
   - `bash scripts/reputation/run_weighted_decay_deep_lane.sh --output-json reputation-weighted-decay-report.json`
 - Fixture matrix runner:
   - `python3 scripts/reputation/run_weighted_decay_matrix.py --fixture fixtures/reputation_decay/compact_cases.json --output-json reputation-weighted-decay-report.json`
+  - `python3 scripts/reputation/run_weighted_decay_matrix.py --fixture fixtures/reputation_decay/adversarial_cases.json --output-json reputation-weighted-decay-adversarial-report.json`
+- Property invariant runner:
+  - `cargo test -p kamn-core --test trust_score_property_invariants`
+- Runtime budget control:
+  - `REPUTATION_WEIGHTED_DECAY_MAX_SECONDS` (lane fails closed when runtime exceeds budget).
 
 ## Validation and Error Handling
 - Invalid rate inputs return typed errors:

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -78,6 +78,7 @@ bash "$ROOT_DIR/scripts/escrow/test_generate_settlement_reconciliation_evidence_
 bash "$ROOT_DIR/scripts/escrow/test_run_settlement_reconciliation_contract_lane.sh"
 bash "$ROOT_DIR/scripts/escrow/test_run_settlement_reconciliation_race_matrix.sh"
 bash "$ROOT_DIR/scripts/reputation/test_run_weighted_decay_contract_lane.sh"
+bash "$ROOT_DIR/scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh"
 bash "$ROOT_DIR/scripts/reputation/test_run_weighted_decay_matrix.sh"
 bash "$ROOT_DIR/scripts/reputation/test_run_weighted_decay_deep_lane.sh"
 bash "$ROOT_DIR/scripts/reputation/test_generate_reputation_dispute_evidence_bundle.sh"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -842,6 +842,12 @@ assert_eq "$(extract_output "$reputation_decay_contract_script_output" "run_repu
 assert_eq "$(extract_output "$reputation_decay_contract_script_output" "run_reputation_dispute_contract_tests")" "true" "weighted decay contract script changes must also run dispute contract lane"
 assert_eq "$(extract_output "$reputation_decay_contract_script_output" "test_scope")" "reputation-decay-contract" "weighted decay contract script changes should set reputation-decay-contract scope"
 
+reputation_decay_policy_checker_output="$(run_selector $'scripts/reputation/check_weighted_decay_property_policy.sh')"
+assert_eq "$(extract_output "$reputation_decay_policy_checker_output" "run_rust")" "false" "weighted decay policy checker script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$reputation_decay_policy_checker_output" "run_reputation_decay_contract_tests")" "true" "weighted decay policy checker changes must run weighted decay contract lane"
+assert_eq "$(extract_output "$reputation_decay_policy_checker_output" "run_reputation_dispute_contract_tests")" "true" "weighted decay policy checker changes must also run dispute contract lane"
+assert_eq "$(extract_output "$reputation_decay_policy_checker_output" "test_scope")" "reputation-decay-contract" "weighted decay policy checker changes should set reputation-decay-contract scope"
+
 reputation_decay_contract_fixture_output="$(run_selector $'fixtures/reputation_decay/compact_cases.json')"
 assert_eq "$(extract_output "$reputation_decay_contract_fixture_output" "run_rust")" "false" "weighted decay fixture-only changes should avoid rust lane"
 assert_eq "$(extract_output "$reputation_decay_contract_fixture_output" "run_reputation_decay_contract_tests")" "true" "weighted decay fixture changes must run weighted decay contract lane"

--- a/scripts/reputation/check_weighted_decay_property_policy.sh
+++ b/scripts/reputation/check_weighted_decay_property_policy.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/reputation/check_weighted_decay_property_policy.sh \
+    --bundle-file <path>
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+from typing import Any, Dict
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "lane",
+    "evidence_key",
+    "reason_key",
+    "compact_matrix",
+    "adversarial_matrix",
+    "anti_gaming_coverage",
+    "property_suite_status",
+    "runtime_budget_status",
+    "ci_fast_gate",
+    "decision_reasons",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+if payload["schema_version"] != "kamn.reputation.weighted-decay.property-evidence.v1":
+    fail("unexpected schema_version for weighted decay property evidence bundle")
+
+lane = payload["lane"]
+if lane not in {"contract", "deep"}:
+    fail("lane must be contract or deep")
+
+expected_evidence_key = f"weighted_decay_property_contract:{lane}:v1"
+if payload["evidence_key"] != expected_evidence_key:
+    fail(
+        "evidence_key mismatch: "
+        f"expected {expected_evidence_key}, found {payload['evidence_key']}"
+    )
+
+property_suite_status = payload["property_suite_status"]
+if property_suite_status not in {"pass", "fail"}:
+    fail("property_suite_status must be pass or fail")
+
+runtime_budget_status = payload["runtime_budget_status"]
+if runtime_budget_status not in {"within", "exceeded"}:
+    fail("runtime_budget_status must be within or exceeded")
+
+ci_fast_gate = payload["ci_fast_gate"]
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci_fast_gate must be PASS or FAIL")
+
+decision_reasons = payload["decision_reasons"]
+if not isinstance(decision_reasons, list) or not all(
+    isinstance(item, str) and item for item in decision_reasons
+):
+    fail("decision_reasons must be an array of non-empty strings")
+
+
+def validate_matrix(matrix: Dict[str, Any], label: str) -> Dict[str, Any]:
+    if not isinstance(matrix, dict):
+        fail(f"{label} matrix must be an object")
+    for field in ("status", "case_count", "failed_count", "failed_case_ids", "cases"):
+        if field not in matrix:
+            fail(f"{label} matrix missing field: {field}")
+    if matrix["status"] not in {"pass", "fail"}:
+        fail(f"{label} matrix status must be pass or fail")
+    if not isinstance(matrix["case_count"], int):
+        fail(f"{label} matrix case_count must be an integer")
+    if not isinstance(matrix["failed_count"], int):
+        fail(f"{label} matrix failed_count must be an integer")
+    if not isinstance(matrix["failed_case_ids"], list) or not all(
+        isinstance(item, str) and item for item in matrix["failed_case_ids"]
+    ):
+        fail(f"{label} matrix failed_case_ids must be an array of strings")
+    if matrix["failed_case_ids"] != sorted(matrix["failed_case_ids"]):
+        fail(f"{label} matrix failed_case_ids must be sorted and deterministic")
+    if not isinstance(matrix["cases"], list):
+        fail(f"{label} matrix cases must be an array")
+
+    normalized_cases = []
+    for index, case in enumerate(matrix["cases"]):
+        if not isinstance(case, dict):
+            fail(f"{label} matrix case[{index}] must be an object")
+        for field in (
+            "expected_abuse_penalty_kind",
+            "actual_abuse_penalty_kind",
+            "passed",
+        ):
+            if field not in case:
+                fail(f"{label} matrix case[{index}] missing field: {field}")
+        if not isinstance(case["expected_abuse_penalty_kind"], str) or not case[
+            "expected_abuse_penalty_kind"
+        ]:
+            fail(
+                f"{label} matrix case[{index}] expected_abuse_penalty_kind must be a non-empty string"
+            )
+        if not isinstance(case["actual_abuse_penalty_kind"], str) or not case[
+            "actual_abuse_penalty_kind"
+        ]:
+            fail(
+                f"{label} matrix case[{index}] actual_abuse_penalty_kind must be a non-empty string"
+            )
+        if not isinstance(case["passed"], bool):
+            fail(f"{label} matrix case[{index}] passed must be a boolean")
+        normalized_cases.append(case)
+
+    return {
+        "status": matrix["status"],
+        "failed_count": matrix["failed_count"],
+        "cases": normalized_cases,
+    }
+
+
+compact = validate_matrix(payload["compact_matrix"], "compact")
+adversarial = validate_matrix(payload["adversarial_matrix"], "adversarial")
+combined_cases = compact["cases"] + adversarial["cases"]
+
+
+def observed(kind: str) -> bool:
+    return any(
+        case["expected_abuse_penalty_kind"] == kind
+        and case["actual_abuse_penalty_kind"] == kind
+        and case["passed"]
+        for case in combined_cases
+    )
+
+
+coverage = payload["anti_gaming_coverage"]
+if not isinstance(coverage, dict):
+    fail("anti_gaming_coverage must be an object")
+for field in (
+    "reciprocity_penalty_observed",
+    "burst_penalty_observed",
+    "churn_penalty_observed",
+):
+    if field not in coverage:
+        fail(f"anti_gaming_coverage missing field: {field}")
+    if not isinstance(coverage[field], bool):
+        fail(f"anti_gaming_coverage.{field} must be a boolean")
+
+derived_coverage = {
+    "reciprocity_penalty_observed": observed("ReciprocityRing"),
+    "burst_penalty_observed": observed("BurstSpam"),
+    "churn_penalty_observed": observed("ChurnSpike"),
+}
+
+for key, value in derived_coverage.items():
+    if coverage[key] != value:
+        fail(
+            f"anti_gaming_coverage mismatch for {key}: expected {value}, found {coverage[key]}"
+        )
+
+expected_go = True
+if compact["status"] != "pass":
+    expected_go = False
+if adversarial["status"] != "pass":
+    expected_go = False
+if compact["failed_count"] != 0:
+    expected_go = False
+if adversarial["failed_count"] != 0:
+    expected_go = False
+if not coverage["reciprocity_penalty_observed"]:
+    expected_go = False
+if not coverage["burst_penalty_observed"]:
+    expected_go = False
+if not coverage["churn_penalty_observed"]:
+    expected_go = False
+if property_suite_status != "pass":
+    expected_go = False
+if runtime_budget_status != "within":
+    expected_go = False
+if lane == "contract" and ci_fast_gate != "PASS":
+    expected_go = False
+
+expected_decision = "GO" if expected_go else "NO-GO"
+actual_decision = payload["final_decision"]
+if actual_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+if actual_decision != expected_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {actual_decision}"
+    )
+
+expected_reason_key = f"weighted_decay_property_contract_reason:{actual_decision}:v1"
+if payload["reason_key"] != expected_reason_key:
+    fail(
+        "reason_key mismatch: "
+        f"expected {expected_reason_key}, found {payload['reason_key']}"
+    )
+
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"schema_version={payload['schema_version']}")
+print(f"evidence_key={payload['evidence_key']}")
+print(f"reason_key={payload['reason_key']}")
+print(f"final_decision={actual_decision}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh
+++ b/scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh \
+    --output-file <path> \
+    --lane contract|deep \
+    --compact-report-file <path> \
+    --adversarial-report-file <path> \
+    --property-suite-status pass|fail \
+    --runtime-budget-status within|exceeded \
+    --ci-fast-gate PASS|FAIL
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+output_file=""
+lane=""
+compact_report_file=""
+adversarial_report_file=""
+property_suite_status=""
+runtime_budget_status=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --lane)
+      lane="${2:-}"
+      shift 2
+      ;;
+    --compact-report-file)
+      compact_report_file="${2:-}"
+      shift 2
+      ;;
+    --adversarial-report-file)
+      adversarial_report_file="${2:-}"
+      shift 2
+      ;;
+    --property-suite-status)
+      property_suite_status="${2:-}"
+      shift 2
+      ;;
+    --runtime-budget-status)
+      runtime_budget_status="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$lane" || -z "$compact_report_file" || -z "$adversarial_report_file" || -z "$property_suite_status" || -z "$runtime_budget_status" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all weighted decay property evidence bundle arguments are required"
+fi
+
+if [[ ! -f "$compact_report_file" ]]; then
+  fail "compact report file not found: $compact_report_file"
+fi
+
+if [[ ! -f "$adversarial_report_file" ]]; then
+  fail "adversarial report file not found: $adversarial_report_file"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$lane" "$compact_report_file" "$adversarial_report_file" "$property_suite_status" "$runtime_budget_status" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import sys
+from typing import Any, Dict, List
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+(
+    output_file,
+    generated_at,
+    lane,
+    compact_report_file,
+    adversarial_report_file,
+    property_suite_status,
+    runtime_budget_status,
+    ci_fast_gate,
+) = sys.argv[1:]
+
+if lane not in {"contract", "deep"}:
+    fail("lane must be contract or deep")
+if property_suite_status not in {"pass", "fail"}:
+    fail("property-suite-status must be pass or fail")
+if runtime_budget_status not in {"within", "exceeded"}:
+    fail("runtime-budget-status must be within or exceeded")
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci-fast-gate must be PASS or FAIL")
+
+
+def parse_report(path: str, label: str) -> Dict[str, Any]:
+    report = json.loads(pathlib.Path(path).read_text())
+    if report.get("schema_version") != "kamn.reputation.weighted-decay.matrix.v1":
+        fail(f"{label} report schema_version mismatch")
+    status = report.get("status")
+    if status not in {"pass", "fail"}:
+        fail(f"{label} report status must be pass or fail")
+    case_count = report.get("case_count")
+    failed_count = report.get("failed_count")
+    failed_case_ids = report.get("failed_case_ids")
+    cases = report.get("cases")
+
+    if not isinstance(case_count, int):
+        fail(f"{label} report case_count must be an integer")
+    if not isinstance(failed_count, int):
+        fail(f"{label} report failed_count must be an integer")
+    if not isinstance(failed_case_ids, list) or not all(
+        isinstance(item, str) and item for item in failed_case_ids
+    ):
+        fail(f"{label} report failed_case_ids must be an array of non-empty strings")
+    if failed_case_ids != sorted(failed_case_ids):
+        fail(f"{label} report failed_case_ids must be sorted and deterministic")
+    if not isinstance(cases, list):
+        fail(f"{label} report cases must be an array")
+
+    normalized_cases: List[Dict[str, Any]] = []
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            fail(f"{label} report case[{index}] must be an object")
+        expected_kind = case.get("expected_abuse_penalty_kind")
+        actual_kind = case.get("actual_abuse_penalty_kind")
+        passed = case.get("passed")
+        if not isinstance(expected_kind, str) or not expected_kind:
+            fail(f"{label} report case[{index}] expected_abuse_penalty_kind must be a string")
+        if not isinstance(actual_kind, str) or not actual_kind:
+            fail(f"{label} report case[{index}] actual_abuse_penalty_kind must be a string")
+        if not isinstance(passed, bool):
+            fail(f"{label} report case[{index}] passed must be a boolean")
+        normalized_cases.append(
+            {
+                "expected_abuse_penalty_kind": expected_kind,
+                "actual_abuse_penalty_kind": actual_kind,
+                "passed": passed,
+            }
+        )
+
+    return {
+        "status": status,
+        "case_count": case_count,
+        "failed_count": failed_count,
+        "failed_case_ids": failed_case_ids,
+        "cases": normalized_cases,
+    }
+
+
+compact = parse_report(compact_report_file, "compact")
+adversarial = parse_report(adversarial_report_file, "adversarial")
+combined_cases = compact["cases"] + adversarial["cases"]
+
+
+def penalty_observed(kind: str) -> bool:
+    return any(
+        case["expected_abuse_penalty_kind"] == kind
+        and case["actual_abuse_penalty_kind"] == kind
+        and case["passed"]
+        for case in combined_cases
+    )
+
+
+reciprocity_penalty_observed = penalty_observed("ReciprocityRing")
+burst_penalty_observed = penalty_observed("BurstSpam")
+churn_penalty_observed = penalty_observed("ChurnSpike")
+
+decision_reasons: List[str] = []
+if compact["status"] != "pass":
+    decision_reasons.append("compact_matrix_not_pass")
+if adversarial["status"] != "pass":
+    decision_reasons.append("adversarial_matrix_not_pass")
+if compact["failed_count"] != 0:
+    decision_reasons.append("compact_matrix_failures_present")
+if adversarial["failed_count"] != 0:
+    decision_reasons.append("adversarial_matrix_failures_present")
+if not reciprocity_penalty_observed:
+    decision_reasons.append("reciprocity_penalty_not_observed")
+if not burst_penalty_observed:
+    decision_reasons.append("burst_penalty_not_observed")
+if not churn_penalty_observed:
+    decision_reasons.append("churn_penalty_not_observed")
+if property_suite_status != "pass":
+    decision_reasons.append("property_suite_failed")
+if runtime_budget_status != "within":
+    decision_reasons.append("runtime_budget_exceeded")
+if lane == "contract" and ci_fast_gate != "PASS":
+    decision_reasons.append("ci_fast_gate_failed")
+
+final_decision = "GO" if not decision_reasons else "NO-GO"
+if not decision_reasons:
+    decision_reasons.append("all weighted decay anti-gaming property checks passed")
+
+evidence_key = f"weighted_decay_property_contract:{lane}:v1"
+reason_key = f"weighted_decay_property_contract_reason:{final_decision}:v1"
+
+payload = {
+    "schema_version": "kamn.reputation.weighted-decay.property-evidence.v1",
+    "generated_at": generated_at,
+    "lane": lane,
+    "evidence_key": evidence_key,
+    "reason_key": reason_key,
+    "compact_matrix": compact,
+    "adversarial_matrix": adversarial,
+    "anti_gaming_coverage": {
+        "reciprocity_penalty_observed": reciprocity_penalty_observed,
+        "burst_penalty_observed": burst_penalty_observed,
+        "churn_penalty_observed": churn_penalty_observed,
+    },
+    "property_suite_status": property_suite_status,
+    "runtime_budget_status": runtime_budget_status,
+    "ci_fast_gate": ci_fast_gate,
+    "decision_reasons": decision_reasons,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'schema_version=kamn.reputation.weighted-decay.property-evidence.v1\n'
+printf 'evidence_key=weighted_decay_property_contract:%s:v1\n' "$lane"
+printf 'reason_key=weighted_decay_property_contract_reason:%s:v1\n' "$final_decision"
+printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/reputation/run_weighted_decay_contract_lane.sh
+++ b/scripts/reputation/run_weighted_decay_contract_lane.sh
@@ -3,18 +3,79 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MATRIX_SCRIPT="$ROOT_DIR/scripts/reputation/run_weighted_decay_matrix.py"
-FIXTURE_FILE="$ROOT_DIR/fixtures/reputation_decay/compact_cases.json"
+COMPACT_FIXTURE="$ROOT_DIR/fixtures/reputation_decay/compact_cases.json"
+ADVERSARIAL_FIXTURE="$ROOT_DIR/fixtures/reputation_decay/adversarial_cases.json"
+GENERATOR="$ROOT_DIR/scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/reputation/check_weighted_decay_property_policy.sh"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-report_json="$TMP_DIR/reputation-weighted-decay-contract-report.json"
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/reputation/run_weighted_decay_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+EOF
+}
 
-cargo test -p kamn-core --test trust_score_engine >/dev/null
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "weighted decay property evidence generator is not executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "weighted decay property policy checker is not executable"
+fi
+
+if [ "$skip_tests" != true ]; then
+  cargo test -p kamn-core --test trust_score_engine >/dev/null
+  cargo test -p kamn-core --test trust_score_property_invariants >/dev/null
+  cargo test -p kamn-core --test trust_score_engine_docs >/dev/null
+fi
+
+start_epoch="$(date +%s)"
+compact_report_json="$TMP_DIR/reputation-weighted-decay-compact-contract-report.json"
+adversarial_report_json="$TMP_DIR/reputation-weighted-decay-adversarial-contract-report.json"
 
 matrix_output="$(
   python3 "$MATRIX_SCRIPT" \
-    --fixture "$FIXTURE_FILE" \
-    --output-json "$report_json"
+    --fixture "$COMPACT_FIXTURE" \
+    --output-json "$compact_report_json"
 )"
 
 if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
@@ -22,4 +83,57 @@ if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
   exit 1
 fi
 
+adversarial_matrix_output="$(
+  python3 "$MATRIX_SCRIPT" \
+    --fixture "$ADVERSARIAL_FIXTURE" \
+    --output-json "$adversarial_report_json"
+)"
+
+if ! printf '%s\n' "$adversarial_matrix_output" | grep -q '^status=pass;'; then
+  echo "expected weighted decay adversarial matrix to pass" >&2
+  exit 1
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/reputation-weighted-decay-property-contract-bundle.json"
+fi
+
+max_seconds="${REPUTATION_WEIGHTED_DECAY_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+runtime_budget_status="within"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  runtime_budget_status="exceeded"
+fi
+
+generation_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --lane contract \
+    --compact-report-file "$compact_report_json" \
+    --adversarial-report-file "$adversarial_report_json" \
+    --property-suite-status pass \
+    --runtime-budget-status "$runtime_budget_status" \
+    --ci-fast-gate PASS
+)"
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+policy_decision="$(extract_value "$policy_output" "final_decision")"
+
+if [ "$runtime_budget_status" = "exceeded" ]; then
+  if [ "$policy_decision" != "NO-GO" ]; then
+    fail "expected NO-GO weighted decay policy decision when runtime budget is exceeded"
+  fi
+  fail "weighted decay contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+if [ "$policy_decision" != "GO" ]; then
+  fail "expected GO weighted decay policy decision for contract lane"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'schema_version=%s\n' "$(extract_value "$policy_output" "schema_version")"
+printf 'evidence_key=%s\n' "$(extract_value "$generation_output" "evidence_key")"
+printf 'reason_key=%s\n' "$(extract_value "$generation_output" "reason_key")"
+printf 'final_decision=%s\n' "$policy_decision"
 echo "weighted decay contract lane tests passed."

--- a/scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh
+++ b/scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/reputation/check_weighted_decay_property_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected weighted decay property evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected weighted decay property policy checker to be executable" >&2
+  exit 1
+fi
+
+compact_report="$TMP_DIR/weighted-decay-compact-go.json"
+cat >"$compact_report" <<'JSON'
+{
+  "schema_version": "kamn.reputation.weighted-decay.matrix.v1",
+  "status": "pass",
+  "case_count": 3,
+  "failed_count": 0,
+  "failed_case_ids": [],
+  "cases": [
+    {
+      "case_id": "clean-go-001",
+      "expected_abuse_penalty_kind": "None",
+      "actual_abuse_penalty_kind": "None",
+      "passed": true
+    },
+    {
+      "case_id": "reciprocity-ring-001",
+      "expected_abuse_penalty_kind": "ReciprocityRing",
+      "actual_abuse_penalty_kind": "ReciprocityRing",
+      "passed": true
+    },
+    {
+      "case_id": "burst-spam-001",
+      "expected_abuse_penalty_kind": "BurstSpam",
+      "actual_abuse_penalty_kind": "BurstSpam",
+      "passed": true
+    }
+  ]
+}
+JSON
+
+adversarial_report="$TMP_DIR/weighted-decay-adversarial-go.json"
+cat >"$adversarial_report" <<'JSON'
+{
+  "schema_version": "kamn.reputation.weighted-decay.matrix.v1",
+  "status": "pass",
+  "case_count": 2,
+  "failed_count": 0,
+  "failed_case_ids": [],
+  "cases": [
+    {
+      "case_id": "churn-spike-001",
+      "expected_abuse_penalty_kind": "ChurnSpike",
+      "actual_abuse_penalty_kind": "ChurnSpike",
+      "passed": true
+    },
+    {
+      "case_id": "compound-abuse-001",
+      "expected_abuse_penalty_kind": "Compound",
+      "actual_abuse_penalty_kind": "Compound",
+      "passed": true
+    }
+  ]
+}
+JSON
+
+go_bundle="$TMP_DIR/weighted-decay-property-go-bundle.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --lane contract \
+    --compact-report-file "$compact_report" \
+    --adversarial-report-file "$adversarial_report" \
+    --property-suite-status pass \
+    --runtime-budget-status within \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO weighted decay property evidence generation to succeed"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO weighted decay property evidence decision"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO weighted decay property policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO weighted decay property policy decision"
+
+adversarial_fail_report="$TMP_DIR/weighted-decay-adversarial-fail.json"
+cat >"$adversarial_fail_report" <<'JSON'
+{
+  "schema_version": "kamn.reputation.weighted-decay.matrix.v1",
+  "status": "fail",
+  "case_count": 2,
+  "failed_count": 1,
+  "failed_case_ids": ["churn-spike-001"],
+  "cases": [
+    {
+      "case_id": "churn-spike-001",
+      "expected_abuse_penalty_kind": "ChurnSpike",
+      "actual_abuse_penalty_kind": "BurstSpam",
+      "passed": false
+    },
+    {
+      "case_id": "compound-abuse-001",
+      "expected_abuse_penalty_kind": "Compound",
+      "actual_abuse_penalty_kind": "Compound",
+      "passed": true
+    }
+  ]
+}
+JSON
+
+no_go_bundle="$TMP_DIR/weighted-decay-property-no-go-bundle.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --lane contract \
+    --compact-report-file "$compact_report" \
+    --adversarial-report-file "$adversarial_fail_report" \
+    --property-suite-status pass \
+    --runtime-budget-status within \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$no_go_output" "status")" "generated" "expected NO-GO weighted decay property evidence generation to succeed"
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO weighted decay property evidence decision"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO weighted decay property policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO weighted decay property policy decision"
+
+tampered_bundle="$TMP_DIR/weighted-decay-property-tampered.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered weighted decay property evidence to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch for tampered weighted decay property evidence" >&2
+  exit 1
+fi
+
+# Regression: #933
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO mismatch for weighted decay anti-gaming regression path" >&2
+  exit 1
+fi
+
+echo "weighted decay property evidence bundle tests passed."

--- a/scripts/reputation/test_run_weighted_decay_contract_lane.sh
+++ b/scripts/reputation/test_run_weighted_decay_contract_lane.sh
@@ -3,11 +3,34 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/reputation/run_weighted_decay_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-output="$(bash "$SCRIPT")"
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected weighted decay contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/weighted-decay-property-contract-bundle.json"
+output="$(bash "$SCRIPT" --output-file "$bundle_file")"
 
 if ! printf '%s\n' "$output" | grep -q "weighted decay contract lane tests passed."; then
   echo "expected success output from weighted decay contract lane" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected weighted decay contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.reputation.weighted-decay.property-evidence.v1"' "$bundle_file"; then
+  echo "expected weighted decay property evidence schema marker" >&2
+  exit 1
+fi
+
+if ! grep -q "check_weighted_decay_property_policy.sh" "$SCRIPT"; then
+  echo "expected weighted decay contract lane to execute weighted decay policy checker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Adds a deterministic weighted-decay anti-gaming property evidence contract lane for reputation scoring, including fail-closed policy checking and bounded runtime enforcement for low-cost CI.

## Changes
- `scripts/reputation/generate_weighted_decay_property_evidence_bundle.sh`: new weighted-decay property evidence generator.
- `scripts/reputation/check_weighted_decay_property_policy.sh`: new policy checker that recomputes anti-gaming coverage and decision rules.
- `scripts/reputation/run_weighted_decay_contract_lane.sh`: upgraded to run compact + adversarial matrix reports, property invariant tests, policy evidence generation/checking, and runtime budget guard.
- `scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh`: GO/NO-GO + tamper regression tests (`Regression: #933`).
- `scripts/reputation/test_run_weighted_decay_contract_lane.sh`: validates emitted evidence bundle schema and policy-checker wiring.
- `docs/foundation/trust-score-engine.md`: added anti-gaming property lane commands, runtime-budget contract, and regression marker.
- `crates/kamn-core/tests/trust_score_engine_docs.rs`: docs contract coverage for new scripts/fixtures/property lane marker.
- `scripts/ci/test_select_targets.sh`: selector matrix coverage for weighted-decay policy checker script path.
- `scripts/ci/test_ci_tools.sh`: includes new weighted-decay property evidence bundle test.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh`
  - `expected weighted decay property evidence generator to be executable`
- `bash scripts/reputation/test_run_weighted_decay_contract_lane.sh`
  - `expected weighted decay contract lane script to be executable`
- `cargo test -p kamn-core --test trust_score_engine_docs`
  - failed missing weighted-decay property script references and `Regression: #933` docs marker.

### 🟢 Green Phase
- `bash scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh`
- `bash scripts/reputation/test_run_weighted_decay_contract_lane.sh`
- `bash scripts/reputation/test_run_weighted_decay_matrix.sh`
- `bash scripts/reputation/test_run_weighted_decay_deep_lane.sh`
- `cargo test -p kamn-core --test trust_score_engine_docs`

### 🔁 Regression
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test trust_score_engine`, `cargo test -p kamn-core --test trust_score_property_invariants` | |
| Functional   | ✅ | `scripts/reputation/test_generate_weighted_decay_property_evidence_bundle.sh` | |
| Integration  | ✅ | `scripts/reputation/test_run_weighted_decay_contract_lane.sh`, `scripts/reputation/test_run_weighted_decay_deep_lane.sh`, `scripts/ci/test_select_targets.sh` | |
| Regression   | ✅ | tampered final-decision mismatch assertion (`Regression: #933`) + docs regression marker check | |
| Performance  | ✅ | runtime budget guard in `run_weighted_decay_contract_lane.sh` via `REPUTATION_WEIGHTED_DECAY_MAX_SECONDS` | |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore previous weighted-decay lane behavior.

## Documentation Updates
- `docs/foundation/trust-score-engine.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #933