### PR TITLE
test(reputation): enforce dispute reason-code policy contracts (#934)

### DIFF
--- a/crates/kamn-core/tests/reputation_state_model_docs.rs
+++ b/crates/kamn-core/tests/reputation_state_model_docs.rs
@@ -31,6 +31,7 @@ fn doc_contains_dispute_evidence_bundle_contract() {
     assert!(DOC.contains("## Deterministic Reputation Dispute Evidence Contract"));
     assert!(DOC.contains("generate_reputation_dispute_evidence_bundle.sh"));
     assert!(DOC.contains("check_reputation_dispute_policy.sh"));
+    assert!(DOC.contains("reason_key"));
     assert!(DOC.contains("run_reputation_dispute_contract_lane.sh"));
     assert!(DOC.contains("run_reputation_dispute_deep_lane.sh"));
     assert!(DOC.contains("run_reputation_dispute_matrix.py"));
@@ -66,5 +67,13 @@ fn regression_requires_weighted_decay_abuse_guard_marker() {
     // Regression: #730
     assert!(DOC.contains(
         "replayed reciprocity, burst-spam, and churn abuse fixtures remain penalized (`Regression: #730`)."
+    ));
+}
+
+#[test]
+fn regression_requires_dispute_reason_code_policy_guard_marker() {
+    // Regression: #934
+    assert!(DOC.contains(
+        "reason-code mismatch or tampered dispute evidence payloads force `NO-GO` (`Regression: #934`)."
     ));
 }

--- a/docs/foundation/reputation-state-model.md
+++ b/docs/foundation/reputation-state-model.md
@@ -47,6 +47,10 @@ Trust score boundary checks are inclusive for `1000`.
 ## Deterministic Reputation Dispute Evidence Contract (Issue #738)
 Dispute adjudication uses machine-verifiable bundles so resolution outcomes stay reproducible and tamper-evident.
 
+- Schema contract:
+  - `schema_version`: `kamn.reputation.dispute-evidence.v1`
+  - `reason_key`: `reputation_dispute_reason_codes:<final_decision>:v1`
+  - `reason_codes`: sorted deterministic policy failure codes
 - Evidence bundle generator:
   - `bash scripts/reputation/generate_reputation_dispute_evidence_bundle.sh --output-file /tmp/reputation-dispute.json --dispute-id dispute-001 --subject-did did:kamn:agent-001 --reviewer-did did:kamn:reviewer-001 --dispute-reason-code QUALITY --evidence-uri s3://kamn-audit/reputation/dispute-001.json --evidence-sha256 sha256:1111111111111111111111111111111111111111111111111111111111111111 --evidence-hash-verified PASS --original-trust-score 640 --proposed-trust-score 560 --max-adjustment-points 120 --policy-window-open true --approval-recorded true --ci-fast-gate PASS`
 - Policy checker:
@@ -57,8 +61,11 @@ Dispute adjudication uses machine-verifiable bundles so resolution outcomes stay
   - `bash scripts/reputation/run_reputation_dispute_deep_lane.sh --output-json reputation-dispute-report.json`
 - Replay matrix runner:
   - `python3 scripts/reputation/run_reputation_dispute_matrix.py --fixture fixtures/reputation_dispute/replay_cases.json --output-json reputation-dispute-report.json`
+- Runtime budget control:
+  - `REPUTATION_DISPUTE_MAX_SECONDS` (contract lane fails closed when runtime exceeds budget)
 - Regression policy:
   - tampered evidence hashes, score-adjustment limit bypasses, and closed-policy-window decisions force `NO-GO` (`Regression: #730`).
+  - reason-code mismatch or tampered dispute evidence payloads force `NO-GO` (`Regression: #934`).
 
 ## Weighted Decay and Anti-Gaming Threshold Contract (Issue #736)
 Trust-score updates apply deterministic weighted decay windows and typed abuse-threshold penalties before score persistence.

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -85,6 +85,7 @@ bash "$ROOT_DIR/scripts/reputation/test_generate_reputation_dispute_evidence_bun
 bash "$ROOT_DIR/scripts/reputation/test_run_reputation_dispute_contract_lane.sh"
 bash "$ROOT_DIR/scripts/reputation/test_run_reputation_dispute_matrix.sh"
 bash "$ROOT_DIR/scripts/reputation/test_run_reputation_dispute_deep_lane.sh"
+bash "$ROOT_DIR/scripts/reputation/test_check_reputation_dispute_reason_code_policy.sh"
 bash "$ROOT_DIR/scripts/token/test_generate_token_launch_handoff_evidence_bundle.sh"
 bash "$ROOT_DIR/scripts/token/test_run_token_launch_handoff_contract_lane.sh"
 bash "$ROOT_DIR/scripts/token/test_run_token_launch_handoff_deep_lane.sh"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -860,6 +860,12 @@ assert_eq "$(extract_output "$reputation_contract_script_output" "run_reputation
 assert_eq "$(extract_output "$reputation_contract_script_output" "run_reputation_dispute_contract_tests")" "true" "reputation contract script changes must run reputation dispute contract lane"
 assert_eq "$(extract_output "$reputation_contract_script_output" "test_scope")" "reputation-contract" "reputation contract script changes should set reputation-contract scope"
 
+reputation_policy_checker_output="$(run_selector $'scripts/reputation/check_reputation_dispute_policy.sh')"
+assert_eq "$(extract_output "$reputation_policy_checker_output" "run_rust")" "false" "reputation policy checker script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$reputation_policy_checker_output" "run_reputation_decay_contract_tests")" "false" "dispute policy checker changes should not run weighted decay contract lane"
+assert_eq "$(extract_output "$reputation_policy_checker_output" "run_reputation_dispute_contract_tests")" "true" "reputation policy checker changes must run reputation dispute contract lane"
+assert_eq "$(extract_output "$reputation_policy_checker_output" "test_scope")" "reputation-contract" "reputation policy checker changes should set reputation-contract scope"
+
 reputation_contract_fixture_output="$(run_selector $'fixtures/reputation_dispute/replay_cases.json')"
 assert_eq "$(extract_output "$reputation_contract_fixture_output" "run_rust")" "false" "reputation fixture-only changes should avoid rust lane"
 assert_eq "$(extract_output "$reputation_contract_fixture_output" "run_reputation_decay_contract_tests")" "false" "dispute fixture changes should not run weighted decay contract lane"

--- a/scripts/reputation/check_reputation_dispute_policy.sh
+++ b/scripts/reputation/check_reputation_dispute_policy.sh
@@ -74,6 +74,7 @@ required_fields = (
     "policy_window_open",
     "approval_recorded",
     "ci_fast_gate",
+    "reason_key",
     "policy_checks",
     "reason_codes",
     "final_decision",
@@ -91,6 +92,10 @@ for field in ("policy_window_open", "approval_recorded"):
 
 if payload["ci_fast_gate"] not in {"PASS", "FAIL"}:
     fail("ci_fast_gate must be PASS or FAIL")
+
+reason_key = payload["reason_key"]
+if not isinstance(reason_key, str) or not reason_key:
+    fail("reason_key must be a non-empty string")
 
 evidence_bundle = payload["evidence_bundle"]
 if not isinstance(evidence_bundle, dict):
@@ -191,6 +196,13 @@ if actual_decision != expected_decision:
         f"expected final_decision={expected_decision}, found {actual_decision}"
     )
 
+expected_reason_key = f"reputation_dispute_reason_codes:{actual_decision}:v1"
+if reason_key != expected_reason_key:
+    fail(
+        "reason_key mismatch: "
+        f"expected {expected_reason_key}, found {reason_key}"
+    )
+
 failed_checks: List[str] = []
 if not did_fields_valid:
     failed_checks.append("did_fields_invalid")
@@ -210,6 +222,20 @@ if not approval_satisfied:
     failed_checks.append("approval_missing")
 if not ci_fast_gate_passed:
     failed_checks.append("ci_fast_gate_failed")
+failed_checks = sorted(failed_checks)
+
+reason_codes = payload["reason_codes"]
+if not isinstance(reason_codes, list):
+    fail("reason_codes must be an array")
+if not all(isinstance(item, str) and item for item in reason_codes):
+    fail("reason_codes must contain non-empty strings")
+if reason_codes != sorted(reason_codes):
+    fail("reason_codes must be sorted and deterministic")
+if reason_codes != failed_checks:
+    fail(
+        "reason_codes mismatch: "
+        f"expected reason_codes={failed_checks}, found {reason_codes}"
+    )
 
 failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
 print("status=ok")

--- a/scripts/reputation/generate_reputation_dispute_evidence_bundle.sh
+++ b/scripts/reputation/generate_reputation_dispute_evidence_bundle.sh
@@ -215,6 +215,7 @@ is_go = (
     and ci_fast_gate_passed
 )
 final_decision = "GO" if is_go else "NO-GO"
+reason_key = f"reputation_dispute_reason_codes:{final_decision}:v1"
 
 reason_codes = []
 if not did_fields_valid:
@@ -235,6 +236,7 @@ if not approval_satisfied:
     reason_codes.append("approval_missing")
 if not ci_fast_gate_passed:
     reason_codes.append("ci_fast_gate_failed")
+reason_codes = sorted(reason_codes)
 
 payload = {
     "schema_version": "kamn.reputation.dispute-evidence.v1",
@@ -257,6 +259,7 @@ payload = {
     "policy_window_open": policy_window_open,
     "approval_recorded": approval_recorded,
     "ci_fast_gate": ci_fast_gate,
+    "reason_key": reason_key,
     "policy_checks": {
         "did_fields_valid": did_fields_valid,
         "evidence_uri_present": evidence_uri_present,
@@ -280,4 +283,5 @@ PY
 
 printf 'status=generated\n'
 printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "reputation_dispute_reason_codes:${final_decision}:v1"
 printf 'final_decision=%s\n' "$final_decision"

--- a/scripts/reputation/run_reputation_dispute_contract_lane.sh
+++ b/scripts/reputation/run_reputation_dispute_contract_lane.sh
@@ -7,11 +7,72 @@ POLICY_CHECKER="$ROOT_DIR/scripts/reputation/check_reputation_dispute_policy.sh"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-BUNDLE_FILE="$TMP_DIR/reputation-dispute-contract.json"
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/reputation/run_reputation_dispute_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "reputation dispute evidence generator is not executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "reputation dispute policy checker is not executable"
+fi
+
+if [ "$skip_tests" != true ]; then
+  cargo test -p kamn-core --test reputation_state_model_docs >/dev/null
+  cargo test -p kamn-core --test reputation_signal_routing_docs >/dev/null
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/reputation-dispute-contract.json"
+fi
+
+start_epoch="$(date +%s)"
 
 generator_output="$(
   bash "$GENERATOR" \
-    --output-file "$BUNDLE_FILE" \
+    --output-file "$output_file" \
     --dispute-id "dispute-contract-001" \
     --subject-did "did:kamn:agent-contract-001" \
     --reviewer-did "did:kamn:reviewer-contract-001" \
@@ -32,7 +93,7 @@ if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
   exit 1
 fi
 
-policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$BUNDLE_FILE")"
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
 if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
   echo "expected reputation dispute contract lane policy decision to be GO" >&2
   exit 1
@@ -43,4 +104,14 @@ if ! printf '%s\n' "$policy_output" | grep -q "^failed_checks=none$"; then
   exit 1
 fi
 
+max_seconds="${REPUTATION_DISPUTE_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  fail "reputation dispute contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "$(extract_value "$generator_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
 echo "reputation dispute contract lane tests passed."

--- a/scripts/reputation/test_check_reputation_dispute_reason_code_policy.sh
+++ b/scripts/reputation/test_check_reputation_dispute_reason_code_policy.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/reputation/generate_reputation_dispute_evidence_bundle.sh"
+CHECKER="$ROOT_DIR/scripts/reputation/check_reputation_dispute_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected reputation dispute evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected reputation dispute policy checker to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/reputation-dispute-go.json"
+bash "$GENERATOR" \
+  --output-file "$bundle_file" \
+  --dispute-id "dispute-go-reason-code-001" \
+  --subject-did "did:kamn:agent-go-001" \
+  --reviewer-did "did:kamn:reviewer-go-001" \
+  --dispute-reason-code "QUALITY" \
+  --evidence-uri "s3://kamn-audit/reputation/dispute-go-reason-code-001.json" \
+  --evidence-sha256 "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  --evidence-hash-verified "PASS" \
+  --original-trust-score 650 \
+  --proposed-trust-score 600 \
+  --max-adjustment-points 90 \
+  --policy-window-open true \
+  --approval-recorded true \
+  --ci-fast-gate PASS >/dev/null
+
+tampered_bundle="$TMP_DIR/reputation-dispute-tampered-reason-codes.json"
+cp "$bundle_file" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["reason_codes"] = ["policy_window_closed"]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered reason_codes payload to fail dispute policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "reason_codes mismatch"; then
+  echo "expected reason_codes mismatch failure for tampered dispute policy payload" >&2
+  exit 1
+fi
+
+# Regression: #934
+if ! printf '%s\n' "$tampered_output" | grep -q "expected reason_codes"; then
+  echo "expected explicit reason code mismatch output for dispute policy regression path" >&2
+  exit 1
+fi
+
+echo "reputation dispute reason-code policy checker tests passed."

--- a/scripts/reputation/test_generate_reputation_dispute_evidence_bundle.sh
+++ b/scripts/reputation/test_generate_reputation_dispute_evidence_bundle.sh
@@ -31,6 +31,11 @@ if ! printf '%s\n' "$generator_output" | grep -q "^status=generated$"; then
   exit 1
 fi
 
+if ! printf '%s\n' "$generator_output" | grep -q "^reason_key=reputation_dispute_reason_codes:GO:v1$"; then
+  echo "expected GO reason key for reputation dispute go case" >&2
+  exit 1
+fi
+
 if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
   echo "expected GO final decision for reputation dispute go case" >&2
   exit 1
@@ -45,6 +50,7 @@ bundle_path = pathlib.Path(sys.argv[1])
 payload = json.loads(bundle_path.read_text(encoding="utf-8"))
 
 assert payload["schema_version"] == "kamn.reputation.dispute-evidence.v1"
+assert payload["reason_key"] == "reputation_dispute_reason_codes:GO:v1"
 assert payload["policy_checks"]["evidence_hash_matches"] is True
 assert payload["policy_checks"]["score_adjustment_within_limit"] is True
 assert payload["final_decision"] == "GO"
@@ -82,6 +88,11 @@ tampered_output="$(
 
 if ! printf '%s\n' "$tampered_output" | grep -q "^final_decision=NO-GO$"; then
   echo "expected NO-GO decision for tampered evidence case" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "^reason_key=reputation_dispute_reason_codes:NO-GO:v1$"; then
+  echo "expected NO-GO reason key for tampered evidence case" >&2
   exit 1
 fi
 

--- a/scripts/reputation/test_run_reputation_dispute_contract_lane.sh
+++ b/scripts/reputation/test_run_reputation_dispute_contract_lane.sh
@@ -3,11 +3,34 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/reputation/run_reputation_dispute_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-output="$(bash "$SCRIPT")"
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected reputation dispute contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/reputation-dispute-contract-bundle.json"
+output="$(bash "$SCRIPT" --output-file "$bundle_file")"
 
 if ! printf '%s\n' "$output" | grep -q "reputation dispute contract lane tests passed."; then
   echo "expected success output from reputation dispute contract lane" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected reputation dispute contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.reputation.dispute-evidence.v1"' "$bundle_file"; then
+  echo "expected reputation dispute evidence schema marker" >&2
+  exit 1
+fi
+
+if ! grep -q '"reason_key": "reputation_dispute_reason_codes:GO:v1"' "$bundle_file"; then
+  echo "expected reputation dispute reason key marker in emitted bundle" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Hardens reputation dispute evidence contracts with deterministic reason-code keying and strict reason-code mismatch policy checks, plus bounded runtime enforcement in the dispute contract lane.

## Changes
- `scripts/reputation/generate_reputation_dispute_evidence_bundle.sh`: adds deterministic `reason_key` and sorted `reason_codes` output.
- `scripts/reputation/check_reputation_dispute_policy.sh`: enforces `reason_key` consistency and rejects tampered/mismatched `reason_codes` payloads.
- `scripts/reputation/run_reputation_dispute_contract_lane.sh`: adds `--output-file`/`--skip-tests`, docs test hooks, output contract fields, and runtime budget guard (`REPUTATION_DISPUTE_MAX_SECONDS`).
- `scripts/reputation/test_check_reputation_dispute_reason_code_policy.sh`: new tamper/mismatch regression contract test (`Regression: #934`).
- `scripts/reputation/test_generate_reputation_dispute_evidence_bundle.sh`: verifies GO/NO-GO reason keys.
- `scripts/reputation/test_run_reputation_dispute_contract_lane.sh`: asserts evidence bundle emission + reason key marker.
- `docs/foundation/reputation-state-model.md`: documents dispute reason-code schema/rules and runtime budget contract.
- `crates/kamn-core/tests/reputation_state_model_docs.rs`: docs contract checks for `reason_key` and `Regression: #934` marker.
- `scripts/ci/test_select_targets.sh`: selector contract assertion for dispute policy checker path.
- `scripts/ci/test_ci_tools.sh`: includes new dispute reason-code policy checker test.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/reputation/test_check_reputation_dispute_reason_code_policy.sh`
  - `expected reputation dispute evidence generator to be executable`
- `bash scripts/reputation/test_run_reputation_dispute_contract_lane.sh`
  - `expected reputation dispute contract lane script to be executable`
- `bash scripts/reputation/test_generate_reputation_dispute_evidence_bundle.sh`
  - `expected GO reason key for reputation dispute go case`
- `cargo test -p kamn-core --test reputation_state_model_docs`
  - failed missing `reason_key` and `Regression: #934` docs markers.

### 🟢 Green Phase
- `bash scripts/reputation/test_generate_reputation_dispute_evidence_bundle.sh`
- `bash scripts/reputation/test_check_reputation_dispute_reason_code_policy.sh`
- `bash scripts/reputation/test_run_reputation_dispute_contract_lane.sh`
- `bash scripts/reputation/test_run_reputation_dispute_matrix.sh`
- `bash scripts/reputation/test_run_reputation_dispute_deep_lane.sh`
- `cargo test -p kamn-core --test reputation_state_model_docs`

### 🔁 Regression
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | dispute payload validation in `check_reputation_dispute_policy.sh` + docs tests | |
| Functional   | ✅ | `test_generate_reputation_dispute_evidence_bundle.sh`, `test_check_reputation_dispute_reason_code_policy.sh` | |
| Integration  | ✅ | `test_run_reputation_dispute_contract_lane.sh`, `test_run_reputation_dispute_matrix.sh`, `test_select_targets.sh` | |
| Regression   | ✅ | reason-code tamper mismatch rejection (`Regression: #934`) | |
| Performance  | ✅ | runtime budget guard in `run_reputation_dispute_contract_lane.sh` (`REPUTATION_DISPUTE_MAX_SECONDS`) | |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore previous dispute lane behavior.

## Documentation Updates
- `docs/foundation/reputation-state-model.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #934