### PR TITLE
docs(observability): add moderation recovery hook contracts (#924)

### DIFF
--- a/crates/kamn-core/tests/observability_stack_docs.rs
+++ b/crates/kamn-core/tests/observability_stack_docs.rs
@@ -29,6 +29,15 @@ fn doc_contains_post_cutover_slo_evidence_contract() {
 }
 
 #[test]
+fn doc_contains_moderation_recovery_observability_hooks() {
+    assert!(DOC.contains("## Moderation and Recovery Observability Hooks"));
+    assert!(DOC.contains("run_reputation_signal_quarantine_contract_lane.sh"));
+    assert!(DOC.contains("run_reputation_recovery_contract_lane.sh"));
+    assert!(DOC.contains("ingestion_action"));
+    assert!(DOC.contains("recovery_action"));
+}
+
+#[test]
 fn regression_requires_availability_critical_rule() {
     // Regression: #206
     assert!(DOC.contains("`Availability`: critical when below minimum threshold."));
@@ -48,5 +57,13 @@ fn regression_requires_post_cutover_slo_stale_evidence_guard() {
     // Regression: #711
     assert!(DOC.contains(
         "stale snapshots and incomplete SLO evidence force `NO-GO` (`Regression: #711`)."
+    ));
+}
+
+#[test]
+fn regression_requires_moderation_recovery_observability_guard() {
+    // Regression: #924
+    assert!(DOC.contains(
+        "quarantined stale/replayed signals and irreversible recovery reversals must remain visible through deterministic evidence keys (`Regression: #924`)."
     ));
 }

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -53,10 +53,24 @@ Launch expansion decisions require deterministic SLO evidence export and fail-cl
 - Regression policy:
   - stale snapshots and incomplete SLO evidence force `NO-GO` (`Regression: #711`).
 
+## Moderation and Recovery Observability Hooks (Issue #924)
+Reputation moderation actions publish deterministic quarantine/recovery evidence so operator dashboards can audit why signals were held or penalties reversed.
+
+- Quarantine observability lane:
+  - `bash scripts/reputation/run_reputation_signal_quarantine_contract_lane.sh`
+  - emits deterministic `reason_key`, `reason_codes`, and `ingestion_action` fields.
+- Recovery observability lane:
+  - `bash scripts/reputation/run_reputation_recovery_contract_lane.sh`
+  - emits deterministic `reason_key`, `reason_codes`, and `recovery_action` fields.
+- Regression policy:
+  - quarantined stale/replayed signals and irreversible recovery reversals must remain visible through deterministic evidence keys (`Regression: #924`).
+
 ## Local Validation
 Run from repository root:
 
 ```bash
+bash scripts/reputation/test_run_reputation_signal_quarantine_contract_lane.sh
+bash scripts/reputation/test_run_reputation_recovery_contract_lane.sh
 bash scripts/canary/test_generate_post_cutover_slo_evidence_bundle.sh
 bash scripts/canary/test_run_post_cutover_slo_contract_lane.sh
 cargo test -p kamn-core --test observability_stack


### PR DESCRIPTION
## Summary
Completes the remaining #924 documentation scope by adding explicit moderation/recovery observability hook contracts and regression markers.

## Changes
- `docs/foundation/observability-slo-dashboards.md`: added moderation/recovery observability hook section for quarantine and recovery evidence lanes with deterministic key/action fields.
- `crates/kamn-core/tests/observability_stack_docs.rs`: added docs contract assertions and regression marker coverage for the new observability hook section.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed new docs section and regression markers are enforced by docs tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | docs contract assertions for moderation/recovery hooks |
| Functional  | ✅     | observability docs include deterministic lane commands and fields |
| Integration | ✅     | observability docs/tests align with merged reputation lane scripts |
| Regression  | ✅     | `Regression: #924` marker enforced in docs tests |

Closes #924