### PR TITLE
test(deploy): add deployment slo rollback contract lane (#944)

### DIFF
--- a/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
+++ b/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
@@ -63,6 +63,17 @@ fn runbook_contains_live_network_pilot_rollback_evidence_gate() {
 }
 
 #[test]
+fn runbook_contains_deployment_slo_rollback_contract_lane() {
+    assert!(RUNBOOK.contains("## Deployment SLO Evidence and Rollback Automation Contract"));
+    assert!(RUNBOOK.contains("run_deployment_slo_rollback_lane.sh"));
+    assert!(RUNBOOK.contains("check_deployment_slo_rollback_policy.sh"));
+    assert!(RUNBOOK.contains("run_deployment_slo_rollback_contract_lane.sh"));
+    assert!(RUNBOOK.contains("kamn.deploy.slo-rollback-report.v1"));
+    assert!(RUNBOOK.contains("KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS"));
+    assert!(RUNBOOK.contains("KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS"));
+}
+
+#[test]
 fn regression_requires_watchdog_evidence_capture_and_fast_lane() {
     // Regression: #383
     assert!(RUNBOOK.contains(
@@ -86,5 +97,13 @@ fn regression_requires_live_network_pilot_rollback_guard_marker() {
     // Regression: #830
     assert!(RUNBOOK.contains(
         "pilot rollback remains mandatory when deep-lane evidence is stale, missing, or policy-invalid (`Regression: #830`)."
+    ));
+}
+
+#[test]
+fn regression_requires_deployment_slo_rollback_fail_closed_rules() {
+    // Regression: #944
+    assert!(RUNBOOK.contains(
+        "SLO gate drift, rollback automation evidence drift, docs parity drift, or runtime budget overflow force `NO-GO` (`Regression: #944`)."
     ));
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -49,17 +49,22 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
 - Dashboard backend session/auth freshness command changes map to dashboard contract scope:
   - `run_dashboard_contract_tests=true`
   - `test_scope=frontend-contract`
+- Deployment SLO/rollback command changes map to deploy scope:
+  - `run_deploy_preflight_tests=true`
+  - `test_scope=deploy`
 
 Required demo lane command contract:
 
 - `bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed-integration-contract-report.json`
 - `bash scripts/dashboard/run_backend_session_auth_freshness_contract_lane.sh --output-file /tmp/dashboard-backend-session-auth-freshness-contract-report.json`
+- `bash scripts/deploy/run_deployment_slo_rollback_contract_lane.sh --output-file /tmp/deployment-slo-rollback-contract-report.json`
 
 Regression policy:
 
 - make-target and selector workflow drift remains fail-closed (`Regression: #900`).
 - command-surface parity drift remains fail-closed (`Regression: #939`).
 - dashboard backend session/auth freshness selector/docs parity remains fail-closed (`Regression: #941`).
+- deployment slo/rollback selector/docs parity remains fail-closed (`Regression: #944`).
 
 ## Budget Telemetry and Enforcement
 Both lanes call `scripts/ci/evaluate_budget.sh` at the end of the run to:

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -55,6 +55,29 @@ Release promotion requires machine-validated DR drill evidence and SLO gate chec
 - Regression policy:
   - missing/incomplete DR evidence and SLO threshold violations force `NO-GO` (`Regression: #623`).
 
+## Deployment SLO Evidence and Rollback Automation Contract
+Deterministic deployment SLO/rollback policy checks are enforced through a bounded deployment lane:
+
+- Lane command:
+  - `bash scripts/deploy/run_deployment_slo_rollback_lane.sh --output-json /tmp/deployment-slo-rollback-report.json`
+- Policy checker command:
+  - `bash scripts/deploy/check_deployment_slo_rollback_policy.sh --report-file /tmp/deployment-slo-rollback-report.json`
+- Contract lane command:
+  - `bash scripts/deploy/run_deployment_slo_rollback_contract_lane.sh --output-file /tmp/deployment-slo-rollback-contract-report.json`
+
+Runtime budget controls:
+
+- `KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS`
+- `KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS`
+
+Required schema/reason markers:
+
+- `kamn.deploy.slo-rollback-report.v1`
+- `deployment_slo_rollback_reason_codes:GO:v1`
+- `deployment_slo_rollback_reason_codes:NO-GO:v1`
+
+The lane fails closed: SLO gate drift, rollback automation evidence drift, docs parity drift, or runtime budget overflow force `NO-GO` (`Regression: #944`).
+
 ## Live-Network Pilot Rollback Evidence Gate (Issue #830)
 Pilot rollback readiness requires deterministic deep-lane evidence and policy validation before release continuity is approved.
 

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -233,7 +233,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    scripts/deploy/*)
+    scripts/deploy/*|docs/foundation/upgrade-rollback-runbook.md|crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs)
       DEPLOY_SCRIPT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -25,12 +25,16 @@ required_snippets=(
   "live_transport_parity_languages=rust,python,typescript"
   "run_dashboard_contract_tests=true"
   "test_scope=frontend-contract"
+  "run_deploy_preflight_tests=true"
+  "test_scope=deploy"
   "run_localhost_signed_integration_contract_lane.sh"
   "run_backend_session_auth_freshness_contract_lane.sh"
+  "run_deployment_slo_rollback_contract_lane.sh"
   "scripts/ci/select_targets.sh"
   "Regression: #900"
   "Regression: #939"
   "Regression: #941"
+  "Regression: #944"
 )
 
 for snippet in "${required_snippets[@]}"; do

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -131,6 +131,27 @@ assert_eq "$(extract_output "$deploy_output" "live_transport_parity_languages")"
 assert_eq "$(extract_output "$deploy_output" "run_sdk_parity_matrix")" "false" "deploy-only changes should skip sdk parity matrix"
 assert_eq "$(extract_output "$deploy_output" "test_scope")" "deploy" "deploy-only changes must use deploy scope"
 
+rollback_runbook_output="$(run_selector $'docs/foundation/upgrade-rollback-runbook.md')"
+assert_eq "$(extract_output "$rollback_runbook_output" "docs_only")" "true" "upgrade rollback runbook updates should remain docs-only"
+assert_eq "$(extract_output "$rollback_runbook_output" "run_rust")" "false" "upgrade rollback runbook updates should avoid rust lane"
+assert_eq "$(extract_output "$rollback_runbook_output" "run_deploy_preflight_tests")" "true" "upgrade rollback runbook updates must run deploy preflight tests"
+assert_eq "$(extract_output "$rollback_runbook_output" "test_scope")" "deploy" "upgrade rollback runbook updates should use deploy scope"
+
+deployment_slo_lane_output="$(run_selector $'scripts/deploy/run_deployment_slo_rollback_lane.sh')"
+assert_eq "$(extract_output "$deployment_slo_lane_output" "run_rust")" "false" "deployment slo/rollback lane changes should avoid rust lane"
+assert_eq "$(extract_output "$deployment_slo_lane_output" "run_deploy_preflight_tests")" "true" "deployment slo/rollback lane changes must run deploy preflight tests"
+assert_eq "$(extract_output "$deployment_slo_lane_output" "test_scope")" "deploy" "deployment slo/rollback lane changes should set deploy scope"
+
+deployment_slo_policy_output="$(run_selector $'scripts/deploy/check_deployment_slo_rollback_policy.sh')"
+assert_eq "$(extract_output "$deployment_slo_policy_output" "run_rust")" "false" "deployment slo/rollback policy checker changes should avoid rust lane"
+assert_eq "$(extract_output "$deployment_slo_policy_output" "run_deploy_preflight_tests")" "true" "deployment slo/rollback policy checker changes must run deploy preflight tests"
+assert_eq "$(extract_output "$deployment_slo_policy_output" "test_scope")" "deploy" "deployment slo/rollback policy checker changes should set deploy scope"
+
+deployment_slo_contract_output="$(run_selector $'scripts/deploy/run_deployment_slo_rollback_contract_lane.sh')"
+assert_eq "$(extract_output "$deployment_slo_contract_output" "run_rust")" "false" "deployment slo/rollback contract lane changes should avoid rust lane"
+assert_eq "$(extract_output "$deployment_slo_contract_output" "run_deploy_preflight_tests")" "true" "deployment slo/rollback contract lane changes must run deploy preflight tests"
+assert_eq "$(extract_output "$deployment_slo_contract_output" "test_scope")" "deploy" "deployment slo/rollback contract lane changes should set deploy scope"
+
 # Regression: #463
 runner_output_file="$(mktemp)"
 runner_docs_output="$(GITHUB_OUTPUT="$runner_output_file" run_selector $'docs/foundation/ci-caching-parallelism.md')"

--- a/scripts/deploy/check_deployment_slo_rollback_policy.sh
+++ b/scripts/deploy/check_deployment_slo_rollback_policy.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/deploy/check_deployment_slo_rollback_policy.sh \
+    --report-file <path>
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+report_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report-file)
+      report_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$report_file" ]]; then
+  usage
+  fail "--report-file is required"
+fi
+
+if [[ ! -f "$report_file" ]]; then
+  fail "report file not found: $report_file"
+fi
+
+output="$(
+  python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+from typing import List
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+
+required_fields = (
+    "schema_version",
+    "evidence_key",
+    "status",
+    "final_decision",
+    "reason_key",
+    "elapsed_seconds",
+    "max_seconds",
+    "skip_commands",
+    "dr_bundle_file",
+    "generator_exit_code",
+    "policy_exit_code",
+    "dr_bundle_final_decision",
+    "policy_final_decision",
+    "deployment_lane_passed",
+    "slo_gate_passed",
+    "rollback_automation_passed",
+    "docs_contract_passed",
+    "command_count",
+    "commands",
+    "reason_codes",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing field: {field}")
+
+if payload["schema_version"] != "kamn.deploy.slo-rollback-report.v1":
+    fail("unexpected schema_version for deployment slo/rollback report")
+if payload["evidence_key"] != "deployment_slo_rollback:v1":
+    fail("unexpected evidence_key for deployment slo/rollback report")
+
+status = payload["status"]
+if status not in {"pass", "fail"}:
+    fail("status must be pass or fail")
+
+final_decision = payload["final_decision"]
+if final_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+
+expected_reason_key = f"deployment_slo_rollback_reason_codes:{final_decision}:v1"
+if payload["reason_key"] != expected_reason_key:
+    fail(
+        "reason_key mismatch: "
+        f"expected {expected_reason_key}, found {payload['reason_key']}"
+    )
+
+if not isinstance(payload["elapsed_seconds"], int):
+    fail("elapsed_seconds must be an integer")
+if not isinstance(payload["max_seconds"], int):
+    fail("max_seconds must be an integer")
+if payload["max_seconds"] < 0:
+    fail("max_seconds must be non-negative")
+
+if not isinstance(payload["skip_commands"], bool):
+    fail("skip_commands must be boolean")
+if not isinstance(payload["dr_bundle_file"], str) or not payload["dr_bundle_file"]:
+    fail("dr_bundle_file must be a non-empty string")
+
+for field in ("generator_exit_code", "policy_exit_code", "command_count"):
+    if not isinstance(payload[field], int):
+        fail(f"{field} must be an integer")
+
+for field in ("dr_bundle_final_decision", "policy_final_decision"):
+    if not isinstance(payload[field], str) or not payload[field]:
+        fail(f"{field} must be a non-empty string")
+
+for field in (
+    "deployment_lane_passed",
+    "slo_gate_passed",
+    "rollback_automation_passed",
+    "docs_contract_passed",
+):
+    if not isinstance(payload[field], bool):
+        fail(f"{field} must be boolean")
+
+commands = payload["commands"]
+if not isinstance(commands, list):
+    fail("commands must be an array")
+if not all(isinstance(item, str) and item for item in commands):
+    fail("commands must contain non-empty strings")
+if payload["command_count"] != len(commands):
+    fail("command_count must match commands length")
+
+reason_codes = payload["reason_codes"]
+if not isinstance(reason_codes, list):
+    fail("reason_codes must be an array")
+if not all(isinstance(item, str) and item for item in reason_codes):
+    fail("reason_codes must contain non-empty strings")
+if reason_codes != sorted(reason_codes):
+    fail("reason_codes must be sorted and deterministic")
+
+expected_reasons: List[str] = []
+if not payload["deployment_lane_passed"]:
+    expected_reasons.append("deployment_lane_failed")
+if not payload["slo_gate_passed"]:
+    expected_reasons.append("slo_gate_missing")
+if not payload["rollback_automation_passed"]:
+    expected_reasons.append("rollback_automation_missing")
+if not payload["docs_contract_passed"]:
+    expected_reasons.append("docs_contract_missing")
+if payload["elapsed_seconds"] > payload["max_seconds"]:
+    expected_reasons.append("runtime_budget_exceeded")
+expected_reasons = sorted(expected_reasons)
+
+expected_status = "pass" if not expected_reasons else "fail"
+expected_decision = "GO" if not expected_reasons else "NO-GO"
+
+if status != expected_status:
+    fail(f"status mismatch: expected {expected_status}, found {status}")
+if final_decision != expected_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_decision}, found {final_decision}"
+    )
+if reason_codes != expected_reasons:
+    fail(
+        "reason_codes mismatch: "
+        f"expected reason_codes={expected_reasons}, found {reason_codes}"
+    )
+
+failed_checks = ",".join(expected_reasons) if expected_reasons else "none"
+print("status=ok")
+print(f"report_file={path}")
+print(f"reason_key={payload['reason_key']}")
+print(f"final_decision={final_decision}")
+print(f"failed_checks={failed_checks}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/deploy/run_deployment_slo_rollback_contract_lane.sh
+++ b/scripts/deploy/run_deployment_slo_rollback_contract_lane.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/deploy/run_deployment_slo_rollback_contract_lane.sh \
+    [--output-file <path>]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/deploy/run_deployment_slo_rollback_lane.sh"
+CHECKER="$ROOT_DIR/scripts/deploy/check_deployment_slo_rollback_policy.sh"
+RUNBOOK_DOC="$ROOT_DIR/docs/foundation/upgrade-rollback-runbook.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+output_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  fail "expected deployment slo/rollback lane script to be executable"
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  fail "expected deployment slo/rollback policy checker to be executable"
+fi
+
+if [ ! -f "$RUNBOOK_DOC" ]; then
+  fail "expected upgrade rollback runbook doc to exist"
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/deployment-slo-rollback-contract-report.json"
+fi
+
+max_contract_seconds="${KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS:-240}"
+if [[ ! "$max_contract_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  fail "KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS must be a positive integer"
+fi
+
+start_epoch="$(date +%s)"
+
+go_output="$(
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS="$max_contract_seconds" \
+  bash "$LANE_SCRIPT" --output-json "$output_file"
+)"
+
+if ! printf '%s\n' "$go_output" | grep -q '^status=pass$'; then
+  fail "expected deployment slo/rollback lane GO run to report pass status"
+fi
+if ! printf '%s\n' "$go_output" | grep -q '^final_decision=GO$'; then
+  fail "expected deployment slo/rollback lane GO run to report GO decision"
+fi
+if ! printf '%s\n' "$go_output" | grep -q '^reason_key=deployment_slo_rollback_reason_codes:GO:v1$'; then
+  fail "expected deployment slo/rollback lane GO run to emit deterministic GO reason key"
+fi
+
+go_policy_output="$(bash "$CHECKER" --report-file "$output_file")"
+if ! printf '%s\n' "$go_policy_output" | grep -q '^status=ok$'; then
+  fail "expected deployment slo/rollback policy checker status marker for GO report"
+fi
+if ! printf '%s\n' "$go_policy_output" | grep -q '^final_decision=GO$'; then
+  fail "expected deployment slo/rollback policy checker GO decision for GO report"
+fi
+if ! printf '%s\n' "$go_policy_output" | grep -q '^failed_checks=none$'; then
+  fail "expected deployment slo/rollback policy checker no failed checks for GO report"
+fi
+
+rollback_no_go_report="$TMP_DIR/deployment-slo-rollback-no-go.json"
+set +e
+rollback_no_go_output="$(
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_SKIP_COMMANDS=true \
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_ROLLBACK_AUTOMATION_MISSING=true \
+  bash "$LANE_SCRIPT" --output-json "$rollback_no_go_report" 2>&1
+)"
+rollback_no_go_code=$?
+set -e
+
+if [ "$rollback_no_go_code" -eq 0 ]; then
+  fail "expected forced rollback automation missing deployment slo/rollback lane run to fail closed"
+fi
+
+if ! printf '%s\n' "$rollback_no_go_output" | grep -q 'rollback_automation_missing'; then
+  fail "expected forced rollback automation missing lane run to emit rollback_automation_missing reason code"
+fi
+
+rollback_no_go_policy_output="$(bash "$CHECKER" --report-file "$rollback_no_go_report")"
+if ! printf '%s\n' "$rollback_no_go_policy_output" | grep -q '^final_decision=NO-GO$'; then
+  fail "expected deployment slo/rollback policy checker NO-GO decision for rollback-missing report"
+fi
+if ! printf '%s\n' "$rollback_no_go_policy_output" | grep -q 'rollback_automation_missing'; then
+  fail "expected deployment slo/rollback policy checker failed checks to include rollback_automation_missing"
+fi
+
+if ! grep -q 'run_deployment_slo_rollback_lane.sh' "$RUNBOOK_DOC"; then
+  fail "expected upgrade rollback runbook to reference deployment slo/rollback lane command"
+fi
+if ! grep -q 'check_deployment_slo_rollback_policy.sh' "$RUNBOOK_DOC"; then
+  fail "expected upgrade rollback runbook to reference deployment slo/rollback policy checker command"
+fi
+if ! grep -q 'run_deployment_slo_rollback_contract_lane.sh' "$RUNBOOK_DOC"; then
+  fail "expected upgrade rollback runbook to reference deployment slo/rollback contract lane command"
+fi
+if ! grep -q 'kamn.deploy.slo-rollback-report.v1' "$RUNBOOK_DOC"; then
+  fail "expected upgrade rollback runbook to reference deployment slo/rollback schema marker"
+fi
+if ! grep -q 'Regression: #944' "$RUNBOOK_DOC"; then
+  fail "expected upgrade rollback runbook to include Regression: #944 marker"
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_contract_seconds" ]; then
+  fail "deployment slo/rollback contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'report_file=%s\n' "$output_file"
+printf 'final_decision=GO\n'
+echo "deployment slo/rollback contract lane tests passed."

--- a/scripts/deploy/run_deployment_slo_rollback_lane.sh
+++ b/scripts/deploy/run_deployment_slo_rollback_lane.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/deploy/run_deployment_slo_rollback_lane.sh \
+    --output-json <path>
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/deploy/generate_dr_evidence_bundle.sh"
+SLO_CHECKER="$ROOT_DIR/scripts/deploy/check_release_slo_gates.sh"
+RUNBOOK_DOC="$ROOT_DIR/docs/foundation/upgrade-rollback-runbook.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+output_json=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_json" ]]; then
+  usage
+  fail "--output-json is required"
+fi
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "expected deployment DR evidence generator to be executable"
+fi
+
+if [ ! -x "$SLO_CHECKER" ]; then
+  fail "expected deployment SLO gate checker to be executable"
+fi
+
+if [ ! -f "$RUNBOOK_DOC" ]; then
+  fail "expected upgrade rollback runbook doc to exist"
+fi
+
+max_seconds="${KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS:-180}"
+skip_commands="${KAMN_DEPLOYMENT_SLO_ROLLBACK_SKIP_COMMANDS:-false}"
+force_rollback_automation_missing="${KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_ROLLBACK_AUTOMATION_MISSING:-false}"
+force_slo_gate_missing="${KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_SLO_GATE_MISSING:-false}"
+force_docs_contract_missing="${KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_DOCS_CONTRACT_MISSING:-false}"
+force_lane_failure="${KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_LANE_FAILURE:-false}"
+
+if [[ ! "$max_seconds" =~ ^[0-9]+$ ]]; then
+  fail "KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS must be a non-negative integer"
+fi
+
+for value_name in \
+  skip_commands \
+  force_rollback_automation_missing \
+  force_slo_gate_missing \
+  force_docs_contract_missing \
+  force_lane_failure; do
+  value="${!value_name}"
+  if [[ "$value" != "true" && "$value" != "false" ]]; then
+    fail "invalid boolean for ${value_name}: ${value}"
+  fi
+done
+
+mkdir -p "$(dirname "$output_json")"
+start_epoch="$(date +%s)"
+
+commands=()
+bundle_file="$TMP_DIR/deployment-slo-rollback-dr-evidence.json"
+generator_output=""
+policy_output=""
+generator_exit_code=0
+policy_exit_code=0
+deployment_lane_passed=true
+
+demo_drill_id="dr-rollback-contract-2026-02-09"
+recovery_rto_seconds=240
+recovery_rpo_seconds=90
+max_rto_seconds=300
+max_rpo_seconds=120
+rollback_restored=true
+evidence_complete=true
+ci_fast_gate=PASS
+
+if [[ "$force_lane_failure" == "true" ]]; then
+  deployment_lane_passed=false
+  generator_exit_code=1
+  policy_exit_code=1
+elif [[ "$skip_commands" != "true" ]]; then
+  commands+=("bash scripts/deploy/generate_dr_evidence_bundle.sh --output-file ${bundle_file} --drill-id ${demo_drill_id} --recovery-rto-seconds ${recovery_rto_seconds} --recovery-rpo-seconds ${recovery_rpo_seconds} --max-rto-seconds ${max_rto_seconds} --max-rpo-seconds ${max_rpo_seconds} --rollback-restored ${rollback_restored} --evidence-complete ${evidence_complete} --ci-fast-gate ${ci_fast_gate}")
+  set +e
+  generator_output="$(
+    bash "$GENERATOR" \
+      --output-file "$bundle_file" \
+      --drill-id "$demo_drill_id" \
+      --recovery-rto-seconds "$recovery_rto_seconds" \
+      --recovery-rpo-seconds "$recovery_rpo_seconds" \
+      --max-rto-seconds "$max_rto_seconds" \
+      --max-rpo-seconds "$max_rpo_seconds" \
+      --rollback-restored "$rollback_restored" \
+      --evidence-complete "$evidence_complete" \
+      --ci-fast-gate "$ci_fast_gate" 2>&1
+  )"
+  generator_exit_code=$?
+  set -e
+
+  if [ "$generator_exit_code" -eq 0 ]; then
+    commands+=("bash scripts/deploy/check_release_slo_gates.sh --bundle-file ${bundle_file}")
+    set +e
+    policy_output="$(bash "$SLO_CHECKER" --bundle-file "$bundle_file" 2>&1)"
+    policy_exit_code=$?
+    set -e
+  else
+    policy_exit_code=1
+  fi
+
+  if [ "$generator_exit_code" -ne 0 ] || [ "$policy_exit_code" -ne 0 ]; then
+    deployment_lane_passed=false
+  fi
+fi
+
+dr_bundle_final_decision="unknown"
+if [[ "$skip_commands" != "true" && -n "$generator_output" ]]; then
+  maybe_dr_decision="$(extract_value "$generator_output" "final_decision")"
+  if [[ -n "$maybe_dr_decision" ]]; then
+    dr_bundle_final_decision="$maybe_dr_decision"
+  fi
+fi
+
+policy_final_decision="unknown"
+if [[ "$skip_commands" != "true" && -n "$policy_output" ]]; then
+  maybe_policy_decision="$(extract_value "$policy_output" "final_decision")"
+  if [[ -n "$maybe_policy_decision" ]]; then
+    policy_final_decision="$maybe_policy_decision"
+  fi
+fi
+
+slo_gate_passed=true
+if [[ "$skip_commands" != "true" ]]; then
+  if [ "$deployment_lane_passed" != "true" ] || [ "$policy_final_decision" != "GO" ]; then
+    slo_gate_passed=false
+  fi
+fi
+
+rollback_automation_passed=true
+if [[ "$skip_commands" != "true" ]]; then
+  if [ "$deployment_lane_passed" != "true" ]; then
+    rollback_automation_passed=false
+  else
+    set +e
+    python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+dr = payload.get("dr_evidence", {})
+if dr.get("rollback_restored") is not True:
+    raise SystemExit(1)
+if dr.get("evidence_complete") is not True:
+    raise SystemExit(1)
+PY
+    rollback_status=$?
+    set -e
+    if [ "$rollback_status" -ne 0 ]; then
+      rollback_automation_passed=false
+    fi
+  fi
+fi
+
+if [[ "$force_rollback_automation_missing" == "true" ]]; then
+  rollback_automation_passed=false
+fi
+
+if [[ "$force_slo_gate_missing" == "true" ]]; then
+  slo_gate_passed=false
+fi
+
+docs_contract_passed=true
+required_doc_snippets=(
+  "## Deployment SLO Evidence and Rollback Automation Contract"
+  "run_deployment_slo_rollback_lane.sh"
+  "check_deployment_slo_rollback_policy.sh"
+  "run_deployment_slo_rollback_contract_lane.sh"
+  "kamn.deploy.slo-rollback-report.v1"
+  "KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS"
+  "KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS"
+  "Regression: #944"
+)
+
+for snippet in "${required_doc_snippets[@]}"; do
+  if ! grep -Fq "$snippet" "$RUNBOOK_DOC"; then
+    docs_contract_passed=false
+    break
+  fi
+done
+
+if [[ "$force_docs_contract_missing" == "true" ]]; then
+  docs_contract_passed=false
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+
+reason_codes=()
+if [ "$deployment_lane_passed" != "true" ]; then
+  reason_codes+=("deployment_lane_failed")
+fi
+if [ "$slo_gate_passed" != "true" ]; then
+  reason_codes+=("slo_gate_missing")
+fi
+if [ "$rollback_automation_passed" != "true" ]; then
+  reason_codes+=("rollback_automation_missing")
+fi
+if [ "$docs_contract_passed" != "true" ]; then
+  reason_codes+=("docs_contract_missing")
+fi
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  reason_codes+=("runtime_budget_exceeded")
+fi
+
+if [ "${#reason_codes[@]}" -gt 0 ]; then
+  mapfile -t reason_codes < <(printf '%s\n' "${reason_codes[@]}" | sort -u)
+fi
+
+status="pass"
+final_decision="GO"
+if [ "${#reason_codes[@]}" -gt 0 ]; then
+  status="fail"
+  final_decision="NO-GO"
+fi
+reason_key="deployment_slo_rollback_reason_codes:${final_decision}:v1"
+
+reason_codes_csv="none"
+if [ "${#reason_codes[@]}" -gt 0 ]; then
+  reason_codes_csv="$(printf '%s,' "${reason_codes[@]}" | sed 's/,$//')"
+fi
+
+python3 - "$output_json" "$status" "$final_decision" "$reason_key" "$elapsed_seconds" "$max_seconds" "$skip_commands" "$bundle_file" "$generator_exit_code" "$policy_exit_code" "$dr_bundle_final_decision" "$policy_final_decision" "$deployment_lane_passed" "$slo_gate_passed" "$rollback_automation_passed" "$docs_contract_passed" "$reason_codes_csv" "${commands[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+output_file = pathlib.Path(sys.argv[1])
+status = sys.argv[2]
+final_decision = sys.argv[3]
+reason_key = sys.argv[4]
+elapsed_seconds = int(sys.argv[5])
+max_seconds = int(sys.argv[6])
+skip_commands = sys.argv[7] == "true"
+bundle_file = sys.argv[8]
+generator_exit_code = int(sys.argv[9])
+policy_exit_code = int(sys.argv[10])
+dr_bundle_final_decision = sys.argv[11]
+policy_final_decision = sys.argv[12]
+deployment_lane_passed = sys.argv[13] == "true"
+slo_gate_passed = sys.argv[14] == "true"
+rollback_automation_passed = sys.argv[15] == "true"
+docs_contract_passed = sys.argv[16] == "true"
+reason_codes_csv = sys.argv[17]
+commands = sys.argv[18:]
+
+payload = {
+    "schema_version": "kamn.deploy.slo-rollback-report.v1",
+    "evidence_key": "deployment_slo_rollback:v1",
+    "status": status,
+    "final_decision": final_decision,
+    "reason_key": reason_key,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "skip_commands": skip_commands,
+    "dr_bundle_file": bundle_file,
+    "generator_exit_code": generator_exit_code,
+    "policy_exit_code": policy_exit_code,
+    "dr_bundle_final_decision": dr_bundle_final_decision,
+    "policy_final_decision": policy_final_decision,
+    "deployment_lane_passed": deployment_lane_passed,
+    "slo_gate_passed": slo_gate_passed,
+    "rollback_automation_passed": rollback_automation_passed,
+    "docs_contract_passed": docs_contract_passed,
+    "command_count": len(commands),
+    "commands": commands,
+    "reason_codes": [] if reason_codes_csv == "none" else reason_codes_csv.split(","),
+}
+output_file.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+printf 'status=%s\n' "$status"
+printf 'final_decision=%s\n' "$final_decision"
+printf 'elapsed_seconds=%s\n' "$elapsed_seconds"
+printf 'reason_codes=%s\n' "$reason_codes_csv"
+printf 'reason_key=%s\n' "$reason_key"
+printf 'report_file=%s\n' "$output_json"
+
+if [ "$status" != "pass" ]; then
+  fail "deployment slo/rollback lane failed closed: ${reason_codes_csv}"
+fi
+
+echo "deployment slo/rollback lane tests passed."

--- a/scripts/deploy/test_check_deployment_slo_rollback_policy.sh
+++ b/scripts/deploy/test_check_deployment_slo_rollback_policy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/deploy/run_deployment_slo_rollback_lane.sh"
+CHECKER="$ROOT_DIR/scripts/deploy/check_deployment_slo_rollback_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected deployment slo/rollback lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected deployment slo/rollback policy checker script to be executable" >&2
+  exit 1
+fi
+
+go_report="$TMP_DIR/deployment-slo-rollback-go.json"
+KAMN_DEPLOYMENT_SLO_ROLLBACK_SKIP_COMMANDS=true \
+bash "$LANE_SCRIPT" --output-json "$go_report" >/dev/null
+
+go_checker_output="$(bash "$CHECKER" --report-file "$go_report")"
+if ! printf '%s\n' "$go_checker_output" | grep -q '^status=ok$'; then
+  echo "expected deployment slo/rollback policy checker status marker for GO report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$go_checker_output" | grep -q '^final_decision=GO$'; then
+  echo "expected deployment slo/rollback policy checker GO decision for GO report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$go_checker_output" | grep -q '^failed_checks=none$'; then
+  echo "expected deployment slo/rollback policy checker no failed checks for GO report" >&2
+  exit 1
+fi
+
+rollback_no_go_report="$TMP_DIR/deployment-slo-rollback-no-go.json"
+set +e
+KAMN_DEPLOYMENT_SLO_ROLLBACK_SKIP_COMMANDS=true \
+KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_ROLLBACK_AUTOMATION_MISSING=true \
+bash "$LANE_SCRIPT" --output-json "$rollback_no_go_report" >/dev/null 2>&1
+rollback_no_go_code=$?
+set -e
+
+if [ "$rollback_no_go_code" -eq 0 ]; then
+  echo "expected forced rollback automation missing deployment slo/rollback lane run to fail closed" >&2
+  exit 1
+fi
+
+rollback_no_go_checker_output="$(bash "$CHECKER" --report-file "$rollback_no_go_report")"
+if ! printf '%s\n' "$rollback_no_go_checker_output" | grep -q '^final_decision=NO-GO$'; then
+  echo "expected deployment slo/rollback policy checker NO-GO decision for rollback-missing report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$rollback_no_go_checker_output" | grep -q 'rollback_automation_missing'; then
+  echo "expected deployment slo/rollback policy checker failed checks to include rollback_automation_missing" >&2
+  exit 1
+fi
+
+tampered_report="$TMP_DIR/deployment-slo-rollback-tampered.json"
+cp "$go_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["reason_codes"] = ["rollback_automation_missing"]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$CHECKER" --report-file "$tampered_report" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered deployment slo/rollback report to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q 'reason_codes mismatch'; then
+  echo "expected reason_codes mismatch failure for tampered deployment slo/rollback report" >&2
+  exit 1
+fi
+
+# Regression: #944
+if ! printf '%s\n' "$tampered_output" | grep -q 'expected reason_codes'; then
+  echo "expected explicit reason-code mismatch output for deployment slo/rollback regression path" >&2
+  exit 1
+fi
+
+echo "deployment slo/rollback policy checker tests passed."

--- a/scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh
+++ b/scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/deploy/run_deployment_slo_rollback_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected deployment slo/rollback contract lane script to be executable" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/deployment-slo-rollback-contract-report.json"
+output="$(
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS=240 \
+  bash "$SCRIPT" --output-file "$report_file"
+)"
+
+if ! printf '%s\n' "$output" | grep -q 'deployment slo/rollback contract lane tests passed.'; then
+  echo "expected success output from deployment slo/rollback contract lane" >&2
+  exit 1
+fi
+
+if [ ! -f "$report_file" ]; then
+  echo "expected deployment slo/rollback contract lane to emit report file" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.deploy.slo-rollback-report.v1"' "$report_file"; then
+  echo "expected deployment slo/rollback report schema marker in contract lane output" >&2
+  exit 1
+fi
+
+if ! grep -q '"final_decision": "GO"' "$report_file"; then
+  echo "expected GO final decision in deployment slo/rollback contract lane report" >&2
+  exit 1
+fi
+
+if ! grep -q 'check_deployment_slo_rollback_policy.sh' "$SCRIPT"; then
+  echo "expected deployment slo/rollback contract lane to execute policy checker" >&2
+  exit 1
+fi
+
+echo "deployment slo/rollback contract lane script tests passed."

--- a/scripts/deploy/test_run_deployment_slo_rollback_lane.sh
+++ b/scripts/deploy/test_run_deployment_slo_rollback_lane.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/deploy/run_deployment_slo_rollback_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected deployment slo/rollback lane script to be executable" >&2
+  exit 1
+fi
+
+go_report="$TMP_DIR/deployment-slo-rollback-go.json"
+go_output="$(
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_SKIP_COMMANDS=true \
+  bash "$SCRIPT" --output-json "$go_report"
+)"
+
+if ! printf '%s\n' "$go_output" | grep -q '^status=pass$'; then
+  echo "expected deployment slo/rollback lane to report pass status for deterministic GO path" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$go_output" | grep -q '^final_decision=GO$'; then
+  echo "expected deployment slo/rollback lane to report GO decision for deterministic GO path" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$go_output" | grep -q '^reason_codes=none$'; then
+  echo "expected deployment slo/rollback lane to report no reason codes for deterministic GO path" >&2
+  exit 1
+fi
+
+python3 - "$go_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.deploy.slo-rollback-report.v1":
+    raise SystemExit("unexpected schema_version for deployment slo/rollback report")
+if payload.get("status") != "pass":
+    raise SystemExit("expected pass status for deterministic deployment slo/rollback GO path")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected GO final decision for deterministic deployment slo/rollback GO path")
+if payload.get("reason_codes") != []:
+    raise SystemExit("expected empty reason_codes for deterministic deployment slo/rollback GO path")
+if payload.get("rollback_automation_passed") is not True:
+    raise SystemExit("expected rollback_automation_passed=true for deterministic deployment slo/rollback GO path")
+if payload.get("slo_gate_passed") is not True:
+    raise SystemExit("expected slo_gate_passed=true for deterministic deployment slo/rollback GO path")
+if payload.get("docs_contract_passed") is not True:
+    raise SystemExit("expected docs_contract_passed=true for deterministic deployment slo/rollback GO path")
+PY
+
+set +e
+rollback_no_go_output="$(
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_SKIP_COMMANDS=true \
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_FORCE_ROLLBACK_AUTOMATION_MISSING=true \
+  bash "$SCRIPT" --output-json "$TMP_DIR/deployment-slo-rollback-no-go.json" 2>&1
+)"
+rollback_no_go_code=$?
+set -e
+
+if [ "$rollback_no_go_code" -eq 0 ]; then
+  echo "expected forced rollback automation missing deployment slo/rollback lane run to fail closed" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$rollback_no_go_output" | grep -q 'rollback_automation_missing'; then
+  echo "expected forced rollback automation missing deployment slo/rollback lane run to emit rollback_automation_missing reason code" >&2
+  exit 1
+fi
+
+set +e
+invalid_env_output="$(
+  KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS=invalid \
+  bash "$SCRIPT" --output-json "$TMP_DIR/deployment-slo-rollback-invalid-env.json" 2>&1
+)"
+invalid_env_code=$?
+set -e
+
+if [ "$invalid_env_code" -eq 0 ]; then
+  echo "expected invalid KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS to fail" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$invalid_env_output" | grep -q 'KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS'; then
+  echo "expected explicit validation output for invalid deployment slo/rollback max seconds env var" >&2
+  exit 1
+fi
+
+echo "deployment slo/rollback lane script tests passed."

--- a/scripts/deploy/test_run_dr_evidence_contract_lane.sh
+++ b/scripts/deploy/test_run_dr_evidence_contract_lane.sh
@@ -34,4 +34,10 @@ if ! grep -q "dr-evidence-report.json" "$DEEP_SCRIPT"; then
   exit 1
 fi
 
+# Keep deployment SLO/rollback automation contract coverage on the deploy lane
+# without widening workflow command count.
+bash "$ROOT_DIR/scripts/deploy/test_run_deployment_slo_rollback_lane.sh"
+bash "$ROOT_DIR/scripts/deploy/test_check_deployment_slo_rollback_policy.sh"
+bash "$ROOT_DIR/scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh"
+
 echo "dr evidence contract lane script tests passed."


### PR DESCRIPTION
## Summary
Adds a deterministic deployment SLO evidence and rollback automation contract lane with fail-closed policy checking, runtime budgets, and docs/selector command parity enforcement. This hardens deploy-go/no-go decision quality while keeping CI routing bounded to deploy scope.

Closes #944

## Changes
- `scripts/deploy/run_deployment_slo_rollback_lane.sh`: new bounded lane that generates deterministic deployment SLO/rollback reports and fails closed with stable reason codes.
- `scripts/deploy/check_deployment_slo_rollback_policy.sh`: new policy checker that validates schema/decision derivation and rejects reason-code tampering.
- `scripts/deploy/run_deployment_slo_rollback_contract_lane.sh`: new contract orchestrator covering GO and forced NO-GO paths plus docs parity checks.
- `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`: lane unit/functional tests.
- `scripts/deploy/test_check_deployment_slo_rollback_policy.sh`: policy functional/regression tests.
- `scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh`: contract-lane integration smoke test.
- `scripts/deploy/test_run_dr_evidence_contract_lane.sh`: deploy lane integration now includes deployment SLO/rollback contract checks.
- `docs/foundation/upgrade-rollback-runbook.md`: adds deployment SLO/rollback contract commands, markers, runtime env controls, and fail-closed regression rule.
- `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs`: adds runbook contract and regression assertions for #944.
- `scripts/ci/select_targets.sh`: routes `upgrade-rollback-runbook` contract surfaces to deploy scope.
- `scripts/ci/test_select_targets.sh`: adds selector regression assertions for new deployment SLO/rollback command surfaces and runbook docs routing.
- `docs/ci/strategy.md`: documents deploy scope mapping and command contract for deployment SLO/rollback lane.
- `scripts/ci/test_ci_strategy_contract.sh`: enforces new strategy doc snippets and regression marker for #944.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
bash scripts/deploy/test_run_deployment_slo_rollback_lane.sh
bash scripts/deploy/test_check_deployment_slo_rollback_policy.sh
bash scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh
```
Output:
```text
expected deployment slo/rollback lane script to be executable
expected deployment slo/rollback lane script to be executable
expected deployment slo/rollback contract lane script to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/deploy/test_run_deployment_slo_rollback_lane.sh
bash scripts/deploy/test_check_deployment_slo_rollback_policy.sh
bash scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh
bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_strategy_contract.sh
cargo test -p kamn-core --test upgrade_rollback_runbook_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
Output (summary):
```text
deployment slo/rollback lane script tests passed.
deployment slo/rollback policy checker tests passed.
deployment slo/rollback contract lane script tests passed.
dr evidence contract lane script tests passed.
select_targets matrix regression tests passed.
CI strategy contract tests passed.
upgrade_rollback_runbook_docs: 12 passed, 0 failed.
```

### 🔁 Regression
Command:
```bash
bash scripts/ci/test_ci_tools.sh
```
Output (summary):
```text
All CI tool regression tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`, `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs` | |
| Functional   | ✅     | `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`, `scripts/deploy/test_check_deployment_slo_rollback_policy.sh` | |
| Integration  | ✅     | `scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh`, `scripts/deploy/test_run_dr_evidence_contract_lane.sh`, `scripts/ci/test_select_targets.sh`, `scripts/ci/test_ci_strategy_contract.sh` | |
| Regression   | ✅     | Tampered reason-code rejection and runbook fail-closed marker (`Regression: #944`) | |
| Performance  | ✅     | Runtime budget enforcement via `KAMN_DEPLOYMENT_SLO_ROLLBACK_MAX_SECONDS` and `KAMN_DEPLOYMENT_SLO_ROLLBACK_CONTRACT_MAX_SECONDS` | |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: Revert commit `3131958` to remove deployment SLO/rollback lane surfaces and restore prior deploy contract behavior.

## Documentation Updates
- `docs/foundation/upgrade-rollback-runbook.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
