### PR TITLE
feat(bridges): add dry-run adapter conformance lane

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -258,6 +258,7 @@ jobs:
           bash scripts/bridge/run_telegram_ingress_contract_lane.sh --skip-replay
           bash scripts/bridge/run_bridge_ingress_relay_contract_lane.sh --skip-replay
           bash scripts/bridge/run_bridge_outbound_quorum_contract_lane.sh --skip-intent-lane
+          bash scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh --output-json bridge-adapter-conformance-contract-report.json
           bash scripts/bridge/run_bridge_replay_redaction_contract_lane.sh --skip-replay --replay-report-file bridge-replay-report.json
           bash scripts/bridge/run_localhost_bridge_demo_evidence_contract_lane.sh --skip-replay --replay-report-file bridge-replay-report.json
 

--- a/crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs
+++ b/crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs
@@ -28,3 +28,19 @@ fn doc_includes_cross_chain_receipt_finality_test_command() {
     assert!(DOC.contains("test_generate_cross_chain_outbound_intent_evidence_bundle.sh"));
     assert!(DOC.contains("test_run_cross_chain_outbound_intent_contract_lane.sh"));
 }
+
+#[test]
+fn doc_includes_bridge_adapter_conformance_contract() {
+    assert!(DOC.contains("## Bridge Adapter Dry-Run Conformance Contract (Issue #907)"));
+    assert!(DOC.contains("kamn.bridge.adapter-conformance.v1"));
+    assert!(DOC.contains("kamn.bridge.adapter-conformance.matrix-report.v1"));
+    assert!(DOC.contains("bridge_adapter_conformance_reason_codes:GO:v1"));
+    assert!(DOC.contains("bridge_adapter_conformance_reason_codes:NO-GO:v1"));
+    assert!(DOC.contains("Regression: #907"));
+}
+
+#[test]
+fn doc_includes_bridge_adapter_conformance_test_commands() {
+    assert!(DOC.contains("test_generate_bridge_adapter_conformance_evidence_bundle.sh"));
+    assert!(DOC.contains("test_run_bridge_adapter_conformance_contract_lane.sh"));
+}

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -61,6 +61,9 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
 - Settlement evidence command changes map to escrow scope:
   - `run_settlement_reconciliation_contract_tests=true`
   - `test_scope=escrow-contract`
+- Bridge adapter dry-run conformance command changes map to bridge scope:
+  - `run_bridge_replay_harness=true`
+  - `test_scope=bridge`
 - Post-cutover SLO/alert evidence command changes map to canary scope:
   - `run_launch_canary_contract_tests=true`
   - `test_scope=canary-contract`
@@ -80,6 +83,7 @@ Required demo lane command contract:
 - `bash scripts/frontend/run_dashboard_shell_determinism_matrix_contract_lane.sh --output-file /tmp/dashboard-shell-matrix-contract-report.json`
 - `bash scripts/deploy/run_deployment_slo_rollback_contract_lane.sh --output-file /tmp/deployment-slo-rollback-contract-report.json`
 - `bash scripts/escrow/run_settlement_reconciliation_contract_lane.sh`
+- `bash scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh --output-json /tmp/bridge-adapter-conformance-contract-report.json`
 - `bash scripts/canary/run_post_cutover_slo_contract_lane.sh`
 - `bash scripts/compliance/run_classification_redaction_contract_lane.sh --output-file /tmp/classification-redaction-contract-report.json`
 - `bash scripts/governance/run_governance_lifecycle_rollback_contract_lane.sh --output-file /tmp/governance-lifecycle-rollback-contract-report.json`
@@ -94,6 +98,7 @@ Regression policy:
 - dashboard backend session/auth freshness selector/docs parity remains fail-closed (`Regression: #941`).
 - deployment slo/rollback selector/docs parity remains fail-closed (`Regression: #944`).
 - settlement evidence selector/docs parity remains fail-closed (`Regression: #906`).
+- bridge adapter conformance selector/docs parity remains fail-closed (`Regression: #907`).
 - post-cutover slo/alert selector/docs parity remains fail-closed (`Regression: #913`).
 - classification/redaction compliance selector/docs parity remains fail-closed (`Regression: #914`).
 - governance lifecycle/rollback selector/docs parity remains fail-closed (`Regression: #910`).

--- a/docs/foundation/cross-chain-bridge-adapters.md
+++ b/docs/foundation/cross-chain-bridge-adapters.md
@@ -68,6 +68,20 @@ This document captures cross-chain adapter and receipt-finality normalization sl
   - recomputes expected final decision from bundle fields.
   - rejects tampered `final_decision` mismatches fail closed (`Regression: #742`).
 
+## Bridge Adapter Dry-Run Conformance Contract (Issue #907)
+- Dry-run bridge adapter conformance evidence schema:
+  - `kamn.bridge.adapter-conformance.v1`
+- Matrix report schema:
+  - `kamn.bridge.adapter-conformance.matrix-report.v1`
+- Conformance decision policy:
+  - `GO` requires `dry_run=true`, request/receipt schema-version equality, required-field subset compatibility, and `ci_fast_gate=PASS`.
+  - `NO-GO` is mandatory on any schema drift, missing required fields, disabled dry-run mode, or CI fast-gate failure.
+- Deterministic reason-key contract:
+  - `bridge_adapter_conformance_reason_codes:GO:v1`
+  - `bridge_adapter_conformance_reason_codes:NO-GO:v1`
+- Drift handling:
+  - checker recomputes final decision and reason key from payload facts and fails closed on tampering (`Regression: #907`).
+
 ## Processing Flow
 - `process_inbound(...)`:
   - validates listener and chain route mapping.
@@ -88,6 +102,8 @@ cargo test -p kamn-core --test cross_chain_bridge
 cargo test -p kamn-core --test cross_chain_receipt_finality
 bash scripts/bridge/test_generate_cross_chain_outbound_intent_evidence_bundle.sh
 bash scripts/bridge/test_run_cross_chain_outbound_intent_contract_lane.sh
+bash scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh
+bash scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core

--- a/fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json
+++ b/fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "kamn.bridge.adapter-conformance.fixture.v1",
+  "cases": [
+    {
+      "case_id": "go_dry_run_schema_compatible",
+      "adapter_id": "adapter-discord-settlement-v1",
+      "bridge_network": "ethereum",
+      "dry_run": true,
+      "request_expected_schema_version": "kamn.bridge.settlement-request.v1",
+      "request_observed_schema_version": "kamn.bridge.settlement-request.v1",
+      "request_required_fields": [
+        "request_id",
+        "destination_channel",
+        "payload_hash"
+      ],
+      "request_observed_fields": [
+        "destination_channel",
+        "payload_hash",
+        "request_id",
+        "trace_id"
+      ],
+      "receipt_expected_schema_version": "kamn.bridge.settlement-receipt.v1",
+      "receipt_observed_schema_version": "kamn.bridge.settlement-receipt.v1",
+      "receipt_required_fields": [
+        "receipt_id",
+        "settlement_ref",
+        "finality"
+      ],
+      "receipt_observed_fields": [
+        "receipt_id",
+        "settlement_ref",
+        "finality",
+        "gas_used"
+      ],
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "GO"
+    },
+    {
+      "case_id": "no_go_request_schema_drift",
+      "adapter_id": "adapter-discord-settlement-v1",
+      "bridge_network": "ethereum",
+      "dry_run": true,
+      "request_expected_schema_version": "kamn.bridge.settlement-request.v1",
+      "request_observed_schema_version": "kamn.bridge.settlement-request.v2",
+      "request_required_fields": [
+        "request_id",
+        "destination_channel",
+        "payload_hash"
+      ],
+      "request_observed_fields": [
+        "request_id",
+        "destination_channel"
+      ],
+      "receipt_expected_schema_version": "kamn.bridge.settlement-receipt.v1",
+      "receipt_observed_schema_version": "kamn.bridge.settlement-receipt.v1",
+      "receipt_required_fields": [
+        "receipt_id",
+        "settlement_ref",
+        "finality"
+      ],
+      "receipt_observed_fields": [
+        "receipt_id",
+        "settlement_ref",
+        "finality"
+      ],
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    },
+    {
+      "case_id": "no_go_receipt_schema_and_ci_drift",
+      "adapter_id": "adapter-solana-settlement-v1",
+      "bridge_network": "solana",
+      "dry_run": false,
+      "request_expected_schema_version": "kamn.bridge.settlement-request.v1",
+      "request_observed_schema_version": "kamn.bridge.settlement-request.v1",
+      "request_required_fields": [
+        "request_id",
+        "destination_channel",
+        "payload_hash"
+      ],
+      "request_observed_fields": [
+        "request_id",
+        "destination_channel",
+        "payload_hash"
+      ],
+      "receipt_expected_schema_version": "kamn.bridge.settlement-receipt.v1",
+      "receipt_observed_schema_version": "kamn.bridge.settlement-receipt.v2",
+      "receipt_required_fields": [
+        "receipt_id",
+        "settlement_ref",
+        "finality"
+      ],
+      "receipt_observed_fields": [
+        "receipt_id",
+        "finality"
+      ],
+      "ci_fast_gate": "FAIL",
+      "expected_final_decision": "NO-GO"
+    }
+  ]
+}

--- a/scripts/bridge/check_bridge_adapter_conformance_policy.sh
+++ b/scripts/bridge/check_bridge_adapter_conformance_policy.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/bridge/check_bridge_adapter_conformance_policy.sh \
+    --bundle-file <path>
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+bundle_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-file)
+      bundle_file="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$bundle_file" ]]; then
+  usage
+  fail "--bundle-file is required"
+fi
+
+if [[ ! -f "$bundle_file" ]]; then
+  fail "bundle file not found: $bundle_file"
+fi
+
+output="$(
+  python3 - "$bundle_file" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+def ensure_string_list(value: object, field_name: str) -> list[str]:
+    if not isinstance(value, list):
+        fail(f"{field_name} must be an array")
+    if not all(isinstance(item, str) for item in value):
+        fail(f"{field_name} entries must be strings")
+    normalized = [item.strip() for item in value if item.strip()]
+    return normalized
+
+
+def normalize_set(values: list[str]) -> list[str]:
+    return sorted(set(values))
+
+
+bundle_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(bundle_path.read_text())
+except json.JSONDecodeError as exc:
+    fail(f"bundle file is not valid JSON: {exc}")
+
+required_fields = (
+    "schema_version",
+    "generated_at",
+    "adapter_id",
+    "bridge_network",
+    "dry_run",
+    "request_contract",
+    "receipt_contract",
+    "ci_fast_gate",
+    "reason_key",
+    "reason_codes",
+    "decision_reasons",
+    "final_decision",
+)
+for field in required_fields:
+    if field not in payload:
+        fail(f"missing bundle field: {field}")
+
+if payload["schema_version"] != "kamn.bridge.adapter-conformance.v1":
+    fail("unexpected schema_version for bridge adapter conformance evidence bundle")
+
+if not isinstance(payload["adapter_id"], str) or not payload["adapter_id"].strip():
+    fail("adapter_id must be a non-empty string")
+
+if payload["bridge_network"] not in {"ethereum", "solana", "near", "custom"}:
+    fail("bridge_network must be ethereum|solana|near|custom")
+
+if not isinstance(payload["dry_run"], bool):
+    fail("dry_run must be a boolean")
+
+if payload["ci_fast_gate"] not in {"PASS", "FAIL"}:
+    fail("ci_fast_gate must be PASS or FAIL")
+
+request_contract = payload["request_contract"]
+if not isinstance(request_contract, dict):
+    fail("request_contract must be an object")
+receipt_contract = payload["receipt_contract"]
+if not isinstance(receipt_contract, dict):
+    fail("receipt_contract must be an object")
+
+for section_name, section in (("request_contract", request_contract), ("receipt_contract", receipt_contract)):
+    for key in (
+        "expected_schema_version",
+        "observed_schema_version",
+        "required_fields",
+        "observed_fields",
+        "missing_required_fields",
+    ):
+        if key not in section:
+            fail(f"{section_name} missing field: {key}")
+    if not isinstance(section["expected_schema_version"], str):
+        fail(f"{section_name}.expected_schema_version must be a string")
+    if not isinstance(section["observed_schema_version"], str):
+        fail(f"{section_name}.observed_schema_version must be a string")
+
+request_required_fields = normalize_set(
+    ensure_string_list(request_contract["required_fields"], "request_contract.required_fields")
+)
+request_observed_fields = normalize_set(
+    ensure_string_list(request_contract["observed_fields"], "request_contract.observed_fields")
+)
+request_missing_required_fields = normalize_set(
+    ensure_string_list(
+        request_contract["missing_required_fields"], "request_contract.missing_required_fields"
+    )
+)
+
+receipt_required_fields = normalize_set(
+    ensure_string_list(receipt_contract["required_fields"], "receipt_contract.required_fields")
+)
+receipt_observed_fields = normalize_set(
+    ensure_string_list(receipt_contract["observed_fields"], "receipt_contract.observed_fields")
+)
+receipt_missing_required_fields = normalize_set(
+    ensure_string_list(
+        receipt_contract["missing_required_fields"], "receipt_contract.missing_required_fields"
+    )
+)
+
+computed_request_missing_required_fields = sorted(
+    [field for field in request_required_fields if field not in set(request_observed_fields)]
+)
+computed_receipt_missing_required_fields = sorted(
+    [field for field in receipt_required_fields if field not in set(receipt_observed_fields)]
+)
+
+if request_missing_required_fields != computed_request_missing_required_fields:
+    fail(
+        "request missing_required_fields mismatch: "
+        f"expected {computed_request_missing_required_fields}, found {request_missing_required_fields}"
+    )
+if receipt_missing_required_fields != computed_receipt_missing_required_fields:
+    fail(
+        "receipt missing_required_fields mismatch: "
+        f"expected {computed_receipt_missing_required_fields}, found {receipt_missing_required_fields}"
+    )
+
+reason_key = payload["reason_key"]
+if not isinstance(reason_key, str):
+    fail("reason_key must be a string")
+reason_codes = ensure_string_list(payload["reason_codes"], "reason_codes")
+decision_reasons = ensure_string_list(payload["decision_reasons"], "decision_reasons")
+
+expected_reason_codes: list[str] = []
+if not payload["dry_run"]:
+    expected_reason_codes.append("dry_run_disabled")
+if request_contract["expected_schema_version"] != request_contract["observed_schema_version"]:
+    expected_reason_codes.append("request_schema_version_mismatch")
+if receipt_contract["expected_schema_version"] != receipt_contract["observed_schema_version"]:
+    expected_reason_codes.append("receipt_schema_version_mismatch")
+if not request_required_fields:
+    expected_reason_codes.append("request_required_fields_contract_missing")
+if computed_request_missing_required_fields:
+    expected_reason_codes.append("request_required_fields_missing")
+if not receipt_required_fields:
+    expected_reason_codes.append("receipt_required_fields_contract_missing")
+if computed_receipt_missing_required_fields:
+    expected_reason_codes.append("receipt_required_fields_missing")
+if payload["ci_fast_gate"] != "PASS":
+    expected_reason_codes.append("ci_fast_gate_failed")
+
+expected_final_decision = "GO"
+if expected_reason_codes:
+    expected_final_decision = "NO-GO"
+else:
+    expected_reason_codes = [
+        "adapter_conformance_dry_run_mode",
+        "adapter_request_receipt_contracts_compatible",
+    ]
+
+actual_final_decision = payload["final_decision"]
+if actual_final_decision not in {"GO", "NO-GO"}:
+    fail("final_decision must be GO or NO-GO")
+if actual_final_decision != expected_final_decision:
+    fail(
+        "policy decision mismatch: "
+        f"expected final_decision={expected_final_decision}, found {actual_final_decision}"
+    )
+
+if reason_codes != expected_reason_codes:
+    fail(
+        "reason_codes mismatch: "
+        f"expected {expected_reason_codes}, found {reason_codes}"
+    )
+
+if decision_reasons != expected_reason_codes:
+    fail(
+        "decision_reasons mismatch: "
+        f"expected {expected_reason_codes}, found {decision_reasons}"
+    )
+
+expected_reason_key = f"bridge_adapter_conformance_reason_codes:{expected_final_decision}:v1"
+if reason_key != expected_reason_key:
+    fail(
+        "reason_key mismatch: "
+        f"expected {expected_reason_key}, found {reason_key}"
+    )
+
+print("status=ok")
+print(f"bundle_file={bundle_path}")
+print(f"final_decision={actual_final_decision}")
+print(f"reason_key={reason_key}")
+print(f"decision_reasons={'; '.join(expected_reason_codes)}")
+PY
+)"
+
+printf '%s\n' "$output"

--- a/scripts/bridge/generate_bridge_adapter_conformance_evidence_bundle.sh
+++ b/scripts/bridge/generate_bridge_adapter_conformance_evidence_bundle.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/bridge/generate_bridge_adapter_conformance_evidence_bundle.sh \
+    --output-file <path> \
+    --adapter-id <value> \
+    --bridge-network ethereum|solana|near|custom \
+    --dry-run true|false \
+    --request-expected-schema-version <value> \
+    --request-observed-schema-version <value> \
+    --request-required-fields <csv> \
+    --request-observed-fields <csv> \
+    --receipt-expected-schema-version <value> \
+    --receipt-observed-schema-version <value> \
+    --receipt-required-fields <csv> \
+    --receipt-observed-fields <csv> \
+    --ci-fast-gate PASS|FAIL
+EOF
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+output_file=""
+adapter_id=""
+bridge_network=""
+dry_run=""
+request_expected_schema_version=""
+request_observed_schema_version=""
+request_required_fields=""
+request_observed_fields=""
+receipt_expected_schema_version=""
+receipt_observed_schema_version=""
+receipt_required_fields=""
+receipt_observed_fields=""
+ci_fast_gate=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --adapter-id)
+      adapter_id="${2:-}"
+      shift 2
+      ;;
+    --bridge-network)
+      bridge_network="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="${2:-}"
+      shift 2
+      ;;
+    --request-expected-schema-version)
+      request_expected_schema_version="${2:-}"
+      shift 2
+      ;;
+    --request-observed-schema-version)
+      request_observed_schema_version="${2:-}"
+      shift 2
+      ;;
+    --request-required-fields)
+      request_required_fields="${2:-}"
+      shift 2
+      ;;
+    --request-observed-fields)
+      request_observed_fields="${2:-}"
+      shift 2
+      ;;
+    --receipt-expected-schema-version)
+      receipt_expected_schema_version="${2:-}"
+      shift 2
+      ;;
+    --receipt-observed-schema-version)
+      receipt_observed_schema_version="${2:-}"
+      shift 2
+      ;;
+    --receipt-required-fields)
+      receipt_required_fields="${2:-}"
+      shift 2
+      ;;
+    --receipt-observed-fields)
+      receipt_observed_fields="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$adapter_id" || -z "$bridge_network" || -z "$dry_run" || -z "$request_expected_schema_version" || -z "$request_observed_schema_version" || -z "$request_required_fields" || -z "$request_observed_fields" || -z "$receipt_expected_schema_version" || -z "$receipt_observed_schema_version" || -z "$receipt_required_fields" || -z "$receipt_observed_fields" || -z "$ci_fast_gate" ]]; then
+  usage
+  fail "all bridge adapter conformance evidence arguments are required"
+fi
+
+mkdir -p "$(dirname "$output_file")"
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+final_decision="$(
+  python3 - "$output_file" "$generated_at" "$adapter_id" "$bridge_network" "$dry_run" "$request_expected_schema_version" "$request_observed_schema_version" "$request_required_fields" "$request_observed_fields" "$receipt_expected_schema_version" "$receipt_observed_schema_version" "$receipt_required_fields" "$receipt_observed_fields" "$ci_fast_gate" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def parse_csv(raw: str) -> list[str]:
+    fields = [part.strip() for part in raw.split(",")]
+    normalized = sorted({field for field in fields if field})
+    return normalized
+
+
+(
+    output_file,
+    generated_at,
+    adapter_id,
+    bridge_network,
+    dry_run_raw,
+    request_expected_schema_version,
+    request_observed_schema_version,
+    request_required_fields_raw,
+    request_observed_fields_raw,
+    receipt_expected_schema_version,
+    receipt_observed_schema_version,
+    receipt_required_fields_raw,
+    receipt_observed_fields_raw,
+    ci_fast_gate,
+) = sys.argv[1:]
+
+if bridge_network not in {"ethereum", "solana", "near", "custom"}:
+    fail("bridge-network must be ethereum|solana|near|custom")
+
+if dry_run_raw not in {"true", "false"}:
+    fail("dry-run must be true or false")
+dry_run = dry_run_raw == "true"
+
+if ci_fast_gate not in {"PASS", "FAIL"}:
+    fail("ci-fast-gate must be PASS or FAIL")
+
+if not adapter_id.strip():
+    fail("adapter-id must be non-empty")
+
+request_required_fields = parse_csv(request_required_fields_raw)
+request_observed_fields = parse_csv(request_observed_fields_raw)
+receipt_required_fields = parse_csv(receipt_required_fields_raw)
+receipt_observed_fields = parse_csv(receipt_observed_fields_raw)
+
+request_missing_required_fields = sorted(
+    [field for field in request_required_fields if field not in set(request_observed_fields)]
+)
+receipt_missing_required_fields = sorted(
+    [field for field in receipt_required_fields if field not in set(receipt_observed_fields)]
+)
+
+reason_codes: list[str] = []
+
+if not dry_run:
+    reason_codes.append("dry_run_disabled")
+if request_expected_schema_version != request_observed_schema_version:
+    reason_codes.append("request_schema_version_mismatch")
+if receipt_expected_schema_version != receipt_observed_schema_version:
+    reason_codes.append("receipt_schema_version_mismatch")
+if not request_required_fields:
+    reason_codes.append("request_required_fields_contract_missing")
+if request_missing_required_fields:
+    reason_codes.append("request_required_fields_missing")
+if not receipt_required_fields:
+    reason_codes.append("receipt_required_fields_contract_missing")
+if receipt_missing_required_fields:
+    reason_codes.append("receipt_required_fields_missing")
+if ci_fast_gate != "PASS":
+    reason_codes.append("ci_fast_gate_failed")
+
+final_decision = "GO" if not reason_codes else "NO-GO"
+if final_decision == "GO":
+    reason_codes = [
+        "adapter_conformance_dry_run_mode",
+        "adapter_request_receipt_contracts_compatible",
+    ]
+
+reason_key = f"bridge_adapter_conformance_reason_codes:{final_decision}:v1"
+
+payload = {
+    "schema_version": "kamn.bridge.adapter-conformance.v1",
+    "generated_at": generated_at,
+    "adapter_id": adapter_id,
+    "bridge_network": bridge_network,
+    "dry_run": dry_run,
+    "request_contract": {
+        "expected_schema_version": request_expected_schema_version,
+        "observed_schema_version": request_observed_schema_version,
+        "required_fields": request_required_fields,
+        "observed_fields": request_observed_fields,
+        "missing_required_fields": request_missing_required_fields,
+    },
+    "receipt_contract": {
+        "expected_schema_version": receipt_expected_schema_version,
+        "observed_schema_version": receipt_observed_schema_version,
+        "required_fields": receipt_required_fields,
+        "observed_fields": receipt_observed_fields,
+        "missing_required_fields": receipt_missing_required_fields,
+    },
+    "ci_fast_gate": ci_fast_gate,
+    "reason_key": reason_key,
+    "reason_codes": reason_codes,
+    "decision_reasons": reason_codes,
+    "final_decision": final_decision,
+}
+
+path = pathlib.Path(output_file)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+print(final_decision)
+PY
+)"
+
+reason_key="bridge_adapter_conformance_reason_codes:${final_decision}:v1"
+
+printf 'status=generated\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'final_decision=%s\n' "$final_decision"
+printf 'reason_key=%s\n' "$reason_key"

--- a/scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh
+++ b/scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_adapter_conformance_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json"
+
+output_json=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  echo "expected bridge adapter conformance matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected bridge adapter conformance fixture file to exist" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+report_file="$TMP_DIR/bridge-adapter-conformance-contract-report.json"
+
+matrix_output="$(
+  python3 "$MATRIX_SCRIPT" \
+    --fixture "$FIXTURE_FILE" \
+    --max-cases 3 \
+    --output-json "$report_file"
+)"
+if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
+  echo "expected bridge adapter conformance contract matrix to pass" >&2
+  exit 1
+fi
+
+cargo test -p kamn-core --test bridge_adapter -- regression_rejects_adapter_outbound_request_id_mutation --exact >/dev/null
+cargo test -p kamn-core --test cross_chain_bridge_adapters_docs >/dev/null
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_file" "$output_json"
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt 120 ]; then
+  echo "bridge adapter conformance contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+echo "bridge adapter conformance contract lane tests passed."

--- a/scripts/bridge/run_bridge_adapter_conformance_matrix.py
+++ b/scripts/bridge/run_bridge_adapter_conformance_matrix.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+GENERATOR = ROOT_DIR / "scripts/bridge/generate_bridge_adapter_conformance_evidence_bundle.sh"
+POLICY_CHECKER = ROOT_DIR / "scripts/bridge/check_bridge_adapter_conformance_policy.sh"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fixture",
+        default=str(
+            ROOT_DIR
+            / "fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json"
+        ),
+    )
+    parser.add_argument("--output-json", default="")
+    parser.add_argument(
+        "--max-cases",
+        type=int,
+        default=0,
+        help="Optional cap for first N cases to evaluate.",
+    )
+    return parser.parse_args()
+
+
+def parse_key_values(stdout: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for line in stdout.splitlines():
+        raw = line.strip()
+        if not raw or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        values[key] = value
+    return values
+
+
+def csv_fields(values: Any) -> str:
+    if isinstance(values, list):
+        normalized = sorted({str(item).strip() for item in values if str(item).strip()})
+        return ",".join(normalized)
+    return ""
+
+
+def run_generator(case: Dict[str, Any], bundle_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(GENERATOR),
+        "--output-file",
+        str(bundle_path),
+        "--adapter-id",
+        str(case["adapter_id"]),
+        "--bridge-network",
+        str(case["bridge_network"]),
+        "--dry-run",
+        "true" if bool(case["dry_run"]) else "false",
+        "--request-expected-schema-version",
+        str(case["request_expected_schema_version"]),
+        "--request-observed-schema-version",
+        str(case["request_observed_schema_version"]),
+        "--request-required-fields",
+        csv_fields(case["request_required_fields"]),
+        "--request-observed-fields",
+        csv_fields(case["request_observed_fields"]),
+        "--receipt-expected-schema-version",
+        str(case["receipt_expected_schema_version"]),
+        "--receipt-observed-schema-version",
+        str(case["receipt_observed_schema_version"]),
+        "--receipt-required-fields",
+        csv_fields(case["receipt_required_fields"]),
+        "--receipt-observed-fields",
+        csv_fields(case["receipt_observed_fields"]),
+        "--ci-fast-gate",
+        str(case["ci_fast_gate"]),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def run_policy_checker(bundle_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(POLICY_CHECKER),
+        "--bundle-file",
+        str(bundle_path),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        print(f"status=fail; reason=fixture-not-found; fixture={fixture_path}")
+        return 2
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if fixture.get("schema_version") != "kamn.bridge.adapter-conformance.fixture.v1":
+        print("status=fail; reason=invalid-fixture-schema")
+        return 2
+
+    cases = fixture.get("cases")
+    if not isinstance(cases, list):
+        print("status=fail; reason=invalid-fixture-cases")
+        return 2
+
+    selected_cases = cases[: args.max_cases] if args.max_cases > 0 else cases
+    tmp_dir = Path(subprocess.check_output(["mktemp", "-d"], text=True, cwd=ROOT_DIR).strip())
+    try:
+        failed_case_ids: List[str] = []
+        report_cases: List[Dict[str, Any]] = []
+
+        for index, case in enumerate(selected_cases):
+            if not isinstance(case, dict):
+                failed_case_ids.append(f"invalid-case-{index}")
+                report_cases.append(
+                    {
+                        "case_id": f"invalid-case-{index}",
+                        "passed": False,
+                        "error": "case payload is not an object",
+                    }
+                )
+                continue
+
+            case_id = str(case.get("case_id", f"case-{index}"))
+            bundle_path = tmp_dir / f"{case_id}.json"
+            expected_decision = str(case.get("expected_final_decision", "GO"))
+
+            generated = run_generator(case, bundle_path)
+            if generated.returncode != 0:
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_final_decision": expected_decision,
+                        "passed": False,
+                        "stage": "generate",
+                        "error": (generated.stderr.strip() or generated.stdout.strip()),
+                    }
+                )
+                continue
+
+            generated_values = parse_key_values(generated.stdout)
+            generated_decision = generated_values.get("final_decision", "")
+
+            checked = run_policy_checker(bundle_path)
+            if checked.returncode != 0:
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_final_decision": expected_decision,
+                        "generated_final_decision": generated_decision,
+                        "passed": False,
+                        "stage": "policy-check",
+                        "error": (checked.stderr.strip() or checked.stdout.strip()),
+                    }
+                )
+                continue
+
+            checked_values = parse_key_values(checked.stdout)
+            checked_decision = checked_values.get("final_decision", "")
+
+            passed = generated_decision == expected_decision and checked_decision == expected_decision
+            if not passed:
+                failed_case_ids.append(case_id)
+
+            report_cases.append(
+                {
+                    "case_id": case_id,
+                    "expected_final_decision": expected_decision,
+                    "generated_final_decision": generated_decision,
+                    "checked_final_decision": checked_decision,
+                    "passed": passed,
+                }
+            )
+
+        status = "pass" if not failed_case_ids else "fail"
+        report = {
+            "schema_version": "kamn.bridge.adapter-conformance.matrix-report.v1",
+            "status": status,
+            "fixture": str(fixture_path),
+            "case_count": len(selected_cases),
+            "failed_count": len(failed_case_ids),
+            "failed_case_ids": failed_case_ids,
+            "cases": report_cases,
+        }
+
+        if args.output_json:
+            Path(args.output_json).write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+
+        if status == "pass":
+            print(f"status=pass; cases={len(selected_cases)}; failed=0")
+            return 0
+
+        print(
+            "status=fail; "
+            f"cases={len(selected_cases)}; failed={len(failed_case_ids)}; "
+            f"failed_ids={','.join(failed_case_ids)}"
+        )
+        return 1
+    finally:
+        subprocess.run(["rm", "-rf", str(tmp_dir)], check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh
+++ b/scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/bridge/generate_bridge_adapter_conformance_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/bridge/check_bridge_adapter_conformance_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected bridge adapter conformance evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected bridge adapter conformance policy checker to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/bridge-adapter-conformance-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --adapter-id "adapter-discord-settlement-v1" \
+    --bridge-network ethereum \
+    --dry-run true \
+    --request-expected-schema-version "kamn.bridge.settlement-request.v1" \
+    --request-observed-schema-version "kamn.bridge.settlement-request.v1" \
+    --request-required-fields "request_id,destination_channel,payload_hash" \
+    --request-observed-fields "destination_channel,payload_hash,request_id" \
+    --receipt-expected-schema-version "kamn.bridge.settlement-receipt.v1" \
+    --receipt-observed-schema-version "kamn.bridge.settlement-receipt.v1" \
+    --receipt-required-fields "receipt_id,settlement_ref,finality" \
+    --receipt-observed-fields "finality,receipt_id,settlement_ref" \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO bundle generation to pass"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO policy decision"
+assert_eq "$(extract_value "$go_output" "reason_key")" "bridge_adapter_conformance_reason_codes:GO:v1" "expected GO reason key marker"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO bundle policy check to pass"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO policy checker decision"
+assert_eq "$(extract_value "$go_policy_output" "reason_key")" "bridge_adapter_conformance_reason_codes:GO:v1" "expected GO policy checker reason key marker"
+
+no_go_bundle="$TMP_DIR/bridge-adapter-conformance-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --adapter-id "adapter-discord-settlement-v1" \
+    --bridge-network ethereum \
+    --dry-run true \
+    --request-expected-schema-version "kamn.bridge.settlement-request.v1" \
+    --request-observed-schema-version "kamn.bridge.settlement-request.v2" \
+    --request-required-fields "request_id,destination_channel,payload_hash" \
+    --request-observed-fields "destination_channel,request_id" \
+    --receipt-expected-schema-version "kamn.bridge.settlement-receipt.v1" \
+    --receipt-observed-schema-version "kamn.bridge.settlement-receipt.v1" \
+    --receipt-required-fields "receipt_id,settlement_ref,finality" \
+    --receipt-observed-fields "receipt_id,settlement_ref" \
+    --ci-fast-gate FAIL
+)"
+
+assert_eq "$(extract_value "$no_go_output" "status")" "generated" "expected NO-GO bundle generation to pass"
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO policy decision"
+assert_eq "$(extract_value "$no_go_output" "reason_key")" "bridge_adapter_conformance_reason_codes:NO-GO:v1" "expected NO-GO reason key marker"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO bundle policy check to pass"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO policy checker decision"
+assert_eq "$(extract_value "$no_go_policy_output" "reason_key")" "bridge_adapter_conformance_reason_codes:NO-GO:v1" "expected NO-GO policy checker reason key marker"
+
+tampered_bundle="$TMP_DIR/bridge-adapter-conformance-tampered.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "GO"
+payload["reason_key"] = "bridge_adapter_conformance_reason_codes:GO:v1"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered bridge adapter conformance bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch error for tampered bridge adapter conformance bundle" >&2
+  exit 1
+fi
+
+# Regression: #907
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO mismatch marker for bridge adapter conformance tamper regression" >&2
+  exit 1
+fi
+
+echo "bridge adapter conformance evidence bundle tests passed."

--- a/scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh
+++ b/scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/bridge/run_bridge_adapter_conformance_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected bridge adapter conformance contract lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  echo "expected bridge adapter conformance matrix script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected bridge adapter conformance fixture file to exist" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/bridge-adapter-conformance-contract-report.json"
+lane_output="$(bash "$LANE_SCRIPT" --output-json "$report_file")"
+if ! printf '%s\n' "$lane_output" | grep -q "bridge adapter conformance contract lane tests passed."; then
+  echo "expected bridge adapter conformance contract lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -f "$report_file" ]; then
+  echo "expected bridge adapter conformance contract lane to emit report artifact" >&2
+  exit 1
+fi
+
+if ! grep -q '"status": "pass"' "$report_file"; then
+  echo "expected bridge adapter conformance contract report to pass" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.bridge.adapter-conformance.matrix-report.v1"' "$report_file"; then
+  echo "expected bridge adapter conformance contract report schema marker" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_bridge_adapter_conformance_matrix.py" "$LANE_SCRIPT"; then
+  echo "expected bridge adapter conformance contract lane to invoke matrix runner" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bridge_adapter_conformance/request_receipt_schema_cases.json" "$LANE_SCRIPT"; then
+  echo "expected bridge adapter conformance contract lane to use conformance fixture set" >&2
+  exit 1
+fi
+
+echo "bridge adapter conformance contract lane script tests passed."

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -415,7 +415,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/tests/bridge_adapter.rs|crates/kamn-core/src/cross_chain_receipt.rs|crates/kamn-core/tests/cross_chain_receipt_finality.rs|crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs|docs/foundation/bridge-adapter-abstraction.md|docs/foundation/cross-chain-bridge-adapters.md|docs/foundation/bridge-quorum-runtime.md|scripts/bridge/*|fixtures/bridge_replay/*|fixtures/bridge_outbound_intent/*)
+    crates/kamn-core/src/bridge_adapter.rs|crates/kamn-core/tests/bridge_adapter.rs|crates/kamn-core/src/cross_chain_receipt.rs|crates/kamn-core/tests/cross_chain_receipt_finality.rs|crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs|docs/foundation/bridge-adapter-abstraction.md|docs/foundation/cross-chain-bridge-adapters.md|docs/foundation/bridge-quorum-runtime.md|scripts/bridge/*|fixtures/bridge_replay/*|fixtures/bridge_outbound_intent/*|fixtures/bridge_adapter_conformance/*)
       BRIDGE_REPLAY_RELATED_CHANGED=true
       BRIDGE_SUITE_ADAPTER=true
       BRIDGE_SUITE_TELEGRAM=true

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -31,12 +31,15 @@ required_snippets=(
   "test_scope=deploy"
   "run_settlement_reconciliation_contract_tests=true"
   "test_scope=escrow-contract"
+  "run_bridge_replay_harness=true"
+  "test_scope=bridge"
   "run_localhost_signed_integration_contract_lane.sh"
   "run_backend_session_auth_freshness_contract_lane.sh"
   "run_dashboard_stale_error_budget_contract_lane.sh"
   "run_dashboard_shell_determinism_matrix_contract_lane.sh"
   "run_deployment_slo_rollback_contract_lane.sh"
   "run_settlement_reconciliation_contract_lane.sh"
+  "run_bridge_adapter_conformance_contract_lane.sh"
   "run_post_cutover_slo_contract_lane.sh"
   "run_classification_redaction_contract_lane.sh"
   "run_quorum_attestation_replay_contract_lane.sh"
@@ -51,6 +54,7 @@ required_snippets=(
   "Regression: #943"
   "Regression: #941"
   "Regression: #944"
+  "Regression: #907"
 )
 
 for snippet in "${required_snippets[@]}"; do

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -130,6 +130,8 @@ bash "$ROOT_DIR/scripts/bridge/test_run_localhost_bridge_relay_demo_contract_lan
 bash "$ROOT_DIR/scripts/bridge/test_generate_localhost_bridge_demo_evidence_bundle.sh"
 bash "$ROOT_DIR/scripts/bridge/test_run_localhost_bridge_demo_evidence_contract_lane.sh"
 bash "$ROOT_DIR/scripts/bridge/test_run_localhost_bridge_demo_evidence_deep_lane.sh"
+bash "$ROOT_DIR/scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh"
+bash "$ROOT_DIR/scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh"
 bash "$ROOT_DIR/scripts/deploy/test_preflight_topology.sh"
 bash "$ROOT_DIR/scripts/deploy/test_generate_bundle.sh"
 bash "$ROOT_DIR/scripts/deploy/test_generate_gonogo_evidence_bundle.sh"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -478,6 +478,12 @@ assert_eq "$(extract_output "$bridge_outbound_fixture_output" "run_bridge_replay
 assert_eq "$(extract_output "$bridge_outbound_fixture_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge,discord_bridge,cross_chain_bridge" "bridge outbound fixture-only changes should select all bridge suites"
 assert_eq "$(extract_output "$bridge_outbound_fixture_output" "test_scope")" "bridge" "bridge outbound fixture-only changes should set bridge scope"
 
+bridge_conformance_fixture_output="$(run_selector $'fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json')"
+assert_eq "$(extract_output "$bridge_conformance_fixture_output" "run_rust")" "false" "bridge conformance fixture-only changes should avoid rust lane"
+assert_eq "$(extract_output "$bridge_conformance_fixture_output" "run_bridge_replay_harness")" "true" "bridge conformance fixture-only changes must run bridge replay harness"
+assert_eq "$(extract_output "$bridge_conformance_fixture_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge,discord_bridge,cross_chain_bridge" "bridge conformance fixture-only changes should select all bridge suites"
+assert_eq "$(extract_output "$bridge_conformance_fixture_output" "test_scope")" "bridge" "bridge conformance fixture-only changes should set bridge scope"
+
 frontend_output="$(run_selector $'packages/kamn-dashboard/tests/dashboard.test.ts')"
 assert_eq "$(extract_output "$frontend_output" "run_rust")" "false" "frontend-only changes should avoid rust lane"
 assert_eq "$(extract_output "$frontend_output" "run_frontend_dashboard_tests")" "true" "frontend-only changes must run dashboard tests"

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -542,6 +542,11 @@ if ! grep -Fq "bash scripts/bridge/run_bridge_outbound_quorum_contract_lane.sh -
   exit 1
 fi
 
+if ! grep -Fq "bash scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh --output-json bridge-adapter-conformance-contract-report.json" "$FAST_WORKFLOW"; then
+  echo "expected bridge adapter conformance contract lane command in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 if ! grep -Fq "bash scripts/bridge/run_bridge_replay_redaction_contract_lane.sh --skip-replay --replay-report-file bridge-replay-report.json" "$FAST_WORKFLOW"; then
   echo "expected bridge replay/redaction contract lane command in ci-fast-gate.yml" >&2
   exit 1


### PR DESCRIPTION
## Summary
Implements issue #907 by adding a deterministic dry-run bridge adapter conformance lane for settlement request/receipt schema compatibility, with fail-closed drift enforcement and CI selector/workflow routing. This closes the gap between modeled bridge contracts and enforceable conformance evidence checks.

Closes #907

## Changes
- `fixtures/bridge_adapter_conformance/request_receipt_schema_cases.json`: Added deterministic conformance fixture matrix.
- `scripts/bridge/generate_bridge_adapter_conformance_evidence_bundle.sh`: Added conformance evidence generator with deterministic reason keys.
- `scripts/bridge/check_bridge_adapter_conformance_policy.sh`: Added fail-closed checker that recomputes decision/reason contracts.
- `scripts/bridge/run_bridge_adapter_conformance_matrix.py`: Added fixture-driven matrix runner and structured report output.
- `scripts/bridge/run_bridge_adapter_conformance_contract_lane.sh`: Added bounded PR-fast contract lane (max-cases + runtime budget).
- `scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh`: Added GO/NO-GO/tamper regression coverage (`Regression: #907`).
- `scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh`: Added lane/report contract checks.
- `docs/foundation/cross-chain-bridge-adapters.md`: Added dry-run conformance policy contract section and local commands.
- `crates/kamn-core/tests/cross_chain_bridge_adapters_docs.rs`: Added docs contract assertions for #907 section and commands.
- `scripts/ci/select_targets.sh`: Routed `fixtures/bridge_adapter_conformance/*` into bridge scope.
- `scripts/ci/test_select_targets.sh`: Added selector regression for conformance fixture routing.
- `docs/ci/strategy.md`: Added bridge conformance selector mapping, command-surface contract entry, and regression marker.
- `scripts/ci/test_ci_strategy_contract.sh`: Added required strategy snippets for bridge conformance.
- `.github/workflows/ci-fast-gate.yml`: Added conformance lane execution inside bridge harness step.
- `scripts/ci/test_workflow_scope_policy.sh`: Added workflow policy assertion for bridge conformance command.
- `scripts/ci/test_ci_tools.sh`: Included new bridge conformance tests in CI tool regression suite.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh`
Output:
- `expected bridge adapter conformance evidence generator to be executable`

Command:
- `bash scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh`
Output:
- `expected bridge adapter conformance contract lane script to be executable`

### 🟢 Green Phase
Commands:
- `bash scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh`
- `bash scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh`
- `cargo test -p kamn-core --test cross_chain_bridge_adapters_docs`

Pass markers:
- `bridge adapter conformance evidence bundle tests passed.`
- `bridge adapter conformance contract lane script tests passed.`
- `test result: ok. 6 passed; 0 failed`

### 🔁 Regression
Commands:
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `bash scripts/ci/test_ci_tools.sh`

Pass summary:
- Selector/docs/workflow policy checks passed.
- Formatting/lint checks passed.
- Full CI tools regression suite passed (`All CI tool regression tests passed.`).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh` (field/schema/reason-key validation paths) | |
| Functional   | ✅ | `scripts/bridge/test_run_bridge_adapter_conformance_contract_lane.sh` | |
| Integration  | ✅ | `scripts/ci/test_select_targets.sh`, `.github/workflows/ci-fast-gate.yml` + `scripts/ci/test_workflow_scope_policy.sh`, `scripts/ci/test_ci_strategy_contract.sh` | |
| Regression   | ✅ | Tamper fail-closed assertion in `scripts/bridge/test_generate_bridge_adapter_conformance_evidence_bundle.sh` (`Regression: #907`) | |
| Performance  | ✅ | Runtime budget guard (`<=120s`) + bounded fixture execution (`--max-cases 3`) in contract lane | |

## Risks & Rollback
- Risk: low/med; bridge harness now includes one additional script invocation in fast gate.
- Compatibility: no breaking API changes.
- Rollback: revert this PR commit to remove lane wiring and restore prior bridge harness behavior.

## Documentation Updates
- `docs/foundation/cross-chain-bridge-adapters.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
