### PR TITLE
fix(task): enforce task+escrow transition reason-code contracts

### DIFF
--- a/crates/kamn-core/src/escrow.rs
+++ b/crates/kamn-core/src/escrow.rs
@@ -50,10 +50,41 @@ pub enum EscrowSettlementAction {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EscrowTransitionAction {
+    Release {
+        amount: u128,
+    },
+    RefundRemaining,
+    Dispute,
+    Resolve {
+        release_to_payee: u128,
+        refund_to_payer: u128,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EscrowTransitionEvidence {
+    pub from: EscrowStatus,
+    pub action: EscrowTransitionAction,
+    pub to: EscrowStatus,
+    pub reason_code: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowSettlementOutcome {
     Settled { status: EscrowStatus },
     Pending { reason: &'static str },
     Rejected { reason: &'static str },
+}
+
+impl EscrowSettlementOutcome {
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::Settled { .. } => "escrow_settlement_finalized",
+            Self::Pending { .. } => "escrow_settlement_pending_receipt_finality",
+            Self::Rejected { .. } => "escrow_settlement_rejected_receipt_finality",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,6 +237,29 @@ impl EscrowLifecycle {
         Ok(())
     }
 
+    pub fn apply_transition_with_evidence(
+        &mut self,
+        action: EscrowTransitionAction,
+    ) -> Result<EscrowTransitionEvidence, EscrowLifecycleError> {
+        let from = self.status();
+        match action.clone() {
+            EscrowTransitionAction::Release { amount } => self.release(amount)?,
+            EscrowTransitionAction::RefundRemaining => self.refund_remaining()?,
+            EscrowTransitionAction::Dispute => self.dispute()?,
+            EscrowTransitionAction::Resolve {
+                release_to_payee,
+                refund_to_payer,
+            } => self.resolve(release_to_payee, refund_to_payer)?,
+        }
+
+        Ok(EscrowTransitionEvidence {
+            from,
+            action,
+            to: self.status(),
+            reason_code: "escrow_transition_allowed",
+        })
+    }
+
     pub fn reconcile_receipt_finality(
         &mut self,
         receipt_id: &str,
@@ -273,6 +327,21 @@ pub enum EscrowLifecycleError {
         timeout_unix: u64,
     },
     AmountOverflow,
+}
+
+impl EscrowLifecycleError {
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::ZeroAmount => "escrow_amount_zero",
+            Self::MissingReceiptEvidence => "escrow_receipt_missing",
+            Self::InvalidReceiptFinality { .. } => "escrow_receipt_finality_invalid",
+            Self::InvalidAmount { .. } => "escrow_amount_invalid",
+            Self::InvalidTransition { .. } => "escrow_transition_invalid",
+            Self::ResolutionMismatch { .. } => "escrow_resolution_mismatch",
+            Self::TimeoutNotElapsed { .. } => "escrow_timeout_not_elapsed",
+            Self::AmountOverflow => "escrow_amount_overflow",
+        }
+    }
 }
 
 impl fmt::Display for EscrowLifecycleError {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -224,7 +224,7 @@ pub use durable_guard_store::{
 };
 pub use escrow::{
     EscrowLifecycle, EscrowLifecycleError, EscrowReceiptFinality, EscrowSettlementAction,
-    EscrowSettlementOutcome, EscrowStatus,
+    EscrowSettlementOutcome, EscrowStatus, EscrowTransitionAction, EscrowTransitionEvidence,
 };
 pub use governance_workflow::{
     GovernanceExecutionRecord, GovernanceParameterChangeDraft, GovernanceProposalDraft,
@@ -356,7 +356,9 @@ pub use state::{
 pub use task_artifacts::{
     TaskArtifactError, TaskArtifactRecord, TaskArtifactRegistry, TaskArtifactSubmission,
 };
-pub use task_lifecycle::{TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
+pub use task_lifecycle::{
+    TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition, TaskTransitionEvidence,
+};
 pub use task_operations::{
     FileTaskOperationSnapshotStore, InMemoryTaskOperationSnapshotStore, SwarmTaskDraft,
     TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskOperationRecord,

--- a/crates/kamn-core/src/task_lifecycle.rs
+++ b/crates/kamn-core/src/task_lifecycle.rs
@@ -25,6 +25,14 @@ pub enum TaskTransition {
     Cancel,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TaskTransitionEvidence {
+    pub from: TaskState,
+    pub transition: TaskTransition,
+    pub to: TaskState,
+    pub reason_code: &'static str,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskLifecycle {
     task_id: String,
@@ -61,42 +69,29 @@ impl TaskLifecycle {
             return Err(TaskLifecycleError::TerminalState(self.state));
         }
 
-        let next = match (self.state, transition) {
-            (TaskState::Submitted, TaskTransition::Accept) => TaskState::Accepted,
-            (TaskState::Submitted, TaskTransition::Cancel) => TaskState::Cancelled,
-
-            (TaskState::Accepted, TaskTransition::Delegate) => TaskState::Delegated,
-            (TaskState::Accepted, TaskTransition::StartWork) => TaskState::InProgress,
-            (TaskState::Accepted, TaskTransition::Cancel) => TaskState::Cancelled,
-
-            (TaskState::Delegated, TaskTransition::StartWork) => TaskState::InProgress,
-            (TaskState::Delegated, TaskTransition::Cancel) => TaskState::Cancelled,
-
-            (TaskState::InProgress, TaskTransition::Block) => TaskState::Blocked,
-            (TaskState::InProgress, TaskTransition::RequestInput) => TaskState::InputRequired,
-            (TaskState::InProgress, TaskTransition::Complete) => TaskState::Completed,
-            (TaskState::InProgress, TaskTransition::Fail) => TaskState::Failed,
-            (TaskState::InProgress, TaskTransition::Cancel) => TaskState::Cancelled,
-
-            (TaskState::InputRequired, TaskTransition::StartWork) => TaskState::InProgress,
-            (TaskState::InputRequired, TaskTransition::Fail) => TaskState::Failed,
-            (TaskState::InputRequired, TaskTransition::Cancel) => TaskState::Cancelled,
-
-            (TaskState::Blocked, TaskTransition::StartWork) => TaskState::InProgress,
-            (TaskState::Blocked, TaskTransition::Fail) => TaskState::Failed,
-            (TaskState::Blocked, TaskTransition::Cancel) => TaskState::Cancelled,
-
-            _ => {
-                return Err(TaskLifecycleError::InvalidTransition {
-                    from: self.state,
-                    transition,
-                });
-            }
-        };
+        let next =
+            next_state(self.state, transition).ok_or(TaskLifecycleError::InvalidTransition {
+                from: self.state,
+                transition,
+            })?;
 
         self.state = next;
         self.history.push(next);
         Ok(())
+    }
+
+    pub fn transition_with_evidence(
+        &mut self,
+        transition: TaskTransition,
+    ) -> Result<TaskTransitionEvidence, TaskLifecycleError> {
+        let from = self.state();
+        self.transition(transition)?;
+        Ok(TaskTransitionEvidence {
+            from,
+            transition,
+            to: self.state(),
+            reason_code: "task_transition_allowed",
+        })
     }
 
     pub fn restore(task_id: &str, history: Vec<TaskState>) -> Result<Self, TaskLifecycleError> {
@@ -143,6 +138,17 @@ pub enum TaskLifecycleError {
     TerminalState(TaskState),
 }
 
+impl TaskLifecycleError {
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::EmptyTaskId => "task_id_empty",
+            Self::InvalidHistory(_) => "task_history_invalid",
+            Self::InvalidTransition { .. } => "task_transition_invalid_edge",
+            Self::TerminalState(_) => "task_transition_terminal_state",
+        }
+    }
+}
+
 impl fmt::Display for TaskLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -161,6 +167,36 @@ impl fmt::Display for TaskLifecycleError {
 }
 
 impl std::error::Error for TaskLifecycleError {}
+
+fn next_state(from: TaskState, transition: TaskTransition) -> Option<TaskState> {
+    match (from, transition) {
+        (TaskState::Submitted, TaskTransition::Accept) => Some(TaskState::Accepted),
+        (TaskState::Submitted, TaskTransition::Cancel) => Some(TaskState::Cancelled),
+
+        (TaskState::Accepted, TaskTransition::Delegate) => Some(TaskState::Delegated),
+        (TaskState::Accepted, TaskTransition::StartWork) => Some(TaskState::InProgress),
+        (TaskState::Accepted, TaskTransition::Cancel) => Some(TaskState::Cancelled),
+
+        (TaskState::Delegated, TaskTransition::StartWork) => Some(TaskState::InProgress),
+        (TaskState::Delegated, TaskTransition::Cancel) => Some(TaskState::Cancelled),
+
+        (TaskState::InProgress, TaskTransition::Block) => Some(TaskState::Blocked),
+        (TaskState::InProgress, TaskTransition::RequestInput) => Some(TaskState::InputRequired),
+        (TaskState::InProgress, TaskTransition::Complete) => Some(TaskState::Completed),
+        (TaskState::InProgress, TaskTransition::Fail) => Some(TaskState::Failed),
+        (TaskState::InProgress, TaskTransition::Cancel) => Some(TaskState::Cancelled),
+
+        (TaskState::InputRequired, TaskTransition::StartWork) => Some(TaskState::InProgress),
+        (TaskState::InputRequired, TaskTransition::Fail) => Some(TaskState::Failed),
+        (TaskState::InputRequired, TaskTransition::Cancel) => Some(TaskState::Cancelled),
+
+        (TaskState::Blocked, TaskTransition::StartWork) => Some(TaskState::InProgress),
+        (TaskState::Blocked, TaskTransition::Fail) => Some(TaskState::Failed),
+        (TaskState::Blocked, TaskTransition::Cancel) => Some(TaskState::Cancelled),
+
+        _ => None,
+    }
+}
 
 fn transition_between(from: TaskState, to: TaskState) -> Option<TaskTransition> {
     match (from, to) {

--- a/crates/kamn-core/tests/escrow_lifecycle_docs.rs
+++ b/crates/kamn-core/tests/escrow_lifecycle_docs.rs
@@ -27,6 +27,16 @@ fn doc_contains_chain_receipt_finality_adapter_contract() {
 }
 
 #[test]
+fn doc_contains_transition_evidence_reason_code_contract() {
+    assert!(DOC.contains("## Transition Evidence and Reason-Code Contract (Issue #903)"));
+    assert!(DOC.contains("apply_transition_with_evidence"));
+    assert!(DOC.contains("EscrowTransitionEvidence"));
+    assert!(DOC.contains("escrow_transition_allowed"));
+    assert!(DOC.contains("escrow_transition_invalid"));
+    assert!(DOC.contains("escrow_settlement_finalized"));
+}
+
+#[test]
 fn doc_contains_timeout_finality_race_matrix_contract() {
     assert!(DOC.contains("## Timeout/Finality Race Matrix Evidence"));
     assert!(DOC.contains("run_settlement_reconciliation_race_matrix.py"));
@@ -46,5 +56,13 @@ fn regression_requires_ledger_reference_guard_marker() {
     // Regression: #717
     assert!(DOC.contains(
         "missing ledger reference evidence and ledger amount drift force `NO-GO` (`Regression: #717`).",
+    ));
+}
+
+#[test]
+fn regression_requires_transition_reason_code_guard_marker() {
+    // Regression: #903
+    assert!(DOC.contains(
+        "transition reason-code drift and illegal transition acceptance fail closed (`Regression: #903`).",
     ));
 }

--- a/crates/kamn-core/tests/task_escrow_transition_contracts.rs
+++ b/crates/kamn-core/tests/task_escrow_transition_contracts.rs
@@ -1,0 +1,169 @@
+use kamn_core::{
+    EscrowLifecycle, EscrowReceiptFinality, EscrowSettlementAction, EscrowSettlementOutcome,
+    EscrowStatus, EscrowTransitionAction, TaskLifecycle, TaskState, TaskTransition,
+};
+use std::time::Instant;
+
+#[test]
+fn unit_task_transition_error_reason_codes_are_deterministic() {
+    let empty_error = TaskLifecycle::new("").expect_err("empty task id must fail");
+    assert_eq!(empty_error.reason_code(), "task_id_empty");
+
+    let mut lifecycle = TaskLifecycle::new("task-reason-invalid")
+        .expect("task lifecycle should initialize for invalid-transition reason code");
+    let invalid_error = lifecycle
+        .transition(TaskTransition::Complete)
+        .expect_err("submitted->complete must be rejected");
+    assert_eq!(invalid_error.reason_code(), "task_transition_invalid_edge");
+
+    lifecycle
+        .transition(TaskTransition::Accept)
+        .expect("accept should succeed");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("start work should succeed");
+    lifecycle
+        .transition(TaskTransition::Complete)
+        .expect("complete should succeed");
+    let terminal_error = lifecycle
+        .transition(TaskTransition::Fail)
+        .expect_err("terminal state must reject follow-up transitions");
+    assert_eq!(
+        terminal_error.reason_code(),
+        "task_transition_terminal_state"
+    );
+}
+
+#[test]
+fn functional_task_transition_with_evidence_reports_allowed_reason_code() {
+    let mut lifecycle = TaskLifecycle::new("task-evidence-flow")
+        .expect("task lifecycle should initialize for evidence flow");
+
+    let accept_evidence = lifecycle
+        .transition_with_evidence(TaskTransition::Accept)
+        .expect("submitted->accept should succeed");
+    assert_eq!(accept_evidence.from, TaskState::Submitted);
+    assert_eq!(accept_evidence.transition, TaskTransition::Accept);
+    assert_eq!(accept_evidence.to, TaskState::Accepted);
+    assert_eq!(accept_evidence.reason_code, "task_transition_allowed");
+
+    let start_evidence = lifecycle
+        .transition_with_evidence(TaskTransition::StartWork)
+        .expect("accepted->in_progress should succeed");
+    assert_eq!(start_evidence.from, TaskState::Accepted);
+    assert_eq!(start_evidence.to, TaskState::InProgress);
+    assert_eq!(start_evidence.reason_code, "task_transition_allowed");
+}
+
+#[test]
+fn unit_escrow_transition_error_reason_codes_are_deterministic() {
+    let mut escrow = EscrowLifecycle::new(25).expect("escrow should initialize");
+    let zero_release_error = escrow.release(0).expect_err("zero release must fail");
+    assert_eq!(zero_release_error.reason_code(), "escrow_amount_zero");
+
+    escrow.release(25).expect("release should succeed");
+    let dispute_after_release_error = escrow
+        .dispute()
+        .expect_err("released escrow must reject dispute");
+    assert_eq!(
+        dispute_after_release_error.reason_code(),
+        "escrow_transition_invalid"
+    );
+}
+
+#[test]
+fn functional_escrow_transition_with_evidence_reports_allowed_reason_code() {
+    let mut escrow = EscrowLifecycle::new(40).expect("escrow should initialize");
+    let release_evidence = escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Release { amount: 15 })
+        .expect("release should succeed");
+
+    assert_eq!(release_evidence.reason_code, "escrow_transition_allowed");
+    assert_eq!(release_evidence.from, EscrowStatus::Funded);
+    assert_eq!(
+        release_evidence.action,
+        EscrowTransitionAction::Release { amount: 15 }
+    );
+    assert!(matches!(
+        release_evidence.to,
+        EscrowStatus::PartiallyReleased {
+            released: 15,
+            remaining: 25
+        }
+    ));
+}
+
+#[test]
+fn integration_task_completion_and_escrow_settlement_emit_expected_evidence() {
+    let mut lifecycle =
+        TaskLifecycle::new("task-escrow-integration").expect("task lifecycle should initialize");
+    lifecycle
+        .transition_with_evidence(TaskTransition::Accept)
+        .expect("accept should succeed");
+    lifecycle
+        .transition_with_evidence(TaskTransition::StartWork)
+        .expect("start work should succeed");
+    let completion_evidence = lifecycle
+        .transition_with_evidence(TaskTransition::Complete)
+        .expect("complete should succeed");
+    assert_eq!(completion_evidence.to, TaskState::Completed);
+    assert_eq!(completion_evidence.reason_code, "task_transition_allowed");
+
+    let mut escrow = EscrowLifecycle::new(80).expect("escrow should initialize");
+    let settlement_outcome = escrow
+        .reconcile_receipt_finality(
+            "receipt-escrow-integration",
+            EscrowReceiptFinality::Final,
+            EscrowSettlementAction::Release { amount: 80 },
+        )
+        .expect("final receipt should settle release action");
+    assert!(matches!(
+        settlement_outcome,
+        EscrowSettlementOutcome::Settled {
+            status: EscrowStatus::Released
+        }
+    ));
+    assert_eq!(
+        settlement_outcome.reason_code(),
+        "escrow_settlement_finalized"
+    );
+}
+
+#[test]
+fn regression_rejects_dispute_after_release_with_stable_reason_code() {
+    // Regression: #903
+    let mut escrow = EscrowLifecycle::new(10).expect("escrow should initialize");
+    escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Release { amount: 10 })
+        .expect("release should succeed");
+
+    let error = escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Dispute)
+        .expect_err("released escrow must reject dispute action");
+    assert_eq!(error.reason_code(), "escrow_transition_invalid");
+}
+
+#[test]
+fn performance_transition_evidence_checks_stay_within_budget() {
+    let start = Instant::now();
+    for _ in 0..256 {
+        let mut task = TaskLifecycle::new("task-perf").expect("task lifecycle should initialize");
+        task.transition_with_evidence(TaskTransition::Accept)
+            .expect("accept should succeed");
+        task.transition_with_evidence(TaskTransition::StartWork)
+            .expect("start should succeed");
+        task.transition_with_evidence(TaskTransition::Complete)
+            .expect("complete should succeed");
+
+        let mut escrow = EscrowLifecycle::new(12).expect("escrow should initialize");
+        escrow
+            .apply_transition_with_evidence(EscrowTransitionAction::Release { amount: 12 })
+            .expect("release should succeed");
+    }
+
+    let elapsed_millis = start.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 900,
+        "task/escrow transition evidence contract lane exceeded budget: {elapsed_millis}ms"
+    );
+}

--- a/crates/kamn-core/tests/task_state_machine_docs.rs
+++ b/crates/kamn-core/tests/task_state_machine_docs.rs
@@ -1,0 +1,35 @@
+const DOC: &str = include_str!("../../../docs/foundation/task-state-machine.md");
+
+#[test]
+fn doc_contains_task_lifecycle_scope_and_transition_map() {
+    assert!(DOC.contains("# Task State Machine and Transition Validator"));
+    assert!(DOC.contains("TaskLifecycle::new(task_id)"));
+    assert!(DOC.contains("## Supported Transitions"));
+}
+
+#[test]
+fn doc_contains_transition_evidence_reason_code_contract() {
+    assert!(DOC.contains("## Transition Evidence and Reason-Code Contract"));
+    assert!(DOC.contains("transition_with_evidence(TaskTransition)"));
+    assert!(DOC.contains("TaskTransitionEvidence"));
+    assert!(DOC.contains("task_transition_allowed"));
+    assert!(DOC.contains("task_transition_invalid_edge"));
+    assert!(DOC.contains("task_transition_terminal_state"));
+    assert!(DOC.contains("task_history_invalid"));
+    assert!(DOC.contains("task_id_empty"));
+}
+
+#[test]
+fn doc_includes_transition_contract_validation_commands() {
+    assert!(DOC.contains("cargo test -p kamn-core --test task_state_machine"));
+    assert!(DOC.contains("cargo test -p kamn-core --test task_escrow_transition_contracts"));
+    assert!(DOC.contains("cargo test -p kamn-core --test task_state_machine_docs"));
+}
+
+#[test]
+fn regression_marker_for_transition_reason_code_drift_is_present() {
+    // Regression: #903
+    assert!(DOC.contains(
+        "transition reason-code drift and illegal transition acceptance fail closed (`Regression: #903`)."
+    ));
+}

--- a/docs/foundation/escrow-lifecycle.md
+++ b/docs/foundation/escrow-lifecycle.md
@@ -23,6 +23,26 @@ For PaymentOffer and PaymentConfirm workflow integration controls, see `docs/fou
 - Reject invalid transitions from terminal states.
 - Reject dispute resolution splits that do not reconcile exactly to remaining funds.
 
+## Transition Evidence and Reason-Code Contract (Issue #903)
+- `EscrowLifecycle::apply_transition_with_evidence(...)` emits deterministic mutation evidence for authorized transitions:
+  - `EscrowTransitionEvidence { from, action, to, reason_code }`
+  - allowed transition reason code: `escrow_transition_allowed`
+- Rejected transition reason codes are deterministic via `EscrowLifecycleError::reason_code()`:
+  - `escrow_amount_zero`
+  - `escrow_receipt_missing`
+  - `escrow_receipt_finality_invalid`
+  - `escrow_amount_invalid`
+  - `escrow_transition_invalid`
+  - `escrow_resolution_mismatch`
+  - `escrow_timeout_not_elapsed`
+  - `escrow_amount_overflow`
+- Receipt-finality settlement outcomes expose deterministic reason codes:
+  - `escrow_settlement_finalized`
+  - `escrow_settlement_pending_receipt_finality`
+  - `escrow_settlement_rejected_receipt_finality`
+- Regression policy:
+  - transition reason-code drift and illegal transition acceptance fail closed (`Regression: #903`).
+
 ## Settlement Reconciliation Evidence Contract (Issue #687)
 Settlement reconciliation evidence is captured as machine-readable JSON so release gates can audit escrow outcomes against receipt finality and timeout rules.
 
@@ -68,6 +88,7 @@ bash scripts/escrow/test_generate_settlement_reconciliation_evidence_bundle.sh
 bash scripts/escrow/test_run_settlement_reconciliation_contract_lane.sh
 bash scripts/escrow/test_run_settlement_reconciliation_race_matrix.sh
 cargo test -p kamn-core --test escrow_lifecycle
+cargo test -p kamn-core --test task_escrow_transition_contracts
 cargo test -p kamn-core --test escrow_lifecycle_docs
 cargo fmt --check
 cargo clippy -- -D warnings

--- a/docs/foundation/task-state-machine.md
+++ b/docs/foundation/task-state-machine.md
@@ -45,6 +45,18 @@ Any transition outside this map is rejected.
 - Terminal states reject follow-up transitions (`TerminalState`).
 - Illegal transitions return `InvalidTransition { from, transition }`.
 
+## Transition Evidence and Reason-Code Contract
+- `TaskLifecycle::transition_with_evidence(TaskTransition)` emits deterministic evidence for authorized transitions:
+  - `TaskTransitionEvidence { from, transition, to, reason_code }`
+  - allowed transition reason code: `task_transition_allowed`
+- Rejected transition reason codes are deterministic via `TaskLifecycleError::reason_code()`:
+  - `task_id_empty`
+  - `task_history_invalid`
+  - `task_transition_invalid_edge`
+  - `task_transition_terminal_state`
+- Regression policy:
+  - transition reason-code drift and illegal transition acceptance fail closed (`Regression: #903`).
+
 ## Local Validation
 Run from repository root:
 
@@ -52,6 +64,8 @@ Run from repository root:
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test -p kamn-core --test task_state_machine
+cargo test -p kamn-core --test task_escrow_transition_contracts
+cargo test -p kamn-core --test task_state_machine_docs
 cargo test -p kamn-core --test swarm_task_dag
 cargo test -p kamn-core --test task_operation_snapshot
 cargo test -p kamn-core

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -317,7 +317,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    docs/foundation/task-operations.md|crates/kamn-core/tests/task_operations_docs.rs|scripts/task/*task_operation_snapshot*)
+    docs/foundation/task-operations.md|docs/foundation/task-state-machine.md|crates/kamn-core/tests/task_operations_docs.rs|crates/kamn-core/tests/task_state_machine_docs.rs|crates/kamn-core/tests/task_escrow_transition_contracts.rs|scripts/task/*task_operation_snapshot*)
       TASK_OPERATION_SNAPSHOT_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -848,6 +848,12 @@ assert_eq "$(extract_output "$task_contract_docs_output" "run_task_operation_sna
 assert_eq "$(extract_output "$task_contract_docs_output" "run_federated_delegation_settlement_contract_tests")" "true" "task operation contract docs must run federated delegation settlement contract lane"
 assert_eq "$(extract_output "$task_contract_docs_output" "test_scope")" "task-contract" "task operation contract docs should set task-contract scope"
 
+task_state_machine_docs_output="$(run_selector $'docs/foundation/task-state-machine.md')"
+assert_eq "$(extract_output "$task_state_machine_docs_output" "run_rust")" "false" "task state machine docs should avoid rust lane"
+assert_eq "$(extract_output "$task_state_machine_docs_output" "run_task_operation_snapshot_contract_tests")" "true" "task state machine docs must run task operation snapshot contract lane"
+assert_eq "$(extract_output "$task_state_machine_docs_output" "run_federated_delegation_settlement_contract_tests")" "false" "task state machine docs should not force federated delegation settlement contract lane"
+assert_eq "$(extract_output "$task_state_machine_docs_output" "test_scope")" "task-contract" "task state machine docs should set task-contract scope"
+
 task_contract_script_output="$(run_selector $'scripts/task/run_task_operation_snapshot_contract_lane.sh')"
 assert_eq "$(extract_output "$task_contract_script_output" "run_rust")" "false" "task operation contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$task_contract_script_output" "run_task_operation_snapshot_contract_tests")" "true" "task operation contract script changes must run task operation snapshot contract lane"

--- a/scripts/task/run_task_operation_snapshot_contract_lane.sh
+++ b/scripts/task/run_task_operation_snapshot_contract_lane.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 cargo test -p kamn-core --lib task_operations::tests:: >/dev/null
 cargo test -p kamn-core --test task_operations >/dev/null
 cargo test -p kamn-core --test task_operation_snapshot >/dev/null
+cargo test -p kamn-core --test task_state_machine >/dev/null
+cargo test -p kamn-core --test task_state_machine_docs >/dev/null
+cargo test -p kamn-core --test task_escrow_transition_contracts >/dev/null
 cargo test -p kamn-core --test task_operations_docs >/dev/null
 
 echo "task operation snapshot contract lane tests passed."

--- a/scripts/task/test_run_task_operation_snapshot_contract_lane.sh
+++ b/scripts/task/test_run_task_operation_snapshot_contract_lane.sh
@@ -24,6 +24,16 @@ if ! grep -q "task operation snapshot contract lane tests passed." "$TMP_OUT"; t
   exit 1
 fi
 
+if ! grep -q "task_state_machine" "$FAST_SCRIPT"; then
+  echo "expected task operation snapshot fast-lane to include task state machine contract tests" >&2
+  exit 1
+fi
+
+if ! grep -q "task_escrow_transition_contracts" "$FAST_SCRIPT"; then
+  echo "expected task operation snapshot fast-lane to include task/escrow transition contract tests" >&2
+  exit 1
+fi
+
 if ! grep -Fq "run_task_operation_snapshot_contract_lane.sh" "$DEEP_SCRIPT"; then
   echo "expected deep-lane script to execute task operation snapshot fast-lane checks first" >&2
   exit 1


### PR DESCRIPTION
Closes #903

## Summary
This change hardens task and escrow state-machine transitions by introducing explicit transition evidence and stable reason-code contracts for both allowed and denied paths. It also adds regression tests and fast CI lane wiring so transition contract drift fails quickly and cheaply.

## Changes
- `crates/kamn-core/src/task_lifecycle.rs`: added `TaskTransitionEvidence`, `transition_with_evidence`, deterministic `reason_code()` for lifecycle errors, and shared transition mapping helper.
- `crates/kamn-core/src/escrow.rs`: added `EscrowTransitionAction`, `EscrowTransitionEvidence`, `apply_transition_with_evidence`, and deterministic reason-code accessors for settlement and lifecycle errors.
- `crates/kamn-core/src/lib.rs`: exported new transition evidence/action types.
- `crates/kamn-core/tests/task_escrow_transition_contracts.rs`: added unit/functional/integration/performance/regression contract coverage for task/escrow transition evidence and reason codes.
- `crates/kamn-core/tests/task_state_machine_docs.rs`: added docs contract checks for task transition evidence + regression marker.
- `crates/kamn-core/tests/escrow_lifecycle_docs.rs`: extended docs contract checks for escrow transition evidence + regression marker.
- `docs/foundation/task-state-machine.md`: documented transition evidence/reason-code contract and local validation commands.
- `docs/foundation/escrow-lifecycle.md`: documented escrow transition evidence/reason-code contract and regression marker.
- `scripts/task/run_task_operation_snapshot_contract_lane.sh`: included new task contract tests in fast lane.
- `scripts/task/test_run_task_operation_snapshot_contract_lane.sh`: asserted new lane coverage.
- `scripts/ci/select_targets.sh`: mapped task doc/test contract changes to task contract lane.
- `scripts/ci/test_select_targets.sh`: added selector regression case for task-state-machine docs.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: transition evidence+reason-code behavior verified via targeted task/escrow contract and docs tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Deterministic task/escrow error reason-code mapping assertions |
| Functional  | ✅     | Allowed transition evidence emits expected reason codes |
| Integration | ✅     | Task completion + escrow settlement evidence contract path |
| Regression  | ✅     | Invalid transition/terminal-state and docs marker guards for #903 |

## Commands Run
- `cargo test -p kamn-core --test task_escrow_transition_contracts --test task_state_machine_docs`
- `cargo test -p kamn-core --test escrow_lifecycle_docs`
- `bash scripts/task/test_run_task_operation_snapshot_contract_lane.sh`
- `bash scripts/ci/test_select_targets.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
