### PR TITLE
test(task): add dispute/refund property and concurrency contracts

### DIFF
--- a/crates/kamn-core/tests/concurrency_state_mutation.rs
+++ b/crates/kamn-core/tests/concurrency_state_mutation.rs
@@ -1,6 +1,6 @@
 use kamn_core::{
-    PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, RuntimeLifecycleError,
-    TaskOperationEngine, TaskOperationError, TaskState,
+    EscrowLifecycle, EscrowTransitionAction, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
+    RuntimeLifecycleError, TaskOperationEngine, TaskOperationError, TaskState,
 };
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
@@ -168,6 +168,107 @@ fn run_peer_lifecycle_race(peer_id: &str) -> ([usize; 3], [usize; 3], PeerLifecy
         .expect("peer lifecycle lock should acquire")
         .state();
     (success_by_phase, invalid_by_phase, final_state)
+}
+
+fn run_escrow_dispute_refund_race(total_amount: u128) -> (usize, usize, u128, u128, u128) {
+    let escrow = Arc::new(Mutex::new(
+        EscrowLifecycle::new(total_amount).expect("escrow should initialize"),
+    ));
+    let barrier = Arc::new(Barrier::new(2));
+    let actions = [
+        EscrowTransitionAction::Dispute,
+        EscrowTransitionAction::RefundRemaining,
+    ];
+    let mut handles = Vec::new();
+
+    for action in actions {
+        let escrow = Arc::clone(&escrow);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            escrow
+                .lock()
+                .expect("escrow lock should acquire")
+                .apply_transition_with_evidence(action)
+        }));
+    }
+
+    let mut success_count = 0_usize;
+    let mut invalid_count = 0_usize;
+
+    for handle in handles {
+        match handle
+            .join()
+            .expect("escrow dispute/refund thread should join")
+        {
+            Ok(evidence) => {
+                success_count += 1;
+                assert_eq!(evidence.reason_code, "escrow_transition_allowed");
+            }
+            Err(error) => {
+                invalid_count += 1;
+                assert_eq!(error.reason_code(), "escrow_transition_invalid");
+            }
+        }
+    }
+
+    let escrow = escrow.lock().expect("escrow lock should acquire");
+    (
+        success_count,
+        invalid_count,
+        escrow.released_amount(),
+        escrow.refunded_amount(),
+        escrow.remaining_amount(),
+    )
+}
+
+fn run_escrow_refund_race(
+    total_amount: u128,
+) -> (usize, usize, Vec<&'static str>, u128, u128, u128) {
+    let escrow = Arc::new(Mutex::new(
+        EscrowLifecycle::new(total_amount).expect("escrow should initialize"),
+    ));
+    let barrier = Arc::new(Barrier::new(2));
+    let mut handles = Vec::new();
+
+    for _ in 0..2 {
+        let escrow = Arc::clone(&escrow);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            escrow
+                .lock()
+                .expect("escrow lock should acquire")
+                .apply_transition_with_evidence(EscrowTransitionAction::RefundRemaining)
+        }));
+    }
+
+    let mut success_count = 0_usize;
+    let mut invalid_count = 0_usize;
+    let mut error_reason_codes = Vec::new();
+
+    for handle in handles {
+        match handle.join().expect("escrow refund thread should join") {
+            Ok(evidence) => {
+                success_count += 1;
+                assert_eq!(evidence.reason_code, "escrow_transition_allowed");
+            }
+            Err(error) => {
+                invalid_count += 1;
+                error_reason_codes.push(error.reason_code());
+            }
+        }
+    }
+
+    let escrow = escrow.lock().expect("escrow lock should acquire");
+    (
+        success_count,
+        invalid_count,
+        error_reason_codes,
+        escrow.released_amount(),
+        escrow.refunded_amount(),
+        escrow.remaining_amount(),
+    )
 }
 
 #[test]
@@ -353,6 +454,43 @@ fn integration_peer_lifecycle_concurrency_replay_is_deterministic_across_rounds(
 }
 
 #[test]
+fn functional_escrow_dispute_refund_concurrency_replay_fixture_preserves_terminal_snapshot() {
+    let totals = [3_u128, 5, 8, 13];
+
+    for total_amount in totals {
+        let (success_count, invalid_count, released, refunded, remaining) =
+            run_escrow_dispute_refund_race(total_amount);
+
+        assert!(success_count >= 1);
+        assert!(success_count <= 2);
+        assert_eq!(success_count + invalid_count, 2);
+        assert_eq!(released, 0);
+        assert_eq!(refunded, total_amount);
+        assert_eq!(remaining, 0);
+    }
+}
+
+#[test]
+fn integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds() {
+    let mut baseline: Option<(u128, u128, u128)> = None;
+
+    for round in 0..24 {
+        let (_success_count, _invalid_count, released, refunded, remaining) =
+            run_escrow_dispute_refund_race(21);
+        let summary = (released, refunded, remaining);
+
+        if let Some(expected) = baseline {
+            assert_eq!(
+                summary, expected,
+                "escrow dispute/refund race snapshot drifted in round {round}"
+            );
+        } else {
+            baseline = Some(summary);
+        }
+    }
+}
+
+#[test]
 fn regression_concurrency_accept_race_never_allows_multiple_winners() {
     // Regression: #844
     let contenders = [
@@ -383,6 +521,27 @@ fn regression_concurrency_accept_race_never_allows_multiple_winners() {
 }
 
 #[test]
+fn regression_escrow_refund_race_never_allows_multiple_refund_winners() {
+    // Regression: #904
+    for round in 0..32 {
+        let (success_count, invalid_count, error_reason_codes, released, refunded, remaining) =
+            run_escrow_refund_race(34);
+        assert_eq!(
+            success_count, 1,
+            "round {round} must have one refund winner"
+        );
+        assert_eq!(
+            invalid_count, 1,
+            "round {round} must reject exactly one replayed refund attempt"
+        );
+        assert_eq!(released, 0);
+        assert_eq!(refunded, 34);
+        assert_eq!(remaining, 0);
+        assert_eq!(error_reason_codes, vec!["escrow_transition_invalid"]);
+    }
+}
+
+#[test]
 fn performance_concurrency_state_mutation_contract_lane_stays_within_budget() {
     let started = Instant::now();
     let contenders = [
@@ -402,6 +561,28 @@ fn performance_concurrency_state_mutation_contract_lane_stays_within_budget() {
     assert!(
         elapsed_millis < 800,
         "concurrency state mutation contract lane exceeded budget: {elapsed_millis}ms"
+    );
+}
+
+#[test]
+fn performance_escrow_dispute_refund_concurrency_lane_stays_within_budget() {
+    let started = Instant::now();
+
+    for _ in 0..64 {
+        let (success_count, invalid_count, released, refunded, remaining) =
+            run_escrow_dispute_refund_race(55);
+        assert!(success_count >= 1);
+        assert!(success_count <= 2);
+        assert_eq!(success_count + invalid_count, 2);
+        assert_eq!(released, 0);
+        assert_eq!(refunded, 55);
+        assert_eq!(remaining, 0);
+    }
+
+    let elapsed_millis = started.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 600,
+        "escrow dispute/refund concurrency contract lane exceeded budget: {elapsed_millis}ms"
     );
 }
 

--- a/crates/kamn-core/tests/dispute_refund_transition_contracts.rs
+++ b/crates/kamn-core/tests/dispute_refund_transition_contracts.rs
@@ -1,0 +1,288 @@
+use kamn_core::{
+    EscrowLifecycle, EscrowLifecycleError, EscrowStatus, EscrowTransitionAction, TaskLifecycle,
+    TaskState, TaskTransition,
+};
+use std::time::Instant;
+
+#[derive(Debug, Clone, Copy)]
+enum DisputeRefundAction {
+    ReleaseOne,
+    Dispute,
+    ResolveHalfSplit,
+    RefundRemaining,
+}
+
+const DISPUTE_REFUND_ACTIONS: [DisputeRefundAction; 4] = [
+    DisputeRefundAction::ReleaseOne,
+    DisputeRefundAction::Dispute,
+    DisputeRefundAction::ResolveHalfSplit,
+    DisputeRefundAction::RefundRemaining,
+];
+
+fn for_each_dispute_refund_sequence(max_len: usize, mut f: impl FnMut(&[DisputeRefundAction])) {
+    fn recurse(
+        target_len: usize,
+        current: &mut Vec<DisputeRefundAction>,
+        f: &mut impl FnMut(&[DisputeRefundAction]),
+    ) {
+        if current.len() == target_len {
+            f(current.as_slice());
+            return;
+        }
+
+        for action in DISPUTE_REFUND_ACTIONS {
+            current.push(action);
+            recurse(target_len, current, f);
+            current.pop();
+        }
+    }
+
+    let mut current = Vec::new();
+    for len in 1..=max_len {
+        recurse(len, &mut current, &mut f);
+    }
+}
+
+fn assert_escrow_amount_contract(escrow: &EscrowLifecycle, total_amount: u128) {
+    let released = escrow.released_amount();
+    let refunded = escrow.refunded_amount();
+    let remaining = escrow.remaining_amount();
+    assert_eq!(released + refunded + remaining, total_amount);
+    assert!(released <= total_amount);
+    assert!(refunded <= total_amount);
+    assert!(remaining <= total_amount);
+}
+
+fn apply_action(
+    escrow: &mut EscrowLifecycle,
+    action: DisputeRefundAction,
+) -> Result<&'static str, EscrowLifecycleError> {
+    let transition_action = match action {
+        DisputeRefundAction::ReleaseOne => EscrowTransitionAction::Release { amount: 1 },
+        DisputeRefundAction::Dispute => EscrowTransitionAction::Dispute,
+        DisputeRefundAction::ResolveHalfSplit => {
+            let remaining = escrow.remaining_amount();
+            let release_to_payee = remaining / 2;
+            let refund_to_payer = remaining.saturating_sub(release_to_payee);
+            EscrowTransitionAction::Resolve {
+                release_to_payee,
+                refund_to_payer,
+            }
+        }
+        DisputeRefundAction::RefundRemaining => EscrowTransitionAction::RefundRemaining,
+    };
+
+    let evidence = escrow.apply_transition_with_evidence(transition_action)?;
+    assert_eq!(evidence.reason_code, "escrow_transition_allowed");
+    Ok(evidence.reason_code)
+}
+
+fn run_sequence_trace(
+    total_amount: u128,
+    sequence: &[DisputeRefundAction],
+) -> (EscrowStatus, u128, u128, u128, Vec<String>) {
+    let mut escrow = EscrowLifecycle::new(total_amount).expect("escrow should initialize");
+    let mut trace = Vec::new();
+
+    for action in sequence {
+        let before_status = escrow.status();
+        let before_released = escrow.released_amount();
+        let before_refunded = escrow.refunded_amount();
+        let before_remaining = escrow.remaining_amount();
+
+        match apply_action(&mut escrow, *action) {
+            Ok(reason_code) => {
+                trace.push(format!(
+                    "ok:{reason_code}:{before_status:?}->{:?}",
+                    escrow.status()
+                ));
+            }
+            Err(error) => {
+                trace.push(format!("err:{}:{before_status:?}", error.reason_code()));
+                assert_eq!(escrow.status(), before_status);
+                assert_eq!(escrow.released_amount(), before_released);
+                assert_eq!(escrow.refunded_amount(), before_refunded);
+                assert_eq!(escrow.remaining_amount(), before_remaining);
+            }
+        }
+
+        assert_escrow_amount_contract(&escrow, total_amount);
+    }
+
+    (
+        escrow.status(),
+        escrow.released_amount(),
+        escrow.refunded_amount(),
+        escrow.remaining_amount(),
+        trace,
+    )
+}
+
+#[test]
+fn unit_dispute_refund_error_reason_codes_remain_stable() {
+    let mut refunded = EscrowLifecycle::new(10).expect("escrow should initialize");
+    refunded
+        .refund_remaining()
+        .expect("funded->refunded transition should succeed");
+    let dispute_after_refund = refunded.dispute().expect_err("dispute replay should fail");
+    assert_eq!(
+        dispute_after_refund.reason_code(),
+        "escrow_transition_invalid"
+    );
+
+    let mut disputed = EscrowLifecycle::new(11).expect("escrow should initialize");
+    disputed
+        .dispute()
+        .expect("funded->disputed transition should succeed");
+    let mismatch_error = disputed
+        .resolve(3, 3)
+        .expect_err("resolution split mismatch should fail");
+    assert_eq!(mismatch_error.reason_code(), "escrow_resolution_mismatch");
+}
+
+#[test]
+fn functional_dispute_then_refund_remaining_emits_allowed_evidence() {
+    let mut escrow = EscrowLifecycle::new(13).expect("escrow should initialize");
+
+    let dispute_evidence = escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Dispute)
+        .expect("funded->disputed transition should succeed");
+    assert_eq!(dispute_evidence.reason_code, "escrow_transition_allowed");
+    assert_eq!(dispute_evidence.from, EscrowStatus::Funded);
+    assert_eq!(dispute_evidence.to, EscrowStatus::Disputed);
+
+    let refund_evidence = escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::RefundRemaining)
+        .expect("disputed->refunded transition should succeed");
+    assert_eq!(refund_evidence.reason_code, "escrow_transition_allowed");
+    assert_eq!(refund_evidence.from, EscrowStatus::Disputed);
+    assert_eq!(refund_evidence.to, EscrowStatus::Refunded);
+    assert_eq!(escrow.refunded_amount(), 13);
+    assert_eq!(escrow.remaining_amount(), 0);
+}
+
+#[test]
+fn functional_property_dispute_refund_sequences_preserve_contracts() {
+    let totals = [3_u128, 5, 8];
+
+    for total_amount in totals {
+        for_each_dispute_refund_sequence(4, |sequence| {
+            let (_status, _released, _refunded, _remaining, _trace) =
+                run_sequence_trace(total_amount, sequence);
+        });
+    }
+}
+
+#[test]
+fn integration_dispute_refund_replay_traces_are_deterministic() {
+    let totals = [3_u128, 5, 8];
+
+    for total_amount in totals {
+        for_each_dispute_refund_sequence(3, |sequence| {
+            let first = run_sequence_trace(total_amount, sequence);
+            let second = run_sequence_trace(total_amount, sequence);
+            assert_eq!(first, second);
+        });
+    }
+}
+
+#[test]
+fn integration_task_completion_and_refund_resolution_contracts_stay_coherent() {
+    let mut lifecycle =
+        TaskLifecycle::new("task-904-integration").expect("task lifecycle should initialize");
+    let accept = lifecycle
+        .transition_with_evidence(TaskTransition::Accept)
+        .expect("submitted->accepted should succeed");
+    let start = lifecycle
+        .transition_with_evidence(TaskTransition::StartWork)
+        .expect("accepted->in_progress should succeed");
+    let complete = lifecycle
+        .transition_with_evidence(TaskTransition::Complete)
+        .expect("in_progress->completed should succeed");
+
+    assert_eq!(accept.reason_code, "task_transition_allowed");
+    assert_eq!(start.reason_code, "task_transition_allowed");
+    assert_eq!(complete.reason_code, "task_transition_allowed");
+    assert_eq!(lifecycle.state(), TaskState::Completed);
+
+    let mut escrow = EscrowLifecycle::new(17).expect("escrow should initialize");
+    escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Dispute)
+        .expect("funded->disputed should succeed");
+    escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Resolve {
+            release_to_payee: 8,
+            refund_to_payer: 9,
+        })
+        .expect("disputed->resolved should succeed");
+
+    assert_eq!(
+        escrow.status(),
+        EscrowStatus::Resolved {
+            released_total: 8,
+            refunded_total: 9,
+        }
+    );
+    assert_eq!(escrow.remaining_amount(), 0);
+}
+
+#[test]
+fn regression_replay_dispute_after_refund_fails_closed_with_reason_code() {
+    // Regression: #904
+    let mut escrow = EscrowLifecycle::new(9).expect("escrow should initialize");
+    escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::RefundRemaining)
+        .expect("initial refund should succeed");
+
+    let replay_error = escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Dispute)
+        .expect_err("dispute replay after refund must fail");
+    assert_eq!(replay_error.reason_code(), "escrow_transition_invalid");
+    assert_eq!(escrow.status(), EscrowStatus::Refunded);
+    assert_eq!(escrow.refunded_amount(), 9);
+    assert_eq!(escrow.remaining_amount(), 0);
+}
+
+#[test]
+fn regression_dispute_resolution_split_mismatch_preserves_disputed_state() {
+    // Regression: #904
+    let mut escrow = EscrowLifecycle::new(12).expect("escrow should initialize");
+    escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Dispute)
+        .expect("dispute transition should succeed");
+
+    let before_status = escrow.status();
+    let before_released = escrow.released_amount();
+    let before_refunded = escrow.refunded_amount();
+    let before_remaining = escrow.remaining_amount();
+
+    let mismatch_error = escrow
+        .apply_transition_with_evidence(EscrowTransitionAction::Resolve {
+            release_to_payee: 6,
+            refund_to_payer: 3,
+        })
+        .expect_err("invalid split should fail closed");
+    assert_eq!(mismatch_error.reason_code(), "escrow_resolution_mismatch");
+    assert_eq!(escrow.status(), before_status);
+    assert_eq!(escrow.released_amount(), before_released);
+    assert_eq!(escrow.refunded_amount(), before_refunded);
+    assert_eq!(escrow.remaining_amount(), before_remaining);
+}
+
+#[test]
+fn performance_dispute_refund_property_contract_lane_stays_within_budget() {
+    let started = Instant::now();
+    let totals = [2_u128, 3, 5];
+
+    for total_amount in totals {
+        for_each_dispute_refund_sequence(4, |sequence| {
+            let _ = run_sequence_trace(total_amount, sequence);
+        });
+    }
+
+    let elapsed_millis = started.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 700,
+        "dispute/refund property contract lane exceeded budget: {elapsed_millis}ms"
+    );
+}

--- a/crates/kamn-core/tests/invariants_docs.rs
+++ b/crates/kamn-core/tests/invariants_docs.rs
@@ -10,3 +10,13 @@ fn doc_contains_runtime_invariant_harness_coverage_contract() {
     assert!(DOC.contains("check_invariant_fuzz_concurrency_policy.sh"));
     assert!(DOC.contains("kamn.runtime.invariant-fuzz-concurrency-contract-report.v1"));
 }
+
+#[test]
+fn regression_requires_dispute_refund_property_and_concurrency_contract_markers() {
+    // Regression: #904
+    assert!(DOC.contains("## Dispute/Refund Property and Concurrency Contracts (Issue #904)"));
+    assert!(DOC.contains("dispute_refund_transition_contracts"));
+    assert!(DOC.contains("run_lifecycle_property_contract_lane.sh"));
+    assert!(DOC.contains("run_concurrency_state_mutation_contract_lane.sh"));
+    assert!(DOC.contains("Regression: #904"));
+}

--- a/crates/kamn-core/tests/performance_target_benchmarking_docs.rs
+++ b/crates/kamn-core/tests/performance_target_benchmarking_docs.rs
@@ -44,3 +44,17 @@ fn regression_requires_runtime_invariant_fuzz_concurrency_budget_contract() {
     assert!(DOC.contains("KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS=180"));
     assert!(DOC.contains("kamn.runtime.invariant-fuzz-concurrency-contract-report.v1"));
 }
+
+#[test]
+fn regression_requires_dispute_refund_runtime_budget_contract() {
+    // Regression: #904
+    assert!(DOC.contains(
+        "## Dispute/Refund Property and Concurrency Runtime Budget Contract (Issue #904)"
+    ));
+    assert!(DOC.contains("dispute_refund_transition_contracts"));
+    assert!(DOC.contains("performance_dispute_refund_property_contract_lane_stays_within_budget"));
+    assert!(DOC.contains(
+        "integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds"
+    ));
+    assert!(DOC.contains("Regression: #904"));
+}

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -36,6 +36,19 @@ This document defines the canonical transaction invariant catalog and error taxo
 - Report schema:
   - `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`
 
+## Dispute/Refund Property and Concurrency Contracts (Issue #904)
+- Property + replay trace contract lane:
+  - `cargo test -p kamn-core --test dispute_refund_transition_contracts functional_property_dispute_refund_sequences_preserve_contracts -- --exact`
+  - `cargo test -p kamn-core --test dispute_refund_transition_contracts integration_dispute_refund_replay_traces_are_deterministic -- --exact`
+- Concurrency replay determinism contract lane:
+  - `cargo test -p kamn-core --test concurrency_state_mutation functional_escrow_dispute_refund_concurrency_replay_fixture_preserves_terminal_snapshot -- --exact`
+  - `cargo test -p kamn-core --test concurrency_state_mutation integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds -- --exact`
+- Fast CI lane scripts:
+  - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh`
+  - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
+- Fail-closed regression marker:
+  - dispute/refund replay mutation drift is rejected (`Regression: #904`).
+
 ## Validation
 Run from repository root:
 

--- a/docs/foundation/performance-target-benchmarking.md
+++ b/docs/foundation/performance-target-benchmarking.md
@@ -63,6 +63,22 @@ Each failed metric includes:
   - lane fails closed when elapsed runtime exceeds the budget.
   - report schema remains deterministic: `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`.
 
+## Dispute/Refund Property and Concurrency Runtime Budget Contract (Issue #904)
+- Property lane budget test:
+  - `cargo test -p kamn-core --test dispute_refund_transition_contracts performance_dispute_refund_property_contract_lane_stays_within_budget -- --exact`
+  - bounded dataset: totals `[2, 3, 5]`, max sequence depth `4`.
+  - runtime target: `< 700ms`.
+- Concurrency lane budget and determinism tests:
+  - `cargo test -p kamn-core --test concurrency_state_mutation integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds -- --exact`
+  - `cargo test -p kamn-core --test concurrency_state_mutation performance_escrow_dispute_refund_concurrency_lane_stays_within_budget -- --exact`
+  - bounded replay rounds: `24` determinism checks and `64` budget checks.
+  - runtime target: `< 600ms`.
+- Fast lane script coverage:
+  - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh`
+  - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
+- Fail-closed regression marker:
+  - dispute/refund replay and refund-race multi-winner drift is rejected (`Regression: #904`).
+
 ## CI Threshold Gate Contract
 - Threshold profile source: `.ci/performance-targets.env`.
 - Required report metrics:

--- a/scripts/runtime/run_concurrency_state_mutation_contract_lane.sh
+++ b/scripts/runtime/run_concurrency_state_mutation_contract_lane.sh
@@ -11,8 +11,12 @@ cargo test -p kamn-core --test concurrency_state_mutation task_submit_concurrenc
 cargo test -p kamn-core --test concurrency_state_mutation peer_lifecycle_concurrency_preserves_transition_contract_across_phases -- --exact >/dev/null
 cargo test -p kamn-core --test concurrency_state_mutation functional_task_accept_concurrency_replay_fixture_preserves_invariants -- --exact >/dev/null
 cargo test -p kamn-core --test concurrency_state_mutation integration_peer_lifecycle_concurrency_replay_is_deterministic_across_rounds -- --exact >/dev/null
+cargo test -p kamn-core --test concurrency_state_mutation functional_escrow_dispute_refund_concurrency_replay_fixture_preserves_terminal_snapshot -- --exact >/dev/null
+cargo test -p kamn-core --test concurrency_state_mutation integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds -- --exact >/dev/null
 cargo test -p kamn-core --test concurrency_state_mutation regression_concurrency_accept_race_never_allows_multiple_winners -- --exact >/dev/null
+cargo test -p kamn-core --test concurrency_state_mutation regression_escrow_refund_race_never_allows_multiple_refund_winners -- --exact >/dev/null
 cargo test -p kamn-core --test concurrency_state_mutation performance_concurrency_state_mutation_contract_lane_stays_within_budget -- --exact >/dev/null
+cargo test -p kamn-core --test concurrency_state_mutation performance_escrow_dispute_refund_concurrency_lane_stays_within_budget -- --exact >/dev/null
 
 cargo test -p kamn-core --test runtime_network_docs doc_contains_concurrency_harness_contract_rules -- --exact >/dev/null
 

--- a/scripts/runtime/run_lifecycle_property_contract_lane.sh
+++ b/scripts/runtime/run_lifecycle_property_contract_lane.sh
@@ -12,6 +12,11 @@ cargo test -p kamn-core --test task_state_machine task_lifecycle_property_termin
 cargo test -p kamn-core --test escrow_lifecycle escrow_property_generated_action_sequences_preserve_amount_and_status_invariants -- --exact >/dev/null
 cargo test -p kamn-core --test escrow_lifecycle escrow_property_terminal_statuses_reject_all_mutating_actions -- --exact >/dev/null
 
+cargo test -p kamn-core --test dispute_refund_transition_contracts functional_property_dispute_refund_sequences_preserve_contracts -- --exact >/dev/null
+cargo test -p kamn-core --test dispute_refund_transition_contracts integration_dispute_refund_replay_traces_are_deterministic -- --exact >/dev/null
+cargo test -p kamn-core --test dispute_refund_transition_contracts regression_replay_dispute_after_refund_fails_closed_with_reason_code -- --exact >/dev/null
+cargo test -p kamn-core --test dispute_refund_transition_contracts performance_dispute_refund_property_contract_lane_stays_within_budget -- --exact >/dev/null
+
 cargo test -p kamn-core --test runtime_peer_lifecycle peer_lifecycle_property_generated_event_sequences_match_transition_contract -- --exact >/dev/null
 cargo test -p kamn-core --test runtime_peer_lifecycle peer_lifecycle_property_sequence_replay_is_deterministic -- --exact >/dev/null
 cargo test -p kamn-core --test runtime_peer_lifecycle peer_lifecycle_property_roundtrip_disconnect_recovers_connection_path -- --exact >/dev/null

--- a/scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
@@ -25,13 +25,33 @@ if ! grep -q "integration_peer_lifecycle_concurrency_replay_is_deterministic_acr
   exit 1
 fi
 
+if ! grep -q "functional_escrow_dispute_refund_concurrency_replay_fixture_preserves_terminal_snapshot" "$FAST_SCRIPT"; then
+  echo "expected concurrency contract lane to include escrow dispute/refund functional replay coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds" "$FAST_SCRIPT"; then
+  echo "expected concurrency contract lane to include escrow dispute/refund integration replay determinism coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "regression_concurrency_accept_race_never_allows_multiple_winners" "$FAST_SCRIPT"; then
   echo "expected concurrency contract lane to include regression winner exclusivity coverage" >&2
   exit 1
 fi
 
+if ! grep -q "regression_escrow_refund_race_never_allows_multiple_refund_winners" "$FAST_SCRIPT"; then
+  echo "expected concurrency contract lane to include escrow refund race regression coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "performance_concurrency_state_mutation_contract_lane_stays_within_budget" "$FAST_SCRIPT"; then
   echo "expected concurrency contract lane to include performance budget coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_escrow_dispute_refund_concurrency_lane_stays_within_budget" "$FAST_SCRIPT"; then
+  echo "expected concurrency contract lane to include escrow dispute/refund performance budget coverage" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_lifecycle_property_contract_lane.sh
+++ b/scripts/runtime/test_run_lifecycle_property_contract_lane.sh
@@ -24,6 +24,21 @@ if ! grep -q "peer_lifecycle_property_generated_event_sequences_match_transition
   exit 1
 fi
 
+if ! grep -q "dispute_refund_transition_contracts" "$CONTRACT_LANE"; then
+  echo "expected lifecycle property contract lane to cover dispute/refund property contracts" >&2
+  exit 1
+fi
+
+if ! grep -q "integration_dispute_refund_replay_traces_are_deterministic" "$CONTRACT_LANE"; then
+  echo "expected lifecycle property contract lane to cover dispute/refund replay determinism integration test" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_dispute_refund_property_contract_lane_stays_within_budget" "$CONTRACT_LANE"; then
+  echo "expected lifecycle property contract lane to enforce dispute/refund property runtime budget contract" >&2
+  exit 1
+fi
+
 lane_output="$(bash "$CONTRACT_LANE")"
 if ! printf '%s\n' "$lane_output" | grep -q "runtime lifecycle property contract lane tests passed."; then
   echo "expected runtime lifecycle property contract lane success marker" >&2


### PR DESCRIPTION
Closes #904

## Summary
This PR adds bounded, deterministic dispute/refund property and concurrency contract coverage for task/escrow flows, plus docs and runtime lane wiring to keep the checks fast and CI-cost efficient. It extends regression guards for replay and refund-race edge cases while preserving fail-closed behavior.

## Changes
- `crates/kamn-core/tests/dispute_refund_transition_contracts.rs`: added new unit/functional/integration/regression/performance contract tests for dispute/refund sequence invariants, replay determinism, and reason-code stability.
- `crates/kamn-core/tests/concurrency_state_mutation.rs`: added escrow dispute/refund replay fixture tests, integration determinism replay tests, refund race regression tests, and bounded concurrency performance budget checks.
- `scripts/runtime/run_lifecycle_property_contract_lane.sh`: wired new dispute/refund property/replay/regression/performance exact tests into the fast lifecycle property lane.
- `scripts/runtime/test_run_lifecycle_property_contract_lane.sh`: added lane-contract assertions for dispute/refund property wiring and budget test coverage.
- `scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`: wired escrow dispute/refund functional/integration/regression/performance exact tests into fast concurrency lane.
- `scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh`: added lane-contract assertions for escrow dispute/refund concurrency wiring.
- `docs/foundation/invariants.md`: added `## Dispute/Refund Property and Concurrency Contracts (Issue #904)` with commands and regression marker.
- `docs/foundation/performance-target-benchmarking.md`: added `## Dispute/Refund Property and Concurrency Runtime Budget Contract (Issue #904)` with bounded-runtime targets.
- `crates/kamn-core/tests/invariants_docs.rs`: added docs regression checks for #904 contract section/markers.
- `crates/kamn-core/tests/performance_target_benchmarking_docs.rs`: added docs regression checks for #904 budget contract section/markers.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: dispute/refund bounded property + concurrency lane script checks verified locally

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Stable reason-code mapping assertions for dispute/refund edge errors |
| Functional  | ✅     | Dispute/refund sequence property contracts + escrow concurrency replay fixture checks |
| Integration | ✅     | Replay determinism across sequences and across concurrent rounds |
| Regression  | ✅     | Replay-after-refund and refund-race multi-winner fail-closed guards (`Regression: #904`) |

## Commands Run
- `cargo test -p kamn-core --test dispute_refund_transition_contracts --test invariants_docs --test performance_target_benchmarking_docs`
- `cargo test -p kamn-core --test concurrency_state_mutation`
- `bash scripts/runtime/test_run_lifecycle_property_contract_lane.sh`
- `bash scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
