### PR TITLE
feat(identity): add DID lifecycle mutation transaction contracts

### DIFF
--- a/crates/kamn-core/src/did_registry.rs
+++ b/crates/kamn-core/src/did_registry.rs
@@ -8,6 +8,42 @@ struct DidRegistryRecord {
     revoked: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DidLifecycleMutationAction {
+    Rotate { document: DidDocument },
+    Revoke,
+    Recover { document: DidDocument },
+}
+
+impl DidLifecycleMutationAction {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Rotate { .. } => "rotate",
+            Self::Revoke => "revoke",
+            Self::Recover { .. } => "recover",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DidLifecycleMutationRequest {
+    pub did: AgentDid,
+    pub actor_did: String,
+    pub nonce: u64,
+    pub action: DidLifecycleMutationAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DidLifecycleMutationEvidence {
+    pub did: String,
+    pub actor_did: String,
+    pub nonce: u64,
+    pub action: &'static str,
+    pub from_revoked: bool,
+    pub to_revoked: bool,
+    pub reason_code: &'static str,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DidSubmissionRetryClass {
     NewSubmission,
@@ -122,6 +158,7 @@ pub struct DidRegistry {
     records: HashMap<AgentDid, DidRegistryRecord>,
     submission_keys_by_did: HashMap<AgentDid, String>,
     finality_by_did: HashMap<AgentDid, DidSubmissionFinalityRecord>,
+    last_mutation_nonce_by_did: HashMap<AgentDid, u64>,
 }
 
 impl DidRegistry {
@@ -367,6 +404,109 @@ impl DidRegistry {
         self.finality_by_did.get(did)
     }
 
+    pub fn apply_lifecycle_mutation(
+        &mut self,
+        request: DidLifecycleMutationRequest,
+    ) -> Result<DidLifecycleMutationEvidence, DidRegistryError> {
+        let did = request.did;
+        let did_id = did.as_str().to_owned();
+
+        if request.nonce == 0 {
+            return Err(DidRegistryError::InvalidMutationNonce {
+                did: did_id,
+                nonce: request.nonce,
+            });
+        }
+
+        if let Some(last_nonce) = self.last_mutation_nonce_by_did.get(&did) {
+            if request.nonce <= *last_nonce {
+                return Err(DidRegistryError::ReplayedMutationNonce {
+                    did: did.as_str().to_owned(),
+                    last_nonce: *last_nonce,
+                    found: request.nonce,
+                });
+            }
+        }
+
+        let from_revoked = self
+            .records
+            .get(&did)
+            .map(|record| record.revoked)
+            .ok_or_else(|| DidRegistryError::NotFound(did.as_str().to_owned()))?;
+
+        self.authorize_mutation_actor(&did, &request.actor_did)?;
+        let action = request.action.label();
+
+        match request.action {
+            DidLifecycleMutationAction::Rotate { document } => {
+                if from_revoked {
+                    return Err(DidRegistryError::InvalidLifecycleMutationTransition {
+                        did: did.as_str().to_owned(),
+                        action,
+                        from_revoked,
+                    });
+                }
+
+                Self::validate_document_did(&did, &document)?;
+                let record = self
+                    .records
+                    .get_mut(&did)
+                    .ok_or_else(|| DidRegistryError::NotFound(did.as_str().to_owned()))?;
+                record.document = document;
+            }
+            DidLifecycleMutationAction::Revoke => {
+                if from_revoked {
+                    return Err(DidRegistryError::InvalidLifecycleMutationTransition {
+                        did: did.as_str().to_owned(),
+                        action,
+                        from_revoked,
+                    });
+                }
+
+                let record = self
+                    .records
+                    .get_mut(&did)
+                    .ok_or_else(|| DidRegistryError::NotFound(did.as_str().to_owned()))?;
+                record.revoked = true;
+            }
+            DidLifecycleMutationAction::Recover { document } => {
+                if !from_revoked {
+                    return Err(DidRegistryError::InvalidLifecycleMutationTransition {
+                        did: did.as_str().to_owned(),
+                        action,
+                        from_revoked,
+                    });
+                }
+
+                Self::validate_document_did(&did, &document)?;
+                let record = self
+                    .records
+                    .get_mut(&did)
+                    .ok_or_else(|| DidRegistryError::NotFound(did.as_str().to_owned()))?;
+                record.document = document;
+                record.revoked = false;
+            }
+        }
+
+        self.last_mutation_nonce_by_did
+            .insert(did.clone(), request.nonce);
+        let to_revoked = self
+            .records
+            .get(&did)
+            .map(|record| record.revoked)
+            .unwrap_or(false);
+
+        Ok(DidLifecycleMutationEvidence {
+            did: did.as_str().to_owned(),
+            actor_did: request.actor_did,
+            nonce: request.nonce,
+            action,
+            from_revoked,
+            to_revoked,
+            reason_code: "did_lifecycle_mutation_allowed",
+        })
+    }
+
     fn classify_retry_by_key(
         &self,
         did: &AgentDid,
@@ -399,6 +539,33 @@ impl DidRegistry {
         }
         Ok(())
     }
+
+    fn authorize_mutation_actor(
+        &self,
+        did: &AgentDid,
+        actor_did: &str,
+    ) -> Result<(), DidRegistryError> {
+        let record = self
+            .records
+            .get(did)
+            .ok_or_else(|| DidRegistryError::NotFound(did.as_str().to_owned()))?;
+        let required_actor = record
+            .document
+            .metadata
+            .operator
+            .clone()
+            .unwrap_or_else(|| did.as_str().to_owned());
+
+        if actor_did != required_actor {
+            return Err(DidRegistryError::UnauthorizedMutationActor {
+                did: did.as_str().to_owned(),
+                actor_did: actor_did.to_owned(),
+                required_actor,
+            });
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -428,6 +595,48 @@ pub enum DidRegistryError {
         expected: String,
         actual: String,
     },
+    InvalidMutationNonce {
+        did: String,
+        nonce: u64,
+    },
+    ReplayedMutationNonce {
+        did: String,
+        last_nonce: u64,
+        found: u64,
+    },
+    UnauthorizedMutationActor {
+        did: String,
+        actor_did: String,
+        required_actor: String,
+    },
+    InvalidLifecycleMutationTransition {
+        did: String,
+        action: &'static str,
+        from_revoked: bool,
+    },
+}
+
+impl DidRegistryError {
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::AlreadyRegistered(_) => "did_registry_already_registered",
+            Self::ConflictingFinalityUpdate { .. } => "did_registry_finality_conflict",
+            Self::ConflictingSubmissionIdempotencyKey { .. } => {
+                "did_registry_submission_key_conflict"
+            }
+            Self::NotFound(_) => "did_registry_not_found",
+            Self::StaleFinalityUpdate { .. } => "did_registry_finality_stale",
+            Self::UnknownSubmissionIdempotencyKey { .. } => "did_registry_submission_key_unknown",
+            Self::Revoked(_) => "did_registry_revoked",
+            Self::DocumentDidMismatch { .. } => "did_registry_document_did_mismatch",
+            Self::InvalidMutationNonce { .. } => "did_lifecycle_mutation_nonce_invalid",
+            Self::ReplayedMutationNonce { .. } => "did_lifecycle_mutation_nonce_replay",
+            Self::UnauthorizedMutationActor { .. } => "did_lifecycle_mutation_unauthorized_actor",
+            Self::InvalidLifecycleMutationTransition { .. } => {
+                "did_lifecycle_mutation_invalid_transition"
+            }
+        }
+    }
 }
 
 impl fmt::Display for DidRegistryError {
@@ -467,6 +676,39 @@ impl fmt::Display for DidRegistryError {
                 write!(
                     f,
                     "did document id mismatch, expected {expected}, got {actual}"
+                )
+            }
+            Self::InvalidMutationNonce { did, nonce } => {
+                write!(f, "invalid lifecycle mutation nonce for did {did}: {nonce}")
+            }
+            Self::ReplayedMutationNonce {
+                did,
+                last_nonce,
+                found,
+            } => {
+                write!(
+                    f,
+                    "replayed lifecycle mutation nonce for did {did}; last {last_nonce}, found {found}"
+                )
+            }
+            Self::UnauthorizedMutationActor {
+                did,
+                actor_did,
+                required_actor,
+            } => {
+                write!(
+                    f,
+                    "unauthorized lifecycle mutation actor for did {did}; actor {actor_did}, required {required_actor}"
+                )
+            }
+            Self::InvalidLifecycleMutationTransition {
+                did,
+                action,
+                from_revoked,
+            } => {
+                write!(
+                    f,
+                    "invalid lifecycle mutation transition for did {did}; action {action}, revoked={from_revoked}"
                 )
             }
         }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -205,7 +205,8 @@ pub use did::{
 };
 pub use did_registry::{
     DidChainSubmissionOutcome, DidChainSubmissionReceipt, DidChainSubmissionRequest,
-    DidChainSubmissionResult, DidRegistrationChainAdapter, DidRegistry, DidRegistryError,
+    DidChainSubmissionResult, DidLifecycleMutationAction, DidLifecycleMutationEvidence,
+    DidLifecycleMutationRequest, DidRegistrationChainAdapter, DidRegistry, DidRegistryError,
     DidSubmissionFinalityRecord, DidSubmissionFinalityStatus, DidSubmissionRetryClass,
     InMemoryDidRegistrationChainAdapter,
 };

--- a/crates/kamn-core/tests/agent_interop_wave_docs.rs
+++ b/crates/kamn-core/tests/agent_interop_wave_docs.rs
@@ -1,0 +1,15 @@
+const DOC: &str = include_str!("../../../docs/planning/agent-interop-wave.md");
+
+#[test]
+fn doc_contains_did_lifecycle_contract_lane_commands() {
+    assert!(DOC.contains("## DID Lifecycle Mutation Contract Lane (Issue #889)"));
+    assert!(DOC.contains("did_lifecycle_mutation_transactions"));
+    assert!(DOC.contains("run_did_registry_contract_lane.sh"));
+    assert!(DOC.contains("did_lifecycle_mutation_reason_codes:GO:v1"));
+}
+
+#[test]
+fn regression_requires_did_lifecycle_drift_fail_closed_marker() {
+    // Regression: #889
+    assert!(DOC.contains("Regression: #889"));
+}

--- a/crates/kamn-core/tests/did_registry_transactions.rs
+++ b/crates/kamn-core/tests/did_registry_transactions.rs
@@ -1,8 +1,9 @@
 use kamn_core::{
     canonical_did_document, AgentDid, AgentDidMetadata, DidChainSubmissionOutcome, DidDocument,
-    DidRegistry, DidRegistryError, DidSubmissionFinalityStatus, DidSubmissionRetryClass,
-    InMemoryDidRegistrationChainAdapter,
+    DidLifecycleMutationAction, DidLifecycleMutationRequest, DidRegistry, DidRegistryError,
+    DidSubmissionFinalityStatus, DidSubmissionRetryClass, InMemoryDidRegistrationChainAdapter,
 };
+use std::time::Instant;
 
 fn metadata(model_family: &str) -> AgentDidMetadata {
     AgentDidMetadata {
@@ -313,4 +314,233 @@ fn regression_chain_submission_adapter_exposes_rejected_outcome_without_panickin
         rejected.outcome,
         DidChainSubmissionOutcome::Rejected { .. }
     ));
+}
+
+#[test]
+fn unit_lifecycle_mutation_nonce_guards_emit_deterministic_reason_codes() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:lifecycle-unit-1").expect("did should parse");
+    let mut initial_document = document_for(&did, "claude-4");
+    initial_document.metadata.operator = Some("kamn:did:human:ops-1".to_owned());
+    registry
+        .register(did.clone(), initial_document.clone())
+        .expect("register should succeed");
+
+    let zero_nonce_error = registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-1".to_owned(),
+            nonce: 0,
+            action: DidLifecycleMutationAction::Revoke,
+        })
+        .expect_err("zero nonce mutation should fail");
+    assert_eq!(
+        zero_nonce_error.reason_code(),
+        "did_lifecycle_mutation_nonce_invalid"
+    );
+
+    registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-1".to_owned(),
+            nonce: 1,
+            action: DidLifecycleMutationAction::Rotate {
+                document: initial_document,
+            },
+        })
+        .expect("first mutation should succeed");
+
+    let replay_error = registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-1".to_owned(),
+            nonce: 1,
+            action: DidLifecycleMutationAction::Revoke,
+        })
+        .expect_err("replayed nonce should fail");
+    assert_eq!(
+        replay_error.reason_code(),
+        "did_lifecycle_mutation_nonce_replay"
+    );
+}
+
+#[test]
+fn functional_lifecycle_rotate_mutation_updates_document_and_emits_allowed_reason_code() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:lifecycle-func-1").expect("did should parse");
+    let mut initial_document = document_for(&did, "claude-4");
+    initial_document.metadata.operator = Some("kamn:did:human:ops-2".to_owned());
+    registry
+        .register(did.clone(), initial_document)
+        .expect("register should succeed");
+
+    let mut rotated_document = document_for(&did, "gpt-5");
+    rotated_document.metadata.operator = Some("kamn:did:human:ops-2".to_owned());
+    let evidence = registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-2".to_owned(),
+            nonce: 7,
+            action: DidLifecycleMutationAction::Rotate {
+                document: rotated_document,
+            },
+        })
+        .expect("rotate mutation should succeed");
+
+    assert_eq!(evidence.reason_code, "did_lifecycle_mutation_allowed");
+    assert_eq!(
+        registry
+            .resolve(&did)
+            .expect("resolve should succeed")
+            .metadata
+            .model_family,
+        "gpt-5"
+    );
+}
+
+#[test]
+fn integration_lifecycle_revoke_then_recover_restores_active_resolution() {
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:lifecycle-int-1").expect("did should parse");
+    let mut initial_document = document_for(&did, "claude-4");
+    initial_document.metadata.operator = Some("kamn:did:human:ops-3".to_owned());
+    registry
+        .register(did.clone(), initial_document)
+        .expect("register should succeed");
+
+    registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-3".to_owned(),
+            nonce: 1,
+            action: DidLifecycleMutationAction::Revoke,
+        })
+        .expect("revoke mutation should succeed");
+    assert_eq!(
+        registry.resolve(&did),
+        Err(DidRegistryError::Revoked(did.as_str().to_owned()))
+    );
+
+    let mut recovered_document = document_for(&did, "claude-4.1");
+    recovered_document.metadata.operator = Some("kamn:did:human:ops-3".to_owned());
+    let recovery_evidence = registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-3".to_owned(),
+            nonce: 2,
+            action: DidLifecycleMutationAction::Recover {
+                document: recovered_document,
+            },
+        })
+        .expect("recover mutation should succeed");
+
+    assert_eq!(
+        recovery_evidence.reason_code,
+        "did_lifecycle_mutation_allowed"
+    );
+    assert_eq!(
+        registry
+            .resolve(&did)
+            .expect("resolve should recover")
+            .metadata
+            .model_family,
+        "claude-4.1"
+    );
+}
+
+#[test]
+fn regression_lifecycle_replayed_or_unauthorized_mutation_fails_closed() {
+    // Regression: #889
+    let mut registry = DidRegistry::new();
+    let did = AgentDid::parse("kamn:did:agent:lifecycle-reg-1").expect("did should parse");
+    let mut document = document_for(&did, "claude-4");
+    document.metadata.operator = Some("kamn:did:human:ops-4".to_owned());
+    registry
+        .register(did.clone(), document)
+        .expect("register should succeed");
+
+    let unauthorized_error = registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:intruder-4".to_owned(),
+            nonce: 1,
+            action: DidLifecycleMutationAction::Revoke,
+        })
+        .expect_err("unauthorized mutation must fail");
+    assert_eq!(
+        unauthorized_error.reason_code(),
+        "did_lifecycle_mutation_unauthorized_actor"
+    );
+
+    registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-4".to_owned(),
+            nonce: 1,
+            action: DidLifecycleMutationAction::Revoke,
+        })
+        .expect("authorized revoke should succeed");
+
+    let replay_error = registry
+        .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-4".to_owned(),
+            nonce: 1,
+            action: DidLifecycleMutationAction::Recover {
+                document: {
+                    let mut recovered = document_for(&did, "claude-4.2");
+                    recovered.metadata.operator = Some("kamn:did:human:ops-4".to_owned());
+                    recovered
+                },
+            },
+        })
+        .expect_err("replayed mutation nonce must fail");
+    assert_eq!(
+        replay_error.reason_code(),
+        "did_lifecycle_mutation_nonce_replay"
+    );
+}
+
+#[test]
+fn performance_lifecycle_mutation_contract_lane_stays_within_budget() {
+    let started = Instant::now();
+
+    for round in 0..64 {
+        let mut registry = DidRegistry::new();
+        let did = AgentDid::parse(format!("kamn:did:agent:lifecycle-perf-{round}").as_str())
+            .expect("did should parse");
+        let mut document = document_for(&did, "claude-4");
+        document.metadata.operator = Some("kamn:did:human:ops-perf".to_owned());
+        registry
+            .register(did.clone(), document)
+            .expect("register should succeed");
+
+        registry
+            .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+                did: did.clone(),
+                actor_did: "kamn:did:human:ops-perf".to_owned(),
+                nonce: 1,
+                action: DidLifecycleMutationAction::Revoke,
+            })
+            .expect("revoke should succeed");
+
+        let mut recovered_document = document_for(&did, "claude-4.1");
+        recovered_document.metadata.operator = Some("kamn:did:human:ops-perf".to_owned());
+        registry
+            .apply_lifecycle_mutation(DidLifecycleMutationRequest {
+                did,
+                actor_did: "kamn:did:human:ops-perf".to_owned(),
+                nonce: 2,
+                action: DidLifecycleMutationAction::Recover {
+                    document: recovered_document,
+                },
+            })
+            .expect("recover should succeed");
+    }
+
+    let elapsed_millis = started.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 800,
+        "did lifecycle mutation contract lane exceeded budget: {elapsed_millis}ms"
+    );
 }

--- a/crates/kamn-core/tests/did_registry_transactions_docs.rs
+++ b/crates/kamn-core/tests/did_registry_transactions_docs.rs
@@ -29,3 +29,18 @@ fn regression_doc_marks_stale_duplicate_conflict_guard() {
     // Regression: #678
     assert!(DOC.contains("Regression: #678"));
 }
+
+#[test]
+fn doc_contains_lifecycle_mutation_transaction_contracts() {
+    assert!(DOC.contains("DidLifecycleMutationRequest"));
+    assert!(DOC.contains("apply_lifecycle_mutation"));
+    assert!(DOC.contains("did_lifecycle_mutation_allowed"));
+    assert!(DOC.contains("did_lifecycle_mutation_nonce_replay"));
+    assert!(DOC.contains("did_lifecycle_mutation_unauthorized_actor"));
+}
+
+#[test]
+fn regression_doc_marks_lifecycle_mutation_fail_closed_guard() {
+    // Regression: #889
+    assert!(DOC.contains("Regression: #889"));
+}

--- a/docs/foundation/did-registry-transactions.md
+++ b/docs/foundation/did-registry-transactions.md
@@ -32,12 +32,25 @@ register/resolve/update/revoke transaction behavior.
   - stale sequence is rejected (`DidRegistryError::StaleFinalityUpdate`)
   - conflicting update at same sequence is rejected (`DidRegistryError::ConflictingFinalityUpdate`)
   - unknown key is rejected (`DidRegistryError::UnknownSubmissionIdempotencyKey`)
+- `apply_lifecycle_mutation(request)` enforces deterministic DID mutation transactions for:
+  - `DidLifecycleMutationAction::Rotate { document }`
+  - `DidLifecycleMutationAction::Revoke`
+  - `DidLifecycleMutationAction::Recover { document }`
+- `DidLifecycleMutationRequest` includes `did`, `actor_did`, `nonce`, and `action`.
+- Successful mutation emits `DidLifecycleMutationEvidence` with
+  `reason_code=did_lifecycle_mutation_allowed`.
+- Lifecycle mutation reason codes are deterministic:
+  - `did_lifecycle_mutation_nonce_invalid`
+  - `did_lifecycle_mutation_nonce_replay`
+  - `did_lifecycle_mutation_unauthorized_actor`
+  - `did_lifecycle_mutation_invalid_transition`
 
 ## Validation Rules
 - The DID document `id` must match the target `did`.
 - Document mismatch is rejected with `DidRegistryError::DocumentDidMismatch`.
 - retry classification and finality checks are deterministic across duplicate/stale/conflict outcomes (`Regression: #678`).
 - chain adapter submission contract remains deterministic through `InMemoryDidRegistrationChainAdapter` for low-cost CI verification.
+- Lifecycle mutation nonce replay, unauthorized actor mutation, and invalid revoke/recover transitions fail closed (`Regression: #889`).
 
 ## Local Validation
 Run from repository root:
@@ -51,6 +64,9 @@ cargo test -p kamn-core --test did_registry_transactions -- functional_chain_sub
 cargo test -p kamn-core --test did_registry_transactions -- integration_chain_submission_adapter_deduplicates_retry_outcomes
 cargo test -p kamn-core --test did_registry_transactions -- regression_chain_submission_adapter_exposes_rejected_outcome_without_panicking
 cargo test -p kamn-core --test did_registry_transactions -- regression_register_finality_rejects_stale_or_conflicting_updates
+cargo test -p kamn-core --test did_registry_transactions -- functional_lifecycle_rotate_mutation_updates_document_and_emits_allowed_reason_code
+cargo test -p kamn-core --test did_registry_transactions -- integration_lifecycle_revoke_then_recover_restores_active_resolution
+cargo test -p kamn-core --test did_registry_transactions -- regression_lifecycle_replayed_or_unauthorized_mutation_fails_closed
 bash scripts/did/run_did_registry_contract_lane.sh
 cargo test -p kamn-core
 ```

--- a/docs/planning/agent-interop-wave.md
+++ b/docs/planning/agent-interop-wave.md
@@ -1,0 +1,34 @@
+# Agent Identity and Protocol Interop Wave (Issue #887)
+
+This plan tracks deterministic DID lifecycle and protocol interop contract lanes required for production-grade identity safety.
+
+## DID Lifecycle Mutation Contract Lane (Issue #889)
+- Lifecycle mutation API contract:
+  - `DidLifecycleMutationRequest`
+  - `DidLifecycleMutationAction::{Rotate, Revoke, Recover}`
+  - `DidLifecycleMutationEvidence`
+- Fast lane commands:
+  - mutation suite label: `did_lifecycle_mutation_transactions`
+  - `cargo test -p kamn-core --test did_registry_transactions -- functional_lifecycle_rotate_mutation_updates_document_and_emits_allowed_reason_code -- --exact`
+  - `cargo test -p kamn-core --test did_registry_transactions -- integration_lifecycle_revoke_then_recover_restores_active_resolution -- --exact`
+  - `cargo test -p kamn-core --test did_registry_transactions -- regression_lifecycle_replayed_or_unauthorized_mutation_fails_closed -- --exact`
+  - `cargo test -p kamn-core --test did_registry_transactions -- performance_lifecycle_mutation_contract_lane_stays_within_budget -- --exact`
+  - `bash scripts/did/run_did_registry_contract_lane.sh`
+- Deterministic lifecycle mutation reason codes:
+  - `did_lifecycle_mutation_allowed`
+  - `did_lifecycle_mutation_nonce_invalid`
+  - `did_lifecycle_mutation_nonce_replay`
+  - `did_lifecycle_mutation_unauthorized_actor`
+  - `did_lifecycle_mutation_invalid_transition`
+- Contract-lane decision key:
+  - `did_lifecycle_mutation_reason_codes:GO:v1`
+
+Fail-closed regression marker:
+- replayed nonce, unauthorized actor mutation, and invalid revoked/active lifecycle transitions are rejected (`Regression: #889`).
+
+## CI Routing Contract
+- DID lifecycle-related docs and script changes must remain on bounded DID contract scope:
+  - `docs/foundation/did-registry-transactions.md`
+  - `docs/planning/agent-interop-wave.md`
+  - `scripts/did/run_did_registry_contract_lane.sh`
+  - `scripts/did/test_run_did_registry_contract_lane.sh`

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -261,7 +261,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/did_registry.rs|crates/kamn-core/tests/did_registry_transactions.rs|crates/kamn-core/tests/did_registry_transactions_docs.rs|docs/foundation/did-registry-transactions.md|scripts/did/*did_registry*)
+    crates/kamn-core/src/did_registry.rs|crates/kamn-core/tests/did_registry_transactions.rs|crates/kamn-core/tests/did_registry_transactions_docs.rs|crates/kamn-core/tests/agent_interop_wave_docs.rs|docs/foundation/did-registry-transactions.md|docs/planning/agent-interop-wave.md|scripts/did/*did_registry*)
       DID_REGISTRY_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -609,6 +609,12 @@ assert_eq "$(extract_output "$did_contract_script_output" "run_did_registry_cont
 assert_eq "$(extract_output "$did_contract_script_output" "run_federated_did_handshake_contract_tests")" "false" "did registry script changes should not run federated DID handshake lane"
 assert_eq "$(extract_output "$did_contract_script_output" "test_scope")" "did-contract" "did contract script changes should set did-contract scope"
 
+agent_interop_wave_doc_output="$(run_selector $'docs/planning/agent-interop-wave.md')"
+assert_eq "$(extract_output "$agent_interop_wave_doc_output" "run_rust")" "false" "agent interop planning doc-only changes should avoid rust lane"
+assert_eq "$(extract_output "$agent_interop_wave_doc_output" "run_did_registry_contract_tests")" "true" "agent interop planning docs must run did registry contract lane"
+assert_eq "$(extract_output "$agent_interop_wave_doc_output" "run_federated_did_handshake_contract_tests")" "false" "agent interop planning docs should not run federated DID handshake lane by default"
+assert_eq "$(extract_output "$agent_interop_wave_doc_output" "test_scope")" "did-contract" "agent interop planning docs should set did-contract scope"
+
 federated_did_contract_docs_output="$(run_selector $'docs/foundation/did-method.md')"
 assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_rust")" "false" "federated DID docs should avoid rust lane"
 assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_did_registry_contract_tests")" "false" "federated DID docs should not trigger did registry contract lane"

--- a/scripts/did/run_did_registry_contract_lane.sh
+++ b/scripts/did/run_did_registry_contract_lane.sh
@@ -10,7 +10,13 @@ bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --t
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions regression_chain_submission_adapter_exposes_rejected_outcome_without_panicking
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions integration_register_retry_and_finality_boundary_is_idempotent
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions regression_register_finality_rejects_stale_or_conflicting_updates
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions unit_lifecycle_mutation_nonce_guards_emit_deterministic_reason_codes
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions functional_lifecycle_rotate_mutation_updates_document_and_emits_allowed_reason_code
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions integration_lifecycle_revoke_then_recover_restores_active_resolution
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions regression_lifecycle_replayed_or_unauthorized_mutation_fails_closed
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions performance_lifecycle_mutation_contract_lane_stays_within_budget
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_registry_transactions_docs
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test agent_interop_wave_docs
 
 if ! grep -Fq "register_with_retry_guard" docs/foundation/did-registry-transactions.md; then
   echo "expected retry guard contract in did-registry-transactions.md" >&2
@@ -24,6 +30,21 @@ fi
 
 if ! grep -Fq "Regression: #678" docs/foundation/did-registry-transactions.md; then
   echo "expected regression marker for DID finality guards in did-registry-transactions.md" >&2
+  exit 1
+fi
+
+if ! grep -Fq "apply_lifecycle_mutation" docs/foundation/did-registry-transactions.md; then
+  echo "expected lifecycle mutation contract in did-registry-transactions.md" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Regression: #889" docs/foundation/did-registry-transactions.md; then
+  echo "expected lifecycle mutation regression marker in did-registry-transactions.md" >&2
+  exit 1
+fi
+
+if ! grep -Fq "did_lifecycle_mutation_reason_codes:GO:v1" docs/planning/agent-interop-wave.md; then
+  echo "expected lifecycle mutation reason-key contract in agent-interop-wave planning doc" >&2
   exit 1
 fi
 

--- a/scripts/did/test_run_did_registry_contract_lane.sh
+++ b/scripts/did/test_run_did_registry_contract_lane.sh
@@ -48,4 +48,34 @@ if ! grep -q "regression_register_finality_rejects_stale_or_conflicting_updates"
   exit 1
 fi
 
+if ! grep -q "unit_lifecycle_mutation_nonce_guards_emit_deterministic_reason_codes" "$SCRIPT"; then
+  echo "expected did registry lane to include DID lifecycle mutation nonce unit coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "functional_lifecycle_rotate_mutation_updates_document_and_emits_allowed_reason_code" "$SCRIPT"; then
+  echo "expected did registry lane to include DID lifecycle rotate mutation functional coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "integration_lifecycle_revoke_then_recover_restores_active_resolution" "$SCRIPT"; then
+  echo "expected did registry lane to include DID lifecycle revoke/recover integration coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "regression_lifecycle_replayed_or_unauthorized_mutation_fails_closed" "$SCRIPT"; then
+  echo "expected did registry lane to include DID lifecycle replay/authorization regression coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_lifecycle_mutation_contract_lane_stays_within_budget" "$SCRIPT"; then
+  echo "expected did registry lane to include DID lifecycle mutation performance budget coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "agent_interop_wave_docs" "$SCRIPT"; then
+  echo "expected did registry lane to include agent interop planning docs contract coverage" >&2
+  exit 1
+fi
+
 echo "did registry contract lane script tests passed."


### PR DESCRIPTION
Closes #889

## Summary
This PR adds deterministic DID lifecycle mutation transaction contracts for rotate/revoke/recover actions with strict nonce replay guards, actor authorization enforcement, stable reason-code mapping, and bounded DID contract lane/docs routing updates.

## Changes
- `crates/kamn-core/src/did_registry.rs`: added lifecycle mutation request/action/evidence types, `DidRegistry::apply_lifecycle_mutation(...)`, deterministic nonce replay checks, actor authorization checks, transition guards, and explicit `DidRegistryError::reason_code()` mapping.
- `crates/kamn-core/src/lib.rs`: exported lifecycle mutation transaction types.
- `crates/kamn-core/tests/did_registry_transactions.rs`: added unit/functional/integration/regression/performance tests for lifecycle nonce, authorization, rotate/revoke/recover behavior, and runtime budget.
- `crates/kamn-core/tests/did_registry_transactions_docs.rs`: added docs contract checks for lifecycle mutation API/reason-code markers and regression marker.
- `crates/kamn-core/tests/agent_interop_wave_docs.rs`: added planning-doc contract tests for #889 lane commands/reason key.
- `docs/foundation/did-registry-transactions.md`: documented lifecycle mutation transaction contracts, deterministic reason codes, and local validation commands.
- `docs/planning/agent-interop-wave.md`: added DID lifecycle mutation contract-lane plan, reason-key contract, and CI routing expectations.
- `scripts/did/run_did_registry_contract_lane.sh`: wired new lifecycle unit/functional/integration/regression/performance tests and planning-doc contract checks.
- `scripts/did/test_run_did_registry_contract_lane.sh`: added lane-contract assertions for new lifecycle coverage.
- `scripts/ci/select_targets.sh`: mapped `docs/planning/agent-interop-wave.md` and lifecycle docs test path to DID contract scope.
- `scripts/ci/test_select_targets.sh`: added selector regression assertions for agent interop planning docs DID routing behavior.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: DID lifecycle mutation contract lane + selector routing checks validated locally

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Mutation nonce invalid/replay reason-code guards |
| Functional  | ✅     | Rotate mutation updates deterministic document state |
| Integration | ✅     | Revoke-then-recover mutation flow restores active DID resolution |
| Regression  | ✅     | Unauthorized/replayed lifecycle mutation fail-closed (`Regression: #889`) |

## Commands Run
- `cargo test -p kamn-core --test did_registry_transactions --test did_registry_transactions_docs --test agent_interop_wave_docs`
- `bash scripts/did/test_run_did_registry_contract_lane.sh`
- `bash scripts/ci/test_select_targets.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
