### PR TITLE
feat(kolme): add adapter-backed runtime commit client (#979)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -313,6 +313,182 @@ pub trait KolmeRuntimeCommitClient {
     ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError>;
 }
 
+/// Typed transport error class emitted when adapter-backed provider calls fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitTransportErrorKind {
+    /// Provider call timed out.
+    Timeout,
+    /// Provider transport/channel is unavailable.
+    Unavailable,
+    /// Provider response payload is malformed.
+    MalformedResponse,
+}
+
+/// Provider-facing error for runtime commit adapter wiring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitProviderError {
+    /// Provider call timed out before a response.
+    Timeout,
+    /// Provider transport/channel is unavailable.
+    Unavailable { reason: String },
+    /// Provider emitted malformed payload/shape.
+    MalformedResponse { reason: String },
+}
+
+impl fmt::Display for KolmeRuntimeCommitProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "provider request timed out"),
+            Self::Unavailable { reason } => write!(f, "provider unavailable: {reason}"),
+            Self::MalformedResponse { reason } => {
+                write!(f, "provider malformed response: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KolmeRuntimeCommitProviderError {}
+
+/// Provider receipt payload returned by adapter-facing transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitProviderReceipt {
+    /// Provider identifier returned by upstream.
+    pub provider: String,
+    /// Commit identifier returned by upstream.
+    pub commit_id: String,
+    /// Receipt finality classification returned by upstream.
+    pub finality: KolmeCommitReceiptFinality,
+}
+
+/// Provider submission outcome used by adapter-backed runtime commit clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitProviderOutcome {
+    /// Provider accepted the submission.
+    Submitted(KolmeRuntimeCommitProviderReceipt),
+    /// Provider detected duplicate idempotency key.
+    Duplicate(KolmeRuntimeCommitProviderReceipt),
+    /// Provider rejected the submission with explicit reason.
+    Rejected { reason: String },
+}
+
+/// Provider interface consumed by the adapter-backed runtime commit client.
+pub trait KolmeRuntimeCommitProvider {
+    /// Submits canonical wire payload with deterministic idempotency key.
+    fn submit_runtime_commit(
+        &mut self,
+        wire_payload: &str,
+        idempotency_key: &str,
+    ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError>;
+}
+
+/// Adapter-backed runtime commit client that enforces provider and finality policies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterBackedKolmeRuntimeCommitClient<P> {
+    expected_provider: String,
+    provider: P,
+}
+
+impl<P: KolmeRuntimeCommitProvider> AdapterBackedKolmeRuntimeCommitClient<P> {
+    /// Builds adapter-backed client with expected provider identifier.
+    pub fn new(expected_provider: &str, provider: P) -> Result<Self, KolmeRuntimeCommitError> {
+        if expected_provider.trim().is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "expected_provider",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            expected_provider: expected_provider.to_owned(),
+            provider,
+        })
+    }
+}
+
+impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
+    for AdapterBackedKolmeRuntimeCommitClient<P>
+{
+    fn submit_commit(
+        &mut self,
+        request: &KolmeRuntimeCommitRequest,
+    ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
+        request.validate()?;
+        let provider_outcome = self
+            .provider
+            .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
+            .map_err(map_provider_error)?;
+        map_provider_outcome(provider_outcome, self.expected_provider.as_str())
+    }
+}
+
+fn map_provider_error(error: KolmeRuntimeCommitProviderError) -> KolmeRuntimeCommitError {
+    match error {
+        KolmeRuntimeCommitProviderError::Timeout => KolmeRuntimeCommitError::ProviderTransport {
+            kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+            detail: "provider request timed out".to_owned(),
+        },
+        KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+            KolmeRuntimeCommitError::ProviderTransport {
+                kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                detail: reason,
+            }
+        }
+        KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+            KolmeRuntimeCommitError::ProviderTransport {
+                kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                detail: reason,
+            }
+        }
+    }
+}
+
+fn map_provider_outcome(
+    outcome: KolmeRuntimeCommitProviderOutcome,
+    expected_provider: &str,
+) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
+    match outcome {
+        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => {
+            let runtime_receipt = map_provider_receipt(receipt, expected_provider)?;
+            Ok(KolmeRuntimeCommitOutcome::Submitted(runtime_receipt))
+        }
+        KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => {
+            let runtime_receipt = map_provider_receipt(receipt, expected_provider)?;
+            Ok(KolmeRuntimeCommitOutcome::Duplicate(runtime_receipt))
+        }
+        KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
+            Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
+        }
+    }
+}
+
+fn map_provider_receipt(
+    receipt: KolmeRuntimeCommitProviderReceipt,
+    expected_provider: &str,
+) -> Result<KolmeRuntimeCommitReceipt, KolmeRuntimeCommitError> {
+    if receipt.provider != expected_provider {
+        return Err(KolmeRuntimeCommitError::ProviderMismatch {
+            expected: expected_provider.to_owned(),
+            observed: receipt.provider,
+        });
+    }
+    if receipt.commit_id.trim().is_empty() {
+        return Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "receipt_commit_id",
+            reason: "must not be empty",
+        });
+    }
+    if !matches!(receipt.finality, KolmeCommitReceiptFinality::Final) {
+        return Err(KolmeRuntimeCommitError::NonFinalReceipt {
+            commit_id: receipt.commit_id,
+            finality: receipt.finality,
+        });
+    }
+    Ok(KolmeRuntimeCommitReceipt {
+        provider: receipt.provider,
+        commit_id: receipt.commit_id,
+        finality: receipt.finality,
+    })
+}
+
 /// Deterministic in-memory commit client used for contract tests and local development.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct InMemoryKolmeRuntimeCommitClient {
@@ -431,6 +607,27 @@ pub enum KolmeRuntimeCommitError {
         /// Observed incoming value.
         observed: String,
     },
+    /// Provider transport failed while submitting runtime commit payload.
+    ProviderTransport {
+        /// Typed transport error kind.
+        kind: KolmeRuntimeCommitTransportErrorKind,
+        /// Deterministic detail text for the transport error.
+        detail: String,
+    },
+    /// Provider identifier did not match configured expected provider.
+    ProviderMismatch {
+        /// Configured provider identifier.
+        expected: String,
+        /// Observed provider identifier from response.
+        observed: String,
+    },
+    /// Provider returned a non-final receipt which is rejected in adapter mode.
+    NonFinalReceipt {
+        /// Commit identifier returned by provider.
+        commit_id: String,
+        /// Observed non-final receipt state.
+        finality: KolmeCommitReceiptFinality,
+    },
 }
 
 impl fmt::Display for KolmeRuntimeCommitError {
@@ -452,6 +649,21 @@ impl fmt::Display for KolmeRuntimeCommitError {
             } => write!(
                 f,
                 "receipt field mismatch for {field}: expected '{expected}', observed '{observed}'"
+            ),
+            Self::ProviderTransport { kind, detail } => {
+                write!(f, "provider transport failure ({kind:?}): {detail}")
+            }
+            Self::ProviderMismatch { expected, observed } => write!(
+                f,
+                "provider mismatch: expected '{expected}', observed '{observed}'"
+            ),
+            Self::NonFinalReceipt {
+                commit_id,
+                finality,
+            } => write!(
+                f,
+                "provider receipt must be final for commit '{commit_id}', observed {}",
+                commit_finality_label(*finality)
             ),
         }
     }
@@ -506,6 +718,14 @@ fn lifecycle_state_label(state: RuntimeCommitLifecycleState) -> &'static str {
         RuntimeCommitLifecycleState::Pending => "pending",
         RuntimeCommitLifecycleState::Finalized => "finalized",
         RuntimeCommitLifecycleState::Failed => "failed",
+    }
+}
+
+fn commit_finality_label(finality: KolmeCommitReceiptFinality) -> &'static str {
+    match finality {
+        KolmeCommitReceiptFinality::Pending => "pending",
+        KolmeCommitReceiptFinality::Final => "final",
+        KolmeCommitReceiptFinality::Failed => "failed",
     }
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -252,10 +252,13 @@ pub use key_lifecycle::{
 };
 pub use key_recovery::{KeyRecoveryManager, RecoveryError, RecoveryState};
 pub use kolme_runtime_commit::{
-    InMemoryKolmeRuntimeCommitClient, KolmeCommitReceiptFinality, KolmeRuntimeCommitClient,
-    KolmeRuntimeCommitError, KolmeRuntimeCommitOutcome, KolmeRuntimeCommitReceipt,
-    KolmeRuntimeCommitRequest, RuntimeCommitFinalityProjection, RuntimeCommitLifecycleRecord,
-    RuntimeCommitLifecycleState, RuntimeCommitPipeline,
+    AdapterBackedKolmeRuntimeCommitClient, InMemoryKolmeRuntimeCommitClient,
+    KolmeCommitReceiptFinality, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
+    KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderReceipt,
+    KolmeRuntimeCommitReceipt, KolmeRuntimeCommitRequest, KolmeRuntimeCommitTransportErrorKind,
+    RuntimeCommitFinalityProjection, RuntimeCommitLifecycleRecord, RuntimeCommitLifecycleState,
+    RuntimeCommitPipeline,
 };
 pub use message_delivery_guards::{
     DeliveryFailureCode, DeliveryGuardInput, DeliveryGuardSnapshot, DeliveryGuardSnapshotError,

--- a/crates/kamn-core/tests/kolme_integration_roadmap_docs.rs
+++ b/crates/kamn-core/tests/kolme_integration_roadmap_docs.rs
@@ -5,6 +5,7 @@ fn roadmap_contains_version_and_runtime_commit_contract_lane_commands() {
     assert!(ROADMAP.contains("validate_version_compatibility.py"));
     assert!(ROADMAP.contains("run_version_compatibility_contract_lane.sh"));
     assert!(ROADMAP.contains("run_runtime_commit_contract_lane.sh"));
+    assert!(ROADMAP.contains("docs/foundation/kolme-runtime-commit-client.md"));
     assert!(ROADMAP.contains("check_runtime_commit_replay_policy.py"));
     assert!(ROADMAP.contains("run_runtime_commit_replay_tamper_matrix.py"));
     assert!(ROADMAP.contains("run_runtime_commit_replay_contract_lane.sh"));
@@ -18,4 +19,5 @@ fn regression_guards_include_legacy_and_runtime_commit_markers() {
     assert!(ROADMAP.contains("`Regression: #825`"));
     assert!(ROADMAP.contains("`Regression: #826`"));
     assert!(ROADMAP.contains("`Regression: #827`"));
+    assert!(ROADMAP.contains("`Regression: #979`"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -1,7 +1,13 @@
 use kamn_core::{
-    InMemoryKolmeRuntimeCommitClient, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
-    KolmeRuntimeCommitOutcome, KolmeRuntimeCommitRequest,
+    AdapterBackedKolmeRuntimeCommitClient, InMemoryKolmeRuntimeCommitClient,
+    KolmeCommitReceiptFinality, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
+    KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderReceipt,
+    KolmeRuntimeCommitRequest, KolmeRuntimeCommitTransportErrorKind, RuntimeCommitLifecycleState,
+    RuntimeCommitPipeline,
 };
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::time::Instant;
 
 const FIXTURE: &str =
@@ -17,6 +23,42 @@ struct FixtureCase {
     payload_hash: String,
     expected_status: String,
     expected_reason: String,
+}
+
+type ProviderCalls = Rc<RefCell<Vec<(String, String)>>>;
+
+#[derive(Debug, Clone)]
+struct RecordingProvider {
+    calls: ProviderCalls,
+    result: Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError>,
+}
+
+impl RecordingProvider {
+    fn with_result(
+        result: Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError>,
+    ) -> (Self, ProviderCalls) {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        (
+            Self {
+                calls: calls.clone(),
+                result,
+            },
+            calls,
+        )
+    }
+}
+
+impl KolmeRuntimeCommitProvider for RecordingProvider {
+    fn submit_runtime_commit(
+        &mut self,
+        wire_payload: &str,
+        idempotency_key: &str,
+    ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
+        self.calls
+            .borrow_mut()
+            .push((wire_payload.to_owned(), idempotency_key.to_owned()));
+        self.result.clone()
+    }
 }
 
 fn parse_fixture_cases() -> Vec<FixtureCase> {
@@ -187,5 +229,175 @@ fn performance_runtime_commit_contract_lane_stays_within_budget() {
     assert!(
         elapsed_millis < 300,
         "runtime commit contract lane exceeded budget: {elapsed_millis}ms"
+    );
+}
+
+#[test]
+fn unit_adapter_normalizes_wire_payload_and_idempotency_key_before_submit() {
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-adapter-100",
+        "state:adapter",
+        "kamn:did:agent:runtime-node-adapter-1",
+        9,
+        "payload:adapter",
+    )
+    .expect("request should build");
+    let expected_payload = request.to_wire_payload();
+    let expected_key = request.idempotency_key().to_owned();
+
+    let (provider, calls) = RecordingProvider::with_result(Ok(
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-local".to_owned(),
+            commit_id: "kolme-commit:adapter-100".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }),
+    ));
+    let mut client =
+        AdapterBackedKolmeRuntimeCommitClient::new("kolme-local", provider).expect("client");
+
+    let outcome = client
+        .submit_commit(&request)
+        .expect("adapter submit should succeed");
+    assert!(matches!(outcome, KolmeRuntimeCommitOutcome::Submitted(_)));
+
+    let calls = calls.borrow();
+    assert_eq!(
+        calls.len(),
+        1,
+        "adapter must submit exactly one provider call"
+    );
+    assert_eq!(calls[0].0, expected_payload);
+    assert_eq!(calls[0].1, expected_key);
+}
+
+#[test]
+fn functional_adapter_maps_transport_provider_and_finality_failures_to_typed_errors() {
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-adapter-101",
+        "state:adapter",
+        "kamn:did:agent:runtime-node-adapter-2",
+        4,
+        "payload:adapter",
+    )
+    .expect("request should build");
+
+    let (timeout_provider, _calls) =
+        RecordingProvider::with_result(Err(KolmeRuntimeCommitProviderError::Timeout));
+    let mut timeout_client =
+        AdapterBackedKolmeRuntimeCommitClient::new("kolme-local", timeout_provider)
+            .expect("client");
+    assert_eq!(
+        timeout_client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::ProviderTransport {
+            kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+            detail: "provider request timed out".to_owned(),
+        })
+    );
+
+    let (mismatch_provider, _calls) = RecordingProvider::with_result(Ok(
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-remote".to_owned(),
+            commit_id: "kolme-commit:adapter-101".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }),
+    ));
+    let mut mismatch_client =
+        AdapterBackedKolmeRuntimeCommitClient::new("kolme-local", mismatch_provider)
+            .expect("client");
+    assert_eq!(
+        mismatch_client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::ProviderMismatch {
+            expected: "kolme-local".to_owned(),
+            observed: "kolme-remote".to_owned(),
+        })
+    );
+
+    let (pending_provider, _calls) = RecordingProvider::with_result(Ok(
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-local".to_owned(),
+            commit_id: "kolme-commit:adapter-102".to_owned(),
+            finality: KolmeCommitReceiptFinality::Pending,
+        }),
+    ));
+    let mut pending_client =
+        AdapterBackedKolmeRuntimeCommitClient::new("kolme-local", pending_provider)
+            .expect("client");
+    assert_eq!(
+        pending_client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::NonFinalReceipt {
+            commit_id: "kolme-commit:adapter-102".to_owned(),
+            finality: KolmeCommitReceiptFinality::Pending,
+        })
+    );
+}
+
+#[test]
+fn integration_runtime_pipeline_accepts_adapter_backed_final_receipts() {
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-adapter-103",
+        "state:adapter",
+        "kamn:did:agent:runtime-node-adapter-3",
+        5,
+        "payload:adapter",
+    )
+    .expect("request should build");
+
+    let (provider, _calls) = RecordingProvider::with_result(Ok(
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-local".to_owned(),
+            commit_id: "kolme-commit:adapter-103".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }),
+    ));
+    let mut client =
+        AdapterBackedKolmeRuntimeCommitClient::new("kolme-local", provider).expect("client");
+    let mut pipeline = RuntimeCommitPipeline::new();
+
+    let record = pipeline
+        .submit_with_client(&mut client, request)
+        .expect("pipeline submit should succeed");
+    assert_eq!(record.state, RuntimeCommitLifecycleState::Finalized);
+    assert!(!record.needs_requeue);
+}
+
+#[test]
+fn regression_adapter_path_keeps_receipt_provider_mismatch_fail_closed() {
+    // Regression: #979
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-adapter-104",
+        "state:adapter",
+        "kamn:did:agent:runtime-node-adapter-4",
+        6,
+        "payload:adapter",
+    )
+    .expect("request should build");
+
+    let (provider, _calls) = RecordingProvider::with_result(Ok(
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-local".to_owned(),
+            commit_id: "kolme-commit:adapter-104".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }),
+    ));
+    let mut client =
+        AdapterBackedKolmeRuntimeCommitClient::new("kolme-local", provider).expect("client");
+    let mut pipeline = RuntimeCommitPipeline::new();
+
+    let record = pipeline
+        .submit_with_client(&mut client, request)
+        .expect("pipeline submit should succeed");
+    assert_eq!(record.receipt_provider.as_deref(), Some("kolme-local"));
+    assert_eq!(
+        pipeline.apply_receipt_finality(
+            "op-sync-adapter-104",
+            KolmeCommitReceiptFinality::Final,
+            "kolme-remote",
+            "kolme-commit:adapter-104",
+        ),
+        Err(KolmeRuntimeCommitError::ReceiptFieldMismatch {
+            field: "receipt_provider",
+            expected: "kolme-local".to_owned(),
+            observed: "kolme-remote".to_owned(),
+        })
     );
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -1,0 +1,20 @@
+const DOC: &str = include_str!("../../../docs/foundation/kolme-runtime-commit-client.md");
+
+#[test]
+fn doc_contains_adapter_types_and_validation_commands() {
+    assert!(DOC.contains("AdapterBackedKolmeRuntimeCommitClient"));
+    assert!(DOC.contains("KolmeRuntimeCommitProvider"));
+    assert!(DOC.contains("KolmeRuntimeCommitProviderOutcome"));
+    assert!(DOC.contains("KolmeRuntimeCommitProviderReceipt"));
+    assert!(DOC.contains("KolmeRuntimeCommitProviderError"));
+    assert!(DOC.contains("KolmeRuntimeCommitTransportErrorKind"));
+    assert!(DOC.contains("cargo test -p kamn-core --test kolme_runtime_commit_client"));
+    assert!(DOC.contains("scripts/kolme/run_runtime_commit_contract_lane.sh"));
+}
+
+#[test]
+fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marker() {
+    // Regression: #979
+    assert!(DOC.contains("`Regression: #979`"));
+    assert!(DOC.contains("provider mismatch/non-final receipts remain fail-closed"));
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -1,0 +1,77 @@
+# Kolme Runtime Commit Adapter Contract (Issue #979)
+
+This document captures the adapter-backed runtime commit client that maps
+deterministic request payloads into provider calls with explicit typed failure
+handling.
+
+## Scope Delivered
+
+- Added provider-facing adapter interfaces in `kamn-core`:
+  - `KolmeRuntimeCommitProvider`
+  - `KolmeRuntimeCommitProviderOutcome`
+  - `KolmeRuntimeCommitProviderReceipt`
+  - `KolmeRuntimeCommitProviderError`
+- Added adapter-backed runtime commit client:
+  - `AdapterBackedKolmeRuntimeCommitClient<P>`
+- Added typed transport error classification:
+  - `KolmeRuntimeCommitTransportErrorKind::{Timeout, Unavailable, MalformedResponse}`
+- Extended runtime commit error contracts:
+  - `KolmeRuntimeCommitError::ProviderTransport`
+  - `KolmeRuntimeCommitError::ProviderMismatch`
+  - `KolmeRuntimeCommitError::NonFinalReceipt`
+- Added adapter integration coverage in:
+  - `crates/kamn-core/tests/kolme_runtime_commit_client.rs`
+
+## Deterministic Request Normalization Rules
+
+- Adapter submissions call provider transport with:
+  - canonical request payload from `KolmeRuntimeCommitRequest::to_wire_payload()`
+  - deterministic idempotency key from `KolmeRuntimeCommitRequest::idempotency_key()`
+- The adapter preserves validation semantics from
+  `KolmeRuntimeCommitRequest::validate()` before provider dispatch.
+
+## Provider and Finality Policy Rules
+
+- `expected_provider` is mandatory and must be non-empty at client construction.
+- Provider response must return matching `receipt.provider`.
+- Provider response `receipt.commit_id` must be non-empty.
+- Adapter mode requires `receipt.finality == Final`.
+- `Pending` or `Failed` receipt finality is rejected as `NonFinalReceipt`.
+
+## Typed Failure Mapping
+
+- Provider timeout:
+  - `KolmeRuntimeCommitProviderError::Timeout`
+  - mapped to `KolmeRuntimeCommitError::ProviderTransport { kind: Timeout, ... }`
+- Provider channel unavailable:
+  - `KolmeRuntimeCommitProviderError::Unavailable { reason }`
+  - mapped to `KolmeRuntimeCommitError::ProviderTransport { kind: Unavailable, ... }`
+- Provider malformed response:
+  - `KolmeRuntimeCommitProviderError::MalformedResponse { reason }`
+  - mapped to `KolmeRuntimeCommitError::ProviderTransport { kind: MalformedResponse, ... }`
+- Provider identity mismatch:
+  - mapped to `KolmeRuntimeCommitError::ProviderMismatch`
+- Non-final provider receipt:
+  - mapped to `KolmeRuntimeCommitError::NonFinalReceipt`
+
+## Validation Commands
+
+Run targeted checks first:
+
+```bash
+cargo test -p kamn-core --test kolme_runtime_commit_client
+cargo test -p kamn-core --test kolme_runtime_commit_finality
+bash scripts/kolme/run_runtime_commit_contract_lane.sh
+```
+
+Then run broader regression:
+
+```bash
+cargo test -p kamn-core
+```
+
+## Regression Markers
+
+- Mutated invalid runtime commit requests remain fail-closed (`Regression: #825`).
+- Replay/tamper mismatch policy remains fail-closed (`Regression: #827`).
+- Adapter provider mismatch/non-final receipts remain fail-closed (`Regression: #979`).

--- a/docs/planning/kolme-integration-roadmap.md
+++ b/docs/planning/kolme-integration-roadmap.md
@@ -21,6 +21,8 @@ across Kolme upgrades.
 - Runtime commit contract lane:
   - `bash scripts/kolme/run_runtime_commit_contract_lane.sh`
   - fixture: `fixtures/kolme_commit/runtime_commit_request_cases.txt`
+- Runtime commit adapter contract reference:
+  - `docs/foundation/kolme-runtime-commit-client.md`
 - Runtime commit replay policy checker:
   - `python3 scripts/kolme/check_runtime_commit_replay_policy.py --operation-id op-go-001 --idempotency-key kolme-runtime-commit:op-go-001:state:agent:1:12 --receipt-provider kolme-local --expected-receipt-provider kolme-local --receipt-commit-id kolme-commit:op-go-001:agent:1:12 --expected-receipt-commit-id kolme-commit:op-go-001:agent:1:12 --nonce-monotonic true --replay-detected false --payload-hash-match true --receipt-finality FINAL --ci-fast-gate PASS --output-json /tmp/kolme-runtime-commit-replay-policy.json`
 - Runtime commit replay matrix command:
@@ -57,6 +59,7 @@ across Kolme upgrades.
 - Malformed runtime commit request shapes remain fail-closed (`Regression: #825`).
 - Runtime commit finality projection blocks invalid lifecycle regression to pending (`Regression: #826`).
 - Runtime commit replay/tamper mismatch policy emits fail-closed reason codes (`Regression: #827`).
+- Adapter provider mismatch and non-final receipt handling remain fail-closed (`Regression: #979`).
 
 ## Local Validation
 

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -283,12 +283,12 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/kolme_runtime_commit.rs|crates/kamn-core/tests/kolme_runtime_commit_client.rs|crates/kamn-core/tests/kolme_runtime_commit_finality.rs)
+    crates/kamn-core/src/kolme_runtime_commit.rs|crates/kamn-core/tests/kolme_runtime_commit_client.rs|crates/kamn-core/tests/kolme_runtime_commit_finality.rs|crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs)
       KOLME_VERSION_COMPATIBILITY_CONTRACT_CHANGED=true
       RUST_CHANGED=true
       classified=true
       ;;
-    docs/planning/kolme-integration-roadmap.md|docs/foundation/release-gonogo-checklist.md|scripts/kolme/validate_version_compatibility.py|scripts/kolme/run_version_compatibility_replay.py|scripts/kolme/run_version_compatibility_contract_lane.sh|scripts/kolme/run_version_compatibility_replay_deep_lane.sh|scripts/kolme/run_runtime_commit_contract_lane.sh|scripts/kolme/check_runtime_commit_replay_policy.py|scripts/kolme/run_runtime_commit_replay_tamper_matrix.py|scripts/kolme/run_runtime_commit_replay_contract_lane.sh|scripts/kolme/test_validate_version_compatibility.sh|scripts/kolme/test_check_runtime_commit_replay_policy.sh|scripts/kolme/test_run_version_compatibility_contract_lane.sh|scripts/kolme/test_run_runtime_commit_contract_lane.sh|scripts/kolme/test_run_runtime_commit_replay_contract_lane.sh|fixtures/kolme_compatibility/version_compatibility_cases.json|fixtures/kolme_commit/runtime_commit_request_cases.txt|fixtures/kolme_commit/runtime_commit_replay_tamper_cases.json|crates/kamn-core/tests/kolme_integration_roadmap_docs.rs)
+    docs/planning/kolme-integration-roadmap.md|docs/foundation/kolme-runtime-commit-client.md|docs/foundation/release-gonogo-checklist.md|scripts/kolme/validate_version_compatibility.py|scripts/kolme/run_version_compatibility_replay.py|scripts/kolme/run_version_compatibility_contract_lane.sh|scripts/kolme/run_version_compatibility_replay_deep_lane.sh|scripts/kolme/run_runtime_commit_contract_lane.sh|scripts/kolme/check_runtime_commit_replay_policy.py|scripts/kolme/run_runtime_commit_replay_tamper_matrix.py|scripts/kolme/run_runtime_commit_replay_contract_lane.sh|scripts/kolme/test_validate_version_compatibility.sh|scripts/kolme/test_check_runtime_commit_replay_policy.sh|scripts/kolme/test_run_version_compatibility_contract_lane.sh|scripts/kolme/test_run_runtime_commit_contract_lane.sh|scripts/kolme/test_run_runtime_commit_replay_contract_lane.sh|fixtures/kolme_compatibility/version_compatibility_cases.json|fixtures/kolme_commit/runtime_commit_request_cases.txt|fixtures/kolme_commit/runtime_commit_replay_tamper_cases.json|crates/kamn-core/tests/kolme_integration_roadmap_docs.rs)
       KOLME_VERSION_COMPATIBILITY_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -871,6 +871,13 @@ assert_eq "$(extract_output "$kolme_version_contract_docs_output" "run_kolme_ver
 assert_eq "$(extract_output "$kolme_version_contract_docs_output" "run_kolme_triadic_devnet_smoke_contract_tests")" "false" "Kolme version roadmap docs should skip triadic devnet smoke contract lane"
 assert_eq "$(extract_output "$kolme_version_contract_docs_output" "test_scope")" "kolme-version-contract" "Kolme version roadmap docs should set kolme-version-contract scope"
 
+kolme_runtime_commit_client_docs_output="$(run_selector $'docs/foundation/kolme-runtime-commit-client.md')"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_output" "run_rust")" "false" "Kolme runtime commit client docs should avoid rust lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_output" "run_kolme_snapshot_drift_contract_tests")" "false" "Kolme runtime commit client docs should skip Kolme snapshot drift contract lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_output" "run_kolme_version_compatibility_contract_tests")" "true" "Kolme runtime commit client docs must run Kolme version compatibility contract lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_output" "run_kolme_triadic_devnet_smoke_contract_tests")" "false" "Kolme runtime commit client docs should skip triadic devnet smoke contract lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_output" "test_scope")" "kolme-version-contract" "Kolme runtime commit client docs should set kolme-version-contract scope"
+
 kolme_version_contract_script_output="$(run_selector $'scripts/kolme/validate_version_compatibility.py')"
 assert_eq "$(extract_output "$kolme_version_contract_script_output" "run_rust")" "false" "Kolme version validator script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$kolme_version_contract_script_output" "run_kolme_snapshot_drift_contract_tests")" "false" "Kolme version validator script changes should skip Kolme snapshot drift contract lane"
@@ -905,6 +912,13 @@ assert_eq "$(extract_output "$kolme_runtime_commit_finality_test_output" "run_ko
 assert_eq "$(extract_output "$kolme_runtime_commit_finality_test_output" "run_kolme_version_compatibility_contract_tests")" "true" "Kolme runtime commit finality rust tests must run Kolme version compatibility contract lane"
 assert_eq "$(extract_output "$kolme_runtime_commit_finality_test_output" "run_kolme_triadic_devnet_smoke_contract_tests")" "false" "Kolme runtime commit finality rust tests should skip triadic devnet smoke contract lane"
 assert_eq "$(extract_output "$kolme_runtime_commit_finality_test_output" "test_scope")" "targeted" "Kolme runtime commit finality rust tests should keep targeted scope"
+
+kolme_runtime_commit_client_docs_test_output="$(run_selector $'crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs')"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_test_output" "run_rust")" "true" "Kolme runtime commit client docs rust tests should run rust lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_test_output" "run_kolme_snapshot_drift_contract_tests")" "false" "Kolme runtime commit client docs rust tests should skip Kolme snapshot drift contract lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_test_output" "run_kolme_version_compatibility_contract_tests")" "true" "Kolme runtime commit client docs rust tests must run Kolme version compatibility contract lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_test_output" "run_kolme_triadic_devnet_smoke_contract_tests")" "false" "Kolme runtime commit client docs rust tests should skip triadic devnet smoke contract lane"
+assert_eq "$(extract_output "$kolme_runtime_commit_client_docs_test_output" "test_scope")" "targeted" "Kolme runtime commit client docs rust tests should keep targeted scope"
 
 kolme_runtime_commit_replay_policy_script_output="$(run_selector $'scripts/kolme/check_runtime_commit_replay_policy.py')"
 assert_eq "$(extract_output "$kolme_runtime_commit_replay_policy_script_output" "run_rust")" "false" "Kolme runtime commit replay policy script-only changes should avoid rust lane"


### PR DESCRIPTION
Closes #979

## Summary
Adds a provider-backed Kolme runtime commit adapter to `kamn-core` with deterministic request/idempotency normalization and explicit typed error mapping for transport, provider mismatch, and non-final receipt failures. This closes the task slice while keeping fast-gate CI routing bounded to the existing Kolme version compatibility lane.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added provider trait/outcome/error contracts, `AdapterBackedKolmeRuntimeCommitClient`, and typed adapter failure mappings.
- `crates/kamn-core/src/lib.rs`: exported new adapter/provider public types.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: added unit/functional/integration/regression adapter tests.
- `docs/foundation/kolme-runtime-commit-client.md`: added runtime commit adapter contract documentation.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: added docs-contract coverage for new foundation doc and regression marker.
- `docs/planning/kolme-integration-roadmap.md` and `crates/kamn-core/tests/kolme_integration_roadmap_docs.rs`: linked adapter contract reference and added `Regression: #979` guard.
- `scripts/ci/select_targets.sh` and `scripts/ci/test_select_targets.sh`: routed new doc/test paths to the Kolme version compatibility contract scope.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `cargo test -p kamn-core --test kolme_runtime_commit_client --test kolme_runtime_commit_finality --test kolme_runtime_commit_client_docs --test kolme_integration_roadmap_docs`, `bash scripts/kolme/test_run_runtime_commit_contract_lane.sh`, and `bash scripts/ci/test_select_targets.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | deterministic payload/idempotency adapter normalization coverage in `kolme_runtime_commit_client` |
| Functional  | ✅ | adapter success + typed transport/provider/finality failure mapping |
| Integration | ✅ | `RuntimeCommitPipeline` exercised with adapter-backed client |
| Regression  | ✅ | provider mismatch/non-final receipt fail-closed (`Regression: #979`) |
