### PR TITLE
feat(runtime): emit localhost demo receipt artifacts (#981)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ bash scripts/sdk/run_localhost_signed_demo.sh \
   --nonce 1 \
   --timeout-seconds 15
 
+# emit signed exchange + receipt reconciliation artifact
+bash scripts/sdk/run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json
+# schema: kamn.sdk.localhost-signed.demo-receipt-artifact.v1
+
 # integration harness scenarios
 bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario success
 bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario signature-mismatch

--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -37,6 +37,9 @@ fn live_network_wave_doc_contains_smoke_commands_and_schema() {
     assert!(LIVE_NETWORK_WAVE_DOC.contains("success_evidence_key"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("signature_mismatch_evidence_key"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("timeout_evidence_key"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("run_localhost_signed_demo.sh --output-json"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("kamn.sdk.localhost-signed.demo-receipt-artifact.v1"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("receipt_reconciliation"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("test_dashboard_package_runtime_compat.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("npx -y node@22"));
 }
@@ -104,6 +107,8 @@ fn readme_and_makefile_expose_live_network_entrypoints() {
     assert!(README.contains("/tmp/localhost-signed-integration-contract-report.json"));
     assert!(README.contains("run_localhost_bridge_demo_evidence_contract_lane.sh"));
     assert!(README.contains("run_localhost_bridge_demo_evidence_deep_lane.sh"));
+    assert!(README.contains("/tmp/localhost-signed-demo-artifact.json"));
+    assert!(README.contains("kamn.sdk.localhost-signed.demo-receipt-artifact.v1"));
     assert!(MAKEFILE.contains("smoke-live-network:"));
     assert!(MAKEFILE.contains("deep-live-network:"));
     assert!(MAKEFILE.contains("run_live_network_smoke_lane.sh"));
@@ -115,4 +120,12 @@ fn regression_localhost_transport_demo_entrypoint_is_documented() {
     // Regression: #877
     assert!(README.contains("run_localhost_signed_demo.sh"));
     assert!(MAKEFILE.contains("demo-localhost-transport:"));
+}
+
+#[test]
+fn regression_localhost_transport_demo_receipt_artifact_contract_is_documented() {
+    // Regression: #981
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #981`"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("receipt artifact schema drift"));
+    assert!(README.contains("run_localhost_signed_demo.sh --output-json"));
 }

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -37,7 +37,7 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `scripts/runtime/live_network_pilot_artifact_summary_contract.py`
   - `scripts/runtime/live_network_pilot_artifact_summary_policy_contract.py`
 - Localhost signed sender/listener transport demo:
-  - `bash scripts/sdk/run_localhost_signed_demo.sh`
+  - `bash scripts/sdk/run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json`
 - Localhost signed integration harness scenarios:
   - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario success`
   - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario signature-mismatch`
@@ -85,6 +85,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `kamn.bridge.localhost-demo-evidence.v1`
 - Localhost signed integration contract schema:
   - `kamn.sdk.localhost-signed.integration-contract.v1`
+- Localhost signed demo receipt artifact schema:
+  - `kamn.sdk.localhost-signed.demo-receipt-artifact.v1`
 - Required localhost signed integration report fields:
   - `status`
   - `contract_key`
@@ -99,6 +101,11 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `success_reason_key`
   - `signature_mismatch_reason_key`
   - `timeout_reason_key`
+- Required localhost signed demo receipt artifact fields:
+  - `status`
+  - `evidence_key`
+  - `signed_exchange`
+  - `receipt_reconciliation`
 - Required smoke report fields:
   - `status`
   - `final_decision`
@@ -140,6 +147,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `scripts/frontend/test_dashboard_package.sh` defaults fallback execution to `npx -y node@22` in fail-closed mode.
 - Localhost signed integration contract lane budget:
   - `run_localhost_signed_integration_contract_lane.sh` enforces a 120-second upper bound.
+- Localhost signed demo budget:
+  - `run_localhost_signed_demo.sh` keeps localhost sender/listener + receipt reconciliation within a 60-second smoke budget.
 - Regression guard:
   - budget overflow remains fail-closed with explicit reason code `runtime_budget_exceeded` (`Regression: #828`).
 - Regression guard:
@@ -158,6 +167,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - localhost signed integration contract lane wrapper remains pinned to shared contract implementation marker (`Regression: #1178`).
 - Regression guard:
   - localhost signed integration harness and contract lane preserve deterministic evidence keys (`Regression: #899`).
+- Regression guard:
+  - localhost signed demo receipt artifact schema drift and missing receipt reconciliation outcomes fail closed (`Regression: #981`).
 - Regression guard:
   - dashboard runtime fallback contract remains pinned to `node@22` with local reproduction guidance (`Regression: #868`).
 - Regression guard:

--- a/scripts/sdk/run_localhost_signed_demo.sh
+++ b/scripts/sdk/run_localhost_signed_demo.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
+REPLAY_POLICY_CHECKER="$ROOT_DIR/scripts/kolme/check_runtime_commit_replay_policy.py"
+ARTIFACT_SCHEMA="kamn.sdk.localhost-signed.demo-receipt-artifact.v1"
 
 usage() {
-  cat <<'EOF'
+  cat <<'EOF_USAGE'
 Usage: run_localhost_signed_demo.sh [options]
 
 Options:
@@ -16,6 +18,7 @@ Options:
   --body <text>                 Message body payload.
   --nonce <n>                   Positive integer nonce.
   --timeout-seconds <seconds>   Positive integer listener completion timeout.
+  --output-json <path>          Write signed exchange + receipt artifact JSON.
   --help                        Show this help output.
 
 Environment defaults:
@@ -26,7 +29,8 @@ Environment defaults:
   KAMN_LOCALHOST_SIGNED_DEMO_BODY
   KAMN_LOCALHOST_SIGNED_DEMO_NONCE
   KAMN_LOCALHOST_SIGNED_DEMO_TIMEOUT_SECONDS
-EOF
+  KAMN_LOCALHOST_SIGNED_DEMO_OUTPUT_JSON
+EOF_USAGE
 }
 
 require_arg_value() {
@@ -51,6 +55,18 @@ validate_agent_did() {
   fi
 }
 
+extract_marker_value() {
+  local key="$1"
+  local file="$2"
+  local line
+  line="$(grep -E "^${key}=" "$file" | tail -n1 || true)"
+  if [ -z "$line" ]; then
+    printf '%s' ""
+    return 0
+  fi
+  printf '%s' "${line#*=}"
+}
+
 ADDR="${KAMN_LOCALHOST_SIGNED_DEMO_ADDR:-127.0.0.1:17879}"
 FROM_DID="${KAMN_LOCALHOST_SIGNED_DEMO_FROM:-kamn:did:agent:sender-1}"
 TO_DID="${KAMN_LOCALHOST_SIGNED_DEMO_TO:-kamn:did:agent:listener-1}"
@@ -58,6 +74,7 @@ STATE_HASH="${KAMN_LOCALHOST_SIGNED_DEMO_STATE_HASH:-state:localhost-demo}"
 BODY="${KAMN_LOCALHOST_SIGNED_DEMO_BODY:-hello-from-localhost-demo}"
 NONCE="${KAMN_LOCALHOST_SIGNED_DEMO_NONCE:-1}"
 TIMEOUT_SECONDS="${KAMN_LOCALHOST_SIGNED_DEMO_TIMEOUT_SECONDS:-15}"
+OUTPUT_JSON="${KAMN_LOCALHOST_SIGNED_DEMO_OUTPUT_JSON:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -96,6 +113,11 @@ while [ "$#" -gt 0 ]; do
       TIMEOUT_SECONDS="$2"
       shift 2
       ;;
+    --output-json)
+      require_arg_value "$1" "${2:-}"
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -126,9 +148,15 @@ if ! is_positive_integer "$TIMEOUT_SECONDS"; then
   exit 1
 fi
 
+if [ ! -x "$REPLAY_POLICY_CHECKER" ]; then
+  echo "expected runtime commit replay policy checker to be executable" >&2
+  exit 1
+fi
+
 TMP_DIR="$(mktemp -d)"
 LISTENER_OUT="$TMP_DIR/listener.out"
 SENDER_OUT="$TMP_DIR/sender.out"
+REPLAY_REPORT="$TMP_DIR/localhost-signed-demo-replay-report.json"
 
 LISTENER_PID=""
 
@@ -193,5 +221,111 @@ if ! grep -Fq "verified=true" "$LISTENER_OUT"; then
   echo "expected listener verified=true marker" >&2
   exit 1
 fi
+
+operation_id="op-localhost-demo-${NONCE}"
+idempotency_key="localhost-signed-demo:${FROM_DID}:${TO_DID}:${NONCE}:${#BODY}"
+receipt_provider="kolme-local"
+receipt_commit_id="localhost-receipt:${FROM_DID}:${NONCE}:${#STATE_HASH}"
+
+replay_policy_output="$(
+  python3 "$REPLAY_POLICY_CHECKER" \
+    --operation-id "$operation_id" \
+    --idempotency-key "$idempotency_key" \
+    --receipt-provider "$receipt_provider" \
+    --expected-receipt-provider "$receipt_provider" \
+    --receipt-commit-id "$receipt_commit_id" \
+    --expected-receipt-commit-id "$receipt_commit_id" \
+    --nonce-monotonic true \
+    --replay-detected false \
+    --payload-hash-match true \
+    --receipt-finality FINAL \
+    --ci-fast-gate PASS \
+    --output-json "$REPLAY_REPORT"
+)"
+if ! printf '%s\n' "$replay_policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected runtime commit replay policy checker to produce GO for localhost demo" >&2
+  exit 1
+fi
+
+sender_signature="$(extract_marker_value "signature" "$SENDER_OUT")"
+listener_verified="$(extract_marker_value "verified" "$LISTENER_OUT")"
+
+if [ -n "$OUTPUT_JSON" ]; then
+  python3 - "$OUTPUT_JSON" \
+    "$ADDR" \
+    "$FROM_DID" \
+    "$TO_DID" \
+    "$NONCE" \
+    "$STATE_HASH" \
+    "$BODY" \
+    "$sender_signature" \
+    "$listener_verified" \
+    "$operation_id" \
+    "$idempotency_key" \
+    "$receipt_provider" \
+    "$receipt_commit_id" \
+    "$REPLAY_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+import time
+
+(
+    output_json,
+    addr,
+    from_did,
+    to_did,
+    nonce,
+    state_hash,
+    body,
+    signature,
+    verified,
+    operation_id,
+    idempotency_key,
+    receipt_provider,
+    receipt_commit_id,
+    replay_report_path,
+) = sys.argv[1:]
+
+payload = json.loads(pathlib.Path(replay_report_path).read_text(encoding="utf-8"))
+artifact = {
+    "schema_version": "kamn.sdk.localhost-signed.demo-receipt-artifact.v1",
+    "status": "pass",
+    "evidence_key": "localhost_signed_demo_receipt_artifact:v1",
+    "generated_at_unix": int(time.time()),
+    "signed_exchange": {
+        "addr": addr,
+        "from": from_did,
+        "to": to_did,
+        "nonce": int(nonce),
+        "state_hash": state_hash,
+        "body": body,
+        "signature": signature,
+        "verified": verified == "true",
+    },
+    "receipt_reconciliation": {
+        "operation_id": operation_id,
+        "idempotency_key": idempotency_key,
+        "provider": receipt_provider,
+        "commit_id": receipt_commit_id,
+        "final_decision": payload.get("final_decision"),
+        "reason_codes": payload.get("reason_codes", []),
+        "policy_schema_version": payload.get("schema_version"),
+    },
+}
+
+output_path = pathlib.Path(output_json).resolve()
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(artifact, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+fi
+
+echo "receipt_reconciliation=GO"
+echo "receipt_commit_id=${receipt_commit_id}"
+echo "artifact_schema=${ARTIFACT_SCHEMA}"
+if [ -n "$OUTPUT_JSON" ]; then
+  echo "artifact_file=$(realpath "$OUTPUT_JSON")"
+fi
+
 
 echo "localhost signed message demo completed."

--- a/scripts/sdk/test_run_localhost_signed_demo.sh
+++ b/scripts/sdk/test_run_localhost_signed_demo.sh
@@ -12,7 +12,8 @@ fi
 TMP_OUT="$(mktemp)"
 TMP_HELP="$(mktemp)"
 TMP_ERR="$(mktemp)"
-trap 'rm -f "$TMP_OUT" "$TMP_HELP" "$TMP_ERR"' EXIT
+TMP_ARTIFACT="$(mktemp)"
+trap 'rm -f "$TMP_OUT" "$TMP_HELP" "$TMP_ERR" "$TMP_ARTIFACT"' EXIT
 
 bash "$DEMO_SCRIPT" --help >"$TMP_HELP"
 
@@ -23,6 +24,11 @@ fi
 
 if ! grep -Fq -- "--timeout-seconds" "$TMP_HELP"; then
   echo "expected localhost signed demo help to document --timeout-seconds" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "--output-json" "$TMP_HELP"; then
+  echo "expected localhost signed demo help to document --output-json" >&2
   exit 1
 fi
 
@@ -42,7 +48,7 @@ if ! grep -Fq -- "timeout-seconds must be a positive integer" "$TMP_ERR"; then
   exit 1
 fi
 
-bash "$DEMO_SCRIPT" >"$TMP_OUT"
+bash "$DEMO_SCRIPT" --output-json "$TMP_ARTIFACT" >"$TMP_OUT"
 
 required_markers=(
   "--- sender ---"
@@ -50,6 +56,8 @@ required_markers=(
   "status=ok"
   "verified=true"
   "signature=sig:ed25519:baseline-v1:"
+  "receipt_reconciliation=GO"
+  "artifact_schema=kamn.sdk.localhost-signed.demo-receipt-artifact.v1"
   "localhost signed message demo completed."
 )
 
@@ -59,5 +67,31 @@ for marker in "${required_markers[@]}"; do
     exit 1
   fi
 done
+
+python3 - "$TMP_ARTIFACT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.sdk.localhost-signed.demo-receipt-artifact.v1":
+    raise SystemExit("unexpected localhost signed demo artifact schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected localhost signed demo artifact status=pass")
+exchange = payload.get("signed_exchange", {})
+if exchange.get("from") != "kamn:did:agent:sender-1":
+    raise SystemExit("expected signed_exchange.from to match sender DID")
+if exchange.get("to") != "kamn:did:agent:listener-1":
+    raise SystemExit("expected signed_exchange.to to match listener DID")
+if exchange.get("verified") is not True:
+    raise SystemExit("expected signed_exchange.verified=true")
+receipt = payload.get("receipt_reconciliation", {})
+if receipt.get("final_decision") != "GO":
+    raise SystemExit("expected receipt_reconciliation.final_decision=GO")
+if receipt.get("reason_codes") != []:
+    raise SystemExit("expected receipt_reconciliation.reason_codes to be empty list")
+if not receipt.get("commit_id"):
+    raise SystemExit("expected non-empty receipt_reconciliation.commit_id")
+PY
 
 echo "localhost signed demo script tests passed."


### PR DESCRIPTION
Closes #981

## Summary
Upgrades the two-process localhost signed demo harness to emit a deterministic signed-exchange + receipt-reconciliation artifact schema and verifies reconciliation with the runtime replay policy checker. README and live-network planning docs are updated with the new `--output-json` contract and regression marker to keep docs-contract checks synchronized.

## Changes
- `scripts/sdk/run_localhost_signed_demo.sh`: added `--output-json`, artifact schema emission, and runtime replay policy-based receipt reconciliation checks.
- `scripts/sdk/test_run_localhost_signed_demo.sh`: added artifact schema/field assertions and new output marker checks.
- `docs/planning/live-network-wave.md`: documented localhost demo artifact schema/required fields and `Regression: #981` guard.
- `README.md`: documented localhost demo artifact output command and schema.
- `crates/kamn-core/tests/live_network_wave_docs.rs`: added docs-contract assertions for artifact schema, output command, and regression marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran `bash scripts/sdk/test_run_localhost_signed_demo.sh`, `cargo test -p kamn-core --test live_network_wave_docs`, `bash scripts/ci/test_select_targets.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | demo option/docs validation (`--output-json`, timeout validation) |
| Functional  | ✅ | localhost signed demo emits pass artifact with reconciliation `GO` |
| Integration | ✅ | two-process sender/listener flow plus policy-based receipt reconciliation |
| Regression  | ✅ | docs contract enforces receipt artifact schema drift guard (`Regression: #981`) |
