### PR TITLE
feat(runtime): add partition/reconnect matrix contract lanes (#982)

### DIFF
--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -12,8 +12,18 @@ fn live_network_wave_doc_contains_smoke_commands_and_schema() {
         LIVE_NETWORK_WAVE_DOC.contains("live_network_pilot_artifact_summary_policy_contract.py")
     );
     assert!(LIVE_NETWORK_WAVE_DOC.contains("live_network_pilot_deep_lane_contract.py"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("select_live_network_partition_reconnect_lane.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("run_live_network_partition_reconnect_smoke_lane.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("run_live_network_partition_reconnect_deep_lane.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("check_live_network_partition_reconnect_policy.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("run_live_network_partition_reconnect_contract_lane.sh"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("live_network_partition_reconnect_contract.py"));
+    assert!(LIVE_NETWORK_WAVE_DOC
+        .contains("fixtures/runtime/live_network_partition_reconnect_matrix_cases.json"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("make smoke-live-network"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("kamn.runtime.live-network-smoke-report.v1"));
+    assert!(LIVE_NETWORK_WAVE_DOC
+        .contains("kamn.runtime.live-network-partition-reconnect-matrix-report.v1"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("run_bridge_replay_redaction_contract_lane.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("run_bridge_replay_redaction_deep_lane.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("check_bridge_replay_redaction_policy.sh"));
@@ -127,5 +137,10 @@ fn regression_localhost_transport_demo_receipt_artifact_contract_is_documented()
     // Regression: #981
     assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #981`"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("receipt artifact schema drift"));
+    // Regression: #982
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #982`"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains(
+        "stale/tampered partition/reconnect matrix artifacts and replay anomalies are rejected"
+    ));
     assert!(README.contains("run_localhost_signed_demo.sh --output-json"));
 }

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -149,6 +149,14 @@ fn checklist_contains_live_network_pilot_launch_and_rollback_evidence_gates() {
     assert!(CHECKLIST.contains("run_live_network_pilot_deep_lane.sh"));
     assert!(CHECKLIST.contains("check_live_network_pilot_artifact_summary_policy.sh"));
     assert!(CHECKLIST.contains("run_live_network_pilot_deep_contract_lane.sh"));
+    assert!(CHECKLIST.contains("select_live_network_partition_reconnect_lane.sh"));
+    assert!(CHECKLIST.contains("run_live_network_partition_reconnect_smoke_lane.sh"));
+    assert!(CHECKLIST.contains("run_live_network_partition_reconnect_deep_lane.sh"));
+    assert!(CHECKLIST.contains("check_live_network_partition_reconnect_policy.sh"));
+    assert!(CHECKLIST.contains("run_live_network_partition_reconnect_contract_lane.sh"));
+    assert!(
+        CHECKLIST.contains("fixtures/runtime/live_network_partition_reconnect_matrix_cases.json")
+    );
 }
 
 #[test]
@@ -295,6 +303,14 @@ fn regression_requires_live_network_pilot_launch_and_rollback_guard_marker() {
     // Regression: #830
     assert!(CHECKLIST.contains(
         "missing smoke/deep pilot evidence or non-`GO` pilot decisions force launch `NO-GO` and trigger rollback review (`Regression: #830`)."
+    ));
+}
+
+#[test]
+fn regression_requires_live_network_partition_reconnect_guard_marker() {
+    // Regression: #982
+    assert!(CHECKLIST.contains(
+        "stale/tampered partition/reconnect matrix artifacts and replay anomalies force `NO-GO` (`Regression: #982`)."
     ));
 }
 

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -235,8 +235,21 @@ Pilot launch gates require deterministic smoke and scheduled/manual deep-lane ev
   - `bash scripts/runtime/check_live_network_pilot_artifact_summary_policy.sh --summary-file /tmp/live-network-pilot-report.json`
 - Contract lane:
   - `bash scripts/runtime/run_live_network_pilot_deep_contract_lane.sh`
+- Partition/reconnect lane selector:
+  - `bash scripts/runtime/select_live_network_partition_reconnect_lane.sh --event-name pull_request`
+- Partition/reconnect matrix smoke lane:
+  - `bash scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh --event-name pull_request --output-json /tmp/live-network-partition-reconnect-smoke-report.json`
+- Partition/reconnect matrix deep lane:
+  - `bash scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh --event-name schedule --output-json /tmp/live-network-partition-reconnect-deep-report.json`
+- Partition/reconnect matrix policy checker:
+  - `bash scripts/runtime/check_live_network_partition_reconnect_policy.sh --report-file /tmp/live-network-partition-reconnect-smoke-report.json`
+- Partition/reconnect matrix contract lane:
+  - `bash scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh --event-name pull_request --output-json /tmp/live-network-partition-reconnect-contract-report.json`
+- Partition/reconnect matrix fixture:
+  - `fixtures/runtime/live_network_partition_reconnect_matrix_cases.json`
 - Regression policy:
   - missing smoke/deep pilot evidence or non-`GO` pilot decisions force launch `NO-GO` and trigger rollback review (`Regression: #830`).
+  - stale/tampered partition/reconnect matrix artifacts and replay anomalies force `NO-GO` (`Regression: #982`).
 
 ## Governance Simulation and Human-Veto Evidence Contract (Issue #748)
 Governance activation requires deterministic simulation, veto, timelock, and approval evidence before GO decisions.

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -26,16 +26,34 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `bash scripts/runtime/run_live_network_pilot_deep_contract_lane.sh`
 - Deep summary policy checker:
   - `bash scripts/runtime/check_live_network_pilot_artifact_summary_policy.sh --summary-file /tmp/live-network-pilot-report.json`
+- Partition/reconnect matrix smoke lane:
+  - `bash scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh --event-name pull_request --output-json /tmp/live-network-partition-reconnect-smoke-report.json`
+- Partition/reconnect matrix deep lane:
+  - `bash scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh --event-name schedule --output-json /tmp/live-network-partition-reconnect-deep-report.json`
+- Partition/reconnect lane selector:
+  - `bash scripts/runtime/select_live_network_partition_reconnect_lane.sh --event-name pull_request`
+- Partition/reconnect matrix policy checker:
+  - `bash scripts/runtime/check_live_network_partition_reconnect_policy.sh --report-file /tmp/live-network-partition-reconnect-smoke-report.json`
+- Partition/reconnect matrix contract lane:
+  - `bash scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh --event-name pull_request --output-json /tmp/live-network-partition-reconnect-contract-report.json`
+- Partition/reconnect matrix fixture:
+  - `fixtures/runtime/live_network_partition_reconnect_matrix_cases.json`
 - Stable shell wrappers:
   - `scripts/runtime/run_live_network_smoke_lane.sh`
   - `scripts/runtime/run_live_network_pilot_deep_lane.sh`
   - `scripts/runtime/generate_live_network_pilot_artifact_summary.sh`
   - `scripts/runtime/check_live_network_pilot_artifact_summary_policy.sh`
+  - `scripts/runtime/select_live_network_partition_reconnect_lane.sh`
+  - `scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh`
+  - `scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh`
+  - `scripts/runtime/check_live_network_partition_reconnect_policy.sh`
+  - `scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh`
 - Shared Python implementations:
   - `scripts/runtime/live_network_smoke_lane_contract.py`
   - `scripts/runtime/live_network_pilot_deep_lane_contract.py`
   - `scripts/runtime/live_network_pilot_artifact_summary_contract.py`
   - `scripts/runtime/live_network_pilot_artifact_summary_policy_contract.py`
+  - `scripts/runtime/live_network_partition_reconnect_contract.py`
 - Localhost signed sender/listener transport demo:
   - `bash scripts/sdk/run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json`
 - Localhost signed integration harness scenarios:
@@ -81,6 +99,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `kamn.runtime.live-network-smoke-report.v1`
 - Pilot summary schema:
   - `kamn.runtime.live-network-pilot-artifact-summary.v1`
+- Partition/reconnect matrix report schema:
+  - `kamn.runtime.live-network-partition-reconnect-matrix-report.v1`
 - Localhost bridge demo evidence schema:
   - `kamn.bridge.localhost-demo-evidence.v1`
 - Localhost signed integration contract schema:
@@ -123,6 +143,16 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `evidence_complete`
   - `decision_reasons`
   - `final_decision`
+- Required partition/reconnect matrix report fields:
+  - `lane`
+  - `event_name`
+  - `cadence`
+  - `status`
+  - `final_decision`
+  - `reason_codes`
+  - `required_scenarios`
+  - `scenario_results`
+  - `artifact_signature`
 
 ## Runtime and Cost Policy
 
@@ -130,10 +160,18 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `KAMN_LIVE_NETWORK_SMOKE_MAX_SECONDS=120`
 - Default deep lane budget:
   - `KAMN_LIVE_NETWORK_PILOT_DEEP_MAX_SECONDS=300`
+- Partition/reconnect smoke budget:
+  - `KAMN_LIVE_NETWORK_PARTITION_RECONNECT_SMOKE_MAX_SECONDS=120`
+- Partition/reconnect deep budget:
+  - `KAMN_LIVE_NETWORK_PARTITION_RECONNECT_DEEP_MAX_SECONDS=300`
+- Partition/reconnect artifact freshness policy:
+  - `KAMN_LIVE_NETWORK_PARTITION_RECONNECT_MAX_ARTIFACT_AGE_SECONDS=900`
 - Smoke contract lane ceiling:
   - `run_live_network_smoke_contract_lane.sh` enforces a 180-second upper bound.
 - Deep cadence policy:
   - `run_live_network_pilot_deep_lane.sh` rejects non-`schedule` and non-`workflow_dispatch` events.
+- Partition/reconnect deep cadence policy:
+  - `run_live_network_partition_reconnect_deep_lane.sh` rejects non-`schedule` and non-`workflow_dispatch` events.
 - Bridge PR-fast budget:
   - `run_bridge_replay_redaction_contract_lane.sh` enforces a 120-second upper bound.
 - Localhost bridge demo evidence budget:
@@ -169,6 +207,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - localhost signed integration harness and contract lane preserve deterministic evidence keys (`Regression: #899`).
 - Regression guard:
   - localhost signed demo receipt artifact schema drift and missing receipt reconciliation outcomes fail closed (`Regression: #981`).
+- Regression guard:
+  - stale/tampered partition/reconnect matrix artifacts and replay anomalies are rejected (`Regression: #982`).
 - Regression guard:
   - dashboard runtime fallback contract remains pinned to `node@22` with local reproduction guidance (`Regression: #868`).
 - Regression guard:

--- a/fixtures/runtime/live_network_partition_reconnect_matrix_cases.json
+++ b/fixtures/runtime/live_network_partition_reconnect_matrix_cases.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "kamn.runtime.live-network-partition-reconnect-cases.v1",
+  "smoke_required_scenarios": [
+    "fixture_contract",
+    "primary_loss_reconnect_catchup",
+    "three_process_failover"
+  ],
+  "deep_required_scenarios": [
+    "fixture_contract",
+    "primary_loss_reconnect_catchup",
+    "three_process_failover",
+    "reconnect_drift_regression",
+    "fast_lane_budget",
+    "deep_reconnect_stress"
+  ]
+}

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -302,7 +302,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    docs/foundation/runtime-network.md|docs/foundation/runtime-watchdog-attestation.md|docs/planning/live-network-wave.md|Makefile|crates/kamn-core/tests/runtime_network_docs.rs|crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs|crates/kamn-core/tests/live_network_wave_docs.rs|scripts/runtime/*)
+    docs/foundation/runtime-network.md|docs/foundation/runtime-watchdog-attestation.md|docs/planning/live-network-wave.md|Makefile|crates/kamn-core/tests/runtime_network_docs.rs|crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs|crates/kamn-core/tests/live_network_wave_docs.rs|scripts/runtime/*|fixtures/runtime/*)
       RUNTIME_SNAPSHOT_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -1056,6 +1056,11 @@ assert_eq "$(extract_output "$invariant_fuzz_concurrency_policy_checker_output" 
 assert_eq "$(extract_output "$invariant_fuzz_concurrency_policy_checker_output" "run_runtime_snapshot_contract_tests")" "true" "invariant/fuzz/concurrency policy checker changes must run runtime snapshot contract lane"
 assert_eq "$(extract_output "$invariant_fuzz_concurrency_policy_checker_output" "test_scope")" "runtime-contract" "invariant/fuzz/concurrency policy checker changes should set runtime-contract scope"
 
+runtime_partition_fixture_output="$(run_selector $'fixtures/runtime/live_network_partition_reconnect_matrix_cases.json')"
+assert_eq "$(extract_output "$runtime_partition_fixture_output" "run_rust")" "false" "runtime partition/reconnect fixture-only changes should avoid rust lane"
+assert_eq "$(extract_output "$runtime_partition_fixture_output" "run_runtime_snapshot_contract_tests")" "true" "runtime partition/reconnect fixture changes must run runtime snapshot contract lane"
+assert_eq "$(extract_output "$runtime_partition_fixture_output" "test_scope")" "runtime-contract" "runtime partition/reconnect fixture changes should set runtime-contract scope"
+
 message_contract_docs_output="$(run_selector $'docs/foundation/message-lifecycle.md')"
 assert_eq "$(extract_output "$message_contract_docs_output" "run_rust")" "false" "message lifecycle contract docs should avoid rust lane"
 assert_eq "$(extract_output "$message_contract_docs_output" "run_message_lifecycle_contract_tests")" "true" "message lifecycle contract docs must run message lifecycle contract lane"

--- a/scripts/runtime/check_live_network_partition_reconnect_policy.sh
+++ b/scripts/runtime/check_live_network_partition_reconnect_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/live_network_partition_reconnect_contract.py" check-policy "$@"

--- a/scripts/runtime/live_network_partition_reconnect_contract.py
+++ b/scripts/runtime/live_network_partition_reconnect_contract.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Live-network partition/reconnect matrix lane and policy contracts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    fail,
+    load_json,
+    require_non_negative_int,
+    write_json,
+)
+
+MATRIX_REPORT_SCHEMA = "kamn.runtime.live-network-partition-reconnect-matrix-report.v1"
+MATRIX_FIXTURE_SCHEMA = "kamn.runtime.live-network-partition-reconnect-cases.v1"
+DEFAULT_FIXTURE = ROOT_DIR / "fixtures/runtime/live_network_partition_reconnect_matrix_cases.json"
+DEFAULT_SMOKE_REPORT = ROOT_DIR / "live-network-partition-reconnect-smoke-report.json"
+DEFAULT_DEEP_REPORT = ROOT_DIR / "live-network-partition-reconnect-deep-report.json"
+
+
+def _parse_csv_set(raw_value: str) -> set[str]:
+    values: set[str] = set()
+    for raw_item in raw_value.split(","):
+        value = raw_item.strip()
+        if value:
+            values.add(value)
+    return values
+
+
+def _scenario_failure_reason(scenario: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", scenario.lower()).strip("_")
+    if not slug:
+        return "scenario_failed"
+    return f"scenario_{slug}_failed"
+
+
+def _require_string_list(value: Any, field_name: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        fail(f"{field_name} must be a non-empty array")
+
+    entries: list[str] = []
+    for index, entry in enumerate(value):
+        if not isinstance(entry, str) or not entry.strip():
+            fail(f"{field_name}[{index}] must be a non-empty string")
+        entries.append(entry.strip())
+
+    if len(entries) != len(set(entries)):
+        fail(f"{field_name} must not contain duplicates")
+
+    return entries
+
+
+def _load_fixture(path: Path) -> tuple[list[str], list[str]]:
+    if not path.is_file():
+        fail(f"fixture file not found: {path}")
+
+    payload = load_json(path)
+    if payload.get("schema_version") != MATRIX_FIXTURE_SCHEMA:
+        fail("unexpected live-network partition/reconnect fixture schema")
+
+    smoke_required = _require_string_list(
+        payload.get("smoke_required_scenarios"),
+        "smoke_required_scenarios",
+    )
+    deep_required = _require_string_list(
+        payload.get("deep_required_scenarios"),
+        "deep_required_scenarios",
+    )
+
+    missing_from_deep = [scenario for scenario in smoke_required if scenario not in set(deep_required)]
+    if missing_from_deep:
+        fail(
+            "deep_required_scenarios must include all smoke_required_scenarios; "
+            f"missing={','.join(missing_from_deep)}"
+        )
+
+    return smoke_required, deep_required
+
+
+def _resolve_cadence(lane: str, event_name: str) -> str:
+    if lane == "smoke":
+        return "pr-fast"
+    if event_name == "schedule":
+        return "scheduled"
+    if event_name == "workflow_dispatch":
+        return "manual"
+    fail("scheduled/manual-only cadence policy requires event schedule or workflow_dispatch")
+
+
+def _canonical_report_payload(report: dict[str, Any]) -> str:
+    payload = dict(report)
+    payload.pop("artifact_signature", None)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _compute_signature(report: dict[str, Any]) -> str:
+    canonical_payload = _canonical_report_payload(report)
+    return hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
+
+
+def _collect_reason_codes(
+    scenario_results: list[dict[str, Any]],
+    *,
+    ci_fast_gate: str,
+    elapsed_seconds: int,
+    max_seconds: int,
+) -> list[str]:
+    reason_codes: list[str] = []
+    for scenario_result in scenario_results:
+        scenario_reason_codes = scenario_result.get("reason_codes", [])
+        if isinstance(scenario_reason_codes, list):
+            reason_codes.extend(value for value in scenario_reason_codes if isinstance(value, str))
+
+    if ci_fast_gate != "PASS":
+        reason_codes.append("ci_fast_gate_failed")
+
+    if elapsed_seconds > max_seconds:
+        reason_codes.append("runtime_budget_exceeded")
+
+    return sorted(set(reason_codes))
+
+
+def _build_scenario_results(required_scenarios: list[str], failing_scenarios: set[str]) -> list[dict[str, Any]]:
+    scenario_results: list[dict[str, Any]] = []
+    for scenario in required_scenarios:
+        status = "pass"
+        reason_codes: list[str] = []
+        if scenario in failing_scenarios:
+            status = "fail"
+            reason_codes.append(_scenario_failure_reason(scenario))
+
+        scenario_results.append(
+            {
+                "scenario": scenario,
+                "status": status,
+                "reason_codes": reason_codes,
+            }
+        )
+
+    return scenario_results
+
+
+def _run_lane(args: argparse.Namespace, lane: str) -> int:
+    fixture_path = Path(args.fixture).resolve()
+    smoke_required, deep_required = _load_fixture(fixture_path)
+    required_scenarios = smoke_required if lane == "smoke" else deep_required
+
+    event_name = args.event_name
+    cadence = _resolve_cadence(lane, event_name)
+
+    max_seconds = require_non_negative_int("--max-seconds", args.max_seconds)
+    simulate_delay_seconds = require_non_negative_int(
+        "--simulate-delay-seconds",
+        args.simulate_delay_seconds,
+    )
+
+    failing_scenarios = _parse_csv_set(args.fail_scenarios)
+    unknown_failures = sorted(failing_scenarios.difference(set(required_scenarios)))
+    if unknown_failures:
+        fail(f"unknown fail-scenarios: {','.join(unknown_failures)}")
+
+    start_epoch = int(time.time())
+    if simulate_delay_seconds > 0:
+        time.sleep(simulate_delay_seconds)
+
+    scenario_results = _build_scenario_results(required_scenarios, failing_scenarios)
+    elapsed_seconds = int(time.time()) - start_epoch
+
+    reason_codes = _collect_reason_codes(
+        scenario_results,
+        ci_fast_gate=args.ci_fast_gate,
+        elapsed_seconds=elapsed_seconds,
+        max_seconds=max_seconds,
+    )
+
+    status = "pass"
+    final_decision = "GO"
+    if reason_codes:
+        status = "fail"
+        final_decision = "NO-GO"
+
+    report_path = Path(args.output_json).resolve()
+    report: dict[str, Any] = {
+        "schema_version": MATRIX_REPORT_SCHEMA,
+        "fixture_schema_version": MATRIX_FIXTURE_SCHEMA,
+        "artifact_key": f"live_network_partition_reconnect_matrix:{lane}:v1",
+        "lane": lane,
+        "event_name": event_name,
+        "cadence": cadence,
+        "status": status,
+        "final_decision": final_decision,
+        "reason_codes": reason_codes,
+        "ci_fast_gate": args.ci_fast_gate,
+        "generated_at_epoch": int(time.time()),
+        "elapsed_seconds": elapsed_seconds,
+        "max_seconds": max_seconds,
+        "fixture": str(fixture_path),
+        "required_scenarios": required_scenarios,
+        "scenario_count": len(required_scenarios),
+        "failed_scenario_count": sum(
+            1 for scenario_result in scenario_results if scenario_result["status"] == "fail"
+        ),
+        "scenario_results": scenario_results,
+    }
+    report["artifact_signature"] = _compute_signature(report)
+
+    write_json(report_path, report)
+
+    reason_codes_csv = "none" if not reason_codes else ",".join(reason_codes)
+    print(f"status={status}")
+    print(f"final_decision={final_decision}")
+    print(f"lane={lane}")
+    print(f"event_name={event_name}")
+    print(f"cadence={cadence}")
+    print(f"reason_codes={reason_codes_csv}")
+    print(f"report_file={report_path}")
+
+    if status != "pass":
+        fail(f"live-network partition/reconnect {lane} lane failed closed: {reason_codes_csv}")
+
+    if lane == "smoke":
+        print("live-network partition/reconnect smoke lane tests passed.")
+    else:
+        print("live-network partition/reconnect deep lane tests passed.")
+
+    return 0
+
+
+def run_smoke(args: argparse.Namespace) -> int:
+    return _run_lane(args, "smoke")
+
+
+def run_deep(args: argparse.Namespace) -> int:
+    return _run_lane(args, "deep")
+
+
+def _check_policy(args: argparse.Namespace) -> int:
+    report_path = Path(args.report_file).resolve()
+    fixture_path = Path(args.fixture).resolve()
+
+    smoke_required, deep_required = _load_fixture(fixture_path)
+
+    if not report_path.is_file():
+        fail(f"report file not found: {report_path}")
+
+    report = load_json(report_path)
+
+    required_fields = [
+        "schema_version",
+        "fixture_schema_version",
+        "artifact_key",
+        "artifact_signature",
+        "lane",
+        "event_name",
+        "cadence",
+        "status",
+        "final_decision",
+        "reason_codes",
+        "ci_fast_gate",
+        "generated_at_epoch",
+        "elapsed_seconds",
+        "max_seconds",
+        "fixture",
+        "required_scenarios",
+        "scenario_count",
+        "failed_scenario_count",
+        "scenario_results",
+    ]
+    missing_fields = [field_name for field_name in required_fields if field_name not in report]
+    if missing_fields:
+        fail(f"missing required report fields: {','.join(missing_fields)}")
+
+    if report["schema_version"] != MATRIX_REPORT_SCHEMA:
+        fail("unexpected live-network partition/reconnect report schema")
+
+    if report["fixture_schema_version"] != MATRIX_FIXTURE_SCHEMA:
+        fail("unexpected live-network partition/reconnect fixture schema marker")
+
+    lane = report["lane"]
+    if lane not in {"smoke", "deep"}:
+        fail("lane must be smoke or deep")
+
+    event_name = report["event_name"]
+    if not isinstance(event_name, str) or not event_name:
+        fail("event_name must be a non-empty string")
+
+    cadence = report["cadence"]
+    if not isinstance(cadence, str) or not cadence:
+        fail("cadence must be a non-empty string")
+
+    expected_cadence = _resolve_cadence(lane, event_name)
+    if cadence != expected_cadence:
+        fail(f"cadence mismatch: expected {expected_cadence}, found {cadence}")
+
+    status = report["status"]
+    if status not in {"pass", "fail"}:
+        fail("status must be pass or fail")
+
+    final_decision = report["final_decision"]
+    if final_decision not in {"GO", "NO-GO"}:
+        fail("final_decision must be GO or NO-GO")
+
+    if report["ci_fast_gate"] not in {"PASS", "FAIL"}:
+        fail("ci_fast_gate must be PASS or FAIL")
+
+    generated_at_epoch = report["generated_at_epoch"]
+    if not isinstance(generated_at_epoch, int) or generated_at_epoch < 0:
+        fail("generated_at_epoch must be a non-negative integer")
+
+    elapsed_seconds = report["elapsed_seconds"]
+    if not isinstance(elapsed_seconds, int) or elapsed_seconds < 0:
+        fail("elapsed_seconds must be a non-negative integer")
+
+    max_seconds = report["max_seconds"]
+    if not isinstance(max_seconds, int) or max_seconds < 0:
+        fail("max_seconds must be a non-negative integer")
+
+    scenario_count = report["scenario_count"]
+    if not isinstance(scenario_count, int) or scenario_count < 0:
+        fail("scenario_count must be a non-negative integer")
+
+    failed_scenario_count = report["failed_scenario_count"]
+    if not isinstance(failed_scenario_count, int) or failed_scenario_count < 0:
+        fail("failed_scenario_count must be a non-negative integer")
+
+    required_scenarios = _require_string_list(report["required_scenarios"], "required_scenarios")
+    expected_required = smoke_required if lane == "smoke" else deep_required
+    if required_scenarios != expected_required:
+        fail(
+            "required_scenarios mismatch: "
+            f"expected {expected_required}, found {required_scenarios}"
+        )
+
+    if scenario_count != len(required_scenarios):
+        fail(
+            "scenario_count mismatch: "
+            f"expected {len(required_scenarios)}, found {scenario_count}"
+        )
+
+    scenario_results = report["scenario_results"]
+    if not isinstance(scenario_results, list):
+        fail("scenario_results must be an array")
+    if len(scenario_results) != len(required_scenarios):
+        fail(
+            "scenario_results length mismatch: "
+            f"expected {len(required_scenarios)}, found {len(scenario_results)}"
+        )
+
+    derived_failed_count = 0
+    for index, expected_scenario in enumerate(required_scenarios):
+        scenario_result = scenario_results[index]
+        if not isinstance(scenario_result, dict):
+            fail(f"scenario_results[{index}] must be an object")
+
+        scenario_name = scenario_result.get("scenario")
+        if scenario_name != expected_scenario:
+            fail(
+                f"scenario_results[{index}].scenario mismatch: "
+                f"expected {expected_scenario}, found {scenario_name}"
+            )
+
+        scenario_status = scenario_result.get("status")
+        if scenario_status not in {"pass", "fail"}:
+            fail(f"scenario_results[{index}].status must be pass or fail")
+
+        scenario_reason_codes = scenario_result.get("reason_codes")
+        if not isinstance(scenario_reason_codes, list) or not all(
+            isinstance(value, str) and value for value in scenario_reason_codes
+        ):
+            fail(f"scenario_results[{index}].reason_codes must be a list of strings")
+
+        expected_scenario_reason_codes: list[str] = []
+        if scenario_status == "fail":
+            expected_scenario_reason_codes.append(_scenario_failure_reason(expected_scenario))
+            derived_failed_count += 1
+
+        if scenario_reason_codes != expected_scenario_reason_codes:
+            fail(
+                f"scenario_results[{index}].reason_codes mismatch: "
+                f"expected {expected_scenario_reason_codes}, found {scenario_reason_codes}"
+            )
+
+    if failed_scenario_count != derived_failed_count:
+        fail(
+            "failed_scenario_count mismatch: "
+            f"expected {derived_failed_count}, found {failed_scenario_count}"
+        )
+
+    reason_codes = report["reason_codes"]
+    if not isinstance(reason_codes, list) or not all(
+        isinstance(value, str) and value for value in reason_codes
+    ):
+        fail("reason_codes must be a list of strings")
+    if reason_codes != sorted(set(reason_codes)):
+        fail("reason_codes must be sorted and unique")
+
+    expected_reason_codes = _collect_reason_codes(
+        scenario_results,
+        ci_fast_gate=report["ci_fast_gate"],
+        elapsed_seconds=elapsed_seconds,
+        max_seconds=max_seconds,
+    )
+
+    if reason_codes != expected_reason_codes:
+        fail(
+            "reason_codes mismatch: "
+            f"expected {expected_reason_codes}, found {reason_codes}"
+        )
+
+    expected_status = "pass" if not expected_reason_codes else "fail"
+    expected_final_decision = "GO" if not expected_reason_codes else "NO-GO"
+
+    if status != expected_status:
+        fail(f"status mismatch: expected {expected_status}, found {status}")
+
+    if final_decision != expected_final_decision:
+        fail(
+            f"expected final_decision={expected_final_decision}, found {final_decision}"
+        )
+
+    expected_signature = _compute_signature(report)
+    if report["artifact_signature"] != expected_signature:
+        fail("matrix artifact signature mismatch")
+
+    max_artifact_age_seconds = require_non_negative_int(
+        "--max-artifact-age-seconds",
+        args.max_artifact_age_seconds,
+    )
+
+    now_epoch = int(time.time())
+    if args.now_epoch:
+        now_epoch = require_non_negative_int("--now-epoch", args.now_epoch)
+
+    if now_epoch < generated_at_epoch:
+        fail("--now-epoch must be >= generated_at_epoch")
+
+    artifact_age_seconds = now_epoch - generated_at_epoch
+    if artifact_age_seconds > max_artifact_age_seconds:
+        fail(
+            "matrix artifact is stale: "
+            f"age_seconds={artifact_age_seconds} "
+            f"max_artifact_age_seconds={max_artifact_age_seconds}"
+        )
+
+    failed_checks = "none" if not expected_reason_codes else ",".join(expected_reason_codes)
+    if expected_final_decision == "GO":
+        print("status=ok")
+        print(f"final_decision={expected_final_decision}")
+        print(f"failed_checks={failed_checks}")
+        print(f"report_file={report_path}")
+        return 0
+
+    print("status=fail")
+    print(f"final_decision={expected_final_decision}")
+    print(f"failed_checks={failed_checks}")
+    print(f"report_file={report_path}")
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Live-network partition/reconnect matrix lane and policy contracts."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    smoke = subparsers.add_parser("run-smoke", help="Run PR-fast matrix smoke lane")
+    smoke.add_argument("--fixture", default=str(DEFAULT_FIXTURE))
+    smoke.add_argument("--output-json", default=str(DEFAULT_SMOKE_REPORT))
+    smoke.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", "pull_request"))
+    smoke.add_argument(
+        "--max-seconds",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_SMOKE_MAX_SECONDS", "120"),
+    )
+    smoke.add_argument(
+        "--simulate-delay-seconds",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_SIMULATE_DELAY_SECONDS", "0"),
+    )
+    smoke.add_argument(
+        "--fail-scenarios",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_FAIL_SCENARIOS", ""),
+    )
+    smoke.add_argument(
+        "--ci-fast-gate",
+        choices=("PASS", "FAIL"),
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_CI_FAST_GATE", "PASS"),
+    )
+    smoke.set_defaults(handler=run_smoke)
+
+    deep = subparsers.add_parser("run-deep", help="Run scheduled/manual matrix deep lane")
+    deep.add_argument("--fixture", default=str(DEFAULT_FIXTURE))
+    deep.add_argument("--output-json", default=str(DEFAULT_DEEP_REPORT))
+    deep.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", "schedule"))
+    deep.add_argument(
+        "--max-seconds",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_DEEP_MAX_SECONDS", "300"),
+    )
+    deep.add_argument(
+        "--simulate-delay-seconds",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_SIMULATE_DELAY_SECONDS", "0"),
+    )
+    deep.add_argument(
+        "--fail-scenarios",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_FAIL_SCENARIOS", ""),
+    )
+    deep.add_argument(
+        "--ci-fast-gate",
+        choices=("PASS", "FAIL"),
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_CI_FAST_GATE", "PASS"),
+    )
+    deep.set_defaults(handler=run_deep)
+
+    check_policy = subparsers.add_parser("check-policy", help="Validate matrix report policy")
+    check_policy.add_argument("--report-file", required=True)
+    check_policy.add_argument("--fixture", default=str(DEFAULT_FIXTURE))
+    check_policy.add_argument(
+        "--max-artifact-age-seconds",
+        default=os.environ.get("KAMN_LIVE_NETWORK_PARTITION_RECONNECT_MAX_ARTIFACT_AGE_SECONDS", "900"),
+    )
+    check_policy.add_argument("--now-epoch", default="")
+    check_policy.set_defaults(handler=_check_policy)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh
+++ b/scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SELECTOR="$ROOT_DIR/scripts/runtime/select_live_network_partition_reconnect_lane.sh"
+SMOKE_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh"
+DEEP_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_live_network_partition_reconnect_policy.sh"
+FIXTURE_FILE="$ROOT_DIR/fixtures/runtime/live_network_partition_reconnect_matrix_cases.json"
+LIVE_NETWORK_DOC="$ROOT_DIR/docs/planning/live-network-wave.md"
+GONOGO_DOC="$ROOT_DIR/docs/foundation/release-gonogo-checklist.md"
+
+event_name="${GITHUB_EVENT_NAME:-pull_request}"
+output_json="$ROOT_DIR/live-network-partition-reconnect-contract-report.json"
+max_seconds=""
+simulate_delay_seconds=0
+max_artifact_age_seconds="${KAMN_LIVE_NETWORK_PARTITION_RECONNECT_MAX_ARTIFACT_AGE_SECONDS:-900}"
+fail_scenarios=""
+ci_fast_gate="PASS"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --event-name)
+      event_name="${2:-}"
+      shift 2
+      ;;
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --simulate-delay-seconds)
+      simulate_delay_seconds="${2:-}"
+      shift 2
+      ;;
+    --max-artifact-age-seconds)
+      max_artifact_age_seconds="${2:-}"
+      shift 2
+      ;;
+    --fail-scenarios)
+      fail_scenarios="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage:
+  bash scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh \
+    [--event-name <github-event>] \
+    [--output-json <path>] \
+    [--max-seconds <seconds>] \
+    [--simulate-delay-seconds <seconds>] \
+    [--max-artifact-age-seconds <seconds>] \
+    [--fail-scenarios <comma-separated-scenarios>] \
+    [--ci-fast-gate PASS|FAIL]
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for numeric_arg in "$simulate_delay_seconds" "$max_artifact_age_seconds"; do
+  case "$numeric_arg" in
+    ''|*[!0-9]*)
+      echo "numeric arguments must be non-negative integers" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$max_seconds" ]]; then
+  case "$max_seconds" in
+    ''|*[!0-9]*)
+      echo "--max-seconds must be a non-negative integer" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
+  echo "--ci-fast-gate must be PASS or FAIL" >&2
+  exit 1
+fi
+
+if [[ ! -x "$SELECTOR" || ! -x "$SMOKE_LANE" || ! -x "$DEEP_LANE" || ! -x "$POLICY_CHECKER" ]]; then
+  echo "expected partition/reconnect selector and lane scripts to be executable" >&2
+  exit 1
+fi
+
+if [[ ! -f "$FIXTURE_FILE" ]]; then
+  echo "expected partition/reconnect matrix fixture file to exist" >&2
+  exit 1
+fi
+
+if [[ ! -f "$LIVE_NETWORK_DOC" || ! -f "$GONOGO_DOC" ]]; then
+  echo "expected live-network planning and release go/no-go docs to exist" >&2
+  exit 1
+fi
+
+selection_output="$(bash "$SELECTOR" --event-name "$event_name")"
+selected_lane="$(printf '%s\n' "$selection_output" | awk -F= '/^lane=/{print $2}')"
+cadence="$(printf '%s\n' "$selection_output" | awk -F= '/^cadence=/{print $2}')"
+
+if [[ -z "$selected_lane" ]]; then
+  echo "selector did not produce a lane" >&2
+  exit 1
+fi
+
+if [[ "$selected_lane" == "smoke" ]]; then
+  lane_command=(
+    bash "$SMOKE_LANE"
+    --event-name "$event_name"
+    --output-json "$output_json"
+    --simulate-delay-seconds "$simulate_delay_seconds"
+    --ci-fast-gate "$ci_fast_gate"
+  )
+else
+  lane_command=(
+    bash "$DEEP_LANE"
+    --event-name "$event_name"
+    --output-json "$output_json"
+    --simulate-delay-seconds "$simulate_delay_seconds"
+    --ci-fast-gate "$ci_fast_gate"
+  )
+fi
+
+if [[ -n "$max_seconds" ]]; then
+  lane_command+=(--max-seconds "$max_seconds")
+fi
+
+if [[ -n "$fail_scenarios" ]]; then
+  lane_command+=(--fail-scenarios "$fail_scenarios")
+fi
+
+lane_output="$("${lane_command[@]}")"
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$output_json" \
+    --max-artifact-age-seconds "$max_artifact_age_seconds" 2>&1
+)"
+
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected partition/reconnect policy checker to emit status=ok" >&2
+  exit 1
+fi
+
+for required_ref in \
+  "run_live_network_partition_reconnect_smoke_lane.sh" \
+  "run_live_network_partition_reconnect_deep_lane.sh" \
+  "select_live_network_partition_reconnect_lane.sh" \
+  "check_live_network_partition_reconnect_policy.sh" \
+  "run_live_network_partition_reconnect_contract_lane.sh"; do
+  if ! grep -q "$required_ref" "$LIVE_NETWORK_DOC"; then
+    echo "expected live-network wave doc to reference $required_ref" >&2
+    exit 1
+  fi
+  if ! grep -q "$required_ref" "$GONOGO_DOC"; then
+    echo "expected release go/no-go checklist to reference $required_ref" >&2
+    exit 1
+  fi
+done
+
+if ! printf '%s\n' "$lane_output" | grep -q "lane=$selected_lane"; then
+  echo "expected partition/reconnect lane output to include selected lane marker" >&2
+  exit 1
+fi
+
+echo "lane=$selected_lane"
+echo "cadence=$cadence"
+echo "policy=ok"
+echo "live-network partition/reconnect contract lane tests passed."

--- a/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh
+++ b/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/live_network_partition_reconnect_contract.py" run-deep "$@"

--- a/scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh
+++ b/scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/live_network_partition_reconnect_contract.py" run-smoke "$@"

--- a/scripts/runtime/run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/run_runtime_snapshot_contract_lane.sh
@@ -20,6 +20,11 @@ bash scripts/runtime/test_select_failover_sync_drill_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_deep_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_suite.sh >/dev/null
+bash scripts/runtime/test_select_live_network_partition_reconnect_lane.sh >/dev/null
+bash scripts/runtime/test_run_live_network_partition_reconnect_smoke_lane.sh >/dev/null
+bash scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh >/dev/null
+bash scripts/runtime/test_check_live_network_partition_reconnect_policy.sh >/dev/null
+bash scripts/runtime/test_run_live_network_partition_reconnect_contract_lane.sh >/dev/null
 bash scripts/runtime/test_generate_live_network_pilot_artifact_summary.sh >/dev/null
 bash scripts/runtime/test_run_live_network_pilot_deep_lane.sh >/dev/null
 bash scripts/runtime/test_run_live_network_pilot_deep_contract_lane.sh >/dev/null

--- a/scripts/runtime/select_live_network_partition_reconnect_lane.sh
+++ b/scripts/runtime/select_live_network_partition_reconnect_lane.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "${key}=${value}"
+    } >>"$GITHUB_OUTPUT"
+  else
+    printf '%s=%s\n' "$key" "$value"
+  fi
+}
+
+event_name="${GITHUB_EVENT_NAME:-pull_request}"
+force_lane=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --event-name)
+      event_name="${2:-}"
+      shift 2
+      ;;
+    --force-lane)
+      force_lane="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage:
+  bash scripts/runtime/select_live_network_partition_reconnect_lane.sh \
+    [--event-name <github-event>] \
+    [--force-lane smoke|deep]
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+selected_lane=""
+cadence="pr-fast"
+
+if [[ -n "$force_lane" ]]; then
+  case "$force_lane" in
+    smoke|deep)
+      selected_lane="$force_lane"
+      ;;
+    *)
+      echo "invalid forced lane: $force_lane (expected smoke or deep)" >&2
+      exit 1
+      ;;
+  esac
+else
+  case "$event_name" in
+    schedule|workflow_dispatch)
+      selected_lane="deep"
+      ;;
+    pull_request|pull_request_target|push|merge_group)
+      selected_lane="smoke"
+      ;;
+    *)
+      selected_lane="smoke"
+      ;;
+  esac
+fi
+
+run_smoke="false"
+run_deep="false"
+if [[ "$selected_lane" == "deep" ]]; then
+  run_deep="true"
+  if [[ "$event_name" == "workflow_dispatch" ]]; then
+    cadence="manual"
+  else
+    cadence="scheduled"
+  fi
+else
+  run_smoke="true"
+fi
+
+write_output "event_name" "$event_name"
+write_output "lane" "$selected_lane"
+write_output "run_smoke" "$run_smoke"
+write_output "run_deep" "$run_deep"
+write_output "cadence" "$cadence"

--- a/scripts/runtime/test_check_live_network_partition_reconnect_policy.sh
+++ b/scripts/runtime/test_check_live_network_partition_reconnect_policy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_live_network_partition_reconnect_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SMOKE_LANE" ]; then
+  echo "expected partition/reconnect smoke lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected partition/reconnect policy checker script to be executable" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/partition-reconnect-report.json"
+bash "$SMOKE_LANE" --event-name pull_request --output-json "$report_file" >/dev/null
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$report_file" \
+    --max-artifact-age-seconds 900 2>&1
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected partition/reconnect policy checker success status" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected partition/reconnect policy checker GO decision for baseline report" >&2
+  exit 1
+fi
+
+tampered_report="$TMP_DIR/partition-reconnect-report.tampered.json"
+cp "$report_file" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --max-artifact-age-seconds 900 2>&1
+)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered partition/reconnect report to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=GO"; then
+  echo "expected partition/reconnect tampered decision mismatch marker" >&2
+  exit 1
+fi
+
+stale_report="$TMP_DIR/partition-reconnect-report.stale.json"
+cp "$report_file" "$stale_report"
+python3 - "$stale_report" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["generated_at_epoch"] = 0
+
+canonical_payload = dict(payload)
+canonical_payload.pop("artifact_signature", None)
+canonical = json.dumps(canonical_payload, sort_keys=True, separators=(",", ":"))
+payload["artifact_signature"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+stale_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$stale_report" \
+    --max-artifact-age-seconds 1 \
+    --now-epoch 5 2>&1
+)"
+stale_code=$?
+set -e
+
+if [ "$stale_code" -eq 0 ]; then
+  echo "expected stale partition/reconnect report to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$stale_output" | grep -q "matrix artifact is stale"; then
+  echo "expected partition/reconnect stale artifact policy marker" >&2
+  exit 1
+fi
+
+echo "partition/reconnect policy checker tests passed."

--- a/scripts/runtime/test_run_live_network_partition_reconnect_contract_lane.sh
+++ b/scripts/runtime/test_run_live_network_partition_reconnect_contract_lane.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected partition/reconnect contract lane script to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "select_live_network_partition_reconnect_lane.sh" "$CONTRACT_LANE"; then
+  echo "expected partition/reconnect contract lane to use lane selector" >&2
+  exit 1
+fi
+
+if ! grep -q "check_live_network_partition_reconnect_policy.sh" "$CONTRACT_LANE"; then
+  echo "expected partition/reconnect contract lane to enforce policy checker" >&2
+  exit 1
+fi
+
+smoke_output="$(
+  bash "$CONTRACT_LANE" \
+    --event-name pull_request \
+    --output-json "$TMP_REPORT"
+)"
+if ! printf '%s\n' "$smoke_output" | grep -q "live-network partition/reconnect contract lane tests passed."; then
+  echo "expected partition/reconnect contract lane smoke success marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$smoke_output" | grep -q '^lane=smoke$'; then
+  echo "expected partition/reconnect contract lane to select smoke lane for pull_request" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("lane") != "smoke":
+    raise SystemExit("expected smoke lane report for pull_request")
+if payload.get("status") != "pass":
+    raise SystemExit("expected smoke lane report status=pass")
+PY
+
+deep_output="$(
+  bash "$CONTRACT_LANE" \
+    --event-name schedule \
+    --output-json "$TMP_REPORT"
+)"
+if ! printf '%s\n' "$deep_output" | grep -q "live-network partition/reconnect contract lane tests passed."; then
+  echo "expected partition/reconnect contract lane deep success marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$deep_output" | grep -q '^lane=deep$'; then
+  echo "expected partition/reconnect contract lane to select deep lane for schedule" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("lane") != "deep":
+    raise SystemExit("expected deep lane report for schedule")
+if payload.get("cadence") != "scheduled":
+    raise SystemExit("expected scheduled cadence in deep lane report")
+if payload.get("status") != "pass":
+    raise SystemExit("expected deep lane report status=pass")
+PY
+
+echo "partition/reconnect contract lane script tests passed."

--- a/scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh
+++ b/scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEEP_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$DEEP_LANE" ]; then
+  echo "expected partition/reconnect deep lane script to be executable" >&2
+  exit 1
+fi
+
+lane_output="$(bash "$DEEP_LANE" --event-name schedule --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$lane_output" | grep -q "live-network partition/reconnect deep lane tests passed."; then
+  echo "expected partition/reconnect deep lane success marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.live-network-partition-reconnect-matrix-report.v1":
+    raise SystemExit("unexpected partition/reconnect deep report schema")
+if payload.get("lane") != "deep":
+    raise SystemExit("expected deep lane report")
+if payload.get("cadence") != "scheduled":
+    raise SystemExit("expected scheduled cadence for deep lane")
+if payload.get("status") != "pass":
+    raise SystemExit("expected deep lane status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected deep lane final_decision=GO")
+if payload.get("scenario_count") != 6:
+    raise SystemExit("expected deep lane scenario count to include stress scenarios")
+PY
+
+set +e
+invalid_event_output="$(
+  bash "$DEEP_LANE" --event-name pull_request --output-json "$TMP_REPORT" 2>&1
+)"
+invalid_event_code=$?
+set -e
+
+if [ "$invalid_event_code" -eq 0 ]; then
+  echo "expected partition/reconnect deep lane to reject non-scheduled cadence events" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$invalid_event_output" | grep -q "scheduled/manual-only cadence policy"; then
+  echo "expected partition/reconnect deep lane cadence policy rejection marker" >&2
+  exit 1
+fi
+
+echo "partition/reconnect deep lane script tests passed."

--- a/scripts/runtime/test_run_live_network_partition_reconnect_smoke_lane.sh
+++ b/scripts/runtime/test_run_live_network_partition_reconnect_smoke_lane.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_smoke_lane.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$SMOKE_LANE" ]; then
+  echo "expected partition/reconnect smoke lane script to be executable" >&2
+  exit 1
+fi
+
+lane_output="$(bash "$SMOKE_LANE" --event-name pull_request --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$lane_output" | grep -q "live-network partition/reconnect smoke lane tests passed."; then
+  echo "expected partition/reconnect smoke lane success marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.live-network-partition-reconnect-matrix-report.v1":
+    raise SystemExit("unexpected partition/reconnect smoke report schema")
+if payload.get("lane") != "smoke":
+    raise SystemExit("expected smoke lane report")
+if payload.get("status") != "pass":
+    raise SystemExit("expected smoke lane status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected smoke lane final_decision=GO")
+required = payload.get("required_scenarios", [])
+if required != [
+    "fixture_contract",
+    "primary_loss_reconnect_catchup",
+    "three_process_failover",
+]:
+    raise SystemExit("unexpected smoke required scenario set")
+PY
+
+set +e
+failed_output="$(
+  bash "$SMOKE_LANE" \
+    --event-name pull_request \
+    --output-json "$TMP_REPORT" \
+    --fail-scenarios three_process_failover 2>&1
+)"
+failed_code=$?
+set -e
+
+if [ "$failed_code" -eq 0 ]; then
+  echo "expected partition/reconnect smoke lane to fail with injected scenario failure" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$failed_output" | grep -q "scenario_three_process_failover_failed"; then
+  echo "expected injected scenario failure reason code in smoke lane output" >&2
+  exit 1
+fi
+
+# Regression: #982
+set +e
+budget_output="$(
+  bash "$SMOKE_LANE" \
+    --event-name pull_request \
+    --output-json "$TMP_REPORT" \
+    --simulate-delay-seconds 1 \
+    --max-seconds 0 2>&1
+)"
+budget_code=$?
+set -e
+
+if [ "$budget_code" -eq 0 ]; then
+  echo "expected partition/reconnect smoke lane budget guard to fail over-budget runs" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$budget_output" | grep -q "runtime_budget_exceeded"; then
+  echo "expected runtime budget regression reason code for partition/reconnect smoke lane" >&2
+  exit 1
+fi
+
+echo "partition/reconnect smoke lane script tests passed."

--- a/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
@@ -89,6 +89,31 @@ if ! grep -q "test_run_failover_sync_drill_suite.sh" "$FAST_SCRIPT"; then
   exit 1
 fi
 
+if ! grep -q "test_select_live_network_partition_reconnect_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include partition/reconnect lane selector coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_live_network_partition_reconnect_smoke_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include partition/reconnect smoke lane coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_live_network_partition_reconnect_deep_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include partition/reconnect deep lane coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_check_live_network_partition_reconnect_policy.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include partition/reconnect policy checker coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_live_network_partition_reconnect_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include partition/reconnect contract lane coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "test_generate_live_network_pilot_artifact_summary.sh" "$FAST_SCRIPT"; then
   echo "expected runtime snapshot contract lane to include live-network pilot artifact summary coverage" >&2
   exit 1

--- a/scripts/runtime/test_select_live_network_partition_reconnect_lane.sh
+++ b/scripts/runtime/test_select_live_network_partition_reconnect_lane.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SELECTOR="$ROOT_DIR/scripts/runtime/select_live_network_partition_reconnect_lane.sh"
+
+if [ ! -x "$SELECTOR" ]; then
+  echo "expected partition/reconnect lane selector to be executable" >&2
+  exit 1
+fi
+
+pull_request_output="$(bash "$SELECTOR" --event-name pull_request)"
+if ! printf '%s\n' "$pull_request_output" | grep -q '^lane=smoke$'; then
+  echo "expected pull_request routing to smoke lane" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$pull_request_output" | grep -q '^run_smoke=true$'; then
+  echo "expected pull_request to run smoke lane" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$pull_request_output" | grep -q '^run_deep=false$'; then
+  echo "expected pull_request to skip deep lane" >&2
+  exit 1
+fi
+
+schedule_output="$(bash "$SELECTOR" --event-name schedule)"
+if ! printf '%s\n' "$schedule_output" | grep -q '^lane=deep$'; then
+  echo "expected schedule routing to deep lane" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$schedule_output" | grep -q '^cadence=scheduled$'; then
+  echo "expected schedule cadence marker" >&2
+  exit 1
+fi
+
+manual_output="$(bash "$SELECTOR" --event-name workflow_dispatch)"
+if ! printf '%s\n' "$manual_output" | grep -q '^lane=deep$'; then
+  echo "expected workflow_dispatch routing to deep lane" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$manual_output" | grep -q '^cadence=manual$'; then
+  echo "expected workflow_dispatch cadence marker" >&2
+  exit 1
+fi
+
+# Regression: #982
+fallback_output="$(bash "$SELECTOR" --event-name release)"
+if ! printf '%s\n' "$fallback_output" | grep -q '^lane=smoke$'; then
+  echo "expected unknown events to fail-safe to smoke lane" >&2
+  exit 1
+fi
+
+echo "partition/reconnect lane selector script tests passed."


### PR DESCRIPTION
## Summary
Adds deterministic live-network partition/reconnect/replay matrix coverage with a PR-fast smoke lane, scheduled/manual deep lane, and fail-closed policy validation for stale/tampered artifacts. This closes the remaining `#982` gap between modeled lane contracts and event-routed matrix execution.

Closes #982

## Changes
- `scripts/runtime/live_network_partition_reconnect_contract.py`: shared matrix runner + policy checker (`run-smoke`, `run-deep`, `check-policy`) with deterministic reason-code outcomes and artifact signature/freshness checks.
- `scripts/runtime/select_live_network_partition_reconnect_lane.sh`: event-driven lane selector (smoke for PR-like events, deep for schedule/manual).
- `scripts/runtime/run_live_network_partition_reconnect_*.sh`, `scripts/runtime/check_live_network_partition_reconnect_policy.sh`: stable shell wrappers.
- `scripts/runtime/run_live_network_partition_reconnect_contract_lane.sh`: selector-driven contract lane that enforces policy checker and docs references.
- `scripts/runtime/test_*live_network_partition_reconnect*.sh`: unit/functional/integration/regression shell tests for selector, smoke, deep, policy, and contract lane.
- `fixtures/runtime/live_network_partition_reconnect_matrix_cases.json`: deterministic scenario matrix fixture.
- `scripts/runtime/run_runtime_snapshot_contract_lane.sh`, `scripts/runtime/test_run_runtime_snapshot_contract_lane.sh`: include new partition/reconnect matrix test stack in runtime contract lane.
- `scripts/ci/select_targets.sh`, `scripts/ci/test_select_targets.sh`: classify `fixtures/runtime/*` as runtime-contract scope to avoid unknown-path full fallback and keep CI cost low.
- `docs/planning/live-network-wave.md`, `docs/foundation/release-gonogo-checklist.md`: commands, fixture/schema, budget/cadence, and `Regression: #982` policy markers.
- `crates/kamn-core/tests/live_network_wave_docs.rs`, `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`: docs-contract assertions for new commands/schema/regression marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: selector routing, smoke/deep lane behavior, stale/tamper fail-closed policy path, runtime lane aggregation, and docs-contract drift checks

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `bash scripts/runtime/test_select_live_network_partition_reconnect_lane.sh`; `bash scripts/runtime/test_check_live_network_partition_reconnect_policy.sh` |
| Functional  | ✅     | `bash scripts/runtime/test_run_live_network_partition_reconnect_smoke_lane.sh`; `bash scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh` |
| Integration | ✅     | `bash scripts/runtime/test_run_live_network_partition_reconnect_contract_lane.sh`; `bash scripts/runtime/test_run_runtime_snapshot_contract_lane.sh` |
| Regression  | ✅     | Stale/tampered artifact rejection, budget overrun, and docs regression markers validated (`Regression: #982`) |
