### PR TITLE
feat(signer): wire canonical provider parser and client path (#986)

### DIFF
--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -78,7 +78,7 @@ pub enum SecureSignerProvider {
 
 impl SecureSignerProvider {
     pub fn from_key_id(key_id: &str) -> Result<Self, SignerBackendError> {
-        Ok(SecureKeyReference::parse(key_id)?.provider)
+        Ok(CanonicalSecureKeyReference::parse(key_id)?.provider)
     }
 
     pub fn backend_name(self) -> &'static str {
@@ -152,7 +152,7 @@ pub enum SignerKeyRole {
 
 impl SignerKeyRole {
     pub fn from_key_id(key_id: &str) -> Result<Self, SignerBackendError> {
-        Ok(SecureKeyReference::parse(key_id)?.key_role)
+        Ok(CanonicalSecureKeyReference::parse(key_id)?.key_role)
     }
 
     pub fn label(self) -> &'static str {
@@ -222,14 +222,14 @@ impl SignerKeyRole {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SecureKeyReference {
-    provider: SecureSignerProvider,
-    key_role: SignerKeyRole,
-    _provider_key_id: String,
+pub struct CanonicalSecureKeyReference {
+    pub provider: SecureSignerProvider,
+    pub key_role: SignerKeyRole,
+    pub provider_key_id: String,
 }
 
-impl SecureKeyReference {
-    fn parse(key_id: &str) -> Result<Self, SignerBackendError> {
+impl CanonicalSecureKeyReference {
+    pub fn parse(key_id: &str) -> Result<Self, SignerBackendError> {
         if !key_id.starts_with("secure:") {
             return Err(SignerBackendError::UnsupportedKeyReference {
                 backend: SECURE_MOCK_BACKEND_NAME.to_owned(),
@@ -256,14 +256,14 @@ impl SecureKeyReference {
             return Ok(Self {
                 provider,
                 key_role,
-                _provider_key_id: provider_key_id.to_owned(),
+                provider_key_id: provider_key_id.to_owned(),
             });
         }
 
         Ok(Self {
             provider: SecureSignerProvider::Mock,
             key_role: SignerKeyRole::Operator,
-            _provider_key_id: suffix.to_owned(),
+            provider_key_id: suffix.to_owned(),
         })
     }
 }
@@ -272,6 +272,42 @@ pub trait SignerBackend {
     fn backend_name(&self) -> &'static str;
     fn sign(&self, request: &SigningRequest) -> Result<String, SignerBackendError>;
     fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError>;
+}
+
+pub trait SecureSignerProviderClient {
+    fn sign_with_provider(
+        &self,
+        request: &SigningRequest,
+        key_reference: &CanonicalSecureKeyReference,
+    ) -> Result<BackendSignature, SignerBackendError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeterministicSecureSignerProviderClient;
+
+impl SecureSignerProviderClient for DeterministicSecureSignerProviderClient {
+    fn sign_with_provider(
+        &self,
+        request: &SigningRequest,
+        key_reference: &CanonicalSecureKeyReference,
+    ) -> Result<BackendSignature, SignerBackendError> {
+        Ok(BackendSignature {
+            backend: key_reference.provider.backend_name().to_owned(),
+            signature: request.expected_signature(),
+        })
+    }
+}
+
+pub type SecureSignerProviderClientSignFn = fn(
+    request: &SigningRequest,
+    key_reference: &CanonicalSecureKeyReference,
+) -> Result<BackendSignature, SignerBackendError>;
+
+fn deterministic_secure_provider_client_sign(
+    request: &SigningRequest,
+    key_reference: &CanonicalSecureKeyReference,
+) -> Result<BackendSignature, SignerBackendError> {
+    DeterministicSecureSignerProviderClient.sign_with_provider(request, key_reference)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -306,9 +342,10 @@ impl SignerBackend for LocalSignerBackend {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct SecureSignerBackend {
     provider_handshake_matrix: SignerProviderHandshakeMatrix,
+    provider_client_sign: SecureSignerProviderClientSignFn,
 }
 
 impl SecureSignerBackend {
@@ -321,15 +358,26 @@ impl SecureSignerBackend {
     pub fn with_provider_handshake_matrix(
         provider_handshake_matrix: SignerProviderHandshakeMatrix,
     ) -> Self {
+        Self::with_provider_client(
+            provider_handshake_matrix,
+            deterministic_secure_provider_client_sign,
+        )
+    }
+
+    pub fn with_provider_client(
+        provider_handshake_matrix: SignerProviderHandshakeMatrix,
+        provider_client_sign: SecureSignerProviderClientSignFn,
+    ) -> Self {
         Self {
             provider_handshake_matrix,
+            provider_client_sign,
         }
     }
 
     fn enforce_key_role_segregation(
         &self,
         request: &SigningRequest,
-        secure_key: &SecureKeyReference,
+        secure_key: &CanonicalSecureKeyReference,
     ) -> Result<(), SignerBackendError> {
         let sender_role = SignerKeyRole::from_sender(&request.sender);
         if sender_role != secure_key.key_role {
@@ -367,14 +415,21 @@ impl SecureSignerBackend {
         &self,
         request: &SigningRequest,
     ) -> Result<BackendSignature, SignerBackendError> {
-        let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        let secure_key = CanonicalSecureKeyReference::parse(&request.key_id)?;
         self.enforce_key_role_segregation(request, &secure_key)?;
         self.enforce_provider_handshake(secure_key.provider)?;
 
-        Ok(BackendSignature {
-            backend: secure_key.provider.backend_name().to_owned(),
-            signature: request.expected_signature(),
-        })
+        let signed = (self.provider_client_sign)(request, &secure_key)?;
+        let expected_backend = secure_key.provider.backend_name().to_owned();
+        if signed.backend != expected_backend {
+            return Err(SignerBackendError::ProviderClientBackendMismatch {
+                expected_backend,
+                provided_backend: signed.backend,
+                key_id: request.key_id.clone(),
+            });
+        }
+
+        Ok(signed)
     }
 
     fn verify_with_backend_name(
@@ -383,7 +438,7 @@ impl SecureSignerBackend {
         request: &SigningRequest,
         signature: &str,
     ) -> Result<(), SignerBackendError> {
-        let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        let secure_key = CanonicalSecureKeyReference::parse(&request.key_id)?;
         let expected_backend = secure_key.provider.backend_name();
         if backend != expected_backend {
             return Err(SignerBackendError::SecureProviderBackendMismatch {
@@ -407,7 +462,7 @@ impl SignerBackend for SecureSignerBackend {
     }
 
     fn verify(&self, request: &SigningRequest, signature: &str) -> Result<(), SignerBackendError> {
-        let secure_key = SecureKeyReference::parse(&request.key_id)?;
+        let secure_key = CanonicalSecureKeyReference::parse(&request.key_id)?;
         self.enforce_key_role_segregation(request, &secure_key)?;
         self.enforce_provider_handshake(secure_key.provider)?;
 
@@ -430,7 +485,7 @@ impl SignerBackend for SecureSignerBackend {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct SignerBackendRouter {
     local: LocalSignerBackend,
     secure: SecureSignerBackend,
@@ -446,9 +501,22 @@ impl SignerBackendRouter {
     pub fn with_provider_handshake_matrix(
         provider_handshake_matrix: SignerProviderHandshakeMatrix,
     ) -> Self {
+        Self::with_provider_client(
+            provider_handshake_matrix,
+            deterministic_secure_provider_client_sign,
+        )
+    }
+
+    pub fn with_provider_client(
+        provider_handshake_matrix: SignerProviderHandshakeMatrix,
+        provider_client_sign: SecureSignerProviderClientSignFn,
+    ) -> Self {
         Self {
             local: LocalSignerBackend,
-            secure: SecureSignerBackend::with_provider_handshake_matrix(provider_handshake_matrix),
+            secure: SecureSignerBackend::with_provider_client(
+                provider_handshake_matrix,
+                provider_client_sign,
+            ),
         }
     }
 
@@ -522,6 +590,11 @@ pub enum SignerBackendError {
     ProviderUnavailable {
         backend: String,
     },
+    ProviderClientBackendMismatch {
+        expected_backend: String,
+        provided_backend: String,
+        key_id: String,
+    },
     SecureProviderBackendMismatch {
         expected_backend: String,
         provided_backend: String,
@@ -579,6 +652,14 @@ impl std::fmt::Display for SignerBackendError {
             Self::ProviderUnavailable { backend } => {
                 write!(f, "signer backend unavailable: {backend}")
             }
+            Self::ProviderClientBackendMismatch {
+                expected_backend,
+                provided_backend,
+                key_id,
+            } => write!(
+                f,
+                "provider client backend mismatch for key {key_id}; expected {expected_backend}, found {provided_backend}"
+            ),
             Self::SecureProviderBackendMismatch {
                 expected_backend,
                 provided_backend,
@@ -622,6 +703,7 @@ impl std::error::Error for SignerBackendError {}
 #[cfg(test)]
 mod tests {
     use super::{
+        deterministic_secure_provider_client_sign, CanonicalSecureKeyReference,
         SecureSignerBackend, SecureSignerProvider, SignerBackend, SignerBackendError,
         SignerKeyRole, SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus,
         SigningRequest,
@@ -701,6 +783,15 @@ mod tests {
     }
 
     #[test]
+    fn canonical_secure_key_reference_parser_preserves_provider_key_scope() {
+        let parsed = CanonicalSecureKeyReference::parse("secure:AWS-KMS:role-TREASURY/key-prod-9")
+            .expect("canonical parser should accept provider + role scoped keys");
+        assert_eq!(parsed.provider, SecureSignerProvider::AwsKmsEmulator);
+        assert_eq!(parsed.key_role, SignerKeyRole::Treasury);
+        assert_eq!(parsed.provider_key_id, "role-TREASURY/key-prod-9");
+    }
+
+    #[test]
     fn handshake_matrix_maps_provider_statuses() {
         let matrix = SignerProviderHandshakeMatrix::with_statuses(
             SignerProviderHandshakeStatus::Available,
@@ -738,6 +829,59 @@ mod tests {
             Err(SignerBackendError::ProviderHandshakeRejected {
                 backend: "secure-aws-kms-emulator".to_owned(),
                 failure_class: "policy-blocked".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn provider_client_maps_backend_from_canonical_reference() {
+        let request = SigningRequest::new(
+            "secure:aws-kms:key-prod-1",
+            "agent-a",
+            1,
+            "payload-1",
+            "state:genesis",
+        )
+        .expect("request should be valid");
+        let key_reference = CanonicalSecureKeyReference::parse(&request.key_id)
+            .expect("canonical parser should parse secure provider key");
+
+        let signed = deterministic_secure_provider_client_sign(&request, &key_reference)
+            .expect("deterministic provider client should sign");
+        assert_eq!(signed.backend, "secure-aws-kms-emulator");
+    }
+
+    #[test]
+    fn secure_backend_rejects_provider_client_backend_mismatch() {
+        fn mismatched_provider_client(
+            request: &SigningRequest,
+            _key_reference: &CanonicalSecureKeyReference,
+        ) -> Result<super::BackendSignature, SignerBackendError> {
+            Ok(super::BackendSignature {
+                backend: "secure-mock".to_owned(),
+                signature: request.expected_signature(),
+            })
+        }
+
+        let backend = SecureSignerBackend::with_provider_client(
+            SignerProviderHandshakeMatrix::with_uniform_availability(true),
+            mismatched_provider_client,
+        );
+        let request = SigningRequest::new(
+            "secure:aws-kms:key-prod-1",
+            "agent-a",
+            1,
+            "payload-1",
+            "state:genesis",
+        )
+        .expect("request should be valid");
+
+        assert_eq!(
+            backend.sign(&request),
+            Err(SignerBackendError::ProviderClientBackendMismatch {
+                expected_backend: "secure-aws-kms-emulator".to_owned(),
+                provided_backend: "secure-mock".to_owned(),
+                key_id: "secure:aws-kms:key-prod-1".to_owned(),
             })
         );
     }

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -1,8 +1,9 @@
+use kamn_core::signer_backend::CanonicalSecureKeyReference;
 use kamn_core::{
     baseline_signature_for_fields, signature_profile_compatibility_fixtures_for_fields,
-    BaselineTransaction, RoleSmokeNetwork, SignerBackendError, SignerBackendRouter,
-    SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus, SigningRequest,
-    TransactionGuards, GENESIS_STATE_HASH,
+    BackendSignature, BaselineTransaction, RoleSmokeNetwork, SignerBackendError,
+    SignerBackendRouter, SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus,
+    SigningRequest, TransactionGuards, GENESIS_STATE_HASH,
 };
 use std::time::Instant;
 
@@ -48,6 +49,48 @@ fn functional_aws_kms_provider_routes_to_production_adapter_backend() {
     router
         .verify_with_backend(&signed.backend, &request, &signed.signature)
         .expect("signature should verify");
+}
+
+#[test]
+fn functional_router_uses_custom_provider_client_mapping_for_secure_provider() {
+    fn custom_provider_client(
+        request: &SigningRequest,
+        key_reference: &CanonicalSecureKeyReference,
+    ) -> Result<BackendSignature, SignerBackendError> {
+        Ok(BackendSignature {
+            backend: key_reference.provider.backend_name().to_owned(),
+            signature: format!(
+                "provider-client:{}",
+                baseline_signature_for_fields(
+                    &request.sender,
+                    request.nonce,
+                    &request.state_hash,
+                    &request.payload,
+                )
+            ),
+        })
+    }
+
+    let router = SignerBackendRouter::with_provider_client(
+        SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        custom_provider_client,
+    );
+    let request = SigningRequest::new(
+        "secure:aws-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    let signed = router
+        .sign_with_secure_fallback(&request)
+        .expect("provider client should sign through secure router");
+    assert_eq!(signed.backend, "secure-aws-kms-emulator");
+    assert!(signed
+        .signature
+        .starts_with("provider-client:sig:ed25519:baseline-v1"));
 }
 
 #[test]
@@ -274,6 +317,47 @@ fn regression_provider_handshake_policy_block_rejects_without_fallback() {
         Err(SignerBackendError::ProviderHandshakeRejected {
             backend: "secure-aws-kms-emulator".to_owned(),
             failure_class: "policy-blocked".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_provider_client_backend_mismatch_is_rejected_without_fallback() {
+    // Regression: #986
+    fn mismatched_provider_client(
+        request: &SigningRequest,
+        _key_reference: &CanonicalSecureKeyReference,
+    ) -> Result<BackendSignature, SignerBackendError> {
+        Ok(BackendSignature {
+            backend: "secure-mock".to_owned(),
+            signature: baseline_signature_for_fields(
+                &request.sender,
+                request.nonce,
+                &request.state_hash,
+                &request.payload,
+            ),
+        })
+    }
+
+    let router = SignerBackendRouter::with_provider_client(
+        SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        mismatched_provider_client,
+    );
+    let request = SigningRequest::new(
+        "secure:aws-kms:key-ops-1",
+        "agent-a",
+        1,
+        "payload-1",
+        GENESIS_STATE_HASH,
+    )
+    .expect("request should be valid");
+
+    assert_eq!(
+        router.sign_with_secure_fallback(&request),
+        Err(SignerBackendError::ProviderClientBackendMismatch {
+            expected_backend: "secure-aws-kms-emulator".to_owned(),
+            provided_backend: "secure-mock".to_owned(),
+            key_id: "secure:aws-kms:key-ops-1".to_owned(),
         })
     );
 }

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -4,7 +4,9 @@ const DOC: &str = include_str!("../../../docs/foundation/signer-backend-abstract
 fn doc_contains_signer_backend_contract_and_router_rules() {
     assert!(DOC.contains("## Scope Delivered"));
     assert!(DOC.contains("SigningRequest"));
+    assert!(DOC.contains("CanonicalSecureKeyReference::parse(...)"));
     assert!(DOC.contains("SignerBackend"));
+    assert!(DOC.contains("SecureSignerProviderClient"));
     assert!(DOC.contains("LocalSignerBackend"));
     assert!(DOC.contains("SecureSignerBackend"));
     assert!(DOC.contains("sign_with_secure_fallback"));
@@ -42,7 +44,13 @@ fn doc_contains_signer_emulator_contract_lane_policy() {
     assert!(DOC.contains(
         "functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider"
     ));
+    assert!(
+        DOC.contains("functional_router_uses_custom_provider_client_mapping_for_secure_provider")
+    );
     assert!(DOC.contains("regression_provider_handshake_policy_block_rejects_without_fallback"));
+    assert!(
+        DOC.contains("regression_provider_client_backend_mismatch_is_rejected_without_fallback")
+    );
     assert!(DOC.contains(
         "integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards"
     ));
@@ -58,6 +66,7 @@ fn doc_contains_production_style_secure_provider_adapter_rules() {
     assert!(DOC.contains("UnsupportedSecureProvider"));
     assert!(DOC.contains("UnsupportedSignerKeyRole"));
     assert!(DOC.contains("MalformedSecureKeyReference"));
+    assert!(DOC.contains("ProviderClientBackendMismatch"));
 }
 
 #[test]

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -5,9 +5,11 @@ This document captures the first implementation slice for signer backend abstrac
 ## Scope Delivered
 - Added `crates/kamn-core/src/signer_backend.rs` with:
   - `SigningRequest` contract and validation.
+  - `CanonicalSecureKeyReference::parse(...)` for deterministic provider/role key-reference normalization.
   - `SignerBackend` trait (`sign` and `verify`).
+  - `SecureSignerProviderClient` interface with deterministic provider adapter mapping.
   - `LocalSignerBackend` and `SecureSignerBackend`.
-  - `SignerBackendRouter` with deterministic `sign_with_secure_fallback(...)` semantics.
+  - `SignerBackendRouter` with deterministic `sign_with_secure_fallback(...)` semantics plus provider-client injection.
   - `BackendSignature` and typed `SignerBackendError`.
 - Added integration tests in `crates/kamn-core/tests/signer_backend.rs`.
 
@@ -33,6 +35,7 @@ This document captures the first implementation slice for signer backend abstrac
   - malformed secure key references are rejected with typed `MalformedSecureKeyReference`.
   - provider handshake policy blocks are rejected with typed `ProviderHandshakeRejected`.
   - `ProviderUnavailable` reports the provider-specific backend when the secure path is disabled.
+  - provider-client backend mismatches are rejected with typed `ProviderClientBackendMismatch`.
 - Router fallback:
   - falls back from secure to local only for `ProviderUnavailable` and `operator` role keys.
   - fallback is denied for privileged roles with typed `FallbackDeniedByRolePolicy`.
@@ -60,7 +63,9 @@ This document captures the first implementation slice for signer backend abstrac
   - `bash scripts/signer/run_signer_emulator_contract_lane.sh`
   - includes provider handshake matrix functional + regression checks:
     - `cargo test -p kamn-core --test signer_backend functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider`
+    - `cargo test -p kamn-core --test signer_backend functional_router_uses_custom_provider_client_mapping_for_secure_provider`
     - `cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback`
+    - `cargo test -p kamn-core --test signer_backend regression_provider_client_backend_mismatch_is_rejected_without_fallback`
     - `cargo test -p kamn-core --test signer_backend integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards`
 - Scheduled provider-integration deep lane:
   - `bash scripts/signer/run_signer_provider_deep_lane.sh`

--- a/scripts/signer/run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/run_signer_emulator_contract_lane.sh
@@ -5,7 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend functional_router_uses_custom_provider_client_mapping_for_secure_provider
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_provider_client_backend_mismatch_is_rejected_without_fallback
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_secure_provider_backend_mismatch_is_rejected
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_contract_lane_stays_within_budget

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -29,8 +29,18 @@ if ! grep -q "functional_provider_handshake_matrix_routes_operator_fallback_for_
   exit 1
 fi
 
+if ! grep -q "functional_router_uses_custom_provider_client_mapping_for_secure_provider" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to include provider client mapping functional coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "regression_provider_handshake_policy_block_rejects_without_fallback" "$FAST_SCRIPT"; then
   echo "expected signer emulator contract lane to include provider handshake policy-block regression coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "regression_provider_client_backend_mismatch_is_rejected_without_fallback" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to include provider client backend mismatch regression coverage" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Introduces a first-class canonical secure key-reference parser and explicit secure provider-client interface wiring in the signer backend/router path. This keeps provider semantics typed and deterministic while preserving fast signer contract-lane behavior.

Closes #986

## Changes
- `crates/kamn-core/src/signer_backend.rs`:
  - added public `CanonicalSecureKeyReference::parse(...)` with deterministic provider/role normalization.
  - added `SecureSignerProviderClient` interface and deterministic provider-client adapter plumbing.
  - added provider-client injection path in `SignerBackendRouter::with_provider_client(...)` and `SecureSignerBackend::with_provider_client(...)`.
  - added fail-closed `ProviderClientBackendMismatch` typed error when provider-client backend metadata drifts from canonical key provider.
  - expanded unit coverage for canonical parser/provider-client behavior.
- `crates/kamn-core/tests/signer_backend.rs`:
  - added functional custom provider-client routing test.
  - added regression guard for provider-client backend mismatch rejection.
- `docs/foundation/signer-backend-abstraction.md`:
  - documented canonical parser contract, provider-client interface, mismatch guard, and lane commands.
- `crates/kamn-core/tests/signer_backend_docs.rs`:
  - updated docs-contract assertions for new parser/interface/mismatch markers and lane commands.
- `scripts/signer/run_signer_emulator_contract_lane.sh`:
  - added new functional/regression signer tests to fast lane.
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`:
  - enforced lane wrapper references for new signer tests.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: signer parser/client wiring, provider mismatch fail-closed path, signer fast-lane wrapper coverage, selector matrix regression run

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test signer_backend -- signer_key_role_parser_rejects_unsupported_role_labels`; `cargo test -p kamn-core --test signer_backend -- functional_router_uses_custom_provider_client_mapping_for_secure_provider` |
| Functional  | ✅     | `cargo test -p kamn-core --test signer_backend -- functional_aws_kms_provider_routes_to_production_adapter_backend`; `cargo test -p kamn-core --test signer_backend -- functional_router_uses_custom_provider_client_mapping_for_secure_provider` |
| Integration | ✅     | `cargo test -p kamn-core --test signer_backend -- integration_router_signed_transaction_passes_transaction_guards`; `bash scripts/signer/test_run_signer_emulator_contract_lane.sh` |
| Regression  | ✅     | `cargo test -p kamn-core --test signer_backend -- regression_provider_client_backend_mismatch_is_rejected_without_fallback`; docs regression guards in `crates/kamn-core/tests/signer_backend_docs.rs` |
