### PR TITLE
fix(signer): enforce privileged fallback handshake contracts

### DIFF
--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -705,8 +705,8 @@ mod tests {
     use super::{
         deterministic_secure_provider_client_sign, CanonicalSecureKeyReference,
         SecureSignerBackend, SecureSignerProvider, SignerBackend, SignerBackendError,
-        SignerKeyRole, SignerProviderHandshakeMatrix, SignerProviderHandshakeStatus,
-        SigningRequest,
+        SignerBackendRouter, SignerKeyRole, SignerProviderHandshakeMatrix,
+        SignerProviderHandshakeStatus, SigningRequest,
     };
 
     #[test]
@@ -804,6 +804,43 @@ mod tests {
         assert_eq!(
             matrix.status_for_provider(SecureSignerProvider::AwsKmsEmulator),
             SignerProviderHandshakeStatus::PolicyBlocked
+        );
+    }
+
+    #[test]
+    fn router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes() {
+        let request = SigningRequest::new(
+            "secure:aws-kms:key-ops-1",
+            "agent-a",
+            1,
+            "payload-1",
+            "state:genesis",
+        )
+        .expect("request should be valid");
+
+        let unavailable_router = SignerBackendRouter::with_provider_handshake_matrix(
+            SignerProviderHandshakeMatrix::with_statuses(
+                SignerProviderHandshakeStatus::Available,
+                SignerProviderHandshakeStatus::Unavailable,
+            ),
+        );
+        let signed = unavailable_router
+            .sign_with_secure_fallback(&request)
+            .expect("unavailable provider should allow operator fallback");
+        assert_eq!(signed.backend, "local-software");
+
+        let policy_blocked_router = SignerBackendRouter::with_provider_handshake_matrix(
+            SignerProviderHandshakeMatrix::with_statuses(
+                SignerProviderHandshakeStatus::Available,
+                SignerProviderHandshakeStatus::PolicyBlocked,
+            ),
+        );
+        assert_eq!(
+            policy_blocked_router.sign_with_secure_fallback(&request),
+            Err(SignerBackendError::ProviderHandshakeRejected {
+                backend: "secure-aws-kms-emulator".to_owned(),
+                failure_class: "policy-blocked".to_owned(),
+            })
         );
     }
 

--- a/crates/kamn-core/tests/signer_backend.rs
+++ b/crates/kamn-core/tests/signer_backend.rs
@@ -256,6 +256,46 @@ fn regression_admin_key_does_not_fallback_when_secure_provider_unavailable() {
 }
 
 #[test]
+fn functional_privileged_roles_deny_fallback_when_provider_unavailable() {
+    let router = SignerBackendRouter::with_provider_handshake_matrix(
+        SignerProviderHandshakeMatrix::with_statuses(
+            SignerProviderHandshakeStatus::Available,
+            SignerProviderHandshakeStatus::Unavailable,
+        ),
+    );
+    let privileged_cases = [
+        (
+            "secure:aws-kms:role-admin/key-ops-1",
+            "admin-agent-a",
+            "admin",
+        ),
+        (
+            "secure:aws-kms:role-treasury/key-ops-1",
+            "treasury-agent-a",
+            "treasury",
+        ),
+        (
+            "secure:aws-kms:role-auditor/key-ops-1",
+            "auditor-agent-a",
+            "auditor",
+        ),
+    ];
+
+    for (key_id, sender, role) in privileged_cases {
+        let request = SigningRequest::new(key_id, sender, 1, "payload-1", GENESIS_STATE_HASH)
+            .expect("request should be valid");
+
+        assert_eq!(
+            router.sign_with_secure_fallback(&request),
+            Err(SignerBackendError::FallbackDeniedByRolePolicy {
+                key_role: role.to_owned(),
+                key_id: key_id.to_owned(),
+            })
+        );
+    }
+}
+
+#[test]
 fn regression_unsupported_secure_key_reference_does_not_fallback() {
     // Regression: #160
     let router = SignerBackendRouter::default();

--- a/crates/kamn-core/tests/signer_backend_docs.rs
+++ b/crates/kamn-core/tests/signer_backend_docs.rs
@@ -40,6 +40,7 @@ fn doc_contains_fallback_semantics_and_transaction_integration() {
 fn doc_contains_signer_emulator_contract_lane_policy() {
     assert!(DOC.contains("## Signer Emulator Contract Lanes"));
     assert!(DOC.contains("bash scripts/signer/run_signer_emulator_contract_lane.sh"));
+    assert!(DOC.contains("bash scripts/signer/run_signer_policy_contract_lane.sh"));
     assert!(DOC.contains("bash scripts/signer/run_signer_provider_deep_lane.sh"));
     assert!(DOC.contains(
         "functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider"
@@ -47,6 +48,9 @@ fn doc_contains_signer_emulator_contract_lane_policy() {
     assert!(
         DOC.contains("functional_router_uses_custom_provider_client_mapping_for_secure_provider")
     );
+    assert!(DOC.contains("functional_privileged_roles_deny_fallback_when_provider_unavailable"));
+    assert!(DOC
+        .contains("router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes"));
     assert!(DOC.contains("regression_provider_handshake_policy_block_rejects_without_fallback"));
     assert!(
         DOC.contains("regression_provider_client_backend_mismatch_is_rejected_without_fallback")
@@ -80,6 +84,9 @@ fn regression_requires_no_fallback_on_unsupported_secure_key_reference() {
         "signer and transaction compatibility fixture matrix decisions stay aligned (`Regression: #677`)."
     ));
     assert!(DOC.contains("Contract lane guards remain required for signer provider compatibility (`Regression: #619`)."));
+    assert!(DOC.contains(
+        "Privileged-role fallback and handshake policy bypass attempts remain fail-closed (`Regression: #987`)."
+    ));
     assert!(DOC.contains(
         "fallback is denied for handshake policy blocks (`ProviderHandshakeRejected`) (`Regression: #677`)."
     ));

--- a/crates/kamn-core/tests/threat_control_matrix_docs.rs
+++ b/crates/kamn-core/tests/threat_control_matrix_docs.rs
@@ -15,6 +15,7 @@ fn matrix_contains_core_threat_entries() {
     assert!(CONTROL_MATRIX.contains("TM-004"));
     assert!(CONTROL_MATRIX.contains("TM-005"));
     assert!(CONTROL_MATRIX.contains("TM-006"));
+    assert!(CONTROL_MATRIX.contains("TM-007"));
 }
 
 #[test]
@@ -29,6 +30,13 @@ fn matrix_maps_controls_to_tests() {
     assert!(CONTROL_MATRIX.contains("governance_quorum_attestation_replay_policy_contract.py"));
     assert!(CONTROL_MATRIX.contains("governance_quorum_attestation_replay_lane_contract.py"));
     assert!(CONTROL_MATRIX.contains("run_quorum_attestation_replay_contract_lane.sh"));
+    assert!(CONTROL_MATRIX.contains("run_signer_policy_contract_lane.sh"));
+    assert!(CONTROL_MATRIX
+        .contains("functional_privileged_roles_deny_fallback_when_provider_unavailable"));
+    assert!(CONTROL_MATRIX
+        .contains("router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes"));
+    assert!(CONTROL_MATRIX
+        .contains("regression_provider_client_backend_mismatch_is_rejected_without_fallback"));
 }
 
 #[test]
@@ -36,4 +44,11 @@ fn matrix_contains_quorum_attestation_replay_guard_entry_details() {
     assert!(
         CONTROL_MATRIX.contains("Quorum attestation evidence drift or replayed approval artifact")
     );
+}
+
+#[test]
+fn matrix_contains_signer_fallback_policy_entry_details() {
+    assert!(CONTROL_MATRIX
+        .contains("Privileged role fallback bypass under secure-provider degradation"));
+    assert!(CONTROL_MATRIX.contains("`Regression: #987`"));
 }

--- a/docs/foundation/signer-backend-abstraction.md
+++ b/docs/foundation/signer-backend-abstraction.md
@@ -69,13 +69,21 @@ This document captures the first implementation slice for signer backend abstrac
     - `cargo test -p kamn-core --test signer_backend integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards`
 - Scheduled provider-integration deep lane:
   - `bash scripts/signer/run_signer_provider_deep_lane.sh`
+- Signer policy fast lane:
+  - `bash scripts/signer/run_signer_policy_contract_lane.sh`
+  - includes privileged-role fallback denial + handshake decision matrix checks:
+    - `cargo test -p kamn-core --test signer_backend functional_privileged_roles_deny_fallback_when_provider_unavailable`
+    - `cargo test -p kamn-core signer_backend::tests::router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes`
+    - `cargo test -p kamn-core --test signer_backend regression_provider_client_backend_mismatch_is_rejected_without_fallback`
 - Contract lane guards remain required for signer provider compatibility (`Regression: #619`).
+- Privileged-role fallback and handshake policy bypass attempts remain fail-closed (`Regression: #987`).
 
 ## Local Validation
 Run from repository root:
 
 ```bash
 bash scripts/signer/run_signer_emulator_contract_lane.sh
+bash scripts/signer/run_signer_policy_contract_lane.sh
 bash scripts/signer/run_signer_provider_deep_lane.sh
 cargo fmt --check
 cargo clippy -- -D warnings

--- a/docs/foundation/threat-control-matrix.md
+++ b/docs/foundation/threat-control-matrix.md
@@ -12,6 +12,7 @@ This matrix translates PRD threat model concerns into enforceable controls, owne
 | TM-004 | Invalid failover action during degraded quorum | Require listener/approver quorum checks before processor promotion | Failover runbook execution gate | DevOps + Governance | `failover_runbook_contains_failover_steps` |
 | TM-005 | Signature metadata downgrade or algorithm drift | Enforce explicit signature algorithm/profile parsing and reject unsupported metadata pairs | Shared signer + transaction profile verification | Security + Backend | `integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards` |
 | TM-006 | Quorum attestation evidence drift or replayed approval artifact | Require deterministic quorum attestation schema checks and replay-guard policy validation before governance execution | Governance quorum attestation lane + policy checker | Governance + Security | `quorum_attestation_replay_guard_policy_contract` |
+| TM-007 | Privileged role fallback bypass under secure-provider degradation | Deny local fallback for privileged signer roles and reject policy-blocked handshake downgrades | Signer policy contract lane + signer backend router | Security + Backend | `functional_privileged_roles_deny_fallback_when_provider_unavailable` |
 
 ## Governance Quorum Attestation Replay Contract
 - Fast lane:
@@ -34,6 +35,18 @@ This matrix translates PRD threat model concerns into enforceable controls, owne
   - `governance_quorum_attestation_reason_codes:NO-GO:v1`
 - Required fail-closed policy:
   - quorum attestation evidence drift and replay attempts must fail closed (`Regression: #911`).
+
+## Signer Privileged Fallback and Handshake Policy Contract
+- Fast lane:
+  - `bash scripts/signer/run_signer_policy_contract_lane.sh`
+- Stable shell wrapper:
+  - `scripts/signer/run_signer_policy_contract_lane.sh`
+- Required signer policy checks:
+  - `cargo test -p kamn-core --test signer_backend functional_privileged_roles_deny_fallback_when_provider_unavailable`
+  - `cargo test -p kamn-core signer_backend::tests::router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes`
+  - `cargo test -p kamn-core --test signer_backend regression_provider_client_backend_mismatch_is_rejected_without_fallback`
+- Required fail-closed policy:
+  - privileged-role fallback bypass attempts and policy-blocked handshake downgrades must fail closed (`Regression: #987`).
 
 ## Ownership and Review Cadence
 - Security owner reviews this matrix each milestone and when new threat classes are introduced.

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -255,7 +255,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/signer_backend.rs|crates/kamn-core/tests/signer_backend.rs|crates/kamn-core/tests/signer_backend_docs.rs|docs/foundation/signer-backend-abstraction.md|scripts/signer/*)
+    crates/kamn-core/src/signer_backend.rs|crates/kamn-core/tests/signer_backend.rs|crates/kamn-core/tests/signer_backend_docs.rs|docs/foundation/signer-backend-abstraction.md|docs/foundation/threat-control-matrix.md|crates/kamn-core/tests/threat_control_matrix_docs.rs|scripts/signer/*)
       SIGNER_EMULATOR_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -776,6 +776,11 @@ assert_eq "$(extract_output "$signer_contract_script_output" "run_rust")" "false
 assert_eq "$(extract_output "$signer_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer contract script changes must run signer emulator contract lane"
 assert_eq "$(extract_output "$signer_contract_script_output" "test_scope")" "signer-contract" "signer contract script changes should set signer-contract scope"
 
+signer_policy_contract_script_output="$(run_selector $'scripts/signer/run_signer_policy_contract_lane.sh')"
+assert_eq "$(extract_output "$signer_policy_contract_script_output" "run_rust")" "false" "signer policy contract script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$signer_policy_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer policy contract script changes must run signer emulator contract lane"
+assert_eq "$(extract_output "$signer_policy_contract_script_output" "test_scope")" "signer-contract" "signer policy contract script changes should set signer-contract scope"
+
 did_contract_docs_output="$(run_selector $'docs/foundation/did-registry-transactions.md')"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_rust")" "false" "did contract docs should avoid rust lane"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_did_registry_contract_tests")" "true" "did contract docs must run did registry contract lane"
@@ -1261,9 +1266,10 @@ assert_eq "$(extract_output "$validator_quorum_reconfiguration_docs_output" "tes
 
 threat_control_matrix_docs_output="$(run_selector $'docs/foundation/threat-control-matrix.md')"
 assert_eq "$(extract_output "$threat_control_matrix_docs_output" "run_rust")" "false" "threat control matrix docs should avoid rust lane"
+assert_eq "$(extract_output "$threat_control_matrix_docs_output" "run_signer_emulator_contract_tests")" "true" "threat control matrix docs must run signer contract lane"
 assert_eq "$(extract_output "$threat_control_matrix_docs_output" "run_governance_simulation_contract_tests")" "true" "threat control matrix docs must run governance simulation contract lane"
 assert_eq "$(extract_output "$threat_control_matrix_docs_output" "run_governance_stake_slash_contract_tests")" "false" "threat control matrix docs should not force governance stake/slash contract lane"
-assert_eq "$(extract_output "$threat_control_matrix_docs_output" "test_scope")" "governance-contract" "threat control matrix docs should set governance-contract scope"
+assert_eq "$(extract_output "$threat_control_matrix_docs_output" "test_scope")" "signer-contract" "threat control matrix docs should set signer-contract scope"
 
 escrow_contract_script_output="$(run_selector $'scripts/escrow/run_settlement_reconciliation_contract_lane.sh')"
 assert_eq "$(extract_output "$escrow_contract_script_output" "run_rust")" "false" "escrow contract script-only changes should avoid rust lane"

--- a/scripts/signer/run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/run_signer_emulator_contract_lane.sh
@@ -12,6 +12,7 @@ bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --t
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_secure_provider_backend_mismatch_is_rejected
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_contract_lane_stays_within_budget
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend_docs
+bash scripts/signer/run_signer_policy_contract_lane.sh
 
 if ! grep -Fq "## Signer Emulator Contract Lanes" docs/foundation/signer-backend-abstraction.md; then
   echo "expected signer emulator contract lane section in signer-backend-abstraction.md" >&2

--- a/scripts/signer/run_signer_policy_contract_lane.sh
+++ b/scripts/signer/run_signer_policy_contract_lane.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend functional_privileged_roles_deny_fallback_when_provider_unavailable
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core signer_backend::tests::router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_provider_handshake_policy_block_rejects_without_fallback
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend regression_provider_client_backend_mismatch_is_rejected_without_fallback
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test threat_control_matrix_docs
+
+if ! grep -Fq "run_signer_policy_contract_lane.sh" docs/foundation/signer-backend-abstraction.md; then
+  echo "expected signer backend abstraction doc to reference signer policy contract lane" >&2
+  exit 1
+fi
+
+if ! grep -Fq "TM-007" docs/foundation/threat-control-matrix.md; then
+  echo "expected threat control matrix to include signer fallback/handshake row" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Regression: #987" docs/foundation/threat-control-matrix.md; then
+  echo "expected threat control matrix to include signer policy regression marker" >&2
+  exit 1
+fi
+
+echo "signer policy contract lane tests passed."

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_emulator_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane.sh"
+POLICY_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_policy_contract_lane.sh"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected signer emulator fast-lane runner to be executable" >&2
@@ -12,6 +13,11 @@ fi
 
 if [ ! -x "$DEEP_SCRIPT" ]; then
   echo "expected signer provider deep-lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_SCRIPT" ]; then
+  echo "expected signer policy contract lane runner to be executable" >&2
   exit 1
 fi
 
@@ -46,6 +52,11 @@ fi
 
 if ! grep -q "integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards" "$FAST_SCRIPT"; then
   echo "expected signer emulator contract lane to include signature profile compatibility matrix integration coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "run_signer_policy_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to invoke signer policy contract lane" >&2
   exit 1
 fi
 

--- a/scripts/signer/test_run_signer_policy_contract_lane.sh
+++ b/scripts/signer/test_run_signer_policy_contract_lane.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POLICY_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_policy_contract_lane.sh"
+
+if [ ! -x "$POLICY_SCRIPT" ]; then
+  echo "expected signer policy contract lane script to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "functional_privileged_roles_deny_fallback_when_provider_unavailable" "$POLICY_SCRIPT"; then
+  echo "expected signer policy contract lane to include privileged-role fallback denial functional coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes" "$POLICY_SCRIPT"; then
+  echo "expected signer policy contract lane to include handshake decision-matrix unit coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "regression_provider_client_backend_mismatch_is_rejected_without_fallback" "$POLICY_SCRIPT"; then
+  echo "expected signer policy contract lane to include provider-client mismatch regression coverage" >&2
+  exit 1
+fi
+
+policy_output="$(bash "$POLICY_SCRIPT")"
+if ! printf '%s\n' "$policy_output" | grep -q "signer policy contract lane tests passed."; then
+  echo "expected signer policy contract lane success marker" >&2
+  exit 1
+fi
+
+echo "signer policy contract lane script tests passed."


### PR DESCRIPTION
## Summary
Enforced fail-closed signer fallback behavior for privileged roles under secure-provider degradation and tightened handshake policy regression coverage. Added a dedicated signer policy contract lane and wired CI target selection so threat-control and signer policy changes run the fast signer contract validation path.

Closes #987

## Changes
- `crates/kamn-core/src/signer_backend.rs`: added router decision-matrix unit coverage for unavailable vs policy-blocked provider handshakes.
- `crates/kamn-core/tests/signer_backend.rs`: added privileged-role fallback denial functional coverage for admin/treasury/auditor and preserved mismatch regression fail-closed checks.
- `crates/kamn-core/tests/signer_backend_docs.rs`: enforced signer policy lane and regression marker doc-contract assertions.
- `crates/kamn-core/tests/threat_control_matrix_docs.rs`: enforced TM-007 signer fallback/handshake row and linked lane checks.
- `docs/foundation/signer-backend-abstraction.md`: documented signer policy fast lane and required regression coverage.
- `docs/foundation/threat-control-matrix.md`: added TM-007 + signer privileged fallback/handshake policy contract section.
- `scripts/signer/run_signer_policy_contract_lane.sh`: new policy lane runner for signer fallback/handshake fail-closed tests.
- `scripts/signer/test_run_signer_policy_contract_lane.sh`: new script contract test for policy lane wiring and success marker.
- `scripts/signer/run_signer_emulator_contract_lane.sh`: now invokes signer policy lane in fast contract path.
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`: added policy lane invocation/executable assertions.
- `scripts/ci/select_targets.sh`: threat-control matrix + docs tests now classify into signer contract lane triggers.
- `scripts/ci/test_select_targets.sh`: expanded selector regression matrix for signer policy lane and threat-control routing expectations.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated signer contract lane wrappers and CI target selector matrix behavior via local shell tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `signer_backend::tests::router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes` and doc-contract tests pass. |
| Functional  | ✅     | `functional_privileged_roles_deny_fallback_when_provider_unavailable` enforced in signer policy lane. |
| Integration | ✅     | Existing signer integration coverage remains green in targeted signer suite. |
| Regression  | ✅     | `regression_provider_handshake_policy_block_rejects_without_fallback` and `regression_provider_client_backend_mismatch_is_rejected_without_fallback` pass in lane. |