### PR TITLE
fix(signer): add secure-provider key lifecycle contract lane

### DIFF
--- a/crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs
+++ b/crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs
@@ -38,3 +38,21 @@ fn regression_doc_marks_missing_keys_or_decision_drift_fail_closed_policy() {
     // Regression: #890
     assert!(DOC.contains("Regression: #890"));
 }
+
+#[test]
+fn doc_contains_secure_provider_key_lifecycle_evidence_contract() {
+    assert!(
+        DOC.contains("## Secure-Provider Key Rotation/Revocation Evidence Contract (Issue #988)")
+    );
+    assert!(DOC.contains("secure_provider_key_lifecycle_contract.py"));
+    assert!(DOC.contains("generate_secure_provider_key_lifecycle_evidence_bundle.sh"));
+    assert!(DOC.contains("check_secure_provider_key_lifecycle_policy.sh"));
+    assert!(DOC.contains("run_secure_provider_key_lifecycle_contract_lane.sh"));
+    assert!(DOC.contains("secure_provider_key_lifecycle_reason_codes:GO:v1"));
+}
+
+#[test]
+fn regression_doc_marks_secure_provider_lifecycle_fail_closed_policy() {
+    // Regression: #988
+    assert!(DOC.contains("Regression: #988"));
+}

--- a/docs/foundation/key-lifecycle-audit-trails.md
+++ b/docs/foundation/key-lifecycle-audit-trails.md
@@ -43,12 +43,35 @@ Lifecycle-sensitive DID mutations must carry deterministic operator-binding auth
 - Regression policy:
   - missing required evidence fields and final-decision drift force `NO-GO` (`Regression: #890`).
 
+## Secure-Provider Key Rotation/Revocation Evidence Contract (Issue #988)
+Secure-provider signer lifecycle events (rotation/revocation) must emit deterministic custody evidence and fail-closed policy outputs before privileged operations proceed.
+
+- Evidence bundle generator:
+  - `bash scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh --output-file /tmp/secure-provider-key-lifecycle.json --secure-key-reference secure:aws-kms:role-operator/key-ops-rotation-988 --provider aws-kms --key-role operator --lifecycle-action rotate --previous-version 8 --target-version 9 --incident-ticket INC-5988 --revocation-reason-code operator-requested --required-approvals 2 --received-approvals 2 --custody-attestation-hash sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --approval-quorum-hash sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --ci-fast-gate PASS`
+- Policy checker:
+  - `bash scripts/signer/check_secure_provider_key_lifecycle_policy.sh --bundle-file /tmp/secure-provider-key-lifecycle.json`
+- PR fast contract lane:
+  - `bash scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh`
+- Stable shell wrappers:
+  - `scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh`
+  - `scripts/signer/check_secure_provider_key_lifecycle_policy.sh`
+  - `scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh`
+- Shared Python implementation:
+  - `scripts/signer/secure_provider_key_lifecycle_contract.py`
+- Decision key contract:
+  - `secure_provider_key_lifecycle_reason_codes:GO:v1`
+- Regression policy:
+  - tampered lifecycle decisions and missing `policy_checks` fail closed (`Regression: #988`).
+
 ## Local Validation
 Run from repository root:
 
 ```bash
 bash scripts/did/test_generate_lifecycle_operator_binding_evidence_bundle.sh
 bash scripts/did/test_run_lifecycle_operator_binding_contract_lane.sh
+bash scripts/signer/test_generate_secure_provider_key_lifecycle_evidence_bundle.sh
+bash scripts/signer/test_run_secure_provider_key_lifecycle_contract_lane.sh
+bash scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh
 cargo test -p kamn-core --test key_lifecycle
 cargo test -p kamn-core --test key_lifecycle_audit_trails_docs
 cargo fmt --check

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -255,7 +255,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/signer_backend.rs|crates/kamn-core/tests/signer_backend.rs|crates/kamn-core/tests/signer_backend_docs.rs|docs/foundation/signer-backend-abstraction.md|docs/foundation/threat-control-matrix.md|crates/kamn-core/tests/threat_control_matrix_docs.rs|scripts/signer/*)
+    crates/kamn-core/src/signer_backend.rs|crates/kamn-core/tests/signer_backend.rs|crates/kamn-core/tests/signer_backend_docs.rs|crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs|docs/foundation/signer-backend-abstraction.md|docs/foundation/threat-control-matrix.md|docs/foundation/key-lifecycle-audit-trails.md|crates/kamn-core/tests/threat_control_matrix_docs.rs|scripts/signer/*)
       SIGNER_EMULATOR_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -781,6 +781,11 @@ assert_eq "$(extract_output "$signer_policy_contract_script_output" "run_rust")"
 assert_eq "$(extract_output "$signer_policy_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer policy contract script changes must run signer emulator contract lane"
 assert_eq "$(extract_output "$signer_policy_contract_script_output" "test_scope")" "signer-contract" "signer policy contract script changes should set signer-contract scope"
 
+signer_key_lifecycle_contract_script_output="$(run_selector $'scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh')"
+assert_eq "$(extract_output "$signer_key_lifecycle_contract_script_output" "run_rust")" "false" "signer key lifecycle contract script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$signer_key_lifecycle_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer key lifecycle contract script changes must run signer emulator contract lane"
+assert_eq "$(extract_output "$signer_key_lifecycle_contract_script_output" "test_scope")" "signer-contract" "signer key lifecycle contract script changes should set signer-contract scope"
+
 did_contract_docs_output="$(run_selector $'docs/foundation/did-registry-transactions.md')"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_rust")" "false" "did contract docs should avoid rust lane"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_did_registry_contract_tests")" "true" "did contract docs must run did registry contract lane"
@@ -789,9 +794,10 @@ assert_eq "$(extract_output "$did_contract_docs_output" "test_scope")" "did-cont
 
 did_key_lifecycle_docs_output="$(run_selector $'docs/foundation/key-lifecycle-audit-trails.md')"
 assert_eq "$(extract_output "$did_key_lifecycle_docs_output" "run_rust")" "false" "lifecycle audit docs should avoid rust lane"
+assert_eq "$(extract_output "$did_key_lifecycle_docs_output" "run_signer_emulator_contract_tests")" "true" "lifecycle audit docs must run signer emulator contract lane"
 assert_eq "$(extract_output "$did_key_lifecycle_docs_output" "run_did_registry_contract_tests")" "true" "lifecycle audit docs must run did registry contract lane"
 assert_eq "$(extract_output "$did_key_lifecycle_docs_output" "run_federated_did_handshake_contract_tests")" "false" "lifecycle audit docs should not run federated DID handshake lane"
-assert_eq "$(extract_output "$did_key_lifecycle_docs_output" "test_scope")" "did-contract" "lifecycle audit docs should set did-contract scope"
+assert_eq "$(extract_output "$did_key_lifecycle_docs_output" "test_scope")" "signer-contract" "lifecycle audit docs should set signer-contract scope"
 
 did_contract_rust_output="$(run_selector $'crates/kamn-core/src/did_registry.rs')"
 assert_eq "$(extract_output "$did_contract_rust_output" "run_rust")" "true" "did registry rust changes should run rust lane"

--- a/scripts/signer/check_secure_provider_key_lifecycle_policy.sh
+++ b/scripts/signer/check_secure_provider_key_lifecycle_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/signer/secure_provider_key_lifecycle_contract.py" check "$@"

--- a/scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh
+++ b/scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/signer/secure_provider_key_lifecycle_contract.py" generate "$@"

--- a/scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh
+++ b/scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/signer/check_secure_provider_key_lifecycle_policy.sh"
+KEY_LIFECYCLE_DOC="$ROOT_DIR/docs/foundation/key-lifecycle-audit-trails.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "secure-provider key-lifecycle evidence generator is not executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "secure-provider key-lifecycle policy checker is not executable"
+fi
+
+if [ ! -f "$KEY_LIFECYCLE_DOC" ]; then
+  fail "expected key lifecycle audit trails doc to exist"
+fi
+
+cd "$ROOT_DIR"
+if [ "$skip_tests" != true ]; then
+  bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend integration_aws_kms_signed_transaction_passes_transaction_guards -- --exact
+  bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test key_lifecycle_audit_trails_docs
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/secure-provider-key-lifecycle-contract.json"
+fi
+
+start_epoch="$(date +%s)"
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --secure-key-reference "secure:aws-kms:role-operator/key-ops-rotation-988" \
+    --provider "aws-kms" \
+    --key-role "operator" \
+    --lifecycle-action "rotate" \
+    --previous-version 8 \
+    --target-version 9 \
+    --incident-ticket "INC-5988" \
+    --revocation-reason-code "operator-requested" \
+    --required-approvals 2 \
+    --received-approvals 2 \
+    --custody-attestation-hash "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    --approval-quorum-hash "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
+  fail "expected secure-provider key-lifecycle evidence generation decision to be GO"
+fi
+if ! printf '%s\n' "$generator_output" | grep -q "^reason_key=secure_provider_key_lifecycle_reason_codes:GO:v1$"; then
+  fail "expected secure-provider key-lifecycle GO reason key marker"
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected secure-provider key-lifecycle policy decision to be GO"
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^failed_checks=none$"; then
+  fail "expected secure-provider key-lifecycle contract lane to report failed_checks=none"
+fi
+
+if ! grep -Fq "run_secure_provider_key_lifecycle_contract_lane.sh" "$KEY_LIFECYCLE_DOC"; then
+  fail "expected key lifecycle audit trails doc to reference secure-provider key-lifecycle contract lane"
+fi
+if ! grep -Fq "Regression: #988" "$KEY_LIFECYCLE_DOC"; then
+  fail "expected key lifecycle audit trails doc to include secure-provider key-lifecycle regression marker"
+fi
+
+max_seconds="${SIGNER_KEY_LIFECYCLE_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  fail "secure-provider key-lifecycle contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "$(extract_value "$policy_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
+echo "secure-provider key-lifecycle contract lane tests passed."

--- a/scripts/signer/run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/run_signer_emulator_contract_lane.sh
@@ -13,6 +13,7 @@ bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --t
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_contract_lane_stays_within_budget
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend_docs
 bash scripts/signer/run_signer_policy_contract_lane.sh
+bash scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh
 
 if ! grep -Fq "## Signer Emulator Contract Lanes" docs/foundation/signer-backend-abstraction.md; then
   echo "expected signer emulator contract lane section in signer-backend-abstraction.md" >&2

--- a/scripts/signer/secure_provider_key_lifecycle_contract.py
+++ b/scripts/signer/secure_provider_key_lifecycle_contract.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Secure-provider signer key-lifecycle evidence generator and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import sys
+from typing import Mapping
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_int,
+    require_keys,
+    require_non_negative_int,
+    require_object,
+    require_pattern,
+    require_string,
+    write_json,
+)
+
+SCHEMA_VERSION = "kamn.signer.secure-provider-key-lifecycle.v1"
+SUPPORTED_PROVIDER = "aws-kms"
+ALLOWED_KEY_ROLES = ("operator", "admin", "treasury", "auditor")
+ALLOWED_LIFECYCLE_ACTIONS = ("rotate", "revoke")
+ALLOWED_REVOCATION_REASON_CODES = (
+    "compromised-key",
+    "operator-requested",
+    "policy-violation",
+    "incident-response",
+)
+
+
+def _is_valid_sha256_digest(value: str) -> bool:
+    return value.startswith("sha256:") and len(value) > len("sha256:")
+
+
+def _is_valid_incident_ticket(value: str) -> bool:
+    return re.fullmatch(r"INC-[0-9]{4,}", value or "") is not None
+
+
+def _compute_policy_checks(
+    secure_key_reference: str,
+    provider: str,
+    key_role: str,
+    lifecycle_action: str,
+    previous_version: int,
+    target_version: int,
+    incident_ticket: str,
+    revocation_reason_code: str,
+    required_approvals: int,
+    received_approvals: int,
+    custody_attestation_hash: str,
+    approval_quorum_hash: str,
+    ci_fast_gate: str,
+) -> Mapping[str, bool]:
+    rotate_transition_valid = (
+        lifecycle_action == "rotate"
+        and previous_version >= 1
+        and target_version == previous_version + 1
+    )
+    revoke_transition_valid = (
+        lifecycle_action == "revoke"
+        and previous_version >= 1
+        and target_version == previous_version
+    )
+
+    return {
+        "provider_supported": provider == SUPPORTED_PROVIDER,
+        "key_reference_scoped": secure_key_reference.startswith(
+            f"secure:{provider}:role-{key_role}/"
+        ),
+        "role_supported": key_role in ALLOWED_KEY_ROLES,
+        "approval_quorum_satisfied": required_approvals > 0
+        and received_approvals >= required_approvals,
+        "custody_attestation_valid": _is_valid_sha256_digest(custody_attestation_hash),
+        "approval_quorum_hash_valid": _is_valid_sha256_digest(approval_quorum_hash),
+        "lifecycle_transition_valid": rotate_transition_valid or revoke_transition_valid,
+        "revoke_reason_present": lifecycle_action != "revoke"
+        or revocation_reason_code in ALLOWED_REVOCATION_REASON_CODES,
+        "incident_ticket_present": _is_valid_incident_ticket(incident_ticket),
+        "ci_fast_gate_passed": ci_fast_gate == "PASS",
+    }
+
+
+def _failed_checks(policy_checks: Mapping[str, bool]) -> list[str]:
+    failed = [name for name, passed in policy_checks.items() if not passed]
+    return sorted(failed)
+
+
+def _reason_messages() -> Mapping[str, str]:
+    return {
+        "provider_supported": f"secure provider must be {SUPPORTED_PROVIDER}",
+        "key_reference_scoped": "secure key reference must be scoped to provider and role",
+        "role_supported": "secure key role is unsupported",
+        "approval_quorum_satisfied": "received approvals are below required approvals",
+        "custody_attestation_valid": "custody attestation hash must be a non-empty sha256 digest",
+        "approval_quorum_hash_valid": "approval quorum hash must be a non-empty sha256 digest",
+        "lifecycle_transition_valid": "lifecycle transition must satisfy rotate/revoke version invariants",
+        "revoke_reason_present": "revoke action requires a supported revocation reason code",
+        "incident_ticket_present": "incident ticket must follow INC-<digits> format",
+        "ci_fast_gate_passed": "ci-fast-gate-failed",
+    }
+
+
+def _require_policy_check_map(payload: Mapping[str, object]) -> Mapping[str, bool]:
+    policy_checks_raw = payload.get("policy_checks")
+    if not isinstance(policy_checks_raw, dict):
+        fail("policy_checks must be an object")
+
+    policy_checks: dict[str, bool] = {}
+    for key_name in _reason_messages().keys():
+        if key_name not in policy_checks_raw:
+            fail(f"missing policy_checks field: {key_name}")
+        value = policy_checks_raw[key_name]
+        if not isinstance(value, bool):
+            fail(f"policy_checks.{key_name} must be boolean")
+        policy_checks[key_name] = value
+
+    return policy_checks
+
+
+def _reason_key(decision: str) -> str:
+    return f"secure_provider_key_lifecycle_reason_codes:{decision}:v1"
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    require_pattern(
+        "secure-key-reference",
+        args.secure_key_reference,
+        r"secure:[a-z0-9-]+:role-[a-z-]+/[A-Za-z0-9._:-]+",
+        "secure-key-reference must follow secure:<provider>:role-<role>/<key-id>",
+    )
+    require_pattern(
+        "provider",
+        args.provider,
+        r"[a-z0-9-]+",
+        "provider must be lowercase alphanumeric with hyphens",
+    )
+    require_pattern(
+        "key-role",
+        args.key_role,
+        r"[a-z-]+",
+        "key-role must be lowercase with optional hyphens",
+    )
+    lifecycle_action = require_enum(
+        "lifecycle-action", args.lifecycle_action, ALLOWED_LIFECYCLE_ACTIONS
+    )
+    previous_version = require_non_negative_int(
+        "previous-version", str(args.previous_version)
+    )
+    target_version = require_non_negative_int("target-version", str(args.target_version))
+    require_pattern(
+        "incident-ticket",
+        args.incident_ticket,
+        r"[A-Za-z0-9-]+",
+        "incident-ticket must be non-empty alphanumeric with hyphens",
+    )
+    require_pattern(
+        "revocation-reason-code",
+        args.revocation_reason_code,
+        r"[a-z-]+",
+        "revocation-reason-code must be lowercase with optional hyphens",
+    )
+    required_approvals = require_non_negative_int(
+        "required-approvals", str(args.required_approvals)
+    )
+    received_approvals = require_non_negative_int(
+        "received-approvals", str(args.received_approvals)
+    )
+    require_enum("ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+
+    policy_checks = _compute_policy_checks(
+        secure_key_reference=args.secure_key_reference,
+        provider=args.provider,
+        key_role=args.key_role,
+        lifecycle_action=lifecycle_action,
+        previous_version=previous_version,
+        target_version=target_version,
+        incident_ticket=args.incident_ticket,
+        revocation_reason_code=args.revocation_reason_code,
+        required_approvals=required_approvals,
+        received_approvals=received_approvals,
+        custody_attestation_hash=args.custody_attestation_hash,
+        approval_quorum_hash=args.approval_quorum_hash,
+        ci_fast_gate=args.ci_fast_gate,
+    )
+
+    decision = DecisionAccumulator()
+    reason_messages = _reason_messages()
+    for check_name in reason_messages:
+        decision.reject_if(not policy_checks[check_name], reason_messages[check_name])
+
+    final_decision, decision_reasons = decision.finalize(
+        "all secure-provider key-lifecycle policy checks satisfied"
+    )
+    reason_key = _reason_key(final_decision)
+    failed_checks = _failed_checks(policy_checks)
+    failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "key_lifecycle": {
+            "secure_key_reference": args.secure_key_reference,
+            "provider": args.provider,
+            "key_role": args.key_role,
+            "lifecycle_action": lifecycle_action,
+            "previous_version": previous_version,
+            "target_version": target_version,
+            "incident_ticket": args.incident_ticket,
+            "revocation_reason_code": args.revocation_reason_code,
+        },
+        "approvals": {
+            "required": required_approvals,
+            "received": received_approvals,
+            "approval_quorum_hash": args.approval_quorum_hash,
+        },
+        "custody_attestation_hash": args.custody_attestation_hash,
+        "ci_fast_gate": args.ci_fast_gate,
+        "policy_checks": policy_checks,
+        "failed_checks": failed_checks,
+        "decision_reasons": decision_reasons,
+        "reason_key": reason_key,
+        "final_decision": final_decision,
+    }
+
+    output_path = Path(args.output_file)
+    write_json(output_path, payload)
+
+    print("status=generated")
+    print(f"bundle_file={output_path}")
+    print(f"final_decision={final_decision}")
+    print(f"reason_key={reason_key}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def check_bundle(args: argparse.Namespace) -> int:
+    bundle_path = Path(args.bundle_file)
+    if not bundle_path.is_file():
+        fail(f"bundle file not found: {bundle_path}")
+
+    payload = load_json(bundle_path)
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "generated_at",
+            "key_lifecycle",
+            "approvals",
+            "custody_attestation_hash",
+            "ci_fast_gate",
+            "policy_checks",
+            "failed_checks",
+            "decision_reasons",
+            "reason_key",
+            "final_decision",
+        ),
+    )
+
+    schema_version = require_string(payload, "schema_version")
+    if schema_version != SCHEMA_VERSION:
+        fail("unexpected schema_version for secure-provider key-lifecycle evidence bundle")
+
+    lifecycle = require_object(payload, "key_lifecycle")
+    secure_key_reference = require_string(lifecycle, "secure_key_reference")
+    provider = require_string(lifecycle, "provider")
+    key_role = require_string(lifecycle, "key_role")
+    lifecycle_action = require_string(lifecycle, "lifecycle_action")
+    if lifecycle_action not in ALLOWED_LIFECYCLE_ACTIONS:
+        fail("key_lifecycle.lifecycle_action must be rotate or revoke")
+    previous_version = require_int(lifecycle, "previous_version", min_value=0)
+    target_version = require_int(lifecycle, "target_version", min_value=0)
+    incident_ticket = require_string(lifecycle, "incident_ticket")
+    revocation_reason_code = require_string(lifecycle, "revocation_reason_code")
+
+    approvals = require_object(payload, "approvals")
+    required_approvals = require_int(approvals, "required", min_value=0)
+    received_approvals = require_int(approvals, "received", min_value=0)
+    approval_quorum_hash = require_string(approvals, "approval_quorum_hash")
+    custody_attestation_hash = require_string(payload, "custody_attestation_hash")
+    ci_fast_gate = require_string(payload, "ci_fast_gate")
+    if ci_fast_gate not in {"PASS", "FAIL"}:
+        fail("ci_fast_gate must be PASS or FAIL")
+
+    derived_checks = _compute_policy_checks(
+        secure_key_reference=secure_key_reference,
+        provider=provider,
+        key_role=key_role,
+        lifecycle_action=lifecycle_action,
+        previous_version=previous_version,
+        target_version=target_version,
+        incident_ticket=incident_ticket,
+        revocation_reason_code=revocation_reason_code,
+        required_approvals=required_approvals,
+        received_approvals=received_approvals,
+        custody_attestation_hash=custody_attestation_hash,
+        approval_quorum_hash=approval_quorum_hash,
+        ci_fast_gate=ci_fast_gate,
+    )
+
+    policy_checks = _require_policy_check_map(payload)
+    for check_name, expected_value in derived_checks.items():
+        if policy_checks[check_name] != expected_value:
+            fail(f"policy_checks.{check_name} does not match derived policy")
+
+    failed_checks = payload.get("failed_checks")
+    if not isinstance(failed_checks, list):
+        fail("failed_checks must be an array")
+    if not all(isinstance(item, str) and item for item in failed_checks):
+        fail("failed_checks must contain non-empty strings")
+    if failed_checks != sorted(failed_checks):
+        fail("failed_checks must be sorted and deterministic")
+
+    expected_failed_checks = _failed_checks(derived_checks)
+    if failed_checks != expected_failed_checks:
+        fail(
+            "failed_checks mismatch: "
+            f"expected failed_checks={expected_failed_checks}, found {failed_checks}"
+        )
+
+    decision_reasons = payload.get("decision_reasons")
+    if not isinstance(decision_reasons, list):
+        fail("decision_reasons must be an array")
+    if not all(isinstance(item, str) and item for item in decision_reasons):
+        fail("decision_reasons must contain non-empty strings")
+
+    expected_decision = "NO-GO" if expected_failed_checks else "GO"
+    actual_decision = require_string(payload, "final_decision")
+    if actual_decision not in {"GO", "NO-GO"}:
+        fail("final_decision must be GO or NO-GO")
+    if actual_decision != expected_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected final_decision={expected_decision}, found {actual_decision}"
+        )
+
+    reason_key = require_string(payload, "reason_key")
+    expected_reason_key = _reason_key(expected_decision)
+    if reason_key != expected_reason_key:
+        fail(
+            "reason key mismatch: "
+            f"expected reason_key={expected_reason_key}, found {reason_key}"
+        )
+
+    failed_checks_value = ",".join(expected_failed_checks) if expected_failed_checks else "none"
+    print("status=ok")
+    print(f"bundle_file={bundle_path}")
+    print(f"final_decision={actual_decision}")
+    print(f"reason_key={reason_key}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Secure-provider signer key-lifecycle evidence contract utilities "
+            "(generate/check)."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--output-file", required=True)
+    generate.add_argument("--secure-key-reference", required=True)
+    generate.add_argument("--provider", required=True)
+    generate.add_argument("--key-role", required=True)
+    generate.add_argument("--lifecycle-action", required=True)
+    generate.add_argument("--previous-version", required=True)
+    generate.add_argument("--target-version", required=True)
+    generate.add_argument("--incident-ticket", required=True)
+    generate.add_argument("--revocation-reason-code", required=True)
+    generate.add_argument("--required-approvals", required=True)
+    generate.add_argument("--received-approvals", required=True)
+    generate.add_argument("--custody-attestation-hash", required=True)
+    generate.add_argument("--approval-quorum-hash", required=True)
+    generate.add_argument("--ci-fast-gate", required=True)
+    generate.set_defaults(handler=generate_bundle)
+
+    check = subparsers.add_parser("check")
+    check.add_argument("--bundle-file", required=True)
+    check.set_defaults(handler=check_bundle)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/signer/test_generate_secure_provider_key_lifecycle_evidence_bundle.sh
+++ b/scripts/signer/test_generate_secure_provider_key_lifecycle_evidence_bundle.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/signer/check_secure_provider_key_lifecycle_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected secure-provider key-lifecycle evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected secure-provider key-lifecycle policy checker to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/secure-provider-key-lifecycle-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --secure-key-reference "secure:aws-kms:role-operator/key-ops-go-988" \
+    --provider "aws-kms" \
+    --key-role "operator" \
+    --lifecycle-action "rotate" \
+    --previous-version 4 \
+    --target-version 5 \
+    --incident-ticket "INC-1988" \
+    --revocation-reason-code "operator-requested" \
+    --required-approvals 2 \
+    --received-approvals 2 \
+    --custody-attestation-hash "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    --approval-quorum-hash "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$go_output" "status")" "generated" "expected GO secure-provider key-lifecycle bundle generation"
+assert_eq "$(extract_value "$go_output" "final_decision")" "GO" "expected GO secure-provider key-lifecycle final decision"
+assert_eq "$(extract_value "$go_output" "reason_key")" "secure_provider_key_lifecycle_reason_codes:GO:v1" "expected GO secure-provider key-lifecycle reason key"
+assert_eq "$(extract_value "$go_output" "failed_checks")" "none" "expected GO secure-provider key-lifecycle failed checks to be none"
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO secure-provider key-lifecycle policy check status"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO secure-provider key-lifecycle policy decision"
+assert_eq "$(extract_value "$go_policy_output" "failed_checks")" "none" "expected GO secure-provider key-lifecycle policy failed checks to be none"
+
+no_go_bundle="$TMP_DIR/secure-provider-key-lifecycle-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --secure-key-reference "secure:aws-kms:role-admin/key-admin-no-go-988" \
+    --provider "aws-kms" \
+    --key-role "admin" \
+    --lifecycle-action "revoke" \
+    --previous-version 7 \
+    --target-version 8 \
+    --incident-ticket "INC-2988" \
+    --revocation-reason-code "policy-violation" \
+    --required-approvals 3 \
+    --received-approvals 1 \
+    --custody-attestation-hash "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" \
+    --approval-quorum-hash "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$no_go_output" "final_decision")" "NO-GO" "expected NO-GO secure-provider key-lifecycle final decision"
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO secure-provider key-lifecycle policy check status"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO secure-provider key-lifecycle policy decision"
+
+tampered_bundle="$TMP_DIR/secure-provider-key-lifecycle-tampered-decision.json"
+cp "$no_go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered secure-provider key-lifecycle bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected secure-provider key-lifecycle policy decision mismatch error for tampered bundle" >&2
+  exit 1
+fi
+
+missing_key_bundle="$TMP_DIR/secure-provider-key-lifecycle-missing-policy.json"
+cp "$go_bundle" "$missing_key_bundle"
+python3 - "$missing_key_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+del payload["policy_checks"]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+missing_key_output="$(bash "$POLICY_CHECKER" --bundle-file "$missing_key_bundle" 2>&1)"
+missing_key_code=$?
+set -e
+
+if [ "$missing_key_code" -eq 0 ]; then
+  echo "expected missing-key secure-provider key-lifecycle bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$missing_key_output" | grep -q "missing bundle field: policy_checks"; then
+  echo "expected missing policy_checks field failure for secure-provider key-lifecycle bundle" >&2
+  exit 1
+fi
+
+# Regression: #988
+if ! printf '%s\n' "$tampered_output" | grep -q "expected final_decision=NO-GO"; then
+  echo "expected explicit NO-GO drift detection marker for secure-provider key-lifecycle regression" >&2
+  exit 1
+fi
+
+echo "secure-provider key-lifecycle evidence bundle tests passed."

--- a/scripts/signer/test_run_secure_provider_key_lifecycle_contract_lane.sh
+++ b/scripts/signer/test_run_secure_provider_key_lifecycle_contract_lane.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected secure-provider key-lifecycle contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/secure-provider-key-lifecycle-contract-bundle.json"
+output="$(bash "$SCRIPT" --output-file "$bundle_file" --skip-tests)"
+
+if ! printf '%s\n' "$output" | grep -q "secure-provider key-lifecycle contract lane tests passed."; then
+  echo "expected success output from secure-provider key-lifecycle contract lane" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected secure-provider key-lifecycle contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.signer.secure-provider-key-lifecycle.v1"' "$bundle_file"; then
+  echo "expected secure-provider key-lifecycle evidence schema marker" >&2
+  exit 1
+fi
+
+if ! grep -q '"reason_key": "secure_provider_key_lifecycle_reason_codes:GO:v1"' "$bundle_file"; then
+  echo "expected secure-provider key-lifecycle GO reason key marker in emitted bundle" >&2
+  exit 1
+fi
+
+echo "secure-provider key-lifecycle contract lane script tests passed."

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_emulator_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane.sh"
 POLICY_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_policy_contract_lane.sh"
+LIFECYCLE_SCRIPT="$ROOT_DIR/scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected signer emulator fast-lane runner to be executable" >&2
@@ -18,6 +19,11 @@ fi
 
 if [ ! -x "$POLICY_SCRIPT" ]; then
   echo "expected signer policy contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$LIFECYCLE_SCRIPT" ]; then
+  echo "expected signer secure-provider key-lifecycle contract lane runner to be executable" >&2
   exit 1
 fi
 
@@ -57,6 +63,11 @@ fi
 
 if ! grep -q "run_signer_policy_contract_lane.sh" "$FAST_SCRIPT"; then
   echo "expected signer emulator contract lane to invoke signer policy contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q "run_secure_provider_key_lifecycle_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to invoke secure-provider key-lifecycle contract lane" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Added secure-provider key rotation/revocation evidence contracts for signer lifecycle governance with deterministic GO/NO-GO policy validation and fail-closed regression checks. Integrated a fast signer lifecycle contract lane into existing signer emulator gating so lifecycle-related changes remain low-cost in PR while preserving strict policy coverage.

Closes #988

## Changes
- `scripts/signer/secure_provider_key_lifecycle_contract.py`: new shared evidence generator/policy checker with deterministic schema, policy-check vector verification, reason key derivation, and decision drift protection.
- `scripts/signer/generate_secure_provider_key_lifecycle_evidence_bundle.sh`: wrapper for lifecycle evidence generation.
- `scripts/signer/check_secure_provider_key_lifecycle_policy.sh`: wrapper for lifecycle policy verification.
- `scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh`: new fast lifecycle contract lane with runtime budget guard and doc contract assertions.
- `scripts/signer/test_generate_secure_provider_key_lifecycle_evidence_bundle.sh`: GO/NO-GO/tamper/missing-field regression coverage for lifecycle evidence contracts.
- `scripts/signer/test_run_secure_provider_key_lifecycle_contract_lane.sh`: verifies lane emits deterministic schema/reason-key output.
- `scripts/signer/run_signer_emulator_contract_lane.sh`: now invokes secure-provider lifecycle contract lane.
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`: enforces lifecycle lane wiring/executability.
- `docs/foundation/key-lifecycle-audit-trails.md`: documented Issue #988 secure-provider lifecycle contract commands and regression policy.
- `crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs`: added doc-contract assertions for lifecycle lane commands and regression marker.
- `scripts/ci/select_targets.sh`: key-lifecycle docs/tests now trigger signer emulator contract lane.
- `scripts/ci/test_select_targets.sh`: expanded selector regressions for lifecycle signer lane routing.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised signer lifecycle evidence/policy scripts and contract-lane wrappers locally

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `test_generate_secure_provider_key_lifecycle_evidence_bundle.sh` validates schema fields, policy vectors, and deterministic outputs. |
| Functional  | ✅     | GO/NO-GO outcomes for rotate/revoke lifecycle scenarios verified via generator + policy checker. |
| Integration | ✅     | `run_secure_provider_key_lifecycle_contract_lane.sh` executes with signer integration/doc-contract checks and is invoked by signer emulator lane. |
| Regression  | ✅     | Tampered `final_decision` and missing `policy_checks` bundles are fail-closed (`Regression: #988`). |