### PR TITLE
fix(signer): add incident recovery lanes and deep cadence guards

### DIFF
--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -60,6 +60,20 @@ fn checklist_contains_durable_guard_recovery_evidence() {
 }
 
 #[test]
+fn checklist_contains_signer_incident_recovery_contract_and_cadence() {
+    assert!(CHECKLIST
+        .contains("## Signer Incident Recovery Contract and Deep-Lane Cadence (Issue #989)"));
+    assert!(CHECKLIST.contains("run_signer_incident_recovery_lane.sh"));
+    assert!(CHECKLIST.contains("check_signer_incident_recovery_policy.sh"));
+    assert!(CHECKLIST.contains("run_signer_incident_recovery_contract_lane.sh"));
+    assert!(CHECKLIST.contains("run_signer_incident_recovery_deep_lane.sh"));
+    assert!(CHECKLIST.contains("kamn.signer.incident-recovery-report.v1"));
+    assert!(CHECKLIST.contains("kamn.signer.incident-recovery-deep-summary.v1"));
+    assert!(CHECKLIST.contains("signer_incident_recovery_reason_codes:GO:v1"));
+    assert!(CHECKLIST.contains("KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE"));
+}
+
+#[test]
 fn checklist_contains_settlement_reconciliation_evidence_contract() {
     assert!(CHECKLIST.contains("## Settlement Reconciliation Evidence Contract"));
     assert!(CHECKLIST.contains("generate_settlement_reconciliation_evidence_bundle.sh",));
@@ -463,5 +477,13 @@ fn regression_requires_post_cutover_slo_shared_contract_lane_marker() {
     // Regression: #1282
     assert!(CHECKLIST.contains(
         "shared contract-lane module marker remains required for docs/contracts drift guard (`Regression: #1282`)."
+    ));
+}
+
+#[test]
+fn regression_requires_signer_incident_recovery_stale_artifact_guard_marker() {
+    // Regression: #989
+    assert!(CHECKLIST.contains(
+        "stale deep-lane artifacts, unscheduled deep-lane execution, and incident recovery policy drift force `NO-GO` (`Regression: #989`)."
     ));
 }

--- a/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
+++ b/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
@@ -56,6 +56,17 @@ fn runbook_contains_dr_evidence_and_slo_gate_contract() {
 }
 
 #[test]
+fn runbook_contains_signer_incident_recovery_contract_lanes() {
+    assert!(RUNBOOK.contains("## Secure-Signer Incident Recovery Contract Lanes (Issue #989)"));
+    assert!(RUNBOOK.contains("run_signer_incident_recovery_lane.sh"));
+    assert!(RUNBOOK.contains("check_signer_incident_recovery_policy.sh"));
+    assert!(RUNBOOK.contains("run_signer_incident_recovery_contract_lane.sh"));
+    assert!(RUNBOOK.contains("run_signer_incident_recovery_deep_lane.sh"));
+    assert!(RUNBOOK.contains("signer_incident_recovery_reason_codes:GO:v1"));
+    assert!(RUNBOOK.contains("KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE"));
+}
+
+#[test]
 fn runbook_contains_live_network_pilot_rollback_evidence_gate() {
     assert!(RUNBOOK.contains("## Live-Network Pilot Rollback Evidence Gate"));
     assert!(RUNBOOK.contains("run_live_network_pilot_deep_lane.sh"));
@@ -127,5 +138,13 @@ fn regression_requires_governance_lifecycle_rollback_fail_closed_guard() {
     // Regression: #910
     assert!(RUNBOOK.contains(
         "illegal lifecycle transitions and rollback integrity drift must fail closed (`Regression: #910`)."
+    ));
+}
+
+#[test]
+fn regression_requires_signer_incident_recovery_fail_closed_guard() {
+    // Regression: #989
+    assert!(RUNBOOK.contains(
+        "runbook-step drift, revocation propagation gaps, stale deep-lane artifacts, or cadence violations force `NO-GO` (`Regression: #989`)."
     ));
 }

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -86,6 +86,31 @@ Durable guard schema evolution and restart invariants must be proven before a re
   - nightly deep bundle store stress executes `performance_bundle_store_deep_lane_stress`.
   - shared contract-lane module marker remains required for docs/contracts drift guard (`Regression: #1242`).
 
+## Signer Incident Recovery Contract and Deep-Lane Cadence (Issue #989)
+Signer incident response readiness must remain deterministic while keeping PR fast-gate cost bounded.
+
+- Incident recovery lane:
+  - `bash scripts/signer/run_signer_incident_recovery_lane.sh --output-json /tmp/signer-incident-recovery-report.json`
+- Policy checker:
+  - `bash scripts/signer/check_signer_incident_recovery_policy.sh --report-file /tmp/signer-incident-recovery-report.json`
+- PR fast contract lane:
+  - `bash scripts/signer/run_signer_incident_recovery_contract_lane.sh --output-file /tmp/signer-incident-recovery-contract-report.json`
+- Scheduled deep lane entrypoint:
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled bash scripts/signer/run_signer_incident_recovery_deep_lane.sh --output-json /tmp/signer-incident-recovery-deep-report.json`
+- Required schema/reason markers:
+  - `kamn.signer.incident-recovery-report.v1`
+  - `kamn.signer.incident-recovery-deep-summary.v1`
+  - `signer_incident_recovery_reason_codes:GO:v1`
+  - `signer_incident_recovery_deep_reason_codes:GO:v1`
+- Runtime/cadence controls:
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_MAX_SECONDS`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_CONTRACT_MAX_SECONDS`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_SECONDS`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_ARTIFACT_AGE_SECONDS`
+- Regression policy:
+  - stale deep-lane artifacts, unscheduled deep-lane execution, and incident recovery policy drift force `NO-GO` (`Regression: #989`).
+
 ## Settlement Reconciliation Evidence Contract (Issue #687)
 Escrow settlement outcomes require deterministic receipt/finality evidence before release approval.
 

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -60,6 +60,40 @@ Release promotion requires machine-validated DR drill evidence and SLO gate chec
 - Regression policy:
   - missing/incomplete DR evidence and SLO threshold violations force `NO-GO` (`Regression: #623`).
 
+## Secure-Signer Incident Recovery Contract Lanes (Issue #989)
+Signer incident response requires deterministic lane reports, fail-closed policy checks, and scheduled deep-lane cadence enforcement.
+
+- Incident recovery lane:
+  - `bash scripts/signer/run_signer_incident_recovery_lane.sh --output-json /tmp/signer-incident-recovery-report.json`
+- Policy checker:
+  - `bash scripts/signer/check_signer_incident_recovery_policy.sh --report-file /tmp/signer-incident-recovery-report.json`
+- PR fast contract lane:
+  - `bash scripts/signer/run_signer_incident_recovery_contract_lane.sh --output-file /tmp/signer-incident-recovery-contract-report.json`
+- Scheduled deep lane:
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled bash scripts/signer/run_signer_incident_recovery_deep_lane.sh --output-json /tmp/signer-incident-recovery-deep-report.json`
+- Stable shell wrappers:
+  - `scripts/signer/run_signer_incident_recovery_lane.sh`
+  - `scripts/signer/check_signer_incident_recovery_policy.sh`
+  - `scripts/signer/run_signer_incident_recovery_contract_lane.sh`
+  - `scripts/signer/run_signer_incident_recovery_deep_lane.sh`
+- Shared Python implementation:
+  - `scripts/signer/signer_incident_recovery_lane.py`
+  - `scripts/signer/signer_incident_recovery_policy_contract.py`
+  - `scripts/signer/signer_incident_recovery_contract_lane_contract.py`
+- Runtime and cadence controls:
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_MAX_SECONDS`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_CONTRACT_MAX_SECONDS`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_SECONDS`
+  - `KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_ARTIFACT_AGE_SECONDS`
+- Required schema/reason markers:
+  - `kamn.signer.incident-recovery-report.v1`
+  - `kamn.signer.incident-recovery-deep-summary.v1`
+  - `signer_incident_recovery_reason_codes:GO:v1`
+  - `signer_incident_recovery_deep_reason_codes:GO:v1`
+- Regression policy:
+  - runbook-step drift, revocation propagation gaps, stale deep-lane artifacts, or cadence violations force `NO-GO` (`Regression: #989`).
+
 ## Deployment SLO Evidence and Rollback Automation Contract
 Deterministic deployment SLO/rollback policy checks are enforced through a bounded deployment lane:
 
@@ -154,6 +188,10 @@ Run from repository root:
 ```bash
 bash scripts/deploy/test_generate_dr_evidence_bundle.sh
 bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
+bash scripts/signer/test_run_signer_incident_recovery_lane.sh
+bash scripts/signer/test_check_signer_incident_recovery_policy.sh
+bash scripts/signer/test_run_signer_incident_recovery_contract_lane.sh
+bash scripts/signer/test_run_signer_incident_recovery_deep_lane.sh
 bash scripts/governance/test_run_governance_lifecycle_rollback_lane.sh
 bash scripts/governance/test_check_governance_lifecycle_rollback_policy.sh
 bash scripts/governance/test_run_governance_lifecycle_rollback_contract_lane.sh

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -255,7 +255,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/signer_backend.rs|crates/kamn-core/tests/signer_backend.rs|crates/kamn-core/tests/signer_backend_docs.rs|crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs|docs/foundation/signer-backend-abstraction.md|docs/foundation/threat-control-matrix.md|docs/foundation/key-lifecycle-audit-trails.md|crates/kamn-core/tests/threat_control_matrix_docs.rs|scripts/signer/*)
+    crates/kamn-core/src/signer_backend.rs|crates/kamn-core/tests/signer_backend.rs|crates/kamn-core/tests/signer_backend_docs.rs|crates/kamn-core/tests/key_lifecycle_audit_trails_docs.rs|crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs|docs/foundation/signer-backend-abstraction.md|docs/foundation/threat-control-matrix.md|docs/foundation/key-lifecycle-audit-trails.md|docs/foundation/upgrade-rollback-runbook.md|crates/kamn-core/tests/threat_control_matrix_docs.rs|scripts/signer/*)
       SIGNER_EMULATOR_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -135,6 +135,7 @@ rollback_runbook_output="$(run_selector $'docs/foundation/upgrade-rollback-runbo
 assert_eq "$(extract_output "$rollback_runbook_output" "docs_only")" "true" "upgrade rollback runbook updates should remain docs-only"
 assert_eq "$(extract_output "$rollback_runbook_output" "run_rust")" "false" "upgrade rollback runbook updates should avoid rust lane"
 assert_eq "$(extract_output "$rollback_runbook_output" "run_deploy_preflight_tests")" "true" "upgrade rollback runbook updates must run deploy preflight tests"
+assert_eq "$(extract_output "$rollback_runbook_output" "run_signer_emulator_contract_tests")" "true" "upgrade rollback runbook updates must run signer contract lane"
 assert_eq "$(extract_output "$rollback_runbook_output" "test_scope")" "deploy" "upgrade rollback runbook updates should use deploy scope"
 
 deployment_slo_lane_output="$(run_selector $'scripts/deploy/run_deployment_slo_rollback_lane.sh')"
@@ -785,6 +786,16 @@ signer_key_lifecycle_contract_script_output="$(run_selector $'scripts/signer/run
 assert_eq "$(extract_output "$signer_key_lifecycle_contract_script_output" "run_rust")" "false" "signer key lifecycle contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$signer_key_lifecycle_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer key lifecycle contract script changes must run signer emulator contract lane"
 assert_eq "$(extract_output "$signer_key_lifecycle_contract_script_output" "test_scope")" "signer-contract" "signer key lifecycle contract script changes should set signer-contract scope"
+
+signer_incident_recovery_contract_script_output="$(run_selector $'scripts/signer/run_signer_incident_recovery_contract_lane.sh')"
+assert_eq "$(extract_output "$signer_incident_recovery_contract_script_output" "run_rust")" "false" "signer incident recovery contract script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$signer_incident_recovery_contract_script_output" "run_signer_emulator_contract_tests")" "true" "signer incident recovery contract script changes must run signer emulator contract lane"
+assert_eq "$(extract_output "$signer_incident_recovery_contract_script_output" "test_scope")" "signer-contract" "signer incident recovery contract script changes should set signer-contract scope"
+
+signer_incident_recovery_deep_script_output="$(run_selector $'scripts/signer/run_signer_incident_recovery_deep_lane.sh')"
+assert_eq "$(extract_output "$signer_incident_recovery_deep_script_output" "run_rust")" "false" "signer incident recovery deep script-only changes should avoid rust lane"
+assert_eq "$(extract_output "$signer_incident_recovery_deep_script_output" "run_signer_emulator_contract_tests")" "true" "signer incident recovery deep script changes must run signer emulator contract lane"
+assert_eq "$(extract_output "$signer_incident_recovery_deep_script_output" "test_scope")" "signer-contract" "signer incident recovery deep script changes should set signer-contract scope"
 
 did_contract_docs_output="$(run_selector $'docs/foundation/did-registry-transactions.md')"
 assert_eq "$(extract_output "$did_contract_docs_output" "run_rust")" "false" "did contract docs should avoid rust lane"

--- a/scripts/signer/check_signer_incident_recovery_policy.sh
+++ b/scripts/signer/check_signer_incident_recovery_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/signer/signer_incident_recovery_policy_contract.py" "$@"

--- a/scripts/signer/run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/run_signer_emulator_contract_lane.sh
@@ -14,6 +14,7 @@ bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --t
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend_docs
 bash scripts/signer/run_signer_policy_contract_lane.sh
 bash scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh
+bash scripts/signer/run_signer_incident_recovery_contract_lane.sh
 
 if ! grep -Fq "## Signer Emulator Contract Lanes" docs/foundation/signer-backend-abstraction.md; then
   echo "expected signer emulator contract lane section in signer-backend-abstraction.md" >&2

--- a/scripts/signer/run_signer_incident_recovery_contract_lane.sh
+++ b/scripts/signer/run_signer_incident_recovery_contract_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/signer/signer_incident_recovery_contract_lane_contract.py" "$@"

--- a/scripts/signer/run_signer_incident_recovery_deep_lane.sh
+++ b/scripts/signer/run_signer_incident_recovery_deep_lane.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled \
+    bash scripts/signer/run_signer_incident_recovery_deep_lane.sh \
+      [--output-json <path>] \
+      [--report-file <path>] \
+      [--skip-contract-lane]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+require_positive_int_env() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || [ "$value" -le 0 ]; then
+    fail "${name} must be a positive integer"
+  fi
+}
+
+output_json="$ROOT_DIR/signer-incident-recovery-deep-report.json"
+report_file=""
+skip_contract_lane=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --report-file)
+      report_file="${2:-}"
+      shift 2
+      ;;
+    --skip-contract-lane)
+      skip_contract_lane=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  fail "expected signer incident recovery contract lane script to be executable"
+fi
+
+cadence="${KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE:-}"
+if [ "$cadence" != "scheduled" ]; then
+  fail "scheduled-only cadence policy requires KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled"
+fi
+
+max_seconds="${KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_SECONDS:-240}"
+max_artifact_age_seconds="${KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_ARTIFACT_AGE_SECONDS:-3600}"
+force_stale_artifact="${KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_STALE_ARTIFACT:-false}"
+require_positive_int_env "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_SECONDS" "$max_seconds"
+require_positive_int_env "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_MAX_ARTIFACT_AGE_SECONDS" "$max_artifact_age_seconds"
+
+if [ "$force_stale_artifact" != "true" ] && [ "$force_stale_artifact" != "false" ]; then
+  fail "KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_STALE_ARTIFACT must be true or false"
+fi
+
+mkdir -p "$(dirname "$output_json")"
+start_epoch="$(date +%s)"
+contract_lane_invoked=false
+
+if [ "$skip_contract_lane" != true ]; then
+  contract_lane_invoked=true
+  if [ -z "$report_file" ]; then
+    report_file="$TMP_DIR/signer-incident-recovery-contract-report.json"
+  fi
+  bash "$CONTRACT_LANE" --output-file "$report_file" >/dev/null
+fi
+
+if [ -z "$report_file" ]; then
+  fail "--report-file is required when --skip-contract-lane is used"
+fi
+
+if [ ! -f "$report_file" ]; then
+  fail "report file not found: $report_file"
+fi
+
+report_meta="$(
+  python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+generated_epoch = payload.get("generated_epoch")
+final_decision = payload.get("final_decision")
+schema_version = payload.get("schema_version")
+if not isinstance(generated_epoch, int):
+    raise SystemExit("generated_epoch must be an integer in signer incident recovery report")
+if not isinstance(final_decision, str):
+    raise SystemExit("final_decision must be a string in signer incident recovery report")
+if not isinstance(schema_version, str):
+    raise SystemExit("schema_version must be a string in signer incident recovery report")
+print(f"generated_epoch={generated_epoch}")
+print(f"final_decision={final_decision}")
+print(f"schema_version={schema_version}")
+PY
+)"
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+source_generated_epoch="$(extract_value "$report_meta" "generated_epoch")"
+source_final_decision="$(extract_value "$report_meta" "final_decision")"
+source_schema_version="$(extract_value "$report_meta" "schema_version")"
+
+if [[ -z "$source_generated_epoch" ]] || [[ ! "$source_generated_epoch" =~ ^[0-9]+$ ]]; then
+  fail "unable to parse generated_epoch from signer incident recovery report"
+fi
+
+artifact_age_seconds="$(( $(date +%s) - source_generated_epoch ))"
+if [ "$force_stale_artifact" = "true" ]; then
+  artifact_age_seconds="$(( max_artifact_age_seconds + 1 ))"
+fi
+
+reason_codes=()
+if [ "$source_final_decision" != "GO" ]; then
+  reason_codes+=("source_report_not_go")
+fi
+if [ "$artifact_age_seconds" -gt "$max_artifact_age_seconds" ]; then
+  reason_codes+=("stale_deep_artifact")
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  reason_codes+=("runtime_budget_exceeded")
+fi
+
+if [ "${#reason_codes[@]}" -gt 0 ]; then
+  IFS=$'\n' read -r -d '' -a reason_codes < <(printf '%s\n' "${reason_codes[@]}" | sort -u && printf '\0')
+fi
+
+status="pass"
+final_decision="GO"
+if [ "${#reason_codes[@]}" -gt 0 ]; then
+  status="fail"
+  final_decision="NO-GO"
+fi
+
+reason_codes_csv="none"
+if [ "${#reason_codes[@]}" -gt 0 ]; then
+  reason_codes_csv="$(IFS=,; echo "${reason_codes[*]}")"
+fi
+reason_key="signer_incident_recovery_deep_reason_codes:${final_decision}:v1"
+
+python3 - "$output_json" "$status" "$final_decision" "$reason_key" "$report_file" "$source_schema_version" "$source_final_decision" "$artifact_age_seconds" "$max_artifact_age_seconds" "$elapsed_seconds" "$max_seconds" "$reason_codes_csv" "$contract_lane_invoked" <<'PY'
+import json
+import pathlib
+import sys
+
+(
+    output_json,
+    status,
+    final_decision,
+    reason_key,
+    report_file,
+    source_schema_version,
+    source_final_decision,
+    artifact_age_seconds,
+    max_artifact_age_seconds,
+    elapsed_seconds,
+    max_seconds,
+    reason_codes_csv,
+    contract_lane_invoked,
+) = sys.argv[1:]
+
+reason_codes = [] if reason_codes_csv == "none" else reason_codes_csv.split(",")
+
+payload = {
+    "schema_version": "kamn.signer.incident-recovery-deep-summary.v1",
+    "lane": "deep",
+    "cadence": "scheduled",
+    "status": status,
+    "final_decision": final_decision,
+    "reason_key": reason_key,
+    "source_report_file": report_file,
+    "source_report_schema": source_schema_version,
+    "source_report_final_decision": source_final_decision,
+    "artifact_age_seconds": int(artifact_age_seconds),
+    "max_artifact_age_seconds": int(max_artifact_age_seconds),
+    "elapsed_seconds": int(elapsed_seconds),
+    "max_seconds": int(max_seconds),
+    "reason_codes": reason_codes,
+    "stale_artifact_blocked": "stale_deep_artifact" in reason_codes,
+    "contract_lane_invoked": contract_lane_invoked == "true",
+}
+
+pathlib.Path(output_json).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [ "$status" != "pass" ]; then
+  fail "signer incident recovery deep lane failed closed: ${reason_codes_csv}"
+fi
+
+echo "signer incident recovery deep lane tests passed."

--- a/scripts/signer/run_signer_incident_recovery_lane.sh
+++ b/scripts/signer/run_signer_incident_recovery_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/signer/signer_incident_recovery_lane.py" "$@"

--- a/scripts/signer/run_signer_provider_deep_lane.sh
+++ b/scripts/signer/run_signer_provider_deep_lane.sh
@@ -6,5 +6,8 @@ cd "$ROOT_DIR"
 
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_bulk_signing_deep_lane -- --ignored
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend --test transaction_guards --test transaction_guards_docs
+KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled \
+  bash scripts/signer/run_signer_incident_recovery_deep_lane.sh \
+    --output-json /tmp/signer-incident-recovery-deep-report.json
 
 echo "signer provider deep lane tests passed."

--- a/scripts/signer/signer_incident_recovery_contract_lane_contract.py
+++ b/scripts/signer/signer_incident_recovery_contract_lane_contract.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Signer incident-recovery contract-lane runner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def usage() -> None:
+    print(
+        "Usage:\n"
+        "  bash scripts/signer/run_signer_incident_recovery_contract_lane.sh \\\n"
+        "    [--output-file <path>]"
+    )
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def run_capture(command: list[str], *, env: dict[str, str] | None = None) -> tuple[int, str]:
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    return result.returncode, output
+
+
+def parse_args(argv: list[str]) -> tuple[int, str]:
+    output_file = ""
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--output-file":
+            if index + 1 >= len(argv):
+                return fail("unknown argument: --output-file"), output_file
+            output_file = argv[index + 1]
+            index += 2
+            continue
+        if arg in {"--help", "-h"}:
+            usage()
+            return 0, output_file
+        return fail(f"unknown argument: {arg}"), output_file
+    return 200, output_file
+
+
+def main(argv: list[str]) -> int:
+    parse_status, output_file_arg = parse_args(argv)
+    if parse_status != 200:
+        return parse_status
+
+    root_dir = Path(__file__).resolve().parents[2]
+    lane_script = root_dir / "scripts/signer/run_signer_incident_recovery_lane.sh"
+    checker = root_dir / "scripts/signer/check_signer_incident_recovery_policy.sh"
+    runbook_doc = root_dir / "docs/foundation/upgrade-rollback-runbook.md"
+    checklist_doc = root_dir / "docs/foundation/release-gonogo-checklist.md"
+
+    if not lane_script.is_file() or not os.access(lane_script, os.X_OK):
+        return fail("expected signer incident recovery lane script to be executable")
+    if not checker.is_file() or not os.access(checker, os.X_OK):
+        return fail("expected signer incident recovery policy checker to be executable")
+    if not runbook_doc.is_file():
+        return fail("expected upgrade rollback runbook doc to exist")
+    if not checklist_doc.is_file():
+        return fail("expected release go/no-go checklist doc to exist")
+
+    max_contract_seconds_raw = os.getenv(
+        "KAMN_SIGNER_INCIDENT_RECOVERY_CONTRACT_MAX_SECONDS", "240"
+    )
+    if not max_contract_seconds_raw.isdigit() or int(max_contract_seconds_raw) <= 0:
+        return fail(
+            "KAMN_SIGNER_INCIDENT_RECOVERY_CONTRACT_MAX_SECONDS must be a positive integer"
+        )
+    max_contract_seconds = int(max_contract_seconds_raw)
+    start_epoch = int(time.time())
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        if output_file_arg:
+            output_file = Path(output_file_arg)
+        else:
+            output_file = Path(temp_dir) / "signer-incident-recovery-contract-report.json"
+
+        go_env = os.environ.copy()
+        go_env["KAMN_SIGNER_INCIDENT_RECOVERY_MAX_SECONDS"] = str(max_contract_seconds)
+        go_code, go_output = run_capture(
+            ["bash", str(lane_script), "--output-json", str(output_file)],
+            env=go_env,
+        )
+        if go_code != 0 or "status=pass" not in go_output:
+            return fail("expected signer incident recovery lane GO run to report pass status")
+        if "final_decision=GO" not in go_output:
+            return fail("expected signer incident recovery lane GO run to report GO decision")
+        if (
+            "reason_key=signer_incident_recovery_reason_codes:GO:v1"
+            not in go_output
+        ):
+            return fail(
+                "expected signer incident recovery lane GO run to emit deterministic GO reason key"
+            )
+
+        go_policy_code, go_policy_output = run_capture(
+            ["bash", str(checker), "--report-file", str(output_file)]
+        )
+        if go_policy_code != 0 or "status=ok" not in go_policy_output:
+            return fail("expected signer incident recovery policy checker status marker for GO report")
+        if "final_decision=GO" not in go_policy_output:
+            return fail("expected signer incident recovery policy checker GO decision for GO report")
+        if "failed_checks=none" not in go_policy_output:
+            return fail(
+                "expected signer incident recovery policy checker no failed checks for GO report"
+            )
+
+        no_go_report = Path(temp_dir) / "signer-incident-recovery-no-go.json"
+        no_go_env = os.environ.copy()
+        no_go_env["KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS"] = "true"
+        no_go_env["KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_RUNBOOK_GAP"] = "true"
+        no_go_code, no_go_output = run_capture(
+            ["bash", str(lane_script), "--output-json", str(no_go_report)],
+            env=no_go_env,
+        )
+        if no_go_code == 0:
+            return fail(
+                "expected forced runbook-gap signer incident recovery lane run to fail closed"
+            )
+        if "incident_runbook_step_missing" not in no_go_output:
+            return fail(
+                "expected forced runbook-gap lane run to emit incident_runbook_step_missing reason code"
+            )
+
+        no_go_policy_code, no_go_policy_output = run_capture(
+            ["bash", str(checker), "--report-file", str(no_go_report)]
+        )
+        if no_go_policy_code != 0 or "final_decision=NO-GO" not in no_go_policy_output:
+            return fail(
+                "expected signer incident recovery policy checker NO-GO decision for runbook-gap report"
+            )
+        if "incident_runbook_step_missing" not in no_go_policy_output:
+            return fail(
+                "expected signer incident recovery policy checker failed checks to include incident_runbook_step_missing"
+            )
+
+        tampered_report = Path(temp_dir) / "signer-incident-recovery-no-go-tampered.json"
+        tampered_payload = json.loads(no_go_report.read_text(encoding="utf-8"))
+        tampered_payload["final_decision"] = "GO"
+        tampered_payload["reason_key"] = "signer_incident_recovery_reason_codes:GO:v1"
+        tampered_report.write_text(
+            json.dumps(tampered_payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        tampered_policy_code, tampered_policy_output = run_capture(
+            ["bash", str(checker), "--report-file", str(tampered_report)]
+        )
+        if tampered_policy_code == 0:
+            return fail(
+                "expected signer incident recovery policy checker to reject tampered NO-GO report"
+            )
+        if "policy decision mismatch" not in tampered_policy_output:
+            return fail(
+                "expected signer incident recovery policy checker mismatch marker for tampered report"
+            )
+
+        runbook_text = runbook_doc.read_text(encoding="utf-8")
+        checklist_text = checklist_doc.read_text(encoding="utf-8")
+        required_runbook_snippets = (
+            "## Secure-Signer Incident Recovery Contract Lanes (Issue #989)",
+            "run_signer_incident_recovery_lane.sh",
+            "check_signer_incident_recovery_policy.sh",
+            "run_signer_incident_recovery_contract_lane.sh",
+            "run_signer_incident_recovery_deep_lane.sh",
+            "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE",
+            "Regression: #989",
+        )
+        for snippet in required_runbook_snippets:
+            if snippet not in runbook_text:
+                return fail(
+                    "expected upgrade rollback runbook to reference signer incident recovery contracts"
+                )
+
+        required_checklist_snippets = (
+            "## Signer Incident Recovery Contract and Deep-Lane Cadence (Issue #989)",
+            "run_signer_incident_recovery_contract_lane.sh",
+            "run_signer_incident_recovery_deep_lane.sh",
+            "check_signer_incident_recovery_policy.sh",
+            "signer_incident_recovery_reason_codes:GO:v1",
+            "Regression: #989",
+        )
+        for snippet in required_checklist_snippets:
+            if snippet not in checklist_text:
+                return fail(
+                    "expected release go/no-go checklist to reference signer incident recovery contracts"
+                )
+
+        elapsed_seconds = int(time.time()) - start_epoch
+        if elapsed_seconds > max_contract_seconds:
+            return fail(
+                "signer incident recovery contract lane exceeded runtime budget: "
+                f"{elapsed_seconds}s"
+            )
+
+        print("status=ok")
+        print(f"report_file={output_file}")
+        print("final_decision=GO")
+        print("signer incident recovery contract lane tests passed.")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/signer/signer_incident_recovery_lane.py
+++ b/scripts/signer/signer_incident_recovery_lane.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Signer incident-recovery lane runner and report emitter."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import ContractError, fail, write_json  # noqa: E402
+
+ROOT_DIR = SCRIPT_DIR.parent.parent
+LIFECYCLE_CONTRACT_LANE = (
+    ROOT_DIR / "scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh"
+)
+RUNBOOK_DOC = ROOT_DIR / "docs/foundation/upgrade-rollback-runbook.md"
+CHECKLIST_DOC = ROOT_DIR / "docs/foundation/release-gonogo-checklist.md"
+
+
+def usage() -> None:
+    print(
+        "Usage:\n"
+        "  bash scripts/signer/run_signer_incident_recovery_lane.sh \\\n"
+        "    --output-json <path>"
+    )
+
+
+def _parse_args(argv: list[str]) -> Path:
+    output_json = ""
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--output-json":
+            if index + 1 >= len(argv):
+                fail("unknown argument: --output-json")
+            output_json = argv[index + 1]
+            index += 2
+            continue
+        if arg in {"--help", "-h"}:
+            usage()
+            raise SystemExit(0)
+        fail(f"unknown argument: {arg}")
+
+    if output_json == "":
+        usage()
+        fail("--output-json is required")
+    return Path(output_json)
+
+
+def _parse_bool_env(name: str, raw_value: str) -> bool:
+    if raw_value == "true":
+        return True
+    if raw_value == "false":
+        return False
+    fail(f"invalid boolean for {name}: {raw_value}")
+
+
+def _parse_non_negative_int_env(name: str, raw_value: str) -> int:
+    if not raw_value.isdigit():
+        fail(f"{name} must be a non-negative integer")
+    return int(raw_value)
+
+
+def _run_command(command: list[str]) -> tuple[int, str]:
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    output = completed.stdout
+    if completed.stderr:
+        output = f"{output}{completed.stderr}"
+    return completed.returncode, output
+
+
+def main(argv: list[str]) -> int:
+    output_json = _parse_args(argv)
+
+    if not LIFECYCLE_CONTRACT_LANE.is_file() or not os.access(
+        LIFECYCLE_CONTRACT_LANE, os.X_OK
+    ):
+        fail("expected signer lifecycle contract lane script to be executable")
+    if not RUNBOOK_DOC.is_file():
+        fail("expected upgrade rollback runbook doc to exist")
+    if not CHECKLIST_DOC.is_file():
+        fail("expected release go/no-go checklist doc to exist")
+
+    max_seconds = _parse_non_negative_int_env(
+        "KAMN_SIGNER_INCIDENT_RECOVERY_MAX_SECONDS",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_MAX_SECONDS", "120"),
+    )
+    simulate_delay_seconds = _parse_non_negative_int_env(
+        "KAMN_SIGNER_INCIDENT_RECOVERY_SIMULATE_DELAY_SECONDS",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_SIMULATE_DELAY_SECONDS", "0"),
+    )
+
+    skip_commands = _parse_bool_env(
+        "skip_commands", os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS", "false")
+    )
+    force_runbook_gap = _parse_bool_env(
+        "force_runbook_gap",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_RUNBOOK_GAP", "false"),
+    )
+    force_revocation_gap = _parse_bool_env(
+        "force_revocation_gap",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_REVOCATION_GAP", "false"),
+    )
+    force_signoff_gap = _parse_bool_env(
+        "force_signoff_gap",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_SIGNOFF_GAP", "false"),
+    )
+    force_docs_contract_missing = _parse_bool_env(
+        "force_docs_contract_missing",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_DOCS_CONTRACT_MISSING", "false"),
+    )
+    force_lane_failure = _parse_bool_env(
+        "force_lane_failure",
+        os.getenv("KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_LANE_FAILURE", "false"),
+    )
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    start_epoch = int(time.time())
+
+    commands: list[str] = []
+    lifecycle_contract_lane_exit_code = 0
+    lifecycle_contract_lane_output = ""
+    lifecycle_contract_lane_passed = True
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        if force_lane_failure:
+            lifecycle_contract_lane_exit_code = 1
+            lifecycle_contract_lane_passed = False
+        elif not skip_commands:
+            lifecycle_bundle = (
+                Path(temp_dir) / "signer-incident-recovery-lifecycle-contract.json"
+            )
+            commands.append(
+                "bash scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh "
+                f"--skip-tests --output-file {lifecycle_bundle}"
+            )
+            lifecycle_contract_lane_exit_code, lifecycle_contract_lane_output = _run_command(
+                [
+                    "bash",
+                    str(LIFECYCLE_CONTRACT_LANE),
+                    "--skip-tests",
+                    "--output-file",
+                    str(lifecycle_bundle),
+                ]
+            )
+            if (
+                lifecycle_contract_lane_exit_code != 0
+                or "secure-provider key-lifecycle contract lane tests passed."
+                not in lifecycle_contract_lane_output
+            ):
+                lifecycle_contract_lane_passed = False
+
+        if simulate_delay_seconds > 0:
+            time.sleep(simulate_delay_seconds)
+
+    runbook_text = RUNBOOK_DOC.read_text(encoding="utf-8")
+    checklist_text = CHECKLIST_DOC.read_text(encoding="utf-8")
+
+    runbook_required_snippets = (
+        "run_signer_incident_recovery_contract_lane.sh",
+        "run_signer_incident_recovery_deep_lane.sh",
+        "check_signer_incident_recovery_policy.sh",
+        "signer_incident_recovery_reason_codes:GO:v1",
+        "Regression: #989",
+    )
+    checklist_required_snippets = (
+        "run_signer_incident_recovery_contract_lane.sh",
+        "run_signer_incident_recovery_deep_lane.sh",
+        "check_signer_incident_recovery_policy.sh",
+        "signer_incident_recovery_reason_codes:GO:v1",
+        "Regression: #989",
+    )
+
+    docs_contract_passed = all(
+        snippet in runbook_text for snippet in runbook_required_snippets
+    ) and all(snippet in checklist_text for snippet in checklist_required_snippets)
+    if force_docs_contract_missing:
+        docs_contract_passed = False
+
+    runbook_steps_present = (
+        "## Watchdog Incident Response Flow" in runbook_text and not force_runbook_gap
+    )
+    rollback_checkpoint_validated = runbook_steps_present
+    revocation_propagation_passed = (
+        lifecycle_contract_lane_passed and not force_revocation_gap
+    )
+    operator_signoff_passed = not force_signoff_gap
+
+    elapsed_seconds = int(time.time()) - start_epoch
+
+    reason_codes: list[str] = []
+    if not runbook_steps_present:
+        reason_codes.append("incident_runbook_step_missing")
+    if not rollback_checkpoint_validated:
+        reason_codes.append("rollback_checkpoint_not_validated")
+    if not revocation_propagation_passed:
+        reason_codes.append("signer_revocation_propagation_missing")
+    if not operator_signoff_passed:
+        reason_codes.append("operator_signoff_missing")
+    if not docs_contract_passed:
+        reason_codes.append("docs_contract_missing")
+    if not lifecycle_contract_lane_passed:
+        reason_codes.append("lifecycle_contract_lane_failed")
+    if elapsed_seconds > max_seconds:
+        reason_codes.append("runtime_budget_exceeded")
+
+    reason_codes = sorted(set(reason_codes))
+    status = "pass"
+    final_decision = "GO"
+    if reason_codes:
+        status = "fail"
+        final_decision = "NO-GO"
+
+    reason_codes_value = ",".join(reason_codes) if reason_codes else "none"
+    reason_key = f"signer_incident_recovery_reason_codes:{final_decision}:v1"
+
+    payload = {
+        "schema_version": "kamn.signer.incident-recovery-report.v1",
+        "evidence_key": "signer_incident_recovery:v1",
+        "status": status,
+        "final_decision": final_decision,
+        "reason_key": reason_key,
+        "elapsed_seconds": elapsed_seconds,
+        "max_seconds": max_seconds,
+        "skip_commands": skip_commands,
+        "command_count": len(commands),
+        "commands": commands,
+        "lifecycle_contract_lane_exit_code": lifecycle_contract_lane_exit_code,
+        "lifecycle_contract_lane_passed": lifecycle_contract_lane_passed,
+        "runbook_steps_present": runbook_steps_present,
+        "rollback_checkpoint_validated": rollback_checkpoint_validated,
+        "revocation_propagation_passed": revocation_propagation_passed,
+        "operator_signoff_passed": operator_signoff_passed,
+        "docs_contract_passed": docs_contract_passed,
+        "reason_codes": reason_codes,
+        "generated_epoch": int(time.time()),
+        "report_generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    write_json(output_json, payload)
+
+    print(f"status={status}")
+    print(f"report_file={output_json}")
+    print(f"reason_key={reason_key}")
+    print(f"final_decision={final_decision}")
+    print(f"reason_codes={reason_codes_value}")
+
+    if status != "pass":
+        fail(f"signer incident recovery lane failed closed: {reason_codes_value}")
+    print("signer incident recovery lane tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/signer/signer_incident_recovery_policy_contract.py
+++ b/scripts/signer/signer_incident_recovery_policy_contract.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Signer incident-recovery lane report policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import ContractError, fail, load_json  # noqa: E402
+
+
+def check_report(args: argparse.Namespace) -> int:
+    if not args.report_file:
+        fail("--report-file is required")
+
+    report_path = Path(args.report_file)
+    if not report_path.is_file():
+        fail(f"report file not found: {report_path}")
+
+    payload = load_json(report_path)
+    required_fields = (
+        "schema_version",
+        "evidence_key",
+        "status",
+        "final_decision",
+        "reason_key",
+        "elapsed_seconds",
+        "max_seconds",
+        "skip_commands",
+        "command_count",
+        "commands",
+        "lifecycle_contract_lane_exit_code",
+        "lifecycle_contract_lane_passed",
+        "runbook_steps_present",
+        "rollback_checkpoint_validated",
+        "revocation_propagation_passed",
+        "operator_signoff_passed",
+        "docs_contract_passed",
+        "reason_codes",
+        "generated_epoch",
+        "report_generated_at",
+    )
+    for field_name in required_fields:
+        if field_name not in payload:
+            fail(f"missing field: {field_name}")
+
+    if payload["schema_version"] != "kamn.signer.incident-recovery-report.v1":
+        fail("unexpected schema_version for signer incident recovery report")
+    if payload["evidence_key"] != "signer_incident_recovery:v1":
+        fail("unexpected evidence_key for signer incident recovery report")
+
+    status = payload["status"]
+    if status not in {"pass", "fail"}:
+        fail("status must be pass or fail")
+
+    final_decision = payload["final_decision"]
+    if final_decision not in {"GO", "NO-GO"}:
+        fail("final_decision must be GO or NO-GO")
+
+    expected_reason_key = f"signer_incident_recovery_reason_codes:{final_decision}:v1"
+    if payload["reason_key"] != expected_reason_key:
+        fail(
+            "reason_key mismatch: "
+            f"expected {expected_reason_key}, found {payload['reason_key']}"
+        )
+
+    for field_name in (
+        "elapsed_seconds",
+        "max_seconds",
+        "command_count",
+        "lifecycle_contract_lane_exit_code",
+        "generated_epoch",
+    ):
+        if not isinstance(payload[field_name], int):
+            fail(f"{field_name} must be an integer")
+
+    if payload["max_seconds"] < 0:
+        fail("max_seconds must be non-negative")
+
+    if not isinstance(payload["skip_commands"], bool):
+        fail("skip_commands must be boolean")
+
+    for field_name in (
+        "lifecycle_contract_lane_passed",
+        "runbook_steps_present",
+        "rollback_checkpoint_validated",
+        "revocation_propagation_passed",
+        "operator_signoff_passed",
+        "docs_contract_passed",
+    ):
+        if not isinstance(payload[field_name], bool):
+            fail(f"{field_name} must be boolean")
+
+    commands = payload["commands"]
+    if not isinstance(commands, list):
+        fail("commands must be an array")
+    if not all(isinstance(item, str) and item for item in commands):
+        fail("commands must contain non-empty strings")
+    if payload["command_count"] != len(commands):
+        fail("command_count must match commands length")
+
+    reason_codes = payload["reason_codes"]
+    if not isinstance(reason_codes, list):
+        fail("reason_codes must be an array")
+    if not all(isinstance(item, str) and item for item in reason_codes):
+        fail("reason_codes must contain non-empty strings")
+    if reason_codes != sorted(reason_codes):
+        fail("reason_codes must be sorted and deterministic")
+
+    expected_reasons: list[str] = []
+    if not payload["runbook_steps_present"]:
+        expected_reasons.append("incident_runbook_step_missing")
+    if not payload["rollback_checkpoint_validated"]:
+        expected_reasons.append("rollback_checkpoint_not_validated")
+    if not payload["revocation_propagation_passed"]:
+        expected_reasons.append("signer_revocation_propagation_missing")
+    if not payload["operator_signoff_passed"]:
+        expected_reasons.append("operator_signoff_missing")
+    if not payload["docs_contract_passed"]:
+        expected_reasons.append("docs_contract_missing")
+    if not payload["lifecycle_contract_lane_passed"]:
+        expected_reasons.append("lifecycle_contract_lane_failed")
+    if payload["elapsed_seconds"] > payload["max_seconds"]:
+        expected_reasons.append("runtime_budget_exceeded")
+    expected_reasons = sorted(expected_reasons)
+
+    expected_status = "pass" if not expected_reasons else "fail"
+    expected_decision = "GO" if not expected_reasons else "NO-GO"
+
+    if status != expected_status:
+        fail(f"status mismatch: expected {expected_status}, found {status}")
+    if final_decision != expected_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected final_decision={expected_decision}, found {final_decision}"
+        )
+    if reason_codes != expected_reasons:
+        fail(
+            "reason_codes mismatch: "
+            f"expected reason_codes={expected_reasons}, found {reason_codes}"
+        )
+
+    failed_checks = ",".join(expected_reasons) if expected_reasons else "none"
+    print("status=ok")
+    print(f"report_file={report_path}")
+    print(f"reason_key={payload['reason_key']}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Signer incident recovery report policy checker."
+    )
+    parser.add_argument("--report-file")
+    parser.set_defaults(handler=check_report)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/signer/test_check_signer_incident_recovery_policy.sh
+++ b/scripts/signer/test_check_signer_incident_recovery_policy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_lane.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/signer/check_signer_incident_recovery_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected signer incident recovery lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected signer incident recovery policy checker to be executable" >&2
+  exit 1
+fi
+
+go_report="$TMP_DIR/signer-incident-recovery-go.json"
+KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS=true bash "$LANE_SCRIPT" --output-json "$go_report" >/dev/null
+go_policy_output="$(bash "$POLICY_CHECKER" --report-file "$go_report")"
+assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected signer incident recovery GO policy check status"
+assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected signer incident recovery GO policy decision"
+assert_eq "$(extract_value "$go_policy_output" "failed_checks")" "none" "expected signer incident recovery GO failed checks marker"
+
+no_go_report="$TMP_DIR/signer-incident-recovery-no-go.json"
+set +e
+KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS=true \
+KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_RUNBOOK_GAP=true \
+  bash "$LANE_SCRIPT" --output-json "$no_go_report" >/dev/null 2>&1
+lane_no_go_code=$?
+set -e
+
+if [ "$lane_no_go_code" -eq 0 ]; then
+  echo "expected signer incident recovery runbook-gap lane path to fail closed" >&2
+  exit 1
+fi
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --report-file "$no_go_report")"
+assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected signer incident recovery NO-GO policy check status"
+assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected signer incident recovery NO-GO policy decision"
+if ! printf '%s\n' "$no_go_policy_output" | grep -q "incident_runbook_step_missing"; then
+  echo "expected signer incident recovery NO-GO failed checks to include incident_runbook_step_missing" >&2
+  exit 1
+fi
+
+tampered_report="$TMP_DIR/signer-incident-recovery-no-go-tampered.json"
+cp "$no_go_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "GO"
+payload["reason_key"] = "signer_incident_recovery_reason_codes:GO:v1"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --report-file "$tampered_report" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered signer incident recovery report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected signer incident recovery policy decision mismatch for tampered report" >&2
+  exit 1
+fi
+
+echo "signer incident recovery policy checker tests passed."

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -6,6 +6,8 @@ FAST_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_emulator_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane.sh"
 POLICY_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_policy_contract_lane.sh"
 LIFECYCLE_SCRIPT="$ROOT_DIR/scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh"
+INCIDENT_CONTRACT_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_contract_lane.sh"
+INCIDENT_DEEP_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_deep_lane.sh"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected signer emulator fast-lane runner to be executable" >&2
@@ -24,6 +26,16 @@ fi
 
 if [ ! -x "$LIFECYCLE_SCRIPT" ]; then
   echo "expected signer secure-provider key-lifecycle contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$INCIDENT_CONTRACT_SCRIPT" ]; then
+  echo "expected signer incident recovery contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$INCIDENT_DEEP_SCRIPT" ]; then
+  echo "expected signer incident recovery deep lane runner to be executable" >&2
   exit 1
 fi
 
@@ -71,8 +83,23 @@ if ! grep -q "run_secure_provider_key_lifecycle_contract_lane.sh" "$FAST_SCRIPT"
   exit 1
 fi
 
+if ! grep -q "run_signer_incident_recovery_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected signer emulator contract lane to invoke signer incident recovery contract lane" >&2
+  exit 1
+fi
+
 if ! grep -Fq "performance_signer_emulator_bulk_signing_deep_lane -- --ignored" "$DEEP_SCRIPT"; then
   echo "expected deep-lane script to execute ignored signer provider stress test" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_signer_incident_recovery_deep_lane.sh" "$DEEP_SCRIPT"; then
+  echo "expected signer provider deep lane script to execute signer incident recovery deep lane" >&2
+  exit 1
+fi
+
+if ! grep -Fq "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled" "$DEEP_SCRIPT"; then
+  echo "expected signer provider deep lane script to set scheduled cadence guard for incident recovery deep lane" >&2
   exit 1
 fi
 

--- a/scripts/signer/test_run_signer_incident_recovery_contract_lane.sh
+++ b/scripts/signer/test_run_signer_incident_recovery_contract_lane.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_contract_lane.sh"
+SHARED_CONTRACT="$ROOT_DIR/scripts/signer/signer_incident_recovery_contract_lane_contract.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected signer incident recovery contract lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$SHARED_CONTRACT" ]; then
+  echo "expected signer incident recovery shared contract-lane module to be executable" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/signer-incident-recovery-contract-report.json"
+output="$(
+  KAMN_SIGNER_INCIDENT_RECOVERY_CONTRACT_MAX_SECONDS=240 \
+  KAMN_SIGNER_INCIDENT_RECOVERY_MAX_SECONDS=120 \
+    bash "$SCRIPT" --output-file "$report_file"
+)"
+
+if ! printf '%s\n' "$output" | grep -q 'signer incident recovery contract lane tests passed.'; then
+  echo "expected success output from signer incident recovery contract lane" >&2
+  exit 1
+fi
+
+if [ ! -f "$report_file" ]; then
+  echo "expected signer incident recovery contract lane to emit report file" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.signer.incident-recovery-report.v1"' "$report_file"; then
+  echo "expected signer incident recovery report schema marker in contract lane output" >&2
+  exit 1
+fi
+
+if ! grep -q '"final_decision": "GO"' "$report_file"; then
+  echo "expected GO final decision in signer incident recovery contract lane report" >&2
+  exit 1
+fi
+
+if ! grep -q 'signer_incident_recovery_contract_lane_contract.py' "$SCRIPT"; then
+  echo "expected signer incident recovery contract lane wrapper to dispatch to shared module" >&2
+  exit 1
+fi
+
+if ! grep -q 'check_signer_incident_recovery_policy.sh' "$SHARED_CONTRACT"; then
+  echo "expected signer incident recovery shared contract-lane module to execute policy checker" >&2
+  exit 1
+fi
+
+if ! grep -q 'KAMN_SIGNER_INCIDENT_RECOVERY_CONTRACT_MAX_SECONDS' "$SHARED_CONTRACT"; then
+  echo "expected signer incident recovery shared contract-lane module to enforce runtime guard env marker" >&2
+  exit 1
+fi
+
+if ! grep -q 'KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_RUNBOOK_GAP' "$SHARED_CONTRACT"; then
+  echo "expected signer incident recovery shared contract-lane module to cover forced runbook-gap path" >&2
+  exit 1
+fi
+
+echo "signer incident recovery contract lane script tests passed."

--- a/scripts/signer/test_run_signer_incident_recovery_deep_lane.sh
+++ b/scripts/signer/test_run_signer_incident_recovery_deep_lane.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_lane.sh"
+DEEP_LANE="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_deep_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected signer incident recovery lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_LANE" ]; then
+  echo "expected signer incident recovery deep lane script to be executable" >&2
+  exit 1
+fi
+
+source_report="$TMP_DIR/signer-incident-recovery-source.json"
+KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS=true bash "$LANE_SCRIPT" --output-json "$source_report" >/dev/null
+
+deep_report="$TMP_DIR/signer-incident-recovery-deep-summary.json"
+set +e
+unscheduled_output="$(
+  bash "$DEEP_LANE" \
+    --skip-contract-lane \
+    --report-file "$source_report" \
+    --output-json "$deep_report" 2>&1
+)"
+unscheduled_code=$?
+set -e
+
+if [ "$unscheduled_code" -eq 0 ]; then
+  echo "expected signer incident recovery deep lane cadence guard to reject unscheduled execution" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$unscheduled_output" | grep -q "scheduled-only"; then
+  echo "expected signer incident recovery deep lane cadence rejection marker" >&2
+  exit 1
+fi
+
+scheduled_output="$(
+  KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled \
+    bash "$DEEP_LANE" \
+      --skip-contract-lane \
+      --report-file "$source_report" \
+      --output-json "$deep_report"
+)"
+if ! printf '%s\n' "$scheduled_output" | grep -q "signer incident recovery deep lane tests passed."; then
+  echo "expected signer incident recovery deep lane success marker" >&2
+  exit 1
+fi
+
+python3 - "$deep_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.signer.incident-recovery-deep-summary.v1":
+    raise SystemExit("unexpected signer incident recovery deep report schema")
+if payload.get("lane") != "deep":
+    raise SystemExit("expected deep lane report")
+if payload.get("status") != "pass":
+    raise SystemExit("expected deep lane to pass under scheduled cadence")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected deep lane GO decision under scheduled cadence")
+PY
+
+set +e
+stale_output="$(
+  KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled \
+  KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_STALE_ARTIFACT=true \
+    bash "$DEEP_LANE" \
+      --skip-contract-lane \
+      --report-file "$source_report" \
+      --output-json "$deep_report" 2>&1
+)"
+stale_code=$?
+set -e
+
+if [ "$stale_code" -eq 0 ]; then
+  echo "expected stale signer incident recovery deep artifact to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$stale_output" | grep -q "stale_deep_artifact"; then
+  echo "expected stale deep artifact reason code marker" >&2
+  exit 1
+fi
+
+echo "signer incident recovery deep lane script tests passed."

--- a/scripts/signer/test_run_signer_incident_recovery_lane.sh
+++ b/scripts/signer/test_run_signer_incident_recovery_lane.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected signer incident recovery lane script to be executable" >&2
+  exit 1
+fi
+
+go_report="$TMP_DIR/signer-incident-recovery-go.json"
+go_output="$(
+  KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS=true \
+    bash "$LANE_SCRIPT" --output-json "$go_report"
+)"
+
+if ! printf '%s\n' "$go_output" | grep -q '^status=pass$'; then
+  echo "expected signer incident recovery lane to report pass status for deterministic GO path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$go_output" | grep -q '^final_decision=GO$'; then
+  echo "expected signer incident recovery lane to report GO decision for deterministic GO path" >&2
+  exit 1
+fi
+
+python3 - "$go_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.signer.incident-recovery-report.v1":
+    raise SystemExit("unexpected schema_version for signer incident recovery report")
+if payload.get("status") != "pass":
+    raise SystemExit("expected pass status for signer incident recovery GO path")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected GO final decision for signer incident recovery GO path")
+if payload.get("reason_codes") != []:
+    raise SystemExit("expected empty reason_codes for signer incident recovery GO path")
+PY
+
+no_go_report="$TMP_DIR/signer-incident-recovery-no-go.json"
+set +e
+no_go_output="$(
+  KAMN_SIGNER_INCIDENT_RECOVERY_SKIP_COMMANDS=true \
+  KAMN_SIGNER_INCIDENT_RECOVERY_FORCE_RUNBOOK_GAP=true \
+    bash "$LANE_SCRIPT" --output-json "$no_go_report" 2>&1
+)"
+no_go_code=$?
+set -e
+
+if [ "$no_go_code" -eq 0 ]; then
+  echo "expected forced runbook-gap signer incident recovery lane run to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$no_go_output" | grep -q 'incident_runbook_step_missing'; then
+  echo "expected forced runbook-gap signer incident recovery lane reason code marker" >&2
+  exit 1
+fi
+
+python3 - "$no_go_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("status") != "fail":
+    raise SystemExit("expected fail status for signer incident recovery runbook-gap path")
+if payload.get("final_decision") != "NO-GO":
+    raise SystemExit("expected NO-GO final decision for signer incident recovery runbook-gap path")
+if "incident_runbook_step_missing" not in payload.get("reason_codes", []):
+    raise SystemExit("expected incident_runbook_step_missing reason code in signer incident recovery runbook-gap path")
+PY
+
+echo "signer incident recovery lane script tests passed."


### PR DESCRIPTION
## Summary
Implemented secure-signer incident recovery fast/deep contract-lane coverage with deterministic fail-closed policy checks and scheduled-only deep-lane cadence enforcement. Updated rollback/go-no-go docs and CI target selection so signer recovery changes remain fast in PR while deep validation stays gated behind explicit scheduled cadence.

Closes #989

## Changes
- `scripts/signer/signer_incident_recovery_lane.py`: new signer incident-recovery lane report generator with deterministic reason-code mapping and runtime budget guard.
- `scripts/signer/signer_incident_recovery_policy_contract.py`: new policy checker validating report schema, decision derivation, and reason-code determinism.
- `scripts/signer/signer_incident_recovery_contract_lane_contract.py`: new contract-lane orchestrator covering GO/NO-GO/tamper paths and docs-contract parity checks.
- `scripts/signer/run_signer_incident_recovery_lane.sh`: wrapper for incident-recovery lane runner.
- `scripts/signer/check_signer_incident_recovery_policy.sh`: wrapper for incident-recovery policy checker.
- `scripts/signer/run_signer_incident_recovery_contract_lane.sh`: wrapper for incident-recovery contract lane.
- `scripts/signer/run_signer_incident_recovery_deep_lane.sh`: scheduled-only deep lane with stale-artifact and runtime budget fail-closed guards.
- `scripts/signer/test_run_signer_incident_recovery_lane.sh`: lane GO/NO-GO behavior coverage.
- `scripts/signer/test_check_signer_incident_recovery_policy.sh`: policy checker GO/NO-GO/tamper coverage.
- `scripts/signer/test_run_signer_incident_recovery_contract_lane.sh`: contract-lane wrapper and shared-module contract tests.
- `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`: deep-lane cadence/stale-artifact regression tests.
- `scripts/signer/run_signer_emulator_contract_lane.sh`: now invokes signer incident-recovery contract lane in fast path.
- `scripts/signer/run_signer_provider_deep_lane.sh`: now invokes signer incident-recovery deep lane with scheduled cadence marker.
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`: added incident-recovery fast/deep invocation and cadence-marker assertions.
- `docs/foundation/upgrade-rollback-runbook.md`: added Issue #989 signer incident recovery lane/deep-lane commands, controls, and regression policy.
- `docs/foundation/release-gonogo-checklist.md`: added signer incident recovery go/no-go contract and deep cadence section.
- `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs`: added runbook contract assertions + Regression #989 marker checks.
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`: added checklist contract assertions + Regression #989 marker checks.
- `scripts/ci/select_targets.sh`: upgrade rollback runbook/doc test changes now also trigger signer contract lane.
- `scripts/ci/test_select_targets.sh`: expanded selector regressions for rollback runbook and new signer incident-recovery scripts.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised signer fast/deep lane scripts, cadence guards, and selector matrix locally

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `test_check_signer_incident_recovery_policy.sh` validates policy reason-code mapping and tamper rejection. |
| Functional  | ✅     | `test_run_signer_incident_recovery_lane.sh` and contract lane tests verify GO/NO-GO incident recovery behavior. |
| Integration | ✅     | signer emulator/deep lane scripts now invoke incident recovery contract/deep lanes; validated via `test_run_signer_emulator_contract_lane.sh` and `run_signer_provider_deep_lane.sh`. |
| Regression  | ✅     | stale deep artifacts, unscheduled deep cadence, and report decision tampering are fail-closed (`Regression: #989`). |