### PR TITLE
fix(message): enforce witness selector and proof artifact schema contracts

### DIFF
--- a/crates/kamn-core/src/zk_message_proofs.rs
+++ b/crates/kamn-core/src/zk_message_proofs.rs
@@ -115,6 +115,21 @@ impl ProcessorProofArtifact {
         require_non_empty_artifact_field("message_id", message_id)?;
         require_non_empty_artifact_field("payload_commitment", payload_commitment)?;
         require_non_empty_artifact_field("proof_value", proof_value)?;
+        if !payload_commitment.starts_with("fnv1a64:") {
+            return Err(ZkDesignError::InvalidProofArtifact(
+                "payload_commitment must start with `fnv1a64:`".to_owned(),
+            ));
+        }
+        if payload_commitment == "fnv1a64:" {
+            return Err(ZkDesignError::InvalidProofArtifact(
+                "payload_commitment must include digest bytes".to_owned(),
+            ));
+        }
+        if !proof_value.starts_with("proof:") {
+            return Err(ZkDesignError::InvalidProofArtifact(
+                "proof_value must start with `proof:`".to_owned(),
+            ));
+        }
         Ok(Self {
             artifact_id: artifact_id.to_owned(),
             message_id: message_id.to_owned(),
@@ -914,6 +929,11 @@ pub fn build_message_witness(
                 "private field names must not be empty".to_owned(),
             ));
         }
+        if !is_valid_private_field_selector(field) {
+            return Err(ZkDesignError::InvalidPrivateField(format!(
+                "private field selector `{field}` must contain only [A-Za-z0-9_.-] and no empty path segments"
+            )));
+        }
         if !envelope.body.contains_key(*field) {
             return Err(ZkDesignError::MissingPrivateField((*field).to_owned()));
         }
@@ -967,6 +987,19 @@ fn require_non_empty_artifact_field(field: &str, value: &str) -> Result<(), ZkDe
         )));
     }
     Ok(())
+}
+
+fn is_valid_private_field_selector(selector: &str) -> bool {
+    let trimmed = selector.trim();
+    if trimmed.is_empty() || trimmed.starts_with('.') || trimmed.ends_with('.') {
+        return false;
+    }
+    if trimmed.contains("..") {
+        return false;
+    }
+    trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.')
 }
 
 fn require_non_empty_consensus_field(

--- a/crates/kamn-core/tests/zk_message_proofs.rs
+++ b/crates/kamn-core/tests/zk_message_proofs.rs
@@ -119,6 +119,50 @@ fn zk_message_proofs_reject_missing_hidden_field() {
 }
 
 #[test]
+fn zk_message_proofs_regression_rejects_malformed_private_field_selector() {
+    // Regression: #993
+    let result = build_message_witness(&valid_envelope(), &["task description"]);
+    assert_eq!(
+        result,
+        Err(ZkDesignError::InvalidPrivateField(
+            "private field selector `task description` must contain only [A-Za-z0-9_.-] and no empty path segments".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn zk_message_proofs_reject_invalid_processor_artifact_commitment_shape() {
+    let result = ProcessorProofArtifact::new(
+        "artifact-shape-1",
+        "urn:uuid:msg-shape-1",
+        "sha256:not-a-witness-commitment",
+        "proof:ok:artifact-shape-1",
+    );
+    assert_eq!(
+        result,
+        Err(ZkDesignError::InvalidProofArtifact(
+            "payload_commitment must start with `fnv1a64:`".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn zk_message_proofs_reject_invalid_processor_artifact_proof_value_shape() {
+    let result = ProcessorProofArtifact::new(
+        "artifact-shape-2",
+        "urn:uuid:msg-shape-2",
+        "fnv1a64:abc",
+        "artifact-shape-2",
+    );
+    assert_eq!(
+        result,
+        Err(ZkDesignError::InvalidProofArtifact(
+            "proof_value must start with `proof:`".to_owned()
+        ))
+    );
+}
+
+#[test]
 fn zk_message_proofs_reports_envelope_validation_failures() {
     let mut envelope = valid_envelope();
     envelope.envelope.type_name = "kamn:message:v2".to_owned();

--- a/crates/kamn-core/tests/zk_message_proofs_docs.rs
+++ b/crates/kamn-core/tests/zk_message_proofs_docs.rs
@@ -54,3 +54,11 @@ fn regression_requires_validator_watchdog_mismatch_projection_rule() {
         "invalid-proof mismatch propagation must project as a critical validator mismatch signal"
     ));
 }
+
+#[test]
+fn regression_requires_witness_artifact_contract_lane_marker() {
+    // Regression: #993
+    assert!(DOC.contains("## Witness and Artifact Schema Contract Lane"));
+    assert!(DOC.contains("run_processor_proof_artifact_contract_lane.sh"));
+    assert!(DOC.contains("private field selector syntax drift is rejected (`Regression: #993`)"));
+}

--- a/docs/foundation/zk-message-proof-design.md
+++ b/docs/foundation/zk-message-proof-design.md
@@ -74,6 +74,20 @@ This spike evaluates feasible zero-knowledge (ZK) message-proof designs for PRD 
   - proof value fails deterministic verification format checks
 - Regression guard: tampered processor proof artifacts are rejected before admission (`Regression: #509`).
 
+## Witness and Artifact Schema Contract Lane
+- Contract lane entrypoint:
+  - `bash scripts/message/run_processor_proof_artifact_contract_lane.sh`
+- Evidence and policy helpers:
+  - `scripts/message/generate_processor_proof_artifact_evidence_bundle.sh`
+  - `scripts/message/check_processor_proof_artifact_policy.sh`
+- Schema and reason-code coverage:
+  - artifact fields (`artifact_id`, `message_id`, `payload_commitment`, `proof_value`) are evaluated with deterministic pass/fail checks.
+  - private selectors are required, deduplicated, and syntax-validated.
+  - policy output emits stable `reason_key` and `failed_checks` projections for GO/NO-GO decisions.
+- Runtime budget:
+  - fast contract lane enforces `PROCESSOR_PROOF_ARTIFACT_MAX_SECONDS` (default `90`) to keep PR cost bounded.
+- Regression guard: private field selector syntax drift is rejected (`Regression: #993`).
+
 ## Validator Quorum and Watchdog Projection Contract
 - Validator proof consensus introduces deterministic attestation artifacts:
   - `ValidatorProofAttestation`
@@ -98,6 +112,7 @@ Run the smallest lane needed for rapid feedback:
 
 ```bash
 cargo test -p kamn-core --test zk_message_proofs --test zk_message_proofs_docs
+bash scripts/message/run_processor_proof_artifact_contract_lane.sh
 cargo fmt --check
 cargo clippy -- -D warnings
 ```

--- a/scripts/message/check_processor_proof_artifact_policy.sh
+++ b/scripts/message/check_processor_proof_artifact_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/message/zk_processor_proof_artifact_contract.py" check "$@"

--- a/scripts/message/generate_processor_proof_artifact_evidence_bundle.sh
+++ b/scripts/message/generate_processor_proof_artifact_evidence_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/message/zk_processor_proof_artifact_contract.py" generate "$@"

--- a/scripts/message/run_message_lifecycle_contract_lane.sh
+++ b/scripts/message/run_message_lifecycle_contract_lane.sh
@@ -6,11 +6,13 @@ KEY_HIERARCHY_LANE="$ROOT_DIR/scripts/message/run_key_hierarchy_invariant_contra
 GROUP_REPLAY_RATCHET_LANE="$ROOT_DIR/scripts/message/run_group_sender_replay_ratchet_contract_lane.sh"
 DIDCOMM_COMPAT_LANE="$ROOT_DIR/scripts/message/run_didcomm_envelope_compatibility_contract_lane.sh"
 A2A_MCP_CONFORMANCE_LANE="$ROOT_DIR/scripts/message/run_a2a_mcp_conformance_contract_lane.sh"
+PROCESSOR_PROOF_ARTIFACT_LANE="$ROOT_DIR/scripts/message/run_processor_proof_artifact_contract_lane.sh"
 
 cargo test -p kamn-core --lib message_lifecycle::tests:: >/dev/null
 cargo test -p kamn-core --test message_lifecycle_docs >/dev/null
 bash "$KEY_HIERARCHY_LANE" >/dev/null
 bash "$GROUP_REPLAY_RATCHET_LANE" >/dev/null
+bash "$PROCESSOR_PROOF_ARTIFACT_LANE" --skip-tests >/dev/null
 bash "$DIDCOMM_COMPAT_LANE" --skip-tests >/dev/null
 bash "$A2A_MCP_CONFORMANCE_LANE" --skip-tests >/dev/null
 

--- a/scripts/message/run_processor_proof_artifact_contract_lane.sh
+++ b/scripts/message/run_processor_proof_artifact_contract_lane.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/message/generate_processor_proof_artifact_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/message/check_processor_proof_artifact_policy.sh"
+ZK_DOC="$ROOT_DIR/docs/foundation/zk-message-proof-design.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/message/run_processor_proof_artifact_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "processor proof artifact evidence generator is not executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "processor proof artifact policy checker is not executable"
+fi
+
+if [ ! -f "$ZK_DOC" ]; then
+  fail "expected zk message proof design doc to exist"
+fi
+
+cd "$ROOT_DIR"
+if [ "$skip_tests" != true ]; then
+  bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_regression_rejects_malformed_private_field_selector -- --exact
+  bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_reject_invalid_processor_artifact_commitment_shape -- --exact
+  bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_reject_invalid_processor_artifact_proof_value_shape -- --exact
+  bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test zk_message_proofs_docs regression_requires_witness_artifact_contract_lane_marker -- --exact
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/processor-proof-artifact-contract.json"
+fi
+
+start_epoch="$(date +%s)"
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --artifact-id "artifact-zk-993" \
+    --message-id "urn:uuid:zk-msg-993" \
+    --payload-commitment "fnv1a64:9b4f3e178aa01234" \
+    --proof-value "proof:ok:artifact-zk-993" \
+    --private-selector "task.description" \
+    --private-selector "task.type" \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
+  fail "expected processor proof artifact evidence generation decision to be GO"
+fi
+if ! printf '%s\n' "$generator_output" | grep -q "^reason_key=zk_processor_proof_artifact_reason_codes:GO:v1$"; then
+  fail "expected processor proof artifact GO reason key marker"
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected processor proof artifact policy decision to be GO"
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^failed_checks=none$"; then
+  fail "expected processor proof artifact contract lane to report failed_checks=none"
+fi
+
+if ! grep -Fq "run_processor_proof_artifact_contract_lane.sh" "$ZK_DOC"; then
+  fail "expected zk message proof design doc to reference processor proof artifact contract lane"
+fi
+if ! grep -Fq "Regression: #993" "$ZK_DOC"; then
+  fail "expected zk message proof design doc to include witness/artifact schema regression marker"
+fi
+
+max_seconds="${PROCESSOR_PROOF_ARTIFACT_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  fail "processor proof artifact contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "$(extract_value "$policy_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
+echo "processor proof artifact contract lane tests passed."

--- a/scripts/message/test_generate_processor_proof_artifact_evidence_bundle.sh
+++ b/scripts/message/test_generate_processor_proof_artifact_evidence_bundle.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/message/generate_processor_proof_artifact_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/message/check_processor_proof_artifact_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "expected processor proof artifact evidence generator to be executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "expected processor proof artifact policy checker to be executable"
+fi
+
+go_bundle="$TMP_DIR/processor-proof-artifact-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --artifact-id "artifact-go-1" \
+    --message-id "urn:uuid:msg-go-1" \
+    --payload-commitment "fnv1a64:1111222233334444" \
+    --proof-value "proof:ok:artifact-go-1" \
+    --private-selector "task.description" \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$go_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO decision for valid processor proof artifact evidence bundle"
+fi
+
+if [ ! -f "$go_bundle" ]; then
+  fail "expected GO processor proof artifact evidence bundle file to be created"
+fi
+if ! grep -q '"schema_version": "kamn.zk.processor-proof-artifact-evidence.v1"' "$go_bundle"; then
+  fail "expected processor proof artifact evidence schema marker"
+fi
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+if ! printf '%s\n' "$go_policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO policy decision for valid processor proof artifact evidence bundle"
+fi
+if ! printf '%s\n' "$go_policy_output" | grep -q "^failed_checks=none$"; then
+  fail "expected no failed checks for valid processor proof artifact evidence bundle"
+fi
+
+no_go_bundle="$TMP_DIR/processor-proof-artifact-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --artifact-id "artifact-no-go-1" \
+    --message-id "urn:uuid:msg-no-go-1" \
+    --payload-commitment "fnv1a64:5555666677778888" \
+    --proof-value "proof:ok:artifact-no-go-1" \
+    --private-selector "task..description" \
+    --ci-fast-gate FAIL
+)"
+if ! printf '%s\n' "$no_go_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO decision for invalid selector and failed ci fast gate"
+fi
+if ! printf '%s\n' "$no_go_output" | grep -q "^reason_key=zk_processor_proof_artifact_reason_codes:NO-GO:v1$"; then
+  fail "expected NO-GO reason key marker for invalid selector path"
+fi
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+if ! printf '%s\n' "$no_go_policy_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO policy decision for invalid selector/ci path"
+fi
+if ! printf '%s\n' "$no_go_policy_output" | grep -q "^failed_checks=ci_fast_gate_passed,private_selector_format_valid$"; then
+  fail "expected ci_fast_gate_passed and private_selector_format_valid failed checks"
+fi
+
+tampered_bundle="$TMP_DIR/processor-proof-artifact-tampered.json"
+cp "$go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_exit=$?
+set -e
+if [ "$tampered_exit" -eq 0 ]; then
+  fail "expected tampered final_decision processor proof artifact bundle to fail validation"
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  fail "expected explicit policy decision mismatch marker for tampered processor proof artifact bundle"
+fi
+
+echo "processor proof artifact evidence bundle tests passed."

--- a/scripts/message/test_run_message_lifecycle_contract_lane.sh
+++ b/scripts/message/test_run_message_lifecycle_contract_lane.sh
@@ -34,6 +34,11 @@ if ! grep -Fq "run_group_sender_replay_ratchet_contract_lane.sh" "$FAST_SCRIPT";
   exit 1
 fi
 
+if ! grep -Fq "run_processor_proof_artifact_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected message lifecycle lane to execute processor proof artifact lane checks" >&2
+  exit 1
+fi
+
 if ! grep -Fq "run_didcomm_envelope_compatibility_contract_lane.sh" "$FAST_SCRIPT"; then
   echo "expected message lifecycle lane to execute DIDComm envelope compatibility lane checks" >&2
   exit 1

--- a/scripts/message/test_run_processor_proof_artifact_contract_lane.sh
+++ b/scripts/message/test_run_processor_proof_artifact_contract_lane.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/message/run_processor_proof_artifact_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected processor proof artifact contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/processor-proof-artifact-contract-bundle.json"
+lane_output="$(bash "$SCRIPT" --output-file "$bundle_file")"
+
+if ! printf '%s\n' "$lane_output" | grep -q "processor proof artifact contract lane tests passed."; then
+  echo "expected processor proof artifact contract lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected processor proof artifact contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.zk.processor-proof-artifact-evidence.v1"' "$bundle_file"; then
+  echo "expected processor proof artifact evidence schema marker" >&2
+  exit 1
+fi
+
+echo "processor proof artifact contract lane script tests passed."

--- a/scripts/message/zk_processor_proof_artifact_contract.py
+++ b/scripts/message/zk_processor_proof_artifact_contract.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Processor proof artifact schema evidence generator and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import sys
+from typing import Mapping
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_keys,
+    require_object,
+    require_string,
+    write_json,
+)
+
+SCHEMA_VERSION = "kamn.zk.processor-proof-artifact-evidence.v1"
+EVIDENCE_KEY = "zk_processor_proof_artifact_contract:evidence:v1"
+REASON_PREFIX = "zk_processor_proof_artifact_reason_codes"
+
+_ARTIFACT_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]+")
+
+
+def _selector_is_valid(selector: str) -> bool:
+    if not selector:
+        return False
+    if selector.startswith(".") or selector.endswith("."):
+        return False
+    if ".." in selector:
+        return False
+    return all(
+        ch.isalnum() or ch in ("_", "-", ".")
+        for ch in selector
+    )
+
+
+def _compute_policy_checks(
+    artifact_id: str,
+    message_id: str,
+    payload_commitment: str,
+    proof_value: str,
+    private_selectors: list[str],
+    ci_fast_gate: str,
+) -> Mapping[str, bool]:
+    deduplicated_selectors = set(private_selectors)
+    return {
+        "artifact_id_format_valid": bool(_ARTIFACT_ID_PATTERN.fullmatch(artifact_id or "")),
+        "message_id_format_valid": message_id.startswith("urn:uuid:"),
+        "payload_commitment_format_valid": payload_commitment.startswith("fnv1a64:")
+        and payload_commitment != "fnv1a64:",
+        "proof_value_format_valid": proof_value.startswith("proof:"),
+        "private_selectors_present": len(private_selectors) > 0,
+        "private_selector_format_valid": all(
+            _selector_is_valid(selector) for selector in private_selectors
+        ),
+        "private_selector_deduplicated": len(deduplicated_selectors)
+        == len(private_selectors),
+        "ci_fast_gate_passed": ci_fast_gate == "PASS",
+    }
+
+
+def _reason_messages() -> Mapping[str, str]:
+    return {
+        "artifact_id_format_valid": "artifact_id must match [A-Za-z0-9._:-]+",
+        "message_id_format_valid": "message_id must start with urn:uuid:",
+        "payload_commitment_format_valid": "payload_commitment must start with fnv1a64:",
+        "proof_value_format_valid": "proof_value must start with proof:",
+        "private_selectors_present": "at least one private selector is required",
+        "private_selector_format_valid": "private selector syntax is invalid",
+        "private_selector_deduplicated": "private selectors must be deduplicated",
+        "ci_fast_gate_passed": "ci-fast-gate-failed",
+    }
+
+
+def _reason_key(decision: str) -> str:
+    return f"{REASON_PREFIX}:{decision}:v1"
+
+
+def _failed_checks(policy_checks: Mapping[str, bool]) -> list[str]:
+    return sorted([name for name, passed in policy_checks.items() if not passed])
+
+
+def _parse_private_selectors(values: list[str]) -> list[str]:
+    selectors: list[str] = []
+    for value in values:
+        parsed = value.strip()
+        if parsed:
+            selectors.append(parsed)
+    return selectors
+
+
+def _require_policy_checks(payload: Mapping[str, object]) -> Mapping[str, bool]:
+    policy_checks_raw = payload.get("policy_checks")
+    if not isinstance(policy_checks_raw, dict):
+        fail("policy_checks must be an object")
+
+    policy_checks: dict[str, bool] = {}
+    for key_name in _reason_messages().keys():
+        if key_name not in policy_checks_raw:
+            fail(f"missing policy_checks field: {key_name}")
+        value = policy_checks_raw[key_name]
+        if not isinstance(value, bool):
+            fail(f"policy_checks.{key_name} must be boolean")
+        policy_checks[key_name] = value
+    return policy_checks
+
+
+def _require_private_selectors(payload: Mapping[str, object]) -> list[str]:
+    selectors_raw = payload.get("private_selectors")
+    if not isinstance(selectors_raw, list):
+        fail("private_selectors must be a list")
+    selectors: list[str] = []
+    for idx, value in enumerate(selectors_raw):
+        if not isinstance(value, str):
+            fail(f"private_selectors[{idx}] must be a string")
+        selectors.append(value)
+    return selectors
+
+
+def _compute_decision(policy_checks: Mapping[str, bool]) -> tuple[str, list[str], list[str]]:
+    decision = DecisionAccumulator()
+    reason_messages = _reason_messages()
+    for check_name in reason_messages:
+        decision.reject_if(not policy_checks[check_name], reason_messages[check_name])
+    final_decision, decision_reasons = decision.finalize(
+        "processor proof artifact schema checks satisfied"
+    )
+    failed_checks = _failed_checks(policy_checks)
+    return final_decision, decision_reasons, failed_checks
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    require_enum("ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+    private_selectors = _parse_private_selectors(args.private_selector)
+    policy_checks = _compute_policy_checks(
+        artifact_id=args.artifact_id,
+        message_id=args.message_id,
+        payload_commitment=args.payload_commitment,
+        proof_value=args.proof_value,
+        private_selectors=private_selectors,
+        ci_fast_gate=args.ci_fast_gate,
+    )
+    final_decision, decision_reasons, failed_checks = _compute_decision(policy_checks)
+    reason_key = _reason_key(final_decision)
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "evidence_key": EVIDENCE_KEY,
+        "artifact": {
+            "artifact_id": args.artifact_id,
+            "message_id": args.message_id,
+            "payload_commitment": args.payload_commitment,
+            "proof_value": args.proof_value,
+        },
+        "private_selectors": private_selectors,
+        "ci_fast_gate": args.ci_fast_gate,
+        "policy_checks": policy_checks,
+        "failed_checks": failed_checks,
+        "decision_reasons": decision_reasons,
+        "reason_key": reason_key,
+        "final_decision": final_decision,
+    }
+
+    output_path = Path(args.output_file)
+    write_json(output_path, payload)
+
+    failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
+    print("status=generated")
+    print(f"bundle_file={output_path}")
+    print(f"evidence_key={EVIDENCE_KEY}")
+    print(f"reason_key={reason_key}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def check_bundle(args: argparse.Namespace) -> int:
+    bundle_path = Path(args.bundle_file)
+    if not bundle_path.is_file():
+        fail(f"bundle file not found: {bundle_path}")
+
+    payload = load_json(bundle_path)
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "generated_at",
+            "evidence_key",
+            "artifact",
+            "private_selectors",
+            "ci_fast_gate",
+            "policy_checks",
+            "failed_checks",
+            "decision_reasons",
+            "reason_key",
+            "final_decision",
+        ),
+    )
+    if require_string(payload, "schema_version") != SCHEMA_VERSION:
+        fail("schema_version must be kamn.zk.processor-proof-artifact-evidence.v1")
+    if require_string(payload, "evidence_key") != EVIDENCE_KEY:
+        fail("evidence_key mismatch")
+    require_string(payload, "generated_at")
+    ci_fast_gate = require_enum(
+        "ci_fast_gate", require_string(payload, "ci_fast_gate"), ("PASS", "FAIL")
+    )
+    final_decision = require_enum(
+        "final_decision", require_string(payload, "final_decision"), ("GO", "NO-GO")
+    )
+    reason_key = require_string(payload, "reason_key")
+
+    artifact = require_object(payload, "artifact")
+    artifact_id = require_string(artifact, "artifact_id")
+    message_id = require_string(artifact, "message_id")
+    payload_commitment = require_string(artifact, "payload_commitment")
+    proof_value = require_string(artifact, "proof_value")
+    private_selectors = _require_private_selectors(payload)
+    reported_policy_checks = _require_policy_checks(payload)
+
+    recomputed_policy_checks = _compute_policy_checks(
+        artifact_id=artifact_id,
+        message_id=message_id,
+        payload_commitment=payload_commitment,
+        proof_value=proof_value,
+        private_selectors=private_selectors,
+        ci_fast_gate=ci_fast_gate,
+    )
+    if reported_policy_checks != recomputed_policy_checks:
+        fail(
+            "policy_checks mismatch: "
+            f"expected {recomputed_policy_checks}, found {reported_policy_checks}"
+        )
+
+    expected_decision, expected_reasons, expected_failed_checks = _compute_decision(
+        recomputed_policy_checks
+    )
+    if final_decision != expected_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected {expected_decision}, found {final_decision}"
+        )
+
+    expected_reason_key = _reason_key(expected_decision)
+    if reason_key != expected_reason_key:
+        fail(f"reason_key mismatch: expected {expected_reason_key}, found {reason_key}")
+
+    decision_reasons = payload.get("decision_reasons")
+    if decision_reasons != expected_reasons:
+        fail(
+            "decision_reasons mismatch: "
+            f"expected {expected_reasons}, found {decision_reasons}"
+        )
+
+    failed_checks = payload.get("failed_checks")
+    if failed_checks != expected_failed_checks:
+        fail(
+            "failed_checks mismatch: "
+            f"expected {expected_failed_checks}, found {failed_checks}"
+        )
+
+    failed_checks_value = ",".join(expected_failed_checks) if expected_failed_checks else "none"
+    print("status=validated")
+    print(f"bundle_file={bundle_path}")
+    print(f"reason_key={expected_reason_key}")
+    print(f"final_decision={expected_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate/check processor proof artifact schema contract evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate", help="Generate evidence bundle")
+    generate_parser.add_argument("--output-file", required=True)
+    generate_parser.add_argument("--artifact-id", required=True)
+    generate_parser.add_argument("--message-id", required=True)
+    generate_parser.add_argument("--payload-commitment", required=True)
+    generate_parser.add_argument("--proof-value", required=True)
+    generate_parser.add_argument(
+        "--private-selector",
+        action="append",
+        default=[],
+        help="Private selector to enforce (repeatable)",
+    )
+    generate_parser.add_argument("--ci-fast-gate", default="PASS")
+    generate_parser.set_defaults(handler=generate_bundle)
+
+    check_parser = subparsers.add_parser("check", help="Validate an evidence bundle")
+    check_parser.add_argument("--bundle-file", required=True)
+    check_parser.set_defaults(handler=check_bundle)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except ContractError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds strict witness-selector and processor proof-artifact schema contracts for ZK message proofs, plus a new fast contract lane and policy evidence checks. This closes the remaining gap between modeled proof concepts and deterministic, auditable contract-lane enforcement for artifact/schema drift.

## Changes
- `crates/kamn-core/src/zk_message_proofs.rs`: enforce private-selector syntax and artifact field schema guards (`payload_commitment` prefix + non-empty digest, `proof_value` prefix).
- `crates/kamn-core/tests/zk_message_proofs.rs`: add regression and schema tests for malformed selectors and malformed artifact fields.
- `crates/kamn-core/tests/zk_message_proofs_docs.rs`: add doc-contract regression for witness/artifact contract-lane marker.
- `docs/foundation/zk-message-proof-design.md`: add witness/artifact schema lane section, scripts, runtime budget, and regression marker.
- `scripts/message/zk_processor_proof_artifact_contract.py`: new generate/check contract logic with deterministic policy checks and reason keys.
- `scripts/message/generate_processor_proof_artifact_evidence_bundle.sh`: generator wrapper.
- `scripts/message/check_processor_proof_artifact_policy.sh`: checker wrapper.
- `scripts/message/run_processor_proof_artifact_contract_lane.sh`: fast-lane runner with runtime budget and doc marker checks.
- `scripts/message/test_generate_processor_proof_artifact_evidence_bundle.sh`: generator/policy contract tests including tamper mismatch path.
- `scripts/message/test_run_processor_proof_artifact_contract_lane.sh`: lane runner smoke contract test.
- `scripts/message/run_message_lifecycle_contract_lane.sh`: wire processor proof artifact lane into message lifecycle contract lane.
- `scripts/message/test_run_message_lifecycle_contract_lane.sh`: assert lane wiring.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test zk_message_proofs --test zk_message_proofs_docs
```
Observed failures before implementation:
- `zk_message_proofs_regression_rejects_malformed_private_field_selector`
- `zk_message_proofs_reject_invalid_processor_artifact_commitment_shape`
- `zk_message_proofs_reject_invalid_processor_artifact_proof_value_shape`
- `regression_requires_witness_artifact_contract_lane_marker`

Representative failure details:
- expected `InvalidPrivateField(...)`, found `MissingPrivateField("task description")`
- expected invalid artifact schema errors, found `Ok(ProcessorProofArtifact { ... })`
- doc missing `## Witness and Artifact Schema Contract Lane`

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test zk_message_proofs --test zk_message_proofs_docs
bash scripts/message/test_generate_processor_proof_artifact_evidence_bundle.sh
bash scripts/message/test_run_processor_proof_artifact_contract_lane.sh
bash scripts/message/test_run_message_lifecycle_contract_lane.sh
```
Result: all pass.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
bash scripts/ci/test_select_targets.sh
```
Result: all pass.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `zk_message_proofs_reject_invalid_processor_artifact_commitment_shape`, `zk_message_proofs_reject_invalid_processor_artifact_proof_value_shape` | |
| Functional   | ✅ | `scripts/message/test_generate_processor_proof_artifact_evidence_bundle.sh` GO/NO-GO policy paths | |
| Integration  | ✅ | `scripts/message/test_run_processor_proof_artifact_contract_lane.sh`, message lifecycle lane wiring test update | |
| Regression   | ✅ | `zk_message_proofs_regression_rejects_malformed_private_field_selector`, `regression_requires_witness_artifact_contract_lane_marker` | |
| Performance  | ✅ | `run_processor_proof_artifact_contract_lane.sh` enforces `PROCESSOR_PROOF_ARTIFACT_MAX_SECONDS` (default 90) | |

## Risks & Rollback
- No breaking API surface expected; stricter schema validation may fail previously-permissive malformed artifact inputs by design.
- Rollback plan: revert this PR commit and rerun message contract lanes to restore prior permissive behavior.

## Documentation Updates
- `docs/foundation/zk-message-proof-design.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant lanes + selector matrix)
- [x] Docs updated (or justified why not)

Closes #993
