### PR TITLE
test(runtime): add zk witness mutation fuzz/property contract lanes

### DIFF
--- a/crates/kamn-core/tests/invariants_docs.rs
+++ b/crates/kamn-core/tests/invariants_docs.rs
@@ -20,3 +20,11 @@ fn regression_requires_dispute_refund_property_and_concurrency_contract_markers(
     assert!(DOC.contains("run_concurrency_state_mutation_contract_lane.sh"));
     assert!(DOC.contains("Regression: #904"));
 }
+
+#[test]
+fn regression_requires_zk_witness_mutation_contract_markers() {
+    // Regression: #994
+    assert!(DOC.contains("run_zk_witness_mutation_contract_lane.sh"));
+    assert!(DOC.contains("run_zk_witness_mutation_deep_lane.sh"));
+    assert!(DOC.contains("KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP"));
+}

--- a/crates/kamn-core/tests/zk_message_proofs_docs.rs
+++ b/crates/kamn-core/tests/zk_message_proofs_docs.rs
@@ -62,3 +62,12 @@ fn regression_requires_witness_artifact_contract_lane_marker() {
     assert!(DOC.contains("run_processor_proof_artifact_contract_lane.sh"));
     assert!(DOC.contains("private field selector syntax drift is rejected (`Regression: #993`)"));
 }
+
+#[test]
+fn regression_requires_witness_mutation_fast_and_deep_lane_markers() {
+    // Regression: #994
+    assert!(DOC.contains("## Witness Mutation Property and Fuzz Lanes"));
+    assert!(DOC.contains("run_zk_witness_mutation_contract_lane.sh"));
+    assert!(DOC.contains("run_zk_witness_mutation_deep_lane.sh"));
+    assert!(DOC.contains("performance_zk_witness_mutation_deep_lane_stress -- --ignored"));
+}

--- a/crates/kamn-core/tests/zk_witness_fuzz_smoke.rs
+++ b/crates/kamn-core/tests/zk_witness_fuzz_smoke.rs
@@ -1,0 +1,316 @@
+use kamn_core::{
+    build_message_witness, AttachmentRef, CanonicalMessageEnvelope, EnvelopeEncryption,
+    EnvelopeHeader, EnvelopeMetadata, EnvelopeProof, MessageEnvelopeError, ZkDesignError,
+};
+use std::collections::BTreeMap;
+use std::panic::catch_unwind;
+use std::time::Instant;
+
+fn base_body() -> BTreeMap<String, String> {
+    let mut body = BTreeMap::new();
+    body.insert("task.type".to_owned(), "analysis".to_owned());
+    body.insert(
+        "task.description".to_owned(),
+        "generated witness payload".to_owned(),
+    );
+    body.insert("task.customer".to_owned(), "acme".to_owned());
+    body
+}
+
+fn valid_envelope() -> CanonicalMessageEnvelope {
+    CanonicalMessageEnvelope {
+        envelope: EnvelopeMetadata {
+            id: "urn:uuid:zk-fuzz-smoke".to_owned(),
+            type_name: "kamn:message:v1".to_owned(),
+            from: "kamn:did:agent:sender-1".to_owned(),
+            to: vec!["kamn:did:agent:recipient-1".to_owned()],
+            created: "2026-02-10T00:00:00.000Z".to_owned(),
+            expires: "2026-02-10T00:10:00.000Z".to_owned(),
+            thread_id: Some("urn:uuid:zk-fuzz-thread".to_owned()),
+            parent_id: None,
+            nonce: 17,
+        },
+        header: EnvelopeHeader {
+            message_type: "Request".to_owned(),
+            priority: "Normal".to_owned(),
+            content_type: "application/json".to_owned(),
+            encryption: EnvelopeEncryption {
+                algorithm: "X25519-XChaCha20-Poly1305".to_owned(),
+                recipient_keys: vec!["kamn:did:agent:recipient-1#key-agreement-1".to_owned()],
+            },
+        },
+        body: base_body(),
+        attachments: vec![AttachmentRef {
+            id: "attachment-1".to_owned(),
+            media_type: "application/json".to_owned(),
+            uri: "ipfs://bafybeizkwitness".to_owned(),
+        }],
+        proof: EnvelopeProof {
+            type_name: "Ed25519Signature2020".to_owned(),
+            created: "2026-02-10T00:00:00.000Z".to_owned(),
+            verification_method: "kamn:did:agent:sender-1#keys-1".to_owned(),
+            proof_purpose: "authentication".to_owned(),
+            proof_value: "z58DAdFfa9SkqZMVPxAQp".to_owned(),
+        },
+    }
+}
+
+fn mutation_slot(seed: u64, slots: usize) -> usize {
+    let mixed = seed
+        .wrapping_mul(11400714819323198485)
+        .wrapping_add(14029467366897019727);
+    (mixed % slots as u64) as usize
+}
+
+fn mutate_selector(seed: u64) -> String {
+    match mutation_slot(seed, 8) {
+        0 => "task.description".to_owned(),
+        1 => "task.type".to_owned(),
+        2 => "task.customer".to_owned(),
+        3 => "task..description".to_owned(),
+        4 => "task description".to_owned(),
+        5 => ".task.description".to_owned(),
+        6 => "task.description.".to_owned(),
+        7 => "task.unknown".to_owned(),
+        _ => unreachable!("selector slot is bounded"),
+    }
+}
+
+fn mutate_envelope_case(
+    mut envelope: CanonicalMessageEnvelope,
+    seed: u64,
+) -> CanonicalMessageEnvelope {
+    match mutation_slot(seed.rotate_left(9), 6) {
+        0 => envelope,
+        1 => {
+            envelope.envelope.type_name = "kamn:message:v2".to_owned();
+            envelope
+        }
+        2 => {
+            envelope.envelope.from = "did:example:sender".to_owned();
+            envelope
+        }
+        3 => {
+            envelope.body.remove("task.description");
+            envelope
+        }
+        4 => {
+            envelope.header.message_type = "UnknownType".to_owned();
+            envelope
+        }
+        5 => {
+            envelope.proof.verification_method = "kamn:did:agent:attacker-1#keys-9".to_owned();
+            envelope
+        }
+        _ => unreachable!("envelope slot is bounded"),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ZkWitnessMutationClass {
+    MalformedSelector,
+    MissingField,
+    TamperedEnvelope,
+}
+
+#[derive(Debug, Clone)]
+struct ZkWitnessMutationCase {
+    id: &'static str,
+    class: ZkWitnessMutationClass,
+    envelope: CanonicalMessageEnvelope,
+    selector: &'static str,
+    expected_error: ZkDesignError,
+}
+
+fn deterministic_zk_witness_mutation_cases() -> Vec<ZkWitnessMutationCase> {
+    let mut tampered_envelope = valid_envelope();
+    tampered_envelope.envelope.type_name = "kamn:message:v2".to_owned();
+
+    vec![
+        ZkWitnessMutationCase {
+            id: "malformed-selector-whitespace",
+            class: ZkWitnessMutationClass::MalformedSelector,
+            envelope: valid_envelope(),
+            selector: "task description",
+            expected_error: ZkDesignError::InvalidPrivateField(
+                "private field selector `task description` must contain only [A-Za-z0-9_.-] and no empty path segments".to_owned(),
+            ),
+        },
+        ZkWitnessMutationCase {
+            id: "missing-selector-field",
+            class: ZkWitnessMutationClass::MissingField,
+            envelope: valid_envelope(),
+            selector: "task.unknown",
+            expected_error: ZkDesignError::MissingPrivateField("task.unknown".to_owned()),
+        },
+        ZkWitnessMutationCase {
+            id: "tampered-envelope-type",
+            class: ZkWitnessMutationClass::TamperedEnvelope,
+            envelope: tampered_envelope,
+            selector: "task.description",
+            expected_error: ZkDesignError::EnvelopeError(MessageEnvelopeError::InvalidEnvelopeType(
+                "kamn:message:v2".to_owned(),
+            )),
+        },
+    ]
+}
+
+#[test]
+fn fuzz_smoke_zk_witness_mutation_lane_is_panic_free_and_deterministic() {
+    for seed in 0_u64..1024 {
+        let envelope = mutate_envelope_case(valid_envelope(), seed);
+        let selector = mutate_selector(seed);
+
+        let first = catch_unwind(|| build_message_witness(&envelope, &[selector.as_str()]));
+        assert!(first.is_ok(), "witness generation panicked for seed {seed}");
+
+        let first = first.expect("panic-free witness result should unwrap");
+        let second = build_message_witness(&envelope, &[selector.as_str()]);
+        assert_eq!(
+            first, second,
+            "witness result should remain deterministic for mutation seed {seed}"
+        );
+    }
+}
+
+#[test]
+fn fuzz_smoke_zk_witness_error_corpus_covers_expected_rejection_classes() {
+    assert_eq!(
+        build_message_witness(&valid_envelope(), &["task..description"]),
+        Err(ZkDesignError::InvalidPrivateField(
+            "private field selector `task..description` must contain only [A-Za-z0-9_.-] and no empty path segments".to_owned(),
+        ))
+    );
+    assert_eq!(
+        build_message_witness(&valid_envelope(), &["task description"]),
+        Err(ZkDesignError::InvalidPrivateField(
+            "private field selector `task description` must contain only [A-Za-z0-9_.-] and no empty path segments".to_owned(),
+        ))
+    );
+    assert_eq!(
+        build_message_witness(&valid_envelope(), &["task.unknown"]),
+        Err(ZkDesignError::MissingPrivateField(
+            "task.unknown".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn functional_zk_witness_mutation_suite_covers_malformed_missing_and_tampered_classes() {
+    let cases = deterministic_zk_witness_mutation_cases();
+    let mut saw_malformed = false;
+    let mut saw_missing = false;
+    let mut saw_tampered = false;
+
+    for case in &cases {
+        let actual = build_message_witness(&case.envelope, &[case.selector])
+            .expect_err("mutation corpus entries must fail closed");
+        assert_eq!(
+            actual, case.expected_error,
+            "unexpected fail-closed reason for case {}",
+            case.id
+        );
+
+        match case.class {
+            ZkWitnessMutationClass::MalformedSelector => saw_malformed = true,
+            ZkWitnessMutationClass::MissingField => saw_missing = true,
+            ZkWitnessMutationClass::TamperedEnvelope => saw_tampered = true,
+        }
+    }
+
+    assert!(
+        saw_malformed,
+        "malformed selector mutation class must be covered"
+    );
+    assert!(
+        saw_missing,
+        "missing selector field mutation class must be covered"
+    );
+    assert!(
+        saw_tampered,
+        "tampered envelope mutation class must be covered"
+    );
+}
+
+#[test]
+fn integration_zk_witness_mutation_fail_closed_reasons_are_explicit_and_deterministic() {
+    for case in deterministic_zk_witness_mutation_cases() {
+        let first =
+            build_message_witness(&case.envelope, &[case.selector]).expect_err("must fail closed");
+        let second =
+            build_message_witness(&case.envelope, &[case.selector]).expect_err("must fail closed");
+        assert_eq!(first, second, "reason drifted for case {}", case.id);
+        let reason = first.to_string();
+        assert!(
+            !reason.trim().is_empty(),
+            "fail-closed reason must be explicit for case {}",
+            case.id
+        );
+    }
+}
+
+#[test]
+fn regression_zk_witness_mutation_reason_signatures_remain_stable() {
+    // Regression: #994
+    let error = build_message_witness(&valid_envelope(), &["task description"])
+        .expect_err("whitespace selector must fail closed");
+    assert_eq!(
+        error,
+        ZkDesignError::InvalidPrivateField(
+            "private field selector `task description` must contain only [A-Za-z0-9_.-] and no empty path segments".to_owned(),
+        )
+    );
+    assert_eq!(
+        error.to_string(),
+        "invalid private field: private field selector `task description` must contain only [A-Za-z0-9_.-] and no empty path segments"
+    );
+}
+
+#[test]
+fn performance_zk_witness_mutation_contract_lane_stays_within_budget() {
+    let started = Instant::now();
+    let mut accepted = 0_u64;
+    let mut rejected = 0_u64;
+
+    for seed in 0_u64..1536 {
+        let envelope = mutate_envelope_case(valid_envelope(), seed);
+        let selector = mutate_selector(seed);
+        if build_message_witness(&envelope, &[selector.as_str()]).is_ok() {
+            accepted += 1;
+        } else {
+            rejected += 1;
+        }
+    }
+
+    assert!(
+        accepted > 0,
+        "mutation lane should retain valid witness samples"
+    );
+    assert!(
+        rejected > 0,
+        "mutation lane should reject invalid witness samples"
+    );
+
+    let elapsed_millis = started.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 450,
+        "zk witness mutation contract lane exceeded budget: {elapsed_millis}ms"
+    );
+}
+
+#[test]
+#[ignore = "scheduled deep mutation stress lane"]
+fn performance_zk_witness_mutation_deep_lane_stress() {
+    let started = Instant::now();
+    for seed in 0_u64..40_000 {
+        let envelope = mutate_envelope_case(valid_envelope(), seed);
+        let selector = mutate_selector(seed);
+        let _ = build_message_witness(&envelope, &[selector.as_str()]);
+    }
+
+    let elapsed_millis = started.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 4_000,
+        "zk witness deep mutation lane exceeded budget: {elapsed_millis}ms"
+    );
+}

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -27,6 +27,11 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh`
 - Fuzz/mutation fail-closed lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
+- ZK witness mutation fast lane:
+  - `bash scripts/runtime/run_zk_witness_mutation_contract_lane.sh`
+- ZK witness mutation deep lane (scheduled):
+  - `bash scripts/runtime/run_zk_witness_mutation_deep_lane.sh`
+  - route via `KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP=true` when running `run_input_mutation_contract_lane.sh`.
 - Concurrency state-mutation lane:
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
 - Combined bounded lane with evidence output:
@@ -48,6 +53,16 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
 - Fail-closed regression marker:
   - dispute/refund replay mutation drift is rejected (`Regression: #904`).
+
+## ZK Witness Mutation Contracts (Issue #994)
+- Fast smoke/property lane:
+  - `cargo test -p kamn-core --test zk_witness_fuzz_smoke fuzz_smoke_zk_witness_mutation_lane_is_panic_free_and_deterministic -- --exact`
+  - `cargo test -p kamn-core --test zk_witness_fuzz_smoke functional_zk_witness_mutation_suite_covers_malformed_missing_and_tampered_classes -- --exact`
+- Deep scheduled lane:
+  - `cargo test -p kamn-core --test zk_witness_fuzz_smoke performance_zk_witness_mutation_deep_lane_stress -- --ignored`
+  - `bash scripts/runtime/run_zk_witness_mutation_deep_lane.sh`
+- Fail-closed regression marker:
+  - selector/envelope mutation reason signatures remain stable (`Regression: #994`).
 
 ## Validation
 Run from repository root:

--- a/docs/foundation/zk-message-proof-design.md
+++ b/docs/foundation/zk-message-proof-design.md
@@ -88,6 +88,21 @@ This spike evaluates feasible zero-knowledge (ZK) message-proof designs for PRD 
   - fast contract lane enforces `PROCESSOR_PROOF_ARTIFACT_MAX_SECONDS` (default `90`) to keep PR cost bounded.
 - Regression guard: private field selector syntax drift is rejected (`Regression: #993`).
 
+## Witness Mutation Property and Fuzz Lanes
+- Fast mutation lane (PR-safe):
+  - `bash scripts/runtime/run_zk_witness_mutation_contract_lane.sh`
+- Scheduled deep mutation lane:
+  - `bash scripts/runtime/run_zk_witness_mutation_deep_lane.sh`
+  - runs `performance_zk_witness_mutation_deep_lane_stress -- --ignored` after fast-lane checks.
+- Mutation classes covered:
+  - malformed selector syntax
+  - missing selector field references
+  - tampered canonical envelope fields
+- Routing:
+  - `scripts/runtime/run_input_mutation_contract_lane.sh` defaults to fast ZK witness mutation checks.
+  - set `KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP=true` to route to deep mutation coverage in scheduled lanes.
+- Regression guard: deterministic witness mutation reason signatures remain stable (`Regression: #994`).
+
 ## Validator Quorum and Watchdog Projection Contract
 - Validator proof consensus introduces deterministic attestation artifacts:
   - `ValidatorProofAttestation`
@@ -113,6 +128,7 @@ Run the smallest lane needed for rapid feedback:
 ```bash
 cargo test -p kamn-core --test zk_message_proofs --test zk_message_proofs_docs
 bash scripts/message/run_processor_proof_artifact_contract_lane.sh
+bash scripts/runtime/run_zk_witness_mutation_contract_lane.sh
 cargo fmt --check
 cargo clippy -- -D warnings
 ```
@@ -121,4 +137,10 @@ Then run the crate regression lane:
 
 ```bash
 cargo test -p kamn-core
+```
+
+Scheduled deep-lane mutation command:
+
+```bash
+bash scripts/runtime/run_zk_witness_mutation_deep_lane.sh
 ```

--- a/scripts/runtime/run_input_mutation_contract_lane.sh
+++ b/scripts/runtime/run_input_mutation_contract_lane.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ZK_WITNESS_MUTATION_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
+ZK_WITNESS_MUTATION_DEEP_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_deep_lane.sh"
 cd "$ROOT_DIR"
 
 # Keep deterministic mutation coverage bounded for fast, low-cost PR validation.
@@ -16,6 +18,12 @@ cargo test -p kamn-core --test did_fuzz_smoke functional_did_mutation_suite_cove
 cargo test -p kamn-core --test did_fuzz_smoke integration_did_mutation_fail_closed_reasons_are_explicit_and_deterministic -- --exact >/dev/null
 cargo test -p kamn-core --test did_fuzz_smoke regression_did_mutation_reason_signatures_remain_stable -- --exact >/dev/null
 cargo test -p kamn-core --test did_fuzz_smoke performance_did_mutation_contract_lane_stays_within_budget -- --exact >/dev/null
+
+if [ "${KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP:-false}" = "true" ]; then
+  bash "$ZK_WITNESS_MUTATION_DEEP_LANE" >/dev/null
+else
+  bash "$ZK_WITNESS_MUTATION_LANE" >/dev/null
+fi
 
 cargo test -p kamn-core --test runtime_network_docs doc_contains_mutation_fail_closed_contract_rules -- --exact >/dev/null
 

--- a/scripts/runtime/run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/run_runtime_snapshot_contract_lane.sh
@@ -16,6 +16,8 @@ cargo test -p kamn-core --test runtime_watchdog_attestation_docs >/dev/null
 cargo test -p kamn-core --test live_network_wave_docs >/dev/null
 bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh >/dev/null
 bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh >/dev/null
+bash scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh >/dev/null
+bash scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh >/dev/null
 bash scripts/runtime/test_select_failover_sync_drill_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_deep_lane.sh >/dev/null

--- a/scripts/runtime/run_zk_witness_mutation_contract_lane.sh
+++ b/scripts/runtime/run_zk_witness_mutation_contract_lane.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+cargo test -p kamn-core --test zk_witness_fuzz_smoke fuzz_smoke_zk_witness_mutation_lane_is_panic_free_and_deterministic -- --exact >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke fuzz_smoke_zk_witness_error_corpus_covers_expected_rejection_classes -- --exact >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke functional_zk_witness_mutation_suite_covers_malformed_missing_and_tampered_classes -- --exact >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke integration_zk_witness_mutation_fail_closed_reasons_are_explicit_and_deterministic -- --exact >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke regression_zk_witness_mutation_reason_signatures_remain_stable -- --exact >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke performance_zk_witness_mutation_contract_lane_stays_within_budget -- --exact >/dev/null
+
+echo "runtime zk witness mutation contract lane tests passed."

--- a/scripts/runtime/run_zk_witness_mutation_deep_lane.sh
+++ b/scripts/runtime/run_zk_witness_mutation_deep_lane.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAST_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
+
+bash "$FAST_LANE" >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke performance_zk_witness_mutation_deep_lane_stress -- --ignored >/dev/null
+
+echo "runtime zk witness mutation deep lane tests passed."

--- a/scripts/runtime/test_run_input_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_input_mutation_contract_lane.sh
@@ -29,6 +29,16 @@ if ! grep -q "regression_did_mutation_reason_signatures_remain_stable" "$CONTRAC
   exit 1
 fi
 
+if ! grep -q "run_zk_witness_mutation_contract_lane.sh" "$CONTRACT_LANE"; then
+  echo "expected mutation lane to include ZK witness mutation contract lane coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP" "$CONTRACT_LANE"; then
+  echo "expected mutation lane to support fast/deep ZK witness mutation routing" >&2
+  exit 1
+fi
+
 lane_output="$(bash "$CONTRACT_LANE")"
 if ! printf '%s\n' "$lane_output" | grep -q "runtime input mutation contract lane tests passed."; then
   echo "expected runtime input mutation contract lane success marker" >&2

--- a/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
@@ -69,6 +69,16 @@ if ! grep -q "test_check_invariant_fuzz_concurrency_policy.sh" "$FAST_SCRIPT"; t
   exit 1
 fi
 
+if ! grep -q "test_run_zk_witness_mutation_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include zk witness mutation fast-lane coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_zk_witness_mutation_deep_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include zk witness mutation deep-lane coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "test_select_failover_sync_drill_lane.sh" "$FAST_SCRIPT"; then
   echo "expected runtime snapshot contract lane to include failover/sync selector contract coverage" >&2
   exit 1

--- a/scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected runtime zk witness mutation contract lane script to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "fuzz_smoke_zk_witness_mutation_lane_is_panic_free_and_deterministic" "$CONTRACT_LANE"; then
+  echo "expected zk witness mutation contract lane to include panic-free deterministic smoke coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "functional_zk_witness_mutation_suite_covers_malformed_missing_and_tampered_classes" "$CONTRACT_LANE"; then
+  echo "expected zk witness mutation contract lane to include malformed/missing/tampered class coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "regression_zk_witness_mutation_reason_signatures_remain_stable" "$CONTRACT_LANE"; then
+  echo "expected zk witness mutation contract lane to include fail-closed regression coverage" >&2
+  exit 1
+fi
+
+lane_output="$(bash "$CONTRACT_LANE")"
+if ! printf '%s\n' "$lane_output" | grep -q "runtime zk witness mutation contract lane tests passed."; then
+  echo "expected runtime zk witness mutation contract lane success marker" >&2
+  exit 1
+fi
+
+echo "runtime zk witness mutation contract lane script tests passed."

--- a/scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh
+++ b/scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAST_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
+DEEP_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_deep_lane.sh"
+
+if [ ! -x "$FAST_LANE" ]; then
+  echo "expected runtime zk witness mutation fast-lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_LANE" ]; then
+  echo "expected runtime zk witness mutation deep-lane script to be executable" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_zk_witness_mutation_contract_lane.sh" "$DEEP_LANE"; then
+  echo "expected zk witness mutation deep lane to execute fast-lane checks first" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_zk_witness_mutation_deep_lane_stress -- --ignored" "$DEEP_LANE"; then
+  echo "expected zk witness mutation deep lane to include ignored deep stress coverage" >&2
+  exit 1
+fi
+
+lane_output="$(bash "$DEEP_LANE")"
+if ! printf '%s\n' "$lane_output" | grep -q "runtime zk witness mutation deep lane tests passed."; then
+  echo "expected runtime zk witness mutation deep lane success marker" >&2
+  exit 1
+fi
+
+echo "runtime zk witness mutation deep lane script tests passed."


### PR DESCRIPTION
## Summary
Adds deterministic ZK witness mutation property/fuzz coverage, including fast and scheduled deep runtime lanes with an explicit low-cost routing toggle. This closes task #994 by moving witness mutation invariants into executable contract-lane checks and updating the required docs.

## Changes
- `crates/kamn-core/tests/zk_witness_fuzz_smoke.rs`: new fuzz/property/integration/regression/performance suite for witness selectors and tampered envelope mutations.
- `scripts/runtime/run_zk_witness_mutation_contract_lane.sh`: fast bounded mutation lane.
- `scripts/runtime/run_zk_witness_mutation_deep_lane.sh`: scheduled deep lane using ignored stress test.
- `scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh`: fast-lane script contract test.
- `scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh`: deep-lane script contract test.
- `scripts/runtime/run_input_mutation_contract_lane.sh`: route ZK mutation checks with default fast lane and optional deep lane via `KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP`.
- `scripts/runtime/test_run_input_mutation_contract_lane.sh`: enforce ZK lane routing markers.
- `scripts/runtime/run_runtime_snapshot_contract_lane.sh`: include ZK mutation lane script tests in runtime contract suite.
- `scripts/runtime/test_run_runtime_snapshot_contract_lane.sh`: assert inclusion of new runtime ZK mutation lane script tests.
- `docs/foundation/zk-message-proof-design.md`: add witness mutation lane section, fast/deep commands, routing details, and regression marker.
- `docs/foundation/invariants.md`: add ZK witness mutation lane coverage and scheduled deep-lane contract references.
- `crates/kamn-core/tests/zk_message_proofs_docs.rs`: add regression doc-contract checks for witness mutation lanes.
- `crates/kamn-core/tests/invariants_docs.rs`: add regression doc-contract checks for ZK witness mutation lane markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
cargo test -p kamn-core --test invariants_docs
cargo test -p kamn-core --test zk_message_proofs_docs
bash scripts/runtime/test_run_input_mutation_contract_lane.sh
```
Observed failures before implementation:
- `regression_requires_zk_witness_mutation_contract_markers` (missing `run_zk_witness_mutation_contract_lane.sh` marker in `invariants.md`)
- `regression_requires_witness_mutation_fast_and_deep_lane_markers` (missing witness mutation lane section in `zk-message-proof-design.md`)
- runtime mutation script test failed: `expected mutation lane to include ZK witness mutation contract lane coverage`

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test zk_witness_fuzz_smoke --test zk_message_proofs_docs --test invariants_docs
bash scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh
bash scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh
bash scripts/runtime/test_run_input_mutation_contract_lane.sh
bash scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
```
Result: all pass.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
bash scripts/ci/test_select_targets.sh
```
Result: all pass.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `fuzz_smoke_zk_witness_error_corpus_covers_expected_rejection_classes` | |
| Functional   | ✅ | `functional_zk_witness_mutation_suite_covers_malformed_missing_and_tampered_classes` | |
| Integration  | ✅ | `integration_zk_witness_mutation_fail_closed_reasons_are_explicit_and_deterministic`, runtime lane script integration tests | |
| Regression   | ✅ | `regression_zk_witness_mutation_reason_signatures_remain_stable`, doc regression checks in `zk_message_proofs_docs.rs` and `invariants_docs.rs` | |
| Performance  | ✅ | `performance_zk_witness_mutation_contract_lane_stays_within_budget`, ignored deep stress `performance_zk_witness_mutation_deep_lane_stress` plus deep lane script | |

## Risks & Rollback
- Risk: runtime snapshot contract lane now runs additional ZK mutation lane script tests, increasing runtime moderately.
- Mitigation: fast lane remains bounded and deep lane runs only when explicitly routed (`KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP=true`).
- Rollback plan: revert this PR commit to restore previous mutation lane composition.

## Documentation Updates
- `docs/foundation/zk-message-proof-design.md`
- `docs/foundation/invariants.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #994
