### PR TITLE
test(runtime): add processor proof admission contract lane (#995)

### DIFF
--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -53,6 +53,7 @@ fn doc_contains_peer_lifecycle_and_queue_rules() {
     assert!(DOC.contains("encoding/character drift cases"));
     assert!(DOC.contains("method mismatch prefix cases"));
     assert!(DOC.contains("run_input_mutation_contract_lane.sh"));
+    assert!(DOC.contains("run_processor_proof_admission_contract_lane.sh"));
     assert!(DOC.contains("single-winner task accept races"));
     assert!(DOC.contains("deterministic peer lifecycle phase summaries"));
     assert!(DOC.contains("run_concurrency_state_mutation_contract_lane.sh"));
@@ -99,6 +100,7 @@ fn doc_contains_fast_and_cost_effective_validation_lane() {
         "cargo test -p kamn-core --test did_fuzz_smoke functional_did_mutation_suite_covers_normalization_encoding_and_method_mismatch_classes -- --exact"
     ));
     assert!(DOC.contains("bash scripts/runtime/run_input_mutation_contract_lane.sh"));
+    assert!(DOC.contains("bash scripts/runtime/run_processor_proof_admission_contract_lane.sh"));
     assert!(DOC.contains(
         "cargo test -p kamn-core --test concurrency_state_mutation functional_task_accept_concurrency_replay_fixture_preserves_invariants -- --exact"
     ));
@@ -170,6 +172,9 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
     ));
     assert!(DOC.contains(
         "invariant/fuzz/concurrency combined lane reason-code policy remains fail-closed (`Regression: #897`)"
+    ));
+    assert!(DOC.contains(
+        "processor proof admission message/commitment/replay/format guards remain fail-closed (`Regression: #995`)"
     ));
 }
 

--- a/crates/kamn-core/tests/zk_message_proofs_docs.rs
+++ b/crates/kamn-core/tests/zk_message_proofs_docs.rs
@@ -71,3 +71,13 @@ fn regression_requires_witness_mutation_fast_and_deep_lane_markers() {
     assert!(DOC.contains("run_zk_witness_mutation_deep_lane.sh"));
     assert!(DOC.contains("performance_zk_witness_mutation_deep_lane_stress -- --ignored"));
 }
+
+#[test]
+fn regression_requires_processor_admission_runtime_lane_markers() {
+    // Regression: #995
+    assert!(DOC.contains("## Processor Admission Runtime Contract Lane"));
+    assert!(DOC.contains("run_processor_proof_admission_contract_lane.sh"));
+    assert!(DOC.contains(
+        "processor proof admission reason signatures remain fail-closed (`Regression: #995`)"
+    ));
+}

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -138,6 +138,13 @@ This document captures the initial runtime-network foundation slice for peer lif
 - All mutation corpus entries must fail closed with explicit typed errors and stable reason strings.
 - Fast contract lane command:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
+- Processor proof admission guard lane command:
+  - `bash scripts/runtime/run_processor_proof_admission_contract_lane.sh`
+- Processor proof admission fail-closed rules:
+  - message-id mismatch
+  - payload commitment mismatch
+  - invalid proof format
+  - replayed artifact id
 
 ## Deterministic Concurrency Harness Rules
 - Shared-state mutation harness in `crates/kamn-core/tests/concurrency_state_mutation.rs` must enforce:
@@ -339,6 +346,7 @@ This document captures the initial runtime-network foundation slice for peer lif
   - snapshot restore cursor mismatch rejection (`Regression: #617`)
   - concurrent accept races never allow multiple winners (`Regression: #844`)
   - deterministic envelope/DID mutation fail-closed reasons remain stable (`Regression: #843`)
+  - processor proof admission message/commitment/replay/format guards remain fail-closed (`Regression: #995`)
   - task/escrow/peer lifecycle generated invariant lanes remain deterministic (`Regression: #842`)
   - invariant/fuzz/concurrency combined lane reason-code policy remains fail-closed (`Regression: #897`)
 - Performance:
@@ -370,6 +378,7 @@ cargo test -p kamn-core --test bridge_quorum_runtime_docs
 cargo test -p kamn-core --test message_envelope_fuzz_smoke functional_envelope_mutation_suite_covers_malformed_truncated_and_tampered_classes -- --exact
 cargo test -p kamn-core --test did_fuzz_smoke functional_did_mutation_suite_covers_normalization_encoding_and_method_mismatch_classes -- --exact
 bash scripts/runtime/run_input_mutation_contract_lane.sh
+bash scripts/runtime/run_processor_proof_admission_contract_lane.sh
 cargo test -p kamn-core --test concurrency_state_mutation functional_task_accept_concurrency_replay_fixture_preserves_invariants -- --exact
 cargo test -p kamn-core --test concurrency_state_mutation integration_peer_lifecycle_concurrency_replay_is_deterministic_across_rounds -- --exact
 bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh

--- a/docs/foundation/zk-message-proof-design.md
+++ b/docs/foundation/zk-message-proof-design.md
@@ -74,6 +74,21 @@ This spike evaluates feasible zero-knowledge (ZK) message-proof designs for PRD 
   - proof value fails deterministic verification format checks
 - Regression guard: tampered processor proof artifacts are rejected before admission (`Regression: #509`).
 
+## Processor Admission Runtime Contract Lane
+- Runtime lane entrypoint:
+  - `bash scripts/runtime/run_processor_proof_admission_contract_lane.sh`
+- Evidence and policy helpers:
+  - `scripts/runtime/generate_processor_proof_admission_evidence_bundle.sh`
+  - `scripts/runtime/check_processor_proof_admission_policy.sh`
+- Runtime lane checks enforce deterministic guards for:
+  - artifact/message identity mismatch rejection
+  - payload commitment mismatch rejection
+  - proof-format invalid payload rejection
+  - replayed artifact ID rejection
+- Runtime budget:
+  - fast contract lane enforces `PROCESSOR_PROOF_ADMISSION_MAX_SECONDS` (default `90`).
+- Regression guard: processor proof admission reason signatures remain fail-closed (`Regression: #995`).
+
 ## Witness and Artifact Schema Contract Lane
 - Contract lane entrypoint:
   - `bash scripts/message/run_processor_proof_artifact_contract_lane.sh`
@@ -127,6 +142,7 @@ Run the smallest lane needed for rapid feedback:
 
 ```bash
 cargo test -p kamn-core --test zk_message_proofs --test zk_message_proofs_docs
+bash scripts/runtime/run_processor_proof_admission_contract_lane.sh
 bash scripts/message/run_processor_proof_artifact_contract_lane.sh
 bash scripts/runtime/run_zk_witness_mutation_contract_lane.sh
 cargo fmt --check

--- a/scripts/runtime/check_processor_proof_admission_policy.sh
+++ b/scripts/runtime/check_processor_proof_admission_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/processor_proof_admission_contract.py" check "$@"

--- a/scripts/runtime/generate_processor_proof_admission_evidence_bundle.sh
+++ b/scripts/runtime/generate_processor_proof_admission_evidence_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/processor_proof_admission_contract.py" generate "$@"

--- a/scripts/runtime/processor_proof_admission_contract.py
+++ b/scripts/runtime/processor_proof_admission_contract.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Processor proof-admission evidence generator and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+from typing import Mapping
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_keys,
+    require_object,
+    require_string,
+    write_json,
+)
+
+SCHEMA_VERSION = "kamn.runtime.processor-proof-admission-report.v1"
+EVIDENCE_KEY = "processor_proof_admission_contract:evidence:v1"
+REASON_PREFIX = "processor_proof_admission_reason_codes"
+
+
+def _parse_bool(name: str, raw_value: str) -> bool:
+    value = (raw_value or "").strip().lower()
+    if value in ("true", "1", "yes", "y"):
+        return True
+    if value in ("false", "0", "no", "n"):
+        return False
+    fail(f"{name} must be true or false")
+
+
+def _compute_policy_checks(
+    message_id_match: bool,
+    commitment_match: bool,
+    proof_format_valid: bool,
+    replay_guard_active: bool,
+    ci_fast_gate: str,
+) -> Mapping[str, bool]:
+    return {
+        "message_id_match": message_id_match,
+        "commitment_match": commitment_match,
+        "proof_format_valid": proof_format_valid,
+        "replay_guard_active": replay_guard_active,
+        "ci_fast_gate_passed": ci_fast_gate == "PASS",
+    }
+
+
+def _reason_messages() -> Mapping[str, str]:
+    return {
+        "message_id_match": "processor admission must reject message_id mismatch",
+        "commitment_match": "processor admission must reject payload commitment mismatch",
+        "proof_format_valid": "processor admission must reject invalid proof format",
+        "replay_guard_active": "processor admission must reject replayed artifact ids",
+        "ci_fast_gate_passed": "ci-fast-gate-failed",
+    }
+
+
+def _reason_key(decision: str) -> str:
+    return f"{REASON_PREFIX}:{decision}:v1"
+
+
+def _failed_checks(policy_checks: Mapping[str, bool]) -> list[str]:
+    return sorted([key for key, passed in policy_checks.items() if not passed])
+
+
+def _require_policy_checks(payload: Mapping[str, object]) -> Mapping[str, bool]:
+    checks_raw = payload.get("policy_checks")
+    if not isinstance(checks_raw, dict):
+        fail("policy_checks must be an object")
+
+    checks: dict[str, bool] = {}
+    for key_name in _reason_messages().keys():
+        if key_name not in checks_raw:
+            fail(f"missing policy_checks field: {key_name}")
+        value = checks_raw[key_name]
+        if not isinstance(value, bool):
+            fail(f"policy_checks.{key_name} must be boolean")
+        checks[key_name] = value
+    return checks
+
+
+def _compute_decision(policy_checks: Mapping[str, bool]) -> tuple[str, list[str], list[str]]:
+    decision = DecisionAccumulator()
+    reason_messages = _reason_messages()
+    for check_name in reason_messages:
+        decision.reject_if(not policy_checks[check_name], reason_messages[check_name])
+    final_decision, decision_reasons = decision.finalize(
+        "processor proof admission checks satisfied"
+    )
+    failed_checks = _failed_checks(policy_checks)
+    return final_decision, decision_reasons, failed_checks
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    ci_fast_gate = require_enum("ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+    policy_checks = _compute_policy_checks(
+        message_id_match=_parse_bool("message-id-match", args.message_id_match),
+        commitment_match=_parse_bool("commitment-match", args.commitment_match),
+        proof_format_valid=_parse_bool("proof-format-valid", args.proof_format_valid),
+        replay_guard_active=_parse_bool("replay-guard-active", args.replay_guard_active),
+        ci_fast_gate=ci_fast_gate,
+    )
+    final_decision, decision_reasons, failed_checks = _compute_decision(policy_checks)
+    reason_key = _reason_key(final_decision)
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "evidence_key": EVIDENCE_KEY,
+        "artifact": {
+            "artifact_id": args.artifact_id,
+            "message_id": args.message_id,
+        },
+        "ci_fast_gate": ci_fast_gate,
+        "policy_checks": policy_checks,
+        "failed_checks": failed_checks,
+        "decision_reasons": decision_reasons,
+        "reason_key": reason_key,
+        "final_decision": final_decision,
+    }
+
+    output_file = Path(args.output_file)
+    write_json(output_file, payload)
+
+    failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
+    print("status=generated")
+    print(f"bundle_file={output_file}")
+    print(f"evidence_key={EVIDENCE_KEY}")
+    print(f"reason_key={reason_key}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def check_bundle(args: argparse.Namespace) -> int:
+    bundle_file = Path(args.bundle_file)
+    if not bundle_file.is_file():
+        fail(f"bundle file not found: {bundle_file}")
+
+    payload = load_json(bundle_file)
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "generated_at",
+            "evidence_key",
+            "artifact",
+            "ci_fast_gate",
+            "policy_checks",
+            "failed_checks",
+            "decision_reasons",
+            "reason_key",
+            "final_decision",
+        ),
+    )
+    if require_string(payload, "schema_version") != SCHEMA_VERSION:
+        fail(f"schema_version must be {SCHEMA_VERSION}")
+    if require_string(payload, "evidence_key") != EVIDENCE_KEY:
+        fail("evidence_key mismatch")
+    require_string(payload, "generated_at")
+
+    artifact = require_object(payload, "artifact")
+    require_string(artifact, "artifact_id")
+    require_string(artifact, "message_id")
+
+    ci_fast_gate = require_enum(
+        "ci_fast_gate", require_string(payload, "ci_fast_gate"), ("PASS", "FAIL")
+    )
+    final_decision = require_enum(
+        "final_decision", require_string(payload, "final_decision"), ("GO", "NO-GO")
+    )
+    reason_key = require_string(payload, "reason_key")
+    checks = _require_policy_checks(payload)
+
+    recomputed_checks = _compute_policy_checks(
+        message_id_match=checks["message_id_match"],
+        commitment_match=checks["commitment_match"],
+        proof_format_valid=checks["proof_format_valid"],
+        replay_guard_active=checks["replay_guard_active"],
+        ci_fast_gate=ci_fast_gate,
+    )
+    if checks != recomputed_checks:
+        fail(f"policy_checks mismatch: expected {recomputed_checks}, found {checks}")
+
+    expected_decision, expected_reasons, expected_failed_checks = _compute_decision(
+        recomputed_checks
+    )
+    if final_decision != expected_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected {expected_decision}, found {final_decision}"
+        )
+    expected_reason_key = _reason_key(expected_decision)
+    if reason_key != expected_reason_key:
+        fail(f"reason_key mismatch: expected {expected_reason_key}, found {reason_key}")
+
+    decision_reasons = payload.get("decision_reasons")
+    if decision_reasons != expected_reasons:
+        fail(
+            "decision_reasons mismatch: "
+            f"expected {expected_reasons}, found {decision_reasons}"
+        )
+
+    failed_checks = payload.get("failed_checks")
+    if failed_checks != expected_failed_checks:
+        fail(
+            "failed_checks mismatch: "
+            f"expected {expected_failed_checks}, found {failed_checks}"
+        )
+
+    failed_checks_value = ",".join(expected_failed_checks) if expected_failed_checks else "none"
+    print("status=validated")
+    print(f"bundle_file={bundle_file}")
+    print(f"reason_key={expected_reason_key}")
+    print(f"final_decision={expected_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate/check processor proof-admission contract evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate", help="Generate evidence bundle")
+    generate_parser.add_argument("--output-file", required=True)
+    generate_parser.add_argument("--artifact-id", required=True)
+    generate_parser.add_argument("--message-id", required=True)
+    generate_parser.add_argument("--message-id-match", required=True)
+    generate_parser.add_argument("--commitment-match", required=True)
+    generate_parser.add_argument("--proof-format-valid", required=True)
+    generate_parser.add_argument("--replay-guard-active", required=True)
+    generate_parser.add_argument("--ci-fast-gate", default="PASS")
+    generate_parser.set_defaults(handler=generate_bundle)
+
+    check_parser = subparsers.add_parser("check", help="Check evidence bundle")
+    check_parser.add_argument("--bundle-file", required=True)
+    check_parser.set_defaults(handler=check_bundle)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except ContractError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime/run_processor_proof_admission_contract_lane.sh
+++ b/scripts/runtime/run_processor_proof_admission_contract_lane.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/runtime/generate_processor_proof_admission_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_processor_proof_admission_policy.sh"
+ZK_DOC="$ROOT_DIR/docs/foundation/zk-message-proof-design.md"
+RUNTIME_DOC="$ROOT_DIR/docs/foundation/runtime-network.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/runtime/run_processor_proof_admission_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "processor proof admission evidence generator is not executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "processor proof admission policy checker is not executable"
+fi
+
+if [ ! -f "$ZK_DOC" ]; then
+  fail "expected zk message proof design doc to exist"
+fi
+
+if [ ! -f "$RUNTIME_DOC" ]; then
+  fail "expected runtime network doc to exist"
+fi
+
+cd "$ROOT_DIR"
+if [ "$skip_tests" != true ]; then
+  cargo test -p kamn-core --test message_lifecycle_proof_admission lifecycle_functional_valid_processor_proof_advances_to_validated -- --exact >/dev/null
+  cargo test -p kamn-core --test message_lifecycle_proof_admission lifecycle_regression_tampered_proof_does_not_advance_validation_state -- --exact >/dev/null
+  cargo test -p kamn-core --test message_lifecycle_proof_admission lifecycle_integration_replayed_artifact_is_rejected_for_second_message -- --exact >/dev/null
+  cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_reject_invalid_processor_artifact_proof_value_shape -- --exact >/dev/null
+  cargo test -p kamn-core --test runtime_network_docs doc_contains_peer_lifecycle_and_queue_rules -- --exact >/dev/null
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/processor-proof-admission-contract.json"
+fi
+
+start_epoch="$(date +%s)"
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --artifact-id "artifact-admission-995" \
+    --message-id "urn:uuid:admission-995" \
+    --message-id-match true \
+    --commitment-match true \
+    --proof-format-valid true \
+    --replay-guard-active true \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
+  fail "expected processor proof admission evidence generation decision to be GO"
+fi
+if ! printf '%s\n' "$generator_output" | grep -q "^reason_key=processor_proof_admission_reason_codes:GO:v1$"; then
+  fail "expected processor proof admission GO reason key marker"
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected processor proof admission policy decision to be GO"
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^failed_checks=none$"; then
+  fail "expected processor proof admission contract lane to report failed_checks=none"
+fi
+
+if ! grep -Fq "run_processor_proof_admission_contract_lane.sh" "$ZK_DOC"; then
+  fail "expected zk message proof design doc to reference processor proof admission contract lane"
+fi
+if ! grep -Fq "run_processor_proof_admission_contract_lane.sh" "$RUNTIME_DOC"; then
+  fail "expected runtime network doc to reference processor proof admission contract lane"
+fi
+if ! grep -Fq "Regression: #995" "$ZK_DOC"; then
+  fail "expected zk message proof design doc to include processor admission regression marker"
+fi
+if ! grep -Fq "Regression: #995" "$RUNTIME_DOC"; then
+  fail "expected runtime network doc to include processor admission regression marker"
+fi
+
+max_seconds="${PROCESSOR_PROOF_ADMISSION_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  fail "processor proof admission contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "$(extract_value "$policy_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
+echo "processor proof admission contract lane tests passed."

--- a/scripts/runtime/run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/run_runtime_snapshot_contract_lane.sh
@@ -18,6 +18,8 @@ bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh >/dev/
 bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh >/dev/null
 bash scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh >/dev/null
 bash scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh >/dev/null
+bash scripts/runtime/test_generate_processor_proof_admission_evidence_bundle.sh >/dev/null
+bash scripts/runtime/test_run_processor_proof_admission_contract_lane.sh >/dev/null
 bash scripts/runtime/test_select_failover_sync_drill_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_deep_lane.sh >/dev/null

--- a/scripts/runtime/test_generate_processor_proof_admission_evidence_bundle.sh
+++ b/scripts/runtime/test_generate_processor_proof_admission_evidence_bundle.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/runtime/generate_processor_proof_admission_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_processor_proof_admission_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "expected processor proof admission evidence generator to be executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "expected processor proof admission policy checker to be executable"
+fi
+
+go_bundle="$TMP_DIR/processor-proof-admission-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --artifact-id "artifact-go-995" \
+    --message-id "urn:uuid:go-995" \
+    --message-id-match true \
+    --commitment-match true \
+    --proof-format-valid true \
+    --replay-guard-active true \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$go_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO decision for valid processor proof admission evidence bundle"
+fi
+if [ ! -f "$go_bundle" ]; then
+  fail "expected GO processor proof admission evidence bundle file to be created"
+fi
+if ! grep -q '"schema_version": "kamn.runtime.processor-proof-admission-report.v1"' "$go_bundle"; then
+  fail "expected processor proof admission evidence schema marker"
+fi
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+if ! printf '%s\n' "$go_policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO policy decision for valid processor proof admission evidence bundle"
+fi
+
+no_go_bundle="$TMP_DIR/processor-proof-admission-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --artifact-id "artifact-no-go-995" \
+    --message-id "urn:uuid:no-go-995" \
+    --message-id-match false \
+    --commitment-match false \
+    --proof-format-valid false \
+    --replay-guard-active false \
+    --ci-fast-gate FAIL
+)"
+if ! printf '%s\n' "$no_go_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO decision for invalid processor proof admission evidence bundle"
+fi
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+if ! printf '%s\n' "$no_go_policy_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO policy decision for invalid processor proof admission evidence bundle"
+fi
+
+tampered_bundle="$TMP_DIR/processor-proof-admission-tampered.json"
+cp "$go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_exit=$?
+set -e
+if [ "$tampered_exit" -eq 0 ]; then
+  fail "expected tampered processor proof admission evidence bundle to fail validation"
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  fail "expected explicit policy decision mismatch marker for tampered processor proof admission bundle"
+fi
+
+echo "processor proof admission evidence bundle tests passed."

--- a/scripts/runtime/test_run_processor_proof_admission_contract_lane.sh
+++ b/scripts/runtime/test_run_processor_proof_admission_contract_lane.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/runtime/run_processor_proof_admission_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected processor proof admission contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/processor-proof-admission-contract-bundle.json"
+lane_output="$(bash "$SCRIPT" --output-file "$bundle_file")"
+
+if ! printf '%s\n' "$lane_output" | grep -q "processor proof admission contract lane tests passed."; then
+  echo "expected processor proof admission contract lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected processor proof admission contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.runtime.processor-proof-admission-report.v1"' "$bundle_file"; then
+  echo "expected processor proof admission evidence schema marker" >&2
+  exit 1
+fi
+
+echo "processor proof admission contract lane script tests passed."

--- a/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
@@ -79,6 +79,16 @@ if ! grep -q "test_run_zk_witness_mutation_deep_lane.sh" "$FAST_SCRIPT"; then
   exit 1
 fi
 
+if ! grep -q "test_run_processor_proof_admission_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include processor proof admission contract coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_generate_processor_proof_admission_evidence_bundle.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include processor proof admission evidence bundle coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "test_select_failover_sync_drill_lane.sh" "$FAST_SCRIPT"; then
   echo "expected runtime snapshot contract lane to include failover/sync selector contract coverage" >&2
   exit 1


### PR DESCRIPTION
## Summary
Add a processor proof admission contract lane that validates message/commitment/replay/format evidence and wires it into the runtime snapshot fast validation path. This closes the #995 regression gap so processor admission checks are fail-closed and continuously verified.

## Changes
- `scripts/runtime/processor_proof_admission_contract.py`: add deterministic admission evidence contract generator with replay/mismatch guard cases.
- `scripts/runtime/generate_processor_proof_admission_evidence_bundle.sh`: add lane evidence generation wrapper.
- `scripts/runtime/check_processor_proof_admission_policy.sh`: add policy evaluation wrapper.
- `scripts/runtime/run_processor_proof_admission_contract_lane.sh`: add end-to-end processor admission lane with bounded runtime checks.
- `scripts/runtime/test_generate_processor_proof_admission_evidence_bundle.sh`: add evidence bundle and tamper regression checks.
- `scripts/runtime/test_run_processor_proof_admission_contract_lane.sh`: add lane smoke contract test.
- `scripts/runtime/run_runtime_snapshot_contract_lane.sh`: include processor admission lane tests in fast snapshot lane.
- `scripts/runtime/test_run_runtime_snapshot_contract_lane.sh`: assert processor admission lane wiring.
- `docs/foundation/zk-message-proof-design.md`: document processor admission lane commands and regression guard.
- `docs/foundation/runtime-network.md`: document runtime lane integration and fail-closed regression markers.
- `crates/kamn-core/tests/zk_message_proofs_docs.rs`: enforce processor admission doc markers (`Regression: #995`).
- `crates/kamn-core/tests/runtime_network_docs.rs`: enforce runtime lane/doc regression markers (`Regression: #995`).

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed targeted Rust doc-contract tests and runtime lane script tests for processor admission and runtime snapshot integration.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test zk_message_proofs_docs --test runtime_network_docs` |
| Functional  | ✅     | `bash scripts/runtime/test_generate_processor_proof_admission_evidence_bundle.sh` |
| Integration | ✅     | `bash scripts/runtime/test_run_processor_proof_admission_contract_lane.sh` and `bash scripts/runtime/test_run_runtime_snapshot_contract_lane.sh` |
| Regression  | ✅     | `Regression: #995` assertions in docs + contract lane tamper checks |

Closes #995
