### PR TITLE
test(runtime): add watchdog proof consensus deep-lane contracts (#996)

### DIFF
--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -174,6 +174,16 @@ fn checklist_contains_live_network_pilot_launch_and_rollback_evidence_gates() {
 }
 
 #[test]
+fn checklist_contains_watchdog_proof_consensus_evidence_contract() {
+    assert!(CHECKLIST.contains("## Validator/Watchdog Proof Consensus Evidence Contract"));
+    assert!(CHECKLIST.contains("run_watchdog_proof_consensus_contract_lane.sh"));
+    assert!(CHECKLIST.contains("run_watchdog_proof_consensus_deep_lane.sh"));
+    assert!(CHECKLIST.contains("generate_watchdog_proof_consensus_evidence_bundle.sh"));
+    assert!(CHECKLIST.contains("check_watchdog_proof_consensus_policy.sh"));
+    assert!(CHECKLIST.contains("KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE"));
+}
+
+#[test]
 fn checklist_contains_governance_simulation_and_human_veto_evidence_contract() {
     assert!(CHECKLIST.contains("## Governance Simulation and Human-Veto Evidence Contract"));
     assert!(CHECKLIST.contains("generate_governance_simulation_evidence_bundle.sh"));
@@ -325,6 +335,14 @@ fn regression_requires_live_network_partition_reconnect_guard_marker() {
     // Regression: #982
     assert!(CHECKLIST.contains(
         "stale/tampered partition/reconnect matrix artifacts and replay anomalies force `NO-GO` (`Regression: #982`)."
+    ));
+}
+
+#[test]
+fn regression_requires_watchdog_proof_consensus_budget_and_cadence_guard_marker() {
+    // Regression: #996
+    assert!(CHECKLIST.contains(
+        "proof-consensus deep-lane budget overruns and unscheduled cadence execution force `NO-GO` (`Regression: #996`)."
     ));
 }
 

--- a/crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs
+++ b/crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs
@@ -46,6 +46,18 @@ fn doc_contains_incident_response_mapping_and_fast_lane() {
 }
 
 #[test]
+fn doc_contains_validator_watchdog_proof_consensus_deep_lane_contract() {
+    assert!(DOC.contains("## Validator/Watchdog Proof Consensus Deep-Lane Contract"));
+    assert!(DOC.contains("run_watchdog_proof_consensus_contract_lane.sh"));
+    assert!(DOC.contains("run_watchdog_proof_consensus_deep_lane.sh"));
+    assert!(DOC.contains("generate_watchdog_proof_consensus_evidence_bundle.sh"));
+    assert!(DOC.contains("check_watchdog_proof_consensus_policy.sh"));
+    assert!(DOC.contains("KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE"));
+    assert!(DOC.contains("KAMN_WATCHDOG_PROOF_CONSENSUS_MAX_SECONDS"));
+    assert!(DOC.contains("KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_MAX_SECONDS"));
+}
+
+#[test]
 fn regression_requires_divergence_and_censorship_guard_rules() {
     // Regression: #383
     assert!(DOC
@@ -69,5 +81,11 @@ fn regression_requires_divergence_and_censorship_guard_rules() {
     assert!(DOC.contains("proof consensus alignment (`ConsensusValid`) projects `info` severity."));
     assert!(DOC.contains(
         "proof consensus invalid/replay/mismatch projects `critical` severity with deterministic fingerprint fields."
+    ));
+    assert!(DOC.contains(
+        "unscheduled proof-consensus deep-lane execution force-fails via scheduled/manual cadence guard (`Regression: #996`)."
+    ));
+    assert!(DOC.contains(
+        "invalid, replay, and mismatch proof-consensus anomaly artifacts must remain `NO-GO` under policy checks (`Regression: #996`)."
     ));
 }

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -276,6 +276,24 @@ Pilot launch gates require deterministic smoke and scheduled/manual deep-lane ev
   - missing smoke/deep pilot evidence or non-`GO` pilot decisions force launch `NO-GO` and trigger rollback review (`Regression: #830`).
   - stale/tampered partition/reconnect matrix artifacts and replay anomalies force `NO-GO` (`Regression: #982`).
 
+## Validator/Watchdog Proof Consensus Evidence Contract (Issue #996)
+Validator/watchdog proof-consensus rollout requires deterministic anomaly evidence and deep-lane budget/cadence controls before release approval.
+
+- Evidence bundle generator:
+  - `bash scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh --output-file /tmp/watchdog-proof-consensus-go.json --message-id urn:uuid:watchdog-proof-go-996 --artifact-id artifact-watchdog-go-996 --consensus-status ConsensusValid --required-quorum 2 --valid-attestation-count 2 --invalid-attestation-count 0 --replay-attestation-count 0 --cadence fast --runtime-seconds 4 --max-seconds 90 --evidence-complete true --ci-fast-gate PASS`
+- Policy checker:
+  - `bash scripts/runtime/check_watchdog_proof_consensus_policy.sh --bundle-file /tmp/watchdog-proof-consensus-go.json`
+- PR fast contract lane:
+  - `bash scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh --output-file /tmp/watchdog-proof-consensus-contract.json`
+- Scheduled/manual deep lane entrypoint:
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE=scheduled bash scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh --event-name schedule --output-json /tmp/watchdog-proof-consensus-deep-summary.json`
+- Runtime/cadence controls:
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_MAX_SECONDS`
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE`
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_MAX_SECONDS`
+- Regression policy:
+  - proof-consensus deep-lane budget overruns and unscheduled cadence execution force `NO-GO` (`Regression: #996`).
+
 ## Governance Simulation and Human-Veto Evidence Contract (Issue #748)
 Governance activation requires deterministic simulation, veto, timelock, and approval evidence before GO decisions.
 

--- a/docs/foundation/runtime-watchdog-attestation.md
+++ b/docs/foundation/runtime-watchdog-attestation.md
@@ -65,6 +65,23 @@ It complements `docs/foundation/watchdog-node-prototype.md` with runtime-facing 
 - backpressure overflow sample validation rejects queue depth above capacity (`Regression: #618`).
 - stale disconnected peer queue purge mapping remains deterministic (`Regression: #618`).
 
+## Validator/Watchdog Proof Consensus Deep-Lane Contract
+- PR-fast contract lane:
+  - `bash scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh`
+- Scheduled/manual deep lane entrypoint:
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE=scheduled bash scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh --event-name schedule --output-json /tmp/watchdog-proof-consensus-deep-summary.json`
+- Evidence generator:
+  - `bash scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh --output-file /tmp/watchdog-proof-consensus-go.json --message-id urn:uuid:watchdog-proof-go-996 --artifact-id artifact-watchdog-go-996 --consensus-status ConsensusValid --required-quorum 2 --valid-attestation-count 2 --invalid-attestation-count 0 --replay-attestation-count 0 --cadence fast --runtime-seconds 4 --max-seconds 90 --evidence-complete true --ci-fast-gate PASS`
+- Policy checker:
+  - `bash scripts/runtime/check_watchdog_proof_consensus_policy.sh --bundle-file /tmp/watchdog-proof-consensus-go.json`
+- Runtime/cadence controls:
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_MAX_SECONDS`
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE`
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_MAX_SECONDS`
+- Regression policy:
+  - unscheduled proof-consensus deep-lane execution force-fails via scheduled/manual cadence guard (`Regression: #996`).
+  - invalid, replay, and mismatch proof-consensus anomaly artifacts must remain `NO-GO` under policy checks (`Regression: #996`).
+
 ## Incident Response Mapping
 - Runtime watchdog output is triaged with `WatchdogSeverity` and `incident_fingerprint`.
 - Incident operators execute deterministic response workflow from `docs/foundation/upgrade-rollback-runbook.md`.
@@ -81,6 +98,9 @@ cargo test -p kamn-core --test upgrade_rollback_runbook_docs
 cargo test -p kamn-core divergence_watchdog
 cargo test -p kamn-core watchdog_anomaly
 cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifies_queue_saturation
+bash scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh
+bash scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh
+bash scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh
 cargo fmt --check
 cargo clippy -p kamn-core -- -D warnings
 ```

--- a/scripts/runtime/check_watchdog_proof_consensus_policy.sh
+++ b/scripts/runtime/check_watchdog_proof_consensus_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/watchdog_proof_consensus_contract.py" check "$@"

--- a/scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh
+++ b/scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/watchdog_proof_consensus_contract.py" generate "$@"

--- a/scripts/runtime/run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/run_runtime_snapshot_contract_lane.sh
@@ -20,6 +20,9 @@ bash scripts/runtime/test_run_zk_witness_mutation_contract_lane.sh >/dev/null
 bash scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh >/dev/null
 bash scripts/runtime/test_generate_processor_proof_admission_evidence_bundle.sh >/dev/null
 bash scripts/runtime/test_run_processor_proof_admission_contract_lane.sh >/dev/null
+bash scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh >/dev/null
+bash scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh >/dev/null
+bash scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh >/dev/null
 bash scripts/runtime/test_select_failover_sync_drill_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh >/dev/null
 bash scripts/runtime/test_run_failover_sync_drill_deep_lane.sh >/dev/null

--- a/scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh
+++ b/scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_watchdog_proof_consensus_policy.sh"
+WATCHDOG_DOC="$ROOT_DIR/docs/foundation/runtime-watchdog-attestation.md"
+GONOGO_DOC="$ROOT_DIR/docs/foundation/release-gonogo-checklist.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "watchdog proof consensus evidence generator is not executable"
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "watchdog proof consensus policy checker is not executable"
+fi
+if [ ! -f "$WATCHDOG_DOC" ]; then
+  fail "expected runtime watchdog attestation doc to exist"
+fi
+if [ ! -f "$GONOGO_DOC" ]; then
+  fail "expected release go/no-go checklist doc to exist"
+fi
+
+cd "$ROOT_DIR"
+if [ "$skip_tests" != true ]; then
+  cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_functional_validator_quorum_consensus_aligned_valid_is_nominal -- --exact >/dev/null
+  cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_integration_rejects_replayed_validator_attestation_id -- --exact >/dev/null
+  cargo test -p kamn-core --test zk_message_proofs zk_message_proofs_regression_projects_validator_invalid_mismatch_to_watchdog_signal -- --exact >/dev/null
+  cargo test -p kamn-core --test runtime_watchdog_attestation_docs doc_contains_validator_watchdog_proof_consensus_deep_lane_contract -- --exact >/dev/null
+  cargo test -p kamn-core --test release_gonogo_checklist_docs checklist_contains_watchdog_proof_consensus_evidence_contract -- --exact >/dev/null
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/watchdog-proof-consensus-contract.json"
+fi
+
+start_epoch="$(date +%s)"
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --message-id "urn:uuid:watchdog-proof-go-996" \
+    --artifact-id "artifact-watchdog-go-996" \
+    --consensus-status ConsensusValid \
+    --required-quorum 2 \
+    --valid-attestation-count 2 \
+    --invalid-attestation-count 0 \
+    --replay-attestation-count 0 \
+    --cadence fast \
+    --runtime-seconds 3 \
+    --max-seconds 90 \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
+  fail "expected watchdog proof consensus evidence generation decision to be GO"
+fi
+if ! printf '%s\n' "$generator_output" | grep -q "^reason_key=watchdog_proof_consensus_reason_codes:GO:v1$"; then
+  fail "expected watchdog proof consensus GO reason key marker"
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected watchdog proof consensus policy decision to be GO"
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^failed_checks=none$"; then
+  fail "expected watchdog proof consensus contract lane to report failed_checks=none"
+fi
+
+if ! grep -Fq "run_watchdog_proof_consensus_contract_lane.sh" "$WATCHDOG_DOC"; then
+  fail "expected runtime watchdog attestation doc to reference watchdog proof consensus contract lane"
+fi
+if ! grep -Fq "run_watchdog_proof_consensus_deep_lane.sh" "$WATCHDOG_DOC"; then
+  fail "expected runtime watchdog attestation doc to reference watchdog proof consensus deep lane"
+fi
+if ! grep -Fq "Regression: #996" "$WATCHDOG_DOC"; then
+  fail "expected runtime watchdog attestation doc to include watchdog proof consensus regression marker"
+fi
+if ! grep -Fq "run_watchdog_proof_consensus_contract_lane.sh" "$GONOGO_DOC"; then
+  fail "expected release go/no-go checklist to reference watchdog proof consensus contract lane"
+fi
+if ! grep -Fq "run_watchdog_proof_consensus_deep_lane.sh" "$GONOGO_DOC"; then
+  fail "expected release go/no-go checklist to reference watchdog proof consensus deep lane"
+fi
+if ! grep -Fq "Regression: #996" "$GONOGO_DOC"; then
+  fail "expected release go/no-go checklist to include watchdog proof consensus regression marker"
+fi
+
+max_seconds="${KAMN_WATCHDOG_PROOF_CONSENSUS_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  fail "watchdog proof consensus contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "$(extract_value "$policy_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
+echo "watchdog proof consensus contract lane tests passed."

--- a/scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh
+++ b/scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh"
+GENERATOR="$ROOT_DIR/scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_watchdog_proof_consensus_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE=scheduled \
+    bash scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh \
+      [--event-name schedule|workflow_dispatch] \
+      [--output-json <path>] \
+      [--max-seconds <int>] \
+      [--skip-contract-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+run_anomaly_case() {
+  local consensus_status="$1"
+  local message_id="$2"
+  local artifact_id="$3"
+  local valid_count="$4"
+  local invalid_count="$5"
+  local replay_count="$6"
+  local cadence="$7"
+  local max_seconds="$8"
+  local bundle_file="$TMP_DIR/watchdog-proof-consensus-${consensus_status}.json"
+
+  local generator_output
+  generator_output="$(
+    bash "$GENERATOR" \
+      --output-file "$bundle_file" \
+      --message-id "$message_id" \
+      --artifact-id "$artifact_id" \
+      --consensus-status "$consensus_status" \
+      --required-quorum 2 \
+      --valid-attestation-count "$valid_count" \
+      --invalid-attestation-count "$invalid_count" \
+      --replay-attestation-count "$replay_count" \
+      --cadence "$cadence" \
+      --runtime-seconds 4 \
+      --max-seconds "$max_seconds" \
+      --evidence-complete true \
+      --ci-fast-gate PASS
+  )"
+  if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=NO-GO$"; then
+    fail "expected watchdog proof consensus ${consensus_status} anomaly evidence to produce NO-GO"
+  fi
+
+  local policy_output
+  policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$bundle_file")"
+  if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=NO-GO$"; then
+    fail "expected watchdog proof consensus ${consensus_status} anomaly policy check to produce NO-GO"
+  fi
+}
+
+event_name="${GITHUB_EVENT_NAME:-schedule}"
+output_json="$ROOT_DIR/watchdog-proof-consensus-deep-summary.json"
+max_seconds="${KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_MAX_SECONDS:-180}"
+skip_contract_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --event-name)
+      event_name="${2:-}"
+      shift 2
+      ;;
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --skip-contract-tests)
+      skip_contract_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  fail "--max-seconds must be a non-negative integer"
+fi
+if [ "$max_seconds" -eq 0 ]; then
+  fail "--max-seconds must be greater than zero"
+fi
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  fail "watchdog proof consensus contract lane is not executable"
+fi
+if [ ! -x "$GENERATOR" ]; then
+  fail "watchdog proof consensus evidence generator is not executable"
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "watchdog proof consensus policy checker is not executable"
+fi
+
+cadence=""
+case "$event_name" in
+  schedule)
+    cadence="scheduled"
+    ;;
+  workflow_dispatch)
+    cadence="manual"
+    ;;
+  *)
+    fail "scheduled/manual-only cadence policy requires event schedule or workflow_dispatch"
+    ;;
+esac
+
+configured_cadence="${KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE:-}"
+if [[ -n "$configured_cadence" ]]; then
+  if [[ "$configured_cadence" != "scheduled" && "$configured_cadence" != "manual" ]]; then
+    fail "KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE must be scheduled or manual"
+  fi
+  if [[ "$configured_cadence" != "$cadence" ]]; then
+    fail "configured deep cadence does not match event-derived cadence"
+  fi
+fi
+
+start_epoch="$(date +%s)"
+status="pass"
+failure_reason=""
+
+contract_bundle="$TMP_DIR/watchdog-proof-consensus-contract.json"
+contract_lane_status="pass"
+set +e
+if [ "$skip_contract_tests" = true ]; then
+  contract_output="$(bash "$CONTRACT_LANE" --skip-tests --output-file "$contract_bundle" 2>&1)"
+else
+  contract_output="$(bash "$CONTRACT_LANE" --output-file "$contract_bundle" 2>&1)"
+fi
+contract_code=$?
+set -e
+if [ "$contract_code" -ne 0 ]; then
+  contract_lane_status="fail"
+  status="fail"
+  failure_reason="watchdog proof consensus contract lane failed"
+fi
+
+if [ "$status" = "pass" ]; then
+  run_anomaly_case ConsensusInvalid \
+    "urn:uuid:watchdog-proof-invalid-996" \
+    "artifact-watchdog-invalid-996" \
+    1 \
+    1 \
+    0 \
+    "$cadence" \
+    "$max_seconds"
+  run_anomaly_case ConsensusReplay \
+    "urn:uuid:watchdog-proof-replay-996" \
+    "artifact-watchdog-replay-996" \
+    1 \
+    0 \
+    1 \
+    "$cadence" \
+    "$max_seconds"
+  run_anomaly_case ValidatorMismatch \
+    "urn:uuid:watchdog-proof-mismatch-996" \
+    "artifact-watchdog-mismatch-996" \
+    1 \
+    1 \
+    0 \
+    "$cadence" \
+    "$max_seconds"
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+budget_status="within"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  budget_status="exceeded"
+  status="fail"
+  failure_reason="watchdog proof consensus deep lane exceeded runtime budget"
+fi
+
+final_decision="GO"
+if [ "$status" != "pass" ]; then
+  final_decision="NO-GO"
+fi
+
+mkdir -p "$(dirname "$output_json")"
+python3 - "$output_json" "$event_name" "$cadence" "$contract_lane_status" "$elapsed_seconds" "$max_seconds" "$budget_status" "$skip_contract_tests" "$final_decision" "$failure_reason" <<'PY'
+import json
+import pathlib
+import sys
+
+(
+    output_json,
+    event_name,
+    cadence,
+    contract_lane_status,
+    elapsed_seconds,
+    max_seconds,
+    budget_status,
+    skip_contract_tests,
+    final_decision,
+    failure_reason,
+) = sys.argv[1:]
+
+payload = {
+    "schema_version": "kamn.runtime.watchdog-proof-consensus-deep-summary.v1",
+    "event_name": event_name,
+    "cadence": cadence,
+    "contract_lane_status": contract_lane_status,
+    "anomaly_matrix_cases": [
+        "ConsensusInvalid",
+        "ConsensusReplay",
+        "ValidatorMismatch",
+    ],
+    "elapsed_seconds": int(elapsed_seconds),
+    "max_seconds": int(max_seconds),
+    "budget_status": budget_status,
+    "skip_contract_tests": skip_contract_tests == "true",
+    "final_decision": final_decision,
+}
+if failure_reason:
+    payload["failure_reason"] = failure_reason
+
+pathlib.Path(output_json).write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [ "$status" != "pass" ]; then
+  printf '%s\n' "$failure_reason" >&2
+  printf '%s\n' "$contract_output" >&2
+  exit 1
+fi
+
+echo "watchdog proof consensus deep lane tests passed."

--- a/scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh
+++ b/scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_watchdog_proof_consensus_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "expected watchdog proof consensus evidence generator to be executable"
+fi
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "expected watchdog proof consensus policy checker to be executable"
+fi
+
+go_bundle="$TMP_DIR/watchdog-proof-consensus-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --message-id "urn:uuid:watchdog-go-996" \
+    --artifact-id "artifact-watchdog-go-996" \
+    --consensus-status ConsensusValid \
+    --required-quorum 2 \
+    --valid-attestation-count 2 \
+    --invalid-attestation-count 0 \
+    --replay-attestation-count 0 \
+    --cadence fast \
+    --runtime-seconds 4 \
+    --max-seconds 90 \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$go_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO decision for valid watchdog proof consensus evidence bundle"
+fi
+if [ ! -f "$go_bundle" ]; then
+  fail "expected GO watchdog proof consensus evidence bundle file to be created"
+fi
+if ! grep -q '"schema_version": "kamn.runtime.watchdog-proof-consensus-report.v1"' "$go_bundle"; then
+  fail "expected watchdog proof consensus evidence schema marker"
+fi
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+if ! printf '%s\n' "$go_policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO policy decision for valid watchdog proof consensus evidence bundle"
+fi
+
+no_go_bundle="$TMP_DIR/watchdog-proof-consensus-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --message-id "urn:uuid:watchdog-no-go-996" \
+    --artifact-id "artifact-watchdog-no-go-996" \
+    --consensus-status ConsensusReplay \
+    --required-quorum 2 \
+    --valid-attestation-count 1 \
+    --invalid-attestation-count 0 \
+    --replay-attestation-count 1 \
+    --cadence scheduled \
+    --runtime-seconds 6 \
+    --max-seconds 90 \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$no_go_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO decision for replay watchdog proof consensus evidence bundle"
+fi
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+if ! printf '%s\n' "$no_go_policy_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO policy decision for replay watchdog proof consensus evidence bundle"
+fi
+
+tampered_bundle="$TMP_DIR/watchdog-proof-consensus-tampered.json"
+cp "$go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_exit=$?
+set -e
+if [ "$tampered_exit" -eq 0 ]; then
+  fail "expected tampered watchdog proof consensus evidence bundle to fail validation"
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  fail "expected explicit policy decision mismatch marker for tampered watchdog proof consensus bundle"
+fi
+
+echo "watchdog proof consensus evidence bundle tests passed."

--- a/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
@@ -89,6 +89,21 @@ if ! grep -q "test_generate_processor_proof_admission_evidence_bundle.sh" "$FAST
   exit 1
 fi
 
+if ! grep -q "test_generate_watchdog_proof_consensus_evidence_bundle.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include watchdog proof consensus evidence bundle coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_watchdog_proof_consensus_contract_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include watchdog proof consensus contract lane coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_watchdog_proof_consensus_deep_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected runtime snapshot contract lane to include watchdog proof consensus deep-lane coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "test_select_failover_sync_drill_lane.sh" "$FAST_SCRIPT"; then
   echo "expected runtime snapshot contract lane to include failover/sync selector contract coverage" >&2
   exit 1

--- a/scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh
+++ b/scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected watchdog proof consensus contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/watchdog-proof-consensus-contract-bundle.json"
+lane_output="$(bash "$SCRIPT" --skip-tests --output-file "$bundle_file")"
+
+if ! printf '%s\n' "$lane_output" | grep -q "watchdog proof consensus contract lane tests passed."; then
+  echo "expected watchdog proof consensus contract lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected watchdog proof consensus contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.runtime.watchdog-proof-consensus-report.v1"' "$bundle_file"; then
+  echo "expected watchdog proof consensus evidence schema marker" >&2
+  exit 1
+fi
+
+echo "watchdog proof consensus contract lane script tests passed."

--- a/scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh
+++ b/scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEEP_LANE="$ROOT_DIR/scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [[ ! -x "$DEEP_LANE" ]]; then
+  echo "expected watchdog proof consensus deep lane script to be executable" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/watchdog-proof-consensus-deep-summary.json"
+lane_output="$(
+  KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE=scheduled \
+  bash "$DEEP_LANE" \
+    --event-name schedule \
+    --skip-contract-tests \
+    --max-seconds 120 \
+    --output-json "$report_json"
+)"
+
+if ! printf '%s\n' "$lane_output" | grep -q "watchdog proof consensus deep lane tests passed."; then
+  echo "expected watchdog proof consensus deep lane success output" >&2
+  exit 1
+fi
+
+python3 - "$report_json" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.watchdog-proof-consensus-deep-summary.v1":
+    raise SystemExit("unexpected watchdog proof consensus deep summary schema")
+if payload.get("event_name") != "schedule":
+    raise SystemExit("expected schedule event in watchdog proof consensus deep summary")
+if payload.get("cadence") != "scheduled":
+    raise SystemExit("expected scheduled cadence in watchdog proof consensus deep summary")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected GO final decision for watchdog proof consensus deep summary")
+if payload.get("budget_status") != "within":
+    raise SystemExit("expected runtime budget within threshold for watchdog proof consensus deep summary")
+PY
+
+set +e
+invalid_event_output="$(
+  bash "$DEEP_LANE" \
+    --event-name pull_request \
+    --output-json "$TMP_DIR/watchdog-proof-consensus-invalid-cadence.json" 2>&1
+)"
+invalid_event_code=$?
+set -e
+
+if [[ "$invalid_event_code" -eq 0 ]]; then
+  echo "expected watchdog proof consensus deep lane to reject pull_request cadence" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$invalid_event_output" | grep -q "scheduled/manual-only cadence policy"; then
+  echo "expected cadence policy rejection marker for watchdog proof consensus deep lane" >&2
+  exit 1
+fi
+
+echo "watchdog proof consensus deep lane script tests passed."

--- a/scripts/runtime/watchdog_proof_consensus_contract.py
+++ b/scripts/runtime/watchdog_proof_consensus_contract.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Watchdog proof-consensus evidence generator and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+from typing import Mapping
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_int,
+    require_keys,
+    require_non_negative_int,
+    require_object,
+    require_positive_int,
+    require_string,
+    write_json,
+)
+
+SCHEMA_VERSION = "kamn.runtime.watchdog-proof-consensus-report.v1"
+EVIDENCE_KEY = "watchdog_proof_consensus_contract:evidence:v1"
+REASON_PREFIX = "watchdog_proof_consensus_reason_codes"
+
+CONSENSUS_STATUSES = (
+    "ConsensusValid",
+    "ConsensusInvalid",
+    "ConsensusReplay",
+    "ValidatorMismatch",
+)
+CADENCE_VALUES = ("fast", "scheduled", "manual")
+PROJECTION_KIND_BY_STATUS = {
+    "ConsensusValid": "ConsensusAligned",
+    "ConsensusInvalid": "InvalidProofConsensus",
+    "ConsensusReplay": "ReplayProofConsensus",
+    "ValidatorMismatch": "ValidatorMismatch",
+}
+PROJECTION_SEVERITY_BY_STATUS = {
+    "ConsensusValid": "info",
+    "ConsensusInvalid": "critical",
+    "ConsensusReplay": "critical",
+    "ValidatorMismatch": "critical",
+}
+
+
+def _parse_bool(name: str, raw_value: str) -> bool:
+    value = (raw_value or "").strip().lower()
+    if value in ("true", "1", "yes", "y"):
+        return True
+    if value in ("false", "0", "no", "n"):
+        return False
+    fail(f"{name} must be true or false")
+
+
+def _reason_messages() -> Mapping[str, str]:
+    return {
+        "consensus_status_go": "consensus status must remain ConsensusValid for GO release posture",
+        "projection_kind_match": "watchdog projection kind must match consensus status",
+        "projection_severity_match": "watchdog projection severity must match consensus status",
+        "quorum_coverage_valid": "attestation coverage must meet required quorum",
+        "runtime_budget_within": "proof-consensus lane exceeded runtime budget",
+        "evidence_complete": "proof-consensus anomaly evidence incomplete",
+        "ci_fast_gate_passed": "ci-fast-gate-failed",
+    }
+
+
+def _reason_key(decision: str) -> str:
+    return f"{REASON_PREFIX}:{decision}:v1"
+
+
+def _failed_checks(policy_checks: Mapping[str, bool]) -> list[str]:
+    return sorted([key for key, passed in policy_checks.items() if not passed])
+
+
+def _compute_policy_checks(
+    consensus_status: str,
+    projection_kind: str,
+    projection_severity: str,
+    required_quorum: int,
+    valid_attestation_count: int,
+    invalid_attestation_count: int,
+    replay_attestation_count: int,
+    runtime_seconds: int,
+    max_seconds: int,
+    evidence_complete: bool,
+    ci_fast_gate: str,
+) -> Mapping[str, bool]:
+    expected_kind = PROJECTION_KIND_BY_STATUS[consensus_status]
+    expected_severity = PROJECTION_SEVERITY_BY_STATUS[consensus_status]
+    total_attestation_count = (
+        valid_attestation_count + invalid_attestation_count + replay_attestation_count
+    )
+
+    return {
+        "consensus_status_go": consensus_status == "ConsensusValid",
+        "projection_kind_match": projection_kind == expected_kind,
+        "projection_severity_match": projection_severity == expected_severity,
+        "quorum_coverage_valid": total_attestation_count >= required_quorum,
+        "runtime_budget_within": runtime_seconds <= max_seconds,
+        "evidence_complete": evidence_complete,
+        "ci_fast_gate_passed": ci_fast_gate == "PASS",
+    }
+
+
+def _compute_decision(policy_checks: Mapping[str, bool]) -> tuple[str, list[str], list[str]]:
+    decision = DecisionAccumulator()
+    reason_messages = _reason_messages()
+    for check_name in reason_messages:
+        decision.reject_if(not policy_checks[check_name], reason_messages[check_name])
+    final_decision, decision_reasons = decision.finalize(
+        "watchdog proof consensus checks satisfied"
+    )
+    failed_checks = _failed_checks(policy_checks)
+    return final_decision, decision_reasons, failed_checks
+
+
+def _require_policy_checks(payload: Mapping[str, object]) -> Mapping[str, bool]:
+    checks_raw = payload.get("policy_checks")
+    if not isinstance(checks_raw, dict):
+        fail("policy_checks must be an object")
+
+    checks: dict[str, bool] = {}
+    for key_name in _reason_messages().keys():
+        if key_name not in checks_raw:
+            fail(f"missing policy_checks field: {key_name}")
+        value = checks_raw[key_name]
+        if not isinstance(value, bool):
+            fail(f"policy_checks.{key_name} must be boolean")
+        checks[key_name] = value
+    return checks
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    consensus_status = require_enum("consensus-status", args.consensus_status, CONSENSUS_STATUSES)
+    cadence = require_enum("cadence", args.cadence, CADENCE_VALUES)
+    ci_fast_gate = require_enum("ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+    required_quorum = require_positive_int("required-quorum", args.required_quorum)
+    valid_attestation_count = require_non_negative_int(
+        "valid-attestation-count", args.valid_attestation_count
+    )
+    invalid_attestation_count = require_non_negative_int(
+        "invalid-attestation-count", args.invalid_attestation_count
+    )
+    replay_attestation_count = require_non_negative_int(
+        "replay-attestation-count", args.replay_attestation_count
+    )
+    runtime_seconds = require_non_negative_int("runtime-seconds", args.runtime_seconds)
+    max_seconds = require_positive_int("max-seconds", args.max_seconds)
+    evidence_complete = _parse_bool("evidence-complete", args.evidence_complete)
+
+    projection_kind = PROJECTION_KIND_BY_STATUS[consensus_status]
+    projection_severity = PROJECTION_SEVERITY_BY_STATUS[consensus_status]
+    policy_checks = _compute_policy_checks(
+        consensus_status=consensus_status,
+        projection_kind=projection_kind,
+        projection_severity=projection_severity,
+        required_quorum=required_quorum,
+        valid_attestation_count=valid_attestation_count,
+        invalid_attestation_count=invalid_attestation_count,
+        replay_attestation_count=replay_attestation_count,
+        runtime_seconds=runtime_seconds,
+        max_seconds=max_seconds,
+        evidence_complete=evidence_complete,
+        ci_fast_gate=ci_fast_gate,
+    )
+
+    final_decision, decision_reasons, failed_checks = _compute_decision(policy_checks)
+    reason_key = _reason_key(final_decision)
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "evidence_key": EVIDENCE_KEY,
+        "message_id": args.message_id,
+        "artifact_id": args.artifact_id,
+        "consensus_status": consensus_status,
+        "projection_kind": projection_kind,
+        "projection_severity": projection_severity,
+        "required_quorum": required_quorum,
+        "valid_attestation_count": valid_attestation_count,
+        "invalid_attestation_count": invalid_attestation_count,
+        "replay_attestation_count": replay_attestation_count,
+        "cadence": cadence,
+        "runtime_seconds": runtime_seconds,
+        "max_seconds": max_seconds,
+        "ci_fast_gate": ci_fast_gate,
+        "evidence_complete": evidence_complete,
+        "policy_checks": policy_checks,
+        "failed_checks": failed_checks,
+        "decision_reasons": decision_reasons,
+        "reason_key": reason_key,
+        "final_decision": final_decision,
+    }
+
+    output_file = Path(args.output_file)
+    write_json(output_file, payload)
+
+    failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
+    print("status=generated")
+    print(f"bundle_file={output_file}")
+    print(f"evidence_key={EVIDENCE_KEY}")
+    print(f"reason_key={reason_key}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def check_bundle(args: argparse.Namespace) -> int:
+    bundle_file = Path(args.bundle_file)
+    if not bundle_file.is_file():
+        fail(f"bundle file not found: {bundle_file}")
+
+    payload = load_json(bundle_file)
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "generated_at",
+            "evidence_key",
+            "message_id",
+            "artifact_id",
+            "consensus_status",
+            "projection_kind",
+            "projection_severity",
+            "required_quorum",
+            "valid_attestation_count",
+            "invalid_attestation_count",
+            "replay_attestation_count",
+            "cadence",
+            "runtime_seconds",
+            "max_seconds",
+            "ci_fast_gate",
+            "evidence_complete",
+            "policy_checks",
+            "failed_checks",
+            "decision_reasons",
+            "reason_key",
+            "final_decision",
+        ),
+    )
+
+    if require_string(payload, "schema_version") != SCHEMA_VERSION:
+        fail(f"schema_version must be {SCHEMA_VERSION}")
+    if require_string(payload, "evidence_key") != EVIDENCE_KEY:
+        fail("evidence_key mismatch")
+    require_string(payload, "generated_at")
+    require_string(payload, "message_id")
+    require_string(payload, "artifact_id")
+
+    consensus_status = require_enum(
+        "consensus_status", require_string(payload, "consensus_status"), CONSENSUS_STATUSES
+    )
+    projection_kind = require_string(payload, "projection_kind")
+    projection_severity = require_string(payload, "projection_severity")
+    cadence = require_enum("cadence", require_string(payload, "cadence"), CADENCE_VALUES)
+    ci_fast_gate = require_enum(
+        "ci_fast_gate", require_string(payload, "ci_fast_gate"), ("PASS", "FAIL")
+    )
+
+    required_quorum = require_int(payload, "required_quorum", min_value=1)
+    valid_attestation_count = require_int(payload, "valid_attestation_count", min_value=0)
+    invalid_attestation_count = require_int(payload, "invalid_attestation_count", min_value=0)
+    replay_attestation_count = require_int(payload, "replay_attestation_count", min_value=0)
+    runtime_seconds = require_int(payload, "runtime_seconds", min_value=0)
+    max_seconds = require_int(payload, "max_seconds", min_value=1)
+
+    evidence_complete_raw = payload.get("evidence_complete")
+    if not isinstance(evidence_complete_raw, bool):
+        fail("evidence_complete must be boolean")
+    evidence_complete = evidence_complete_raw
+
+    expected_kind = PROJECTION_KIND_BY_STATUS[consensus_status]
+    if projection_kind != expected_kind:
+        fail(f"projection_kind mismatch: expected {expected_kind}, found {projection_kind}")
+    expected_severity = PROJECTION_SEVERITY_BY_STATUS[consensus_status]
+    if projection_severity != expected_severity:
+        fail(
+            "projection_severity mismatch: "
+            f"expected {expected_severity}, found {projection_severity}"
+        )
+
+    checks = _require_policy_checks(payload)
+    recomputed_checks = _compute_policy_checks(
+        consensus_status=consensus_status,
+        projection_kind=projection_kind,
+        projection_severity=projection_severity,
+        required_quorum=required_quorum,
+        valid_attestation_count=valid_attestation_count,
+        invalid_attestation_count=invalid_attestation_count,
+        replay_attestation_count=replay_attestation_count,
+        runtime_seconds=runtime_seconds,
+        max_seconds=max_seconds,
+        evidence_complete=evidence_complete,
+        ci_fast_gate=ci_fast_gate,
+    )
+    if checks != recomputed_checks:
+        fail(f"policy_checks mismatch: expected {recomputed_checks}, found {checks}")
+
+    final_decision = require_enum(
+        "final_decision", require_string(payload, "final_decision"), ("GO", "NO-GO")
+    )
+    reason_key = require_string(payload, "reason_key")
+
+    expected_decision, expected_reasons, expected_failed_checks = _compute_decision(
+        recomputed_checks
+    )
+    if final_decision != expected_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected {expected_decision}, found {final_decision}"
+        )
+    expected_reason_key = _reason_key(expected_decision)
+    if reason_key != expected_reason_key:
+        fail(f"reason_key mismatch: expected {expected_reason_key}, found {reason_key}")
+
+    decision_reasons = payload.get("decision_reasons")
+    if decision_reasons != expected_reasons:
+        fail(
+            "decision_reasons mismatch: "
+            f"expected {expected_reasons}, found {decision_reasons}"
+        )
+
+    failed_checks = payload.get("failed_checks")
+    if failed_checks != expected_failed_checks:
+        fail(
+            "failed_checks mismatch: "
+            f"expected {expected_failed_checks}, found {failed_checks}"
+        )
+
+    failed_checks_value = ",".join(expected_failed_checks) if expected_failed_checks else "none"
+    print("status=validated")
+    print(f"bundle_file={bundle_file}")
+    print(f"reason_key={expected_reason_key}")
+    print(f"final_decision={expected_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate/check watchdog proof-consensus contract evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate", help="Generate evidence bundle")
+    generate_parser.add_argument("--output-file", required=True)
+    generate_parser.add_argument("--message-id", required=True)
+    generate_parser.add_argument("--artifact-id", required=True)
+    generate_parser.add_argument("--consensus-status", required=True)
+    generate_parser.add_argument("--required-quorum", required=True)
+    generate_parser.add_argument("--valid-attestation-count", required=True)
+    generate_parser.add_argument("--invalid-attestation-count", required=True)
+    generate_parser.add_argument("--replay-attestation-count", required=True)
+    generate_parser.add_argument("--cadence", default="fast")
+    generate_parser.add_argument("--runtime-seconds", default="0")
+    generate_parser.add_argument("--max-seconds", default="90")
+    generate_parser.add_argument("--evidence-complete", default="true")
+    generate_parser.add_argument("--ci-fast-gate", default="PASS")
+    generate_parser.set_defaults(handler=generate_bundle)
+
+    check_parser = subparsers.add_parser("check", help="Check evidence bundle")
+    check_parser.add_argument("--bundle-file", required=True)
+    check_parser.set_defaults(handler=check_bundle)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except ContractError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add a validator/watchdog proof-consensus evidence contract stack with fast/deep lane runners, fail-closed anomaly policy checks, and runtime budget/cadence enforcement. Wire the new lane tests into the runtime snapshot fast contract lane and document release gating controls.

## Changes
- `scripts/runtime/watchdog_proof_consensus_contract.py`: add deterministic generator/policy checker for proof-consensus status/projection/budget evidence.
- `scripts/runtime/generate_watchdog_proof_consensus_evidence_bundle.sh`: add generator wrapper.
- `scripts/runtime/check_watchdog_proof_consensus_policy.sh`: add policy checker wrapper.
- `scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh`: add PR-fast watchdog proof-consensus contract lane.
- `scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh`: add scheduled/manual deep lane with budget and cadence controls.
- `scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh`: add functional/tamper policy tests.
- `scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh`: add contract lane smoke test.
- `scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh`: add deep lane cadence and summary assertions.
- `scripts/runtime/run_runtime_snapshot_contract_lane.sh`: include watchdog proof-consensus lane tests in fast runtime snapshot lane.
- `scripts/runtime/test_run_runtime_snapshot_contract_lane.sh`: assert watchdog proof-consensus lane integration.
- `docs/foundation/runtime-watchdog-attestation.md`: add deep-lane contract section, controls, and `Regression: #996` markers.
- `docs/foundation/release-gonogo-checklist.md`: add release checklist evidence contract section and `Regression: #996` marker.
- `crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs`: enforce new watchdog proof-consensus doc markers.
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`: enforce new release checklist markers.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed targeted docs tests, watchdog contract/deep lane script tests, runtime snapshot lane script test, and CI target-selection matrix regression tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test runtime_watchdog_attestation_docs --test release_gonogo_checklist_docs` |
| Functional  | ✅     | `bash scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh` |
| Integration | ✅     | `bash scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh`, `bash scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh`, `bash scripts/runtime/test_run_runtime_snapshot_contract_lane.sh` |
| Regression  | ✅     | `Regression: #996` doc-contract assertions + tampered policy mismatch checks |

Closes #996
