### PR TITLE
docs(security): add watchdog proof-consensus matrix controls (#992)

### DIFF
--- a/crates/kamn-core/tests/threat_control_matrix_docs.rs
+++ b/crates/kamn-core/tests/threat_control_matrix_docs.rs
@@ -16,6 +16,7 @@ fn matrix_contains_core_threat_entries() {
     assert!(CONTROL_MATRIX.contains("TM-005"));
     assert!(CONTROL_MATRIX.contains("TM-006"));
     assert!(CONTROL_MATRIX.contains("TM-007"));
+    assert!(CONTROL_MATRIX.contains("TM-008"));
 }
 
 #[test]
@@ -37,6 +38,11 @@ fn matrix_maps_controls_to_tests() {
         .contains("router_decision_matrix_distinguishes_unavailable_vs_policy_blocked_handshakes"));
     assert!(CONTROL_MATRIX
         .contains("regression_provider_client_backend_mismatch_is_rejected_without_fallback"));
+    assert!(CONTROL_MATRIX.contains("run_watchdog_proof_consensus_contract_lane.sh"));
+    assert!(CONTROL_MATRIX.contains("run_watchdog_proof_consensus_deep_lane.sh"));
+    assert!(CONTROL_MATRIX.contains("check_watchdog_proof_consensus_policy.sh"));
+    assert!(CONTROL_MATRIX.contains("watchdog_proof_consensus_reason_codes:GO:v1"));
+    assert!(CONTROL_MATRIX.contains("watchdog_proof_consensus_reason_codes:NO-GO:v1"));
 }
 
 #[test]
@@ -51,4 +57,12 @@ fn matrix_contains_signer_fallback_policy_entry_details() {
     assert!(CONTROL_MATRIX
         .contains("Privileged role fallback bypass under secure-provider degradation"));
     assert!(CONTROL_MATRIX.contains("`Regression: #987`"));
+}
+
+#[test]
+fn matrix_contains_watchdog_proof_consensus_entry_details() {
+    assert!(CONTROL_MATRIX.contains(
+        "Validator/watchdog proof-consensus anomaly evidence missing or cadence/budget guard bypass"
+    ));
+    assert!(CONTROL_MATRIX.contains("`Regression: #996`"));
 }

--- a/docs/foundation/threat-control-matrix.md
+++ b/docs/foundation/threat-control-matrix.md
@@ -13,6 +13,7 @@ This matrix translates PRD threat model concerns into enforceable controls, owne
 | TM-005 | Signature metadata downgrade or algorithm drift | Enforce explicit signature algorithm/profile parsing and reject unsupported metadata pairs | Shared signer + transaction profile verification | Security + Backend | `integration_signature_profile_fixture_matrix_remains_consistent_with_transaction_guards` |
 | TM-006 | Quorum attestation evidence drift or replayed approval artifact | Require deterministic quorum attestation schema checks and replay-guard policy validation before governance execution | Governance quorum attestation lane + policy checker | Governance + Security | `quorum_attestation_replay_guard_policy_contract` |
 | TM-007 | Privileged role fallback bypass under secure-provider degradation | Deny local fallback for privileged signer roles and reject policy-blocked handshake downgrades | Signer policy contract lane + signer backend router | Security + Backend | `functional_privileged_roles_deny_fallback_when_provider_unavailable` |
+| TM-008 | Validator/watchdog proof-consensus anomaly evidence missing or cadence/budget guard bypass | Require deterministic proof-consensus anomaly evidence with scheduled/manual deep-lane cadence and runtime budget policy checks | Runtime watchdog proof-consensus contract lane + deep lane policy checker | Runtime + Security | `run_watchdog_proof_consensus_contract_lane.sh` |
 
 ## Governance Quorum Attestation Replay Contract
 - Fast lane:
@@ -47,6 +48,20 @@ This matrix translates PRD threat model concerns into enforceable controls, owne
   - `cargo test -p kamn-core --test signer_backend regression_provider_client_backend_mismatch_is_rejected_without_fallback`
 - Required fail-closed policy:
   - privileged-role fallback bypass attempts and policy-blocked handshake downgrades must fail closed (`Regression: #987`).
+
+## Runtime Watchdog Proof-Consensus Policy Contract
+- Fast lane:
+  - `bash scripts/runtime/run_watchdog_proof_consensus_contract_lane.sh --output-file /tmp/watchdog-proof-consensus-contract.json`
+- Scheduled/manual deep lane:
+  - `KAMN_WATCHDOG_PROOF_CONSENSUS_DEEP_CADENCE=scheduled bash scripts/runtime/run_watchdog_proof_consensus_deep_lane.sh --event-name schedule --output-json /tmp/watchdog-proof-consensus-deep-summary.json`
+- Policy checker:
+  - `bash scripts/runtime/check_watchdog_proof_consensus_policy.sh --bundle-file /tmp/watchdog-proof-consensus-contract.json`
+- Required schema and reason-key markers:
+  - `watchdog_proof_consensus_reason_codes:GO:v1`
+  - `watchdog_proof_consensus_reason_codes:NO-GO:v1`
+- Required fail-closed policy:
+  - validator/watchdog proof-consensus anomaly evidence must fail closed for invalid/replay/mismatch outcomes.
+  - cadence/budget guard bypass attempts must fail closed (`Regression: #996`).
 
 ## Ownership and Review Cadence
 - Security owner reviews this matrix each milestone and when new threat classes are introduced.


### PR DESCRIPTION
## Summary
Complete the remaining #992 documentation requirement by adding validator/watchdog proof-consensus controls to the threat control matrix and enforcing them with doc-contract tests. This aligns the story outputs with required runtime watchdog and threat-model artifacts.

## Changes
- `docs/foundation/threat-control-matrix.md`: add TM-008 watchdog proof-consensus threat row and a dedicated runtime watchdog proof-consensus policy contract section.
- `crates/kamn-core/tests/threat_control_matrix_docs.rs`: add assertions for TM-008 entry details, lane/policy command markers, reason-key markers, and regression marker `Regression: #996`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed docs-contract suites for release checklist, runtime watchdog attestation, and threat control matrix; ran CI target-selection regression checks.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test threat_control_matrix_docs` |
| Functional  | ✅     | `cargo test -p kamn-core --test runtime_watchdog_attestation_docs --test release_gonogo_checklist_docs --test threat_control_matrix_docs` |
| Integration | ✅     | `bash scripts/ci/test_select_targets.sh` |
| Regression  | ✅     | `Regression: #996` guard markers asserted in threat control matrix docs tests |

Closes #992
