### PR TITLE
feat(identity): add DID service endpoint canonicalization conformance lane (#1000)

### DIFF
--- a/crates/kamn-core/src/did.rs
+++ b/crates/kamn-core/src/did.rs
@@ -100,6 +100,7 @@ pub enum DidDocumentError {
     EmptyModelFamily,
     MissingCapabilities,
     InvalidCapability,
+    InvalidServiceEndpoint(String),
 }
 
 impl fmt::Display for DidDocumentError {
@@ -110,11 +111,67 @@ impl fmt::Display for DidDocumentError {
             Self::EmptyModelFamily => write!(f, "model_family must not be empty"),
             Self::MissingCapabilities => write!(f, "at least one capability is required"),
             Self::InvalidCapability => write!(f, "capability entries must not be empty"),
+            Self::InvalidServiceEndpoint(message) => {
+                write!(f, "invalid service endpoint: {message}")
+            }
         }
     }
 }
 
 impl std::error::Error for DidDocumentError {}
+
+pub fn canonical_service_endpoint(raw_endpoint: &str) -> Result<String, DidDocumentError> {
+    let trimmed = raw_endpoint.trim();
+    if trimmed.is_empty() {
+        return Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint must not be empty".to_owned(),
+        ));
+    }
+    if trimmed.contains('?') || trimmed.contains('#') {
+        return Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint must not include query or fragment".to_owned(),
+        ));
+    }
+
+    let (scheme, remainder) = trimmed.split_once("://").ok_or_else(|| {
+        DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint must include scheme://authority/path".to_owned(),
+        )
+    })?;
+    if !scheme.eq_ignore_ascii_case("kamn") {
+        return Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint scheme must be kamn".to_owned(),
+        ));
+    }
+
+    let (authority, path) = remainder.split_once('/').ok_or_else(|| {
+        DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint must include authority and path".to_owned(),
+        )
+    })?;
+    if !authority.eq_ignore_ascii_case("messaging") {
+        return Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint authority must be messaging".to_owned(),
+        ));
+    }
+    if path.is_empty() || path.contains('/') {
+        return Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint path must be a single segment".to_owned(),
+        ));
+    }
+
+    let normalized_path = path.to_ascii_lowercase();
+    if !normalized_path
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
+    {
+        return Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint path contains invalid characters".to_owned(),
+        ));
+    }
+
+    Ok(format!("kamn://messaging/{normalized_path}"))
+}
 
 pub fn canonical_did_document(
     did: &AgentDid,
@@ -143,7 +200,8 @@ pub fn canonical_did_document(
 
     let key_id = format!("{}#keys-1", did.as_str());
     let service_id = format!("{}#messaging", did.as_str());
-    let service_endpoint = format!("kamn://messaging/{}", did.method_specific_id());
+    let service_endpoint =
+        canonical_service_endpoint(&format!("kamn://messaging/{}", did.method_specific_id()))?;
 
     Ok(DidDocument {
         context: vec![
@@ -172,7 +230,8 @@ pub fn canonical_did_document(
 #[cfg(test)]
 mod tests {
     use super::{
-        canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocumentError,
+        canonical_did_document, canonical_service_endpoint, AgentDid, AgentDidError,
+        AgentDidMetadata, DidDocumentError,
     };
 
     fn metadata() -> AgentDidMetadata {
@@ -203,6 +262,24 @@ mod tests {
         assert_eq!(
             canonical_did_document(&did, "z6Mkey", invalid),
             Err(DidDocumentError::MissingCapabilities)
+        );
+    }
+
+    #[test]
+    fn canonical_service_endpoint_normalizes_scheme_authority_and_path() {
+        assert_eq!(
+            canonical_service_endpoint("  KAMN://MESSAGING/Agent_1  "),
+            Ok("kamn://messaging/agent_1".to_owned())
+        );
+    }
+
+    #[test]
+    fn canonical_service_endpoint_rejects_query_and_fragment() {
+        assert_eq!(
+            canonical_service_endpoint("kamn://messaging/agent-1?channel=dm"),
+            Err(DidDocumentError::InvalidServiceEndpoint(
+                "service endpoint must not include query or fragment".to_owned()
+            ))
         );
     }
 }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -200,8 +200,8 @@ pub use data_classification::{
     DataClassificationLevel, WriteDomain, WriteRequestContext, WriteTag,
 };
 pub use did::{
-    canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocument,
-    DidDocumentError, DidService, DidVerificationMethod,
+    canonical_did_document, canonical_service_endpoint, AgentDid, AgentDidError, AgentDidMetadata,
+    DidDocument, DidDocumentError, DidService, DidVerificationMethod,
 };
 pub use did_registry::{
     DidChainSubmissionOutcome, DidChainSubmissionReceipt, DidChainSubmissionRequest,

--- a/crates/kamn-core/tests/did_core_conformance_docs.rs
+++ b/crates/kamn-core/tests/did_core_conformance_docs.rs
@@ -15,10 +15,18 @@ fn profile_contains_did_core_requirement_mapping() {
 
 #[test]
 fn profile_contains_conformance_decisions_and_open_questions() {
-    assert!(PROFILE.contains("## Conformance Decisions and Open Questions"));
+    assert!(PROFILE.contains("## Conformance Decisions"));
     assert!(PROFILE.contains("Decision: require verificationMethod and capabilityInvocation."));
     assert!(PROFILE.contains("Decision: reject unsupported DID method prefixes."));
-    assert!(PROFILE.contains("Open question: service endpoint canonicalization strategy."));
+    assert!(PROFILE.contains(
+        "Decision: canonical service endpoint is `kamn://messaging/<method-specific-id>` with lowercase scheme/authority and a single normalized path segment."
+    ));
+    assert!(PROFILE.contains(
+        "Decision: endpoint queries/fragments and multi-segment paths are non-conformant."
+    ));
+    assert!(PROFILE.contains(
+        "Decision: unsupported or mixed verification method algorithms remain non-conformant for `kamn:did` baseline profile."
+    ));
 }
 
 #[test]
@@ -26,8 +34,14 @@ fn profile_contains_candidate_test_vectors_and_downstream_categories() {
     assert!(PROFILE.contains("## Candidate Test Vectors"));
     assert!(PROFILE.contains("Vector-C1: valid kamn:did document with required relationships."));
     assert!(PROFILE.contains("Vector-C2: valid update preserving DID subject continuity."));
+    assert!(PROFILE.contains(
+        "Vector-C3: canonicalization normalizes uppercase scheme/authority/identifier to canonical endpoint form."
+    ));
     assert!(PROFILE.contains("Vector-N1: document missing id is rejected."));
     assert!(PROFILE.contains("Vector-N2: unsupported verification method algorithm is rejected."));
+    assert!(PROFILE.contains(
+        "Vector-N3: service endpoint with unsupported scheme, query/fragment, or multi-segment path is rejected."
+    ));
     assert!(PROFILE.contains("## Downstream Test Category Mapping"));
     assert!(PROFILE.contains("Unit: schema-field validator mappings."));
     assert!(PROFILE.contains("Functional: DID document acceptance and rejection examples."));
@@ -39,4 +53,25 @@ fn profile_contains_candidate_test_vectors_and_downstream_categories() {
 fn regression_requires_missing_id_rejection_rule() {
     // Regression: #81
     assert!(PROFILE.contains("Previously non-conformant document (missing id) must be rejected."));
+}
+
+#[test]
+fn profile_contains_service_endpoint_canonicalization_contract_lane() {
+    assert!(PROFILE.contains("## Service Endpoint Canonicalization Conformance Contract"));
+    assert!(PROFILE.contains("run_service_endpoint_canonicalization_contract_lane.sh"));
+    assert!(PROFILE.contains("generate_service_endpoint_canonicalization_evidence_bundle.sh"));
+    assert!(PROFILE.contains("check_service_endpoint_canonicalization_policy.sh"));
+    assert!(PROFILE.contains("run_service_endpoint_canonicalization_matrix.py"));
+    assert!(PROFILE
+        .contains("fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json"));
+    assert!(PROFILE.contains("did_service_endpoint_canonicalization_reason_codes:GO:v1"));
+    assert!(PROFILE.contains("did_service_endpoint_canonicalization_reason_codes:NO-GO:v1"));
+}
+
+#[test]
+fn regression_requires_service_endpoint_non_canonical_rejection_rule() {
+    // Regression: #1000
+    assert!(PROFILE.contains(
+        "non-canonical service endpoint scheme/authority/path combinations must remain rejected (`Regression: #1000`)."
+    ));
 }

--- a/crates/kamn-core/tests/did_fuzz_smoke.rs
+++ b/crates/kamn-core/tests/did_fuzz_smoke.rs
@@ -203,7 +203,8 @@ fn fuzz_smoke_did_document_generation_lane_is_panic_free_and_deterministic() {
                 | DidDocumentError::EmptyAgentType
                 | DidDocumentError::EmptyModelFamily
                 | DidDocumentError::MissingCapabilities
-                | DidDocumentError::InvalidCapability,
+                | DidDocumentError::InvalidCapability
+                | DidDocumentError::InvalidServiceEndpoint(_),
             ) => {}
         }
     }

--- a/crates/kamn-core/tests/did_method.rs
+++ b/crates/kamn-core/tests/did_method.rs
@@ -1,5 +1,6 @@
 use kamn_core::{
-    canonical_did_document, AgentDid, AgentDidError, AgentDidMetadata, DidDocumentError,
+    canonical_did_document, canonical_service_endpoint, AgentDid, AgentDidError, AgentDidMetadata,
+    DidDocumentError,
 };
 
 fn metadata() -> AgentDidMetadata {
@@ -72,5 +73,33 @@ fn canonical_document_rejects_empty_capability_entry() {
     assert_eq!(
         canonical_did_document(&did, "z6Mkey", invalid),
         Err(DidDocumentError::InvalidCapability)
+    );
+}
+
+#[test]
+fn unit_service_endpoint_canonicalization_normalizes_case_and_whitespace() {
+    let endpoint = canonical_service_endpoint("  KAMN://MESSAGING/Agent_77  ")
+        .expect("service endpoint canonicalization should succeed");
+    assert_eq!(endpoint, "kamn://messaging/agent_77".to_owned());
+}
+
+#[test]
+fn functional_service_endpoint_canonicalization_rejects_non_kamn_scheme() {
+    assert_eq!(
+        canonical_service_endpoint("https://messaging/agent-77"),
+        Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint scheme must be kamn".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn regression_service_endpoint_canonicalization_rejects_non_single_segment_path() {
+    // Regression: #1000
+    assert_eq!(
+        canonical_service_endpoint("kamn://messaging/agent-77/extra"),
+        Err(DidDocumentError::InvalidServiceEndpoint(
+            "service endpoint path must be a single segment".to_owned()
+        ))
     );
 }

--- a/crates/kamn-core/tests/did_method_docs.rs
+++ b/crates/kamn-core/tests/did_method_docs.rs
@@ -5,6 +5,14 @@ fn did_method_doc_contains_core_rules() {
     assert!(DID_METHOD_DOC.contains("## DID Validation Rules"));
     assert!(DID_METHOD_DOC.contains("DID must start with `kamn:did:agent:`."));
     assert!(DID_METHOD_DOC.contains("## Canonical DID Document Rules"));
+    assert!(DID_METHOD_DOC.contains(
+        "Canonical service endpoint policy enforces `kamn://messaging/<method-specific-id>`."
+    ));
+    assert!(DID_METHOD_DOC.contains(
+        "Service endpoint canonicalization normalizes scheme/authority/identifier to lowercase."
+    ));
+    assert!(DID_METHOD_DOC
+        .contains("Service endpoints with query/fragment or multi-segment paths are rejected."));
 }
 
 #[test]
@@ -24,4 +32,12 @@ fn regression_requires_federated_handshake_replay_guard_marker() {
     // Regression: #734
     assert!(DID_METHOD_DOC
         .contains("replay/downgrade/tamper attempts force `NO-GO` (`Regression: #734`)."));
+}
+
+#[test]
+fn regression_requires_service_endpoint_canonicalization_guard_marker() {
+    // Regression: #1000
+    assert!(DID_METHOD_DOC.contains(
+        "non-canonical service endpoint scheme/authority/path combinations must remain rejected (`Regression: #1000`)."
+    ));
 }

--- a/docs/foundation/did-core-conformance-kamn-method.md
+++ b/docs/foundation/did-core-conformance-kamn-method.md
@@ -12,18 +12,21 @@ This profile maps the `kamn:did` method schema to DID Core 1.1 conformance requi
 | capabilityInvocation | RECOMMENDED | covered | Required by profile for operator-bound actions. |
 | service | OPTIONAL | partial | Service rules remain profile-constrained. |
 
-## Conformance Decisions and Open Questions
+## Conformance Decisions
 - Decision: require verificationMethod and capabilityInvocation.
 - Decision: reject unsupported DID method prefixes.
 - Decision: treat empty capability relationship arrays as invalid.
-- Open question: service endpoint canonicalization strategy.
-- Open question: multi-key algorithm mixing policy for future revisions.
+- Decision: canonical service endpoint is `kamn://messaging/<method-specific-id>` with lowercase scheme/authority and a single normalized path segment.
+- Decision: endpoint queries/fragments and multi-segment paths are non-conformant.
+- Decision: unsupported or mixed verification method algorithms remain non-conformant for `kamn:did` baseline profile.
 
 ## Candidate Test Vectors
 - Vector-C1: valid kamn:did document with required relationships.
 - Vector-C2: valid update preserving DID subject continuity.
+- Vector-C3: canonicalization normalizes uppercase scheme/authority/identifier to canonical endpoint form.
 - Vector-N1: document missing id is rejected.
 - Vector-N2: unsupported verification method algorithm is rejected.
+- Vector-N3: service endpoint with unsupported scheme, query/fragment, or multi-segment path is rejected.
 - Previously non-conformant document (missing id) must be rejected.
 
 ## Downstream Test Category Mapping
@@ -32,10 +35,30 @@ This profile maps the `kamn:did` method schema to DID Core 1.1 conformance requi
 - Integration: DID registry interaction expectations.
 - Regression: previously non-conformant examples remain rejected.
 
+## Service Endpoint Canonicalization Conformance Contract
+- Vector fixture:
+  - `fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json`
+- Matrix runner:
+  - `python3 scripts/did/run_service_endpoint_canonicalization_matrix.py --fixture fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json --output-json /tmp/did-service-endpoint-canonicalization-matrix-report.json`
+- Evidence bundle generator:
+  - `bash scripts/did/generate_service_endpoint_canonicalization_evidence_bundle.sh --output-file /tmp/did-service-endpoint-canonicalization.json --fixture fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json --ci-fast-gate PASS`
+- Policy checker:
+  - `bash scripts/did/check_service_endpoint_canonicalization_policy.sh --bundle-file /tmp/did-service-endpoint-canonicalization.json`
+- PR fast contract lane:
+  - `bash scripts/did/run_service_endpoint_canonicalization_contract_lane.sh --output-file /tmp/did-service-endpoint-canonicalization-contract.json`
+- Required reason-key markers:
+  - `did_service_endpoint_canonicalization_reason_codes:GO:v1`
+  - `did_service_endpoint_canonicalization_reason_codes:NO-GO:v1`
+- Required fail-closed policy:
+  - non-canonical service endpoint scheme/authority/path combinations must remain rejected (`Regression: #1000`).
+
 ## Local Validation
 Run from repository root:
 
 ```bash
+bash scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh
+bash scripts/did/test_run_service_endpoint_canonicalization_matrix.sh
+bash scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh
 cargo test -p kamn-core --test did_core_conformance_docs
 cargo fmt --check
 cargo clippy -- -D warnings

--- a/docs/foundation/did-method.md
+++ b/docs/foundation/did-method.md
@@ -25,6 +25,9 @@ For DID Core 1.1 conformance mapping of `kamn:did`, see `docs/foundation/did-cor
 - Default verification key id: `<did>#keys-1`.
 - Default service id: `<did>#messaging`.
 - Default service endpoint: `kamn://messaging/<method-specific-id>`.
+- Canonical service endpoint policy enforces `kamn://messaging/<method-specific-id>`.
+- Service endpoint canonicalization normalizes scheme/authority/identifier to lowercase.
+- Service endpoints with query/fragment or multi-segment paths are rejected.
 - Public key and capability entries must be non-empty.
 
 ## Federated DID Handshake Evidence Contract (Issue #752)
@@ -47,6 +50,7 @@ Cross-network DID trust handshakes must emit deterministic evidence before relea
   - `python3 scripts/did/run_federated_did_handshake_matrix.py --fixture fixtures/federated_did_handshake/partition_replay_cases.json --output-json federated-did-handshake-report.json`
 - Regression policy:
   - replay/downgrade/tamper attempts force `NO-GO` (`Regression: #734`).
+  - non-canonical service endpoint scheme/authority/path combinations must remain rejected (`Regression: #1000`).
 
 ## Local Validation
 Run from repository root:
@@ -56,7 +60,11 @@ bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
 bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
 bash scripts/did/test_run_federated_did_handshake_matrix.sh
 bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
+bash scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh
+bash scripts/did/test_run_service_endpoint_canonicalization_matrix.sh
+bash scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh
 cargo test -p kamn-core --test did_method
+cargo test -p kamn-core --test did_method_docs
 cargo fmt --check
 cargo clippy -- -D warnings
 cargo test

--- a/fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json
+++ b/fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json
@@ -1,0 +1,38 @@
+[
+  {
+    "vector_id": "Vector-C1",
+    "input_endpoint": "kamn://messaging/agent-1",
+    "expect_valid": true,
+    "expected_endpoint": "kamn://messaging/agent-1"
+  },
+  {
+    "vector_id": "Vector-C3",
+    "input_endpoint": "  KAMN://MESSAGING/Agent_2  ",
+    "expect_valid": true,
+    "expected_endpoint": "kamn://messaging/agent_2"
+  },
+  {
+    "vector_id": "Vector-N3-scheme",
+    "input_endpoint": "https://messaging/agent-3",
+    "expect_valid": false,
+    "expected_reason": "invalid_scheme"
+  },
+  {
+    "vector_id": "Vector-N3-authority",
+    "input_endpoint": "kamn://relay/agent-4",
+    "expect_valid": false,
+    "expected_reason": "invalid_authority"
+  },
+  {
+    "vector_id": "Vector-N3-path",
+    "input_endpoint": "kamn://messaging/agent-5/extra",
+    "expect_valid": false,
+    "expected_reason": "invalid_path"
+  },
+  {
+    "vector_id": "Vector-N3-query",
+    "input_endpoint": "kamn://messaging/agent-6?channel=dm",
+    "expect_valid": false,
+    "expected_reason": "invalid_query_or_fragment"
+  }
+]

--- a/scripts/did/check_service_endpoint_canonicalization_policy.sh
+++ b/scripts/did/check_service_endpoint_canonicalization_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/did/did_service_endpoint_canonicalization_contract.py" check "$@"

--- a/scripts/did/did_service_endpoint_canonicalization_contract.py
+++ b/scripts/did/did_service_endpoint_canonicalization_contract.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""DID service-endpoint canonicalization conformance contract."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    require_enum,
+    require_keys,
+    write_json,
+)
+
+SCHEMA_VERSION = "kamn.did.service-endpoint-canonicalization-report.v1"
+EVIDENCE_KEY = "did_service_endpoint_canonicalization_contract:evidence:v1"
+REASON_PREFIX = "did_service_endpoint_canonicalization_reason_codes"
+
+
+def _load_fixture(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        fail(f"fixture file not found: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"fixture file is not valid JSON: {exc}")
+
+    if not isinstance(payload, list):
+        fail("fixture payload must be an array")
+
+    vectors: list[dict[str, Any]] = []
+    seen_vector_ids: set[str] = set()
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            fail(f"fixture vector at index {index} must be an object")
+        require_keys(
+            item,
+            (
+                "vector_id",
+                "input_endpoint",
+                "expect_valid",
+            ),
+        )
+        vector_id = item["vector_id"]
+        input_endpoint = item["input_endpoint"]
+        expect_valid = item["expect_valid"]
+        if not isinstance(vector_id, str) or not vector_id.strip():
+            fail(f"fixture vector at index {index} has invalid vector_id")
+        if vector_id in seen_vector_ids:
+            fail(f"fixture vector ids must be unique: {vector_id}")
+        seen_vector_ids.add(vector_id)
+        if not isinstance(input_endpoint, str):
+            fail(f"fixture vector {vector_id} has invalid input_endpoint")
+        if not isinstance(expect_valid, bool):
+            fail(f"fixture vector {vector_id} has invalid expect_valid")
+
+        expected_endpoint = item.get("expected_endpoint")
+        if expected_endpoint is not None and not isinstance(expected_endpoint, str):
+            fail(f"fixture vector {vector_id} expected_endpoint must be a string")
+        expected_reason = item.get("expected_reason")
+        if expected_reason is not None and not isinstance(expected_reason, str):
+            fail(f"fixture vector {vector_id} expected_reason must be a string")
+
+        vectors.append(
+            {
+                "vector_id": vector_id,
+                "input_endpoint": input_endpoint,
+                "expect_valid": expect_valid,
+                "expected_endpoint": expected_endpoint,
+                "expected_reason": expected_reason,
+            }
+        )
+
+    if not vectors:
+        fail("fixture payload must contain at least one vector")
+    return vectors
+
+
+def _canonicalize_service_endpoint(raw_endpoint: str) -> tuple[bool, str | None, str | None]:
+    trimmed = raw_endpoint.strip()
+    if not trimmed:
+        return False, None, "empty_endpoint"
+    if "?" in trimmed or "#" in trimmed:
+        return False, None, "invalid_query_or_fragment"
+    if "://" not in trimmed:
+        return False, None, "invalid_format"
+
+    scheme, remainder = trimmed.split("://", 1)
+    if scheme.lower() != "kamn":
+        return False, None, "invalid_scheme"
+
+    if "/" not in remainder:
+        return False, None, "invalid_format"
+    authority, path = remainder.split("/", 1)
+    if authority.lower() != "messaging":
+        return False, None, "invalid_authority"
+
+    if not path or "/" in path:
+        return False, None, "invalid_path"
+
+    normalized_path = path.lower()
+    if not all(ch.islower() or ch.isdigit() or ch in "-_" for ch in normalized_path):
+        return False, None, "invalid_path_characters"
+
+    return True, f"kamn://messaging/{normalized_path}", None
+
+
+def _evaluate_vectors(vectors: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    vector_results: list[dict[str, Any]] = []
+    mismatch_vector_ids: list[str] = []
+    positive_count = 0
+    negative_count = 0
+
+    for vector in vectors:
+        vector_id = vector["vector_id"]
+        input_endpoint = vector["input_endpoint"]
+        expect_valid = vector["expect_valid"]
+        expected_endpoint = vector.get("expected_endpoint")
+        expected_reason = vector.get("expected_reason")
+
+        if expect_valid:
+            positive_count += 1
+        else:
+            negative_count += 1
+
+        actual_valid, actual_endpoint, actual_reason = _canonicalize_service_endpoint(
+            input_endpoint
+        )
+
+        matches_expectation = actual_valid == expect_valid
+        if expect_valid and expected_endpoint is not None:
+            matches_expectation = matches_expectation and actual_endpoint == expected_endpoint
+        if not expect_valid and expected_reason is not None:
+            matches_expectation = matches_expectation and actual_reason == expected_reason
+
+        if not matches_expectation:
+            mismatch_vector_ids.append(vector_id)
+
+        vector_results.append(
+            {
+                "vector_id": vector_id,
+                "input_endpoint": input_endpoint,
+                "expect_valid": expect_valid,
+                "expected_endpoint": expected_endpoint,
+                "expected_reason": expected_reason,
+                "actual_valid": actual_valid,
+                "actual_endpoint": actual_endpoint,
+                "actual_reason": actual_reason,
+                "matches_expectation": matches_expectation,
+            }
+        )
+
+    summary = {
+        "total_vectors": len(vectors),
+        "positive_vectors": positive_count,
+        "negative_vectors": negative_count,
+        "mismatch_vectors": len(mismatch_vector_ids),
+        "mismatch_vector_ids": sorted(mismatch_vector_ids),
+    }
+    return vector_results, summary
+
+
+def _compute_policy_checks(
+    summary: dict[str, Any],
+    ci_fast_gate: str,
+) -> dict[str, bool]:
+    return {
+        "fixture_loaded": summary["total_vectors"] > 0,
+        "has_positive_case": summary["positive_vectors"] > 0,
+        "has_negative_case": summary["negative_vectors"] > 0,
+        "all_vectors_match_expectation": summary["mismatch_vectors"] == 0,
+        "ci_fast_gate_passed": ci_fast_gate == "PASS",
+    }
+
+
+def _reason_messages() -> dict[str, str]:
+    return {
+        "fixture_loaded": "conformance vector fixture must load",
+        "has_positive_case": "conformance vectors must include positive cases",
+        "has_negative_case": "conformance vectors must include negative cases",
+        "all_vectors_match_expectation": "service endpoint canonicalization vectors diverged from expected outcomes",
+        "ci_fast_gate_passed": "ci-fast-gate-failed",
+    }
+
+
+def _compute_decision(policy_checks: dict[str, bool]) -> tuple[str, list[str], list[str]]:
+    decision = DecisionAccumulator()
+    reason_messages = _reason_messages()
+    for key in reason_messages:
+        decision.reject_if(not policy_checks[key], reason_messages[key])
+    final_decision, decision_reasons = decision.finalize(
+        "service endpoint canonicalization vectors satisfied"
+    )
+    failed_checks = sorted([key for key, passed in policy_checks.items() if not passed])
+    return final_decision, decision_reasons, failed_checks
+
+
+def _reason_key(final_decision: str) -> str:
+    return f"{REASON_PREFIX}:{final_decision}:v1"
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    ci_fast_gate = require_enum("ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+    fixture_file = Path(args.fixture).resolve()
+    vectors = _load_fixture(fixture_file)
+    vector_results, summary = _evaluate_vectors(vectors)
+    policy_checks = _compute_policy_checks(summary, ci_fast_gate)
+    final_decision, decision_reasons, failed_checks = _compute_decision(policy_checks)
+    reason_key = _reason_key(final_decision)
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "evidence_key": EVIDENCE_KEY,
+        "fixture_file": str(fixture_file),
+        "ci_fast_gate": ci_fast_gate,
+        "vector_results": vector_results,
+        "summary": summary,
+        "policy_checks": policy_checks,
+        "failed_checks": failed_checks,
+        "decision_reasons": decision_reasons,
+        "reason_key": reason_key,
+        "final_decision": final_decision,
+    }
+
+    output_file = Path(args.output_file)
+    write_json(output_file, payload)
+
+    failed_checks_value = ",".join(failed_checks) if failed_checks else "none"
+    print("status=generated")
+    print(f"bundle_file={output_file}")
+    print(f"evidence_key={EVIDENCE_KEY}")
+    print(f"reason_key={reason_key}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def check_bundle(args: argparse.Namespace) -> int:
+    bundle_file = Path(args.bundle_file)
+    if not bundle_file.is_file():
+        fail(f"bundle file not found: {bundle_file}")
+
+    try:
+        payload = json.loads(bundle_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"bundle file is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        fail("bundle payload must be an object")
+
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "generated_at",
+            "evidence_key",
+            "fixture_file",
+            "ci_fast_gate",
+            "vector_results",
+            "summary",
+            "policy_checks",
+            "failed_checks",
+            "decision_reasons",
+            "reason_key",
+            "final_decision",
+        ),
+    )
+    if payload["schema_version"] != SCHEMA_VERSION:
+        fail(f"schema_version must be {SCHEMA_VERSION}")
+    if payload["evidence_key"] != EVIDENCE_KEY:
+        fail("evidence_key mismatch")
+
+    if not isinstance(payload["fixture_file"], str) or not payload["fixture_file"]:
+        fail("fixture_file must be a non-empty string")
+    ci_fast_gate = require_enum("ci_fast_gate", payload["ci_fast_gate"], ("PASS", "FAIL"))
+
+    fixture_file = Path(payload["fixture_file"])
+    vectors = _load_fixture(fixture_file)
+    expected_vector_results, expected_summary = _evaluate_vectors(vectors)
+    expected_policy_checks = _compute_policy_checks(expected_summary, ci_fast_gate)
+    expected_decision, expected_reasons, expected_failed_checks = _compute_decision(
+        expected_policy_checks
+    )
+    expected_reason_key = _reason_key(expected_decision)
+
+    if payload["vector_results"] != expected_vector_results:
+        fail("vector_results mismatch against evaluated fixture")
+    if payload["summary"] != expected_summary:
+        fail("summary mismatch against evaluated fixture")
+    if payload["policy_checks"] != expected_policy_checks:
+        fail("policy_checks mismatch against evaluated fixture")
+    if payload["failed_checks"] != expected_failed_checks:
+        fail("failed_checks mismatch against evaluated fixture")
+    if payload["decision_reasons"] != expected_reasons:
+        fail("decision_reasons mismatch against evaluated fixture")
+
+    final_decision = require_enum("final_decision", payload["final_decision"], ("GO", "NO-GO"))
+    if final_decision != expected_decision:
+        fail(
+            f"policy decision mismatch: expected {expected_decision}, found {final_decision}"
+        )
+
+    reason_key = payload["reason_key"]
+    if reason_key != expected_reason_key:
+        fail(f"reason_key mismatch: expected {expected_reason_key}, found {reason_key}")
+
+    failed_checks_value = ",".join(expected_failed_checks) if expected_failed_checks else "none"
+    print("status=validated")
+    print(f"bundle_file={bundle_file}")
+    print(f"reason_key={expected_reason_key}")
+    print(f"final_decision={expected_decision}")
+    print(f"failed_checks={failed_checks_value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate/check DID service-endpoint canonicalization conformance evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate", help="Generate evidence bundle")
+    generate_parser.add_argument("--output-file", required=True)
+    generate_parser.add_argument("--fixture", required=True)
+    generate_parser.add_argument("--ci-fast-gate", default="PASS")
+    generate_parser.set_defaults(handler=generate_bundle)
+
+    check_parser = subparsers.add_parser("check", help="Check evidence bundle")
+    check_parser.add_argument("--bundle-file", required=True)
+    check_parser.set_defaults(handler=check_bundle)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except ContractError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/did/generate_service_endpoint_canonicalization_evidence_bundle.sh
+++ b/scripts/did/generate_service_endpoint_canonicalization_evidence_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/did/did_service_endpoint_canonicalization_contract.py" generate "$@"

--- a/scripts/did/run_did_registry_contract_lane.sh
+++ b/scripts/did/run_did_registry_contract_lane.sh
@@ -19,6 +19,7 @@ bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --t
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test agent_interop_wave_docs
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test key_lifecycle_audit_trails_docs
 bash scripts/did/run_lifecycle_operator_binding_contract_lane.sh --skip-tests
+bash scripts/did/run_service_endpoint_canonicalization_contract_lane.sh --skip-tests
 
 if ! grep -Fq "register_with_retry_guard" docs/foundation/did-registry-transactions.md; then
   echo "expected retry guard contract in did-registry-transactions.md" >&2
@@ -57,6 +58,26 @@ fi
 
 if ! grep -Fq "Regression: #890" docs/planning/agent-interop-wave.md; then
   echo "expected lifecycle operator-binding regression marker in agent-interop-wave planning doc" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_service_endpoint_canonicalization_contract_lane.sh" docs/foundation/did-core-conformance-kamn-method.md; then
+  echo "expected service endpoint canonicalization contract lane command in did core conformance doc" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_service_endpoint_canonicalization_matrix.py" docs/foundation/did-core-conformance-kamn-method.md; then
+  echo "expected service endpoint canonicalization matrix runner command in did core conformance doc" >&2
+  exit 1
+fi
+
+if ! grep -Fq "did_service_endpoint_canonicalization_reason_codes:GO:v1" docs/foundation/did-core-conformance-kamn-method.md; then
+  echo "expected service endpoint canonicalization GO reason-key marker in did core conformance doc" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Regression: #1000" docs/foundation/did-core-conformance-kamn-method.md; then
+  echo "expected service endpoint canonicalization regression marker in did core conformance doc" >&2
   exit 1
 fi
 

--- a/scripts/did/run_service_endpoint_canonicalization_contract_lane.sh
+++ b/scripts/did/run_service_endpoint_canonicalization_contract_lane.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/did/generate_service_endpoint_canonicalization_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/did/check_service_endpoint_canonicalization_policy.sh"
+MATRIX_RUNNER="$ROOT_DIR/scripts/did/run_service_endpoint_canonicalization_matrix.py"
+FIXTURE="$ROOT_DIR/fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json"
+DID_CORE_DOC="$ROOT_DIR/docs/foundation/did-core-conformance-kamn-method.md"
+DID_METHOD_DOC="$ROOT_DIR/docs/foundation/did-method.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/did/run_service_endpoint_canonicalization_contract_lane.sh \
+    [--output-file <path>] \
+    [--skip-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+output_file=""
+skip_tests=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-file)
+      output_file="${2:-}"
+      shift 2
+      ;;
+    --skip-tests)
+      skip_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "service endpoint canonicalization evidence generator is not executable"
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "service endpoint canonicalization policy checker is not executable"
+fi
+if [ ! -x "$MATRIX_RUNNER" ]; then
+  fail "service endpoint canonicalization matrix runner is not executable"
+fi
+if [ ! -f "$FIXTURE" ]; then
+  fail "service endpoint canonicalization fixture file is missing"
+fi
+if [ ! -f "$DID_CORE_DOC" ]; then
+  fail "expected DID core conformance doc to exist"
+fi
+if [ ! -f "$DID_METHOD_DOC" ]; then
+  fail "expected DID method doc to exist"
+fi
+
+cd "$ROOT_DIR"
+if [ "$skip_tests" != true ]; then
+  cargo test -p kamn-core --test did_method unit_service_endpoint_canonicalization_normalizes_case_and_whitespace -- --exact >/dev/null
+  cargo test -p kamn-core --test did_method functional_service_endpoint_canonicalization_rejects_non_kamn_scheme -- --exact >/dev/null
+  cargo test -p kamn-core --test did_method regression_service_endpoint_canonicalization_rejects_non_single_segment_path -- --exact >/dev/null
+  cargo test -p kamn-core --test did_core_conformance_docs profile_contains_service_endpoint_canonicalization_contract_lane -- --exact >/dev/null
+  cargo test -p kamn-core --test did_method_docs regression_requires_service_endpoint_canonicalization_guard_marker -- --exact >/dev/null
+fi
+
+if [[ -z "$output_file" ]]; then
+  output_file="$TMP_DIR/did-service-endpoint-canonicalization-contract.json"
+fi
+
+start_epoch="$(date +%s)"
+
+matrix_report="$TMP_DIR/did-service-endpoint-canonicalization-matrix-report.json"
+matrix_output="$(
+  python3 "$MATRIX_RUNNER" \
+    --fixture "$FIXTURE" \
+    --output-json "$matrix_report"
+)"
+if ! printf '%s\n' "$matrix_output" | grep -q "^final_decision=GO$"; then
+  fail "expected service endpoint canonicalization matrix to produce GO decision"
+fi
+
+generator_output="$(
+  bash "$GENERATOR" \
+    --output-file "$output_file" \
+    --fixture "$FIXTURE" \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=GO$"; then
+  fail "expected service endpoint canonicalization evidence generation decision to be GO"
+fi
+if ! printf '%s\n' "$generator_output" | grep -q "^reason_key=did_service_endpoint_canonicalization_reason_codes:GO:v1$"; then
+  fail "expected service endpoint canonicalization GO reason key marker"
+fi
+
+policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$output_file")"
+if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected service endpoint canonicalization policy decision to be GO"
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^failed_checks=none$"; then
+  fail "expected service endpoint canonicalization contract lane to report failed_checks=none"
+fi
+
+if ! grep -Fq "run_service_endpoint_canonicalization_contract_lane.sh" "$DID_CORE_DOC"; then
+  fail "expected DID core conformance doc to reference service endpoint canonicalization contract lane"
+fi
+if ! grep -Fq "generate_service_endpoint_canonicalization_evidence_bundle.sh" "$DID_CORE_DOC"; then
+  fail "expected DID core conformance doc to reference canonicalization evidence generator"
+fi
+if ! grep -Fq "check_service_endpoint_canonicalization_policy.sh" "$DID_CORE_DOC"; then
+  fail "expected DID core conformance doc to reference canonicalization policy checker"
+fi
+if ! grep -Fq "run_service_endpoint_canonicalization_matrix.py" "$DID_CORE_DOC"; then
+  fail "expected DID core conformance doc to reference canonicalization matrix runner"
+fi
+if ! grep -Fq "Regression: #1000" "$DID_CORE_DOC"; then
+  fail "expected DID core conformance doc to include canonicalization regression marker"
+fi
+if ! grep -Fq "Regression: #1000" "$DID_METHOD_DOC"; then
+  fail "expected DID method doc to include canonicalization regression marker"
+fi
+
+max_seconds="${DID_SERVICE_ENDPOINT_CANONICALIZATION_MAX_SECONDS:-90}"
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  fail "service endpoint canonicalization contract lane exceeded runtime budget: ${elapsed_seconds}s"
+fi
+
+printf 'status=ok\n'
+printf 'bundle_file=%s\n' "$output_file"
+printf 'reason_key=%s\n' "$(extract_value "$policy_output" "reason_key")"
+printf 'final_decision=%s\n' "$(extract_value "$policy_output" "final_decision")"
+echo "service endpoint canonicalization contract lane tests passed."

--- a/scripts/did/run_service_endpoint_canonicalization_matrix.py
+++ b/scripts/did/run_service_endpoint_canonicalization_matrix.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Run DID service-endpoint canonicalization vector matrix."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from did_service_endpoint_canonicalization_contract import (  # noqa: E402
+    _evaluate_vectors,
+    _load_fixture,
+)
+from framework.contract_framework import write_json  # noqa: E402
+
+
+def run_matrix(args: argparse.Namespace) -> int:
+    fixture = Path(args.fixture)
+    output_json = Path(args.output_json)
+
+    vectors = _load_fixture(fixture)
+    _, summary = _evaluate_vectors(vectors)
+    final_decision = "GO" if summary["mismatch_vectors"] == 0 else "NO-GO"
+
+    payload = {
+        "schema_version": "kamn.did.service-endpoint-canonicalization-matrix-report.v1",
+        "fixture_file": str(fixture.resolve()),
+        "summary": summary,
+        "final_decision": final_decision,
+    }
+    write_json(output_json, payload)
+
+    print(f"output_json={output_json}")
+    print(f"final_decision={final_decision}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run DID service-endpoint canonicalization conformance matrix."
+    )
+    parser.add_argument(
+        "--fixture",
+        default=str(
+            ROOT_DIR / "fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json"
+        ),
+    )
+    parser.add_argument(
+        "--output-json",
+        default=str(ROOT_DIR / "did-service-endpoint-canonicalization-matrix-report.json"),
+    )
+    parser.set_defaults(handler=run_matrix)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh
+++ b/scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/did/generate_service_endpoint_canonicalization_evidence_bundle.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/did/check_service_endpoint_canonicalization_policy.sh"
+FIXTURE="$ROOT_DIR/fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  fail "expected service endpoint canonicalization evidence generator to be executable"
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "expected service endpoint canonicalization policy checker to be executable"
+fi
+if [ ! -f "$FIXTURE" ]; then
+  fail "expected service endpoint canonicalization fixture to exist"
+fi
+
+go_bundle="$TMP_DIR/did-service-endpoint-canonicalization-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --fixture "$FIXTURE" \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$go_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO decision for canonical service endpoint conformance fixture"
+fi
+if [ ! -f "$go_bundle" ]; then
+  fail "expected GO canonicalization evidence bundle file to be created"
+fi
+if ! grep -q '"schema_version": "kamn.did.service-endpoint-canonicalization-report.v1"' "$go_bundle"; then
+  fail "expected canonicalization evidence schema marker"
+fi
+
+go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
+if ! printf '%s\n' "$go_policy_output" | grep -q "^final_decision=GO$"; then
+  fail "expected GO policy decision for canonical service endpoint conformance fixture"
+fi
+
+no_go_fixture="$TMP_DIR/nonconformant-vectors.json"
+python3 - "$FIXTURE" "$no_go_fixture" <<'PY'
+import json
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+dest = pathlib.Path(sys.argv[2])
+vectors = json.loads(source.read_text(encoding="utf-8"))
+vectors[0]["expected_endpoint"] = "kamn://messaging/unexpected"
+dest.write_text(json.dumps(vectors, indent=2) + "\n", encoding="utf-8")
+PY
+
+no_go_bundle="$TMP_DIR/did-service-endpoint-canonicalization-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --fixture "$no_go_fixture" \
+    --ci-fast-gate PASS
+)"
+if ! printf '%s\n' "$no_go_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO decision for drifted canonicalization conformance fixture"
+fi
+
+no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
+if ! printf '%s\n' "$no_go_policy_output" | grep -q "^final_decision=NO-GO$"; then
+  fail "expected NO-GO policy decision for drifted canonicalization conformance fixture"
+fi
+
+tampered_bundle="$TMP_DIR/did-service-endpoint-canonicalization-tampered.json"
+cp "$go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_exit=$?
+set -e
+if [ "$tampered_exit" -eq 0 ]; then
+  fail "expected tampered canonicalization evidence bundle to fail validation"
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  fail "expected explicit policy decision mismatch marker for tampered canonicalization bundle"
+fi
+
+echo "service endpoint canonicalization evidence bundle tests passed."

--- a/scripts/did/test_run_did_registry_contract_lane.sh
+++ b/scripts/did/test_run_did_registry_contract_lane.sh
@@ -83,6 +83,11 @@ if ! grep -q "run_lifecycle_operator_binding_contract_lane.sh --skip-tests" "$SC
   exit 1
 fi
 
+if ! grep -q "run_service_endpoint_canonicalization_contract_lane.sh --skip-tests" "$SCRIPT"; then
+  echo "expected did registry lane to invoke service endpoint canonicalization contract lane coverage" >&2
+  exit 1
+fi
+
 if ! grep -q "agent_interop_wave_docs" "$SCRIPT"; then
   echo "expected did registry lane to include agent interop planning docs contract coverage" >&2
   exit 1

--- a/scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh
+++ b/scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/did/run_service_endpoint_canonicalization_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected service endpoint canonicalization contract lane script to be executable" >&2
+  exit 1
+fi
+
+bundle_file="$TMP_DIR/did-service-endpoint-canonicalization-contract-bundle.json"
+lane_output="$(bash "$SCRIPT" --skip-tests --output-file "$bundle_file")"
+
+if ! printf '%s\n' "$lane_output" | grep -q "service endpoint canonicalization contract lane tests passed."; then
+  echo "expected service endpoint canonicalization contract lane success marker" >&2
+  exit 1
+fi
+
+if [ ! -f "$bundle_file" ]; then
+  echo "expected service endpoint canonicalization contract lane to emit evidence bundle" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.did.service-endpoint-canonicalization-report.v1"' "$bundle_file"; then
+  echo "expected service endpoint canonicalization evidence schema marker" >&2
+  exit 1
+fi
+
+echo "service endpoint canonicalization contract lane script tests passed."

--- a/scripts/did/test_run_service_endpoint_canonicalization_matrix.sh
+++ b/scripts/did/test_run_service_endpoint_canonicalization_matrix.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/did/run_service_endpoint_canonicalization_matrix.py"
+FIXTURE="$ROOT_DIR/fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected service endpoint canonicalization matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE" ]; then
+  echo "expected service endpoint canonicalization fixture to exist" >&2
+  exit 1
+fi
+
+output_json="$TMP_DIR/did-service-endpoint-canonicalization-matrix.json"
+matrix_output="$(
+  python3 "$SCRIPT" \
+    --fixture "$FIXTURE" \
+    --output-json "$output_json"
+)"
+
+if ! printf '%s\n' "$matrix_output" | grep -q "^final_decision=GO$"; then
+  echo "expected canonicalization matrix runner to emit GO final decision" >&2
+  exit 1
+fi
+
+python3 - "$output_json" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.did.service-endpoint-canonicalization-matrix-report.v1":
+    raise SystemExit("unexpected canonicalization matrix schema")
+summary = payload.get("summary", {})
+if summary.get("mismatch_vectors") != 0:
+    raise SystemExit("expected zero mismatch vectors for canonicalization fixture")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected GO final decision for canonicalization matrix runner")
+PY
+
+echo "service endpoint canonicalization matrix tests passed."


### PR DESCRIPTION
## Summary
Implement deterministic DID service-endpoint canonicalization rules in `kamn-core` and add fixture-driven conformance contract lanes (generator, policy checker, matrix runner, and fast contract lane). Resolve the DID Core profile open question into explicit policy decisions and wire regression markers for fail-closed endpoint validation.

## Changes
- `crates/kamn-core/src/did.rs`: add `canonical_service_endpoint(...)` with strict canonicalization/rejection rules and `DidDocumentError::InvalidServiceEndpoint`.
- `crates/kamn-core/src/lib.rs`: export `canonical_service_endpoint`.
- `crates/kamn-core/tests/did_method.rs`: add canonicalization unit/functional/regression tests.
- `crates/kamn-core/tests/did_fuzz_smoke.rs`: include new DID error variant in fuzz smoke fail-closed coverage.
- `fixtures/did_core_conformance/service_endpoint_canonicalization_vectors.json`: add deterministic positive/negative canonicalization vectors.
- `scripts/did/did_service_endpoint_canonicalization_contract.py`: add conformance evidence/policy contract implementation.
- `scripts/did/generate_service_endpoint_canonicalization_evidence_bundle.sh`: add generator wrapper.
- `scripts/did/check_service_endpoint_canonicalization_policy.sh`: add policy checker wrapper.
- `scripts/did/run_service_endpoint_canonicalization_matrix.py`: add fixture matrix runner.
- `scripts/did/run_service_endpoint_canonicalization_contract_lane.sh`: add PR-fast contract lane with runtime budget guard.
- `scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh`: add generator/policy tests and tamper regression checks.
- `scripts/did/test_run_service_endpoint_canonicalization_matrix.sh`: add matrix runner contract tests.
- `scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh`: add contract lane smoke test.
- `scripts/did/run_did_registry_contract_lane.sh`: include canonicalization lane coverage and DID Core doc markers.
- `scripts/did/test_run_did_registry_contract_lane.sh`: assert canonicalization lane integration.
- `docs/foundation/did-core-conformance-kamn-method.md`: resolve open questions into decisions and add canonicalization conformance contract section.
- `docs/foundation/did-method.md`: add canonical endpoint policy rules and `Regression: #1000` marker.
- `crates/kamn-core/tests/did_core_conformance_docs.rs`: enforce canonicalization decision/vector/contract markers.
- `crates/kamn-core/tests/did_method_docs.rs`: enforce canonicalization rule/regression markers.

## Risks & Compatibility
- Adds a new `DidDocumentError` variant (`InvalidServiceEndpoint`). Existing exhaustive match sites were updated.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed DID-focused Rust tests, canonicalization script lanes, DID registry lane integration test, and CI target-selection checks.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test did_method --test did_fuzz_smoke` |
| Functional  | ✅     | `bash scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh` |
| Integration | ✅     | `bash scripts/did/test_run_service_endpoint_canonicalization_matrix.sh`, `bash scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh`, `bash scripts/did/test_run_did_registry_contract_lane.sh` |
| Regression  | ✅     | `Regression: #1000` assertions in docs tests + tampered bundle policy mismatch checks |

Closes #1000
