### PR TITLE
feat(devops): harden federated handshake deep-lane policy contracts

### DIFF
--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -129,7 +129,12 @@ jobs:
           bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
           bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
           bash scripts/did/test_run_federated_did_handshake_matrix.sh
-          bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
+
+      - name: Run federated DID handshake deep lane
+        if: steps.scope.outputs.run_federated_did_handshake_deep_lane == 'true'
+        run: |
+          KAMN_FEDERATED_DID_HANDSHAKE_DEEP_CADENCE=scheduled \
+            bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
 
       - name: Run Kolme snapshot drift contract lane
         if: steps.scope.outputs.run_kolme_snapshot_drift_contract_tests == 'true'

--- a/crates/kamn-core/tests/did_method_docs.rs
+++ b/crates/kamn-core/tests/did_method_docs.rs
@@ -30,6 +30,9 @@ fn did_method_doc_contains_federated_handshake_contract() {
     assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_contract_lane.sh"));
     assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_deep_lane.sh"));
     assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_matrix.py"));
+    assert!(DID_METHOD_DOC.contains("check_federated_did_handshake_deep_policy.sh"));
+    assert!(DID_METHOD_DOC.contains("federated_did_handshake_deep_policy_contract.py"));
+    assert!(DID_METHOD_DOC.contains("run_federated_did_handshake_deep_policy_matrix.py"));
     assert!(DID_METHOD_DOC.contains("fixtures/federated_did_handshake/partition_replay_cases.json"));
     assert!(DID_METHOD_DOC.contains(
         "Federated runtime trust-store handshake evaluator fail-closes on trust-store misses and quorum shortfalls."
@@ -67,5 +70,13 @@ fn regression_requires_federated_runtime_trust_store_guard_marker() {
     // Regression: #1002
     assert!(DID_METHOD_DOC.contains(
         "runtime trust-store misses and quorum shortfalls must remain fail-closed with deterministic reason codes (`Regression: #1002`)."
+    ));
+}
+
+#[test]
+fn regression_requires_federated_deep_lane_tamper_guard_marker() {
+    // Regression: #1003
+    assert!(DID_METHOD_DOC.contains(
+        "stale/tampered federated handshake deep-lane summary artifacts must remain `NO-GO` (`Regression: #1003`)."
     ));
 }

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -116,6 +116,9 @@ fn checklist_contains_federated_did_handshake_evidence_contract() {
     assert!(CHECKLIST.contains("run_federated_did_handshake_contract_lane.sh"));
     assert!(CHECKLIST.contains("run_federated_did_handshake_deep_lane.sh"));
     assert!(CHECKLIST.contains("run_federated_did_handshake_matrix.py"));
+    assert!(CHECKLIST.contains("check_federated_did_handshake_deep_policy.sh"));
+    assert!(CHECKLIST.contains("federated_did_handshake_deep_policy_contract.py"));
+    assert!(CHECKLIST.contains("run_federated_did_handshake_deep_policy_matrix.py"));
     assert!(CHECKLIST.contains("fixtures/federated_did_handshake/partition_replay_cases.json"));
     assert!(CHECKLIST.contains("cargo test -p kamn-core --test federated_did_handshake_runtime"));
 }
@@ -376,6 +379,14 @@ fn regression_requires_federated_runtime_trust_store_guard_marker() {
     // Regression: #1002
     assert!(CHECKLIST.contains(
         "runtime trust-store misses and quorum shortfalls must remain fail-closed with deterministic reason codes (`Regression: #1002`)."
+    ));
+}
+
+#[test]
+fn regression_requires_federated_deep_lane_tamper_guard_marker() {
+    // Regression: #1003
+    assert!(CHECKLIST.contains(
+        "stale/tampered federated handshake deep-lane summary artifacts must remain `NO-GO` (`Regression: #1003`)."
     ));
 }
 

--- a/docs/foundation/did-method.md
+++ b/docs/foundation/did-method.md
@@ -50,6 +50,12 @@ Cross-network DID trust handshakes must emit deterministic evidence before relea
   - `bash scripts/did/run_federated_did_handshake_deep_lane.sh --output-json federated-did-handshake-report.json`
 - Partition replay matrix runner:
   - `python3 scripts/did/run_federated_did_handshake_matrix.py --fixture fixtures/federated_did_handshake/partition_replay_cases.json --output-json federated-did-handshake-report.json`
+- Deep-lane summary policy checker:
+  - `bash scripts/did/check_federated_did_handshake_deep_policy.sh --report-file federated-did-handshake-report.json`
+- Deep-lane shared Python policy implementation:
+  - `scripts/did/federated_did_handshake_deep_policy_contract.py`
+- Deep-lane policy matrix runner:
+  - `python3 scripts/did/run_federated_did_handshake_deep_policy_matrix.py --fixture fixtures/federated_did_handshake/deep_lane_policy_cases.json --output-json federated-did-handshake-deep-policy-report.json`
 - Runtime trust-store handshake evaluator:
   - Federated runtime trust-store handshake evaluator fail-closes on trust-store misses and quorum shortfalls.
   - `cargo test -p kamn-core --test federated_did_handshake_runtime`
@@ -58,6 +64,7 @@ Cross-network DID trust handshakes must emit deterministic evidence before relea
   - non-canonical service endpoint scheme/authority/path combinations must remain rejected (`Regression: #1000`).
   - mixed or unsupported verification method algorithm sets must remain rejected under migration policy checks (`Regression: #1001`).
   - runtime trust-store misses and quorum shortfalls must remain fail-closed with deterministic reason codes (`Regression: #1002`).
+  - stale/tampered federated handshake deep-lane summary artifacts must remain `NO-GO` (`Regression: #1003`).
 
 ## Local Validation
 Run from repository root:
@@ -67,6 +74,8 @@ bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
 bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
 bash scripts/did/test_run_federated_did_handshake_matrix.sh
 bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
+bash scripts/did/test_check_federated_did_handshake_deep_policy.sh
+bash scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh
 bash scripts/did/test_generate_service_endpoint_canonicalization_evidence_bundle.sh
 bash scripts/did/test_run_service_endpoint_canonicalization_matrix.sh
 bash scripts/did/test_run_service_endpoint_canonicalization_contract_lane.sh

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -189,11 +189,18 @@ Federated DID trust handshakes require deterministic replay, downgrade, and quor
   - `bash scripts/did/run_federated_did_handshake_deep_lane.sh --output-json federated-did-handshake-report.json`
 - Partition replay matrix runner:
   - `python3 scripts/did/run_federated_did_handshake_matrix.py --fixture fixtures/federated_did_handshake/partition_replay_cases.json --output-json federated-did-handshake-report.json`
+- Deep-lane summary policy checker:
+  - `bash scripts/did/check_federated_did_handshake_deep_policy.sh --report-file federated-did-handshake-report.json`
+- Deep-lane shared Python policy implementation:
+  - `scripts/did/federated_did_handshake_deep_policy_contract.py`
+- Deep-lane policy matrix runner:
+  - `python3 scripts/did/run_federated_did_handshake_deep_policy_matrix.py --fixture fixtures/federated_did_handshake/deep_lane_policy_cases.json --output-json federated-did-handshake-deep-policy-report.json`
 - Runtime trust-store handshake evaluator:
   - `cargo test -p kamn-core --test federated_did_handshake_runtime`
 - Regression policy:
   - replay/downgrade attempts, quorum shortfalls, and tampered final decisions force `NO-GO` (`Regression: #734`).
   - runtime trust-store misses and quorum shortfalls must remain fail-closed with deterministic reason codes (`Regression: #1002`).
+  - stale/tampered federated handshake deep-lane summary artifacts must remain `NO-GO` (`Regression: #1003`).
 
 ## Federated Delegation Settlement Evidence Contract (Issue #754)
 Cross-network task delegation requires deterministic envelope and settlement reference evidence before cross-network approvals.
@@ -471,6 +478,8 @@ bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
 bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
 bash scripts/did/test_run_federated_did_handshake_matrix.sh
 bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
+bash scripts/did/test_check_federated_did_handshake_deep_policy.sh
+bash scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh
 bash scripts/task/test_generate_federated_delegation_settlement_evidence_bundle.sh
 bash scripts/task/test_run_federated_delegation_settlement_contract_lane.sh
 bash scripts/task/test_run_federated_delegation_settlement_matrix.sh

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -180,6 +180,14 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `run_localhost_bridge_demo_evidence_deep_lane.sh` enforces a 300-second upper bound.
 - Bridge deep lane budget:
   - `run_bridge_replay_redaction_deep_lane.sh` enforces a 300-second upper bound.
+- Federated DID handshake PR-fast budget:
+  - `run_federated_did_handshake_contract_lane.sh` enforces a 120-second upper bound.
+- Federated DID handshake deep budget:
+  - `run_federated_did_handshake_deep_lane.sh` enforces a 300-second upper bound.
+- Federated DID handshake deep cadence policy:
+  - `run_federated_did_handshake_deep_lane.sh` rejects non-`schedule` and non-`workflow_dispatch` events.
+- Federated DID handshake fast/deep selector routing:
+  - `scripts/ci/select_targets.sh` keeps `run_federated_did_handshake_deep_lane=false` by default and enables it only when `CI_ENABLE_FEDERATED_DID_HANDSHAKE_DEEP_LANE=true`.
 - Dashboard runtime compatibility guard:
   - `bash scripts/frontend/test_dashboard_package_runtime_compat.sh` validates fallback behavior when local `node` lacks `--experimental-strip-types`.
   - `scripts/frontend/test_dashboard_package.sh` defaults fallback execution to `npx -y node@22` in fail-closed mode.
@@ -207,6 +215,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - localhost signed integration harness and contract lane preserve deterministic evidence keys (`Regression: #899`).
 - Regression guard:
   - localhost signed demo receipt artifact schema drift and missing receipt reconciliation outcomes fail closed (`Regression: #981`).
+- Regression guard:
+  - stale/tampered federated handshake deep-lane summary artifacts fail closed under policy checks (`Regression: #1003`).
 - Regression guard:
   - stale/tampered partition/reconnect matrix artifacts and replay anomalies are rejected (`Regression: #982`).
 - Regression guard:

--- a/fixtures/federated_did_handshake/deep_lane_policy_cases.json
+++ b/fixtures/federated_did_handshake/deep_lane_policy_cases.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "kamn.did.federated-handshake.deep-policy-cases.v1",
+  "cases": [
+    {
+      "case_id": "go_scheduled",
+      "expected_policy_status": "pass",
+      "expected_final_decision": "GO",
+      "report": {
+        "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+        "event_name": "schedule",
+        "cadence": "scheduled",
+        "contract_lane_status": "pass",
+        "matrix_status": "pass",
+        "matrix_case_count": 5,
+        "matrix_failed_count": 0,
+        "matrix_report_file": "/tmp/federated-did-handshake-report.json",
+        "elapsed_seconds": 7,
+        "max_seconds": 180,
+        "budget_status": "within",
+        "reason_codes": [],
+        "final_decision": "GO",
+        "policy_status": "pending"
+      }
+    },
+    {
+      "case_id": "no_go_matrix_failed",
+      "expected_policy_status": "pass",
+      "expected_final_decision": "NO-GO",
+      "report": {
+        "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+        "event_name": "schedule",
+        "cadence": "scheduled",
+        "contract_lane_status": "pass",
+        "matrix_status": "fail",
+        "matrix_case_count": 5,
+        "matrix_failed_count": 1,
+        "matrix_report_file": "/tmp/federated-did-handshake-report.json",
+        "elapsed_seconds": 11,
+        "max_seconds": 180,
+        "budget_status": "within",
+        "reason_codes": [
+          "matrix_failed"
+        ],
+        "final_decision": "NO-GO",
+        "policy_status": "pending"
+      }
+    },
+    {
+      "case_id": "no_go_budget_exceeded",
+      "expected_policy_status": "pass",
+      "expected_final_decision": "NO-GO",
+      "report": {
+        "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+        "event_name": "workflow_dispatch",
+        "cadence": "manual",
+        "contract_lane_status": "pass",
+        "matrix_status": "pass",
+        "matrix_case_count": 5,
+        "matrix_failed_count": 0,
+        "matrix_report_file": "/tmp/federated-did-handshake-report.json",
+        "elapsed_seconds": 241,
+        "max_seconds": 180,
+        "budget_status": "exceeded",
+        "reason_codes": [
+          "runtime_budget_exceeded"
+        ],
+        "final_decision": "NO-GO",
+        "policy_status": "pending"
+      }
+    },
+    {
+      "case_id": "tampered_final_decision_go",
+      "expected_policy_status": "fail",
+      "expected_final_decision": "NO-GO",
+      "report": {
+        "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+        "event_name": "schedule",
+        "cadence": "scheduled",
+        "contract_lane_status": "pass",
+        "matrix_status": "fail",
+        "matrix_case_count": 5,
+        "matrix_failed_count": 2,
+        "matrix_report_file": "/tmp/federated-did-handshake-report.json",
+        "elapsed_seconds": 19,
+        "max_seconds": 180,
+        "budget_status": "within",
+        "reason_codes": [],
+        "final_decision": "GO",
+        "policy_status": "pending"
+      }
+    }
+  ]
+}

--- a/fixtures/federated_did_handshake/partition_replay_cases.json
+++ b/fixtures/federated_did_handshake/partition_replay_cases.json
@@ -36,6 +36,23 @@
       "expected_final_decision": "NO-GO"
     },
     {
+      "case_id": "no_go_partition_sequence_replay",
+      "handshake_id": "federated-partition-replay-001",
+      "subject_did": "kamn:did:agent:federated-worker-2b",
+      "local_network": "kolme-mainnet-a",
+      "remote_network": "kolme-mainnet-b",
+      "resolver_cache_hit": true,
+      "resolver_version": "resolver-v1",
+      "signature_policy": "PASS",
+      "nonce_monotonic": true,
+      "downgrade_detected": false,
+      "partition_sequence_monotonic": false,
+      "required_quorum": 2,
+      "received_quorum": 2,
+      "ci_fast_gate": "PASS",
+      "expected_final_decision": "NO-GO"
+    },
+    {
       "case_id": "no_go_downgrade_attack",
       "handshake_id": "federated-downgrade-001",
       "subject_did": "kamn:did:agent:federated-worker-3",

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -33,6 +33,7 @@ append_summary() {
     echo "- Run signer emulator contract tests: ${RUN_SIGNER_EMULATOR_CONTRACT_TESTS}"
     echo "- Run DID registry contract tests: ${RUN_DID_REGISTRY_CONTRACT_TESTS}"
     echo "- Run federated DID handshake contract tests: ${RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS}"
+    echo "- Run federated DID handshake deep lane: ${RUN_FEDERATED_DID_HANDSHAKE_DEEP_LANE}"
     echo "- Run Kolme snapshot drift contract tests: ${RUN_KOLME_SNAPSHOT_DRIFT_CONTRACT_TESTS}"
     echo "- Run Kolme version compatibility contract tests: ${RUN_KOLME_VERSION_COMPATIBILITY_CONTRACT_TESTS}"
     echo "- Run Kolme triadic devnet smoke contract tests: ${RUN_KOLME_TRIADIC_DEVNET_SMOKE_CONTRACT_TESTS}"
@@ -539,6 +540,7 @@ RUN_DASHBOARD_CONTRACT_TESTS=false
 RUN_SIGNER_EMULATOR_CONTRACT_TESTS=false
 RUN_DID_REGISTRY_CONTRACT_TESTS=false
 RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS=false
+RUN_FEDERATED_DID_HANDSHAKE_DEEP_LANE=false
 RUN_KOLME_SNAPSHOT_DRIFT_CONTRACT_TESTS=false
 RUN_KOLME_VERSION_COMPATIBILITY_CONTRACT_TESTS=false
 RUN_KOLME_TRIADIC_DEVNET_SMOKE_CONTRACT_TESTS=false
@@ -654,6 +656,13 @@ if [ "$FEDERATED_DID_HANDSHAKE_CONTRACT_CHANGED" = true ]; then
   RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS=true
   if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
     TEST_SCOPE="federated-did-contract"
+  fi
+fi
+
+if [ "$FEDERATED_DID_HANDSHAKE_CONTRACT_CHANGED" = true ] && [ "${CI_ENABLE_FEDERATED_DID_HANDSHAKE_DEEP_LANE:-false}" = "true" ]; then
+  RUN_FEDERATED_DID_HANDSHAKE_DEEP_LANE=true
+  if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "federated-did-contract" ]; then
+    TEST_SCOPE="federated-did-deep"
   fi
 fi
 
@@ -918,6 +927,7 @@ write_output "run_dashboard_contract_tests" "$RUN_DASHBOARD_CONTRACT_TESTS"
 write_output "run_signer_emulator_contract_tests" "$RUN_SIGNER_EMULATOR_CONTRACT_TESTS"
 write_output "run_did_registry_contract_tests" "$RUN_DID_REGISTRY_CONTRACT_TESTS"
 write_output "run_federated_did_handshake_contract_tests" "$RUN_FEDERATED_DID_HANDSHAKE_CONTRACT_TESTS"
+write_output "run_federated_did_handshake_deep_lane" "$RUN_FEDERATED_DID_HANDSHAKE_DEEP_LANE"
 write_output "run_kolme_snapshot_drift_contract_tests" "$RUN_KOLME_SNAPSHOT_DRIFT_CONTRACT_TESTS"
 write_output "run_kolme_version_compatibility_contract_tests" "$RUN_KOLME_VERSION_COMPATIBILITY_CONTRACT_TESTS"
 write_output "run_kolme_triadic_devnet_smoke_contract_tests" "$RUN_KOLME_TRIADIC_DEVNET_SMOKE_CONTRACT_TESTS"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -23,16 +23,24 @@ assert_eq() {
 run_selector_with_bridge_deep() {
   local changed_files="$1"
   local bridge_deep="${2:-false}"
+  local federated_did_deep="${3:-false}"
   env -u GITHUB_OUTPUT -u GITHUB_STEP_SUMMARY \
     CI_CHANGED_FILES="$changed_files" \
     CI_ENABLE_BRIDGE_REPLAY_DEEP_LANE="$bridge_deep" \
+    CI_ENABLE_FEDERATED_DID_HANDSHAKE_DEEP_LANE="$federated_did_deep" \
     GITHUB_BASE_REF=__missing__ \
     bash "$SCRIPT"
 }
 
 run_selector() {
   local changed_files="$1"
-  run_selector_with_bridge_deep "$changed_files" "false"
+  run_selector_with_bridge_deep "$changed_files" "false" "false"
+}
+
+run_selector_with_federated_did_deep() {
+  local changed_files="$1"
+  local federated_did_deep="${2:-false}"
+  run_selector_with_bridge_deep "$changed_files" "false" "$federated_did_deep"
 }
 
 docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
@@ -66,6 +74,7 @@ assert_eq "$(extract_output "$docs_output" "run_launch_canary_contract_tests")" 
 assert_eq "$(extract_output "$docs_output" "run_bridge_replay_harness")" "false" "docs_only should not run bridge replay harness"
 assert_eq "$(extract_output "$docs_output" "run_bridge_replay_deep_lane")" "false" "docs_only should not run bridge replay deep lane"
 assert_eq "$(extract_output "$docs_output" "run_localhost_bridge_demo_evidence_deep_lane")" "false" "docs_only should not run localhost bridge demo evidence deep lane"
+assert_eq "$(extract_output "$docs_output" "run_federated_did_handshake_deep_lane")" "false" "docs_only should not run federated DID handshake deep lane"
 assert_eq "$(extract_output "$docs_output" "bridge_replay_suites")" "" "docs_only should not select bridge replay suites"
 assert_eq "$(extract_output "$docs_output" "run_rust_live_transport_contract_tests")" "false" "docs_only should not run rust live transport lane"
 assert_eq "$(extract_output "$docs_output" "run_python_live_transport_contract_tests")" "false" "docs_only should not run python live transport lane"
@@ -120,6 +129,7 @@ assert_eq "$(extract_output "$deploy_output" "run_mainnet_cutover_contract_tests
 assert_eq "$(extract_output "$deploy_output" "run_launch_canary_contract_tests")" "false" "deploy-only changes should skip launch canary contract tests"
 assert_eq "$(extract_output "$deploy_output" "run_bridge_replay_harness")" "false" "deploy-only changes should skip bridge replay harness"
 assert_eq "$(extract_output "$deploy_output" "run_bridge_replay_deep_lane")" "false" "deploy-only changes should skip bridge replay deep lane"
+assert_eq "$(extract_output "$deploy_output" "run_federated_did_handshake_deep_lane")" "false" "deploy-only changes should skip federated DID handshake deep lane"
 assert_eq "$(extract_output "$deploy_output" "bridge_replay_suites")" "" "deploy-only changes should not select bridge replay suites"
 assert_eq "$(extract_output "$deploy_output" "run_rust_live_transport_contract_tests")" "false" "deploy-only changes should skip rust live transport lane"
 assert_eq "$(extract_output "$deploy_output" "run_python_live_transport_contract_tests")" "false" "deploy-only changes should skip python live transport lane"
@@ -218,6 +228,7 @@ assert_eq "$(extract_output "$unknown_output" "run_mainnet_cutover_contract_test
 assert_eq "$(extract_output "$unknown_output" "run_launch_canary_contract_tests")" "false" "unknown paths should not trigger launch canary contract tests"
 assert_eq "$(extract_output "$unknown_output" "run_bridge_replay_harness")" "false" "unknown paths should not trigger bridge replay harness"
 assert_eq "$(extract_output "$unknown_output" "bridge_replay_suites")" "" "unknown paths should not select bridge replay suites"
+assert_eq "$(extract_output "$unknown_output" "run_federated_did_handshake_deep_lane")" "false" "unknown paths should not trigger federated DID handshake deep lane"
 assert_eq "$(extract_output "$unknown_output" "run_rust_live_transport_contract_tests")" "false" "unknown paths should not trigger rust live transport lane"
 assert_eq "$(extract_output "$unknown_output" "run_python_live_transport_contract_tests")" "false" "unknown paths should not trigger python live transport lane"
 assert_eq "$(extract_output "$unknown_output" "run_typescript_live_transport_contract_tests")" "false" "unknown paths should not trigger typescript live transport lane"
@@ -256,6 +267,7 @@ assert_eq "$(extract_output "$targeted_output" "run_token_launch_contract_tests"
 assert_eq "$(extract_output "$targeted_output" "run_treasury_disbursement_contract_tests")" "false" "bridge adapter paths should skip treasury disbursement contract tests"
 assert_eq "$(extract_output "$targeted_output" "run_bridge_replay_harness")" "true" "bridge adapter rust paths should run bridge replay harness"
 assert_eq "$(extract_output "$targeted_output" "run_bridge_replay_deep_lane")" "false" "bridge adapter rust paths should not run bridge replay deep lane by default"
+assert_eq "$(extract_output "$targeted_output" "run_federated_did_handshake_deep_lane")" "false" "bridge adapter rust paths should not run federated DID handshake deep lane"
 assert_eq "$(extract_output "$targeted_output" "bridge_replay_suites")" "bridge_adapter,telegram_bridge,discord_bridge,cross_chain_bridge" "bridge adapter path should select all bridge suites"
 assert_eq "$(extract_output "$targeted_output" "run_kamn_core_missing_docs_policy_contract_tests")" "false" "bridge adapter paths should not trigger kamn-core missing-docs policy checks"
 assert_eq "$(extract_output "$targeted_output" "run_sdk_parity_matrix")" "false" "non-sdk rust paths should skip sdk parity matrix"
@@ -844,25 +856,34 @@ federated_did_contract_docs_output="$(run_selector $'docs/foundation/did-method.
 assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_rust")" "false" "federated DID docs should avoid rust lane"
 assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_did_registry_contract_tests")" "false" "federated DID docs should not trigger did registry contract lane"
 assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID docs must run federated DID handshake contract lane"
+assert_eq "$(extract_output "$federated_did_contract_docs_output" "run_federated_did_handshake_deep_lane")" "false" "federated DID docs should not run deep lane by default"
 assert_eq "$(extract_output "$federated_did_contract_docs_output" "test_scope")" "federated-did-contract" "federated DID docs should set federated-did-contract scope"
 
 federated_did_contract_script_output="$(run_selector $'scripts/did/run_federated_did_handshake_contract_lane.sh')"
 assert_eq "$(extract_output "$federated_did_contract_script_output" "run_rust")" "false" "federated DID contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$federated_did_contract_script_output" "run_did_registry_contract_tests")" "false" "federated DID contract script changes should not trigger did registry lane"
 assert_eq "$(extract_output "$federated_did_contract_script_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID contract script changes must run federated DID handshake lane"
+assert_eq "$(extract_output "$federated_did_contract_script_output" "run_federated_did_handshake_deep_lane")" "false" "federated DID contract script changes should not run deep lane by default"
 assert_eq "$(extract_output "$federated_did_contract_script_output" "test_scope")" "federated-did-contract" "federated DID contract script changes should set federated-did-contract scope"
 
 federated_did_shared_contract_output="$(run_selector $'scripts/did/federated_did_handshake_contract.py')"
 assert_eq "$(extract_output "$federated_did_shared_contract_output" "run_rust")" "false" "federated DID shared contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$federated_did_shared_contract_output" "run_did_registry_contract_tests")" "false" "federated DID shared contract changes should not trigger did registry lane"
 assert_eq "$(extract_output "$federated_did_shared_contract_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID shared contract changes must run federated DID handshake lane"
+assert_eq "$(extract_output "$federated_did_shared_contract_output" "run_federated_did_handshake_deep_lane")" "false" "federated DID shared contract changes should not run deep lane by default"
 assert_eq "$(extract_output "$federated_did_shared_contract_output" "test_scope")" "federated-did-contract" "federated DID shared contract changes should set federated-did-contract scope"
 
 federated_did_contract_fixture_output="$(run_selector $'fixtures/federated_did_handshake/partition_replay_cases.json')"
 assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_rust")" "false" "federated DID fixture-only changes should avoid rust lane"
 assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_did_registry_contract_tests")" "false" "federated DID fixture changes should not trigger did registry lane"
 assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID fixture changes must run federated DID handshake lane"
+assert_eq "$(extract_output "$federated_did_contract_fixture_output" "run_federated_did_handshake_deep_lane")" "false" "federated DID fixture changes should not run deep lane by default"
 assert_eq "$(extract_output "$federated_did_contract_fixture_output" "test_scope")" "federated-did-contract" "federated DID fixture changes should set federated-did-contract scope"
+
+federated_did_deep_requested_output="$(run_selector_with_federated_did_deep $'scripts/did/run_federated_did_handshake_deep_lane.sh' 'true')"
+assert_eq "$(extract_output "$federated_did_deep_requested_output" "run_federated_did_handshake_contract_tests")" "true" "federated DID deep lane request should keep federated handshake contract lane enabled"
+assert_eq "$(extract_output "$federated_did_deep_requested_output" "run_federated_did_handshake_deep_lane")" "true" "federated DID deep lane request should enable deep lane output"
+assert_eq "$(extract_output "$federated_did_deep_requested_output" "test_scope")" "federated-did-deep" "federated DID deep lane request should set federated-did-deep scope"
 
 kolme_contract_docs_output="$(run_selector $'docs/research/kolme-upstream-compatibility.md')"
 assert_eq "$(extract_output "$kolme_contract_docs_output" "run_rust")" "false" "Kolme compatibility docs should avoid rust lane"

--- a/scripts/did/check_federated_did_handshake_deep_policy.sh
+++ b/scripts/did/check_federated_did_handshake_deep_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/did/federated_did_handshake_deep_policy_contract.py" check "$@"

--- a/scripts/did/federated_did_handshake_deep_policy_contract.py
+++ b/scripts/did/federated_did_handshake_deep_policy_contract.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Federated DID handshake deep-lane policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    fail,
+    load_json,
+    require_keys,
+)
+
+SCHEMA_VERSION = "kamn.did.federated-handshake.deep-summary.v1"
+GO_DECISION = "GO"
+NO_GO_DECISION = "NO-GO"
+
+
+def _csv(values: list[str]) -> str:
+    if not values:
+        return "none"
+    return ",".join(values)
+
+
+def _check_report(report_path: Path) -> int:
+    if not report_path.is_file():
+        fail(f"report file not found: {report_path}")
+
+    payload = load_json(report_path)
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "event_name",
+            "cadence",
+            "contract_lane_status",
+            "matrix_status",
+            "matrix_case_count",
+            "matrix_failed_count",
+            "matrix_report_file",
+            "elapsed_seconds",
+            "max_seconds",
+            "budget_status",
+            "reason_codes",
+            "final_decision",
+        ),
+    )
+
+    if payload["schema_version"] != SCHEMA_VERSION:
+        fail("unsupported schema_version for federated DID handshake deep summary")
+
+    event_name = payload["event_name"]
+    if event_name not in {"schedule", "workflow_dispatch"}:
+        fail("event_name must be schedule or workflow_dispatch")
+
+    cadence = payload["cadence"]
+    expected_cadence = "scheduled" if event_name == "schedule" else "manual"
+    if cadence != expected_cadence:
+        fail(f"cadence mismatch: expected {expected_cadence}, found {cadence}")
+
+    contract_lane_status = payload["contract_lane_status"]
+    if contract_lane_status not in {"pass", "fail"}:
+        fail("contract_lane_status must be pass or fail")
+
+    matrix_status = payload["matrix_status"]
+    if matrix_status not in {"pass", "fail"}:
+        fail("matrix_status must be pass or fail")
+
+    matrix_case_count = payload["matrix_case_count"]
+    matrix_failed_count = payload["matrix_failed_count"]
+    if not isinstance(matrix_case_count, int) or matrix_case_count < 0:
+        fail("matrix_case_count must be a non-negative integer")
+    if not isinstance(matrix_failed_count, int) or matrix_failed_count < 0:
+        fail("matrix_failed_count must be a non-negative integer")
+    if matrix_status == "pass" and matrix_failed_count != 0:
+        fail("matrix_failed_count must be zero when matrix_status is pass")
+    if matrix_status == "fail" and matrix_failed_count == 0:
+        fail("matrix_failed_count must be positive when matrix_status is fail")
+
+    if not isinstance(payload["matrix_report_file"], str) or not payload["matrix_report_file"]:
+        fail("matrix_report_file must be a non-empty string")
+
+    elapsed_seconds = payload["elapsed_seconds"]
+    max_seconds = payload["max_seconds"]
+    if not isinstance(elapsed_seconds, int) or elapsed_seconds < 0:
+        fail("elapsed_seconds must be a non-negative integer")
+    if not isinstance(max_seconds, int) or max_seconds <= 0:
+        fail("max_seconds must be a positive integer")
+
+    budget_status = payload["budget_status"]
+    if budget_status not in {"within", "exceeded"}:
+        fail("budget_status must be within or exceeded")
+    if budget_status == "within" and elapsed_seconds > max_seconds:
+        fail("budget_status within is inconsistent with elapsed_seconds/max_seconds")
+    if budget_status == "exceeded" and elapsed_seconds <= max_seconds:
+        fail("budget_status exceeded is inconsistent with elapsed_seconds/max_seconds")
+
+    reason_codes = payload["reason_codes"]
+    if not isinstance(reason_codes, list) or not all(isinstance(item, str) for item in reason_codes):
+        fail("reason_codes must be a string array")
+    if len(reason_codes) != len(set(reason_codes)):
+        fail("reason_codes must not contain duplicates")
+
+    expected_reason_codes: list[str] = []
+    if contract_lane_status != "pass":
+        expected_reason_codes.append("contract_lane_failed")
+    if matrix_status != "pass":
+        expected_reason_codes.append("matrix_failed")
+    if budget_status != "within":
+        expected_reason_codes.append("runtime_budget_exceeded")
+
+    actual_reason_codes = sorted(reason_codes)
+    expected_reason_codes_sorted = sorted(expected_reason_codes)
+    if actual_reason_codes != expected_reason_codes_sorted:
+        fail(
+            "reason_codes mismatch: "
+            f"expected {_csv(expected_reason_codes_sorted)}, found {_csv(actual_reason_codes)}"
+        )
+
+    expected_final_decision = GO_DECISION if not expected_reason_codes else NO_GO_DECISION
+    actual_final_decision = payload["final_decision"]
+    if actual_final_decision not in {GO_DECISION, NO_GO_DECISION}:
+        fail("final_decision must be GO or NO-GO")
+    if actual_final_decision != expected_final_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected final_decision={expected_final_decision}, found {actual_final_decision}"
+        )
+
+    print("status=ok")
+    print(f"report_file={report_path}")
+    print(f"final_decision={actual_final_decision}")
+    print(f"failed_checks={_csv(expected_reason_codes_sorted)}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Federated DID handshake deep-lane policy checker"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check")
+    check.add_argument("--report-file", required=True)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "check":
+        return _check_report(Path(args.report_file))
+
+    fail(f"unsupported command: {args.command}")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/did/run_federated_did_handshake_contract_lane.sh
+++ b/scripts/did/run_federated_did_handshake_contract_lane.sh
@@ -37,6 +37,8 @@ cargo test -p kamn-core --test did_method >/dev/null
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test federated_did_handshake_runtime >/dev/null
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test did_method_docs regression_requires_federated_runtime_trust_store_guard_marker -- --exact >/dev/null
 bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test release_gonogo_checklist_docs regression_requires_federated_runtime_trust_store_guard_marker -- --exact >/dev/null
+bash scripts/did/test_check_federated_did_handshake_deep_policy.sh >/dev/null
+bash scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh >/dev/null
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
 if [ "$elapsed_seconds" -gt 120 ]; then

--- a/scripts/did/run_federated_did_handshake_deep_lane.sh
+++ b/scripts/did/run_federated_did_handshake_deep_lane.sh
@@ -5,39 +5,269 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_LANE="$ROOT_DIR/scripts/did/run_federated_did_handshake_contract_lane.sh"
 MATRIX_SCRIPT="$ROOT_DIR/scripts/did/run_federated_did_handshake_matrix.py"
 FIXTURE_FILE="$ROOT_DIR/fixtures/federated_did_handshake/partition_replay_cases.json"
+POLICY_CHECKER="$ROOT_DIR/scripts/did/check_federated_did_handshake_deep_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-output_json=""
+usage() {
+  cat <<'USAGE'
+Usage:
+  KAMN_FEDERATED_DID_HANDSHAKE_DEEP_CADENCE=scheduled \
+    bash scripts/did/run_federated_did_handshake_deep_lane.sh \
+      [--event-name schedule|workflow_dispatch] \
+      [--output-json <path>] \
+      [--max-seconds <int>] \
+      [--skip-contract-tests]
+USAGE
+}
+
+fail() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  exit 1
+}
+
+event_name="${GITHUB_EVENT_NAME:-schedule}"
+output_json="$ROOT_DIR/federated-did-handshake-report.json"
+max_seconds="${KAMN_FEDERATED_DID_HANDSHAKE_DEEP_MAX_SECONDS:-180}"
+skip_contract_tests=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --event-name)
+      event_name="${2:-}"
+      shift 2
+      ;;
     --output-json)
       output_json="${2:-}"
       shift 2
       ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --skip-contract-tests)
+      skip_contract_tests=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
     *)
-      echo "unknown argument: $1" >&2
-      exit 1
+      fail "unknown argument: $1"
       ;;
   esac
 done
 
-if [[ -z "$output_json" ]]; then
-  output_json="$ROOT_DIR/federated-did-handshake-report.json"
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  fail "--max-seconds must be a non-negative integer"
+fi
+if [ "$max_seconds" -eq 0 ]; then
+  fail "--max-seconds must be greater than zero"
+fi
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  fail "expected federated DID handshake contract lane runner to be executable"
+fi
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  fail "expected federated DID handshake matrix runner to be executable"
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  fail "expected federated DID handshake deep policy checker to be executable"
+fi
+if [ ! -f "$FIXTURE_FILE" ]; then
+  fail "expected federated DID handshake fixture file to exist"
+fi
+
+cadence=""
+case "$event_name" in
+  schedule)
+    cadence="scheduled"
+    ;;
+  workflow_dispatch)
+    cadence="manual"
+    ;;
+  *)
+    fail "scheduled/manual-only cadence policy requires event schedule or workflow_dispatch"
+    ;;
+esac
+
+configured_cadence="${KAMN_FEDERATED_DID_HANDSHAKE_DEEP_CADENCE:-}"
+if [[ -n "$configured_cadence" ]]; then
+  if [[ "$configured_cadence" != "scheduled" && "$configured_cadence" != "manual" ]]; then
+    fail "KAMN_FEDERATED_DID_HANDSHAKE_DEEP_CADENCE must be scheduled or manual"
+  fi
+  if [[ "$configured_cadence" != "$cadence" ]]; then
+    fail "configured deep cadence does not match event-derived cadence"
+  fi
 fi
 
 mkdir -p "$(dirname "$output_json")"
+matrix_report="$TMP_DIR/federated-did-handshake-matrix-report.json"
+start_epoch="$(date +%s)"
+status="pass"
+contract_lane_status="pass"
+matrix_status="pass"
+reason_codes=()
 
-bash "$CONTRACT_LANE" >/dev/null
+if [ "$skip_contract_tests" = true ]; then
+  contract_output="contract lane skipped via --skip-contract-tests"
+  contract_code=0
+else
+  set +e
+  contract_output="$(bash "$CONTRACT_LANE" 2>&1)"
+  contract_code=$?
+  set -e
+fi
 
+if [ "$contract_code" -ne 0 ]; then
+  contract_lane_status="fail"
+  status="fail"
+  reason_codes+=("contract_lane_failed")
+fi
+
+set +e
 matrix_output="$(
   python3 "$MATRIX_SCRIPT" \
     --fixture "$FIXTURE_FILE" \
-    --output-json "$output_json"
+    --output-json "$matrix_report" 2>&1
+)"
+matrix_code=$?
+set -e
+
+if [ "$matrix_code" -ne 0 ] || ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
+  matrix_status="fail"
+  status="fail"
+  reason_codes+=("matrix_failed")
+fi
+
+matrix_counts="$(
+  python3 - "$matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.is_file():
+    print("0 0")
+    raise SystemExit(0)
+
+payload = json.loads(path.read_text(encoding="utf-8"))
+print(f"{int(payload.get('case_count', 0))} {int(payload.get('failed_count', 0))}")
+PY
+)"
+matrix_case_count="$(printf '%s\n' "$matrix_counts" | awk '{print $1}')"
+matrix_failed_count="$(printf '%s\n' "$matrix_counts" | awk '{print $2}')"
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+budget_status="within"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  budget_status="exceeded"
+  status="fail"
+  reason_codes+=("runtime_budget_exceeded")
+fi
+
+reason_codes_json="$(
+  python3 - "${reason_codes[@]:-}" <<'PY'
+import json
+import sys
+
+values = sorted({value for value in sys.argv[1:] if value})
+print(json.dumps(values))
+PY
 )"
 
-if ! printf '%s\n' "$matrix_output" | grep -q '^status=pass;'; then
-  echo "expected federated DID handshake deep matrix to pass" >&2
-  exit 1
+final_decision="GO"
+if [ "$status" != "pass" ]; then
+  final_decision="NO-GO"
+fi
+
+python3 - "$output_json" "$event_name" "$cadence" "$contract_lane_status" "$matrix_status" "$matrix_case_count" "$matrix_failed_count" "$matrix_report" "$elapsed_seconds" "$max_seconds" "$budget_status" "$reason_codes_json" "$final_decision" "$skip_contract_tests" <<'PY'
+import json
+import pathlib
+import sys
+
+(
+    output_json,
+    event_name,
+    cadence,
+    contract_lane_status,
+    matrix_status,
+    matrix_case_count,
+    matrix_failed_count,
+    matrix_report_file,
+    elapsed_seconds,
+    max_seconds,
+    budget_status,
+    reason_codes_json,
+    final_decision,
+    skip_contract_tests,
+) = sys.argv[1:]
+
+payload = {
+    "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+    "event_name": event_name,
+    "cadence": cadence,
+    "contract_lane_status": contract_lane_status,
+    "matrix_status": matrix_status,
+    "matrix_case_count": int(matrix_case_count),
+    "matrix_failed_count": int(matrix_failed_count),
+    "matrix_report_file": matrix_report_file,
+    "elapsed_seconds": int(elapsed_seconds),
+    "max_seconds": int(max_seconds),
+    "budget_status": budget_status,
+    "reason_codes": json.loads(reason_codes_json),
+    "final_decision": final_decision,
+    "policy_status": "pending",
+    "skip_contract_tests": skip_contract_tests == "true",
+}
+
+pathlib.Path(output_json).write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+policy_output="$(bash "$POLICY_CHECKER" --report-file "$output_json" 2>&1)"
+policy_code=$?
+set -e
+
+policy_status="pass"
+if [ "$policy_code" -ne 0 ]; then
+  policy_status="fail"
+  status="fail"
+  reason_codes+=("policy_check_failed")
+  final_decision="NO-GO"
+fi
+
+reason_codes_json="$(
+  python3 - "${reason_codes[@]:-}" <<'PY'
+import json
+import sys
+
+values = sorted({value for value in sys.argv[1:] if value})
+print(json.dumps(values))
+PY
+)"
+
+python3 - "$output_json" "$policy_status" "$final_decision" "$reason_codes_json" <<'PY'
+import json
+import pathlib
+import sys
+
+output_json, policy_status, final_decision, reason_codes_json = sys.argv[1:]
+path = pathlib.Path(output_json)
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["policy_status"] = policy_status
+payload["final_decision"] = final_decision
+payload["reason_codes"] = json.loads(reason_codes_json)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [ "$status" != "pass" ]; then
+  printf '%s\n' "$contract_output" >&2
+  printf '%s\n' "$matrix_output" >&2
+  printf '%s\n' "$policy_output" >&2
+  fail "federated DID handshake deep lane failed closed: $(IFS=,; echo "${reason_codes[*]}")"
 fi
 
 echo "federated DID handshake deep lane tests passed."

--- a/scripts/did/run_federated_did_handshake_deep_policy_matrix.py
+++ b/scripts/did/run_federated_did_handshake_deep_policy_matrix.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+CHECKER = ROOT_DIR / "scripts/did/check_federated_did_handshake_deep_policy.sh"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fixture",
+        default=str(ROOT_DIR / "fixtures/federated_did_handshake/deep_lane_policy_cases.json"),
+    )
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def parse_key_values(stdout: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def run_checker(report_file: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(CHECKER),
+        "--report-file",
+        str(report_file),
+    ]
+    return subprocess.run(command, cwd=ROOT_DIR, text=True, capture_output=True)
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_path = Path(args.fixture)
+    if not fixture_path.is_file():
+        print(f"status=fail; reason=fixture-not-found; fixture={fixture_path}")
+        return 2
+
+    if not CHECKER.is_file():
+        print(f"status=fail; reason=checker-missing; checker={CHECKER}")
+        return 2
+
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != "kamn.did.federated-handshake.deep-policy-cases.v1":
+        print("status=fail; reason=invalid-fixture-schema")
+        return 2
+
+    cases = payload.get("cases")
+    if not isinstance(cases, list) or not cases:
+        print("status=fail; reason=invalid-fixture-cases")
+        return 2
+
+    tmp_dir = Path(subprocess.check_output(["mktemp", "-d"], text=True, cwd=ROOT_DIR).strip())
+    report_cases: list[dict[str, Any]] = []
+    failed_case_ids: list[str] = []
+    try:
+        for index, case in enumerate(cases):
+            if not isinstance(case, dict):
+                case_id = f"invalid-case-{index}"
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "passed": False,
+                        "error": "case entry must be an object",
+                    }
+                )
+                continue
+
+            case_id = str(case.get("case_id", f"case-{index}"))
+            expected_policy_status = str(case.get("expected_policy_status", "pass"))
+            expected_final_decision = str(case.get("expected_final_decision", "GO"))
+            report_payload = case.get("report")
+            if not isinstance(report_payload, dict):
+                failed_case_ids.append(case_id)
+                report_cases.append(
+                    {
+                        "case_id": case_id,
+                        "expected_policy_status": expected_policy_status,
+                        "expected_final_decision": expected_final_decision,
+                        "passed": False,
+                        "error": "report payload must be an object",
+                    }
+                )
+                continue
+
+            report_file = tmp_dir / f"{case_id}.json"
+            report_file.write_text(
+                json.dumps(report_payload, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            checked = run_checker(report_file)
+            actual_policy_status = "pass" if checked.returncode == 0 else "fail"
+            checked_values = parse_key_values(checked.stdout)
+            actual_final_decision = checked_values.get("final_decision", "")
+
+            passed = actual_policy_status == expected_policy_status
+            if expected_policy_status == "pass":
+                passed = passed and actual_final_decision == expected_final_decision
+
+            if not passed:
+                failed_case_ids.append(case_id)
+
+            report_cases.append(
+                {
+                    "case_id": case_id,
+                    "expected_policy_status": expected_policy_status,
+                    "actual_policy_status": actual_policy_status,
+                    "expected_final_decision": expected_final_decision,
+                    "actual_final_decision": actual_final_decision,
+                    "passed": passed,
+                    "checker_stdout": checked.stdout.strip(),
+                    "checker_stderr": checked.stderr.strip(),
+                }
+            )
+
+        status = "pass" if not failed_case_ids else "fail"
+        report = {
+            "schema_version": "kamn.did.federated-handshake.deep-policy-matrix.v1",
+            "status": status,
+            "fixture": str(fixture_path),
+            "case_count": len(cases),
+            "failed_count": len(failed_case_ids),
+            "failed_case_ids": failed_case_ids,
+            "cases": report_cases,
+        }
+
+        if args.output_json:
+            Path(args.output_json).write_text(
+                json.dumps(report, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+        if status == "pass":
+            print(f"status=pass; cases={len(cases)}; failed=0")
+            return 0
+
+        print(
+            "status=fail; "
+            f"cases={len(cases)}; failed={len(failed_case_ids)}; "
+            f"failed_ids={','.join(failed_case_ids)}"
+        )
+        return 1
+    finally:
+        subprocess.run(["rm", "-rf", str(tmp_dir)], check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/did/test_check_federated_did_handshake_deep_policy.sh
+++ b/scripts/did/test_check_federated_did_handshake_deep_policy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/did/check_federated_did_handshake_deep_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected federated DID handshake deep policy checker to be executable" >&2
+  exit 1
+fi
+
+go_report="$TMP_DIR/go-summary.json"
+cat >"$go_report" <<'JSON'
+{
+  "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+  "event_name": "schedule",
+  "cadence": "scheduled",
+  "contract_lane_status": "pass",
+  "matrix_status": "pass",
+  "matrix_case_count": 5,
+  "matrix_failed_count": 0,
+  "matrix_report_file": "/tmp/federated-did-handshake-report.json",
+  "elapsed_seconds": 9,
+  "max_seconds": 180,
+  "budget_status": "within",
+  "reason_codes": [],
+  "final_decision": "GO",
+  "policy_status": "pending"
+}
+JSON
+
+go_output="$(bash "$CHECKER" --report-file "$go_report")"
+if ! printf '%s\n' "$go_output" | grep -q "^status=ok$"; then
+  echo "expected GO summary to pass deep policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$go_output" | grep -q "^final_decision=GO$"; then
+  echo "expected GO summary final decision in deep policy checker output" >&2
+  exit 1
+fi
+
+tampered_report="$TMP_DIR/tampered-summary.json"
+cat >"$tampered_report" <<'JSON'
+{
+  "schema_version": "kamn.did.federated-handshake.deep-summary.v1",
+  "event_name": "schedule",
+  "cadence": "scheduled",
+  "contract_lane_status": "pass",
+  "matrix_status": "fail",
+  "matrix_case_count": 5,
+  "matrix_failed_count": 2,
+  "matrix_report_file": "/tmp/federated-did-handshake-report.json",
+  "elapsed_seconds": 14,
+  "max_seconds": 180,
+  "budget_status": "within",
+  "reason_codes": [],
+  "final_decision": "GO",
+  "policy_status": "pending"
+}
+JSON
+
+set +e
+tampered_output="$(bash "$CHECKER" --report-file "$tampered_report" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered deep summary to fail deep policy checker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "reason_codes mismatch"; then
+  echo "expected reason-code mismatch marker for tampered deep summary" >&2
+  exit 1
+fi
+
+echo "federated DID handshake deep policy checker tests passed."

--- a/scripts/did/test_run_federated_did_handshake_contract_lane.sh
+++ b/scripts/did/test_run_federated_did_handshake_contract_lane.sh
@@ -41,4 +41,14 @@ if ! grep -q "regression_requires_federated_runtime_trust_store_guard_marker" "$
   exit 1
 fi
 
+if ! grep -q "test_check_federated_did_handshake_deep_policy.sh" "$CONTRACT_LANE"; then
+  echo "expected federated DID handshake contract lane to include deep policy checker tests" >&2
+  exit 1
+fi
+
+if ! grep -q "test_run_federated_did_handshake_deep_policy_matrix.sh" "$CONTRACT_LANE"; then
+  echo "expected federated DID handshake contract lane to include deep policy matrix tests" >&2
+  exit 1
+fi
+
 echo "federated DID handshake contract lane script tests passed."

--- a/scripts/did/test_run_federated_did_handshake_deep_lane.sh
+++ b/scripts/did/test_run_federated_did_handshake_deep_lane.sh
@@ -11,7 +11,13 @@ if [ ! -x "$DEEP_LANE" ]; then
   exit 1
 fi
 
-output="$(bash "$DEEP_LANE" --output-json "$TMP_REPORT")"
+output="$(
+  KAMN_FEDERATED_DID_HANDSHAKE_DEEP_CADENCE=scheduled \
+  bash "$DEEP_LANE" \
+    --event-name schedule \
+    --skip-contract-tests \
+    --output-json "$TMP_REPORT"
+)"
 if ! printf '%s\n' "$output" | grep -q "federated DID handshake deep lane tests passed."; then
   echo "expected federated DID handshake deep lane success marker" >&2
   exit 1
@@ -22,16 +28,48 @@ if [ ! -s "$TMP_REPORT" ]; then
   exit 1
 fi
 
+if ! grep -Fq "check_federated_did_handshake_deep_policy.sh" "$DEEP_LANE"; then
+  echo "expected federated DID handshake deep lane to invoke deep policy checker" >&2
+  exit 1
+fi
+
 python3 - "$TMP_REPORT" <<'PY'
 import json
 import pathlib
 import sys
 
 report = json.loads(pathlib.Path(sys.argv[1]).read_text())
-if report.get("schema_version") != "kamn.did.federated-handshake.partition-replay-matrix.v1":
-    raise SystemExit("unexpected federated DID handshake deep report schema version")
-if report.get("status") != "pass":
-    raise SystemExit("expected federated DID handshake deep report to pass")
+if report.get("schema_version") != "kamn.did.federated-handshake.deep-summary.v1":
+    raise SystemExit("unexpected federated DID handshake deep summary schema version")
+if report.get("event_name") != "schedule":
+    raise SystemExit("expected schedule event in federated DID handshake deep summary")
+if report.get("cadence") != "scheduled":
+    raise SystemExit("expected scheduled cadence in federated DID handshake deep summary")
+if report.get("policy_status") != "pass":
+    raise SystemExit("expected federated DID handshake deep policy status to pass")
+if report.get("final_decision") != "GO":
+    raise SystemExit("expected federated DID handshake deep summary to conclude GO")
+if report.get("budget_status") != "within":
+    raise SystemExit("expected federated DID handshake deep summary budget status within")
 PY
+
+set +e
+invalid_event_output="$(
+  bash "$DEEP_LANE" \
+    --event-name pull_request \
+    --output-json "$TMP_REPORT" 2>&1
+)"
+invalid_event_code=$?
+set -e
+
+if [[ "$invalid_event_code" -eq 0 ]]; then
+  echo "expected federated DID handshake deep lane to reject pull_request cadence" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$invalid_event_output" | grep -q "scheduled/manual-only cadence policy"; then
+  echo "expected cadence policy rejection marker for federated DID handshake deep lane" >&2
+  exit 1
+fi
 
 echo "federated DID handshake deep lane script tests passed."

--- a/scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh
+++ b/scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MATRIX_SCRIPT="$ROOT_DIR/scripts/did/run_federated_did_handshake_deep_policy_matrix.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/federated_did_handshake/deep_lane_policy_cases.json"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$MATRIX_SCRIPT" ]; then
+  echo "expected federated DID handshake deep policy matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected federated DID handshake deep policy fixture file to exist" >&2
+  exit 1
+fi
+
+python3 "$MATRIX_SCRIPT" \
+  --fixture "$FIXTURE_FILE" \
+  --output-json "$TMP_REPORT" \
+  >/dev/null
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+report_path = pathlib.Path(sys.argv[1])
+payload = json.loads(report_path.read_text())
+
+if payload.get("schema_version") != "kamn.did.federated-handshake.deep-policy-matrix.v1":
+    raise SystemExit("unexpected federated DID handshake deep policy matrix schema version")
+
+cases = payload.get("cases", [])
+if not cases:
+    raise SystemExit("expected at least one federated DID handshake deep policy matrix case")
+
+if not any(case.get("case_id") == "tampered_final_decision_go" for case in cases):
+    raise SystemExit("expected tampered_final_decision_go case in deep policy matrix report")
+
+tampered_case = next(case for case in cases if case.get("case_id") == "tampered_final_decision_go")
+if tampered_case.get("actual_policy_status") != "fail":
+    raise SystemExit("expected tampered_final_decision_go to fail policy checker")
+PY
+
+echo "federated DID handshake deep policy matrix tests passed."

--- a/scripts/did/test_run_federated_did_handshake_matrix.sh
+++ b/scripts/did/test_run_federated_did_handshake_matrix.sh
@@ -39,6 +39,12 @@ if not cases:
 
 if not any(case.get("case_id") == "no_go_partition_replay" for case in cases):
     raise SystemExit("expected no_go_partition_replay case in federated DID handshake matrix report")
+
+if not any(case.get("case_id") == "no_go_partition_sequence_replay" for case in cases):
+    raise SystemExit("expected no_go_partition_sequence_replay case in federated DID handshake matrix report")
+
+if not any(case.get("case_id") == "no_go_downgrade_attack" for case in cases):
+    raise SystemExit("expected no_go_downgrade_attack case in federated DID handshake matrix report")
 PY
 
 echo "federated DID handshake matrix tests passed."


### PR DESCRIPTION
## Summary
Adds federated DID handshake deep-lane policy contracts and CI fast/deep routing so PR paths stay cheap while scheduled/manual deep validation remains available and fail-closed. This closes partition/replay/downgrade deep-lane policy gaps and tamper-detection contracts.

## Changes
- Deep-lane policy contract stack:
  - Added `scripts/did/federated_did_handshake_deep_policy_contract.py` (deep summary checker contract).
  - Added wrapper `scripts/did/check_federated_did_handshake_deep_policy.sh`.
  - Added deep policy matrix runner `scripts/did/run_federated_did_handshake_deep_policy_matrix.py`.
  - Added tests `scripts/did/test_check_federated_did_handshake_deep_policy.sh` and `scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh`.
- Deep lane runtime hardening:
  - Reworked `scripts/did/run_federated_did_handshake_deep_lane.sh` with scheduled/manual cadence guard, optional skip-contract mode, runtime budget enforcement, deterministic deep summary schema, and policy checker integration.
  - Updated `scripts/did/test_run_federated_did_handshake_deep_lane.sh` for schema/policy/cadence rejection checks.
- Matrix fixture expansion:
  - Updated `fixtures/federated_did_handshake/partition_replay_cases.json` with explicit `no_go_partition_sequence_replay` case.
  - Added `fixtures/federated_did_handshake/deep_lane_policy_cases.json` for deep policy checker matrix cases (including tampered final decision).
- Fast lane integration and test wiring:
  - Updated `scripts/did/run_federated_did_handshake_contract_lane.sh` to include deep policy checker and deep policy matrix tests.
  - Updated `scripts/did/test_run_federated_did_handshake_contract_lane.sh` and `scripts/did/test_run_federated_did_handshake_matrix.sh` with new assertions.
- CI selector and workflow cost routing:
  - Added `run_federated_did_handshake_deep_lane` output in `scripts/ci/select_targets.sh` gated by `CI_ENABLE_FEDERATED_DID_HANDSHAKE_DEEP_LANE=true` and scoped as `federated-did-deep`.
  - Updated `scripts/ci/test_select_targets.sh` for default-off and deep-requested coverage.
  - Updated `.github/workflows/ci-fast-gate.yml` to keep deep lane out of default federated fast lane and run it only when `run_federated_did_handshake_deep_lane == true`.
- Docs and contract markers:
  - Updated `docs/foundation/did-method.md` and `docs/foundation/release-gonogo-checklist.md` with deep policy checker/matrix commands and `Regression: #1003` marker.
  - Updated `docs/planning/live-network-wave.md` for federated deep budget/cadence/selector policy notes.
  - Updated doc contract tests in `crates/kamn-core/tests/did_method_docs.rs` and `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test did_method_docs --test release_gonogo_checklist_docs
```
Failing output excerpt:
```text
assertion failed: DID_METHOD_DOC.contains("check_federated_did_handshake_deep_policy.sh")
assertion failed: DID_METHOD_DOC.contains("... `Regression: #1003` ...")
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test did_method_docs --test release_gonogo_checklist_docs
```
Passing summary:
```text
did_method_docs: 7 passed
release_gonogo_checklist_docs: 56 passed
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test did_method_docs --test release_gonogo_checklist_docs
cargo test -p kamn-core --test live_network_wave_docs
bash scripts/did/test_generate_federated_did_handshake_evidence_bundle.sh
bash scripts/did/test_run_federated_did_handshake_matrix.sh
bash scripts/did/test_check_federated_did_handshake_deep_policy.sh
bash scripts/did/test_run_federated_did_handshake_deep_policy_matrix.sh
bash scripts/did/test_run_federated_did_handshake_contract_lane.sh
bash scripts/did/test_run_federated_did_handshake_deep_lane.sh
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
bash scripts/ci/test_select_targets.sh
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Deep policy checker script tests (`test_check_federated_did_handshake_deep_policy.sh`) | |
| Functional   | ✅ | Deep lane script schema/cadence checks (`test_run_federated_did_handshake_deep_lane.sh`) | |
| Integration  | ✅ | Contract lane integration of deep policy checker + matrix in `run_federated_did_handshake_contract_lane.sh` | |
| Regression   | ✅ | New doc guard marker assertions for `Regression: #1003`; tampered final decision matrix case | |
| Performance  | ✅ | Selector/workflow split keeps deep lane default-off in PR fast lane; explicit deep gating via selector output | |

## Risks & Rollback
- Breaking changes: None expected; deep lane is stricter and fail-closed by design.
- Rollback plan: revert this PR to restore prior deep lane behavior and selector/workflow routing.

## Documentation Updates
- `docs/foundation/did-method.md`
- `docs/foundation/release-gonogo-checklist.md`
- `docs/planning/live-network-wave.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scoped suite)
- [x] Docs updated

Closes #1003
