### PR TITLE
refactor(ci): share DSAR contract-lane runner helpers

### DIFF
--- a/scripts/compliance/dsar_legal_hold_contract_lane_contract.py
+++ b/scripts/compliance/dsar_legal_hold_contract_lane_contract.py
@@ -3,10 +3,17 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_lane_helpers import (  # noqa: E402
+    build_default_bundle_args,
+    run_capture,
+)
 
 
 def usage() -> None:
@@ -18,12 +25,6 @@ def fail(message: str) -> int:
     """Emit stable error and return non-zero."""
     print(message, file=sys.stderr)
     return 1
-
-
-def run_capture(command: list[str]) -> tuple[int, str]:
-    """Run command and return exit code + merged output."""
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
-    return result.returncode, (result.stdout or "") + (result.stderr or "")
 
 
 def main(argv: list[str]) -> int:
@@ -40,37 +41,30 @@ def main(argv: list[str]) -> int:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         bundle_file = Path(temp_dir) / "dsar-contract.json"
+        generator_args = build_default_bundle_args(
+            output_file=str(bundle_file),
+            pairs=(
+                ("--request-id", "dsar-export-contract-001"),
+                ("--subject-did", "did:kamn:subject-contract"),
+                ("--request-type", "EXPORT"),
+                ("--legal-hold-active", "false"),
+                ("--retention-expired", "true"),
+                ("--evidence-complete", "true"),
+                ("--approval-recorded", "true"),
+                ("--tamper-check", "PASS"),
+                ("--ci-fast-gate", "PASS"),
+            ),
+        )
         generator_code, generator_output = run_capture(
-            [
-                "bash",
-                str(generator),
-                "--output-file",
-                str(bundle_file),
-                "--request-id",
-                "dsar-export-contract-001",
-                "--subject-did",
-                "did:kamn:subject-contract",
-                "--request-type",
-                "EXPORT",
-                "--legal-hold-active",
-                "false",
-                "--retention-expired",
-                "true",
-                "--evidence-complete",
-                "true",
-                "--approval-recorded",
-                "true",
-                "--tamper-check",
-                "PASS",
-                "--ci-fast-gate",
-                "PASS",
-            ]
+            ["bash", str(generator), *generator_args],
+            cwd=root_dir,
         )
         if generator_code != 0 or "final_decision=GO" not in generator_output:
             return fail("expected DSAR contract lane bundle decision to be GO")
 
         policy_code, policy_output = run_capture(
-            ["bash", str(policy_checker), "--bundle-file", str(bundle_file)]
+            ["bash", str(policy_checker), "--bundle-file", str(bundle_file)],
+            cwd=root_dir,
         )
         if policy_code != 0 or "final_decision=GO" not in policy_output:
             return fail("expected DSAR contract lane policy check decision to be GO")

--- a/scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh
+++ b/scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh
@@ -52,4 +52,9 @@ if ! grep -q "check_dsar_legal_hold_policy.sh" "$SHARED_CONTRACT"; then
   exit 1
 fi
 
+if ! grep -q "from framework.contract_lane_helpers import" "$SHARED_CONTRACT"; then
+  echo "expected shared DSAR contract-lane implementation to import framework lane helper utilities" >&2
+  exit 1
+fi
+
 echo "dsar legal-hold contract lane script tests passed."


### PR DESCRIPTION
## Summary
Refactors the DSAR legal-hold shared contract-lane runner to use shared framework helper utilities, removing duplicated command orchestration while preserving wrapper behavior and lane output compatibility.

## Changes
- Refactored `scripts/compliance/dsar_legal_hold_contract_lane_contract.py`:
  - now imports `framework.contract_lane_helpers`.
  - uses `build_default_bundle_args(...)` and `run_capture(...)`.
  - removes duplicated local `run_capture` implementation.
- Updated `scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh`:
  - adds assertion that shared DSAR contract-lane implementation imports framework lane helpers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh
```
Failing output excerpt:
```text
expected shared DSAR contract-lane implementation to import framework lane helper utilities
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/framework/test_contract_framework.sh
bash scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh
```
Passing summary:
```text
contract framework unit tests passed.
dsar legal-hold contract lane script tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/framework/test_contract_framework.sh
bash scripts/compliance/test_run_dsar_legal_hold_contract_lane.sh
bash scripts/compliance/test_generate_dsar_legal_hold_evidence_bundle.sh
bash scripts/ci/test_select_targets.sh
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Shared helper unit tests remain green via `scripts/framework/test_contract_framework.sh` | |
| Functional   | ✅ | DSAR lane marker/assertion updates in `test_run_dsar_legal_hold_contract_lane.sh` | |
| Integration  | ✅ | DSAR wrapper -> shared runner execution path validated by contract lane script test | |
| Regression   | ✅ | Existing DSAR tamper/bypass fail-closed checks preserved | |
| Performance  | ✅ | Selector routing remained bounded (`test_select_targets.sh` green) | |

## Risks & Rollback
- Breaking changes: None expected; command surfaces and success markers are unchanged.
- Rollback plan: revert this PR commit to restore previous DSAR runner implementation.

## Documentation Updates
- None required (no operator-facing command/interface changes).

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A: no Rust changes)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scoped suite)
- [x] Docs updated (or justified why not)

Closes #1312
