### PR TITLE
refactor(governance): share simulation lane helper utilities

### DIFF
--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -192,6 +192,8 @@ fn checklist_contains_governance_simulation_and_human_veto_evidence_contract() {
     assert!(CHECKLIST.contains("## Governance Simulation and Human-Veto Evidence Contract"));
     assert!(CHECKLIST.contains("generate_governance_simulation_evidence_bundle.sh"));
     assert!(CHECKLIST.contains("check_governance_simulation_policy.sh"));
+    assert!(CHECKLIST.contains("governance_simulation_contract_lane_contract.py"));
+    assert!(CHECKLIST.contains("framework.contract_lane_helpers"));
     assert!(CHECKLIST.contains("run_governance_simulation_contract_lane.sh"));
     assert!(CHECKLIST.contains("run_governance_simulation_deep_lane.sh"));
     assert!(CHECKLIST.contains("run_governance_simulation_matrix.py"));

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -312,6 +312,8 @@ Governance activation requires deterministic simulation, veto, timelock, and app
   - `scripts/governance/check_governance_simulation_policy.sh`
 - Shared Python implementation:
   - `scripts/governance/governance_simulation_contract.py`
+- Shared Python contract-lane implementation:
+  - `scripts/governance/governance_simulation_contract_lane_contract.py` (uses `framework.contract_lane_helpers`)
 - Evidence bundle generator:
   - `bash scripts/governance/generate_governance_simulation_evidence_bundle.sh --output-file /tmp/governance-simulation.json --proposal-id gov-proposal-activation-001 --simulation-hash sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --simulation-complete true --veto-window-open false --veto-recorded false --timelock-expired true --required-approvals 2 --received-approvals 2 --ci-fast-gate PASS`
 - Policy checker:

--- a/scripts/governance/governance_simulation_contract_lane_contract.py
+++ b/scripts/governance/governance_simulation_contract_lane_contract.py
@@ -3,10 +3,17 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_lane_helpers import (  # noqa: E402
+    build_default_bundle_args,
+    run_capture,
+)
 
 
 def usage() -> None:
@@ -18,12 +25,6 @@ def fail(message: str) -> int:
     """Emit stable error and return non-zero."""
     print(message, file=sys.stderr)
     return 1
-
-
-def run_capture(command: list[str]) -> tuple[int, str]:
-    """Run command and return exit code + merged output."""
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
-    return result.returncode, (result.stdout or "") + (result.stderr or "")
 
 
 def main(argv: list[str]) -> int:
@@ -40,37 +41,33 @@ def main(argv: list[str]) -> int:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         bundle_file = Path(temp_dir) / "governance-contract.json"
+        generator_args = build_default_bundle_args(
+            output_file=str(bundle_file),
+            pairs=(
+                ("--proposal-id", "gov-proposal-contract-001"),
+                (
+                    "--simulation-hash",
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ),
+                ("--simulation-complete", "true"),
+                ("--veto-window-open", "false"),
+                ("--veto-recorded", "false"),
+                ("--timelock-expired", "true"),
+                ("--required-approvals", "2"),
+                ("--received-approvals", "2"),
+                ("--ci-fast-gate", "PASS"),
+            ),
+        )
         generator_code, generator_output = run_capture(
-            [
-                "bash",
-                str(generator),
-                "--output-file",
-                str(bundle_file),
-                "--proposal-id",
-                "gov-proposal-contract-001",
-                "--simulation-hash",
-                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "--simulation-complete",
-                "true",
-                "--veto-window-open",
-                "false",
-                "--veto-recorded",
-                "false",
-                "--timelock-expired",
-                "true",
-                "--required-approvals",
-                "2",
-                "--received-approvals",
-                "2",
-                "--ci-fast-gate",
-                "PASS",
-            ]
+            ["bash", str(generator), *generator_args],
+            cwd=root_dir,
         )
         if generator_code != 0 or "final_decision=GO" not in generator_output:
             return fail("expected governance contract lane bundle decision to be GO")
 
         policy_code, policy_output = run_capture(
-            ["bash", str(policy_checker), "--bundle-file", str(bundle_file)]
+            ["bash", str(policy_checker), "--bundle-file", str(bundle_file)],
+            cwd=root_dir,
         )
         if policy_code != 0 or "final_decision=GO" not in policy_output:
             return fail("expected governance contract lane policy decision to be GO")

--- a/scripts/governance/test_run_governance_simulation_contract_lane.sh
+++ b/scripts/governance/test_run_governance_simulation_contract_lane.sh
@@ -37,6 +37,10 @@ if ! grep -q "check_governance_simulation_policy.sh" "$SHARED_CONTRACT"; then
   echo "expected governance simulation shared contract-lane module to run policy checker" >&2
   exit 1
 fi
+if ! grep -q "from framework.contract_lane_helpers import" "$SHARED_CONTRACT"; then
+  echo "expected governance simulation shared contract-lane module to use framework lane helpers" >&2
+  exit 1
+fi
 
 if ! grep -Fq "run_governance_simulation_contract_lane.sh" "$DEEP_LANE"; then
   echo "expected deep lane script to invoke governance contract lane checks first" >&2


### PR DESCRIPTION
## Summary
This migrates the governance simulation contract-lane runner to shared framework helper utilities to reduce duplicated subprocess/argument plumbing while keeping shell entrypoints stable. It also updates the release go/no-go checklist contract docs and assertions to lock the shared-helper integration.

## Linked Issues
- Closes #1314

## Changes
- `scripts/governance/governance_simulation_contract_lane_contract.py`
  - removed local `run_capture` implementation.
  - imported `build_default_bundle_args` + `run_capture` from `framework.contract_lane_helpers`.
  - preserved existing generator/policy command surfaces and GO decision checks.
- `scripts/governance/test_run_governance_simulation_contract_lane.sh`
  - added regression assertion requiring `from framework.contract_lane_helpers import` marker.
- `docs/foundation/release-gonogo-checklist.md`
  - documented governance simulation contract-lane shared implementation and helper usage.
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`
  - added doc-contract assertions for `governance_simulation_contract_lane_contract.py` and `framework.contract_lane_helpers`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/governance/test_run_governance_simulation_contract_lane.sh
```
Output:
```text
expected governance simulation shared contract-lane module to use framework lane helpers
```

### 🟢 Green Phase
Command:
```bash
bash scripts/governance/test_run_governance_simulation_contract_lane.sh
```
Output:
```text
governance simulation contract lane script tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/governance/test_generate_governance_simulation_evidence_bundle.sh
bash scripts/governance/test_run_governance_simulation_contract_lane.sh
bash scripts/governance/test_run_governance_simulation_matrix.sh
bash scripts/governance/test_run_governance_simulation_deep_lane.sh
bash scripts/framework/test_contract_framework.sh
cargo test -p kamn-core --test release_gonogo_checklist_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
Summary:
- all commands passed cleanly

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | framework helper unit suite via `scripts/framework/test_contract_framework.sh` | |
| Functional   | ✅ | governance simulation evidence bundle + policy checks | |
| Integration  | ✅ | governance simulation contract/deep lane wrapper execution | |
| Regression   | ✅ | helper-import marker assertion and docs-contract guards | |
| Performance  | ✅ | no selector/workflow widening and no deep-lane default changes | |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert this PR to restore the prior lane-runner-local helper implementation.

## Documentation Updates
- `docs/foundation/release-gonogo-checklist.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
