### PR TITLE
feat(framework): add lane manifest schema and runner api

### DIFF
--- a/scripts/framework/lane_manifest.py
+++ b/scripts/framework/lane_manifest.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Lane manifest parser/validator and phase runner helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any, Mapping
+from dataclasses import dataclass
+
+MANIFEST_SCHEMA_VERSION = "kamn.contract-lane.manifest.v1"
+
+
+@dataclass(frozen=True)
+class LaneManifest:
+    """Validated lane manifest model."""
+
+    schema_version: str
+    lane_id: str
+    evidence_key: str
+    reason_key: str
+    phases: dict[str, tuple[str, ...]]
+
+
+def _required_string(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    allow_empty: bool = False,
+) -> str:
+    raw_value = payload.get(key)
+    if not isinstance(raw_value, str):
+        raise ValueError(f"{key} must be a string")
+    value = raw_value.strip()
+    if not allow_empty and value == "":
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _validate_phases(raw_phases: Any) -> dict[str, tuple[str, ...]]:
+    if not isinstance(raw_phases, Mapping) or not raw_phases:
+        raise ValueError("phases must be a non-empty mapping")
+
+    phases: dict[str, tuple[str, ...]] = {}
+    for raw_phase_name, raw_command in raw_phases.items():
+        if not isinstance(raw_phase_name, str) or raw_phase_name.strip() == "":
+            raise ValueError("phase names must be non-empty strings")
+        phase_name = raw_phase_name.strip()
+
+        if not isinstance(raw_command, list) or len(raw_command) == 0:
+            raise ValueError(f"phase '{phase_name}' command must be a non-empty list")
+
+        command_parts: list[str] = []
+        for part in raw_command:
+            if not isinstance(part, str) or part.strip() == "":
+                raise ValueError(f"phase '{phase_name}' command parts must be non-empty strings")
+            command_parts.append(part)
+        phases[phase_name] = tuple(command_parts)
+
+    return phases
+
+
+def parse_manifest(payload: Mapping[str, Any]) -> LaneManifest:
+    """Parse and validate a lane manifest payload."""
+    schema_version = _required_string(payload, "schema_version")
+    if schema_version != MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be '{MANIFEST_SCHEMA_VERSION}'"
+        )
+
+    lane_id = _required_string(payload, "lane_id")
+    evidence_key = _required_string(payload, "evidence_key")
+    reason_key = _required_string(payload, "reason_key")
+    phases = _validate_phases(payload.get("phases"))
+
+    return LaneManifest(
+        schema_version=schema_version,
+        lane_id=lane_id,
+        evidence_key=evidence_key,
+        reason_key=reason_key,
+        phases=phases,
+    )
+
+
+def load_manifest_file(path: Path) -> LaneManifest:
+    """Load and validate a lane manifest JSON file."""
+    raw_payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw_payload, Mapping):
+        raise ValueError("manifest root must be an object")
+    return parse_manifest(raw_payload)
+
+
+def run_lane_phase(
+    manifest: LaneManifest,
+    phase: str,
+    *,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> tuple[int, str]:
+    """Execute a validated phase command and return exit code + merged output."""
+    if phase not in manifest.phases:
+        raise ValueError(f"phase '{phase}' is not defined in manifest '{manifest.lane_id}'")
+
+    phase_command = list(manifest.phases[phase])
+    run_env = os.environ.copy()
+    if env is not None:
+        run_env.update(env)
+
+    result = subprocess.run(
+        phase_command,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(cwd) if cwd is not None else None,
+        env=run_env,
+    )
+    return result.returncode, (result.stdout or "") + (result.stderr or "")

--- a/scripts/framework/test_contract_framework.sh
+++ b/scripts/framework/test_contract_framework.sh
@@ -5,5 +5,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 python3 "$ROOT_DIR/scripts/framework/test_contract_framework.py"
 python3 "$ROOT_DIR/scripts/framework/test_contract_lane_helpers.py"
+python3 "$ROOT_DIR/scripts/framework/test_lane_manifest.py"
 
 echo "contract framework unit tests passed."

--- a/scripts/framework/test_lane_manifest.py
+++ b/scripts/framework/test_lane_manifest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Unit tests for lane manifest parsing and runner helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from lane_manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    LaneManifest,
+    load_manifest_file,
+    parse_manifest,
+    run_lane_phase,
+)
+
+
+class LaneManifestTests(unittest.TestCase):
+    def test_parse_manifest_accepts_valid_payload(self) -> None:
+        manifest = parse_manifest(
+            {
+                "schema_version": MANIFEST_SCHEMA_VERSION,
+                "lane_id": "dashboard.shell.matrix",
+                "evidence_key": "frontend_shell_matrix:v1",
+                "reason_key": "frontend_shell_matrix_reason_codes:GO:v1",
+                "phases": {
+                    "generate": ["python3", "-c", "print('generate')"],
+                    "check": ["python3", "-c", "print('check')"],
+                },
+            }
+        )
+
+        self.assertIsInstance(manifest, LaneManifest)
+        self.assertEqual(manifest.lane_id, "dashboard.shell.matrix")
+        self.assertIn("generate", manifest.phases)
+        self.assertIn("check", manifest.phases)
+
+    def test_parse_manifest_rejects_missing_required_fields(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_manifest(
+                {
+                    "schema_version": MANIFEST_SCHEMA_VERSION,
+                    "lane_id": "dashboard.shell.matrix",
+                    "evidence_key": "frontend_shell_matrix:v1",
+                    "phases": {"generate": ["python3", "-c", "print('generate')"]},
+                }
+            )
+
+    def test_load_manifest_file_parses_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "lane-manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": MANIFEST_SCHEMA_VERSION,
+                        "lane_id": "governance.simulation",
+                        "evidence_key": "governance_simulation:v1",
+                        "reason_key": "governance_simulation_reason_codes:GO:v1",
+                        "phases": {
+                            "run": ["python3", "-c", "print('run')"],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest = load_manifest_file(manifest_path)
+
+        self.assertEqual(manifest.lane_id, "governance.simulation")
+        self.assertIn("run", manifest.phases)
+
+    def test_run_lane_phase_executes_phase_command(self) -> None:
+        manifest = parse_manifest(
+            {
+                "schema_version": MANIFEST_SCHEMA_VERSION,
+                "lane_id": "contract.framework",
+                "evidence_key": "contract_framework:v1",
+                "reason_key": "contract_framework_reason_codes:GO:v1",
+                "phases": {
+                    "test": ["python3", "-c", "print('manifest-phase-ok')"],
+                },
+            }
+        )
+        code, output = run_lane_phase(manifest, "test")
+
+        self.assertEqual(code, 0)
+        self.assertIn("manifest-phase-ok", output)
+
+    def test_run_lane_phase_rejects_unknown_phase(self) -> None:
+        manifest = parse_manifest(
+            {
+                "schema_version": MANIFEST_SCHEMA_VERSION,
+                "lane_id": "contract.framework",
+                "evidence_key": "contract_framework:v1",
+                "reason_key": "contract_framework_reason_codes:GO:v1",
+                "phases": {
+                    "generate": ["python3", "-c", "print('ok')"],
+                },
+            }
+        )
+
+        with self.assertRaises(ValueError):
+            run_lane_phase(manifest, "missing-phase")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a manifest-driven schema/validation layer and shared phase runner API for contract-lane tooling in `scripts/framework`, with unit coverage integrated into the framework regression test entrypoint.

Closes #1338

## Changes
- `scripts/framework/lane_manifest.py`: added `LaneManifest` model, manifest JSON parsing/validation, and `run_lane_phase` execution helper.
- `scripts/framework/test_lane_manifest.py`: added unit tests for valid parsing, required-field validation, file loading, phase execution, and unknown-phase rejection.
- `scripts/framework/test_contract_framework.sh`: now executes the new lane manifest unit test suite.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass (`bash scripts/framework/test_contract_framework.sh`, `python3 scripts/framework/test_lane_manifest.py`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification: red/green cycle confirmed (`ModuleNotFoundError` before implementation; green after module + tests added)

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | New `lane_manifest` parser/runner unit tests |
| Functional  | ✅     | Phase runner executes configured command and captures output |
| Integration | ⚪     | Not applicable for this unit-focused change |
| Regression  | ✅     | Unknown phase and missing required fields fail closed |

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (details below).
Workflow(s) touched: None
Expected runtime delta: None expected
Expected runner-minute delta: None expected
Rollback plan if CI cost/runtime regresses: Revert this PR to remove `lane_manifest` module and test wiring.
