### PR TITLE
feat(framework): add manifest wrapper dispatch runner

### DIFF
--- a/scripts/framework/run_lane_from_manifest.py
+++ b/scripts/framework/run_lane_from_manifest.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Manifest-backed lane runner entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from lane_manifest import load_manifest_file, run_lane_phase
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments for manifest lane runner."""
+    parser = argparse.ArgumentParser(
+        description="Run a configured lane phase from a manifest file."
+    )
+    parser.add_argument("--manifest", required=True, help="Path to lane manifest JSON file.")
+    parser.add_argument("--phase", required=True, help="Phase key to execute from manifest.")
+    parser.add_argument(
+        "--cwd",
+        default="",
+        help="Optional working directory for the phase command.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    """Execute selected manifest phase and emit stable status markers."""
+    args = parse_args(argv)
+    manifest_path = Path(args.manifest)
+
+    try:
+        manifest = load_manifest_file(manifest_path)
+        cwd = Path(args.cwd) if args.cwd else None
+        code, output = run_lane_phase(manifest, args.phase, cwd=cwd)
+    except Exception as exc:  # noqa: BLE001
+        print("status=fail")
+        print(f"error={exc}")
+        return 1
+
+    print(f"lane_id={manifest.lane_id}")
+    print(f"phase={args.phase}")
+    print(f"exit_code={code}")
+    if output.strip() != "":
+        print(output, end="" if output.endswith("\n") else "\n")
+
+    if code == 0:
+        print("status=ok")
+        return 0
+
+    print("status=fail")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/framework/run_manifest_lane.sh
+++ b/scripts/framework/run_manifest_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/framework/run_lane_from_manifest.py" "$@"

--- a/scripts/framework/test_contract_framework.sh
+++ b/scripts/framework/test_contract_framework.sh
@@ -6,5 +6,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 python3 "$ROOT_DIR/scripts/framework/test_contract_framework.py"
 python3 "$ROOT_DIR/scripts/framework/test_contract_lane_helpers.py"
 python3 "$ROOT_DIR/scripts/framework/test_lane_manifest.py"
+python3 "$ROOT_DIR/scripts/framework/test_manifest_wrapper_dispatch.py"
 
 echo "contract framework unit tests passed."

--- a/scripts/framework/test_manifest_wrapper_dispatch.py
+++ b/scripts/framework/test_manifest_wrapper_dispatch.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Tests for manifest lane wrapper dispatch behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+WRAPPER_SCRIPT = ROOT_DIR / "scripts/framework/run_manifest_lane.sh"
+
+
+class ManifestWrapperDispatchTests(unittest.TestCase):
+    def _write_manifest(self, path: Path) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "kamn.contract-lane.manifest.v1",
+                    "lane_id": "framework.dispatch",
+                    "evidence_key": "framework_dispatch:v1",
+                    "reason_key": "framework_dispatch_reason_codes:GO:v1",
+                    "phases": {
+                        "generate": ["python3", "-c", "print('dispatch-ok')"],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_wrapper_executes_manifest_phase(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "manifest.json"
+            self._write_manifest(manifest_path)
+
+            completed = subprocess.run(
+                ["bash", str(WRAPPER_SCRIPT), "--manifest", str(manifest_path), "--phase", "generate"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("status=ok", completed.stdout)
+        self.assertIn("lane_id=framework.dispatch", completed.stdout)
+        self.assertIn("dispatch-ok", completed.stdout)
+
+    def test_wrapper_fails_for_unknown_phase(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "manifest.json"
+            self._write_manifest(manifest_path)
+
+            completed = subprocess.run(
+                ["bash", str(WRAPPER_SCRIPT), "--manifest", str(manifest_path), "--phase", "missing"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("status=fail", completed.stdout + completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a manifest-backed wrapper execution path and dispatch tests so shell wrappers can route lane phases through the shared manifest runner while preserving backward-compatible command surfaces.

Closes #1345

## Changes
- `scripts/framework/run_lane_from_manifest.py`: new CLI entrypoint that loads a lane manifest and executes a selected phase with stable status markers.
- `scripts/framework/run_manifest_lane.sh`: shell wrapper delegating to the manifest runner.
- `scripts/framework/test_manifest_wrapper_dispatch.py`: dispatch tests validating wrapper success path and unknown-phase fail path.
- `scripts/framework/test_contract_framework.sh`: now runs the new wrapper dispatch test suite.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass (`bash scripts/framework/test_contract_framework.sh`, `python3 scripts/framework/test_manifest_wrapper_dispatch.py`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification: red/green cycle confirmed (wrapper missing -> failing dispatch tests, then passing after implementation)

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | New manifest wrapper dispatch tests |
| Functional  | ✅     | Wrapper executes manifest phase and emits status markers |
| Integration | ⚪     | Not applicable for this scoped framework task |
| Regression  | ✅     | Unknown phase path returns fail marker/non-zero status |

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (details below).
Workflow(s) touched: None
Expected runtime delta: None expected
Expected runner-minute delta: None expected
Rollback plan if CI cost/runtime regresses: Revert this PR to restore prior framework-only test wiring.
