### PR TITLE
refactor(framework): share go/policy lane primitives for token and treasury

### DIFF
--- a/scripts/framework/contract_lane_helpers.py
+++ b/scripts/framework/contract_lane_helpers.py
@@ -4,8 +4,13 @@
 from __future__ import annotations
 
 import subprocess
+import time
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
+
+
+class ContractLaneError(RuntimeError):
+    """Raised when a contract-lane helper detects a failed invariant."""
 
 
 def run_capture(command: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
@@ -26,3 +31,55 @@ def build_default_bundle_args(*, output_file: str, pairs: Iterable[tuple[str, st
     for key, value in pairs:
         args.extend([key, value])
     return args
+
+
+def require_output_contains(output: str, *, expected: str, context: str) -> None:
+    """Require output to include expected marker, otherwise raise ContractLaneError."""
+    if expected not in output:
+        raise ContractLaneError(f"{context} missing expected marker: {expected}")
+
+
+def run_go_bundle_policy_pair(
+    *,
+    root_dir: Path,
+    generator: Path,
+    generator_args: Sequence[str],
+    policy_checker: Path,
+    bundle_file: Path,
+    decision_marker: str = "final_decision=GO",
+) -> tuple[str, str]:
+    """Run generator + policy checker pair and require GO decision markers."""
+    generator_command = ["bash", str(generator), *generator_args]
+    generator_code, generator_output = run_capture(generator_command, cwd=root_dir)
+    if generator_code != 0:
+        raise ContractLaneError(
+            f"generator command failed with exit code {generator_code}: {' '.join(generator_command)}"
+        )
+    require_output_contains(
+        generator_output,
+        expected=decision_marker,
+        context="generator output",
+    )
+
+    policy_command = ["bash", str(policy_checker), "--bundle-file", str(bundle_file)]
+    policy_code, policy_output = run_capture(policy_command, cwd=root_dir)
+    if policy_code != 0:
+        raise ContractLaneError(
+            f"policy checker failed with exit code {policy_code}: {' '.join(policy_command)}"
+        )
+    require_output_contains(
+        policy_output,
+        expected=decision_marker,
+        context="policy checker output",
+    )
+    return generator_output, policy_output
+
+
+def enforce_runtime_budget(*, lane_name: str, started_at: float, max_runtime_seconds: int) -> int:
+    """Enforce runtime budget and return elapsed seconds."""
+    elapsed_seconds = int(time.monotonic() - started_at)
+    if elapsed_seconds > max_runtime_seconds:
+        raise ContractLaneError(
+            f"{lane_name} exceeded runtime budget: {elapsed_seconds}s > {max_runtime_seconds}s"
+        )
+    return elapsed_seconds

--- a/scripts/framework/test_contract_lane_helpers.py
+++ b/scripts/framework/test_contract_lane_helpers.py
@@ -3,9 +3,20 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
+import time
 import unittest
+from pathlib import Path
 
-from contract_lane_helpers import build_default_bundle_args, run_capture
+from contract_lane_helpers import (
+    ContractLaneError,
+    build_default_bundle_args,
+    enforce_runtime_budget,
+    require_output_contains,
+    run_capture,
+    run_go_bundle_policy_pair,
+)
 
 
 class ContractLaneHelpersTests(unittest.TestCase):
@@ -26,6 +37,120 @@ class ContractLaneHelpersTests(unittest.TestCase):
         self.assertIn("/tmp/example.json", args)
         self.assertIn("--control-id", args)
         self.assertIn("CC6.1", args)
+
+    def test_require_output_contains_raises_for_missing_marker(self) -> None:
+        with self.assertRaises(ContractLaneError):
+            require_output_contains("status=ok", expected="final_decision=GO", context="test")
+
+    def test_run_go_bundle_policy_pair_accepts_go_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            generator = temp_path / "generator.sh"
+            policy = temp_path / "policy.sh"
+            bundle_file = temp_path / "bundle.json"
+
+            generator.write_text(
+                "\n".join(
+                    (
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        'output_file=""',
+                        'while [ \"$#\" -gt 0 ]; do',
+                        '  case \"$1\" in',
+                        '    --output-file) output_file=\"$2\"; shift 2 ;;',
+                        "    *) shift ;;",
+                        "  esac",
+                        "done",
+                        'printf \"{\\\"schema_version\\\":\\\"v1\\\"}\\n\" > \"$output_file\"',
+                        "echo \"final_decision=GO\"",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            policy.write_text(
+                "\n".join(
+                    (
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        '[ \"$1\" = \"--bundle-file\" ]',
+                        '[ -f \"$2\" ]',
+                        "echo \"final_decision=GO\"",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            os.chmod(generator, 0o755)
+            os.chmod(policy, 0o755)
+
+            generator_output, policy_output = run_go_bundle_policy_pair(
+                root_dir=temp_path,
+                generator=generator,
+                generator_args=("--output-file", str(bundle_file)),
+                policy_checker=policy,
+                bundle_file=bundle_file,
+            )
+
+            self.assertIn("final_decision=GO", generator_output)
+            self.assertIn("final_decision=GO", policy_output)
+
+    def test_run_go_bundle_policy_pair_rejects_missing_go_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            generator = temp_path / "generator.sh"
+            policy = temp_path / "policy.sh"
+            bundle_file = temp_path / "bundle.json"
+
+            generator.write_text(
+                "\n".join(
+                    (
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        'printf \"{}\\n\" > \"$2\"',
+                        "echo \"status=generated\"",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            policy.write_text(
+                "\n".join(
+                    (
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        "echo \"final_decision=GO\"",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            os.chmod(generator, 0o755)
+            os.chmod(policy, 0o755)
+
+            with self.assertRaises(ContractLaneError):
+                run_go_bundle_policy_pair(
+                    root_dir=temp_path,
+                    generator=generator,
+                    generator_args=("--output-file", str(bundle_file)),
+                    policy_checker=policy,
+                    bundle_file=bundle_file,
+                )
+
+    def test_enforce_runtime_budget_reports_elapsed_and_detects_overrun(self) -> None:
+        elapsed = enforce_runtime_budget(
+            lane_name="demo lane",
+            started_at=time.monotonic(),
+            max_runtime_seconds=60,
+        )
+        self.assertGreaterEqual(elapsed, 0)
+
+        with self.assertRaises(ContractLaneError):
+            enforce_runtime_budget(
+                lane_name="demo lane",
+                started_at=time.monotonic() - 2.0,
+                max_runtime_seconds=0,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/token/token_launch_handoff_contract_lane_contract.py
+++ b/scripts/token/token_launch_handoff_contract_lane_contract.py
@@ -3,11 +3,20 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_lane_helpers import (  # noqa: E402
+    ContractLaneError,
+    enforce_runtime_budget,
+    run_capture,
+    run_go_bundle_policy_pair,
+)
 
 MAX_RUNTIME_SECONDS = 90
 
@@ -21,18 +30,6 @@ def fail(message: str) -> int:
     """Emit stable error and return non-zero."""
     print(message, file=sys.stderr)
     return 1
-
-
-def run_capture(command: list[str], *, cwd: Path) -> tuple[int, str]:
-    """Run command and return exit code + merged output."""
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=str(cwd),
-    )
-    return result.returncode, (result.stdout or "") + (result.stderr or "")
 
 
 def main(argv: list[str]) -> int:
@@ -50,10 +47,10 @@ def main(argv: list[str]) -> int:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         bundle_file = Path(temp_dir) / "token-launch-handoff-go.json"
-        generator_code, generator_output = run_capture(
-            [
-                "bash",
-                str(generator),
+        run_go_bundle_policy_pair(
+            root_dir=root_dir,
+            generator=generator,
+            generator_args=(
                 "--output-file",
                 str(bundle_file),
                 "--token-symbol",
@@ -78,18 +75,10 @@ def main(argv: list[str]) -> int:
                 "2",
                 "--ci-fast-gate",
                 "PASS",
-            ],
-            cwd=root_dir,
+            ),
+            policy_checker=policy_checker,
+            bundle_file=bundle_file,
         )
-        if generator_code != 0 or "final_decision=GO" not in generator_output:
-            return fail("expected token launch handoff contract lane decision to be GO")
-
-        policy_code, policy_output = run_capture(
-            ["bash", str(policy_checker), "--bundle-file", str(bundle_file)],
-            cwd=root_dir,
-        )
-        if policy_code != 0 or "final_decision=GO" not in policy_output:
-            return fail("expected token launch handoff policy check decision to be GO")
 
     cargo_commands = (
         ["cargo", "test", "-p", "kamn-core", "--test", "token_config"],
@@ -99,18 +88,21 @@ def main(argv: list[str]) -> int:
     for command in cargo_commands:
         exit_code, _output = run_capture(command, cwd=root_dir)
         if exit_code != 0:
-            return fail(f"expected {' '.join(command)} to pass")
+            raise ContractLaneError(f"expected {' '.join(command)} to pass")
 
-    elapsed_seconds = int(time.monotonic() - start_time)
-    if elapsed_seconds > MAX_RUNTIME_SECONDS:
-        return fail(
-            "token launch handoff contract lane exceeded runtime budget: "
-            f"{elapsed_seconds}s"
-        )
+    enforce_runtime_budget(
+        lane_name="token launch handoff contract lane",
+        started_at=start_time,
+        max_runtime_seconds=MAX_RUNTIME_SECONDS,
+    )
 
     print("token launch handoff contract lane tests passed.")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractLaneError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/treasury/treasury_disbursement_contract_lane_contract.py
+++ b/scripts/treasury/treasury_disbursement_contract_lane_contract.py
@@ -3,11 +3,20 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_lane_helpers import (  # noqa: E402
+    ContractLaneError,
+    enforce_runtime_budget,
+    run_capture,
+    run_go_bundle_policy_pair,
+)
 
 MAX_RUNTIME_SECONDS = 90
 
@@ -21,18 +30,6 @@ def fail(message: str) -> int:
     """Emit stable error and return non-zero."""
     print(message, file=sys.stderr)
     return 1
-
-
-def run_capture(command: list[str], *, cwd: Path) -> tuple[int, str]:
-    """Run command and return exit code + merged output."""
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=str(cwd),
-    )
-    return result.returncode, (result.stdout or "") + (result.stderr or "")
 
 
 def main(argv: list[str]) -> int:
@@ -50,10 +47,10 @@ def main(argv: list[str]) -> int:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         bundle_file = Path(temp_dir) / "treasury-disbursement-go.json"
-        generator_code, generator_output = run_capture(
-            [
-                "bash",
-                str(generator),
+        run_go_bundle_policy_pair(
+            root_dir=root_dir,
+            generator=generator,
+            generator_args=(
                 "--output-file",
                 str(bundle_file),
                 "--disbursement-id",
@@ -78,36 +75,33 @@ def main(argv: list[str]) -> int:
                 "true",
                 "--ci-fast-gate",
                 "PASS",
-            ],
-            cwd=root_dir,
+            ),
+            policy_checker=policy_checker,
+            bundle_file=bundle_file,
         )
-        if generator_code != 0 or "final_decision=GO" not in generator_output:
-            return fail("expected treasury disbursement contract lane decision to be GO")
-
-        policy_code, policy_output = run_capture(
-            ["bash", str(policy_checker), "--bundle-file", str(bundle_file)],
-            cwd=root_dir,
-        )
-        if policy_code != 0 or "final_decision=GO" not in policy_output:
-            return fail("expected treasury disbursement policy check decision to be GO")
 
     test_code, _test_output = run_capture(
         ["cargo", "test", "-p", "kamn-core", "--test", "release_gonogo_checklist_docs"],
         cwd=root_dir,
     )
     if test_code != 0:
-        return fail("expected cargo test -p kamn-core --test release_gonogo_checklist_docs to pass")
-
-    elapsed_seconds = int(time.monotonic() - start_time)
-    if elapsed_seconds > MAX_RUNTIME_SECONDS:
-        return fail(
-            "treasury disbursement contract lane exceeded runtime budget: "
-            f"{elapsed_seconds}s"
+        raise ContractLaneError(
+            "expected cargo test -p kamn-core --test release_gonogo_checklist_docs to pass"
         )
+
+    enforce_runtime_budget(
+        lane_name="treasury disbursement contract lane",
+        started_at=start_time,
+        max_runtime_seconds=MAX_RUNTIME_SECONDS,
+    )
 
     print("treasury disbursement contract lane tests passed.")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractLaneError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Introduce reusable contract-lane primitives for common GO-decision evidence/policy flow checks and runtime budget enforcement.
- Migrate token and treasury shared contract-lane Python modules to those primitives while preserving wrapper command compatibility.

## Linked Issues
- Closes #1355

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A

## Changes
- `scripts/framework/contract_lane_helpers.py`
  - Added `ContractLaneError`.
  - Added `require_output_contains(...)`.
  - Added `run_go_bundle_policy_pair(...)` to centralize generator+policy GO checks.
  - Added `enforce_runtime_budget(...)` for deterministic runtime cap enforcement.
- `scripts/framework/test_contract_lane_helpers.py`
  - Added unit tests for new primitives and failure paths.
- `scripts/token/token_launch_handoff_contract_lane_contract.py`
  - Removed local duplicate subprocess helper.
  - Switched to shared helper primitives.
  - Preserved lane command behavior and success marker.
- `scripts/treasury/treasury_disbursement_contract_lane_contract.py`
  - Removed local duplicate subprocess helper.
  - Switched to shared helper primitives.
  - Preserved lane command behavior and success marker.

## Risks & Compatibility
- Low: wrappers and CLI signatures are unchanged; refactor is internal to shared Python contract lane modules.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `python3 scripts/framework/test_contract_lane_helpers.py` |
| Functional  | ✅ | `bash scripts/token/test_run_token_launch_handoff_contract_lane.sh`; `bash scripts/treasury/test_run_treasury_disbursement_contract_lane.sh` |
| Integration | ✅ | `bash scripts/framework/test_contract_framework.sh`; `GITHUB_OUTPUT=$(mktemp) bash scripts/ci/test_ci_tools.sh` |
| Regression  | ✅ | New helper negative-path tests for missing GO marker and runtime budget overrun |
