### PR TITLE
refactor(framework): migrate canary/token/treasury/guard lanes to manifest runner

### DIFF
--- a/scripts/canary/run_launch_canary_contract_lane.sh
+++ b/scripts/canary/run_launch_canary_contract_lane.sh
@@ -2,5 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/canary_launch_canary_contract_lane.json"
 
-exec python3 "$ROOT_DIR/scripts/canary/launch_canary_contract_lane_contract.py" "$@"
+exec bash "$ROOT_DIR/scripts/framework/run_manifest_lane.sh" \
+  --manifest "$MANIFEST" \
+  --phase contract \
+  --cwd "$ROOT_DIR" \
+  -- "$@"

--- a/scripts/canary/run_post_cutover_slo_contract_lane.sh
+++ b/scripts/canary/run_post_cutover_slo_contract_lane.sh
@@ -2,5 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/canary_post_cutover_slo_contract_lane.json"
 
-exec python3 "$ROOT_DIR/scripts/canary/post_cutover_slo_contract_lane_contract.py" "$@"
+exec bash "$ROOT_DIR/scripts/framework/run_manifest_lane.sh" \
+  --manifest "$MANIFEST" \
+  --phase contract \
+  --cwd "$ROOT_DIR" \
+  -- "$@"

--- a/scripts/canary/test_run_launch_canary_contract_lane.sh
+++ b/scripts/canary/test_run_launch_canary_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/canary/run_launch_canary_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/canary/run_launch_canary_deep_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/canary/launch_canary_contract_lane_contract.py"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/canary_launch_canary_contract_lane.json"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected launch canary fast-lane runner to be executable" >&2
@@ -19,6 +20,10 @@ if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected launch canary shared contract-lane module to be executable" >&2
   exit 1
 fi
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected launch canary contract-lane manifest to exist" >&2
+  exit 1
+fi
 
 tmp_out="$(mktemp)"
 trap 'rm -f "$tmp_out"' EXIT
@@ -28,8 +33,16 @@ if ! grep -q "launch canary contract lane tests passed." "$tmp_out"; then
   echo "expected launch canary contract lane success marker" >&2
   exit 1
 fi
-if ! grep -q "launch_canary_contract_lane_contract.py" "$FAST_SCRIPT"; then
-  echo "expected launch canary fast-lane wrapper to dispatch to shared contract module" >&2
+if ! grep -q "run_manifest_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected launch canary fast-lane wrapper to delegate via manifest runner" >&2
+  exit 1
+fi
+if ! grep -q "canary_launch_canary_contract_lane.json" "$FAST_SCRIPT"; then
+  echo "expected launch canary fast-lane wrapper to reference launch canary manifest" >&2
+  exit 1
+fi
+if ! grep -q "launch_canary_contract_lane_contract.py" "$MANIFEST"; then
+  echo "expected launch canary manifest to dispatch to shared contract module" >&2
   exit 1
 fi
 if ! grep -q "run_launch_canary_matrix.py" "$SHARED_CONTRACT"; then

--- a/scripts/canary/test_run_post_cutover_slo_contract_lane.sh
+++ b/scripts/canary/test_run_post_cutover_slo_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/canary/run_post_cutover_slo_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/canary/run_post_cutover_slo_deep_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/canary/post_cutover_slo_contract_lane_contract.py"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/canary_post_cutover_slo_contract_lane.json"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected post-cutover SLO fast-lane runner to be executable" >&2
@@ -19,6 +20,10 @@ if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected post-cutover SLO shared contract-lane module to be executable" >&2
   exit 1
 fi
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected post-cutover SLO contract-lane manifest to exist" >&2
+  exit 1
+fi
 
 tmp_out="$(mktemp)"
 trap 'rm -f "$tmp_out"' EXIT
@@ -29,8 +34,16 @@ if ! grep -q "post-cutover SLO contract lane tests passed." "$tmp_out"; then
   exit 1
 fi
 
-if ! grep -q "post_cutover_slo_contract_lane_contract.py" "$FAST_SCRIPT"; then
-  echo "expected post-cutover SLO fast-lane wrapper to dispatch to shared contract module" >&2
+if ! grep -q "run_manifest_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected post-cutover SLO fast-lane wrapper to delegate via manifest runner" >&2
+  exit 1
+fi
+if ! grep -q "canary_post_cutover_slo_contract_lane.json" "$FAST_SCRIPT"; then
+  echo "expected post-cutover SLO fast-lane wrapper to reference post-cutover SLO manifest" >&2
+  exit 1
+fi
+if ! grep -q "post_cutover_slo_contract_lane_contract.py" "$MANIFEST"; then
+  echo "expected post-cutover SLO manifest to dispatch to shared contract module" >&2
   exit 1
 fi
 

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -343,7 +343,7 @@ for file in "${CHANGED_FILES[@]}"; do
       RUST_CHANGED=true
       classified=true
       ;;
-    docs/foundation/message-delivery-guards.md|docs/foundation/channel-permissions-retention.md|docs/foundation/release-gonogo-checklist.md|crates/kamn-core/tests/release_gonogo_checklist_docs.rs|scripts/guard/*)
+    docs/foundation/message-delivery-guards.md|docs/foundation/channel-permissions-retention.md|docs/foundation/release-gonogo-checklist.md|crates/kamn-core/tests/release_gonogo_checklist_docs.rs|scripts/guard/*|scripts/framework/manifests/guard_durable_guard_recovery_*)
       DURABLE_GUARD_RECOVERY_CONTRACT_CHANGED=true
       classified=true
       ;;
@@ -379,6 +379,10 @@ for file in "${CHANGED_FILES[@]}"; do
       GOVERNANCE_SIMULATION_CONTRACT_CHANGED=true
       GOVERNANCE_STAKE_SLASH_CONTRACT_CHANGED=true
       REPUTATION_DISPUTE_CONTRACT_CHANGED=true
+      TOKEN_LAUNCH_CONTRACT_CHANGED=true
+      TREASURY_DISBURSEMENT_CONTRACT_CHANGED=true
+      LAUNCH_CANARY_CONTRACT_CHANGED=true
+      DURABLE_GUARD_RECOVERY_CONTRACT_CHANGED=true
       classified=true
       ;;
   esac
@@ -412,14 +416,14 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/token.rs|crates/kamn-core/tests/token_config.rs|crates/kamn-core/tests/token_config_docs.rs|docs/foundation/token-config.md|docs/foundation/token-model.md|docs/foundation/release-gonogo-checklist.md|scripts/token/*|fixtures/token_launch/*)
+    crates/kamn-core/src/token.rs|crates/kamn-core/tests/token_config.rs|crates/kamn-core/tests/token_config_docs.rs|docs/foundation/token-config.md|docs/foundation/token-model.md|docs/foundation/release-gonogo-checklist.md|scripts/token/*|fixtures/token_launch/*|scripts/framework/manifests/token_launch_handoff_*)
       TOKEN_LAUNCH_CONTRACT_CHANGED=true
       classified=true
       ;;
   esac
 
   case "$file" in
-    crates/kamn-core/tests/release_gonogo_checklist_docs.rs|docs/foundation/release-gonogo-checklist.md|docs/foundation/treasury-disbursement-policy.md|scripts/treasury/*|fixtures/treasury_disbursement/*)
+    crates/kamn-core/tests/release_gonogo_checklist_docs.rs|docs/foundation/release-gonogo-checklist.md|docs/foundation/treasury-disbursement-policy.md|scripts/treasury/*|fixtures/treasury_disbursement/*|scripts/framework/manifests/treasury_disbursement_*)
       TREASURY_DISBURSEMENT_CONTRACT_CHANGED=true
       classified=true
       ;;
@@ -427,12 +431,14 @@ for file in "${CHANGED_FILES[@]}"; do
 
   case "$file" in
     scripts/framework/contract_lane_helpers.py|scripts/framework/test_contract_lane_helpers.py)
-      # Framework helper rollout is scoped to migrated compliance/governance/reputation lanes.
+      # Framework helper rollout is scoped to migrated compliance/governance/reputation/token/treasury lanes.
       SOC2_CONTROL_EVIDENCE_CONTRACT_CHANGED=true
       DSAR_LEGAL_HOLD_CONTRACT_CHANGED=true
       GOVERNANCE_SIMULATION_CONTRACT_CHANGED=true
       GOVERNANCE_STAKE_SLASH_CONTRACT_CHANGED=true
       REPUTATION_DISPUTE_CONTRACT_CHANGED=true
+      TOKEN_LAUNCH_CONTRACT_CHANGED=true
+      TREASURY_DISBURSEMENT_CONTRACT_CHANGED=true
       classified=true
       ;;
   esac
@@ -463,7 +469,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    docs/foundation/release-gonogo-checklist.md|docs/foundation/observability-slo-dashboards.md|crates/kamn-core/tests/release_gonogo_checklist_docs.rs|scripts/canary/*|fixtures/launch_canary/*)
+    docs/foundation/release-gonogo-checklist.md|docs/foundation/observability-slo-dashboards.md|crates/kamn-core/tests/release_gonogo_checklist_docs.rs|scripts/canary/*|fixtures/launch_canary/*|scripts/framework/manifests/canary_launch_canary_*|scripts/framework/manifests/canary_post_cutover_slo_*)
       LAUNCH_CANARY_CONTRACT_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -1623,6 +1623,11 @@ assert_eq "$(extract_output "$token_contract_script_output" "run_rust")" "false"
 assert_eq "$(extract_output "$token_contract_script_output" "run_token_launch_contract_tests")" "true" "token launch contract script changes must run token launch contract lane"
 assert_eq "$(extract_output "$token_contract_script_output" "test_scope")" "token-contract" "token launch contract script changes should set token-contract scope"
 
+token_contract_manifest_output="$(run_selector $'scripts/framework/manifests/token_launch_handoff_contract_lane.json')"
+assert_eq "$(extract_output "$token_contract_manifest_output" "run_rust")" "false" "token launch manifest changes should avoid rust lane"
+assert_eq "$(extract_output "$token_contract_manifest_output" "run_token_launch_contract_tests")" "true" "token launch manifest changes must run token launch contract lane"
+assert_eq "$(extract_output "$token_contract_manifest_output" "test_scope")" "token-contract" "token launch manifest changes should set token-contract scope"
+
 token_contract_shared_script_output="$(run_selector $'scripts/token/token_launch_handoff_contract_lane_contract.py')"
 assert_eq "$(extract_output "$token_contract_shared_script_output" "run_rust")" "false" "token launch shared contract-lane script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$token_contract_shared_script_output" "run_token_launch_contract_tests")" "true" "token launch shared contract-lane changes must run token launch contract lane"
@@ -1648,8 +1653,8 @@ assert_eq "$(extract_output "$compliance_framework_helper_output" "run_rust")" "
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_soc2_control_evidence_contract_tests")" "true" "contract lane helper changes must run SOC2 contract lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_dsar_legal_hold_contract_tests")" "true" "contract lane helper changes must run DSAR contract lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_channel_lifecycle_contract_tests")" "false" "contract lane helper changes should not run channel lifecycle lane"
-assert_eq "$(extract_output "$compliance_framework_helper_output" "run_token_launch_contract_tests")" "false" "contract lane helper changes should not run token launch lane"
-assert_eq "$(extract_output "$compliance_framework_helper_output" "run_treasury_disbursement_contract_tests")" "false" "contract lane helper changes should not run treasury lane"
+assert_eq "$(extract_output "$compliance_framework_helper_output" "run_token_launch_contract_tests")" "true" "contract lane helper changes must run token launch lane"
+assert_eq "$(extract_output "$compliance_framework_helper_output" "run_treasury_disbursement_contract_tests")" "true" "contract lane helper changes must run treasury lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_launch_canary_contract_tests")" "false" "contract lane helper changes should not run canary lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_settlement_reconciliation_contract_tests")" "false" "contract lane helper changes should not run escrow lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_mainnet_cutover_contract_tests")" "false" "contract lane helper changes should not run cutover lane"
@@ -1657,7 +1662,7 @@ assert_eq "$(extract_output "$compliance_framework_helper_output" "run_federated
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_governance_simulation_contract_tests")" "true" "contract lane helper changes must run governance simulation lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_governance_stake_slash_contract_tests")" "true" "contract lane helper changes must run governance stake/slash lane"
 assert_eq "$(extract_output "$compliance_framework_helper_output" "run_reputation_dispute_contract_tests")" "true" "contract lane helper changes must run reputation dispute lane"
-assert_eq "$(extract_output "$compliance_framework_helper_output" "test_scope")" "soc2-contract" "contract lane helper changes should set soc2-contract scope"
+assert_eq "$(extract_output "$compliance_framework_helper_output" "test_scope")" "token-contract" "contract lane helper changes should set token-contract scope under selector precedence"
 
 compliance_framework_helper_test_output="$(run_selector $'scripts/framework/test_contract_lane_helpers.py')"
 assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_rust")" "false" "contract lane helper test changes should avoid rust lane"
@@ -1666,8 +1671,9 @@ assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_dsar
 assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_governance_simulation_contract_tests")" "true" "contract lane helper test changes must run governance simulation lane"
 assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_governance_stake_slash_contract_tests")" "true" "contract lane helper test changes must run governance stake/slash lane"
 assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_reputation_dispute_contract_tests")" "true" "contract lane helper test changes must run reputation dispute lane"
-assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_token_launch_contract_tests")" "false" "contract lane helper test changes should not run token launch lane"
-assert_eq "$(extract_output "$compliance_framework_helper_test_output" "test_scope")" "soc2-contract" "contract lane helper test changes should set soc2-contract scope"
+assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_token_launch_contract_tests")" "true" "contract lane helper test changes must run token launch lane"
+assert_eq "$(extract_output "$compliance_framework_helper_test_output" "run_treasury_disbursement_contract_tests")" "true" "contract lane helper test changes must run treasury lane"
+assert_eq "$(extract_output "$compliance_framework_helper_test_output" "test_scope")" "token-contract" "contract lane helper test changes should set token-contract scope under selector precedence"
 
 manifest_runner_framework_output="$(run_selector $'scripts/framework/run_lane_from_manifest.py')"
 assert_eq "$(extract_output "$manifest_runner_framework_output" "run_rust")" "false" "manifest runner framework changes should avoid rust lane"
@@ -1679,7 +1685,10 @@ assert_eq "$(extract_output "$manifest_runner_framework_output" "run_governance_
 assert_eq "$(extract_output "$manifest_runner_framework_output" "run_governance_stake_slash_contract_tests")" "true" "manifest runner framework changes must run governance stake/slash lane"
 assert_eq "$(extract_output "$manifest_runner_framework_output" "run_reputation_decay_contract_tests")" "false" "manifest runner framework changes should not run weighted decay lane"
 assert_eq "$(extract_output "$manifest_runner_framework_output" "run_reputation_dispute_contract_tests")" "true" "manifest runner framework changes must run reputation dispute lane"
-assert_eq "$(extract_output "$manifest_runner_framework_output" "run_token_launch_contract_tests")" "false" "manifest runner framework changes should not run token launch lane"
+assert_eq "$(extract_output "$manifest_runner_framework_output" "run_token_launch_contract_tests")" "true" "manifest runner framework changes must run token launch lane"
+assert_eq "$(extract_output "$manifest_runner_framework_output" "run_treasury_disbursement_contract_tests")" "true" "manifest runner framework changes must run treasury lane"
+assert_eq "$(extract_output "$manifest_runner_framework_output" "run_launch_canary_contract_tests")" "true" "manifest runner framework changes must run canary lane"
+assert_eq "$(extract_output "$manifest_runner_framework_output" "run_durable_guard_recovery_contract_tests")" "true" "manifest runner framework changes must run durable guard recovery lane"
 assert_eq "$(extract_output "$manifest_runner_framework_output" "test_scope")" "frontend-contract" "manifest runner framework changes should keep bounded frontend-contract scope"
 
 token_contract_fixture_output="$(run_selector $'fixtures/token_launch/handoff_invariant_cases.json')"
@@ -1696,6 +1705,11 @@ treasury_contract_script_output="$(run_selector $'scripts/treasury/run_treasury_
 assert_eq "$(extract_output "$treasury_contract_script_output" "run_rust")" "false" "treasury contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$treasury_contract_script_output" "run_treasury_disbursement_contract_tests")" "true" "treasury contract script changes must run treasury contract lane"
 assert_eq "$(extract_output "$treasury_contract_script_output" "test_scope")" "treasury-contract" "treasury contract script changes should set treasury-contract scope"
+
+treasury_contract_manifest_output="$(run_selector $'scripts/framework/manifests/treasury_disbursement_contract_lane.json')"
+assert_eq "$(extract_output "$treasury_contract_manifest_output" "run_rust")" "false" "treasury manifest changes should avoid rust lane"
+assert_eq "$(extract_output "$treasury_contract_manifest_output" "run_treasury_disbursement_contract_tests")" "true" "treasury manifest changes must run treasury contract lane"
+assert_eq "$(extract_output "$treasury_contract_manifest_output" "test_scope")" "treasury-contract" "treasury manifest changes should set treasury-contract scope"
 
 treasury_contract_shared_script_output="$(run_selector $'scripts/treasury/treasury_disbursement_contract_lane_contract.py')"
 assert_eq "$(extract_output "$treasury_contract_shared_script_output" "run_rust")" "false" "treasury shared contract-lane script-only changes should avoid rust lane"
@@ -1737,6 +1751,11 @@ assert_eq "$(extract_output "$canary_contract_script_output" "run_rust")" "false
 assert_eq "$(extract_output "$canary_contract_script_output" "run_launch_canary_contract_tests")" "true" "canary contract script changes must run launch canary lane"
 assert_eq "$(extract_output "$canary_contract_script_output" "test_scope")" "canary-contract" "canary contract script changes should set canary-contract scope"
 
+canary_contract_manifest_output="$(run_selector $'scripts/framework/manifests/canary_launch_canary_contract_lane.json')"
+assert_eq "$(extract_output "$canary_contract_manifest_output" "run_rust")" "false" "canary launch manifest changes should avoid rust lane"
+assert_eq "$(extract_output "$canary_contract_manifest_output" "run_launch_canary_contract_tests")" "true" "canary launch manifest changes must run launch canary lane"
+assert_eq "$(extract_output "$canary_contract_manifest_output" "test_scope")" "canary-contract" "canary launch manifest changes should set canary-contract scope"
+
 canary_contract_shared_script_output="$(run_selector $'scripts/canary/launch_canary_contract_lane_contract.py')"
 assert_eq "$(extract_output "$canary_contract_shared_script_output" "run_rust")" "false" "canary shared contract-lane script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$canary_contract_shared_script_output" "run_launch_canary_contract_tests")" "true" "canary shared contract-lane changes must run launch canary lane"
@@ -1746,6 +1765,11 @@ canary_slo_script_output="$(run_selector $'scripts/canary/run_post_cutover_slo_c
 assert_eq "$(extract_output "$canary_slo_script_output" "run_rust")" "false" "post-cutover SLO script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$canary_slo_script_output" "run_launch_canary_contract_tests")" "true" "post-cutover SLO script changes must run launch canary lane"
 assert_eq "$(extract_output "$canary_slo_script_output" "test_scope")" "canary-contract" "post-cutover SLO script changes should set canary-contract scope"
+
+canary_slo_manifest_output="$(run_selector $'scripts/framework/manifests/canary_post_cutover_slo_contract_lane.json')"
+assert_eq "$(extract_output "$canary_slo_manifest_output" "run_rust")" "false" "post-cutover SLO manifest changes should avoid rust lane"
+assert_eq "$(extract_output "$canary_slo_manifest_output" "run_launch_canary_contract_tests")" "true" "post-cutover SLO manifest changes must run launch canary lane"
+assert_eq "$(extract_output "$canary_slo_manifest_output" "test_scope")" "canary-contract" "post-cutover SLO manifest changes should set canary-contract scope"
 
 canary_slo_shared_contract_output="$(run_selector $'scripts/canary/post_cutover_slo_contract_lane_contract.py')"
 assert_eq "$(extract_output "$canary_slo_shared_contract_output" "run_rust")" "false" "post-cutover SLO shared contract-lane script-only changes should avoid rust lane"
@@ -1803,6 +1827,11 @@ guard_contract_script_output="$(run_selector $'scripts/guard/run_durable_guard_r
 assert_eq "$(extract_output "$guard_contract_script_output" "run_rust")" "false" "durable guard contract script-only changes should avoid rust lane"
 assert_eq "$(extract_output "$guard_contract_script_output" "run_durable_guard_recovery_contract_tests")" "true" "durable guard contract script changes must run durable guard recovery contract lane"
 assert_eq "$(extract_output "$guard_contract_script_output" "test_scope")" "guard-contract" "durable guard contract script changes should set guard-contract scope"
+
+guard_contract_manifest_output="$(run_selector $'scripts/framework/manifests/guard_durable_guard_recovery_contract_lane.json')"
+assert_eq "$(extract_output "$guard_contract_manifest_output" "run_rust")" "false" "durable guard manifest changes should avoid rust lane"
+assert_eq "$(extract_output "$guard_contract_manifest_output" "run_durable_guard_recovery_contract_tests")" "true" "durable guard manifest changes must run durable guard recovery contract lane"
+assert_eq "$(extract_output "$guard_contract_manifest_output" "test_scope")" "guard-contract" "durable guard manifest changes should set guard-contract scope"
 
 guard_shared_contract_output="$(run_selector $'scripts/guard/durable_guard_recovery_contract_lane_contract.py')"
 assert_eq "$(extract_output "$guard_shared_contract_output" "run_rust")" "false" "durable guard shared contract module changes should avoid rust lane"

--- a/scripts/framework/manifests/canary_launch_canary_contract_lane.json
+++ b/scripts/framework/manifests/canary_launch_canary_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "canary.launch_canary.contract",
+  "evidence_key": "launch_canary_contract_lane:v1",
+  "reason_key": "launch_canary_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/canary/launch_canary_contract_lane_contract.py"
+    ]
+  }
+}

--- a/scripts/framework/manifests/canary_post_cutover_slo_contract_lane.json
+++ b/scripts/framework/manifests/canary_post_cutover_slo_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "canary.post_cutover_slo.contract",
+  "evidence_key": "post_cutover_slo_contract_lane:v1",
+  "reason_key": "post_cutover_slo_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/canary/post_cutover_slo_contract_lane_contract.py"
+    ]
+  }
+}

--- a/scripts/framework/manifests/guard_durable_guard_recovery_contract_lane.json
+++ b/scripts/framework/manifests/guard_durable_guard_recovery_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "guard.durable_guard_recovery.contract",
+  "evidence_key": "durable_guard_recovery_contract_lane:v1",
+  "reason_key": "durable_guard_recovery_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/guard/durable_guard_recovery_contract_lane_contract.py"
+    ]
+  }
+}

--- a/scripts/framework/manifests/token_launch_handoff_contract_lane.json
+++ b/scripts/framework/manifests/token_launch_handoff_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "token.launch_handoff.contract",
+  "evidence_key": "token_launch_handoff_contract_lane:v1",
+  "reason_key": "token_launch_handoff_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/token/token_launch_handoff_contract_lane_contract.py"
+    ]
+  }
+}

--- a/scripts/framework/manifests/treasury_disbursement_contract_lane.json
+++ b/scripts/framework/manifests/treasury_disbursement_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "treasury.disbursement.contract",
+  "evidence_key": "treasury_disbursement_contract_lane:v1",
+  "reason_key": "treasury_disbursement_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/treasury/treasury_disbursement_contract_lane_contract.py"
+    ]
+  }
+}

--- a/scripts/framework/test_pilot_lane_manifests.py
+++ b/scripts/framework/test_pilot_lane_manifests.py
@@ -65,6 +65,31 @@ class PilotLaneManifestTests(unittest.TestCase):
                 "reputation.dispute.contract",
                 "scripts/reputation/reputation_dispute_contract_lane_contract.py",
             ),
+            (
+                "canary_launch_canary_contract_lane.json",
+                "canary.launch_canary.contract",
+                "scripts/canary/launch_canary_contract_lane_contract.py",
+            ),
+            (
+                "canary_post_cutover_slo_contract_lane.json",
+                "canary.post_cutover_slo.contract",
+                "scripts/canary/post_cutover_slo_contract_lane_contract.py",
+            ),
+            (
+                "token_launch_handoff_contract_lane.json",
+                "token.launch_handoff.contract",
+                "scripts/token/token_launch_handoff_contract_lane_contract.py",
+            ),
+            (
+                "treasury_disbursement_contract_lane.json",
+                "treasury.disbursement.contract",
+                "scripts/treasury/treasury_disbursement_contract_lane_contract.py",
+            ),
+            (
+                "guard_durable_guard_recovery_contract_lane.json",
+                "guard.durable_guard_recovery.contract",
+                "scripts/guard/durable_guard_recovery_contract_lane_contract.py",
+            ),
         )
 
         for manifest_name, expected_lane_id, expected_script in cases:

--- a/scripts/guard/run_durable_guard_recovery_contract_lane.sh
+++ b/scripts/guard/run_durable_guard_recovery_contract_lane.sh
@@ -2,5 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/guard_durable_guard_recovery_contract_lane.json"
 
-exec python3 "$ROOT_DIR/scripts/guard/durable_guard_recovery_contract_lane_contract.py" "$@"
+exec bash "$ROOT_DIR/scripts/framework/run_manifest_lane.sh" \
+  --manifest "$MANIFEST" \
+  --phase contract \
+  --cwd "$ROOT_DIR" \
+  -- "$@"

--- a/scripts/guard/test_run_durable_guard_recovery_contract_lane.sh
+++ b/scripts/guard/test_run_durable_guard_recovery_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/guard/run_durable_guard_recovery_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/guard/run_durable_guard_recovery_deep_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/guard/durable_guard_recovery_contract_lane_contract.py"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/guard_durable_guard_recovery_contract_lane.json"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected durable guard recovery fast-lane runner to be executable" >&2
@@ -20,9 +21,21 @@ if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected durable guard recovery shared contract module to be executable" >&2
   exit 1
 fi
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected durable guard recovery contract-lane manifest to exist" >&2
+  exit 1
+fi
 
-if ! grep -q "durable_guard_recovery_contract_lane_contract.py" "$FAST_SCRIPT"; then
-  echo "expected durable guard fast-lane wrapper to dispatch to shared contract module" >&2
+if ! grep -q "run_manifest_lane.sh" "$FAST_SCRIPT"; then
+  echo "expected durable guard fast-lane wrapper to delegate via manifest runner" >&2
+  exit 1
+fi
+if ! grep -q "guard_durable_guard_recovery_contract_lane.json" "$FAST_SCRIPT"; then
+  echo "expected durable guard fast-lane wrapper to reference guard manifest" >&2
+  exit 1
+fi
+if ! grep -q "durable_guard_recovery_contract_lane_contract.py" "$MANIFEST"; then
+  echo "expected durable guard manifest to dispatch to shared contract module" >&2
   exit 1
 fi
 

--- a/scripts/token/run_token_launch_handoff_contract_lane.sh
+++ b/scripts/token/run_token_launch_handoff_contract_lane.sh
@@ -2,5 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/token_launch_handoff_contract_lane.json"
 
-exec python3 "$ROOT_DIR/scripts/token/token_launch_handoff_contract_lane_contract.py" "$@"
+exec bash "$ROOT_DIR/scripts/framework/run_manifest_lane.sh" \
+  --manifest "$MANIFEST" \
+  --phase contract \
+  --cwd "$ROOT_DIR" \
+  -- "$@"

--- a/scripts/token/test_run_token_launch_handoff_contract_lane.sh
+++ b/scripts/token/test_run_token_launch_handoff_contract_lane.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_LANE="$ROOT_DIR/scripts/token/run_token_launch_handoff_contract_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/token/token_launch_handoff_contract_lane_contract.py"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/token_launch_handoff_contract_lane.json"
 
 if [ ! -x "$CONTRACT_LANE" ]; then
   echo "expected token launch handoff contract lane script to be executable" >&2
@@ -13,14 +14,26 @@ if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected token launch handoff shared contract-lane module to be executable" >&2
   exit 1
 fi
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected token launch handoff contract-lane manifest to exist" >&2
+  exit 1
+fi
 
 lane_output="$(bash "$CONTRACT_LANE")"
 if ! printf '%s\n' "$lane_output" | grep -q "token launch handoff contract lane tests passed."; then
   echo "expected token launch handoff contract lane success output" >&2
   exit 1
 fi
-if ! grep -q "token_launch_handoff_contract_lane_contract.py" "$CONTRACT_LANE"; then
-  echo "expected token launch handoff contract lane wrapper to dispatch to shared module" >&2
+if ! grep -q "run_manifest_lane.sh" "$CONTRACT_LANE"; then
+  echo "expected token launch handoff contract lane wrapper to delegate via manifest runner" >&2
+  exit 1
+fi
+if ! grep -q "token_launch_handoff_contract_lane.json" "$CONTRACT_LANE"; then
+  echo "expected token launch handoff contract lane wrapper to reference token manifest" >&2
+  exit 1
+fi
+if ! grep -q "token_launch_handoff_contract_lane_contract.py" "$MANIFEST"; then
+  echo "expected token launch handoff manifest to dispatch to shared module" >&2
   exit 1
 fi
 if ! grep -q "generate_token_launch_handoff_evidence_bundle.sh" "$SHARED_CONTRACT"; then

--- a/scripts/treasury/run_treasury_disbursement_contract_lane.sh
+++ b/scripts/treasury/run_treasury_disbursement_contract_lane.sh
@@ -2,5 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/treasury_disbursement_contract_lane.json"
 
-exec python3 "$ROOT_DIR/scripts/treasury/treasury_disbursement_contract_lane_contract.py" "$@"
+exec bash "$ROOT_DIR/scripts/framework/run_manifest_lane.sh" \
+  --manifest "$MANIFEST" \
+  --phase contract \
+  --cwd "$ROOT_DIR" \
+  -- "$@"

--- a/scripts/treasury/test_run_treasury_disbursement_contract_lane.sh
+++ b/scripts/treasury/test_run_treasury_disbursement_contract_lane.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_LANE="$ROOT_DIR/scripts/treasury/run_treasury_disbursement_contract_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/treasury/treasury_disbursement_contract_lane_contract.py"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/treasury_disbursement_contract_lane.json"
 
 if [ ! -x "$CONTRACT_LANE" ]; then
   echo "expected treasury disbursement contract lane script to be executable" >&2
@@ -13,14 +14,26 @@ if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected treasury disbursement shared contract-lane module to be executable" >&2
   exit 1
 fi
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected treasury disbursement contract-lane manifest to exist" >&2
+  exit 1
+fi
 
 lane_output="$(bash "$CONTRACT_LANE")"
 if ! printf '%s\n' "$lane_output" | grep -q "treasury disbursement contract lane tests passed."; then
   echo "expected treasury disbursement contract lane success output" >&2
   exit 1
 fi
-if ! grep -q "treasury_disbursement_contract_lane_contract.py" "$CONTRACT_LANE"; then
-  echo "expected treasury disbursement contract lane wrapper to dispatch to shared module" >&2
+if ! grep -q "run_manifest_lane.sh" "$CONTRACT_LANE"; then
+  echo "expected treasury disbursement contract lane wrapper to delegate via manifest runner" >&2
+  exit 1
+fi
+if ! grep -q "treasury_disbursement_contract_lane.json" "$CONTRACT_LANE"; then
+  echo "expected treasury disbursement contract lane wrapper to reference treasury manifest" >&2
+  exit 1
+fi
+if ! grep -q "treasury_disbursement_contract_lane_contract.py" "$MANIFEST"; then
+  echo "expected treasury disbursement manifest to dispatch to shared module" >&2
   exit 1
 fi
 if ! grep -q "generate_treasury_disbursement_evidence_bundle.sh" "$SHARED_CONTRACT"; then


### PR DESCRIPTION
Closes #1356

## Summary
Migrates five remaining contract lane wrappers to the shared manifest runner so lane execution logic is centralized and domain wrappers stay thin. Adds manifest coverage and CI selector routing so manifest-only edits trigger the correct lane tests.

## Changes
- `scripts/{canary,token,treasury,guard}/run_*_contract_lane.sh`: switched to `contract_lane_runner.sh` manifest dispatch.
- `scripts/framework/manifests/*.json`: added manifests for canary launch, canary post-cutover SLO, token launch handoff, treasury disbursement, and durable guard recovery lanes.
- `scripts/framework/test_pilot_lane_manifests.py`: expanded pilot manifest contract assertions for new manifests.
- `scripts/{canary,token,treasury,guard}/test_run_*_contract_lane.sh`: updated wrappers tests to verify manifest-runner dispatch and path wiring.
- `scripts/ci/select_targets.sh` and `scripts/ci/test_select_targets.sh`: added manifest-aware selector routing and regression coverage for the migrated domains.

## Risks & Compatibility
- None. Wrapper entrypoints and CLI contracts remain stable; execution path is now shared through validated manifests.

## Validation
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual verification: ran targeted lane and selector test suites for migrated scripts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `python3 scripts/framework/test_pilot_lane_manifests.py` |
| Functional  | ✅ | `bash scripts/canary/test_run_launch_canary_contract_lane.sh`; `bash scripts/canary/test_run_post_cutover_slo_contract_lane.sh`; `bash scripts/token/test_run_token_launch_handoff_contract_lane.sh`; `bash scripts/treasury/test_run_treasury_disbursement_contract_lane.sh`; `bash scripts/guard/test_run_durable_guard_recovery_contract_lane.sh` |
| Integration | ✅ | `bash scripts/ci/test_select_targets.sh` |
| Regression  | ✅ | selector matrix expectations for manifest-change paths updated and passing |
