### PR TITLE
docs(kamn-core): graduate three modules from missing-docs allowlist

### DIFF
--- a/crates/kamn-core/src/bootstrap.rs
+++ b/crates/kamn-core/src/bootstrap.rs
@@ -1,3 +1,5 @@
+//! Bootstrap planning for validated config, schema migrations, and runtime wiring.
+
 use crate::config::{ConfigError, NodeConfig};
 use crate::migrations::{MigrationPlan, MigrationRegistry};
 use crate::namespaces::StateNamespaces;
@@ -5,20 +7,29 @@ use crate::runtime::{build_runtime_wiring, RuntimeWiring};
 use crate::state::{AppStateSchema, StateVersion, APP_STATE_VERSION};
 use crate::token::{default_token_config, TokenConfig};
 
+/// Deterministic bootstrap artifact bundling validated config, schema, and wiring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BootstrapPlan {
+    /// Validated node configuration used to build the plan.
     pub config: NodeConfig,
+    /// Canonical state namespaces available to runtime services.
     pub namespaces: StateNamespaces,
+    /// State schema version and namespace metadata.
     pub state_schema: AppStateSchema,
+    /// Token configuration validated during bootstrap.
     pub token_config: TokenConfig,
+    /// Ordered migration plan from persisted to target state version.
     pub migration_plan: MigrationPlan,
+    /// Runtime wiring map for service/component initialization.
     pub wiring: RuntimeWiring,
 }
 
+/// Builds a bootstrap plan for the current application state version.
 pub fn bootstrap(config: NodeConfig) -> Result<BootstrapPlan, ConfigError> {
     bootstrap_from_state_version(config, APP_STATE_VERSION)
 }
 
+/// Builds a bootstrap plan from an explicit persisted state version.
 pub fn bootstrap_from_state_version(
     config: NodeConfig,
     persisted_state_version: StateVersion,

--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1,3 +1,5 @@
+//! Deterministic runtime-commit request/receipt contracts for Kolme integration.
+
 use crate::AgentDid;
 use std::collections::HashMap;
 use std::fmt;
@@ -140,7 +142,10 @@ pub enum KolmeRuntimeCommitOutcome {
     /// Request matched an existing idempotency key.
     Duplicate(KolmeRuntimeCommitReceipt),
     /// Request was rejected with an explicit reason.
-    Rejected { reason: String },
+    Rejected {
+        /// Deterministic rejection reason from provider/runtime policy.
+        reason: String,
+    },
 }
 
 /// Runtime lifecycle state projected from commit receipt outcomes.
@@ -330,9 +335,15 @@ pub enum KolmeRuntimeCommitProviderError {
     /// Provider call timed out before a response.
     Timeout,
     /// Provider transport/channel is unavailable.
-    Unavailable { reason: String },
+    Unavailable {
+        /// Provider-specific availability failure reason.
+        reason: String,
+    },
     /// Provider emitted malformed payload/shape.
-    MalformedResponse { reason: String },
+    MalformedResponse {
+        /// Provider-specific malformed payload reason.
+        reason: String,
+    },
 }
 
 impl fmt::Display for KolmeRuntimeCommitProviderError {
@@ -368,7 +379,10 @@ pub enum KolmeRuntimeCommitProviderOutcome {
     /// Provider detected duplicate idempotency key.
     Duplicate(KolmeRuntimeCommitProviderReceipt),
     /// Provider rejected the submission with explicit reason.
-    Rejected { reason: String },
+    Rejected {
+        /// Deterministic provider rejection reason.
+        reason: String,
+    },
 }
 
 /// Provider interface consumed by the adapter-backed runtime commit client.

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -13,7 +13,6 @@ pub mod agent_upgrade_workflow;
 pub mod anti_spam;
 #[allow(missing_docs)]
 pub mod audit_exports;
-#[allow(missing_docs)]
 pub mod bootstrap;
 #[allow(missing_docs)]
 pub mod bridge_adapter;
@@ -61,7 +60,6 @@ pub mod invariants;
 pub mod key_lifecycle;
 #[allow(missing_docs)]
 pub mod key_recovery;
-#[allow(missing_docs)]
 pub mod kolme_runtime_commit;
 #[allow(missing_docs)]
 pub mod message_delivery_guards;
@@ -102,7 +100,6 @@ pub mod signature_profile;
 pub mod signer_backend;
 #[allow(missing_docs)]
 pub mod smoke;
-#[allow(missing_docs)]
 pub mod state;
 #[allow(missing_docs)]
 pub mod task_artifacts;

--- a/crates/kamn-core/src/state.rs
+++ b/crates/kamn-core/src/state.rs
@@ -1,16 +1,27 @@
+//! Canonical state schema/versioning and deterministic state-key construction.
+
 use std::fmt;
 
 use crate::namespaces::StateNamespaces;
 
+/// Monotonic schema version marker for persisted state layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct StateVersion(pub u32);
+pub struct StateVersion(
+    /// Integer representation of the schema version.
+    pub u32,
+);
 
+/// Current application state schema version.
 pub const APP_STATE_VERSION: StateVersion = StateVersion(1);
+/// Maximum allowed length for each canonical state-key part.
 pub const MAX_STATE_KEY_PART_LEN: usize = 96;
 
+/// Canonical state schema metadata used by bootstrap and migration planning.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppStateSchema {
+    /// Schema version this node expects for persisted state.
     pub version: StateVersion,
+    /// Canonical namespace registry used for state-key composition.
     pub namespaces: StateNamespaces,
 }
 
@@ -23,6 +34,7 @@ impl Default for AppStateSchema {
     }
 }
 
+/// Builds a deterministic canonical state key `<namespace>:<entity>:<id>`.
 pub fn canonical_state_key(
     namespace: &str,
     entity: &str,
@@ -83,18 +95,28 @@ fn validate_key_part(part: &'static str, value: &str) -> Result<(), StateKeyErro
     Ok(())
 }
 
+/// Validation error for canonical state-key construction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StateKeyError {
+    /// Required key part is empty.
     EmptyPart(&'static str),
+    /// One key part exceeds the configured max length.
     PartTooLong {
+        /// Part label that violated the constraint.
         part: &'static str,
+        /// Maximum supported character length.
         max: usize,
+        /// Observed character length.
         actual: usize,
     },
+    /// One key part contains unsupported characters.
     InvalidCharacter {
+        /// Part label that violated character rules.
         part: &'static str,
+        /// Raw value that failed validation.
         value: String,
     },
+    /// Namespace does not use the required `kamn.` prefix.
     NamespacePrefix(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -71,3 +71,21 @@ fn namespaces_module_must_not_return_to_missing_docs_allowlist() {
         "allowlist fixture must keep namespaces module removed"
     );
 }
+
+#[test]
+fn graduated_wave_two_modules_must_not_return_to_missing_docs_allowlist() {
+    // Regression: #1365
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+
+    for module in ["bootstrap", "kolme_runtime_commit", "state"] {
+        assert!(
+            !actual.iter().any(|candidate| candidate == module),
+            "{module} must stay graduated from #[allow(missing_docs)]"
+        );
+        assert!(
+            !expected.iter().any(|candidate| candidate == module),
+            "allowlist fixture must keep {module} removed"
+        );
+    }
+}

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -2,7 +2,6 @@ agent_key_hierarchy
 agent_upgrade_workflow
 anti_spam
 audit_exports
-bootstrap
 bridge_adapter
 channel_models
 channel_policies
@@ -26,7 +25,6 @@ instruction_verify
 invariants
 key_lifecycle
 key_recovery
-kolme_runtime_commit
 message_delivery_guards
 message_envelope
 message_lifecycle
@@ -46,7 +44,6 @@ service_marketplace
 signature_profile
 signer_backend
 smoke
-state
 task_artifacts
 task_lifecycle
 task_operations


### PR DESCRIPTION
Closes #1365

## Summary
Graduates three `kamn-core` module clusters (`bootstrap`, `state`, `kolme_runtime_commit`) from missing-docs allowlist exemptions. Adds missing public rustdoc coverage and strengthens regression checks so these modules cannot silently return to the allowlist.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `bootstrap`, `state`, and `kolme_runtime_commit`.
- `crates/kamn-core/src/bootstrap.rs`: added module/type/field/function rustdoc for public bootstrap API.
- `crates/kamn-core/src/state.rs`: added module/type/field/function/enum rustdoc for public state schema/key APIs.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added module docs and missing variant-field docs for public enums.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed the three graduated modules from allowlist fixture.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard preventing reintroduction of graduated modules.

## Risks & Compatibility
- Low risk. This is documentation/policy graduation only; runtime behavior and public signatures are unchanged.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --all-targets -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: rustdoc warning-fail generation and policy/selector contracts validated locally.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Functional  | ✅ | `RUSTDOCFLAGS="-D warnings" cargo doc -p kamn-core --no-deps` |
| Integration | ✅ | `bash scripts/ci/check_kamn_core_missing_docs_policy.sh`; `bash scripts/ci/test_select_targets.sh` |
| Regression  | ✅ | `bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh` |
