### PR TITLE
feat(runtime): add lifecycle replay artifact contracts (#1360)

### DIFF
--- a/crates/kamn-core/tests/invariants_docs.rs
+++ b/crates/kamn-core/tests/invariants_docs.rs
@@ -4,6 +4,8 @@ const DOC: &str = include_str!("../../../docs/foundation/invariants.md");
 fn doc_contains_runtime_invariant_harness_coverage_contract() {
     assert!(DOC.contains("## Runtime Invariant Harness Coverage (Issue #897)"));
     assert!(DOC.contains("run_lifecycle_property_contract_lane.sh"));
+    assert!(DOC.contains("kamn.runtime.lifecycle-property-contract-report.v1"));
+    assert!(DOC.contains("lifecycle_property_replay:v1"));
     assert!(DOC.contains("run_input_mutation_contract_lane.sh"));
     assert!(DOC.contains("run_concurrency_state_mutation_contract_lane.sh"));
     assert!(DOC.contains("run_invariant_fuzz_concurrency_contract_lane.sh"));

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -25,6 +25,11 @@ This document defines the canonical transaction invariant catalog and error taxo
 ## Runtime Invariant Harness Coverage (Issue #897)
 - Property-based lifecycle invariant lane:
   - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh`
+  - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh --output-json /tmp/lifecycle-property-contract-report.json`
+- Lifecycle property report schema:
+  - `kamn.runtime.lifecycle-property-contract-report.v1`
+- Lifecycle property replay artifact key:
+  - `lifecycle_property_replay:v1`
 - Fuzz/mutation fail-closed lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
 - ZK witness mutation fast lane:
@@ -40,6 +45,8 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `bash scripts/runtime/check_invariant_fuzz_concurrency_policy.sh --report-file /tmp/invariant-fuzz-concurrency-contract-report.json`
 - Report schema:
   - `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`
+- Property lane runtime budget env:
+  - `KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS` (default `120`)
 
 ## Dispute/Refund Property and Concurrency Contracts (Issue #904)
 - Property + replay trace contract lane:

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -13,6 +13,7 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 
 - Property/invariant lane:
   - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh`
+  - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh --output-json /tmp/lifecycle-property-contract-report.json`
 - Mutation/fuzz smoke lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
 - Concurrency race lane:
@@ -25,7 +26,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 ## Determinism Strategy
 
 - Property coverage uses deterministic generated-sequence tests for task,
-  escrow/dispute-refund, and peer lifecycle transitions.
+  escrow/dispute-refund, and peer lifecycle transitions, and emits replay
+  metadata artifact key `lifecycle_property_replay:v1`.
 - Mutation/fuzz smoke lanes use fixed malformed/tampered classes with stable
   fail-closed reason signatures.
 - Concurrency lanes use replay fixtures and deterministic round-based checks to
@@ -33,6 +35,10 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 
 ## Evidence and Policy Contracts
 
+- Lifecycle property report schema:
+  - `kamn.runtime.lifecycle-property-contract-report.v1`
+- Lifecycle property replay artifact key:
+  - `lifecycle_property_replay:v1`
 - Combined lane report schema:
   - `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`
 - Required summary fields:
@@ -40,6 +46,9 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `property_lane_status`
   - `fuzz_lane_status`
   - `concurrency_lane_status`
+  - `property_replay_schema_version`
+  - `property_replay_artifact_key`
+  - `property_replay_test_count`
   - `elapsed_seconds`
   - `max_seconds`
   - `reason_codes`
@@ -48,6 +57,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 
 ## Runtime Budgets
 
+- Property lane runtime budget env:
+  - `KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS` (default `120`)
 - Combined lane runtime budget env:
   - `KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS` (default `180`)
 - ZK witness mutation routing control:

--- a/scripts/runtime/check_invariant_fuzz_concurrency_policy.sh
+++ b/scripts/runtime/check_invariant_fuzz_concurrency_policy.sh
@@ -66,6 +66,9 @@ required_fields = (
     "property_lane_status",
     "fuzz_lane_status",
     "concurrency_lane_status",
+    "property_replay_schema_version",
+    "property_replay_artifact_key",
+    "property_replay_test_count",
     "elapsed_seconds",
     "max_seconds",
     "reason_codes",
@@ -84,6 +87,26 @@ if status not in {"pass", "fail"}:
 for field in ("property_lane_status", "fuzz_lane_status", "concurrency_lane_status"):
     if payload[field] not in {"pass", "fail"}:
         fail(f"{field} must be pass or fail")
+
+property_replay_schema_version = payload["property_replay_schema_version"]
+expected_property_replay_schema_version = "kamn.runtime.lifecycle-property-contract-report.v1"
+if property_replay_schema_version != expected_property_replay_schema_version:
+    fail(
+        "property_replay_schema_version mismatch: "
+        f"expected {expected_property_replay_schema_version}, found {property_replay_schema_version}"
+    )
+
+property_replay_artifact_key = payload["property_replay_artifact_key"]
+expected_property_replay_artifact_key = "lifecycle_property_replay:v1"
+if property_replay_artifact_key != expected_property_replay_artifact_key:
+    fail(
+        "property_replay_artifact_key mismatch: "
+        f"expected {expected_property_replay_artifact_key}, found {property_replay_artifact_key}"
+    )
+
+property_replay_test_count = payload["property_replay_test_count"]
+if not isinstance(property_replay_test_count, int) or property_replay_test_count < 12:
+    fail("property_replay_test_count must be an integer >= 12")
 
 elapsed_seconds = payload["elapsed_seconds"]
 max_seconds = payload["max_seconds"]

--- a/scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh
+++ b/scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh
@@ -47,10 +47,17 @@ if [[ ! "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 start_epoch="$(date +%s)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+property_report="$TMP_DIR/lifecycle-property-contract-report.json"
 
-property_output="$(bash "$PROPERTY_LANE")"
+property_output="$(bash "$PROPERTY_LANE" --output-json "$property_report")"
 if ! printf '%s\n' "$property_output" | grep -Fq "runtime lifecycle property contract lane tests passed."; then
   echo "expected lifecycle property lane success marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$property_output" | grep -Fq "runtime_lifecycle_property_contract_report=$property_report"; then
+  echo "expected lifecycle property lane report marker" >&2
   exit 1
 fi
 
@@ -72,18 +79,30 @@ if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
   exit 1
 fi
 
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
 summary_report="$TMP_DIR/invariant-fuzz-concurrency-contract-report.json"
 
-python3 - "$summary_report" "$elapsed_seconds" "$max_seconds" <<'PY'
+python3 - "$summary_report" "$property_report" "$elapsed_seconds" "$max_seconds" <<'PY'
 import json
 import pathlib
 import sys
 
 report_file = pathlib.Path(sys.argv[1])
-elapsed_seconds = int(sys.argv[2])
-max_seconds = int(sys.argv[3])
+property_report_file = pathlib.Path(sys.argv[2])
+elapsed_seconds = int(sys.argv[3])
+max_seconds = int(sys.argv[4])
+
+property_report = json.loads(property_report_file.read_text(encoding="utf-8"))
+schema_version = property_report.get("schema_version")
+if schema_version != "kamn.runtime.lifecycle-property-contract-report.v1":
+    raise SystemExit("unexpected lifecycle property report schema")
+if property_report.get("status") != "pass":
+    raise SystemExit("lifecycle property report status must be pass")
+artifact_key = property_report.get("replay_artifact_key")
+if artifact_key != "lifecycle_property_replay:v1":
+    raise SystemExit("unexpected lifecycle property replay artifact key")
+executed_tests = property_report.get("executed_tests")
+if not isinstance(executed_tests, list) or not executed_tests:
+    raise SystemExit("lifecycle property report must include non-empty executed_tests")
 
 summary = {
     "schema_version": "kamn.runtime.invariant-fuzz-concurrency-contract-report.v1",
@@ -91,6 +110,9 @@ summary = {
     "property_lane_status": "pass",
     "fuzz_lane_status": "pass",
     "concurrency_lane_status": "pass",
+    "property_replay_schema_version": schema_version,
+    "property_replay_artifact_key": artifact_key,
+    "property_replay_test_count": len(executed_tests),
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
     "reason_codes": ["none"],
@@ -124,6 +146,16 @@ if ! grep -Fq "run_invariant_fuzz_concurrency_contract_lane.sh" "$INVARIANTS_DOC
   exit 1
 fi
 
+if ! grep -Fq "kamn.runtime.lifecycle-property-contract-report.v1" "$INVARIANTS_DOC"; then
+  echo "expected invariants docs to reference lifecycle property report schema" >&2
+  exit 1
+fi
+
+if ! grep -Fq "lifecycle_property_replay:v1" "$INVARIANTS_DOC"; then
+  echo "expected invariants docs to reference lifecycle property replay artifact key" >&2
+  exit 1
+fi
+
 if ! grep -Fq "KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS" "$PERFORMANCE_DOC"; then
   echo "expected performance benchmarking docs to reference invariant/fuzz/concurrency runtime budget env" >&2
   exit 1
@@ -131,6 +163,16 @@ fi
 
 if ! grep -Fq "run_lifecycle_property_contract_lane.sh" "$TESTING_STRATEGY_DOC"; then
   echo "expected invariant/fuzz strategy doc to reference lifecycle property lane command" >&2
+  exit 1
+fi
+
+if ! grep -Fq "kamn.runtime.lifecycle-property-contract-report.v1" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference lifecycle property report schema" >&2
+  exit 1
+fi
+
+if ! grep -Fq "lifecycle_property_replay:v1" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference lifecycle property replay artifact key" >&2
   exit 1
 fi
 
@@ -161,6 +203,11 @@ fi
 
 if ! grep -Fq "KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS" "$TESTING_STRATEGY_DOC"; then
   echo "expected invariant/fuzz strategy doc to reference combined lane runtime budget env" >&2
+  exit 1
+fi
+
+if ! grep -Fq "KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference lifecycle property runtime budget env" >&2
   exit 1
 fi
 

--- a/scripts/runtime/run_lifecycle_property_contract_lane.sh
+++ b/scripts/runtime/run_lifecycle_property_contract_lane.sh
@@ -1,24 +1,104 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/runtime/run_lifecycle_property_contract_lane.sh \
+    [--output-json <path>]
+USAGE
+}
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-# Keep the lane bounded to exact property invariants needed for task/escrow/peer lifecycles.
-cargo test -p kamn-core --test task_state_machine task_lifecycle_property_generated_sequences_preserve_transition_contracts -- --exact >/dev/null
-cargo test -p kamn-core --test task_state_machine task_lifecycle_property_restore_roundtrip_preserves_state_and_history -- --exact >/dev/null
-cargo test -p kamn-core --test task_state_machine task_lifecycle_property_terminal_states_are_absorbing -- --exact >/dev/null
+output_json=""
+max_seconds="${KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS:-120}"
 
-cargo test -p kamn-core --test escrow_lifecycle escrow_property_generated_action_sequences_preserve_amount_and_status_invariants -- --exact >/dev/null
-cargo test -p kamn-core --test escrow_lifecycle escrow_property_terminal_statuses_reject_all_mutating_actions -- --exact >/dev/null
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
-cargo test -p kamn-core --test dispute_refund_transition_contracts functional_property_dispute_refund_sequences_preserve_contracts -- --exact >/dev/null
-cargo test -p kamn-core --test dispute_refund_transition_contracts integration_dispute_refund_replay_traces_are_deterministic -- --exact >/dev/null
-cargo test -p kamn-core --test dispute_refund_transition_contracts regression_replay_dispute_after_refund_fails_closed_with_reason_code -- --exact >/dev/null
-cargo test -p kamn-core --test dispute_refund_transition_contracts performance_dispute_refund_property_contract_lane_stays_within_budget -- --exact >/dev/null
+if [[ ! "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS must be a positive integer" >&2
+  exit 1
+fi
 
-cargo test -p kamn-core --test runtime_peer_lifecycle peer_lifecycle_property_generated_event_sequences_match_transition_contract -- --exact >/dev/null
-cargo test -p kamn-core --test runtime_peer_lifecycle peer_lifecycle_property_sequence_replay_is_deterministic -- --exact >/dev/null
-cargo test -p kamn-core --test runtime_peer_lifecycle peer_lifecycle_property_roundtrip_disconnect_recovers_connection_path -- --exact >/dev/null
+start_epoch="$(date +%s)"
+
+declare -a property_cases=(
+  "task_state_machine:task_lifecycle_property_generated_sequences_preserve_transition_contracts"
+  "task_state_machine:task_lifecycle_property_restore_roundtrip_preserves_state_and_history"
+  "task_state_machine:task_lifecycle_property_terminal_states_are_absorbing"
+  "escrow_lifecycle:escrow_property_generated_action_sequences_preserve_amount_and_status_invariants"
+  "escrow_lifecycle:escrow_property_terminal_statuses_reject_all_mutating_actions"
+  "dispute_refund_transition_contracts:functional_property_dispute_refund_sequences_preserve_contracts"
+  "dispute_refund_transition_contracts:integration_dispute_refund_replay_traces_are_deterministic"
+  "dispute_refund_transition_contracts:regression_replay_dispute_after_refund_fails_closed_with_reason_code"
+  "dispute_refund_transition_contracts:performance_dispute_refund_property_contract_lane_stays_within_budget"
+  "runtime_peer_lifecycle:peer_lifecycle_property_generated_event_sequences_match_transition_contract"
+  "runtime_peer_lifecycle:peer_lifecycle_property_sequence_replay_is_deterministic"
+  "runtime_peer_lifecycle:peer_lifecycle_property_roundtrip_disconnect_recovers_connection_path"
+)
+
+executed_tests=()
+for property_case in "${property_cases[@]}"; do
+  test_target="${property_case%%:*}"
+  test_name="${property_case#*:}"
+  cargo test -p kamn-core --test "$test_target" "$test_name" -- --exact >/dev/null
+  executed_tests+=("$test_name")
+done
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "runtime lifecycle property contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+if [[ -n "$output_json" ]]; then
+  mkdir -p "$(dirname "$output_json")"
+  tests_file="$(mktemp)"
+  trap 'rm -f "$tests_file"' EXIT
+  printf '%s\n' "${executed_tests[@]}" >"$tests_file"
+
+  python3 - "$output_json" "$tests_file" "$elapsed_seconds" "$max_seconds" <<'PY'
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1])
+tests_path = pathlib.Path(sys.argv[2])
+elapsed_seconds = int(sys.argv[3])
+max_seconds = int(sys.argv[4])
+
+tests = [line.strip() for line in tests_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+payload = {
+    "schema_version": "kamn.runtime.lifecycle-property-contract-report.v1",
+    "status": "pass",
+    "suite": "lifecycle_property_contract_lane",
+    "replay_artifact_key": "lifecycle_property_replay:v1",
+    "executed_tests": tests,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "reason_codes": ["none"],
+}
+output_path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+PY
+
+  echo "runtime_lifecycle_property_contract_report=$output_json"
+fi
 
 echo "runtime lifecycle property contract lane tests passed."

--- a/scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
+++ b/scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
@@ -35,7 +35,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["reason_codes"] = ["unexpected_reason_code"]
+payload["property_replay_artifact_key"] = "tampered_artifact_key"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -49,14 +49,14 @@ if [ "$tampered_code" -eq 0 ]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$tampered_output" | grep -Fq "reason_codes mismatch"; then
-  echo "expected explicit reason_codes mismatch policy error" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "property_replay_artifact_key mismatch"; then
+  echo "expected explicit property replay artifact mismatch policy error" >&2
   exit 1
 fi
 
-# Regression: #897
-if ! printf '%s\n' "$tampered_output" | grep -Fq "['none']"; then
-  echo "expected required reason-code marker in invariant/fuzz/concurrency policy regression path" >&2
+# Regression: #1360
+if ! printf '%s\n' "$tampered_output" | grep -Fq "lifecycle_property_replay:v1"; then
+  echo "expected required property replay artifact key marker in policy regression path" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
+++ b/scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
@@ -54,6 +54,9 @@ assert report["status"] == "pass"
 assert report["property_lane_status"] == "pass"
 assert report["fuzz_lane_status"] == "pass"
 assert report["concurrency_lane_status"] == "pass"
+assert report["property_replay_schema_version"] == "kamn.runtime.lifecycle-property-contract-report.v1"
+assert report["property_replay_artifact_key"] == "lifecycle_property_replay:v1"
+assert report["property_replay_test_count"] >= 12
 # Regression: #897
 assert report["reason_codes"] == ["none"]
 PY

--- a/scripts/runtime/test_run_lifecycle_property_contract_lane.sh
+++ b/scripts/runtime/test_run_lifecycle_property_contract_lane.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_lifecycle_property_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$CONTRACT_LANE" ]; then
   echo "expected runtime lifecycle property contract lane script to be executable" >&2
@@ -39,10 +41,31 @@ if ! grep -q "performance_dispute_refund_property_contract_lane_stays_within_bud
   exit 1
 fi
 
-lane_output="$(bash "$CONTRACT_LANE")"
+report_file="$TMP_DIR/lifecycle-property-contract-report.json"
+lane_output="$(bash "$CONTRACT_LANE" --output-json "$report_file")"
 if ! printf '%s\n' "$lane_output" | grep -q "runtime lifecycle property contract lane tests passed."; then
   echo "expected runtime lifecycle property contract lane success marker" >&2
   exit 1
 fi
+
+if ! printf '%s\n' "$lane_output" | grep -q "runtime_lifecycle_property_contract_report=$report_file"; then
+  echo "expected lifecycle property contract lane to emit report path marker" >&2
+  exit 1
+fi
+
+python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["schema_version"] == "kamn.runtime.lifecycle-property-contract-report.v1"
+assert report["status"] == "pass"
+assert report["replay_artifact_key"] == "lifecycle_property_replay:v1"
+assert report["reason_codes"] == ["none"]
+assert len(report["executed_tests"]) >= 12
+assert "integration_dispute_refund_replay_traces_are_deterministic" in report["executed_tests"]
+assert "peer_lifecycle_property_sequence_replay_is_deterministic" in report["executed_tests"]
+PY
 
 echo "runtime lifecycle property contract lane script tests passed."


### PR DESCRIPTION
## Summary
Adds a deterministic lifecycle-property replay artifact contract and propagates that metadata into the combined invariant/fuzz/concurrency report and policy checks. This closes a replay-evidence gap in the property lane while keeping runtime checks bounded and fail-closed.

## Changes
- `scripts/runtime/run_lifecycle_property_contract_lane.sh`: added optional `--output-json` contract report output (`kamn.runtime.lifecycle-property-contract-report.v1`), replay artifact key, executed test inventory, and bounded runtime budget env (`KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS`).
- `scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh`: now consumes lifecycle-property report output and includes replay metadata fields in the combined report.
- `scripts/runtime/check_invariant_fuzz_concurrency_policy.sh`: enforces replay schema/key/test-count fields in addition to existing lane status/reason-code checks.
- Runtime lane tests updated:
  - `scripts/runtime/test_run_lifecycle_property_contract_lane.sh`
  - `scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh`
  - `scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh`
- Documentation updates:
  - `docs/testing/invariant-and-fuzz-strategy.md`
  - `docs/foundation/invariants.md`
- Docs contract update:
  - `crates/kamn-core/tests/invariants_docs.rs`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands and failing outcomes before implementation:
```bash
bash scripts/runtime/test_run_lifecycle_property_contract_lane.sh
# expected lifecycle property contract lane to emit report path marker

bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
# KeyError: 'property_replay_schema_version'

bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
# expected tampered invariant/fuzz/concurrency report to fail policy checker

cargo test -p kamn-core --test invariants_docs
# assertion failed: DOC.contains("kamn.runtime.lifecycle-property-contract-report.v1")
```

### 🟢 Green Phase
```bash
bash scripts/runtime/test_run_lifecycle_property_contract_lane.sh
bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
cargo test -p kamn-core --test invariants_docs
```
All pass after the implementation.

### 🔁 Regression
```bash
bash scripts/ci/test_select_targets.sh
cargo fmt --check
cargo clippy -p kamn-core --all-targets -- -D warnings
```
All pass.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test invariants_docs` updated assertions | |
| Functional   | ✅ | `scripts/runtime/test_run_lifecycle_property_contract_lane.sh` report schema/key checks | |
| Integration  | ✅ | `scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh`, `scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh` | |
| Regression   | ✅ | Red→Green failures for replay metadata drift + `scripts/ci/test_select_targets.sh` | |
| Performance  | N/A | | Runtime budgets enforced via existing bounded lane posture; no throughput target changes. |

## Risks & Rollback
- Risk: low/medium; behavior is additive but policy checker is stricter and will fail closed on replay-metadata drift.
- Rollback: revert this PR to restore prior combined report schema/policy behavior.

## Documentation Updates
- `docs/testing/invariant-and-fuzz-strategy.md`
- `docs/foundation/invariants.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1360
