### PR TITLE
feat(runtime): add fuzz replay artifact contracts (#1361)

### DIFF
--- a/crates/kamn-core/tests/invariants_docs.rs
+++ b/crates/kamn-core/tests/invariants_docs.rs
@@ -7,6 +7,8 @@ fn doc_contains_runtime_invariant_harness_coverage_contract() {
     assert!(DOC.contains("kamn.runtime.lifecycle-property-contract-report.v1"));
     assert!(DOC.contains("lifecycle_property_replay:v1"));
     assert!(DOC.contains("run_input_mutation_contract_lane.sh"));
+    assert!(DOC.contains("kamn.runtime.input-mutation-contract-report.v1"));
+    assert!(DOC.contains("input_mutation_replay:v1"));
     assert!(DOC.contains("run_concurrency_state_mutation_contract_lane.sh"));
     assert!(DOC.contains("run_invariant_fuzz_concurrency_contract_lane.sh"));
     assert!(DOC.contains("check_invariant_fuzz_concurrency_policy.sh"));

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -32,6 +32,11 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `lifecycle_property_replay:v1`
 - Fuzz/mutation fail-closed lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
+  - `bash scripts/runtime/run_input_mutation_contract_lane.sh --output-json /tmp/input-mutation-contract-report.json`
+- Input mutation report schema:
+  - `kamn.runtime.input-mutation-contract-report.v1`
+- Input mutation replay artifact key:
+  - `input_mutation_replay:v1`
 - ZK witness mutation fast lane:
   - `bash scripts/runtime/run_zk_witness_mutation_contract_lane.sh`
 - ZK witness mutation deep lane (scheduled):
@@ -47,6 +52,8 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`
 - Property lane runtime budget env:
   - `KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS` (default `120`)
+- Input mutation lane runtime budget env:
+  - `KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS` (default `120`)
 
 ## Dispute/Refund Property and Concurrency Contracts (Issue #904)
 - Property + replay trace contract lane:

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -16,6 +16,7 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh --output-json /tmp/lifecycle-property-contract-report.json`
 - Mutation/fuzz smoke lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
+  - `bash scripts/runtime/run_input_mutation_contract_lane.sh --output-json /tmp/input-mutation-contract-report.json`
 - Concurrency race lane:
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
 - Combined contract lane:
@@ -29,7 +30,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   escrow/dispute-refund, and peer lifecycle transitions, and emits replay
   metadata artifact key `lifecycle_property_replay:v1`.
 - Mutation/fuzz smoke lanes use fixed malformed/tampered classes with stable
-  fail-closed reason signatures.
+  fail-closed reason signatures and emit replay metadata artifact key
+  `input_mutation_replay:v1`.
 - Concurrency lanes use replay fixtures and deterministic round-based checks to
   guard winner exclusivity and terminal-state safety.
 
@@ -39,6 +41,10 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `kamn.runtime.lifecycle-property-contract-report.v1`
 - Lifecycle property replay artifact key:
   - `lifecycle_property_replay:v1`
+- Input mutation report schema:
+  - `kamn.runtime.input-mutation-contract-report.v1`
+- Input mutation replay artifact key:
+  - `input_mutation_replay:v1`
 - Combined lane report schema:
   - `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`
 - Required summary fields:
@@ -49,6 +55,9 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `property_replay_schema_version`
   - `property_replay_artifact_key`
   - `property_replay_test_count`
+  - `fuzz_replay_schema_version`
+  - `fuzz_replay_artifact_key`
+  - `fuzz_replay_test_count`
   - `elapsed_seconds`
   - `max_seconds`
   - `reason_codes`
@@ -59,6 +68,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 
 - Property lane runtime budget env:
   - `KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS` (default `120`)
+- Input mutation lane runtime budget env:
+  - `KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS` (default `120`)
 - Combined lane runtime budget env:
   - `KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS` (default `180`)
 - ZK witness mutation routing control:

--- a/scripts/runtime/check_invariant_fuzz_concurrency_policy.sh
+++ b/scripts/runtime/check_invariant_fuzz_concurrency_policy.sh
@@ -69,6 +69,9 @@ required_fields = (
     "property_replay_schema_version",
     "property_replay_artifact_key",
     "property_replay_test_count",
+    "fuzz_replay_schema_version",
+    "fuzz_replay_artifact_key",
+    "fuzz_replay_test_count",
     "elapsed_seconds",
     "max_seconds",
     "reason_codes",
@@ -107,6 +110,26 @@ if property_replay_artifact_key != expected_property_replay_artifact_key:
 property_replay_test_count = payload["property_replay_test_count"]
 if not isinstance(property_replay_test_count, int) or property_replay_test_count < 12:
     fail("property_replay_test_count must be an integer >= 12")
+
+fuzz_replay_schema_version = payload["fuzz_replay_schema_version"]
+expected_fuzz_replay_schema_version = "kamn.runtime.input-mutation-contract-report.v1"
+if fuzz_replay_schema_version != expected_fuzz_replay_schema_version:
+    fail(
+        "fuzz_replay_schema_version mismatch: "
+        f"expected {expected_fuzz_replay_schema_version}, found {fuzz_replay_schema_version}"
+    )
+
+fuzz_replay_artifact_key = payload["fuzz_replay_artifact_key"]
+expected_fuzz_replay_artifact_key = "input_mutation_replay:v1"
+if fuzz_replay_artifact_key != expected_fuzz_replay_artifact_key:
+    fail(
+        "fuzz_replay_artifact_key mismatch: "
+        f"expected {expected_fuzz_replay_artifact_key}, found {fuzz_replay_artifact_key}"
+    )
+
+fuzz_replay_test_count = payload["fuzz_replay_test_count"]
+if not isinstance(fuzz_replay_test_count, int) or fuzz_replay_test_count < 10:
+    fail("fuzz_replay_test_count must be an integer >= 10")
 
 elapsed_seconds = payload["elapsed_seconds"]
 max_seconds = payload["max_seconds"]

--- a/scripts/runtime/run_input_mutation_contract_lane.sh
+++ b/scripts/runtime/run_input_mutation_contract_lane.sh
@@ -1,30 +1,141 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/runtime/run_input_mutation_contract_lane.sh \
+    [--output-json <path>]
+USAGE
+}
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ZK_WITNESS_MUTATION_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
 ZK_WITNESS_MUTATION_DEEP_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_deep_lane.sh"
 cd "$ROOT_DIR"
 
-# Keep deterministic mutation coverage bounded for fast, low-cost PR validation.
-cargo test -p kamn-core --test message_envelope_fuzz_smoke fuzz_smoke_envelope_mutation_lane_is_panic_free_and_deterministic -- --exact >/dev/null
-cargo test -p kamn-core --test message_envelope_fuzz_smoke functional_envelope_mutation_suite_covers_malformed_truncated_and_tampered_classes -- --exact >/dev/null
-cargo test -p kamn-core --test message_envelope_fuzz_smoke integration_envelope_mutation_fail_closed_reasons_are_explicit_and_deterministic -- --exact >/dev/null
-cargo test -p kamn-core --test message_envelope_fuzz_smoke regression_envelope_mutation_reason_signatures_remain_stable -- --exact >/dev/null
-cargo test -p kamn-core --test message_envelope_fuzz_smoke performance_envelope_mutation_contract_lane_stays_within_budget -- --exact >/dev/null
+output_json=""
+max_seconds="${KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS:-120}"
 
-cargo test -p kamn-core --test did_fuzz_smoke fuzz_smoke_did_parse_mutations_are_panic_free_and_deterministic -- --exact >/dev/null
-cargo test -p kamn-core --test did_fuzz_smoke functional_did_mutation_suite_covers_normalization_encoding_and_method_mismatch_classes -- --exact >/dev/null
-cargo test -p kamn-core --test did_fuzz_smoke integration_did_mutation_fail_closed_reasons_are_explicit_and_deterministic -- --exact >/dev/null
-cargo test -p kamn-core --test did_fuzz_smoke regression_did_mutation_reason_signatures_remain_stable -- --exact >/dev/null
-cargo test -p kamn-core --test did_fuzz_smoke performance_did_mutation_contract_lane_stays_within_budget -- --exact >/dev/null
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
+if [[ ! "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+
+declare -a envelope_cases=(
+  "fuzz_smoke_envelope_mutation_lane_is_panic_free_and_deterministic"
+  "functional_envelope_mutation_suite_covers_malformed_truncated_and_tampered_classes"
+  "integration_envelope_mutation_fail_closed_reasons_are_explicit_and_deterministic"
+  "regression_envelope_mutation_reason_signatures_remain_stable"
+  "performance_envelope_mutation_contract_lane_stays_within_budget"
+)
+
+declare -a did_cases=(
+  "fuzz_smoke_did_parse_mutations_are_panic_free_and_deterministic"
+  "functional_did_mutation_suite_covers_normalization_encoding_and_method_mismatch_classes"
+  "integration_did_mutation_fail_closed_reasons_are_explicit_and_deterministic"
+  "regression_did_mutation_reason_signatures_remain_stable"
+  "performance_did_mutation_contract_lane_stays_within_budget"
+)
+
+start_epoch="$(date +%s)"
+
+for case_name in "${envelope_cases[@]}"; do
+  cargo test -p kamn-core --test message_envelope_fuzz_smoke "$case_name" -- --exact >/dev/null
+done
+
+for case_name in "${did_cases[@]}"; do
+  cargo test -p kamn-core --test did_fuzz_smoke "$case_name" -- --exact >/dev/null
+done
+
+zk_lane_mode="fast"
 if [ "${KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP:-false}" = "true" ]; then
+  zk_lane_mode="deep"
   bash "$ZK_WITNESS_MUTATION_DEEP_LANE" >/dev/null
 else
   bash "$ZK_WITNESS_MUTATION_LANE" >/dev/null
 fi
 
 cargo test -p kamn-core --test runtime_network_docs doc_contains_mutation_fail_closed_contract_rules -- --exact >/dev/null
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "runtime input mutation contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+if [[ -n "$output_json" ]]; then
+  mkdir -p "$(dirname "$output_json")"
+  envelope_cases_file="$(mktemp)"
+  did_cases_file="$(mktemp)"
+  trap 'rm -f "$envelope_cases_file" "$did_cases_file"' EXIT
+  printf '%s\n' "${envelope_cases[@]}" >"$envelope_cases_file"
+  printf '%s\n' "${did_cases[@]}" >"$did_cases_file"
+
+  python3 - \
+    "$output_json" \
+    "$envelope_cases_file" \
+    "$did_cases_file" \
+    "$zk_lane_mode" \
+    "$elapsed_seconds" \
+    "$max_seconds" <<'PY'
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1])
+envelope_cases_path = pathlib.Path(sys.argv[2])
+did_cases_path = pathlib.Path(sys.argv[3])
+zk_lane_mode = sys.argv[4]
+elapsed_seconds = int(sys.argv[5])
+max_seconds = int(sys.argv[6])
+
+envelope_cases = [
+    line.strip()
+    for line in envelope_cases_path.read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+did_cases = [
+    line.strip()
+    for line in did_cases_path.read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+
+payload = {
+    "schema_version": "kamn.runtime.input-mutation-contract-report.v1",
+    "status": "pass",
+    "suite": "input_mutation_contract_lane",
+    "replay_artifact_key": "input_mutation_replay:v1",
+    "envelope_tests": envelope_cases,
+    "did_tests": did_cases,
+    "envelope_test_count": len(envelope_cases),
+    "did_test_count": len(did_cases),
+    "zk_witness_lane_mode": zk_lane_mode,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "reason_codes": ["none"],
+}
+output_path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+PY
+
+  echo "runtime_input_mutation_contract_report=$output_json"
+fi
 
 echo "runtime input mutation contract lane tests passed."

--- a/scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh
+++ b/scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh
@@ -50,6 +50,7 @@ start_epoch="$(date +%s)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 property_report="$TMP_DIR/lifecycle-property-contract-report.json"
+fuzz_report="$TMP_DIR/input-mutation-contract-report.json"
 
 property_output="$(bash "$PROPERTY_LANE" --output-json "$property_report")"
 if ! printf '%s\n' "$property_output" | grep -Fq "runtime lifecycle property contract lane tests passed."; then
@@ -61,9 +62,13 @@ if ! printf '%s\n' "$property_output" | grep -Fq "runtime_lifecycle_property_con
   exit 1
 fi
 
-fuzz_output="$(bash "$FUZZ_LANE")"
+fuzz_output="$(bash "$FUZZ_LANE" --output-json "$fuzz_report")"
 if ! printf '%s\n' "$fuzz_output" | grep -Fq "runtime input mutation contract lane tests passed."; then
   echo "expected input mutation lane success marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$fuzz_output" | grep -Fq "runtime_input_mutation_contract_report=$fuzz_report"; then
+  echo "expected input mutation lane report marker" >&2
   exit 1
 fi
 
@@ -81,15 +86,16 @@ fi
 
 summary_report="$TMP_DIR/invariant-fuzz-concurrency-contract-report.json"
 
-python3 - "$summary_report" "$property_report" "$elapsed_seconds" "$max_seconds" <<'PY'
+python3 - "$summary_report" "$property_report" "$fuzz_report" "$elapsed_seconds" "$max_seconds" <<'PY'
 import json
 import pathlib
 import sys
 
 report_file = pathlib.Path(sys.argv[1])
 property_report_file = pathlib.Path(sys.argv[2])
-elapsed_seconds = int(sys.argv[3])
-max_seconds = int(sys.argv[4])
+fuzz_report_file = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
 
 property_report = json.loads(property_report_file.read_text(encoding="utf-8"))
 schema_version = property_report.get("schema_version")
@@ -104,6 +110,25 @@ executed_tests = property_report.get("executed_tests")
 if not isinstance(executed_tests, list) or not executed_tests:
     raise SystemExit("lifecycle property report must include non-empty executed_tests")
 
+fuzz_report = json.loads(fuzz_report_file.read_text(encoding="utf-8"))
+fuzz_schema_version = fuzz_report.get("schema_version")
+if fuzz_schema_version != "kamn.runtime.input-mutation-contract-report.v1":
+    raise SystemExit("unexpected input mutation report schema")
+if fuzz_report.get("status") != "pass":
+    raise SystemExit("input mutation report status must be pass")
+fuzz_artifact_key = fuzz_report.get("replay_artifact_key")
+if fuzz_artifact_key != "input_mutation_replay:v1":
+    raise SystemExit("unexpected input mutation replay artifact key")
+envelope_test_count = fuzz_report.get("envelope_test_count")
+did_test_count = fuzz_report.get("did_test_count")
+if (
+    not isinstance(envelope_test_count, int)
+    or envelope_test_count <= 0
+    or not isinstance(did_test_count, int)
+    or did_test_count <= 0
+):
+    raise SystemExit("input mutation report must include positive envelope/did test counts")
+
 summary = {
     "schema_version": "kamn.runtime.invariant-fuzz-concurrency-contract-report.v1",
     "status": "pass",
@@ -113,6 +138,9 @@ summary = {
     "property_replay_schema_version": schema_version,
     "property_replay_artifact_key": artifact_key,
     "property_replay_test_count": len(executed_tests),
+    "fuzz_replay_schema_version": fuzz_schema_version,
+    "fuzz_replay_artifact_key": fuzz_artifact_key,
+    "fuzz_replay_test_count": envelope_test_count + did_test_count,
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
     "reason_codes": ["none"],
@@ -156,6 +184,16 @@ if ! grep -Fq "lifecycle_property_replay:v1" "$INVARIANTS_DOC"; then
   exit 1
 fi
 
+if ! grep -Fq "kamn.runtime.input-mutation-contract-report.v1" "$INVARIANTS_DOC"; then
+  echo "expected invariants docs to reference input mutation report schema" >&2
+  exit 1
+fi
+
+if ! grep -Fq "input_mutation_replay:v1" "$INVARIANTS_DOC"; then
+  echo "expected invariants docs to reference input mutation replay artifact key" >&2
+  exit 1
+fi
+
 if ! grep -Fq "KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS" "$PERFORMANCE_DOC"; then
   echo "expected performance benchmarking docs to reference invariant/fuzz/concurrency runtime budget env" >&2
   exit 1
@@ -173,6 +211,16 @@ fi
 
 if ! grep -Fq "lifecycle_property_replay:v1" "$TESTING_STRATEGY_DOC"; then
   echo "expected invariant/fuzz strategy doc to reference lifecycle property replay artifact key" >&2
+  exit 1
+fi
+
+if ! grep -Fq "kamn.runtime.input-mutation-contract-report.v1" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference input mutation report schema" >&2
+  exit 1
+fi
+
+if ! grep -Fq "input_mutation_replay:v1" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference input mutation replay artifact key" >&2
   exit 1
 fi
 
@@ -208,6 +256,11 @@ fi
 
 if ! grep -Fq "KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS" "$TESTING_STRATEGY_DOC"; then
   echo "expected invariant/fuzz strategy doc to reference lifecycle property runtime budget env" >&2
+  exit 1
+fi
+
+if ! grep -Fq "KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference input mutation runtime budget env" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
+++ b/scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
@@ -35,7 +35,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["property_replay_artifact_key"] = "tampered_artifact_key"
+payload["fuzz_replay_artifact_key"] = "tampered_fuzz_artifact_key"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -49,14 +49,14 @@ if [ "$tampered_code" -eq 0 ]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$tampered_output" | grep -Fq "property_replay_artifact_key mismatch"; then
-  echo "expected explicit property replay artifact mismatch policy error" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "fuzz_replay_artifact_key mismatch"; then
+  echo "expected explicit fuzz replay artifact mismatch policy error" >&2
   exit 1
 fi
 
-# Regression: #1360
-if ! printf '%s\n' "$tampered_output" | grep -Fq "lifecycle_property_replay:v1"; then
-  echo "expected required property replay artifact key marker in policy regression path" >&2
+# Regression: #1361
+if ! printf '%s\n' "$tampered_output" | grep -Fq "input_mutation_replay:v1"; then
+  echo "expected required fuzz replay artifact key marker in policy regression path" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_input_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_input_mutation_contract_lane.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_input_mutation_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$CONTRACT_LANE" ]; then
   echo "expected runtime input mutation contract lane script to be executable" >&2
@@ -39,10 +41,30 @@ if ! grep -q "KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP" "$CONTRACT_LANE"; then
   exit 1
 fi
 
-lane_output="$(bash "$CONTRACT_LANE")"
+report_file="$TMP_DIR/input-mutation-contract-report.json"
+lane_output="$(bash "$CONTRACT_LANE" --output-json "$report_file")"
 if ! printf '%s\n' "$lane_output" | grep -q "runtime input mutation contract lane tests passed."; then
   echo "expected runtime input mutation contract lane success marker" >&2
   exit 1
 fi
+
+if ! printf '%s\n' "$lane_output" | grep -q "runtime_input_mutation_contract_report=$report_file"; then
+  echo "expected runtime input mutation contract lane report path marker" >&2
+  exit 1
+fi
+
+python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["schema_version"] == "kamn.runtime.input-mutation-contract-report.v1"
+assert report["status"] == "pass"
+assert report["replay_artifact_key"] == "input_mutation_replay:v1"
+assert report["reason_codes"] == ["none"]
+assert report["envelope_test_count"] >= 5
+assert report["did_test_count"] >= 5
+PY
 
 echo "runtime input mutation contract lane script tests passed."

--- a/scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
+++ b/scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
@@ -57,6 +57,9 @@ assert report["concurrency_lane_status"] == "pass"
 assert report["property_replay_schema_version"] == "kamn.runtime.lifecycle-property-contract-report.v1"
 assert report["property_replay_artifact_key"] == "lifecycle_property_replay:v1"
 assert report["property_replay_test_count"] >= 12
+assert report["fuzz_replay_schema_version"] == "kamn.runtime.input-mutation-contract-report.v1"
+assert report["fuzz_replay_artifact_key"] == "input_mutation_replay:v1"
+assert report["fuzz_replay_test_count"] >= 10
 # Regression: #897
 assert report["reason_codes"] == ["none"]
 PY


### PR DESCRIPTION
## Summary
Adds bounded fuzz replay artifact contracts for the input-mutation lane and threads that metadata through the combined invariant/fuzz/concurrency report + policy checker. This makes malformed-envelope/DID fuzz evidence replayable and fail-closed under explicit schema/key/count checks.

## Changes
- `scripts/runtime/run_input_mutation_contract_lane.sh`
  - Added optional `--output-json` contract output.
  - Added schema `kamn.runtime.input-mutation-contract-report.v1` and replay key `input_mutation_replay:v1`.
  - Added deterministic test inventory/count fields and bounded runtime budget env `KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS`.
- `scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh`
  - Consumes mutation lane report and emits:
    - `fuzz_replay_schema_version`
    - `fuzz_replay_artifact_key`
    - `fuzz_replay_test_count`
- `scripts/runtime/check_invariant_fuzz_concurrency_policy.sh`
  - Enforces fuzz replay schema/key/count contract fields.
- Updated runtime contract tests:
  - `scripts/runtime/test_run_input_mutation_contract_lane.sh`
  - `scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh`
  - `scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh`
- Updated docs + docs-contract assertions:
  - `docs/testing/invariant-and-fuzz-strategy.md`
  - `docs/foundation/invariants.md`
  - `crates/kamn-core/tests/invariants_docs.rs`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands and failing outcomes before implementation:
```bash
bash scripts/runtime/test_run_input_mutation_contract_lane.sh
# expected runtime input mutation contract lane report path marker

bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
# KeyError: 'fuzz_replay_schema_version'

bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
# expected tampered invariant/fuzz/concurrency report to fail policy checker

cargo test -p kamn-core --test invariants_docs
# assertion failed: DOC.contains("kamn.runtime.input-mutation-contract-report.v1")
```

### 🟢 Green Phase
```bash
bash scripts/runtime/test_run_input_mutation_contract_lane.sh
bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
cargo test -p kamn-core --test invariants_docs
```
All pass after implementation.

### 🔁 Regression
```bash
bash scripts/ci/test_select_targets.sh
cargo fmt --check
cargo clippy -p kamn-core --all-targets -- -D warnings
```
All pass.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test invariants_docs` updated markers | |
| Functional   | ✅ | `scripts/runtime/test_run_input_mutation_contract_lane.sh` report schema/key/count checks | |
| Integration  | ✅ | `scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh`, `scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh` | |
| Regression   | ✅ | Red→Green drift checks + `bash scripts/ci/test_select_targets.sh` | |
| Performance  | N/A | | No throughput target changes; bounded runtime env contracts only. |

## Risks & Rollback
- Risk: low/medium; policy strictness increases and will fail closed on fuzz replay metadata drift.
- Rollback: revert this PR to restore prior fuzz metadata contract behavior.

## Documentation Updates
- `docs/testing/invariant-and-fuzz-strategy.md`
- `docs/foundation/invariants.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1361
