### PR TITLE
feat(runtime): add concurrency replay artifact contracts (#1363)

### DIFF
--- a/crates/kamn-core/tests/invariants_docs.rs
+++ b/crates/kamn-core/tests/invariants_docs.rs
@@ -10,6 +10,8 @@ fn doc_contains_runtime_invariant_harness_coverage_contract() {
     assert!(DOC.contains("kamn.runtime.input-mutation-contract-report.v1"));
     assert!(DOC.contains("input_mutation_replay:v1"));
     assert!(DOC.contains("run_concurrency_state_mutation_contract_lane.sh"));
+    assert!(DOC.contains("kamn.runtime.concurrency-mutation-contract-report.v1"));
+    assert!(DOC.contains("concurrency_mutation_replay:v1"));
     assert!(DOC.contains("run_invariant_fuzz_concurrency_contract_lane.sh"));
     assert!(DOC.contains("check_invariant_fuzz_concurrency_policy.sh"));
     assert!(DOC.contains("kamn.runtime.invariant-fuzz-concurrency-contract-report.v1"));

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -44,6 +44,11 @@ This document defines the canonical transaction invariant catalog and error taxo
   - route via `KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP=true` when running `run_input_mutation_contract_lane.sh`.
 - Concurrency state-mutation lane:
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
+  - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh --output-json /tmp/concurrency-mutation-contract-report.json`
+- Concurrency mutation report schema:
+  - `kamn.runtime.concurrency-mutation-contract-report.v1`
+- Concurrency mutation replay artifact key:
+  - `concurrency_mutation_replay:v1`
 - Combined bounded lane with evidence output:
   - `bash scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh --output-json /tmp/invariant-fuzz-concurrency-contract-report.json`
 - Combined lane policy checker:
@@ -54,6 +59,8 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS` (default `120`)
 - Input mutation lane runtime budget env:
   - `KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS` (default `120`)
+- Concurrency mutation lane runtime budget env:
+  - `KAMN_RUNTIME_CONCURRENCY_MUTATION_MAX_SECONDS` (default `120`)
 
 ## Dispute/Refund Property and Concurrency Contracts (Issue #904)
 - Property + replay trace contract lane:

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -19,6 +19,7 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh --output-json /tmp/input-mutation-contract-report.json`
 - Concurrency race lane:
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
+  - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh --output-json /tmp/concurrency-mutation-contract-report.json`
 - Combined contract lane:
   - `bash scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh --output-json /tmp/invariant-fuzz-concurrency-contract-report.json`
 - Combined policy checker:
@@ -33,7 +34,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   fail-closed reason signatures and emit replay metadata artifact key
   `input_mutation_replay:v1`.
 - Concurrency lanes use replay fixtures and deterministic round-based checks to
-  guard winner exclusivity and terminal-state safety.
+  guard winner exclusivity and terminal-state safety, and emit replay metadata
+  artifact key `concurrency_mutation_replay:v1`.
 
 ## Evidence and Policy Contracts
 
@@ -45,6 +47,10 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `kamn.runtime.input-mutation-contract-report.v1`
 - Input mutation replay artifact key:
   - `input_mutation_replay:v1`
+- Concurrency mutation report schema:
+  - `kamn.runtime.concurrency-mutation-contract-report.v1`
+- Concurrency mutation replay artifact key:
+  - `concurrency_mutation_replay:v1`
 - Combined lane report schema:
   - `kamn.runtime.invariant-fuzz-concurrency-contract-report.v1`
 - Required summary fields:
@@ -58,6 +64,9 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `fuzz_replay_schema_version`
   - `fuzz_replay_artifact_key`
   - `fuzz_replay_test_count`
+  - `concurrency_replay_schema_version`
+  - `concurrency_replay_artifact_key`
+  - `concurrency_replay_test_count`
   - `elapsed_seconds`
   - `max_seconds`
   - `reason_codes`
@@ -70,6 +79,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `KAMN_RUNTIME_LIFECYCLE_PROPERTY_MAX_SECONDS` (default `120`)
 - Input mutation lane runtime budget env:
   - `KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS` (default `120`)
+- Concurrency mutation lane runtime budget env:
+  - `KAMN_RUNTIME_CONCURRENCY_MUTATION_MAX_SECONDS` (default `120`)
 - Combined lane runtime budget env:
   - `KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS` (default `180`)
 - ZK witness mutation routing control:

--- a/scripts/runtime/check_invariant_fuzz_concurrency_policy.sh
+++ b/scripts/runtime/check_invariant_fuzz_concurrency_policy.sh
@@ -72,6 +72,9 @@ required_fields = (
     "fuzz_replay_schema_version",
     "fuzz_replay_artifact_key",
     "fuzz_replay_test_count",
+    "concurrency_replay_schema_version",
+    "concurrency_replay_artifact_key",
+    "concurrency_replay_test_count",
     "elapsed_seconds",
     "max_seconds",
     "reason_codes",
@@ -130,6 +133,26 @@ if fuzz_replay_artifact_key != expected_fuzz_replay_artifact_key:
 fuzz_replay_test_count = payload["fuzz_replay_test_count"]
 if not isinstance(fuzz_replay_test_count, int) or fuzz_replay_test_count < 10:
     fail("fuzz_replay_test_count must be an integer >= 10")
+
+concurrency_replay_schema_version = payload["concurrency_replay_schema_version"]
+expected_concurrency_replay_schema_version = "kamn.runtime.concurrency-mutation-contract-report.v1"
+if concurrency_replay_schema_version != expected_concurrency_replay_schema_version:
+    fail(
+        "concurrency_replay_schema_version mismatch: "
+        f"expected {expected_concurrency_replay_schema_version}, found {concurrency_replay_schema_version}"
+    )
+
+concurrency_replay_artifact_key = payload["concurrency_replay_artifact_key"]
+expected_concurrency_replay_artifact_key = "concurrency_mutation_replay:v1"
+if concurrency_replay_artifact_key != expected_concurrency_replay_artifact_key:
+    fail(
+        "concurrency_replay_artifact_key mismatch: "
+        f"expected {expected_concurrency_replay_artifact_key}, found {concurrency_replay_artifact_key}"
+    )
+
+concurrency_replay_test_count = payload["concurrency_replay_test_count"]
+if not isinstance(concurrency_replay_test_count, int) or concurrency_replay_test_count < 12:
+    fail("concurrency_replay_test_count must be an integer >= 12")
 
 elapsed_seconds = payload["elapsed_seconds"]
 max_seconds = payload["max_seconds"]

--- a/scripts/runtime/run_concurrency_state_mutation_contract_lane.sh
+++ b/scripts/runtime/run_concurrency_state_mutation_contract_lane.sh
@@ -1,23 +1,112 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh \
+    [--output-json <path>]
+USAGE
+}
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-# Keep concurrency lane deterministic and bounded for PR-fast coverage.
-cargo test -p kamn-core --test concurrency_state_mutation unit_concurrency_replay_fixture_entries_are_valid -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation task_accept_concurrency_has_single_winner_and_consistent_state -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation task_submit_concurrency_rejects_duplicate_task_id_deterministically -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation peer_lifecycle_concurrency_preserves_transition_contract_across_phases -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation functional_task_accept_concurrency_replay_fixture_preserves_invariants -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation integration_peer_lifecycle_concurrency_replay_is_deterministic_across_rounds -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation functional_escrow_dispute_refund_concurrency_replay_fixture_preserves_terminal_snapshot -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation regression_concurrency_accept_race_never_allows_multiple_winners -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation regression_escrow_refund_race_never_allows_multiple_refund_winners -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation performance_concurrency_state_mutation_contract_lane_stays_within_budget -- --exact >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation performance_escrow_dispute_refund_concurrency_lane_stays_within_budget -- --exact >/dev/null
+output_json=""
+max_seconds="${KAMN_RUNTIME_CONCURRENCY_MUTATION_MAX_SECONDS:-120}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "KAMN_RUNTIME_CONCURRENCY_MUTATION_MAX_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+
+declare -a concurrency_cases=(
+  "unit_concurrency_replay_fixture_entries_are_valid"
+  "task_accept_concurrency_has_single_winner_and_consistent_state"
+  "task_submit_concurrency_rejects_duplicate_task_id_deterministically"
+  "peer_lifecycle_concurrency_preserves_transition_contract_across_phases"
+  "functional_task_accept_concurrency_replay_fixture_preserves_invariants"
+  "integration_peer_lifecycle_concurrency_replay_is_deterministic_across_rounds"
+  "functional_escrow_dispute_refund_concurrency_replay_fixture_preserves_terminal_snapshot"
+  "integration_escrow_dispute_refund_concurrency_replay_is_deterministic_across_rounds"
+  "regression_concurrency_accept_race_never_allows_multiple_winners"
+  "regression_escrow_refund_race_never_allows_multiple_refund_winners"
+  "performance_concurrency_state_mutation_contract_lane_stays_within_budget"
+  "performance_escrow_dispute_refund_concurrency_lane_stays_within_budget"
+)
+
+start_epoch="$(date +%s)"
+
+for case_name in "${concurrency_cases[@]}"; do
+  cargo test -p kamn-core --test concurrency_state_mutation "$case_name" -- --exact >/dev/null
+done
 
 cargo test -p kamn-core --test runtime_network_docs doc_contains_concurrency_harness_contract_rules -- --exact >/dev/null
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "runtime concurrency state mutation lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+if [[ -n "$output_json" ]]; then
+  mkdir -p "$(dirname "$output_json")"
+  concurrency_cases_file="$(mktemp)"
+  trap 'rm -f "$concurrency_cases_file"' EXIT
+  printf '%s\n' "${concurrency_cases[@]}" >"$concurrency_cases_file"
+
+  python3 - \
+    "$output_json" \
+    "$concurrency_cases_file" \
+    "$elapsed_seconds" \
+    "$max_seconds" <<'PY'
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1])
+cases_path = pathlib.Path(sys.argv[2])
+elapsed_seconds = int(sys.argv[3])
+max_seconds = int(sys.argv[4])
+
+cases = [
+    line.strip()
+    for line in cases_path.read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+
+payload = {
+    "schema_version": "kamn.runtime.concurrency-mutation-contract-report.v1",
+    "status": "pass",
+    "suite": "concurrency_state_mutation_contract_lane",
+    "replay_artifact_key": "concurrency_mutation_replay:v1",
+    "executed_tests": cases,
+    "test_count": len(cases),
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "reason_codes": ["none"],
+}
+output_path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+PY
+
+  echo "runtime_concurrency_mutation_contract_report=$output_json"
+fi
 
 echo "runtime concurrency state mutation contract lane tests passed."

--- a/scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh
+++ b/scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh
@@ -51,6 +51,7 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 property_report="$TMP_DIR/lifecycle-property-contract-report.json"
 fuzz_report="$TMP_DIR/input-mutation-contract-report.json"
+concurrency_report="$TMP_DIR/concurrency-mutation-contract-report.json"
 
 property_output="$(bash "$PROPERTY_LANE" --output-json "$property_report")"
 if ! printf '%s\n' "$property_output" | grep -Fq "runtime lifecycle property contract lane tests passed."; then
@@ -72,9 +73,13 @@ if ! printf '%s\n' "$fuzz_output" | grep -Fq "runtime_input_mutation_contract_re
   exit 1
 fi
 
-concurrency_output="$(bash "$CONCURRENCY_LANE")"
+concurrency_output="$(bash "$CONCURRENCY_LANE" --output-json "$concurrency_report")"
 if ! printf '%s\n' "$concurrency_output" | grep -Fq "runtime concurrency state mutation contract lane tests passed."; then
   echo "expected concurrency state mutation lane success marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$concurrency_output" | grep -Fq "runtime_concurrency_mutation_contract_report=$concurrency_report"; then
+  echo "expected concurrency state mutation lane report marker" >&2
   exit 1
 fi
 
@@ -86,7 +91,7 @@ fi
 
 summary_report="$TMP_DIR/invariant-fuzz-concurrency-contract-report.json"
 
-python3 - "$summary_report" "$property_report" "$fuzz_report" "$elapsed_seconds" "$max_seconds" <<'PY'
+python3 - "$summary_report" "$property_report" "$fuzz_report" "$concurrency_report" "$elapsed_seconds" "$max_seconds" <<'PY'
 import json
 import pathlib
 import sys
@@ -94,8 +99,9 @@ import sys
 report_file = pathlib.Path(sys.argv[1])
 property_report_file = pathlib.Path(sys.argv[2])
 fuzz_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
+concurrency_report_file = pathlib.Path(sys.argv[4])
+elapsed_seconds = int(sys.argv[5])
+max_seconds = int(sys.argv[6])
 
 property_report = json.loads(property_report_file.read_text(encoding="utf-8"))
 schema_version = property_report.get("schema_version")
@@ -129,6 +135,19 @@ if (
 ):
     raise SystemExit("input mutation report must include positive envelope/did test counts")
 
+concurrency_report = json.loads(concurrency_report_file.read_text(encoding="utf-8"))
+concurrency_schema_version = concurrency_report.get("schema_version")
+if concurrency_schema_version != "kamn.runtime.concurrency-mutation-contract-report.v1":
+    raise SystemExit("unexpected concurrency mutation report schema")
+if concurrency_report.get("status") != "pass":
+    raise SystemExit("concurrency mutation report status must be pass")
+concurrency_artifact_key = concurrency_report.get("replay_artifact_key")
+if concurrency_artifact_key != "concurrency_mutation_replay:v1":
+    raise SystemExit("unexpected concurrency mutation replay artifact key")
+concurrency_test_count = concurrency_report.get("test_count")
+if not isinstance(concurrency_test_count, int) or concurrency_test_count <= 0:
+    raise SystemExit("concurrency mutation report must include positive test_count")
+
 summary = {
     "schema_version": "kamn.runtime.invariant-fuzz-concurrency-contract-report.v1",
     "status": "pass",
@@ -141,6 +160,9 @@ summary = {
     "fuzz_replay_schema_version": fuzz_schema_version,
     "fuzz_replay_artifact_key": fuzz_artifact_key,
     "fuzz_replay_test_count": envelope_test_count + did_test_count,
+    "concurrency_replay_schema_version": concurrency_schema_version,
+    "concurrency_replay_artifact_key": concurrency_artifact_key,
+    "concurrency_replay_test_count": concurrency_test_count,
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
     "reason_codes": ["none"],
@@ -194,6 +216,16 @@ if ! grep -Fq "input_mutation_replay:v1" "$INVARIANTS_DOC"; then
   exit 1
 fi
 
+if ! grep -Fq "kamn.runtime.concurrency-mutation-contract-report.v1" "$INVARIANTS_DOC"; then
+  echo "expected invariants docs to reference concurrency mutation report schema" >&2
+  exit 1
+fi
+
+if ! grep -Fq "concurrency_mutation_replay:v1" "$INVARIANTS_DOC"; then
+  echo "expected invariants docs to reference concurrency mutation replay artifact key" >&2
+  exit 1
+fi
+
 if ! grep -Fq "KAMN_RUNTIME_INVARIANT_FUZZ_CONCURRENCY_MAX_SECONDS" "$PERFORMANCE_DOC"; then
   echo "expected performance benchmarking docs to reference invariant/fuzz/concurrency runtime budget env" >&2
   exit 1
@@ -221,6 +253,16 @@ fi
 
 if ! grep -Fq "input_mutation_replay:v1" "$TESTING_STRATEGY_DOC"; then
   echo "expected invariant/fuzz strategy doc to reference input mutation replay artifact key" >&2
+  exit 1
+fi
+
+if ! grep -Fq "kamn.runtime.concurrency-mutation-contract-report.v1" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference concurrency mutation report schema" >&2
+  exit 1
+fi
+
+if ! grep -Fq "concurrency_mutation_replay:v1" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference concurrency mutation replay artifact key" >&2
   exit 1
 fi
 
@@ -261,6 +303,11 @@ fi
 
 if ! grep -Fq "KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS" "$TESTING_STRATEGY_DOC"; then
   echo "expected invariant/fuzz strategy doc to reference input mutation runtime budget env" >&2
+  exit 1
+fi
+
+if ! grep -Fq "KAMN_RUNTIME_CONCURRENCY_MUTATION_MAX_SECONDS" "$TESTING_STRATEGY_DOC"; then
+  echo "expected invariant/fuzz strategy doc to reference concurrency mutation runtime budget env" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
+++ b/scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
@@ -35,7 +35,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["fuzz_replay_artifact_key"] = "tampered_fuzz_artifact_key"
+payload["concurrency_replay_artifact_key"] = "tampered_concurrency_artifact_key"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -49,14 +49,14 @@ if [ "$tampered_code" -eq 0 ]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$tampered_output" | grep -Fq "fuzz_replay_artifact_key mismatch"; then
-  echo "expected explicit fuzz replay artifact mismatch policy error" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "concurrency_replay_artifact_key mismatch"; then
+  echo "expected explicit concurrency replay artifact mismatch policy error" >&2
   exit 1
 fi
 
-# Regression: #1361
-if ! printf '%s\n' "$tampered_output" | grep -Fq "input_mutation_replay:v1"; then
-  echo "expected required fuzz replay artifact key marker in policy regression path" >&2
+# Regression: #1363
+if ! printf '%s\n' "$tampered_output" | grep -Fq "concurrency_mutation_replay:v1"; then
+  echo "expected required concurrency replay artifact key marker in policy regression path" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/runtime/run_concurrency_state_mutation_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/runtime/run_concurrency_state_mutation_deep_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected runtime concurrency state mutation contract lane script to be executable" >&2
@@ -55,11 +57,30 @@ if ! grep -q "performance_escrow_dispute_refund_concurrency_lane_stays_within_bu
   exit 1
 fi
 
-lane_output="$(bash "$FAST_SCRIPT")"
+report_file="$TMP_DIR/concurrency-mutation-contract-report.json"
+lane_output="$(bash "$FAST_SCRIPT" --output-json "$report_file")"
 if ! printf '%s\n' "$lane_output" | grep -q "runtime concurrency state mutation contract lane tests passed."; then
   echo "expected runtime concurrency state mutation contract lane success marker" >&2
   exit 1
 fi
+
+if ! printf '%s\n' "$lane_output" | grep -q "runtime_concurrency_mutation_contract_report=$report_file"; then
+  echo "expected runtime concurrency lane report path marker" >&2
+  exit 1
+fi
+
+python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["schema_version"] == "kamn.runtime.concurrency-mutation-contract-report.v1"
+assert report["status"] == "pass"
+assert report["replay_artifact_key"] == "concurrency_mutation_replay:v1"
+assert report["reason_codes"] == ["none"]
+assert report["test_count"] >= 12
+PY
 
 if ! grep -Fq "run_concurrency_state_mutation_contract_lane.sh" "$DEEP_SCRIPT"; then
   echo "expected deep lane to execute concurrency contract lane baseline first" >&2

--- a/scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
+++ b/scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
@@ -60,6 +60,9 @@ assert report["property_replay_test_count"] >= 12
 assert report["fuzz_replay_schema_version"] == "kamn.runtime.input-mutation-contract-report.v1"
 assert report["fuzz_replay_artifact_key"] == "input_mutation_replay:v1"
 assert report["fuzz_replay_test_count"] >= 10
+assert report["concurrency_replay_schema_version"] == "kamn.runtime.concurrency-mutation-contract-report.v1"
+assert report["concurrency_replay_artifact_key"] == "concurrency_mutation_replay:v1"
+assert report["concurrency_replay_test_count"] >= 12
 # Regression: #897
 assert report["reason_codes"] == ["none"]
 PY


### PR DESCRIPTION
## Summary
Adds deterministic concurrency replay artifact contracts for the concurrency state-mutation lane and threads that metadata into the combined invariant/fuzz/concurrency report and policy checker. This hardens multi-threaded state mutation verification with explicit replay metadata contracts under bounded runtime budgets.

## Changes
- `scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
  - Added optional `--output-json` report output.
  - Added schema `kamn.runtime.concurrency-mutation-contract-report.v1` and replay key `concurrency_mutation_replay:v1`.
  - Added deterministic executed-test inventory/count and bounded runtime env `KAMN_RUNTIME_CONCURRENCY_MUTATION_MAX_SECONDS`.
- `scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh`
  - Consumes concurrency lane report and emits:
    - `concurrency_replay_schema_version`
    - `concurrency_replay_artifact_key`
    - `concurrency_replay_test_count`
- `scripts/runtime/check_invariant_fuzz_concurrency_policy.sh`
  - Enforces concurrency replay schema/key/count fields in fail-closed policy checks.
- Updated runtime contract tests:
  - `scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh`
  - `scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh`
  - `scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh`
- Updated docs + docs-contract assertions:
  - `docs/testing/invariant-and-fuzz-strategy.md`
  - `docs/foundation/invariants.md`
  - `crates/kamn-core/tests/invariants_docs.rs`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands and failing outcomes before implementation:
```bash
bash scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
# expected runtime concurrency lane report path marker

bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
# KeyError: 'concurrency_replay_schema_version'

bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
# expected tampered invariant/fuzz/concurrency report to fail policy checker

cargo test -p kamn-core --test invariants_docs
# assertion failed: DOC.contains("kamn.runtime.concurrency-mutation-contract-report.v1")
```

### 🟢 Green Phase
```bash
bash scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
cargo test -p kamn-core --test invariants_docs
```
All pass after implementation.

### 🔁 Regression
```bash
bash scripts/ci/test_select_targets.sh
cargo fmt --check
cargo clippy -p kamn-core --all-targets -- -D warnings
```
All pass.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test invariants_docs` marker assertions | |
| Functional   | ✅ | `scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh` report schema/key/count checks | |
| Integration  | ✅ | `scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh`, `scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh` | |
| Regression   | ✅ | Red→Green metadata drift checks + `bash scripts/ci/test_select_targets.sh` | |
| Performance  | N/A | | No throughput target changes; bounded runtime env contracts only. |

## Risks & Rollback
- Risk: low/medium; policy strictness increases and fails closed on concurrency replay metadata drift.
- Rollback: revert this PR to restore prior concurrency metadata contract behavior.

## Documentation Updates
- `docs/testing/invariant-and-fuzz-strategy.md`
- `docs/foundation/invariants.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1363
