### PR TITLE
feat(sdk): enforce localhost session admission and replay guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ bash scripts/sdk/run_localhost_signed_demo.sh --output-json /tmp/localhost-signe
 bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario success
 bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario signature-mismatch
 bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario timeout --timeout-seconds 1
+bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario replay-nonce
+bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario admission-guards
 ```
 
 ### Run Localhost Bridge Relay Demo Lane
@@ -145,6 +147,11 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 # success_evidence_key=localhost_signed_integration:success:v1
 # signature_mismatch_evidence_key=localhost_signed_integration:signature-mismatch:v1
 # timeout_evidence_key=localhost_signed_integration:timeout:v1
+# replay_nonce_evidence_key=localhost_signed_integration:replay-nonce:v1
+# admission_guards_evidence_key=localhost_signed_integration:admission-guards:v1
+# replay_nonce_reason_code=replay_nonce_detected
+# admission_guards_reason_code=session_admission_guards_detected
+# admission_reason_codes=["stale_session_detected","unauthorized_sender_detected","malformed_payload_detected"]
 ```
 
 CI fast-gate routes this lane when selector output

--- a/crates/kamn-sdk/examples/localhost_signed_listener.rs
+++ b/crates/kamn-sdk/examples/localhost_signed_listener.rs
@@ -1,20 +1,25 @@
 use kamn_sdk::AgentDid;
 use std::env;
+use std::fs;
 use std::io::Read;
 use std::net::TcpListener;
+use std::path::Path;
 
 #[derive(Debug, Clone)]
 struct ListenerConfig {
     addr: String,
     expected_from: String,
     expected_to: String,
+    expected_session_id: String,
     expected_state_hash: String,
+    nonce_state_file: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 struct WireMessage {
     from: String,
     to: String,
+    session_id: String,
     nonce: u64,
     state_hash: String,
     body: String,
@@ -26,7 +31,9 @@ fn parse_args() -> Result<ListenerConfig, String> {
         addr: "127.0.0.1:17879".to_owned(),
         expected_from: "kamn:did:agent:sender-1".to_owned(),
         expected_to: "kamn:did:agent:listener-1".to_owned(),
+        expected_session_id: "session:localhost-demo:v1".to_owned(),
         expected_state_hash: "state:localhost-demo".to_owned(),
+        nonce_state_file: None,
     };
 
     let mut args = env::args().skip(1);
@@ -38,7 +45,9 @@ fn parse_args() -> Result<ListenerConfig, String> {
             "--addr" => config.addr = value,
             "--expected-from" => config.expected_from = value,
             "--expected-to" => config.expected_to = value,
+            "--expected-session-id" => config.expected_session_id = value,
             "--state-hash" => config.expected_state_hash = value,
+            "--nonce-state-file" => config.nonce_state_file = Some(value),
             other => return Err(format!("unknown argument: {other}")),
         }
     }
@@ -51,12 +60,26 @@ fn parse_args() -> Result<ListenerConfig, String> {
     if config.expected_state_hash.trim().is_empty() {
         return Err("state hash must not be empty".to_owned());
     }
+    if config.expected_session_id.trim().is_empty() {
+        return Err("expected session id must not be empty".to_owned());
+    }
+    if let Some(path) = config.nonce_state_file.as_ref() {
+        if path.trim().is_empty() {
+            return Err("nonce state file path must not be empty".to_owned());
+        }
+    }
     Ok(config)
 }
 
-fn signature_for_fields(from: &str, nonce: u64, state_hash: &str, body: &str) -> String {
+fn signature_for_fields(
+    from: &str,
+    session_id: &str,
+    nonce: u64,
+    state_hash: &str,
+    body: &str,
+) -> String {
     format!(
-        "sig:ed25519:baseline-v1:{from}:{nonce}:{state_hash}:{}",
+        "sig:ed25519:baseline-v1:{from}:{session_id}:{nonce}:{state_hash}:{}",
         body.len()
     )
 }
@@ -64,6 +87,7 @@ fn signature_for_fields(from: &str, nonce: u64, state_hash: &str, body: &str) ->
 fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
     let mut from: Option<String> = None;
     let mut to: Option<String> = None;
+    let mut session_id: Option<String> = None;
     let mut nonce: Option<u64> = None;
     let mut state_hash: Option<String> = None;
     let mut body: Option<String> = None;
@@ -76,6 +100,7 @@ fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
         match key {
             "from" => from = Some(value.to_owned()),
             "to" => to = Some(value.to_owned()),
+            "session_id" => session_id = Some(value.to_owned()),
             "nonce" => {
                 let parsed = value
                     .parse::<u64>()
@@ -92,10 +117,52 @@ fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
     Ok(WireMessage {
         from: from.ok_or_else(|| "wire message missing from".to_owned())?,
         to: to.ok_or_else(|| "wire message missing to".to_owned())?,
+        session_id: session_id.ok_or_else(|| "wire message missing session_id".to_owned())?,
         nonce: nonce.ok_or_else(|| "wire message missing nonce".to_owned())?,
         state_hash: state_hash.ok_or_else(|| "wire message missing state_hash".to_owned())?,
         body: body.ok_or_else(|| "wire message missing body".to_owned())?,
         signature: signature.ok_or_else(|| "wire message missing signature".to_owned())?,
+    })
+}
+
+fn read_highest_nonce(path: &str) -> Result<Option<u64>, String> {
+    let path = Path::new(path);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "failed to read nonce state file {}: {error}",
+            path.display()
+        )
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let nonce = trimmed
+        .parse::<u64>()
+        .map_err(|_| format!("invalid nonce state file {} contents", path.display()))?;
+    Ok(Some(nonce))
+}
+
+fn write_highest_nonce(path: &str, nonce: u64) -> Result<(), String> {
+    let path = Path::new(path);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create nonce state directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    fs::write(path, format!("{nonce}\n")).map_err(|error| {
+        format!(
+            "failed to write nonce state file {}: {error}",
+            path.display()
+        )
     })
 }
 
@@ -135,6 +202,12 @@ fn run() -> Result<(), String> {
             wire.to, config.expected_to
         ));
     }
+    if wire.session_id != config.expected_session_id {
+        return Err(format!(
+            "unexpected session id: found {}, expected {}",
+            wire.session_id, config.expected_session_id
+        ));
+    }
     if wire.state_hash != config.expected_state_hash {
         return Err(format!(
             "unexpected state hash: found {}, expected {}",
@@ -142,10 +215,26 @@ fn run() -> Result<(), String> {
         ));
     }
 
-    let expected_signature =
-        signature_for_fields(&wire.from, wire.nonce, &wire.state_hash, &wire.body);
+    let expected_signature = signature_for_fields(
+        &wire.from,
+        &wire.session_id,
+        wire.nonce,
+        &wire.state_hash,
+        &wire.body,
+    );
     if wire.signature != expected_signature {
         return Err("signature verification failed".to_owned());
+    }
+    if let Some(nonce_state_file) = config.nonce_state_file.as_deref() {
+        if let Some(highest_nonce) = read_highest_nonce(nonce_state_file)? {
+            if wire.nonce <= highest_nonce {
+                return Err(format!(
+                    "replay nonce detected: nonce {} <= highest {}",
+                    wire.nonce, highest_nonce
+                ));
+            }
+        }
+        write_highest_nonce(nonce_state_file, wire.nonce)?;
     }
 
     println!("status=ok");
@@ -153,6 +242,7 @@ fn run() -> Result<(), String> {
     println!("peer_addr={peer_addr}");
     println!("from={}", wire.from);
     println!("to={}", wire.to);
+    println!("session_id={}", wire.session_id);
     println!("nonce={}", wire.nonce);
     println!("state_hash={}", wire.state_hash);
     println!("body={}", wire.body);

--- a/crates/kamn-sdk/examples/localhost_signed_sender.rs
+++ b/crates/kamn-sdk/examples/localhost_signed_sender.rs
@@ -10,6 +10,7 @@ struct SenderConfig {
     addr: String,
     from: String,
     to: String,
+    session_id: String,
     nonce: u64,
     state_hash: String,
     body: String,
@@ -20,6 +21,7 @@ fn parse_args() -> Result<SenderConfig, String> {
         addr: "127.0.0.1:17879".to_owned(),
         from: "kamn:did:agent:sender-1".to_owned(),
         to: "kamn:did:agent:listener-1".to_owned(),
+        session_id: "session:localhost-demo:v1".to_owned(),
         nonce: 1,
         state_hash: "state:localhost-demo".to_owned(),
         body: "hello-from-localhost-demo".to_owned(),
@@ -34,6 +36,7 @@ fn parse_args() -> Result<SenderConfig, String> {
             "--addr" => config.addr = value,
             "--from" => config.from = value,
             "--to" => config.to = value,
+            "--session-id" => config.session_id = value,
             "--nonce" => {
                 config.nonce = value
                     .parse::<u64>()
@@ -54,12 +57,21 @@ fn parse_args() -> Result<SenderConfig, String> {
     if config.state_hash.trim().is_empty() {
         return Err("state hash must not be empty".to_owned());
     }
+    if config.session_id.trim().is_empty() {
+        return Err("session id must not be empty".to_owned());
+    }
     Ok(config)
 }
 
-fn signature_for_fields(from: &str, nonce: u64, state_hash: &str, body: &str) -> String {
+fn signature_for_fields(
+    from: &str,
+    session_id: &str,
+    nonce: u64,
+    state_hash: &str,
+    body: &str,
+) -> String {
     format!(
-        "sig:ed25519:baseline-v1:{from}:{nonce}:{state_hash}:{}",
+        "sig:ed25519:baseline-v1:{from}:{session_id}:{nonce}:{state_hash}:{}",
         body.len()
     )
 }
@@ -86,11 +98,22 @@ fn sanitize(value: &str) -> String {
 
 fn run() -> Result<(), String> {
     let config = parse_args()?;
-    let signature =
-        signature_for_fields(&config.from, config.nonce, &config.state_hash, &config.body);
+    let signature = signature_for_fields(
+        &config.from,
+        &config.session_id,
+        config.nonce,
+        &config.state_hash,
+        &config.body,
+    );
     let wire_payload = format!(
-        "from={}\nto={}\nnonce={}\nstate_hash={}\nbody={}\nsignature={}\n",
-        config.from, config.to, config.nonce, config.state_hash, config.body, signature
+        "from={}\nto={}\nsession_id={}\nnonce={}\nstate_hash={}\nbody={}\nsignature={}\n",
+        config.from,
+        config.to,
+        config.session_id,
+        config.nonce,
+        config.state_hash,
+        config.body,
+        signature
     );
 
     let mut stream = connect_with_retry(&config.addr)?;
@@ -108,6 +131,7 @@ fn run() -> Result<(), String> {
     println!("addr={}", config.addr);
     println!("from={}", config.from);
     println!("to={}", config.to);
+    println!("session_id={}", config.session_id);
     println!("nonce={}", config.nonce);
     println!("state_hash={}", config.state_hash);
     println!("body={}", config.body);

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -180,6 +180,8 @@ This document captures the initial runtime-network foundation slice for peer lif
 ## Localhost Signed Integration Evidence Key Contract Rules
 - Harness command:
   - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario success --output-json /tmp/localhost-signed-harness-success.json`
+  - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario replay-nonce --output-json /tmp/localhost-signed-harness-replay.json`
+  - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario admission-guards --output-json /tmp/localhost-signed-harness-admission.json`
 - Contract lane command:
   - `bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed-integration-contract-report.json`
 - Evidence policy checker:
@@ -191,8 +193,17 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `localhost_signed_integration:success:v1`
   - `localhost_signed_integration:signature-mismatch:v1`
   - `localhost_signed_integration:timeout:v1`
+  - `localhost_signed_integration:replay-nonce:v1`
+  - `localhost_signed_integration:admission-guards:v1`
+- Deterministic reason markers:
+  - `signature_mismatch_detected`
+  - `listener_timeout_detected`
+  - `replay_nonce_detected`
+  - `session_admission_guards_detected`
+  - `admission_reason_codes=["stale_session_detected","unauthorized_sender_detected","malformed_payload_detected"]`
 - Regression policy:
   - deterministic evidence keys and reason keys remain fail-closed (`Regression: #899`).
+  - replay nonce and session admission guards remain fail-closed (`Regression: #1382`).
 
 ## Queue Guard Rules
 - `BoundedRuntimeQueue<T>` is FIFO and preserves insertion order.

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -64,6 +64,8 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         success_report = tmp_dir / "success.json"
         signature_report = tmp_dir / "signature-mismatch.json"
         timeout_report = tmp_dir / "timeout.json"
+        replay_report = tmp_dir / "replay-nonce.json"
+        admission_report = tmp_dir / "admission-guards.json"
         summary_report = tmp_dir / "localhost-signed-integration-contract.json"
 
         success_run = subprocess.run(
@@ -170,9 +172,81 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             "expected localhost signed integration timeout scenario evidence key",
         )
 
+        replay_run = subprocess.run(
+            [
+                "bash",
+                str(harness_runner),
+                "--scenario",
+                "replay-nonce",
+                "--output-json",
+                str(replay_report),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if replay_run.returncode != 0:
+            fail((replay_run.stderr or replay_run.stdout or "replay-nonce scenario failed").strip())
+        replay_output = replay_run.stdout
+        _require_contains(
+            replay_output,
+            "status=pass; scenario=replay-nonce;",
+            "expected localhost signed integration replay nonce scenario status marker",
+        )
+        _require_contains(
+            replay_output,
+            "reason_code=replay_nonce_detected;",
+            "expected localhost signed integration replay nonce scenario reason code marker",
+        )
+        _require_contains(
+            replay_output,
+            "evidence_key=localhost_signed_integration:replay-nonce:v1;",
+            "expected localhost signed integration replay nonce scenario evidence key",
+        )
+
+        admission_run = subprocess.run(
+            [
+                "bash",
+                str(harness_runner),
+                "--scenario",
+                "admission-guards",
+                "--output-json",
+                str(admission_report),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if admission_run.returncode != 0:
+            fail(
+                (
+                    admission_run.stderr
+                    or admission_run.stdout
+                    or "admission-guards scenario failed"
+                ).strip()
+            )
+        admission_output = admission_run.stdout
+        _require_contains(
+            admission_output,
+            "status=pass; scenario=admission-guards;",
+            "expected localhost signed integration admission guards scenario status marker",
+        )
+        _require_contains(
+            admission_output,
+            "reason_code=session_admission_guards_detected;",
+            "expected localhost signed integration admission guards scenario reason code marker",
+        )
+        _require_contains(
+            admission_output,
+            "evidence_key=localhost_signed_integration:admission-guards:v1;",
+            "expected localhost signed integration admission guards scenario evidence key",
+        )
+
         success_payload = load_json(success_report)
         signature_payload = load_json(signature_report)
         timeout_payload = load_json(timeout_report)
+        replay_payload = load_json(replay_report)
+        admission_payload = load_json(admission_report)
         summary = {
             "schema_version": "kamn.sdk.localhost-signed.integration-contract.v1",
             "status": "pass",
@@ -180,17 +254,31 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             "success_scenario_status": success_payload["status"],
             "signature_mismatch_scenario_status": signature_payload["status"],
             "timeout_scenario_status": timeout_payload["status"],
+            "replay_nonce_scenario_status": replay_payload["status"],
+            "admission_guards_scenario_status": admission_payload["status"],
             "success_evidence_key": success_payload["evidence_key"],
             "signature_mismatch_evidence_key": signature_payload["evidence_key"],
             "timeout_evidence_key": timeout_payload["evidence_key"],
+            "replay_nonce_evidence_key": replay_payload["evidence_key"],
+            "admission_guards_evidence_key": admission_payload["evidence_key"],
             "signature_mismatch_reason_code": signature_payload["reason_code"],
             "timeout_reason_code": timeout_payload["reason_code"],
+            "replay_nonce_reason_code": replay_payload["reason_code"],
+            "admission_guards_reason_code": admission_payload["reason_code"],
             "success_reason_key": success_payload["reason_key"],
             "signature_mismatch_reason_key": signature_payload["reason_key"],
             "timeout_reason_key": timeout_payload["reason_key"],
+            "replay_nonce_reason_key": replay_payload["reason_key"],
+            "admission_guards_reason_key": admission_payload["reason_key"],
             "success_elapsed_seconds": success_payload["elapsed_seconds"],
             "signature_mismatch_elapsed_seconds": signature_payload["elapsed_seconds"],
             "timeout_elapsed_seconds": timeout_payload["elapsed_seconds"],
+            "replay_nonce_elapsed_seconds": replay_payload["elapsed_seconds"],
+            "admission_guards_elapsed_seconds": admission_payload["elapsed_seconds"],
+            "replay_guard_status": replay_payload["replay_guard_status"],
+            "replay_rejected_nonce": replay_payload["replay_rejected_nonce"],
+            "admission_guard_status": admission_payload["admission_guard_status"],
+            "admission_reason_codes": admission_payload["admission_reason_codes"],
         }
         summary_report.write_text(
             json.dumps(summary, separators=(",", ":")),
@@ -267,6 +355,8 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         print("localhost_signed_integration_success=pass")
         print("localhost_signed_integration_signature_mismatch=pass")
         print("localhost_signed_integration_timeout=pass")
+        print("localhost_signed_integration_replay_nonce=pass")
+        print("localhost_signed_integration_admission_guards=pass")
         print("localhost_signed_integration_policy=ok")
         print("localhost signed integration contract lane tests passed.")
         return 0

--- a/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
+++ b/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
@@ -34,17 +34,31 @@ def check_report(args: argparse.Namespace) -> int:
         "success_scenario_status",
         "signature_mismatch_scenario_status",
         "timeout_scenario_status",
+        "replay_nonce_scenario_status",
+        "admission_guards_scenario_status",
         "success_evidence_key",
         "signature_mismatch_evidence_key",
         "timeout_evidence_key",
+        "replay_nonce_evidence_key",
+        "admission_guards_evidence_key",
         "signature_mismatch_reason_code",
         "timeout_reason_code",
+        "replay_nonce_reason_code",
+        "admission_guards_reason_code",
         "success_reason_key",
         "signature_mismatch_reason_key",
         "timeout_reason_key",
+        "replay_nonce_reason_key",
+        "admission_guards_reason_key",
         "success_elapsed_seconds",
         "signature_mismatch_elapsed_seconds",
         "timeout_elapsed_seconds",
+        "replay_nonce_elapsed_seconds",
+        "admission_guards_elapsed_seconds",
+        "replay_guard_status",
+        "replay_rejected_nonce",
+        "admission_guard_status",
+        "admission_reason_codes",
     )
     for field_name in required_fields:
         if field_name not in payload:
@@ -64,6 +78,8 @@ def check_report(args: argparse.Namespace) -> int:
         "success_scenario_status",
         "signature_mismatch_scenario_status",
         "timeout_scenario_status",
+        "replay_nonce_scenario_status",
+        "admission_guards_scenario_status",
     ):
         if payload[field_name] not in {"pass", "fail"}:
             fail(f"{field_name} must be pass or fail")
@@ -73,6 +89,13 @@ def check_report(args: argparse.Namespace) -> int:
 
     if payload["timeout_reason_code"] != "listener_timeout_detected":
         fail("timeout_reason_code must be listener_timeout_detected")
+    if payload["replay_nonce_reason_code"] != "replay_nonce_detected":
+        fail("replay_nonce_reason_code must be replay_nonce_detected")
+    if payload["admission_guards_reason_code"] != "session_admission_guards_detected":
+        fail(
+            "admission_guards_reason_code must be "
+            "session_admission_guards_detected"
+        )
 
     if payload["success_evidence_key"] != "localhost_signed_integration:success:v1":
         fail("success_evidence_key must be localhost_signed_integration:success:v1")
@@ -88,6 +111,16 @@ def check_report(args: argparse.Namespace) -> int:
 
     if payload["timeout_evidence_key"] != "localhost_signed_integration:timeout:v1":
         fail("timeout_evidence_key must be localhost_signed_integration:timeout:v1")
+    if payload["replay_nonce_evidence_key"] != "localhost_signed_integration:replay-nonce:v1":
+        fail("replay_nonce_evidence_key must be localhost_signed_integration:replay-nonce:v1")
+    if (
+        payload["admission_guards_evidence_key"]
+        != "localhost_signed_integration:admission-guards:v1"
+    ):
+        fail(
+            "admission_guards_evidence_key must be "
+            "localhost_signed_integration:admission-guards:v1"
+        )
 
     if payload["success_reason_key"] != "localhost_signed_integration_reason:none:v1":
         fail("success_reason_key must be localhost_signed_integration_reason:none:v1")
@@ -109,11 +142,29 @@ def check_report(args: argparse.Namespace) -> int:
             "timeout_reason_key must be "
             "localhost_signed_integration_reason:listener_timeout_detected:v1"
         )
+    if (
+        payload["replay_nonce_reason_key"]
+        != "localhost_signed_integration_reason:replay_nonce_detected:v1"
+    ):
+        fail(
+            "replay_nonce_reason_key must be "
+            "localhost_signed_integration_reason:replay_nonce_detected:v1"
+        )
+    if (
+        payload["admission_guards_reason_key"]
+        != "localhost_signed_integration_reason:session_admission_guards_detected:v1"
+    ):
+        fail(
+            "admission_guards_reason_key must be "
+            "localhost_signed_integration_reason:session_admission_guards_detected:v1"
+        )
 
     for field_name in (
         "success_elapsed_seconds",
         "signature_mismatch_elapsed_seconds",
         "timeout_elapsed_seconds",
+        "replay_nonce_elapsed_seconds",
+        "admission_guards_elapsed_seconds",
     ):
         value = payload[field_name]
         if not isinstance(value, int):
@@ -121,12 +172,35 @@ def check_report(args: argparse.Namespace) -> int:
         if value < 0:
             fail(f"{field_name} must be non-negative")
 
+    if payload["replay_guard_status"] != "pass":
+        fail("replay_guard_status must be pass")
+    replay_rejected_nonce = payload["replay_rejected_nonce"]
+    if not isinstance(replay_rejected_nonce, int) or replay_rejected_nonce <= 0:
+        fail("replay_rejected_nonce must be a positive integer")
+
+    if payload["admission_guard_status"] != "pass":
+        fail("admission_guard_status must be pass")
+    expected_admission_reason_codes = [
+        "stale_session_detected",
+        "unauthorized_sender_detected",
+        "malformed_payload_detected",
+    ]
+    if payload["admission_reason_codes"] != expected_admission_reason_codes:
+        fail(
+            "admission_reason_codes must match deterministic sequence: "
+            f"{expected_admission_reason_codes}"
+        )
+
     expected_status = "pass"
     if payload["success_scenario_status"] != "pass":
         expected_status = "fail"
     if payload["signature_mismatch_scenario_status"] != "pass":
         expected_status = "fail"
     if payload["timeout_scenario_status"] != "pass":
+        expected_status = "fail"
+    if payload["replay_nonce_scenario_status"] != "pass":
+        expected_status = "fail"
+    if payload["admission_guards_scenario_status"] != "pass":
         expected_status = "fail"
 
     if status != expected_status:

--- a/scripts/sdk/localhost_signed_integration_harness_contract.py
+++ b/scripts/sdk/localhost_signed_integration_harness_contract.py
@@ -21,8 +21,12 @@ from framework.contract_framework import ContractError, fail, write_json  # noqa
 
 FROM_DID = "kamn:did:agent:sender-1"
 TO_DID = "kamn:did:agent:listener-1"
+SESSION_ID = "session:localhost-demo:v1"
 STATE_HASH = "state:localhost-demo"
 BODY = "hello-from-localhost-demo"
+NONCE_REPLAY_TEST_VALUE = 7
+UNAUTHORIZED_FROM_DID = "kamn:did:agent:rogue-1"
+STALE_STATE_HASH = "state:localhost-stale"
 
 
 class ScenarioFailure(Exception):
@@ -59,10 +63,28 @@ class HarnessContext:
                 pass
         shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
-    def emit_report(self, status: str, reason_code: str) -> None:
+    def emit_report(
+        self,
+        status: str,
+        reason_code: str,
+        extra_fields: dict[str, object] | None = None,
+    ) -> None:
         elapsed = self.elapsed_seconds()
         evidence_key = f"localhost_signed_integration:{self.scenario}:v1"
         reason_key = f"localhost_signed_integration_reason:{reason_code}:v1"
+        report: dict[str, object] = {
+            "schema_version": "kamn.sdk.localhost-signed.integration-harness.v1",
+            "status": status,
+            "scenario": self.scenario,
+            "evidence_key": evidence_key,
+            "reason_code": reason_code,
+            "reason_key": reason_key,
+            "addr": self.addr,
+            "timeout_seconds": self.timeout_seconds,
+            "elapsed_seconds": elapsed,
+        }
+        if extra_fields:
+            report.update(extra_fields)
 
         print(
             f"status={status}; scenario={self.scenario}; evidence_key={evidence_key}; "
@@ -70,45 +92,46 @@ class HarnessContext:
         )
 
         if self.output_json:
-            write_json(
-                Path(self.output_json),
-                {
-                    "schema_version": "kamn.sdk.localhost-signed.integration-harness.v1",
-                    "status": status,
-                    "scenario": self.scenario,
-                    "evidence_key": evidence_key,
-                    "reason_code": reason_code,
-                    "reason_key": reason_key,
-                    "addr": self.addr,
-                    "timeout_seconds": self.timeout_seconds,
-                    "elapsed_seconds": elapsed,
-                },
-            )
+            write_json(Path(self.output_json), report)
 
     def fail_with_reason(self, reason_code: str) -> None:
         raise ScenarioFailure(reason_code)
 
-    def start_listener(self) -> None:
+    def start_listener(
+        self,
+        *,
+        expected_from: str = FROM_DID,
+        expected_to: str = TO_DID,
+        expected_session_id: str = SESSION_ID,
+        expected_state_hash: str = STATE_HASH,
+        nonce_state_file: Path | None = None,
+    ) -> None:
+        args = [
+            "cargo",
+            "run",
+            "--quiet",
+            "-p",
+            "kamn-sdk",
+            "--example",
+            "localhost_signed_listener",
+            "--",
+            "--addr",
+            self.addr,
+            "--expected-from",
+            expected_from,
+            "--expected-to",
+            expected_to,
+            "--expected-session-id",
+            expected_session_id,
+            "--state-hash",
+            expected_state_hash,
+        ]
+        if nonce_state_file is not None:
+            args.extend(["--nonce-state-file", str(nonce_state_file)])
+
         with self.listener_out.open("w", encoding="utf-8") as listener_stream:
             self.listener_proc = subprocess.Popen(
-                [
-                    "cargo",
-                    "run",
-                    "--quiet",
-                    "-p",
-                    "kamn-sdk",
-                    "--example",
-                    "localhost_signed_listener",
-                    "--",
-                    "--addr",
-                    self.addr,
-                    "--expected-from",
-                    FROM_DID,
-                    "--expected-to",
-                    TO_DID,
-                    "--state-hash",
-                    STATE_HASH,
-                ],
+                args,
                 cwd=ROOT_DIR,
                 stdout=listener_stream,
                 stderr=subprocess.STDOUT,
@@ -128,18 +151,9 @@ class HarnessContext:
 
         return self.listener_proc.returncode or 0
 
-    def send_invalid_signature_payload(self) -> bool:
+    def _send_payload(self, payload: str) -> bool:
         host, port_raw = self.addr.rsplit(":", 1)
         port = int(port_raw)
-        payload = (
-            f"from={FROM_DID}\n"
-            f"to={TO_DID}\n"
-            "nonce=1\n"
-            f"state_hash={STATE_HASH}\n"
-            f"body={BODY}\n"
-            "signature=sig:ed25519:baseline-v1:invalid\n"
-        )
-
         for _ in range(20):
             try:
                 with socket.create_connection((host, port), timeout=1.0) as connection:
@@ -149,8 +163,71 @@ class HarnessContext:
                 time.sleep(0.1)
         return False
 
-    def run_success_scenario(self) -> None:
-        self.start_listener()
+    def _signature_for_fields(
+        self,
+        *,
+        from_did: str,
+        session_id: str,
+        nonce: int,
+        state_hash: str,
+        body: str,
+    ) -> str:
+        return (
+            "sig:ed25519:baseline-v1:"
+            f"{from_did}:{session_id}:{nonce}:{state_hash}:{len(body)}"
+        )
+
+    def _build_wire_payload(
+        self,
+        *,
+        from_did: str,
+        to_did: str,
+        session_id: str,
+        nonce: int,
+        state_hash: str,
+        body: str,
+        signature: str | None = None,
+    ) -> str:
+        signature_value = signature or self._signature_for_fields(
+            from_did=from_did,
+            session_id=session_id,
+            nonce=nonce,
+            state_hash=state_hash,
+            body=body,
+        )
+        payload = (
+            f"from={from_did}\n"
+            f"to={to_did}\n"
+            f"session_id={session_id}\n"
+            f"nonce={nonce}\n"
+            f"state_hash={state_hash}\n"
+            f"body={body}\n"
+            f"signature={signature_value}\n"
+        )
+        return payload
+
+    def send_invalid_signature_payload(self) -> bool:
+        payload = self._build_wire_payload(
+            from_did=FROM_DID,
+            to_did=TO_DID,
+            session_id=SESSION_ID,
+            nonce=1,
+            state_hash=STATE_HASH,
+            body=BODY,
+            signature="sig:ed25519:baseline-v1:invalid",
+        )
+        return self._send_payload(payload)
+
+    def run_sender(
+        self,
+        *,
+        from_did: str = FROM_DID,
+        to_did: str = TO_DID,
+        session_id: str = SESSION_ID,
+        nonce: int = 1,
+        state_hash: str = STATE_HASH,
+        body: str = BODY,
+    ) -> int:
         with self.sender_out.open("w", encoding="utf-8") as sender_stream:
             sender_result = subprocess.run(
                 [
@@ -165,15 +242,17 @@ class HarnessContext:
                     "--addr",
                     self.addr,
                     "--from",
-                    FROM_DID,
+                    from_did,
                     "--to",
-                    TO_DID,
+                    to_did,
+                    "--session-id",
+                    session_id,
                     "--nonce",
-                    "1",
+                    str(nonce),
                     "--state-hash",
-                    STATE_HASH,
+                    state_hash,
                     "--body",
-                    BODY,
+                    body,
                 ],
                 cwd=ROOT_DIR,
                 stdout=sender_stream,
@@ -181,14 +260,30 @@ class HarnessContext:
                 check=False,
                 text=True,
             )
-        if sender_result.returncode != 0:
-            self.fail_with_reason("sender_failed")
+        return sender_result.returncode
 
+    def _require_listener_failure(self, marker: str, failure_reason: str) -> None:
+        listener_text = self.listener_out.read_text(encoding="utf-8")
+        if "status=error" not in listener_text:
+            self.fail_with_reason("listener_error_status_missing")
+        if marker not in listener_text:
+            if "status=ok" in listener_text:
+                self.fail_with_reason(failure_reason)
+            self.fail_with_reason(f"{failure_reason}_not_reported")
+
+    def _wait_listener_success(self) -> None:
         listener_status = self.wait_for_listener()
         if listener_status == 124:
             self.fail_with_reason("listener_timeout")
         if listener_status != 0:
             self.fail_with_reason("listener_failed")
+
+    def run_success_scenario(self) -> None:
+        self.start_listener()
+        if self.run_sender(nonce=1) != 0:
+            self.fail_with_reason("sender_failed")
+
+        self._wait_listener_success()
 
         sender_text = self.sender_out.read_text(encoding="utf-8")
         listener_text = self.listener_out.read_text(encoding="utf-8")
@@ -198,8 +293,20 @@ class HarnessContext:
             self.fail_with_reason("listener_status_missing")
         if "verified=true" not in listener_text:
             self.fail_with_reason("listener_verification_missing")
+        if f"session_id={SESSION_ID}" not in sender_text:
+            self.fail_with_reason("sender_session_id_missing")
+        if f"session_id={SESSION_ID}" not in listener_text:
+            self.fail_with_reason("listener_session_id_missing")
 
-        self.emit_report("pass", "none")
+        self.emit_report(
+            "pass",
+            "none",
+            extra_fields={
+                "signature_guard_status": "pass",
+                "admission_guard_status": "pass",
+                "session_id": SESSION_ID,
+            },
+        )
 
     def run_signature_mismatch_scenario(self) -> None:
         self.start_listener()
@@ -209,16 +316,12 @@ class HarnessContext:
         listener_status = self.wait_for_listener()
         if listener_status == 124:
             self.fail_with_reason("listener_timeout")
-
-        listener_text = self.listener_out.read_text(encoding="utf-8")
-        if "status=error" not in listener_text:
-            self.fail_with_reason("listener_error_status_missing")
-        if "signature verification failed" not in listener_text:
-            if "status=ok" in listener_text:
-                self.fail_with_reason("mismatch_not_detected")
-            self.fail_with_reason("signature_mismatch_not_reported")
-
-        self.emit_report("pass", "signature_mismatch_detected")
+        self._require_listener_failure("signature verification failed", "mismatch_not_detected")
+        self.emit_report(
+            "pass",
+            "signature_mismatch_detected",
+            extra_fields={"signature_guard_status": "pass"},
+        )
 
     def run_timeout_scenario(self) -> None:
         self.start_listener()
@@ -232,6 +335,90 @@ class HarnessContext:
 
         self.emit_report("pass", "listener_timeout_detected")
 
+    def run_replay_nonce_scenario(self) -> None:
+        nonce_state_file = self.tmp_dir / "replay-nonce.state"
+        self.start_listener(nonce_state_file=nonce_state_file)
+        if self.run_sender(nonce=NONCE_REPLAY_TEST_VALUE) != 0:
+            self.fail_with_reason("sender_failed")
+        self._wait_listener_success()
+
+        first_listener_text = self.listener_out.read_text(encoding="utf-8")
+        if "status=ok" not in first_listener_text:
+            self.fail_with_reason("listener_status_missing")
+
+        self.start_listener(nonce_state_file=nonce_state_file)
+        if self.run_sender(nonce=NONCE_REPLAY_TEST_VALUE) != 0:
+            self.fail_with_reason("sender_failed")
+
+        listener_status = self.wait_for_listener()
+        if listener_status == 124:
+            self.fail_with_reason("listener_timeout")
+        self._require_listener_failure("replay nonce detected", "replay_not_detected")
+
+        self.emit_report(
+            "pass",
+            "replay_nonce_detected",
+            extra_fields={
+                "replay_guard_status": "pass",
+                "replay_rejected_nonce": NONCE_REPLAY_TEST_VALUE,
+            },
+        )
+
+    def run_admission_guards_scenario(self) -> None:
+        expected_reason_codes = [
+            "stale_session_detected",
+            "unauthorized_sender_detected",
+            "malformed_payload_detected",
+        ]
+        observed_reason_codes: list[str] = []
+
+        self.start_listener(expected_state_hash=STATE_HASH)
+        if self.run_sender(nonce=3, state_hash=STALE_STATE_HASH) != 0:
+            self.fail_with_reason("sender_failed")
+        listener_status = self.wait_for_listener()
+        if listener_status == 124:
+            self.fail_with_reason("listener_timeout")
+        self._require_listener_failure("unexpected state hash", "stale_session")
+        observed_reason_codes.append("stale_session_detected")
+
+        self.start_listener(expected_from=FROM_DID)
+        if self.run_sender(from_did=UNAUTHORIZED_FROM_DID, nonce=4) != 0:
+            self.fail_with_reason("sender_failed")
+        listener_status = self.wait_for_listener()
+        if listener_status == 124:
+            self.fail_with_reason("listener_timeout")
+        self._require_listener_failure("unexpected sender did", "unauthorized_sender")
+        observed_reason_codes.append("unauthorized_sender_detected")
+
+        self.start_listener()
+        malformed_payload = (
+            f"from={FROM_DID}\n"
+            f"to={TO_DID}\n"
+            f"session_id={SESSION_ID}\n"
+            f"state_hash={STATE_HASH}\n"
+            f"body={BODY}\n"
+            "signature=sig:ed25519:baseline-v1:malformed\n"
+        )
+        if not self._send_payload(malformed_payload):
+            self.fail_with_reason("payload_send_failed")
+        listener_status = self.wait_for_listener()
+        if listener_status == 124:
+            self.fail_with_reason("listener_timeout")
+        self._require_listener_failure("wire message missing nonce", "malformed_payload")
+        observed_reason_codes.append("malformed_payload_detected")
+
+        if observed_reason_codes != expected_reason_codes:
+            self.fail_with_reason("admission_reason_codes_mismatch")
+
+        self.emit_report(
+            "pass",
+            "session_admission_guards_detected",
+            extra_fields={
+                "admission_guard_status": "pass",
+                "admission_reason_codes": observed_reason_codes,
+            },
+        )
+
 
 def _require_positive_int(name: str, raw_value: str) -> int:
     if not raw_value.isdigit() or int(raw_value) <= 0:
@@ -241,8 +428,17 @@ def _require_positive_int(name: str, raw_value: str) -> int:
 
 def run_harness(args: argparse.Namespace) -> int:
     scenario = args.scenario
-    if scenario not in {"success", "signature-mismatch", "timeout"}:
-        fail("scenario must be one of: success, signature-mismatch, timeout")
+    if scenario not in {
+        "success",
+        "signature-mismatch",
+        "timeout",
+        "replay-nonce",
+        "admission-guards",
+    }:
+        fail(
+            "scenario must be one of: success, signature-mismatch, timeout, "
+            "replay-nonce, admission-guards"
+        )
 
     addr = args.addr
     if not addr or ":" not in addr:
@@ -262,8 +458,12 @@ def run_harness(args: argparse.Namespace) -> int:
                 context.run_success_scenario()
             elif scenario == "signature-mismatch":
                 context.run_signature_mismatch_scenario()
-            else:
+            elif scenario == "timeout":
                 context.run_timeout_scenario()
+            elif scenario == "replay-nonce":
+                context.run_replay_nonce_scenario()
+            else:
+                context.run_admission_guards_scenario()
             return 0
         except ScenarioFailure as error:
             context.emit_report("fail", error.reason_code)

--- a/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
+++ b/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
@@ -35,7 +35,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["signature_mismatch_evidence_key"] = "unexpected_evidence_key"
+payload["admission_reason_codes"] = ["tampered_reason_code"]
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -49,14 +49,14 @@ if [ "$tampered_code" -eq 0 ]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$tampered_output" | grep -Fq "signature_mismatch_evidence_key"; then
-  echo "expected explicit signature mismatch evidence-key policy error" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "admission_reason_codes"; then
+  echo "expected explicit admission reason-code policy error" >&2
   exit 1
 fi
 
 # Regression: #880
-if ! printf '%s\n' "$tampered_output" | grep -Fq "localhost_signed_integration:signature-mismatch:v1"; then
-  echo "expected expected evidence-key marker in localhost signed integration policy regression path" >&2
+if ! printf '%s\n' "$tampered_output" | grep -Fq "stale_session_detected"; then
+  echo "expected deterministic admission reason markers in localhost signed integration policy regression path" >&2
   exit 1
 fi
 

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -26,6 +26,8 @@ required_markers=(
   "localhost_signed_integration_success=pass"
   "localhost_signed_integration_signature_mismatch=pass"
   "localhost_signed_integration_timeout=pass"
+  "localhost_signed_integration_replay_nonce=pass"
+  "localhost_signed_integration_admission_guards=pass"
   "localhost_signed_integration_policy=ok"
   "localhost signed integration contract lane tests passed."
 )
@@ -48,6 +50,8 @@ assert report["status"] == "pass"
 assert report["success_scenario_status"] == "pass"
 assert report["signature_mismatch_scenario_status"] == "pass"
 assert report["timeout_scenario_status"] == "pass"
+assert report["replay_nonce_scenario_status"] == "pass"
+assert report["admission_guards_scenario_status"] == "pass"
 assert report["contract_key"] == "localhost_signed_integration_contract:v1"
 assert report["success_evidence_key"] == "localhost_signed_integration:success:v1"
 assert (
@@ -55,6 +59,11 @@ assert (
     == "localhost_signed_integration:signature-mismatch:v1"
 )
 assert report["timeout_evidence_key"] == "localhost_signed_integration:timeout:v1"
+assert report["replay_nonce_evidence_key"] == "localhost_signed_integration:replay-nonce:v1"
+assert (
+    report["admission_guards_evidence_key"]
+    == "localhost_signed_integration:admission-guards:v1"
+)
 assert report["success_reason_key"] == "localhost_signed_integration_reason:none:v1"
 assert (
     report["signature_mismatch_reason_key"]
@@ -64,9 +73,29 @@ assert (
     report["timeout_reason_key"]
     == "localhost_signed_integration_reason:listener_timeout_detected:v1"
 )
+assert (
+    report["replay_nonce_reason_key"]
+    == "localhost_signed_integration_reason:replay_nonce_detected:v1"
+)
+assert (
+    report["admission_guards_reason_key"]
+    == "localhost_signed_integration_reason:session_admission_guards_detected:v1"
+)
 # Regression: #878
 assert report["signature_mismatch_reason_code"] == "signature_mismatch_detected"
 assert report["timeout_reason_code"] == "listener_timeout_detected"
+assert report["replay_nonce_reason_code"] == "replay_nonce_detected"
+assert (
+    report["admission_guards_reason_code"] == "session_admission_guards_detected"
+)
+assert report["replay_guard_status"] == "pass"
+assert report["replay_rejected_nonce"] == 7
+assert report["admission_guard_status"] == "pass"
+assert report["admission_reason_codes"] == [
+    "stale_session_detected",
+    "unauthorized_sender_detected",
+    "malformed_payload_detected",
+]
 PY
 
 if ! grep -Fq "localhost_signed_integration_contract_lane_contract.py" "$LANE_SCRIPT"; then

--- a/scripts/sdk/test_run_localhost_signed_integration_harness.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_harness.sh
@@ -69,7 +69,50 @@ if ! printf '%s\n' "$timeout_output" | grep -Fq "evidence_key=localhost_signed_i
   exit 1
 fi
 
-python3 - "$success_report" "$signature_report" "$timeout_report" <<'PY'
+replay_report="$TMP_DIR/replay-nonce.json"
+replay_output="$(
+  bash "$RUNNER" \
+    --scenario replay-nonce \
+    --output-json "$replay_report"
+)"
+if ! printf '%s\n' "$replay_output" | grep -Fq "status=pass; scenario=replay-nonce;"; then
+  echo "expected replay nonce scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$replay_output" | grep -Fq "reason_code=replay_nonce_detected;"; then
+  echo "expected replay nonce scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$replay_output" | grep -Fq "evidence_key=localhost_signed_integration:replay-nonce:v1;"; then
+  echo "expected replay nonce scenario evidence key from localhost signed integration harness" >&2
+  exit 1
+fi
+
+admission_report="$TMP_DIR/admission-guards.json"
+admission_output="$(
+  bash "$RUNNER" \
+    --scenario admission-guards \
+    --output-json "$admission_report"
+)"
+if ! printf '%s\n' "$admission_output" | grep -Fq "status=pass; scenario=admission-guards;"; then
+  echo "expected admission guards scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$admission_output" | grep -Fq "reason_code=session_admission_guards_detected;"; then
+  echo "expected admission guards scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$admission_output" | grep -Fq "evidence_key=localhost_signed_integration:admission-guards:v1;"; then
+  echo "expected admission guards scenario evidence key from localhost signed integration harness" >&2
+  exit 1
+fi
+
+python3 - \
+  "$success_report" \
+  "$signature_report" \
+  "$timeout_report" \
+  "$replay_report" \
+  "$admission_report" <<'PY'
 import json
 import pathlib
 import sys
@@ -77,6 +120,8 @@ import sys
 success_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 signature_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
 timeout_report = json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8"))
+replay_report = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
+admission_report = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
 
 assert success_report["schema_version"] == "kamn.sdk.localhost-signed.integration-harness.v1"
 assert success_report["status"] == "pass"
@@ -106,6 +151,35 @@ assert timeout_report["evidence_key"] == "localhost_signed_integration:timeout:v
 assert (
     timeout_report["reason_key"]
     == "localhost_signed_integration_reason:listener_timeout_detected:v1"
+)
+
+assert replay_report["status"] == "pass"
+assert replay_report["scenario"] == "replay-nonce"
+assert replay_report["reason_code"] == "replay_nonce_detected"
+assert replay_report["evidence_key"] == "localhost_signed_integration:replay-nonce:v1"
+assert replay_report["replay_guard_status"] == "pass"
+assert replay_report["replay_rejected_nonce"] == 7
+assert (
+    replay_report["reason_key"]
+    == "localhost_signed_integration_reason:replay_nonce_detected:v1"
+)
+
+assert admission_report["status"] == "pass"
+assert admission_report["scenario"] == "admission-guards"
+assert admission_report["reason_code"] == "session_admission_guards_detected"
+assert (
+    admission_report["evidence_key"]
+    == "localhost_signed_integration:admission-guards:v1"
+)
+assert admission_report["admission_guard_status"] == "pass"
+assert admission_report["admission_reason_codes"] == [
+    "stale_session_detected",
+    "unauthorized_sender_detected",
+    "malformed_payload_detected",
+]
+assert (
+    admission_report["reason_key"]
+    == "localhost_signed_integration_reason:session_admission_guards_detected:v1"
 )
 PY
 


### PR DESCRIPTION
Closes #1382
Part of #1379

## Summary
Adds deterministic session admission and replay nonce guards to the localhost signed transport path, and extends the localhost integration lane/policy contracts to enforce those outcomes.

## Changes
- crates/kamn-sdk/examples/localhost_signed_listener.rs: add session_id binding, optional persisted nonce replay guard, and explicit rejection paths.
- crates/kamn-sdk/examples/localhost_signed_sender.rs: include session_id in wire payload/signature generation.
- scripts/sdk/localhost_signed_integration_harness_contract.py: add replay-nonce and admission-guards scenarios with deterministic reason markers.
- scripts/sdk/localhost_signed_integration_contract_lane_contract.py: aggregate replay/admission scenario evidence into contract summary and lane markers.
- scripts/sdk/localhost_signed_integration_evidence_policy_contract.py: enforce new required replay/admission fields and deterministic reason-code sequence.
- scripts/sdk/test_run_localhost_signed_integration_harness.sh: add replay/admission scenario assertions.
- scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh: assert new scenario markers and summary fields.
- scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh: add tamper regression for admission reason policy.
- docs/foundation/runtime-network.md: document replay/session admission contract markers.
- README.md: add replay/admission harness commands and deterministic key/reason markers.

## Risks & Compatibility
- Localhost sender/listener signature payload now includes session_id; scripts/examples using custom raw payloads must include session_id to remain valid.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -p kamn-sdk --examples -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed updated localhost harness/lane/policy scripts and docs contract tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | cargo test -p kamn-sdk |
| Functional  | ✅     | scripts/sdk/test_run_localhost_signed_integration_harness.sh; scripts/sdk/test_run_localhost_signed_demo.sh |
| Integration | ✅     | scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh; scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh |
| Regression  | ✅     | tamper + deterministic reason-key enforcement, runtime/readme docs contract tests |

### Commands run
- cargo fmt --check
- cargo clippy -p kamn-sdk --examples -- -D warnings
- cargo test -p kamn-sdk
- bash scripts/sdk/test_run_localhost_signed_integration_harness.sh
- bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
- bash scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
- bash scripts/sdk/test_run_localhost_signed_demo.sh
- cargo test -p kamn-core --test runtime_network_docs
- cargo test -p kamn-core --test live_network_wave_docs
- cargo test -p kamn-core --test ci_strategy_docs
