### PR TITLE
feat(sdk): enforce localhost fixture and final-decision schema contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,13 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 # timeout_evidence_key=localhost_signed_integration:timeout:v1
 # replay_nonce_evidence_key=localhost_signed_integration:replay-nonce:v1
 # admission_guards_evidence_key=localhost_signed_integration:admission-guards:v1
+# final_decision=GO
+# scenario_fixture_schema_version=kamn.sdk.localhost-signed.integration-fixtures.v1
+# scenario_fixture_ids=["success-v1","signature-mismatch-v1","timeout-v1"]
 # replay_nonce_reason_code=replay_nonce_detected
 # admission_guards_reason_code=session_admission_guards_detected
 # admission_reason_codes=["stale_session_detected","unauthorized_sender_detected","malformed_payload_detected"]
+# fixture_file=fixtures/runtime/localhost_signed_integration_cases.json
 ```
 
 CI fast-gate routes this lane when selector output

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -188,6 +188,9 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json`
 - Contract report schema:
   - `kamn.sdk.localhost-signed.integration-contract.v1`
+- Deterministic fixture corpus:
+  - `fixtures/runtime/localhost_signed_integration_cases.json`
+  - `kamn.sdk.localhost-signed.integration-fixtures.v1`
 - Deterministic keys:
   - `localhost_signed_integration_contract:v1`
   - `localhost_signed_integration:success:v1`
@@ -201,6 +204,7 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `replay_nonce_detected`
   - `session_admission_guards_detected`
   - `admission_reason_codes=["stale_session_detected","unauthorized_sender_detected","malformed_payload_detected"]`
+  - `final_decision=GO` for pass reports
 - Regression policy:
   - deterministic evidence keys and reason keys remain fail-closed (`Regression: #899`).
   - replay nonce and session admission guards remain fail-closed (`Regression: #1382`).

--- a/fixtures/runtime/localhost_signed_integration_cases.json
+++ b/fixtures/runtime/localhost_signed_integration_cases.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "kamn.sdk.localhost-signed.integration-fixtures.v1",
+  "scenario_ids": [
+    "success-v1",
+    "signature-mismatch-v1",
+    "timeout-v1"
+  ],
+  "scenarios": [
+    {
+      "id": "success-v1",
+      "scenario": "success",
+      "expected_status": "pass",
+      "expected_reason_code": "none",
+      "expected_evidence_key": "localhost_signed_integration:success:v1",
+      "expected_reason_key": "localhost_signed_integration_reason:none:v1"
+    },
+    {
+      "id": "signature-mismatch-v1",
+      "scenario": "signature-mismatch",
+      "expected_status": "pass",
+      "expected_reason_code": "signature_mismatch_detected",
+      "expected_evidence_key": "localhost_signed_integration:signature-mismatch:v1",
+      "expected_reason_key": "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+    },
+    {
+      "id": "timeout-v1",
+      "scenario": "timeout",
+      "expected_status": "pass",
+      "expected_reason_code": "listener_timeout_detected",
+      "expected_evidence_key": "localhost_signed_integration:timeout:v1",
+      "expected_reason_key": "localhost_signed_integration_reason:listener_timeout_detected:v1"
+    }
+  ]
+}

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -33,11 +33,56 @@ def _require_file_contains(path: Path, marker: str, message: str) -> None:
     _require_contains(path.read_text(encoding="utf-8"), marker, message)
 
 
+def _load_fixture_contract(
+    fixture_file: Path,
+) -> tuple[str, list[str], dict[str, dict[str, str]]]:
+    payload = load_json(fixture_file)
+    schema_version = payload.get("schema_version")
+    if schema_version != "kamn.sdk.localhost-signed.integration-fixtures.v1":
+        fail("unexpected localhost signed integration fixture schema_version")
+
+    scenario_ids = payload.get("scenario_ids")
+    if scenario_ids != ["success-v1", "signature-mismatch-v1", "timeout-v1"]:
+        fail("scenario_ids must match deterministic localhost fixture contract")
+
+    scenarios = payload.get("scenarios")
+    if not isinstance(scenarios, list):
+        fail("fixture scenarios must be an array")
+
+    fixture_by_scenario: dict[str, dict[str, str]] = {}
+    for scenario_entry in scenarios:
+        if not isinstance(scenario_entry, dict):
+            fail("each fixture scenario entry must be an object")
+        scenario_name = scenario_entry.get("scenario")
+        if not isinstance(scenario_name, str) or not scenario_name:
+            fail("fixture scenario entry must include non-empty scenario")
+        normalized_entry: dict[str, str] = {}
+        for field_name in (
+            "id",
+            "expected_status",
+            "expected_reason_code",
+            "expected_evidence_key",
+            "expected_reason_key",
+        ):
+            value = scenario_entry.get(field_name)
+            if not isinstance(value, str) or not value:
+                fail(f"fixture scenario '{scenario_name}' missing field '{field_name}'")
+            normalized_entry[field_name] = value
+        fixture_by_scenario[scenario_name] = normalized_entry
+
+    for required_scenario in ("success", "signature-mismatch", "timeout"):
+        if required_scenario not in fixture_by_scenario:
+            fail(f"fixture scenarios missing required scenario '{required_scenario}'")
+
+    return schema_version, scenario_ids, fixture_by_scenario
+
+
 def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> int:
     output_json = args.output_json
 
     harness_runner = ROOT_DIR / "scripts/sdk/run_localhost_signed_integration_harness.sh"
     policy_checker = ROOT_DIR / "scripts/sdk/check_localhost_signed_integration_evidence_policy.sh"
+    fixture_file = ROOT_DIR / "fixtures/runtime/localhost_signed_integration_cases.json"
     live_network_doc = ROOT_DIR / "docs/planning/live-network-wave.md"
     runtime_network_doc = ROOT_DIR / "docs/foundation/runtime-network.md"
     readme_file = ROOT_DIR / "README.md"
@@ -46,6 +91,8 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         fail("expected localhost signed integration harness runner to be executable")
     if not _is_executable(policy_checker):
         fail("expected localhost signed integration evidence policy checker to be executable")
+    if not fixture_file.is_file():
+        fail("expected localhost signed integration fixture corpus file to exist")
     if not live_network_doc.is_file():
         fail("expected live-network planning doc to exist")
     if not runtime_network_doc.is_file():
@@ -57,6 +104,9 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
     if not max_seconds_raw.isdigit() or int(max_seconds_raw) <= 0:
         fail("contract max seconds must be a positive integer")
     max_seconds = int(max_seconds_raw)
+    fixture_schema_version, scenario_fixture_ids, fixture_by_scenario = _load_fixture_contract(
+        fixture_file
+    )
 
     start_epoch = int(time.time())
     tmp_dir = Path(tempfile.mkdtemp())
@@ -91,12 +141,12 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         )
         _require_contains(
             success_output,
-            "reason_code=none;",
+            f"reason_code={fixture_by_scenario['success']['expected_reason_code']};",
             "expected localhost signed integration success scenario reason code marker",
         )
         _require_contains(
             success_output,
-            "evidence_key=localhost_signed_integration:success:v1;",
+            f"evidence_key={fixture_by_scenario['success']['expected_evidence_key']};",
             "expected localhost signed integration success scenario evidence key",
         )
 
@@ -129,12 +179,12 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         )
         _require_contains(
             signature_output,
-            "reason_code=signature_mismatch_detected;",
+            f"reason_code={fixture_by_scenario['signature-mismatch']['expected_reason_code']};",
             "expected localhost signed integration signature mismatch scenario reason code marker",
         )
         _require_contains(
             signature_output,
-            "evidence_key=localhost_signed_integration:signature-mismatch:v1;",
+            f"evidence_key={fixture_by_scenario['signature-mismatch']['expected_evidence_key']};",
             "expected localhost signed integration signature mismatch scenario evidence key",
         )
 
@@ -163,12 +213,12 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         )
         _require_contains(
             timeout_output,
-            "reason_code=listener_timeout_detected;",
+            f"reason_code={fixture_by_scenario['timeout']['expected_reason_code']};",
             "expected localhost signed integration timeout scenario reason code marker",
         )
         _require_contains(
             timeout_output,
-            "evidence_key=localhost_signed_integration:timeout:v1;",
+            f"evidence_key={fixture_by_scenario['timeout']['expected_evidence_key']};",
             "expected localhost signed integration timeout scenario evidence key",
         )
 
@@ -250,7 +300,10 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         summary = {
             "schema_version": "kamn.sdk.localhost-signed.integration-contract.v1",
             "status": "pass",
+            "final_decision": "GO",
             "contract_key": "localhost_signed_integration_contract:v1",
+            "scenario_fixture_schema_version": fixture_schema_version,
+            "scenario_fixture_ids": scenario_fixture_ids,
             "success_scenario_status": success_payload["status"],
             "signature_mismatch_scenario_status": signature_payload["status"],
             "timeout_scenario_status": timeout_payload["status"],

--- a/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
+++ b/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
@@ -30,7 +30,10 @@ def check_report(args: argparse.Namespace) -> int:
     required_fields = (
         "schema_version",
         "status",
+        "final_decision",
         "contract_key",
+        "scenario_fixture_schema_version",
+        "scenario_fixture_ids",
         "success_scenario_status",
         "signature_mismatch_scenario_status",
         "timeout_scenario_status",
@@ -70,9 +73,29 @@ def check_report(args: argparse.Namespace) -> int:
     status = payload["status"]
     if status not in {"pass", "fail"}:
         fail("status must be pass or fail")
+    final_decision = payload["final_decision"]
+    if final_decision not in {"GO", "NO-GO"}:
+        fail("final_decision must be GO or NO-GO")
 
     if payload["contract_key"] != "localhost_signed_integration_contract:v1":
         fail("contract_key must be localhost_signed_integration_contract:v1")
+    if (
+        payload["scenario_fixture_schema_version"]
+        != "kamn.sdk.localhost-signed.integration-fixtures.v1"
+    ):
+        fail(
+            "scenario_fixture_schema_version must be "
+            "kamn.sdk.localhost-signed.integration-fixtures.v1"
+        )
+    if payload["scenario_fixture_ids"] != [
+        "success-v1",
+        "signature-mismatch-v1",
+        "timeout-v1",
+    ]:
+        fail(
+            "scenario_fixture_ids must match deterministic fixture ids: "
+            "['success-v1', 'signature-mismatch-v1', 'timeout-v1']"
+        )
 
     for field_name in (
         "success_scenario_status",
@@ -208,8 +231,13 @@ def check_report(args: argparse.Namespace) -> int:
             "policy status mismatch: "
             f"expected status={expected_status}, found {status}"
         )
+    expected_decision = "GO" if expected_status == "pass" else "NO-GO"
+    if final_decision != expected_decision:
+        fail(
+            "final_decision mismatch: "
+            f"expected final_decision={expected_decision}, found {final_decision}"
+        )
 
-    final_decision = "GO" if status == "pass" else "NO-GO"
     print("status=ok")
     print(f"report_file={report_path}")
     print(f"final_decision={final_decision}")

--- a/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
+++ b/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
@@ -25,6 +25,10 @@ if ! printf '%s\n' "$go_output" | grep -Fq "status=ok"; then
   echo "expected localhost signed integration evidence policy checker success status" >&2
   exit 1
 fi
+if ! printf '%s\n' "$go_output" | grep -Fq "final_decision=GO"; then
+  echo "expected localhost signed integration evidence policy checker final decision GO marker" >&2
+  exit 1
+fi
 
 tampered_report="$TMP_DIR/localhost-signed-integration-contract-report.tampered.json"
 cp "$report_file" "$tampered_report"
@@ -57,6 +61,34 @@ fi
 # Regression: #880
 if ! printf '%s\n' "$tampered_output" | grep -Fq "stale_session_detected"; then
   echo "expected deterministic admission reason markers in localhost signed integration policy regression path" >&2
+  exit 1
+fi
+
+decision_tampered_report="$TMP_DIR/localhost-signed-integration-contract-report.decision-tampered.json"
+cp "$report_file" "$decision_tampered_report"
+python3 - "$decision_tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+decision_tampered_output="$(bash "$CHECKER" --report-file "$decision_tampered_report" 2>&1)"
+decision_tampered_code=$?
+set -e
+
+if [ "$decision_tampered_code" -eq 0 ]; then
+  echo "expected final-decision drift report to fail policy checker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$decision_tampered_output" | grep -Fq "final_decision"; then
+  echo "expected explicit final decision mismatch error from policy checker" >&2
   exit 1
 fi
 

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LANE_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/sdk/localhost_signed_integration_contract_lane_contract.py"
+FIXTURE_FILE="$ROOT_DIR/fixtures/runtime/localhost_signed_integration_cases.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -14,6 +15,11 @@ fi
 
 if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected localhost signed integration shared contract lane module to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$FIXTURE_FILE" ]; then
+  echo "expected localhost signed integration fixture corpus to exist" >&2
   exit 1
 fi
 
@@ -47,11 +53,21 @@ import sys
 report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert report["schema_version"] == "kamn.sdk.localhost-signed.integration-contract.v1"
 assert report["status"] == "pass"
+assert report["final_decision"] == "GO"
 assert report["success_scenario_status"] == "pass"
 assert report["signature_mismatch_scenario_status"] == "pass"
 assert report["timeout_scenario_status"] == "pass"
 assert report["replay_nonce_scenario_status"] == "pass"
 assert report["admission_guards_scenario_status"] == "pass"
+assert (
+    report["scenario_fixture_schema_version"]
+    == "kamn.sdk.localhost-signed.integration-fixtures.v1"
+)
+assert report["scenario_fixture_ids"] == [
+    "success-v1",
+    "signature-mismatch-v1",
+    "timeout-v1",
+]
 assert report["contract_key"] == "localhost_signed_integration_contract:v1"
 assert report["success_evidence_key"] == "localhost_signed_integration:success:v1"
 assert (
@@ -98,6 +114,20 @@ assert report["admission_reason_codes"] == [
 ]
 PY
 
+python3 - "$FIXTURE_FILE" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["schema_version"] == "kamn.sdk.localhost-signed.integration-fixtures.v1"
+assert payload["scenario_ids"] == [
+    "success-v1",
+    "signature-mismatch-v1",
+    "timeout-v1",
+]
+PY
+
 if ! grep -Fq "localhost_signed_integration_contract_lane_contract.py" "$LANE_SCRIPT"; then
   echo "expected localhost signed integration contract lane wrapper to dispatch shared contract module" >&2
   exit 1
@@ -105,6 +135,11 @@ fi
 
 if ! grep -Fq "check_localhost_signed_integration_evidence_policy.sh" "$SHARED_CONTRACT"; then
   echo "expected localhost signed integration shared contract lane module to enforce evidence policy checker" >&2
+  exit 1
+fi
+
+if ! grep -Fq "fixtures/runtime/localhost_signed_integration_cases.json" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to enforce fixture corpus contract" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #1383
Closes #1390
Part of #1379

## Summary
Adds deterministic fixture-corpus enforcement and explicit final decision schema fields to the localhost signed integration contract lane so policy checks fail closed on report drift.

## Changes
- fixtures/runtime/localhost_signed_integration_cases.json: add stable fixture corpus (scenario IDs + expected reason/evidence keys).
- scripts/sdk/localhost_signed_integration_contract_lane_contract.py: load/enforce fixture contract; use fixture expectations for core scenario markers; emit final_decision and fixture metadata in summary report.
- scripts/sdk/localhost_signed_integration_evidence_policy_contract.py: require and validate final_decision + fixture schema/id fields.
- scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh: add fixture corpus assertions and final_decision/report schema assertions.
- scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh: add final_decision tamper regression check.
- docs/foundation/runtime-network.md: document fixture corpus + final decision marker.
- README.md: document fixture and final-decision report markers.

## Risks & Compatibility
- None.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -p kamn-sdk --examples -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised updated localhost lane/policy tests and docs contract tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | policy/schema validation paths covered via deterministic script tests |
| Functional  | ✅     | scripts/sdk/test_run_localhost_signed_integration_harness.sh; scripts/sdk/test_run_localhost_signed_demo.sh |
| Integration | ✅     | scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh; scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh |
| Regression  | ✅     | explicit final_decision tamper + fixture ID/schema drift guards |

### Commands run
- cargo fmt --check
- cargo clippy -p kamn-sdk --examples -- -D warnings
- bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
- bash scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
- bash scripts/sdk/test_run_localhost_signed_integration_harness.sh
- bash scripts/sdk/test_run_localhost_signed_demo.sh
- cargo test -p kamn-core --test runtime_network_docs
- cargo test -p kamn-core --test live_network_wave_docs
- cargo test -p kamn-core --test ci_strategy_docs
