### PR TITLE
feat(sdk): enforce localhost session expiry guard evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,16 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 # success_evidence_key=localhost_signed_integration:success:v1
 # signature_mismatch_evidence_key=localhost_signed_integration:signature-mismatch:v1
 # timeout_evidence_key=localhost_signed_integration:timeout:v1
+# session_expired_evidence_key=localhost_signed_integration:session-expired:v1
 # replay_nonce_evidence_key=localhost_signed_integration:replay-nonce:v1
 # admission_guards_evidence_key=localhost_signed_integration:admission-guards:v1
 # final_decision=GO
 # scenario_fixture_schema_version=kamn.sdk.localhost-signed.integration-fixtures.v1
 # scenario_fixture_ids=["success-v1","signature-mismatch-v1","timeout-v1"]
+# session_expired_reason_code=session_expired_detected
 # replay_nonce_reason_code=replay_nonce_detected
 # admission_guards_reason_code=session_admission_guards_detected
+# expiry_guard_status=pass
 # admission_reason_codes=["stale_session_detected","unauthorized_sender_detected","malformed_payload_detected"]
 # fixture_file=fixtures/runtime/localhost_signed_integration_cases.json
 ```

--- a/crates/kamn-sdk/examples/localhost_signed_listener.rs
+++ b/crates/kamn-sdk/examples/localhost_signed_listener.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::Read;
 use std::net::TcpListener;
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone)]
 struct ListenerConfig {
@@ -11,6 +12,7 @@ struct ListenerConfig {
     expected_from: String,
     expected_to: String,
     expected_session_id: String,
+    session_max_age_seconds: u64,
     expected_state_hash: String,
     nonce_state_file: Option<String>,
 }
@@ -20,6 +22,7 @@ struct WireMessage {
     from: String,
     to: String,
     session_id: String,
+    session_epoch_seconds: u64,
     nonce: u64,
     state_hash: String,
     body: String,
@@ -32,6 +35,7 @@ fn parse_args() -> Result<ListenerConfig, String> {
         expected_from: "kamn:did:agent:sender-1".to_owned(),
         expected_to: "kamn:did:agent:listener-1".to_owned(),
         expected_session_id: "session:localhost-demo:v1".to_owned(),
+        session_max_age_seconds: 300,
         expected_state_hash: "state:localhost-demo".to_owned(),
         nonce_state_file: None,
     };
@@ -46,6 +50,11 @@ fn parse_args() -> Result<ListenerConfig, String> {
             "--expected-from" => config.expected_from = value,
             "--expected-to" => config.expected_to = value,
             "--expected-session-id" => config.expected_session_id = value,
+            "--session-max-age-seconds" => {
+                config.session_max_age_seconds = value
+                    .parse::<u64>()
+                    .map_err(|_| "session max age seconds must be an unsigned integer".to_owned())?
+            }
             "--state-hash" => config.expected_state_hash = value,
             "--nonce-state-file" => config.nonce_state_file = Some(value),
             other => return Err(format!("unknown argument: {other}")),
@@ -63,6 +72,9 @@ fn parse_args() -> Result<ListenerConfig, String> {
     if config.expected_session_id.trim().is_empty() {
         return Err("expected session id must not be empty".to_owned());
     }
+    if config.session_max_age_seconds == 0 {
+        return Err("session max age seconds must be greater than zero".to_owned());
+    }
     if let Some(path) = config.nonce_state_file.as_ref() {
         if path.trim().is_empty() {
             return Err("nonce state file path must not be empty".to_owned());
@@ -74,12 +86,13 @@ fn parse_args() -> Result<ListenerConfig, String> {
 fn signature_for_fields(
     from: &str,
     session_id: &str,
+    session_epoch_seconds: u64,
     nonce: u64,
     state_hash: &str,
     body: &str,
 ) -> String {
     format!(
-        "sig:ed25519:baseline-v1:{from}:{session_id}:{nonce}:{state_hash}:{}",
+        "sig:ed25519:baseline-v1:{from}:{session_id}:{session_epoch_seconds}:{nonce}:{state_hash}:{}",
         body.len()
     )
 }
@@ -88,6 +101,7 @@ fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
     let mut from: Option<String> = None;
     let mut to: Option<String> = None;
     let mut session_id: Option<String> = None;
+    let mut session_epoch_seconds: Option<u64> = None;
     let mut nonce: Option<u64> = None;
     let mut state_hash: Option<String> = None;
     let mut body: Option<String> = None;
@@ -101,6 +115,12 @@ fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
             "from" => from = Some(value.to_owned()),
             "to" => to = Some(value.to_owned()),
             "session_id" => session_id = Some(value.to_owned()),
+            "session_epoch_seconds" => {
+                let parsed = value
+                    .parse::<u64>()
+                    .map_err(|_| "session epoch seconds must be an unsigned integer".to_owned())?;
+                session_epoch_seconds = Some(parsed);
+            }
             "nonce" => {
                 let parsed = value
                     .parse::<u64>()
@@ -118,6 +138,8 @@ fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
         from: from.ok_or_else(|| "wire message missing from".to_owned())?,
         to: to.ok_or_else(|| "wire message missing to".to_owned())?,
         session_id: session_id.ok_or_else(|| "wire message missing session_id".to_owned())?,
+        session_epoch_seconds: session_epoch_seconds
+            .ok_or_else(|| "wire message missing session_epoch_seconds".to_owned())?,
         nonce: nonce.ok_or_else(|| "wire message missing nonce".to_owned())?,
         state_hash: state_hash.ok_or_else(|| "wire message missing state_hash".to_owned())?,
         body: body.ok_or_else(|| "wire message missing body".to_owned())?,
@@ -170,6 +192,13 @@ fn sanitize(value: &str) -> String {
     value.replace('\n', " ")
 }
 
+fn now_epoch_seconds() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| "failed to compute current epoch seconds".to_owned())
+}
+
 fn run() -> Result<(), String> {
     let config = parse_args()?;
     let listener = TcpListener::bind(&config.addr)
@@ -218,12 +247,27 @@ fn run() -> Result<(), String> {
     let expected_signature = signature_for_fields(
         &wire.from,
         &wire.session_id,
+        wire.session_epoch_seconds,
         wire.nonce,
         &wire.state_hash,
         &wire.body,
     );
     if wire.signature != expected_signature {
         return Err("signature verification failed".to_owned());
+    }
+    let now_epoch = now_epoch_seconds()?;
+    if wire.session_epoch_seconds > now_epoch {
+        return Err(format!(
+            "session epoch is in the future: {} > {}",
+            wire.session_epoch_seconds, now_epoch
+        ));
+    }
+    let session_age_seconds = now_epoch - wire.session_epoch_seconds;
+    if session_age_seconds > config.session_max_age_seconds {
+        return Err(format!(
+            "session expired: age {}s exceeds max_age {}s",
+            session_age_seconds, config.session_max_age_seconds
+        ));
     }
     if let Some(nonce_state_file) = config.nonce_state_file.as_deref() {
         if let Some(highest_nonce) = read_highest_nonce(nonce_state_file)? {
@@ -243,6 +287,7 @@ fn run() -> Result<(), String> {
     println!("from={}", wire.from);
     println!("to={}", wire.to);
     println!("session_id={}", wire.session_id);
+    println!("session_epoch_seconds={}", wire.session_epoch_seconds);
     println!("nonce={}", wire.nonce);
     println!("state_hash={}", wire.state_hash);
     println!("body={}", wire.body);

--- a/crates/kamn-sdk/examples/localhost_signed_sender.rs
+++ b/crates/kamn-sdk/examples/localhost_signed_sender.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::net::{Shutdown, TcpStream};
 use std::thread;
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone)]
 struct SenderConfig {
@@ -11,9 +12,17 @@ struct SenderConfig {
     from: String,
     to: String,
     session_id: String,
+    session_epoch_seconds: u64,
     nonce: u64,
     state_hash: String,
     body: String,
+}
+
+fn now_epoch_seconds() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| "failed to compute session epoch seconds".to_owned())
 }
 
 fn parse_args() -> Result<SenderConfig, String> {
@@ -22,6 +31,7 @@ fn parse_args() -> Result<SenderConfig, String> {
         from: "kamn:did:agent:sender-1".to_owned(),
         to: "kamn:did:agent:listener-1".to_owned(),
         session_id: "session:localhost-demo:v1".to_owned(),
+        session_epoch_seconds: now_epoch_seconds()?,
         nonce: 1,
         state_hash: "state:localhost-demo".to_owned(),
         body: "hello-from-localhost-demo".to_owned(),
@@ -37,6 +47,11 @@ fn parse_args() -> Result<SenderConfig, String> {
             "--from" => config.from = value,
             "--to" => config.to = value,
             "--session-id" => config.session_id = value,
+            "--session-epoch-seconds" => {
+                config.session_epoch_seconds = value
+                    .parse::<u64>()
+                    .map_err(|_| "session epoch seconds must be an unsigned integer".to_owned())?;
+            }
             "--nonce" => {
                 config.nonce = value
                     .parse::<u64>()
@@ -60,18 +75,22 @@ fn parse_args() -> Result<SenderConfig, String> {
     if config.session_id.trim().is_empty() {
         return Err("session id must not be empty".to_owned());
     }
+    if config.session_epoch_seconds == 0 {
+        return Err("session epoch seconds must be greater than zero".to_owned());
+    }
     Ok(config)
 }
 
 fn signature_for_fields(
     from: &str,
     session_id: &str,
+    session_epoch_seconds: u64,
     nonce: u64,
     state_hash: &str,
     body: &str,
 ) -> String {
     format!(
-        "sig:ed25519:baseline-v1:{from}:{session_id}:{nonce}:{state_hash}:{}",
+        "sig:ed25519:baseline-v1:{from}:{session_id}:{session_epoch_seconds}:{nonce}:{state_hash}:{}",
         body.len()
     )
 }
@@ -101,15 +120,17 @@ fn run() -> Result<(), String> {
     let signature = signature_for_fields(
         &config.from,
         &config.session_id,
+        config.session_epoch_seconds,
         config.nonce,
         &config.state_hash,
         &config.body,
     );
     let wire_payload = format!(
-        "from={}\nto={}\nsession_id={}\nnonce={}\nstate_hash={}\nbody={}\nsignature={}\n",
+        "from={}\nto={}\nsession_id={}\nsession_epoch_seconds={}\nnonce={}\nstate_hash={}\nbody={}\nsignature={}\n",
         config.from,
         config.to,
         config.session_id,
+        config.session_epoch_seconds,
         config.nonce,
         config.state_hash,
         config.body,
@@ -132,6 +153,7 @@ fn run() -> Result<(), String> {
     println!("from={}", config.from);
     println!("to={}", config.to);
     println!("session_id={}", config.session_id);
+    println!("session_epoch_seconds={}", config.session_epoch_seconds);
     println!("nonce={}", config.nonce);
     println!("state_hash={}", config.state_hash);
     println!("body={}", config.body);

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -180,6 +180,7 @@ This document captures the initial runtime-network foundation slice for peer lif
 ## Localhost Signed Integration Evidence Key Contract Rules
 - Harness command:
   - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario success --output-json /tmp/localhost-signed-harness-success.json`
+  - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario session-expired --output-json /tmp/localhost-signed-harness-session-expired.json`
   - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario replay-nonce --output-json /tmp/localhost-signed-harness-replay.json`
   - `bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario admission-guards --output-json /tmp/localhost-signed-harness-admission.json`
 - Contract lane command:
@@ -196,15 +197,22 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `localhost_signed_integration:success:v1`
   - `localhost_signed_integration:signature-mismatch:v1`
   - `localhost_signed_integration:timeout:v1`
+  - `localhost_signed_integration:session-expired:v1`
   - `localhost_signed_integration:replay-nonce:v1`
   - `localhost_signed_integration:admission-guards:v1`
 - Deterministic reason markers:
   - `signature_mismatch_detected`
   - `listener_timeout_detected`
+  - `session_expired_detected`
   - `replay_nonce_detected`
   - `session_admission_guards_detected`
+  - `expiry_guard_status=pass`
   - `admission_reason_codes=["stale_session_detected","unauthorized_sender_detected","malformed_payload_detected"]`
   - `final_decision=GO` for pass reports
+- Session nonce/expiry guard rules:
+  - payload must include `session_epoch_seconds`
+  - listener enforces `--session-max-age-seconds` fail-closed admission checks
+  - stale session epochs are rejected before delivery acceptance
 - Regression policy:
   - deterministic evidence keys and reason keys remain fail-closed (`Regression: #899`).
   - replay nonce and session admission guards remain fail-closed (`Regression: #1382`).

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -114,6 +114,7 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         success_report = tmp_dir / "success.json"
         signature_report = tmp_dir / "signature-mismatch.json"
         timeout_report = tmp_dir / "timeout.json"
+        session_expired_report = tmp_dir / "session-expired.json"
         replay_report = tmp_dir / "replay-nonce.json"
         admission_report = tmp_dir / "admission-guards.json"
         summary_report = tmp_dir / "localhost-signed-integration-contract.json"
@@ -222,6 +223,44 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             "expected localhost signed integration timeout scenario evidence key",
         )
 
+        session_expired_run = subprocess.run(
+            [
+                "bash",
+                str(harness_runner),
+                "--scenario",
+                "session-expired",
+                "--output-json",
+                str(session_expired_report),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if session_expired_run.returncode != 0:
+            fail(
+                (
+                    session_expired_run.stderr
+                    or session_expired_run.stdout
+                    or "session-expired scenario failed"
+                ).strip()
+            )
+        session_expired_output = session_expired_run.stdout
+        _require_contains(
+            session_expired_output,
+            "status=pass; scenario=session-expired;",
+            "expected localhost signed integration session-expired scenario status marker",
+        )
+        _require_contains(
+            session_expired_output,
+            "reason_code=session_expired_detected;",
+            "expected localhost signed integration session-expired scenario reason code marker",
+        )
+        _require_contains(
+            session_expired_output,
+            "evidence_key=localhost_signed_integration:session-expired:v1;",
+            "expected localhost signed integration session-expired scenario evidence key",
+        )
+
         replay_run = subprocess.run(
             [
                 "bash",
@@ -295,6 +334,7 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         success_payload = load_json(success_report)
         signature_payload = load_json(signature_report)
         timeout_payload = load_json(timeout_report)
+        session_expired_payload = load_json(session_expired_report)
         replay_payload = load_json(replay_report)
         admission_payload = load_json(admission_report)
         summary = {
@@ -307,27 +347,33 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             "success_scenario_status": success_payload["status"],
             "signature_mismatch_scenario_status": signature_payload["status"],
             "timeout_scenario_status": timeout_payload["status"],
+            "session_expired_scenario_status": session_expired_payload["status"],
             "replay_nonce_scenario_status": replay_payload["status"],
             "admission_guards_scenario_status": admission_payload["status"],
             "success_evidence_key": success_payload["evidence_key"],
             "signature_mismatch_evidence_key": signature_payload["evidence_key"],
             "timeout_evidence_key": timeout_payload["evidence_key"],
+            "session_expired_evidence_key": session_expired_payload["evidence_key"],
             "replay_nonce_evidence_key": replay_payload["evidence_key"],
             "admission_guards_evidence_key": admission_payload["evidence_key"],
             "signature_mismatch_reason_code": signature_payload["reason_code"],
             "timeout_reason_code": timeout_payload["reason_code"],
+            "session_expired_reason_code": session_expired_payload["reason_code"],
             "replay_nonce_reason_code": replay_payload["reason_code"],
             "admission_guards_reason_code": admission_payload["reason_code"],
             "success_reason_key": success_payload["reason_key"],
             "signature_mismatch_reason_key": signature_payload["reason_key"],
             "timeout_reason_key": timeout_payload["reason_key"],
+            "session_expired_reason_key": session_expired_payload["reason_key"],
             "replay_nonce_reason_key": replay_payload["reason_key"],
             "admission_guards_reason_key": admission_payload["reason_key"],
             "success_elapsed_seconds": success_payload["elapsed_seconds"],
             "signature_mismatch_elapsed_seconds": signature_payload["elapsed_seconds"],
             "timeout_elapsed_seconds": timeout_payload["elapsed_seconds"],
+            "session_expired_elapsed_seconds": session_expired_payload["elapsed_seconds"],
             "replay_nonce_elapsed_seconds": replay_payload["elapsed_seconds"],
             "admission_guards_elapsed_seconds": admission_payload["elapsed_seconds"],
+            "expiry_guard_status": session_expired_payload["expiry_guard_status"],
             "replay_guard_status": replay_payload["replay_guard_status"],
             "replay_rejected_nonce": replay_payload["replay_rejected_nonce"],
             "admission_guard_status": admission_payload["admission_guard_status"],
@@ -408,6 +454,7 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         print("localhost_signed_integration_success=pass")
         print("localhost_signed_integration_signature_mismatch=pass")
         print("localhost_signed_integration_timeout=pass")
+        print("localhost_signed_integration_session_expired=pass")
         print("localhost_signed_integration_replay_nonce=pass")
         print("localhost_signed_integration_admission_guards=pass")
         print("localhost_signed_integration_policy=ok")

--- a/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
+++ b/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
@@ -37,27 +37,33 @@ def check_report(args: argparse.Namespace) -> int:
         "success_scenario_status",
         "signature_mismatch_scenario_status",
         "timeout_scenario_status",
+        "session_expired_scenario_status",
         "replay_nonce_scenario_status",
         "admission_guards_scenario_status",
         "success_evidence_key",
         "signature_mismatch_evidence_key",
         "timeout_evidence_key",
+        "session_expired_evidence_key",
         "replay_nonce_evidence_key",
         "admission_guards_evidence_key",
         "signature_mismatch_reason_code",
         "timeout_reason_code",
+        "session_expired_reason_code",
         "replay_nonce_reason_code",
         "admission_guards_reason_code",
         "success_reason_key",
         "signature_mismatch_reason_key",
         "timeout_reason_key",
+        "session_expired_reason_key",
         "replay_nonce_reason_key",
         "admission_guards_reason_key",
         "success_elapsed_seconds",
         "signature_mismatch_elapsed_seconds",
         "timeout_elapsed_seconds",
+        "session_expired_elapsed_seconds",
         "replay_nonce_elapsed_seconds",
         "admission_guards_elapsed_seconds",
+        "expiry_guard_status",
         "replay_guard_status",
         "replay_rejected_nonce",
         "admission_guard_status",
@@ -101,6 +107,7 @@ def check_report(args: argparse.Namespace) -> int:
         "success_scenario_status",
         "signature_mismatch_scenario_status",
         "timeout_scenario_status",
+        "session_expired_scenario_status",
         "replay_nonce_scenario_status",
         "admission_guards_scenario_status",
     ):
@@ -112,6 +119,8 @@ def check_report(args: argparse.Namespace) -> int:
 
     if payload["timeout_reason_code"] != "listener_timeout_detected":
         fail("timeout_reason_code must be listener_timeout_detected")
+    if payload["session_expired_reason_code"] != "session_expired_detected":
+        fail("session_expired_reason_code must be session_expired_detected")
     if payload["replay_nonce_reason_code"] != "replay_nonce_detected":
         fail("replay_nonce_reason_code must be replay_nonce_detected")
     if payload["admission_guards_reason_code"] != "session_admission_guards_detected":
@@ -134,6 +143,14 @@ def check_report(args: argparse.Namespace) -> int:
 
     if payload["timeout_evidence_key"] != "localhost_signed_integration:timeout:v1":
         fail("timeout_evidence_key must be localhost_signed_integration:timeout:v1")
+    if (
+        payload["session_expired_evidence_key"]
+        != "localhost_signed_integration:session-expired:v1"
+    ):
+        fail(
+            "session_expired_evidence_key must be "
+            "localhost_signed_integration:session-expired:v1"
+        )
     if payload["replay_nonce_evidence_key"] != "localhost_signed_integration:replay-nonce:v1":
         fail("replay_nonce_evidence_key must be localhost_signed_integration:replay-nonce:v1")
     if (
@@ -166,6 +183,14 @@ def check_report(args: argparse.Namespace) -> int:
             "localhost_signed_integration_reason:listener_timeout_detected:v1"
         )
     if (
+        payload["session_expired_reason_key"]
+        != "localhost_signed_integration_reason:session_expired_detected:v1"
+    ):
+        fail(
+            "session_expired_reason_key must be "
+            "localhost_signed_integration_reason:session_expired_detected:v1"
+        )
+    if (
         payload["replay_nonce_reason_key"]
         != "localhost_signed_integration_reason:replay_nonce_detected:v1"
     ):
@@ -186,6 +211,7 @@ def check_report(args: argparse.Namespace) -> int:
         "success_elapsed_seconds",
         "signature_mismatch_elapsed_seconds",
         "timeout_elapsed_seconds",
+        "session_expired_elapsed_seconds",
         "replay_nonce_elapsed_seconds",
         "admission_guards_elapsed_seconds",
     ):
@@ -195,6 +221,8 @@ def check_report(args: argparse.Namespace) -> int:
         if value < 0:
             fail(f"{field_name} must be non-negative")
 
+    if payload["expiry_guard_status"] != "pass":
+        fail("expiry_guard_status must be pass")
     if payload["replay_guard_status"] != "pass":
         fail("replay_guard_status must be pass")
     replay_rejected_nonce = payload["replay_rejected_nonce"]
@@ -220,6 +248,8 @@ def check_report(args: argparse.Namespace) -> int:
     if payload["signature_mismatch_scenario_status"] != "pass":
         expected_status = "fail"
     if payload["timeout_scenario_status"] != "pass":
+        expected_status = "fail"
+    if payload["session_expired_scenario_status"] != "pass":
         expected_status = "fail"
     if payload["replay_nonce_scenario_status"] != "pass":
         expected_status = "fail"

--- a/scripts/sdk/localhost_signed_integration_harness_contract.py
+++ b/scripts/sdk/localhost_signed_integration_harness_contract.py
@@ -27,6 +27,8 @@ BODY = "hello-from-localhost-demo"
 NONCE_REPLAY_TEST_VALUE = 7
 UNAUTHORIZED_FROM_DID = "kamn:did:agent:rogue-1"
 STALE_STATE_HASH = "state:localhost-stale"
+SESSION_MAX_AGE_SECONDS = 300
+SESSION_EXPIRED_MAX_AGE_SECONDS = 1
 
 
 class ScenarioFailure(Exception):
@@ -103,6 +105,7 @@ class HarnessContext:
         expected_from: str = FROM_DID,
         expected_to: str = TO_DID,
         expected_session_id: str = SESSION_ID,
+        session_max_age_seconds: int = SESSION_MAX_AGE_SECONDS,
         expected_state_hash: str = STATE_HASH,
         nonce_state_file: Path | None = None,
     ) -> None:
@@ -123,6 +126,8 @@ class HarnessContext:
             expected_to,
             "--expected-session-id",
             expected_session_id,
+            "--session-max-age-seconds",
+            str(session_max_age_seconds),
             "--state-hash",
             expected_state_hash,
         ]
@@ -168,13 +173,14 @@ class HarnessContext:
         *,
         from_did: str,
         session_id: str,
+        session_epoch_seconds: int,
         nonce: int,
         state_hash: str,
         body: str,
     ) -> str:
         return (
             "sig:ed25519:baseline-v1:"
-            f"{from_did}:{session_id}:{nonce}:{state_hash}:{len(body)}"
+            f"{from_did}:{session_id}:{session_epoch_seconds}:{nonce}:{state_hash}:{len(body)}"
         )
 
     def _build_wire_payload(
@@ -183,6 +189,7 @@ class HarnessContext:
         from_did: str,
         to_did: str,
         session_id: str,
+        session_epoch_seconds: int,
         nonce: int,
         state_hash: str,
         body: str,
@@ -191,6 +198,7 @@ class HarnessContext:
         signature_value = signature or self._signature_for_fields(
             from_did=from_did,
             session_id=session_id,
+            session_epoch_seconds=session_epoch_seconds,
             nonce=nonce,
             state_hash=state_hash,
             body=body,
@@ -199,6 +207,7 @@ class HarnessContext:
             f"from={from_did}\n"
             f"to={to_did}\n"
             f"session_id={session_id}\n"
+            f"session_epoch_seconds={session_epoch_seconds}\n"
             f"nonce={nonce}\n"
             f"state_hash={state_hash}\n"
             f"body={body}\n"
@@ -211,6 +220,7 @@ class HarnessContext:
             from_did=FROM_DID,
             to_did=TO_DID,
             session_id=SESSION_ID,
+            session_epoch_seconds=int(time.time()),
             nonce=1,
             state_hash=STATE_HASH,
             body=BODY,
@@ -224,10 +234,12 @@ class HarnessContext:
         from_did: str = FROM_DID,
         to_did: str = TO_DID,
         session_id: str = SESSION_ID,
+        session_epoch_seconds: int | None = None,
         nonce: int = 1,
         state_hash: str = STATE_HASH,
         body: str = BODY,
     ) -> int:
+        epoch_value = session_epoch_seconds if session_epoch_seconds is not None else int(time.time())
         with self.sender_out.open("w", encoding="utf-8") as sender_stream:
             sender_result = subprocess.run(
                 [
@@ -247,6 +259,8 @@ class HarnessContext:
                     to_did,
                     "--session-id",
                     session_id,
+                    "--session-epoch-seconds",
+                    str(epoch_value),
                     "--nonce",
                     str(nonce),
                     "--state-hash",
@@ -297,6 +311,10 @@ class HarnessContext:
             self.fail_with_reason("sender_session_id_missing")
         if f"session_id={SESSION_ID}" not in listener_text:
             self.fail_with_reason("listener_session_id_missing")
+        if "session_epoch_seconds=" not in sender_text:
+            self.fail_with_reason("sender_session_epoch_missing")
+        if "session_epoch_seconds=" not in listener_text:
+            self.fail_with_reason("listener_session_epoch_missing")
 
         self.emit_report(
             "pass",
@@ -304,6 +322,7 @@ class HarnessContext:
             extra_fields={
                 "signature_guard_status": "pass",
                 "admission_guard_status": "pass",
+                "expiry_guard_status": "pass",
                 "session_id": SESSION_ID,
             },
         )
@@ -334,6 +353,22 @@ class HarnessContext:
             self.listener_proc.wait(timeout=2)
 
         self.emit_report("pass", "listener_timeout_detected")
+
+    def run_session_expired_scenario(self) -> None:
+        self.start_listener(session_max_age_seconds=SESSION_EXPIRED_MAX_AGE_SECONDS)
+        if self.run_sender(nonce=2, session_epoch_seconds=1) != 0:
+            self.fail_with_reason("sender_failed")
+
+        listener_status = self.wait_for_listener()
+        if listener_status == 124:
+            self.fail_with_reason("listener_timeout")
+        self._require_listener_failure("session expired", "session_expired")
+
+        self.emit_report(
+            "pass",
+            "session_expired_detected",
+            extra_fields={"expiry_guard_status": "pass"},
+        )
 
     def run_replay_nonce_scenario(self) -> None:
         nonce_state_file = self.tmp_dir / "replay-nonce.state"
@@ -395,6 +430,7 @@ class HarnessContext:
             f"from={FROM_DID}\n"
             f"to={TO_DID}\n"
             f"session_id={SESSION_ID}\n"
+            f"session_epoch_seconds={int(time.time())}\n"
             f"state_hash={STATE_HASH}\n"
             f"body={BODY}\n"
             "signature=sig:ed25519:baseline-v1:malformed\n"
@@ -432,12 +468,13 @@ def run_harness(args: argparse.Namespace) -> int:
         "success",
         "signature-mismatch",
         "timeout",
+        "session-expired",
         "replay-nonce",
         "admission-guards",
     }:
         fail(
             "scenario must be one of: success, signature-mismatch, timeout, "
-            "replay-nonce, admission-guards"
+            "session-expired, replay-nonce, admission-guards"
         )
 
     addr = args.addr
@@ -460,6 +497,8 @@ def run_harness(args: argparse.Namespace) -> int:
                 context.run_signature_mismatch_scenario()
             elif scenario == "timeout":
                 context.run_timeout_scenario()
+            elif scenario == "session-expired":
+                context.run_session_expired_scenario()
             elif scenario == "replay-nonce":
                 context.run_replay_nonce_scenario()
             else:

--- a/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
+++ b/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
@@ -64,6 +64,39 @@ if ! printf '%s\n' "$tampered_output" | grep -Fq "stale_session_detected"; then
   exit 1
 fi
 
+expiry_tampered_report="$TMP_DIR/localhost-signed-integration-contract-report.expiry-tampered.json"
+cp "$report_file" "$expiry_tampered_report"
+python3 - "$expiry_tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["session_expired_reason_code"] = "tampered_expiry_reason"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+expiry_tampered_output="$(bash "$CHECKER" --report-file "$expiry_tampered_report" 2>&1)"
+expiry_tampered_code=$?
+set -e
+
+if [ "$expiry_tampered_code" -eq 0 ]; then
+  echo "expected session-expired reason drift report to fail policy checker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$expiry_tampered_output" | grep -Fq "session_expired_reason_code"; then
+  echo "expected explicit session expired reason-code policy error" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$expiry_tampered_output" | grep -Fq "session_expired_detected"; then
+  echo "expected deterministic session-expired reason marker in policy regression path" >&2
+  exit 1
+fi
+
 decision_tampered_report="$TMP_DIR/localhost-signed-integration-contract-report.decision-tampered.json"
 cp "$report_file" "$decision_tampered_report"
 python3 - "$decision_tampered_report" <<'PY'

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -32,6 +32,7 @@ required_markers=(
   "localhost_signed_integration_success=pass"
   "localhost_signed_integration_signature_mismatch=pass"
   "localhost_signed_integration_timeout=pass"
+  "localhost_signed_integration_session_expired=pass"
   "localhost_signed_integration_replay_nonce=pass"
   "localhost_signed_integration_admission_guards=pass"
   "localhost_signed_integration_policy=ok"
@@ -57,6 +58,7 @@ assert report["final_decision"] == "GO"
 assert report["success_scenario_status"] == "pass"
 assert report["signature_mismatch_scenario_status"] == "pass"
 assert report["timeout_scenario_status"] == "pass"
+assert report["session_expired_scenario_status"] == "pass"
 assert report["replay_nonce_scenario_status"] == "pass"
 assert report["admission_guards_scenario_status"] == "pass"
 assert (
@@ -75,6 +77,10 @@ assert (
     == "localhost_signed_integration:signature-mismatch:v1"
 )
 assert report["timeout_evidence_key"] == "localhost_signed_integration:timeout:v1"
+assert (
+    report["session_expired_evidence_key"]
+    == "localhost_signed_integration:session-expired:v1"
+)
 assert report["replay_nonce_evidence_key"] == "localhost_signed_integration:replay-nonce:v1"
 assert (
     report["admission_guards_evidence_key"]
@@ -90,6 +96,10 @@ assert (
     == "localhost_signed_integration_reason:listener_timeout_detected:v1"
 )
 assert (
+    report["session_expired_reason_key"]
+    == "localhost_signed_integration_reason:session_expired_detected:v1"
+)
+assert (
     report["replay_nonce_reason_key"]
     == "localhost_signed_integration_reason:replay_nonce_detected:v1"
 )
@@ -100,10 +110,12 @@ assert (
 # Regression: #878
 assert report["signature_mismatch_reason_code"] == "signature_mismatch_detected"
 assert report["timeout_reason_code"] == "listener_timeout_detected"
+assert report["session_expired_reason_code"] == "session_expired_detected"
 assert report["replay_nonce_reason_code"] == "replay_nonce_detected"
 assert (
     report["admission_guards_reason_code"] == "session_admission_guards_detected"
 )
+assert report["expiry_guard_status"] == "pass"
 assert report["replay_guard_status"] == "pass"
 assert report["replay_rejected_nonce"] == 7
 assert report["admission_guard_status"] == "pass"

--- a/scripts/sdk/test_run_localhost_signed_integration_harness.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_harness.sh
@@ -69,6 +69,25 @@ if ! printf '%s\n' "$timeout_output" | grep -Fq "evidence_key=localhost_signed_i
   exit 1
 fi
 
+session_expired_report="$TMP_DIR/session-expired.json"
+session_expired_output="$(
+  bash "$RUNNER" \
+    --scenario session-expired \
+    --output-json "$session_expired_report"
+)"
+if ! printf '%s\n' "$session_expired_output" | grep -Fq "status=pass; scenario=session-expired;"; then
+  echo "expected session-expired scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$session_expired_output" | grep -Fq "reason_code=session_expired_detected;"; then
+  echo "expected session-expired scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$session_expired_output" | grep -Fq "evidence_key=localhost_signed_integration:session-expired:v1;"; then
+  echo "expected session-expired scenario evidence key from localhost signed integration harness" >&2
+  exit 1
+fi
+
 replay_report="$TMP_DIR/replay-nonce.json"
 replay_output="$(
   bash "$RUNNER" \
@@ -111,6 +130,7 @@ python3 - \
   "$success_report" \
   "$signature_report" \
   "$timeout_report" \
+  "$session_expired_report" \
   "$replay_report" \
   "$admission_report" <<'PY'
 import json
@@ -120,8 +140,9 @@ import sys
 success_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 signature_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
 timeout_report = json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8"))
-replay_report = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
-admission_report = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
+session_expired_report = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
+replay_report = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
+admission_report = json.loads(pathlib.Path(sys.argv[6]).read_text(encoding="utf-8"))
 
 assert success_report["schema_version"] == "kamn.sdk.localhost-signed.integration-harness.v1"
 assert success_report["status"] == "pass"
@@ -151,6 +172,19 @@ assert timeout_report["evidence_key"] == "localhost_signed_integration:timeout:v
 assert (
     timeout_report["reason_key"]
     == "localhost_signed_integration_reason:listener_timeout_detected:v1"
+)
+
+assert session_expired_report["status"] == "pass"
+assert session_expired_report["scenario"] == "session-expired"
+assert session_expired_report["reason_code"] == "session_expired_detected"
+assert (
+    session_expired_report["evidence_key"]
+    == "localhost_signed_integration:session-expired:v1"
+)
+assert session_expired_report["expiry_guard_status"] == "pass"
+assert (
+    session_expired_report["reason_key"]
+    == "localhost_signed_integration_reason:session_expired_detected:v1"
 )
 
 assert replay_report["status"] == "pass"


### PR DESCRIPTION
Closes #1388
Part of #1379

## Summary
Adds deterministic session-epoch expiry guard enforcement to localhost signed transport admission, with explicit session-expired evidence markers in harness, lane summary, and policy checks.

## Changes
- crates/kamn-sdk/examples/localhost_signed_sender.rs: add session_epoch_seconds argument/default and include it in wire payload/signature.
- crates/kamn-sdk/examples/localhost_signed_listener.rs: enforce session_max_age_seconds fail-closed admission checks and include session_epoch_seconds in signature verification.
- scripts/sdk/localhost_signed_integration_harness_contract.py: add session-expired scenario and expiry marker propagation.
- scripts/sdk/localhost_signed_integration_contract_lane_contract.py: execute session-expired scenario and include expiry guard fields in summary report.
- scripts/sdk/localhost_signed_integration_evidence_policy_contract.py: enforce session_expired fields and expiry_guard_status.
- scripts/sdk/test_run_localhost_signed_integration_harness.sh: add session-expired scenario assertions.
- scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh: add session-expired marker/report assertions.
- scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh: add session-expired reason-code tamper regression.
- README.md and docs/foundation/runtime-network.md: document session-expired markers and nonce/expiry guard rules.

## Risks & Compatibility
- Localhost sender/listener payload/signature now includes session_epoch_seconds; custom raw payload senders must provide this field.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -p kamn-sdk --examples -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised updated localhost harness/lane/policy/demo scripts and docs contract tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | policy field validation and guard assertions via deterministic script checks |
| Functional  | ✅     | scripts/sdk/test_run_localhost_signed_integration_harness.sh; scripts/sdk/test_run_localhost_signed_demo.sh |
| Integration | ✅     | scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh; scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh |
| Regression  | ✅     | session_expired_reason_code drift and final decision consistency tamper checks |

### Commands run
- cargo fmt --check
- cargo clippy -p kamn-sdk --examples -- -D warnings
- cargo test -p kamn-sdk
- bash scripts/sdk/test_run_localhost_signed_integration_harness.sh
- bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
- bash scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
- bash scripts/sdk/test_run_localhost_signed_demo.sh
- cargo test -p kamn-core --test runtime_network_docs
- cargo test -p kamn-core --test live_network_wave_docs
- cargo test -p kamn-core --test ci_strategy_docs
