### PR TITLE
feat(sdk): add malformed-signature reason-code taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 # contract_key=localhost_signed_integration_contract:v1
 # success_evidence_key=localhost_signed_integration:success:v1
 # signature_mismatch_evidence_key=localhost_signed_integration:signature-mismatch:v1
+# malformed_signature_evidence_key=localhost_signed_integration:malformed-signature:v1
 # timeout_evidence_key=localhost_signed_integration:timeout:v1
 # session_expired_evidence_key=localhost_signed_integration:session-expired:v1
 # replay_nonce_evidence_key=localhost_signed_integration:replay-nonce:v1
@@ -153,6 +154,7 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 # final_decision=GO
 # scenario_fixture_schema_version=kamn.sdk.localhost-signed.integration-fixtures.v1
 # scenario_fixture_ids=["success-v1","signature-mismatch-v1","timeout-v1"]
+# malformed_signature_reason_code=malformed_signature_detected
 # session_expired_reason_code=session_expired_detected
 # replay_nonce_reason_code=replay_nonce_detected
 # admission_guards_reason_code=session_admission_guards_detected

--- a/crates/kamn-sdk/examples/localhost_signed_listener.rs
+++ b/crates/kamn-sdk/examples/localhost_signed_listener.rs
@@ -97,6 +97,10 @@ fn signature_for_fields(
     )
 }
 
+fn has_supported_signature_prefix(signature: &str) -> bool {
+    signature.starts_with("sig:ed25519:baseline-v1:")
+}
+
 fn parse_wire_message(payload: &str) -> Result<WireMessage, String> {
     let mut from: Option<String> = None;
     let mut to: Option<String> = None;
@@ -252,6 +256,9 @@ fn run() -> Result<(), String> {
         &wire.state_hash,
         &wire.body,
     );
+    if !has_supported_signature_prefix(&wire.signature) {
+        return Err("malformed signature format".to_owned());
+    }
     if wire.signature != expected_signature {
         return Err("signature verification failed".to_owned());
     }

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -196,12 +196,14 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `localhost_signed_integration_contract:v1`
   - `localhost_signed_integration:success:v1`
   - `localhost_signed_integration:signature-mismatch:v1`
+  - `localhost_signed_integration:malformed-signature:v1`
   - `localhost_signed_integration:timeout:v1`
   - `localhost_signed_integration:session-expired:v1`
   - `localhost_signed_integration:replay-nonce:v1`
   - `localhost_signed_integration:admission-guards:v1`
 - Deterministic reason markers:
   - `signature_mismatch_detected`
+  - `malformed_signature_detected`
   - `listener_timeout_detected`
   - `session_expired_detected`
   - `replay_nonce_detected`
@@ -213,6 +215,9 @@ This document captures the initial runtime-network foundation slice for peer lif
   - payload must include `session_epoch_seconds`
   - listener enforces `--session-max-age-seconds` fail-closed admission checks
   - stale session epochs are rejected before delivery acceptance
+- Signature failure taxonomy:
+  - malformed signature encoding/profile -> `malformed_signature_detected`
+  - deterministic signature mismatch against expected fields -> `signature_mismatch_detected`
 - Regression policy:
   - deterministic evidence keys and reason keys remain fail-closed (`Regression: #899`).
   - replay nonce and session admission guards remain fail-closed (`Regression: #1382`).

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -113,6 +113,7 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
     try:
         success_report = tmp_dir / "success.json"
         signature_report = tmp_dir / "signature-mismatch.json"
+        malformed_signature_report = tmp_dir / "malformed-signature.json"
         timeout_report = tmp_dir / "timeout.json"
         session_expired_report = tmp_dir / "session-expired.json"
         replay_report = tmp_dir / "replay-nonce.json"
@@ -187,6 +188,44 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             signature_output,
             f"evidence_key={fixture_by_scenario['signature-mismatch']['expected_evidence_key']};",
             "expected localhost signed integration signature mismatch scenario evidence key",
+        )
+
+        malformed_signature_run = subprocess.run(
+            [
+                "bash",
+                str(harness_runner),
+                "--scenario",
+                "malformed-signature",
+                "--output-json",
+                str(malformed_signature_report),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if malformed_signature_run.returncode != 0:
+            fail(
+                (
+                    malformed_signature_run.stderr
+                    or malformed_signature_run.stdout
+                    or "malformed-signature scenario failed"
+                ).strip()
+            )
+        malformed_signature_output = malformed_signature_run.stdout
+        _require_contains(
+            malformed_signature_output,
+            "status=pass; scenario=malformed-signature;",
+            "expected localhost signed integration malformed signature scenario status marker",
+        )
+        _require_contains(
+            malformed_signature_output,
+            "reason_code=malformed_signature_detected;",
+            "expected localhost signed integration malformed signature scenario reason code marker",
+        )
+        _require_contains(
+            malformed_signature_output,
+            "evidence_key=localhost_signed_integration:malformed-signature:v1;",
+            "expected localhost signed integration malformed signature scenario evidence key",
         )
 
         timeout_run = subprocess.run(
@@ -333,6 +372,7 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
 
         success_payload = load_json(success_report)
         signature_payload = load_json(signature_report)
+        malformed_signature_payload = load_json(malformed_signature_report)
         timeout_payload = load_json(timeout_report)
         session_expired_payload = load_json(session_expired_report)
         replay_payload = load_json(replay_report)
@@ -346,29 +386,34 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             "scenario_fixture_ids": scenario_fixture_ids,
             "success_scenario_status": success_payload["status"],
             "signature_mismatch_scenario_status": signature_payload["status"],
+            "malformed_signature_scenario_status": malformed_signature_payload["status"],
             "timeout_scenario_status": timeout_payload["status"],
             "session_expired_scenario_status": session_expired_payload["status"],
             "replay_nonce_scenario_status": replay_payload["status"],
             "admission_guards_scenario_status": admission_payload["status"],
             "success_evidence_key": success_payload["evidence_key"],
             "signature_mismatch_evidence_key": signature_payload["evidence_key"],
+            "malformed_signature_evidence_key": malformed_signature_payload["evidence_key"],
             "timeout_evidence_key": timeout_payload["evidence_key"],
             "session_expired_evidence_key": session_expired_payload["evidence_key"],
             "replay_nonce_evidence_key": replay_payload["evidence_key"],
             "admission_guards_evidence_key": admission_payload["evidence_key"],
             "signature_mismatch_reason_code": signature_payload["reason_code"],
+            "malformed_signature_reason_code": malformed_signature_payload["reason_code"],
             "timeout_reason_code": timeout_payload["reason_code"],
             "session_expired_reason_code": session_expired_payload["reason_code"],
             "replay_nonce_reason_code": replay_payload["reason_code"],
             "admission_guards_reason_code": admission_payload["reason_code"],
             "success_reason_key": success_payload["reason_key"],
             "signature_mismatch_reason_key": signature_payload["reason_key"],
+            "malformed_signature_reason_key": malformed_signature_payload["reason_key"],
             "timeout_reason_key": timeout_payload["reason_key"],
             "session_expired_reason_key": session_expired_payload["reason_key"],
             "replay_nonce_reason_key": replay_payload["reason_key"],
             "admission_guards_reason_key": admission_payload["reason_key"],
             "success_elapsed_seconds": success_payload["elapsed_seconds"],
             "signature_mismatch_elapsed_seconds": signature_payload["elapsed_seconds"],
+            "malformed_signature_elapsed_seconds": malformed_signature_payload["elapsed_seconds"],
             "timeout_elapsed_seconds": timeout_payload["elapsed_seconds"],
             "session_expired_elapsed_seconds": session_expired_payload["elapsed_seconds"],
             "replay_nonce_elapsed_seconds": replay_payload["elapsed_seconds"],
@@ -453,6 +498,7 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
 
         print("localhost_signed_integration_success=pass")
         print("localhost_signed_integration_signature_mismatch=pass")
+        print("localhost_signed_integration_malformed_signature=pass")
         print("localhost_signed_integration_timeout=pass")
         print("localhost_signed_integration_session_expired=pass")
         print("localhost_signed_integration_replay_nonce=pass")

--- a/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
+++ b/scripts/sdk/localhost_signed_integration_evidence_policy_contract.py
@@ -36,29 +36,34 @@ def check_report(args: argparse.Namespace) -> int:
         "scenario_fixture_ids",
         "success_scenario_status",
         "signature_mismatch_scenario_status",
+        "malformed_signature_scenario_status",
         "timeout_scenario_status",
         "session_expired_scenario_status",
         "replay_nonce_scenario_status",
         "admission_guards_scenario_status",
         "success_evidence_key",
         "signature_mismatch_evidence_key",
+        "malformed_signature_evidence_key",
         "timeout_evidence_key",
         "session_expired_evidence_key",
         "replay_nonce_evidence_key",
         "admission_guards_evidence_key",
         "signature_mismatch_reason_code",
+        "malformed_signature_reason_code",
         "timeout_reason_code",
         "session_expired_reason_code",
         "replay_nonce_reason_code",
         "admission_guards_reason_code",
         "success_reason_key",
         "signature_mismatch_reason_key",
+        "malformed_signature_reason_key",
         "timeout_reason_key",
         "session_expired_reason_key",
         "replay_nonce_reason_key",
         "admission_guards_reason_key",
         "success_elapsed_seconds",
         "signature_mismatch_elapsed_seconds",
+        "malformed_signature_elapsed_seconds",
         "timeout_elapsed_seconds",
         "session_expired_elapsed_seconds",
         "replay_nonce_elapsed_seconds",
@@ -106,6 +111,7 @@ def check_report(args: argparse.Namespace) -> int:
     for field_name in (
         "success_scenario_status",
         "signature_mismatch_scenario_status",
+        "malformed_signature_scenario_status",
         "timeout_scenario_status",
         "session_expired_scenario_status",
         "replay_nonce_scenario_status",
@@ -116,6 +122,8 @@ def check_report(args: argparse.Namespace) -> int:
 
     if payload["signature_mismatch_reason_code"] != "signature_mismatch_detected":
         fail("signature_mismatch_reason_code must be signature_mismatch_detected")
+    if payload["malformed_signature_reason_code"] != "malformed_signature_detected":
+        fail("malformed_signature_reason_code must be malformed_signature_detected")
 
     if payload["timeout_reason_code"] != "listener_timeout_detected":
         fail("timeout_reason_code must be listener_timeout_detected")
@@ -139,6 +147,14 @@ def check_report(args: argparse.Namespace) -> int:
         fail(
             "signature_mismatch_evidence_key must be "
             "localhost_signed_integration:signature-mismatch:v1"
+        )
+    if (
+        payload["malformed_signature_evidence_key"]
+        != "localhost_signed_integration:malformed-signature:v1"
+    ):
+        fail(
+            "malformed_signature_evidence_key must be "
+            "localhost_signed_integration:malformed-signature:v1"
         )
 
     if payload["timeout_evidence_key"] != "localhost_signed_integration:timeout:v1":
@@ -172,6 +188,14 @@ def check_report(args: argparse.Namespace) -> int:
         fail(
             "signature_mismatch_reason_key must be "
             "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+        )
+    if (
+        payload["malformed_signature_reason_key"]
+        != "localhost_signed_integration_reason:malformed_signature_detected:v1"
+    ):
+        fail(
+            "malformed_signature_reason_key must be "
+            "localhost_signed_integration_reason:malformed_signature_detected:v1"
         )
 
     if (
@@ -210,6 +234,7 @@ def check_report(args: argparse.Namespace) -> int:
     for field_name in (
         "success_elapsed_seconds",
         "signature_mismatch_elapsed_seconds",
+        "malformed_signature_elapsed_seconds",
         "timeout_elapsed_seconds",
         "session_expired_elapsed_seconds",
         "replay_nonce_elapsed_seconds",
@@ -246,6 +271,8 @@ def check_report(args: argparse.Namespace) -> int:
     if payload["success_scenario_status"] != "pass":
         expected_status = "fail"
     if payload["signature_mismatch_scenario_status"] != "pass":
+        expected_status = "fail"
+    if payload["malformed_signature_scenario_status"] != "pass":
         expected_status = "fail"
     if payload["timeout_scenario_status"] != "pass":
         expected_status = "fail"

--- a/scripts/sdk/localhost_signed_integration_harness_contract.py
+++ b/scripts/sdk/localhost_signed_integration_harness_contract.py
@@ -228,6 +228,19 @@ class HarnessContext:
         )
         return self._send_payload(payload)
 
+    def send_malformed_signature_payload(self) -> bool:
+        payload = self._build_wire_payload(
+            from_did=FROM_DID,
+            to_did=TO_DID,
+            session_id=SESSION_ID,
+            session_epoch_seconds=int(time.time()),
+            nonce=1,
+            state_hash=STATE_HASH,
+            body=BODY,
+            signature="malformed-signature",
+        )
+        return self._send_payload(payload)
+
     def run_sender(
         self,
         *,
@@ -339,6 +352,21 @@ class HarnessContext:
         self.emit_report(
             "pass",
             "signature_mismatch_detected",
+            extra_fields={"signature_guard_status": "pass"},
+        )
+
+    def run_malformed_signature_scenario(self) -> None:
+        self.start_listener()
+        if not self.send_malformed_signature_payload():
+            self.fail_with_reason("payload_send_failed")
+
+        listener_status = self.wait_for_listener()
+        if listener_status == 124:
+            self.fail_with_reason("listener_timeout")
+        self._require_listener_failure("malformed signature format", "malformed_signature")
+        self.emit_report(
+            "pass",
+            "malformed_signature_detected",
             extra_fields={"signature_guard_status": "pass"},
         )
 
@@ -467,14 +495,15 @@ def run_harness(args: argparse.Namespace) -> int:
     if scenario not in {
         "success",
         "signature-mismatch",
+        "malformed-signature",
         "timeout",
         "session-expired",
         "replay-nonce",
         "admission-guards",
     }:
         fail(
-            "scenario must be one of: success, signature-mismatch, timeout, "
-            "session-expired, replay-nonce, admission-guards"
+            "scenario must be one of: success, signature-mismatch, malformed-signature, "
+            "timeout, session-expired, replay-nonce, admission-guards"
         )
 
     addr = args.addr
@@ -495,6 +524,8 @@ def run_harness(args: argparse.Namespace) -> int:
                 context.run_success_scenario()
             elif scenario == "signature-mismatch":
                 context.run_signature_mismatch_scenario()
+            elif scenario == "malformed-signature":
+                context.run_malformed_signature_scenario()
             elif scenario == "timeout":
                 context.run_timeout_scenario()
             elif scenario == "session-expired":

--- a/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
+++ b/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
@@ -64,6 +64,39 @@ if ! printf '%s\n' "$tampered_output" | grep -Fq "stale_session_detected"; then
   exit 1
 fi
 
+malformed_signature_tampered_report="$TMP_DIR/localhost-signed-integration-contract-report.malformed-signature-tampered.json"
+cp "$report_file" "$malformed_signature_tampered_report"
+python3 - "$malformed_signature_tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["malformed_signature_reason_code"] = "tampered_signature_reason"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+malformed_signature_tampered_output="$(bash "$CHECKER" --report-file "$malformed_signature_tampered_report" 2>&1)"
+malformed_signature_tampered_code=$?
+set -e
+
+if [ "$malformed_signature_tampered_code" -eq 0 ]; then
+  echo "expected malformed-signature reason drift report to fail policy checker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$malformed_signature_tampered_output" | grep -Fq "malformed_signature_reason_code"; then
+  echo "expected explicit malformed signature reason-code policy error" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$malformed_signature_tampered_output" | grep -Fq "malformed_signature_detected"; then
+  echo "expected deterministic malformed-signature reason marker in policy regression path" >&2
+  exit 1
+fi
+
 expiry_tampered_report="$TMP_DIR/localhost-signed-integration-contract-report.expiry-tampered.json"
 cp "$report_file" "$expiry_tampered_report"
 python3 - "$expiry_tampered_report" <<'PY'

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -31,6 +31,7 @@ lane_output="$(
 required_markers=(
   "localhost_signed_integration_success=pass"
   "localhost_signed_integration_signature_mismatch=pass"
+  "localhost_signed_integration_malformed_signature=pass"
   "localhost_signed_integration_timeout=pass"
   "localhost_signed_integration_session_expired=pass"
   "localhost_signed_integration_replay_nonce=pass"
@@ -57,6 +58,7 @@ assert report["status"] == "pass"
 assert report["final_decision"] == "GO"
 assert report["success_scenario_status"] == "pass"
 assert report["signature_mismatch_scenario_status"] == "pass"
+assert report["malformed_signature_scenario_status"] == "pass"
 assert report["timeout_scenario_status"] == "pass"
 assert report["session_expired_scenario_status"] == "pass"
 assert report["replay_nonce_scenario_status"] == "pass"
@@ -76,6 +78,10 @@ assert (
     report["signature_mismatch_evidence_key"]
     == "localhost_signed_integration:signature-mismatch:v1"
 )
+assert (
+    report["malformed_signature_evidence_key"]
+    == "localhost_signed_integration:malformed-signature:v1"
+)
 assert report["timeout_evidence_key"] == "localhost_signed_integration:timeout:v1"
 assert (
     report["session_expired_evidence_key"]
@@ -90,6 +96,10 @@ assert report["success_reason_key"] == "localhost_signed_integration_reason:none
 assert (
     report["signature_mismatch_reason_key"]
     == "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+)
+assert (
+    report["malformed_signature_reason_key"]
+    == "localhost_signed_integration_reason:malformed_signature_detected:v1"
 )
 assert (
     report["timeout_reason_key"]
@@ -109,6 +119,7 @@ assert (
 )
 # Regression: #878
 assert report["signature_mismatch_reason_code"] == "signature_mismatch_detected"
+assert report["malformed_signature_reason_code"] == "malformed_signature_detected"
 assert report["timeout_reason_code"] == "listener_timeout_detected"
 assert report["session_expired_reason_code"] == "session_expired_detected"
 assert report["replay_nonce_reason_code"] == "replay_nonce_detected"

--- a/scripts/sdk/test_run_localhost_signed_integration_harness.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_harness.sh
@@ -49,6 +49,25 @@ if ! printf '%s\n' "$signature_output" | grep -Fq "evidence_key=localhost_signed
   exit 1
 fi
 
+malformed_signature_report="$TMP_DIR/malformed-signature.json"
+malformed_signature_output="$(
+  bash "$RUNNER" \
+    --scenario malformed-signature \
+    --output-json "$malformed_signature_report"
+)"
+if ! printf '%s\n' "$malformed_signature_output" | grep -Fq "status=pass; scenario=malformed-signature;"; then
+  echo "expected malformed signature scenario status summary from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$malformed_signature_output" | grep -Fq "reason_code=malformed_signature_detected;"; then
+  echo "expected malformed signature scenario reason code from localhost signed integration harness" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$malformed_signature_output" | grep -Fq "evidence_key=localhost_signed_integration:malformed-signature:v1;"; then
+  echo "expected malformed signature scenario evidence key from localhost signed integration harness" >&2
+  exit 1
+fi
+
 timeout_report="$TMP_DIR/timeout.json"
 timeout_output="$(
   bash "$RUNNER" \
@@ -129,6 +148,7 @@ fi
 python3 - \
   "$success_report" \
   "$signature_report" \
+  "$malformed_signature_report" \
   "$timeout_report" \
   "$session_expired_report" \
   "$replay_report" \
@@ -139,10 +159,11 @@ import sys
 
 success_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 signature_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-timeout_report = json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8"))
-session_expired_report = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
-replay_report = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
-admission_report = json.loads(pathlib.Path(sys.argv[6]).read_text(encoding="utf-8"))
+malformed_signature_report = json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8"))
+timeout_report = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
+session_expired_report = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
+replay_report = json.loads(pathlib.Path(sys.argv[6]).read_text(encoding="utf-8"))
+admission_report = json.loads(pathlib.Path(sys.argv[7]).read_text(encoding="utf-8"))
 
 assert success_report["schema_version"] == "kamn.sdk.localhost-signed.integration-harness.v1"
 assert success_report["status"] == "pass"
@@ -163,6 +184,19 @@ assert (
 assert (
     signature_report["reason_key"]
     == "localhost_signed_integration_reason:signature_mismatch_detected:v1"
+)
+
+assert malformed_signature_report["status"] == "pass"
+assert malformed_signature_report["scenario"] == "malformed-signature"
+assert malformed_signature_report["reason_code"] == "malformed_signature_detected"
+assert (
+    malformed_signature_report["evidence_key"]
+    == "localhost_signed_integration:malformed-signature:v1"
+)
+assert malformed_signature_report["signature_guard_status"] == "pass"
+assert (
+    malformed_signature_report["reason_key"]
+    == "localhost_signed_integration_reason:malformed_signature_detected:v1"
 )
 
 assert timeout_report["status"] == "pass"


### PR DESCRIPTION
Closes #1389
Part of #1379

## Summary
Stabilizes signature failure taxonomy in localhost signed transport by introducing deterministic malformed-signature detection and enforcing dedicated malformed-signature reason/evidence fields in harness, lane, and policy checks.

## Changes
- crates/kamn-sdk/examples/localhost_signed_listener.rs: add malformed signature format check before deterministic signature equality validation.
- scripts/sdk/localhost_signed_integration_harness_contract.py: add malformed-signature scenario and emit malformed_signature_detected marker.
- scripts/sdk/localhost_signed_integration_contract_lane_contract.py: execute malformed-signature scenario and include malformed-signature report fields.
- scripts/sdk/localhost_signed_integration_evidence_policy_contract.py: require and validate malformed-signature reason/evidence/status fields.
- scripts/sdk/test_run_localhost_signed_integration_harness.sh: add malformed-signature scenario assertions.
- scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh: add malformed-signature lane marker/report assertions.
- scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh: add malformed-signature reason drift tamper regression.
- docs/foundation/runtime-network.md and README.md: document malformed-signature marker taxonomy.

## Risks & Compatibility
- None.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -p kamn-sdk --examples -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised localhost harness/lane/policy/demo scripts and docs contract tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | deterministic policy validation for malformed signature taxonomy |
| Functional  | ✅     | scripts/sdk/test_run_localhost_signed_integration_harness.sh; scripts/sdk/test_run_localhost_signed_demo.sh |
| Integration | ✅     | scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh; scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh |
| Regression  | ✅     | malformed_signature_reason_code tamper drift fail-closed check |

### Commands run
- cargo fmt --check
- cargo clippy -p kamn-sdk --examples -- -D warnings
- cargo test -p kamn-sdk
- bash scripts/sdk/test_run_localhost_signed_integration_harness.sh
- bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
- bash scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh
- bash scripts/sdk/test_run_localhost_signed_demo.sh
- cargo test -p kamn-core --test runtime_network_docs
- cargo test -p kamn-core --test live_network_wave_docs
- cargo test -p kamn-core --test ci_strategy_docs
