### PR TITLE
feat(sdk): add live transport replay/tamper evidence contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 CI fast-gate routes this lane when selector output
 `run_localhost_signed_integration_contract_lane_tests` is `true`.
 
+### Run Live Transport Replay/Tamper Contract Lane
+
+```bash
+bash scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh \
+  --output-report /tmp/live-transport-replay-tamper-contract-report.json
+bash scripts/sdk/check_live_transport_replay_tamper_policy.sh \
+  --bundle-file /tmp/live-transport-replay-tamper-contract-report.json
+# schema: kamn.sdk.live-transport-replay-tamper-evidence.v1
+```
+
 ### Run Localhost Bridge Demo Evidence Contract Lane (Fast)
 
 ```bash

--- a/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
+++ b/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
@@ -1,0 +1,15 @@
+const DOC: &str = include_str!("../../../docs/testing/invariant-and-fuzz-strategy.md");
+
+#[test]
+fn doc_contains_live_transport_replay_tamper_contract_commands() {
+    assert!(DOC.contains("run_live_transport_replay_tamper_contract_lane.sh"));
+    assert!(DOC.contains("check_live_transport_replay_tamper_policy.sh"));
+    assert!(DOC.contains("kamn.sdk.live-transport-replay-tamper-evidence.v1"));
+}
+
+#[test]
+fn regression_requires_live_transport_replay_tamper_contract_markers() {
+    // Regression: #1380
+    assert!(DOC.contains("/tmp/live-transport-replay-tamper-contract-report.json"));
+    assert!(DOC.contains("bundle-file /tmp/live-transport-replay-tamper-contract-report.json"));
+}

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -214,3 +214,16 @@ fn doc_contains_localhost_signed_integration_evidence_key_contract_rules() {
     assert!(DOC.contains("localhost_signed_integration:timeout:v1"));
     assert!(DOC.contains("Regression: #899"));
 }
+
+#[test]
+fn doc_contains_live_transport_replay_tamper_evidence_contract_rules() {
+    assert!(DOC.contains("## Live Transport Replay/Tamper Evidence Contract Rules"));
+    assert!(DOC.contains("generate_live_transport_replay_tamper_evidence_bundle.sh"));
+    assert!(DOC.contains("check_live_transport_replay_tamper_policy.sh"));
+    assert!(DOC.contains("run_live_transport_replay_tamper_contract_lane.sh"));
+    assert!(DOC.contains("kamn.sdk.live-transport-replay-tamper-evidence.v1"));
+    assert!(DOC.contains("malformed_signature_detected"));
+    assert!(DOC.contains("replay_nonce_detected"));
+    assert!(DOC.contains("tamper_payload_detected"));
+    assert!(DOC.contains("Regression: #1380"));
+}

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -222,6 +222,25 @@ This document captures the initial runtime-network foundation slice for peer lif
   - deterministic evidence keys and reason keys remain fail-closed (`Regression: #899`).
   - replay nonce and session admission guards remain fail-closed (`Regression: #1382`).
 
+## Live Transport Replay/Tamper Evidence Contract Rules
+- Evidence generator command:
+  - `bash scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh --output-file /tmp/live-transport-replay-tamper-bundle.json --transport-lane-id localhost-signed-integration --message-id msg-001 --from-did kamn:did:agent:sender-1 --to-did kamn:did:agent:listener-1 --nonce 41 --signature-status valid --replay-detected false --tamper-detected false --ci-fast-gate PASS`
+- Evidence policy checker:
+  - `bash scripts/sdk/check_live_transport_replay_tamper_policy.sh --bundle-file /tmp/live-transport-replay-tamper-bundle.json`
+- Contract lane command:
+  - `bash scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh --output-report /tmp/live-transport-replay-tamper-contract-report.json`
+- Evidence schema:
+  - `kamn.sdk.live-transport-replay-tamper-evidence.v1`
+- Deterministic replay/tamper reason codes:
+  - `none`
+  - `signature_mismatch_detected`
+  - `malformed_signature_detected`
+  - `replay_nonce_detected`
+  - `tamper_payload_detected`
+  - `ci_fast_gate_failed`
+- Regression policy:
+  - tampered final decision, reason-key drift, and replay/tamper marker drift fail closed (`Regression: #1380`).
+
 ## Queue Guard Rules
 - `BoundedRuntimeQueue<T>` is FIFO and preserves insertion order.
 - Capacity must be greater than zero.

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -24,6 +24,10 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `bash scripts/runtime/run_invariant_fuzz_concurrency_contract_lane.sh --output-json /tmp/invariant-fuzz-concurrency-contract-report.json`
 - Combined policy checker:
   - `bash scripts/runtime/check_invariant_fuzz_concurrency_policy.sh --report-file /tmp/invariant-fuzz-concurrency-contract-report.json`
+- Live transport replay/tamper contract lane:
+  - `bash scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh --output-report /tmp/live-transport-replay-tamper-contract-report.json`
+- Live transport replay/tamper policy checker:
+  - `bash scripts/sdk/check_live_transport_replay_tamper_policy.sh --bundle-file /tmp/live-transport-replay-tamper-contract-report.json`
 
 ## Determinism Strategy
 
@@ -72,6 +76,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `reason_codes`
 - Required pass reason code:
   - `none`
+- Live transport replay/tamper report schema:
+  - `kamn.sdk.live-transport-replay-tamper-evidence.v1`
 
 ## Runtime Budgets
 

--- a/scripts/sdk/check_live_transport_replay_tamper_policy.sh
+++ b/scripts/sdk/check_live_transport_replay_tamper_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/sdk/live_transport_replay_tamper_contract.py" check "$@"

--- a/scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh
+++ b/scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/sdk/live_transport_replay_tamper_contract.py" generate "$@"

--- a/scripts/sdk/live_transport_replay_tamper_contract.py
+++ b/scripts/sdk/live_transport_replay_tamper_contract.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Live transport replay/tamper evidence generator and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    fail,
+    load_json,
+    require_enum,
+    require_keys,
+    require_non_negative_int,
+    require_pattern,
+    require_string,
+    write_json,
+)
+
+SCHEMA_VERSION = "kamn.sdk.live-transport-replay-tamper-evidence.v1"
+
+
+def _parse_bool(name: str, raw_value: str) -> bool:
+    if raw_value not in {"true", "false"}:
+        fail(f"{name} must be true or false")
+    return raw_value == "true"
+
+
+def _reason_key(reason_code: str) -> str:
+    return f"live_transport_replay_tamper_reason:{reason_code}:v1"
+
+
+def _derive_reason_codes(
+    *,
+    signature_status: str,
+    replay_detected: bool,
+    tamper_detected: bool,
+    ci_fast_gate: str,
+) -> list[str]:
+    reason_codes: list[str] = []
+    if signature_status == "mismatch":
+        reason_codes.append("signature_mismatch_detected")
+    elif signature_status == "malformed":
+        reason_codes.append("malformed_signature_detected")
+
+    if replay_detected:
+        reason_codes.append("replay_nonce_detected")
+    if tamper_detected:
+        reason_codes.append("tamper_payload_detected")
+    if ci_fast_gate != "PASS":
+        reason_codes.append("ci_fast_gate_failed")
+
+    if not reason_codes:
+        return ["none"]
+    return reason_codes
+
+
+def _expected_decision(reason_codes: list[str]) -> str:
+    return "GO" if reason_codes == ["none"] else "NO-GO"
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    transport_lane_id = require_pattern(
+        "transport-lane-id",
+        args.transport_lane_id,
+        r"[a-z0-9._:-]+",
+        "transport-lane-id must be lowercase and URL-safe",
+    )
+    message_id = require_pattern(
+        "message-id",
+        args.message_id,
+        r"[A-Za-z0-9._:-]+",
+        "message-id must be non-empty and URL-safe",
+    )
+    from_did = require_pattern(
+        "from-did",
+        args.from_did,
+        r"kamn:did:agent:[A-Za-z0-9_.:-]+",
+        "from-did must be a valid kamn agent DID",
+    )
+    to_did = require_pattern(
+        "to-did",
+        args.to_did,
+        r"kamn:did:agent:[A-Za-z0-9_.:-]+",
+        "to-did must be a valid kamn agent DID",
+    )
+    nonce = require_non_negative_int("nonce", str(args.nonce))
+    if nonce <= 0:
+        fail("nonce must be greater than zero")
+
+    signature_status = require_enum(
+        "signature-status", args.signature_status, ("valid", "mismatch", "malformed")
+    )
+    replay_detected = _parse_bool("replay-detected", args.replay_detected)
+    tamper_detected = _parse_bool("tamper-detected", args.tamper_detected)
+    ci_fast_gate = require_enum("ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+
+    reason_codes = _derive_reason_codes(
+        signature_status=signature_status,
+        replay_detected=replay_detected,
+        tamper_detected=tamper_detected,
+        ci_fast_gate=ci_fast_gate,
+    )
+    reason_keys = [_reason_key(code) for code in reason_codes]
+    final_decision = _expected_decision(reason_codes)
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "transport_lane_id": transport_lane_id,
+        "message": {
+            "message_id": message_id,
+            "from_did": from_did,
+            "to_did": to_did,
+            "nonce": nonce,
+        },
+        "signature_status": signature_status,
+        "replay_detected": replay_detected,
+        "tamper_detected": tamper_detected,
+        "ci_fast_gate": ci_fast_gate,
+        "reason_codes": reason_codes,
+        "reason_keys": reason_keys,
+        "final_decision": final_decision,
+    }
+
+    output_path = Path(args.output_file)
+    write_json(output_path, payload)
+
+    print("status=generated")
+    print(f"bundle_file={output_path}")
+    print(f"final_decision={final_decision}")
+    return 0
+
+
+def check_bundle(args: argparse.Namespace) -> int:
+    bundle_path = Path(args.bundle_file)
+    if not bundle_path.is_file():
+        fail(f"bundle file not found: {bundle_path}")
+
+    payload = load_json(bundle_path)
+    require_keys(
+        payload,
+        (
+            "schema_version",
+            "generated_at",
+            "transport_lane_id",
+            "message",
+            "signature_status",
+            "replay_detected",
+            "tamper_detected",
+            "ci_fast_gate",
+            "reason_codes",
+            "reason_keys",
+            "final_decision",
+        ),
+    )
+
+    schema_version = require_string(payload, "schema_version")
+    if schema_version != SCHEMA_VERSION:
+        fail("unexpected schema_version for live transport replay/tamper evidence bundle")
+
+    transport_lane_id = require_string(payload, "transport_lane_id")
+    require_pattern(
+        "transport_lane_id",
+        transport_lane_id,
+        r"[a-z0-9._:-]+",
+        "transport_lane_id must be lowercase and URL-safe",
+    )
+    signature_status = require_enum(
+        "signature_status",
+        require_string(payload, "signature_status"),
+        ("valid", "mismatch", "malformed"),
+    )
+    ci_fast_gate = require_enum(
+        "ci_fast_gate",
+        require_string(payload, "ci_fast_gate"),
+        ("PASS", "FAIL"),
+    )
+
+    replay_detected = payload.get("replay_detected")
+    if not isinstance(replay_detected, bool):
+        fail("replay_detected must be a boolean")
+    tamper_detected = payload.get("tamper_detected")
+    if not isinstance(tamper_detected, bool):
+        fail("tamper_detected must be a boolean")
+
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        fail("message must be an object")
+    message_id = require_string(message, "message_id")
+    require_pattern(
+        "message.message_id",
+        message_id,
+        r"[A-Za-z0-9._:-]+",
+        "message.message_id must be non-empty and URL-safe",
+    )
+    require_pattern(
+        "message.from_did",
+        require_string(message, "from_did"),
+        r"kamn:did:agent:[A-Za-z0-9_.:-]+",
+        "message.from_did must be a valid kamn agent DID",
+    )
+    require_pattern(
+        "message.to_did",
+        require_string(message, "to_did"),
+        r"kamn:did:agent:[A-Za-z0-9_.:-]+",
+        "message.to_did must be a valid kamn agent DID",
+    )
+    nonce = message.get("nonce")
+    if not isinstance(nonce, int):
+        fail("message.nonce must be an integer")
+    if nonce <= 0:
+        fail("message.nonce must be greater than zero")
+
+    reason_codes = payload.get("reason_codes")
+    if not isinstance(reason_codes, list):
+        fail("reason_codes must be an array")
+    if not reason_codes or not all(isinstance(code, str) and code for code in reason_codes):
+        fail("reason_codes must contain non-empty strings")
+    reason_keys = payload.get("reason_keys")
+    if not isinstance(reason_keys, list):
+        fail("reason_keys must be an array")
+    if len(reason_keys) != len(reason_codes):
+        fail("reason_keys must match reason_codes length")
+    if not all(isinstance(key, str) and key for key in reason_keys):
+        fail("reason_keys must contain non-empty strings")
+
+    expected_reason_codes = _derive_reason_codes(
+        signature_status=signature_status,
+        replay_detected=replay_detected,
+        tamper_detected=tamper_detected,
+        ci_fast_gate=ci_fast_gate,
+    )
+    if reason_codes != expected_reason_codes:
+        fail(
+            "reason_codes mismatch: "
+            f"expected reason_codes={expected_reason_codes}, found {reason_codes}"
+        )
+
+    expected_reason_keys = [_reason_key(code) for code in expected_reason_codes]
+    if reason_keys != expected_reason_keys:
+        fail(
+            "reason_keys mismatch: "
+            f"expected reason_keys={expected_reason_keys}, found {reason_keys}"
+        )
+
+    final_decision = require_enum(
+        "final_decision", require_string(payload, "final_decision"), ("GO", "NO-GO")
+    )
+    expected_decision = _expected_decision(expected_reason_codes)
+    if final_decision != expected_decision:
+        fail(
+            "policy decision mismatch: "
+            f"expected final_decision={expected_decision}, found {final_decision}"
+        )
+
+    print("status=ok")
+    print(f"bundle_file={bundle_path}")
+    print(f"final_decision={final_decision}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Live transport replay/tamper evidence contract utilities."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--output-file", required=True)
+    generate.add_argument("--transport-lane-id", required=True)
+    generate.add_argument("--message-id", required=True)
+    generate.add_argument("--from-did", required=True)
+    generate.add_argument("--to-did", required=True)
+    generate.add_argument("--nonce", required=True)
+    generate.add_argument("--signature-status", required=True)
+    generate.add_argument("--replay-detected", required=True)
+    generate.add_argument("--tamper-detected", required=True)
+    generate.add_argument("--ci-fast-gate", required=True)
+    generate.set_defaults(handler=generate_bundle)
+
+    check = subparsers.add_parser("check")
+    check.add_argument("--bundle-file", required=True)
+    check.set_defaults(handler=check_bundle)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py
+++ b/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Live transport replay/tamper contract lane runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import ContractError, fail  # noqa: E402
+
+
+def _is_executable(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def _require_contains_line(output: str, marker: str, message: str) -> None:
+    if marker not in output.splitlines():
+        fail(message)
+
+
+def _require_contains_text(output: str, marker: str, message: str) -> None:
+    if marker not in output:
+        fail(message)
+
+
+def run_lane(args: argparse.Namespace) -> int:
+    generator = ROOT_DIR / "scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh"
+    checker = ROOT_DIR / "scripts/sdk/check_live_transport_replay_tamper_policy.sh"
+    runtime_doc = ROOT_DIR / "docs/foundation/runtime-network.md"
+    invariant_doc = ROOT_DIR / "docs/testing/invariant-and-fuzz-strategy.md"
+
+    if not _is_executable(generator):
+        fail("expected replay/tamper evidence generator to be executable")
+    if not _is_executable(checker):
+        fail("expected replay/tamper evidence policy checker to be executable")
+    if not runtime_doc.is_file():
+        fail("expected runtime-network doc to exist")
+    if not invariant_doc.is_file():
+        fail("expected invariant-and-fuzz-strategy doc to exist")
+
+    max_seconds_raw = os.environ.get("KAMN_SDK_REPLAY_TAMPER_CONTRACT_MAX_SECONDS", "90")
+    if not max_seconds_raw.isdigit() or int(max_seconds_raw) <= 0:
+        fail("KAMN_SDK_REPLAY_TAMPER_CONTRACT_MAX_SECONDS must be a positive integer")
+    max_seconds = int(max_seconds_raw)
+
+    start_epoch = int(time.time())
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        go_bundle = (
+            Path(args.output_report)
+            if args.output_report
+            else tmp_path / "live-transport-replay-tamper-go.json"
+        )
+
+        go_generate = subprocess.run(
+            [
+                "bash",
+                str(generator),
+                "--output-file",
+                str(go_bundle),
+                "--transport-lane-id",
+                "localhost-signed-integration",
+                "--message-id",
+                "msg-go-001",
+                "--from-did",
+                "kamn:did:agent:sender-1",
+                "--to-did",
+                "kamn:did:agent:listener-1",
+                "--nonce",
+                "41",
+                "--signature-status",
+                "valid",
+                "--replay-detected",
+                "false",
+                "--tamper-detected",
+                "false",
+                "--ci-fast-gate",
+                "PASS",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if go_generate.returncode != 0:
+            fail((go_generate.stderr or go_generate.stdout or "GO bundle generation failed").strip())
+        _require_contains_line(
+            go_generate.stdout,
+            "status=generated",
+            "expected GO replay/tamper evidence generation status marker",
+        )
+        _require_contains_line(
+            go_generate.stdout,
+            "final_decision=GO",
+            "expected GO replay/tamper evidence final decision marker",
+        )
+
+        go_check = subprocess.run(
+            ["bash", str(checker), "--bundle-file", str(go_bundle)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if go_check.returncode != 0:
+            fail((go_check.stderr or go_check.stdout or "GO policy check failed").strip())
+        _require_contains_line(
+            go_check.stdout,
+            "status=ok",
+            "expected GO replay/tamper policy checker status marker",
+        )
+        _require_contains_line(
+            go_check.stdout,
+            "final_decision=GO",
+            "expected GO replay/tamper policy checker final decision marker",
+        )
+
+        no_go_bundle = tmp_path / "live-transport-replay-tamper-no-go.json"
+        no_go_generate = subprocess.run(
+            [
+                "bash",
+                str(generator),
+                "--output-file",
+                str(no_go_bundle),
+                "--transport-lane-id",
+                "localhost-signed-integration",
+                "--message-id",
+                "msg-no-go-001",
+                "--from-did",
+                "kamn:did:agent:sender-1",
+                "--to-did",
+                "kamn:did:agent:listener-1",
+                "--nonce",
+                "41",
+                "--signature-status",
+                "malformed",
+                "--replay-detected",
+                "true",
+                "--tamper-detected",
+                "true",
+                "--ci-fast-gate",
+                "PASS",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if no_go_generate.returncode != 0:
+            fail(
+                (no_go_generate.stderr or no_go_generate.stdout or "NO-GO generation failed").strip()
+            )
+        _require_contains_line(
+            no_go_generate.stdout,
+            "final_decision=NO-GO",
+            "expected NO-GO replay/tamper final decision marker",
+        )
+
+        no_go_check = subprocess.run(
+            ["bash", str(checker), "--bundle-file", str(no_go_bundle)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if no_go_check.returncode != 0:
+            fail((no_go_check.stderr or no_go_check.stdout or "NO-GO policy check failed").strip())
+        _require_contains_line(
+            no_go_check.stdout,
+            "final_decision=NO-GO",
+            "expected NO-GO replay/tamper policy checker final decision marker",
+        )
+
+        tampered_bundle = tmp_path / "live-transport-replay-tamper-tampered.json"
+        payload = json.loads(no_go_bundle.read_text(encoding="utf-8"))
+        payload["final_decision"] = "GO"
+        tampered_bundle.write_text(
+            json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+        )
+
+        tampered_check = subprocess.run(
+            ["bash", str(checker), "--bundle-file", str(tampered_bundle)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if tampered_check.returncode == 0:
+            fail("expected tampered replay/tamper evidence bundle to fail policy checker")
+        _require_contains_text(
+            tampered_check.stderr or tampered_check.stdout,
+            "policy decision mismatch",
+            "expected policy decision mismatch marker for tampered replay/tamper bundle",
+        )
+
+        runtime_doc_text = runtime_doc.read_text(encoding="utf-8")
+        if "run_live_transport_replay_tamper_contract_lane.sh" not in runtime_doc_text:
+            fail("expected runtime-network doc to reference replay/tamper contract lane command")
+        if "generate_live_transport_replay_tamper_evidence_bundle.sh" not in runtime_doc_text:
+            fail("expected runtime-network doc to reference replay/tamper generator command")
+        if "check_live_transport_replay_tamper_policy.sh" not in runtime_doc_text:
+            fail("expected runtime-network doc to reference replay/tamper policy checker command")
+        if "kamn.sdk.live-transport-replay-tamper-evidence.v1" not in runtime_doc_text:
+            fail("expected runtime-network doc to reference replay/tamper schema marker")
+
+        invariant_doc_text = invariant_doc.read_text(encoding="utf-8")
+        if "run_live_transport_replay_tamper_contract_lane.sh" not in invariant_doc_text:
+            fail("expected invariant-and-fuzz strategy doc to reference replay/tamper contract lane")
+        if "check_live_transport_replay_tamper_policy.sh" not in invariant_doc_text:
+            fail("expected invariant-and-fuzz strategy doc to reference replay/tamper policy checker")
+
+        elapsed_seconds = int(time.time()) - start_epoch
+        if elapsed_seconds > max_seconds:
+            fail(f"replay/tamper contract lane exceeded runtime budget: {elapsed_seconds}s")
+
+        print("status=ok")
+        print(f"report_file={go_bundle}")
+        print("final_decision=GO")
+        print("live transport replay/tamper contract lane tests passed.")
+        return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run live transport replay/tamper evidence contract lane."
+    )
+    parser.add_argument("--output-report", default="")
+    parser.set_defaults(handler=run_lane)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh
+++ b/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py" "$@"

--- a/scripts/sdk/test_check_live_transport_replay_tamper_policy.sh
+++ b/scripts/sdk/test_check_live_transport_replay_tamper_policy.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh"
+CHECKER="$ROOT_DIR/scripts/sdk/check_live_transport_replay_tamper_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected live transport replay/tamper evidence generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected live transport replay/tamper policy checker to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/live-transport-replay-tamper-go.json"
+bash "$GENERATOR" \
+  --output-file "$go_bundle" \
+  --transport-lane-id "localhost-signed-integration" \
+  --message-id "msg-go-001" \
+  --from-did "kamn:did:agent:sender-1" \
+  --to-did "kamn:did:agent:listener-1" \
+  --nonce 41 \
+  --signature-status valid \
+  --replay-detected false \
+  --tamper-detected false \
+  --ci-fast-gate PASS >/dev/null
+
+go_output="$(bash "$CHECKER" --bundle-file "$go_bundle")"
+if [ "$(extract_value "$go_output" "status")" != "ok" ]; then
+  echo "expected replay/tamper policy checker to pass for GO bundle" >&2
+  exit 1
+fi
+if [ "$(extract_value "$go_output" "final_decision")" != "GO" ]; then
+  echo "expected replay/tamper policy checker to return GO for GO bundle" >&2
+  exit 1
+fi
+
+tampered_bundle="$TMP_DIR/live-transport-replay-tamper-go.tampered.json"
+cp "$go_bundle" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$CHECKER" --bundle-file "$tampered_bundle" 2>&1)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered replay/tamper evidence bundle to fail policy checker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
+  echo "expected policy decision mismatch error for tampered final decision" >&2
+  exit 1
+fi
+
+echo "live transport replay/tamper policy checker tests passed."

--- a/scripts/sdk/test_generate_live_transport_replay_tamper_evidence_bundle.sh
+++ b/scripts/sdk/test_generate_live_transport_replay_tamper_evidence_bundle.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected live transport replay/tamper evidence generator to be executable" >&2
+  exit 1
+fi
+
+go_bundle="$TMP_DIR/live-transport-replay-tamper-go.json"
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$go_bundle" \
+    --transport-lane-id "localhost-signed-integration" \
+    --message-id "msg-go-001" \
+    --from-did "kamn:did:agent:sender-1" \
+    --to-did "kamn:did:agent:listener-1" \
+    --nonce 41 \
+    --signature-status valid \
+    --replay-detected false \
+    --tamper-detected false \
+    --ci-fast-gate PASS
+)"
+
+if [ "$(extract_value "$go_output" "status")" != "generated" ]; then
+  echo "expected GO replay/tamper evidence bundle generation to succeed" >&2
+  exit 1
+fi
+if [ "$(extract_value "$go_output" "final_decision")" != "GO" ]; then
+  echo "expected GO replay/tamper final decision for clean input" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.sdk.live-transport-replay-tamper-evidence.v1"' "$go_bundle"; then
+  echo "expected replay/tamper evidence bundle schema marker" >&2
+  exit 1
+fi
+
+no_go_bundle="$TMP_DIR/live-transport-replay-tamper-no-go.json"
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$no_go_bundle" \
+    --transport-lane-id "localhost-signed-integration" \
+    --message-id "msg-no-go-001" \
+    --from-did "kamn:did:agent:sender-1" \
+    --to-did "kamn:did:agent:listener-1" \
+    --nonce 41 \
+    --signature-status malformed \
+    --replay-detected true \
+    --tamper-detected true \
+    --ci-fast-gate PASS
+)"
+
+if [ "$(extract_value "$no_go_output" "final_decision")" != "NO-GO" ]; then
+  echo "expected NO-GO replay/tamper final decision for malformed+replay+tamper input" >&2
+  exit 1
+fi
+
+if ! grep -q '"malformed_signature_detected"' "$no_go_bundle"; then
+  echo "expected malformed signature reason marker in replay/tamper NO-GO bundle" >&2
+  exit 1
+fi
+if ! grep -q '"replay_nonce_detected"' "$no_go_bundle"; then
+  echo "expected replay nonce reason marker in replay/tamper NO-GO bundle" >&2
+  exit 1
+fi
+if ! grep -q '"tamper_payload_detected"' "$no_go_bundle"; then
+  echo "expected tamper reason marker in replay/tamper NO-GO bundle" >&2
+  exit 1
+fi
+
+echo "live transport replay/tamper evidence bundle generator tests passed."

--- a/scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh
+++ b/scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh"
+SHARED_SCRIPT="$ROOT_DIR/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected live transport replay/tamper contract lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$SHARED_SCRIPT" ]; then
+  echo "expected shared live transport replay/tamper contract lane implementation to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q 'live_transport_replay_tamper_contract_lane_contract.py' "$SCRIPT"; then
+  echo "expected replay/tamper contract lane wrapper to delegate to shared implementation" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/live-transport-replay-tamper-contract-report.json"
+output="$(bash "$SCRIPT" --output-report "$report_file")"
+
+if ! printf '%s\n' "$output" | grep -q 'live transport replay/tamper contract lane tests passed.'; then
+  echo "expected success output from live transport replay/tamper contract lane" >&2
+  exit 1
+fi
+
+if [ ! -f "$report_file" ]; then
+  echo "expected replay/tamper contract lane to emit report file" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.sdk.live-transport-replay-tamper-evidence.v1"' "$report_file"; then
+  echo "expected replay/tamper contract lane report schema marker" >&2
+  exit 1
+fi
+
+if ! grep -q '"final_decision": "GO"' "$report_file"; then
+  echo "expected GO final decision in replay/tamper contract lane report" >&2
+  exit 1
+fi
+
+if ! grep -q 'generate_live_transport_replay_tamper_evidence_bundle.sh' "$SHARED_SCRIPT"; then
+  echo "expected replay/tamper contract lane implementation to execute evidence generator" >&2
+  exit 1
+fi
+
+if ! grep -q 'check_live_transport_replay_tamper_policy.sh' "$SHARED_SCRIPT"; then
+  echo "expected replay/tamper contract lane implementation to execute policy checker" >&2
+  exit 1
+fi
+
+if ! grep -q 'docs/foundation/runtime-network.md' "$SHARED_SCRIPT"; then
+  echo "expected replay/tamper contract lane implementation to verify runtime-network docs reference" >&2
+  exit 1
+fi
+
+if ! grep -q 'docs/testing/invariant-and-fuzz-strategy.md' "$SHARED_SCRIPT"; then
+  echo "expected replay/tamper contract lane implementation to verify invariant/fuzz strategy docs reference" >&2
+  exit 1
+fi
+
+echo "live transport replay/tamper contract lane tests passed."


### PR DESCRIPTION
Closes #1384
Part of #1380

## Summary
Adds a dedicated live transport replay/tamper evidence contract stack for SDK workflows: evidence generator, policy checker, and contract lane wrapper with fail-closed tamper detection.

## Changes
- scripts/sdk/live_transport_replay_tamper_contract.py: new generate/check contract utility with deterministic reason-code and final-decision logic.
- scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh: generator wrapper.
- scripts/sdk/check_live_transport_replay_tamper_policy.sh: policy-check wrapper.
- scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py: contract lane runner that validates GO/NO-GO/tampered paths.
- scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh: contract lane wrapper.
- scripts/sdk/test_generate_live_transport_replay_tamper_evidence_bundle.sh: generator tests.
- scripts/sdk/test_check_live_transport_replay_tamper_policy.sh: policy-check tests.
- scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh: lane wrapper integration tests.
- docs/foundation/runtime-network.md: replay/tamper schema and command contracts.
- docs/testing/invariant-and-fuzz-strategy.md: replay/tamper lane and checker references.
- crates/kamn-core/tests/runtime_network_docs.rs: new runtime doc contract assertions.
- crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs: new docs contract tests.
- README.md: replay/tamper lane command entrypoint.

## Risks & Compatibility
- None.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -p kamn-sdk --examples -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised replay/tamper generator, checker, lane, and docs-contract tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | schema/decision/reason-key validation in contract utility + tests |
| Functional  | ✅     | scripts/sdk/test_generate_live_transport_replay_tamper_evidence_bundle.sh |
| Integration | ✅     | scripts/sdk/test_check_live_transport_replay_tamper_policy.sh; scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh |
| Regression  | ✅     | tampered final-decision mismatch fail-closed assertions |

### Commands run
- python3 -m py_compile scripts/sdk/live_transport_replay_tamper_contract.py scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py
- bash scripts/sdk/test_generate_live_transport_replay_tamper_evidence_bundle.sh
- bash scripts/sdk/test_check_live_transport_replay_tamper_policy.sh
- bash scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh
- cargo fmt --check
- cargo clippy -p kamn-sdk --examples -- -D warnings
- cargo test -p kamn-core --test runtime_network_docs
- cargo test -p kamn-core --test invariant_and_fuzz_strategy_docs
