### PR TITLE
feat(sdk): add replay/tamper fast and deep lane wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,15 @@ CI fast-gate routes this lane when selector output
 ```bash
 bash scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh \
   --output-report /tmp/live-transport-replay-tamper-contract-report.json
+bash scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh \
+  --output-report /tmp/live-transport-replay-tamper-fast-report.json
+bash scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh \
+  --output-report /tmp/live-transport-replay-tamper-deep-report.json
 bash scripts/sdk/check_live_transport_replay_tamper_policy.sh \
   --bundle-file /tmp/live-transport-replay-tamper-contract-report.json
 # schema: kamn.sdk.live-transport-replay-tamper-evidence.v1
+# lane_mode markers: fast/deep
+# deep lane marker: deep_no_go_status=verified
 ```
 
 ### Run Localhost Bridge Demo Evidence Contract Lane (Fast)

--- a/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
+++ b/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
@@ -3,6 +3,8 @@ const DOC: &str = include_str!("../../../docs/testing/invariant-and-fuzz-strateg
 #[test]
 fn doc_contains_live_transport_replay_tamper_contract_commands() {
     assert!(DOC.contains("run_live_transport_replay_tamper_contract_lane.sh"));
+    assert!(DOC.contains("run_live_transport_replay_tamper_fast_lane.sh"));
+    assert!(DOC.contains("run_live_transport_replay_tamper_deep_lane.sh"));
     assert!(DOC.contains("check_live_transport_replay_tamper_policy.sh"));
     assert!(DOC.contains("kamn.sdk.live-transport-replay-tamper-evidence.v1"));
 }

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -221,9 +221,14 @@ fn doc_contains_live_transport_replay_tamper_evidence_contract_rules() {
     assert!(DOC.contains("generate_live_transport_replay_tamper_evidence_bundle.sh"));
     assert!(DOC.contains("check_live_transport_replay_tamper_policy.sh"));
     assert!(DOC.contains("run_live_transport_replay_tamper_contract_lane.sh"));
+    assert!(DOC.contains("run_live_transport_replay_tamper_fast_lane.sh"));
+    assert!(DOC.contains("run_live_transport_replay_tamper_deep_lane.sh"));
     assert!(DOC.contains("kamn.sdk.live-transport-replay-tamper-evidence.v1"));
     assert!(DOC.contains("malformed_signature_detected"));
     assert!(DOC.contains("replay_nonce_detected"));
     assert!(DOC.contains("tamper_payload_detected"));
+    assert!(DOC.contains("lane_mode=fast"));
+    assert!(DOC.contains("lane_mode=deep"));
+    assert!(DOC.contains("deep_no_go_status=verified"));
     assert!(DOC.contains("Regression: #1380"));
 }

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -229,6 +229,10 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `bash scripts/sdk/check_live_transport_replay_tamper_policy.sh --bundle-file /tmp/live-transport-replay-tamper-bundle.json`
 - Contract lane command:
   - `bash scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh --output-report /tmp/live-transport-replay-tamper-contract-report.json`
+- Fast lane wrapper:
+  - `bash scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh --output-report /tmp/live-transport-replay-tamper-fast-report.json`
+- Deep lane wrapper:
+  - `bash scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh --output-report /tmp/live-transport-replay-tamper-deep-report.json`
 - Evidence schema:
   - `kamn.sdk.live-transport-replay-tamper-evidence.v1`
 - Deterministic replay/tamper reason codes:
@@ -240,6 +244,10 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `ci_fast_gate_failed`
 - Regression policy:
   - tampered final decision, reason-key drift, and replay/tamper marker drift fail closed (`Regression: #1380`).
+- Lane mode markers:
+  - `lane_mode=fast`
+  - `lane_mode=deep`
+  - `deep_no_go_status=verified` (deep lane only)
 
 ## Queue Guard Rules
 - `BoundedRuntimeQueue<T>` is FIFO and preserves insertion order.

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -26,6 +26,10 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `bash scripts/runtime/check_invariant_fuzz_concurrency_policy.sh --report-file /tmp/invariant-fuzz-concurrency-contract-report.json`
 - Live transport replay/tamper contract lane:
   - `bash scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh --output-report /tmp/live-transport-replay-tamper-contract-report.json`
+- Live transport replay/tamper fast lane:
+  - `bash scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh --output-report /tmp/live-transport-replay-tamper-fast-report.json`
+- Live transport replay/tamper deep lane:
+  - `bash scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh --output-report /tmp/live-transport-replay-tamper-deep-report.json`
 - Live transport replay/tamper policy checker:
   - `bash scripts/sdk/check_live_transport_replay_tamper_policy.sh --bundle-file /tmp/live-transport-replay-tamper-contract-report.json`
 

--- a/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py
+++ b/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py
@@ -34,6 +34,7 @@ def _require_contains_text(output: str, marker: str, message: str) -> None:
 
 
 def run_lane(args: argparse.Namespace) -> int:
+    mode = args.mode
     generator = ROOT_DIR / "scripts/sdk/generate_live_transport_replay_tamper_evidence_bundle.sh"
     checker = ROOT_DIR / "scripts/sdk/check_live_transport_replay_tamper_policy.sh"
     runtime_doc = ROOT_DIR / "docs/foundation/runtime-network.md"
@@ -201,6 +202,10 @@ def run_lane(args: argparse.Namespace) -> int:
         runtime_doc_text = runtime_doc.read_text(encoding="utf-8")
         if "run_live_transport_replay_tamper_contract_lane.sh" not in runtime_doc_text:
             fail("expected runtime-network doc to reference replay/tamper contract lane command")
+        if "run_live_transport_replay_tamper_fast_lane.sh" not in runtime_doc_text:
+            fail("expected runtime-network doc to reference replay/tamper fast lane command")
+        if "run_live_transport_replay_tamper_deep_lane.sh" not in runtime_doc_text:
+            fail("expected runtime-network doc to reference replay/tamper deep lane command")
         if "generate_live_transport_replay_tamper_evidence_bundle.sh" not in runtime_doc_text:
             fail("expected runtime-network doc to reference replay/tamper generator command")
         if "check_live_transport_replay_tamper_policy.sh" not in runtime_doc_text:
@@ -211,8 +216,77 @@ def run_lane(args: argparse.Namespace) -> int:
         invariant_doc_text = invariant_doc.read_text(encoding="utf-8")
         if "run_live_transport_replay_tamper_contract_lane.sh" not in invariant_doc_text:
             fail("expected invariant-and-fuzz strategy doc to reference replay/tamper contract lane")
+        if "run_live_transport_replay_tamper_fast_lane.sh" not in invariant_doc_text:
+            fail("expected invariant-and-fuzz strategy doc to reference replay/tamper fast lane")
+        if "run_live_transport_replay_tamper_deep_lane.sh" not in invariant_doc_text:
+            fail("expected invariant-and-fuzz strategy doc to reference replay/tamper deep lane")
         if "check_live_transport_replay_tamper_policy.sh" not in invariant_doc_text:
             fail("expected invariant-and-fuzz strategy doc to reference replay/tamper policy checker")
+
+        if mode == "deep":
+            deep_no_go_bundle = tmp_path / "live-transport-replay-tamper-deep-no-go.json"
+            deep_no_go_generate = subprocess.run(
+                [
+                    "bash",
+                    str(generator),
+                    "--output-file",
+                    str(deep_no_go_bundle),
+                    "--transport-lane-id",
+                    "localhost-signed-integration",
+                    "--message-id",
+                    "msg-deep-no-go-001",
+                    "--from-did",
+                    "kamn:did:agent:sender-1",
+                    "--to-did",
+                    "kamn:did:agent:listener-1",
+                    "--nonce",
+                    "42",
+                    "--signature-status",
+                    "mismatch",
+                    "--replay-detected",
+                    "false",
+                    "--tamper-detected",
+                    "false",
+                    "--ci-fast-gate",
+                    "FAIL",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if deep_no_go_generate.returncode != 0:
+                fail(
+                    (
+                        deep_no_go_generate.stderr
+                        or deep_no_go_generate.stdout
+                        or "deep NO-GO generation failed"
+                    ).strip()
+                )
+            _require_contains_line(
+                deep_no_go_generate.stdout,
+                "final_decision=NO-GO",
+                "expected deep replay/tamper generation to produce NO-GO",
+            )
+
+            deep_no_go_check = subprocess.run(
+                ["bash", str(checker), "--bundle-file", str(deep_no_go_bundle)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if deep_no_go_check.returncode != 0:
+                fail(
+                    (
+                        deep_no_go_check.stderr
+                        or deep_no_go_check.stdout
+                        or "deep NO-GO policy check failed"
+                    ).strip()
+                )
+            _require_contains_line(
+                deep_no_go_check.stdout,
+                "final_decision=NO-GO",
+                "expected deep replay/tamper policy checker to keep NO-GO decision",
+            )
 
         elapsed_seconds = int(time.time()) - start_epoch
         if elapsed_seconds > max_seconds:
@@ -220,6 +294,9 @@ def run_lane(args: argparse.Namespace) -> int:
 
         print("status=ok")
         print(f"report_file={go_bundle}")
+        print(f"lane_mode={mode}")
+        if mode == "deep":
+            print("deep_no_go_status=verified")
         print("final_decision=GO")
         print("live transport replay/tamper contract lane tests passed.")
         return 0
@@ -230,6 +307,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run live transport replay/tamper evidence contract lane."
     )
     parser.add_argument("--output-report", default="")
+    parser.add_argument("--mode", default="fast", choices=("fast", "deep"))
     parser.set_defaults(handler=run_lane)
     return parser
 

--- a/scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh
+++ b/scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec bash "$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh" --mode deep "$@"

--- a/scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh
+++ b/scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec bash "$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh" --mode fast "$@"

--- a/scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh
+++ b/scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected live transport replay/tamper deep lane script to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q 'run_live_transport_replay_tamper_contract_lane.sh' "$SCRIPT"; then
+  echo "expected replay/tamper deep lane wrapper to delegate to contract lane script" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/live-transport-replay-tamper-deep-report.json"
+output="$(bash "$SCRIPT" --output-report "$report_file")"
+
+if ! printf '%s\n' "$output" | grep -q 'lane_mode=deep'; then
+  echo "expected replay/tamper deep lane mode marker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$output" | grep -q 'deep_no_go_status=verified'; then
+  echo "expected replay/tamper deep lane NO-GO verification marker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$output" | grep -q 'final_decision=GO'; then
+  echo "expected replay/tamper deep lane final decision marker" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.sdk.live-transport-replay-tamper-evidence.v1"' "$report_file"; then
+  echo "expected replay/tamper deep lane report schema marker" >&2
+  exit 1
+fi
+
+echo "live transport replay/tamper deep lane tests passed."

--- a/scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh
+++ b/scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh"
+SHARED_SCRIPT="$ROOT_DIR/scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected live transport replay/tamper fast lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$SHARED_SCRIPT" ]; then
+  echo "expected shared replay/tamper lane contract implementation to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q 'run_live_transport_replay_tamper_contract_lane.sh' "$SCRIPT"; then
+  echo "expected replay/tamper fast lane wrapper to delegate to contract lane script" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/live-transport-replay-tamper-fast-report.json"
+output="$(bash "$SCRIPT" --output-report "$report_file")"
+
+if ! printf '%s\n' "$output" | grep -q 'lane_mode=fast'; then
+  echo "expected replay/tamper fast lane mode marker" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$output" | grep -q 'final_decision=GO'; then
+  echo "expected replay/tamper fast lane final decision marker" >&2
+  exit 1
+fi
+
+if ! grep -q '"schema_version": "kamn.sdk.live-transport-replay-tamper-evidence.v1"' "$report_file"; then
+  echo "expected replay/tamper fast lane report schema marker" >&2
+  exit 1
+fi
+
+echo "live transport replay/tamper fast lane tests passed."


### PR DESCRIPTION
Closes #1385
Part of #1380

## Summary
Adds explicit fast/deep wrapper integration for live transport replay/tamper contract lanes, with deterministic lane-mode markers and deep-lane NO-GO verification output.

## Changes
- scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh: new fast wrapper.
- scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh: new deep wrapper.
- scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py: add --mode fast|deep support; deep mode executes additional NO-GO verification path; emit lane_mode and deep_no_go_status markers.
- scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh: fast wrapper integration test.
- scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh: deep wrapper integration test.
- docs/foundation/runtime-network.md: add fast/deep wrapper command contracts and lane mode markers.
- docs/testing/invariant-and-fuzz-strategy.md: add fast/deep wrapper command surface.
- README.md: add fast/deep wrapper entrypoints.
- crates/kamn-core/tests/runtime_network_docs.rs and crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs: docs-contract assertions for fast/deep markers.

## Risks & Compatibility
- None.

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -p kamn-sdk --examples -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised fast/deep wrapper scripts and replay/tamper docs-contract tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | mode-marker and docs-contract assertions |
| Functional  | ✅     | scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh; scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh |
| Integration | ✅     | scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh |
| Regression  | ✅     | deep NO-GO verification marker and tamper mismatch behavior retained |

### Commands run
- bash scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh
- bash scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh
- bash scripts/sdk/test_generate_live_transport_replay_tamper_evidence_bundle.sh
- bash scripts/sdk/test_check_live_transport_replay_tamper_policy.sh
- bash scripts/sdk/test_run_live_transport_replay_tamper_contract_lane.sh
- cargo fmt --check
- cargo clippy -p kamn-sdk --examples -- -D warnings
- cargo test -p kamn-core --test runtime_network_docs
- cargo test -p kamn-core --test invariant_and_fuzz_strategy_docs
