### PR TITLE
feat(kolme): map backend receipt aliases and tx-hash commit ids (#1412)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -528,7 +528,7 @@ fn parse_live_provider_response(
     match status.as_str() {
         "submitted" | "duplicate" => {
             let provider = required_response_field(&fields, "provider")?;
-            let commit_id = required_response_field(&fields, "commit_id")?;
+            let commit_id = resolve_commit_id(&fields)?;
             let finality_value = required_response_field(&fields, "finality")?;
             let finality = parse_receipt_finality(finality_value.as_str())?;
             let receipt = KolmeRuntimeCommitProviderReceipt {
@@ -747,13 +747,74 @@ fn required_response_field(
     Ok(trimmed.to_owned())
 }
 
+fn resolve_commit_id(
+    fields: &HashMap<String, String>,
+) -> Result<String, KolmeRuntimeCommitProviderError> {
+    if let Some(commit_id) = fields.get("commit_id") {
+        let trimmed = commit_id.trim();
+        if trimmed.is_empty() {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "field must not be empty: commit_id".to_owned(),
+            });
+        }
+        return Ok(trimmed.to_owned());
+    }
+
+    let tx_hash = fields
+        .get("tx_hash")
+        .or_else(|| fields.get("txhash"))
+        .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "missing required field: commit_id".to_owned(),
+        })?;
+    let tx_hash = tx_hash.trim();
+    if tx_hash.is_empty() {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "field must not be empty: tx_hash".to_owned(),
+        });
+    }
+
+    let block_height = match fields.get("block_height") {
+        Some(raw_height) => Some(parse_block_height(raw_height.as_str())?),
+        None => None,
+    };
+    Ok(deterministic_backend_commit_id(tx_hash, block_height))
+}
+
+fn parse_block_height(raw: &str) -> Result<u64, KolmeRuntimeCommitProviderError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "field must not be empty: block_height".to_owned(),
+        });
+    }
+    let height =
+        trimmed
+            .parse::<u64>()
+            .map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid block_height value: {trimmed}"),
+            })?;
+    if height == 0 {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "block_height must be positive".to_owned(),
+        });
+    }
+    Ok(height)
+}
+
+fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> String {
+    match block_height {
+        Some(height) => format!("kolme-commit:{tx_hash}:h{height}"),
+        None => format!("kolme-commit:{tx_hash}"),
+    }
+}
+
 fn parse_receipt_finality(
     value: &str,
 ) -> Result<KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderError> {
     match value {
-        "pending" => Ok(KolmeCommitReceiptFinality::Pending),
-        "final" => Ok(KolmeCommitReceiptFinality::Final),
-        "failed" => Ok(KolmeCommitReceiptFinality::Failed),
+        "pending" | "accepted" | "mempool" => Ok(KolmeCommitReceiptFinality::Pending),
+        "final" | "confirmed" | "finalized" => Ok(KolmeCommitReceiptFinality::Final),
+        "failed" | "rejected" => Ok(KolmeCommitReceiptFinality::Failed),
         _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
             reason: format!("invalid finality value: {value}"),
         }),

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -540,3 +540,70 @@ fn regression_live_provider_fails_closed_for_malformed_response_shape() {
         "provider must fail closed for malformed backend responses"
     );
 }
+
+#[test]
+fn functional_live_provider_maps_tx_hash_and_block_height_to_deterministic_commit_id() {
+    let response = r#"{"status":"submitted","provider":"kolme-fork-local","tx_hash":"ab12cd34","block_height":"42","finality":"confirmed"}"#.to_owned();
+    let (transport, _calls) = RecordingTransport::with_result(Ok(response));
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "http://127.0.0.1:3030",
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-live-provider-003",
+        "state:live",
+        "kamn:did:agent:live-provider-3",
+        57,
+        "payload:live-provider",
+    )
+    .expect("request should build");
+
+    let outcome = provider
+        .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
+        .expect("provider should map tx_hash response");
+    assert_eq!(
+        outcome,
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-fork-local".to_owned(),
+            commit_id: "kolme-commit:ab12cd34:h42".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        })
+    );
+}
+
+#[test]
+fn regression_live_provider_normalizes_backend_finality_aliases() {
+    // Regression: #1412
+    let response = r#"{"status":"duplicate","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"accepted"}"#.to_owned();
+    let (transport, _calls) = RecordingTransport::with_result(Ok(response));
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "http://127.0.0.1:3030",
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-live-provider-004",
+        "state:live",
+        "kamn:did:agent:live-provider-4",
+        58,
+        "payload:live-provider",
+    )
+    .expect("request should build");
+
+    let outcome = provider
+        .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
+        .expect("provider should map finality alias");
+    assert_eq!(
+        outcome,
+        KolmeRuntimeCommitProviderOutcome::Duplicate(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-fork-local".to_owned(),
+            commit_id: "kolme-commit:ab12cd34:h42".to_owned(),
+            finality: KolmeCommitReceiptFinality::Pending,
+        })
+    );
+}


### PR DESCRIPTION
## Summary
- Extend live provider response mapping to support deterministic backend receipt translation semantics.
- Add fallback commit-id synthesis from backend `tx_hash`/`block_height` when explicit `commit_id` is absent.
- Normalize backend finality aliases (`accepted`, `confirmed`, `finalized`) into KAMN finality categories with fail-closed validation.

## Linked Issues
- Closes #1412
- Refs #1408
- Refs #1407

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A
