### PR TITLE
feat(kolme): add finality checker and polling contracts (#1413)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -415,6 +415,107 @@ pub struct KolmeRuntimeCommitLiveProvider<T> {
     transport: T,
 }
 
+/// Transport abstraction for querying runtime commit finality from a live backend.
+pub trait KolmeRuntimeCommitFinalityTransport {
+    /// Fetches one finality response payload for the provided commit identifier.
+    fn fetch_runtime_commit_finality(
+        &mut self,
+        base_url: &str,
+        status_path: &str,
+        commit_id: &str,
+    ) -> Result<String, KolmeRuntimeCommitProviderError>;
+}
+
+/// Deterministic finality checker for live backend runtime commit receipts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitFinalityChecker<T> {
+    base_url: String,
+    status_path: String,
+    transport: T,
+}
+
+impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T> {
+    /// Builds a finality checker with deterministic endpoint validation.
+    pub fn new(
+        base_url: &str,
+        status_path: &str,
+        transport: T,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        if base_url.trim().is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_base_url",
+                reason: "must not be empty",
+            });
+        }
+        if status_path.trim().is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_status_path",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            base_url: base_url.trim().to_owned(),
+            status_path: status_path.trim().to_owned(),
+            transport,
+        })
+    }
+
+    /// Fetches and parses one backend finality response for the provided commit.
+    pub fn check_commit_finality(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        if commit_id.trim().is_empty() {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "commit_id must not be empty".to_owned(),
+            });
+        }
+
+        let response = self.transport.fetch_runtime_commit_finality(
+            self.base_url.as_str(),
+            self.status_path.as_str(),
+            commit_id,
+        )?;
+        let fields = parse_response_fields(response.as_str())?;
+        let provider = required_response_field(&fields, "provider")?;
+        let observed_commit_id = resolve_commit_id(&fields)?;
+        if observed_commit_id != commit_id {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!(
+                    "commit_id mismatch: expected '{commit_id}', observed '{observed_commit_id}'"
+                ),
+            });
+        }
+        let finality_value = required_response_field(&fields, "finality")?;
+        let finality = parse_receipt_finality(finality_value.as_str())?;
+        Ok(KolmeRuntimeCommitProviderReceipt {
+            provider,
+            commit_id: observed_commit_id,
+            finality,
+        })
+    }
+
+    /// Polls backend finality and returns the first non-pending receipt.
+    pub fn poll_finality(
+        &mut self,
+        commit_id: &str,
+        max_attempts: u32,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        if max_attempts == 0 {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "max_attempts must be positive".to_owned(),
+            });
+        }
+        for _ in 0..max_attempts {
+            let receipt = self.check_commit_finality(commit_id)?;
+            if !matches!(receipt.finality, KolmeCommitReceiptFinality::Pending) {
+                return Ok(receipt);
+            }
+        }
+        Err(KolmeRuntimeCommitProviderError::Timeout)
+    }
+}
+
 impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
     /// Builds a live provider with deterministic endpoint validation.
     pub fn new(

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -253,6 +253,7 @@ pub use key_recovery::{KeyRecoveryManager, RecoveryError, RecoveryState};
 pub use kolme_runtime_commit::{
     AdapterBackedKolmeRuntimeCommitClient, InMemoryKolmeRuntimeCommitClient,
     KolmeCommitReceiptFinality, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitFinalityTransport,
     KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider,
     KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
     KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderTransport,

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -1,6 +1,7 @@
 use kamn_core::{
     AdapterBackedKolmeRuntimeCommitClient, InMemoryKolmeRuntimeCommitClient,
     KolmeCommitReceiptFinality, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitFinalityTransport,
     KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider,
     KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
     KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderTransport,
@@ -8,6 +9,7 @@ use kamn_core::{
     RuntimeCommitPipeline,
 };
 use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::rc::Rc;
 use std::time::Instant;
 
@@ -28,6 +30,7 @@ struct FixtureCase {
 
 type ProviderCalls = Rc<RefCell<Vec<(String, String)>>>;
 type TransportCalls = Rc<RefCell<Vec<(String, String, String, String)>>>;
+type FinalityTransportCalls = Rc<RefCell<Vec<(String, String, String)>>>;
 
 #[derive(Debug, Clone)]
 struct RecordingProvider {
@@ -99,6 +102,47 @@ impl KolmeRuntimeCommitProviderTransport for RecordingTransport {
             idempotency_key.to_owned(),
         ));
         self.result.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RecordingFinalityTransport {
+    calls: FinalityTransportCalls,
+    responses: Rc<RefCell<VecDeque<Result<String, KolmeRuntimeCommitProviderError>>>>,
+}
+
+impl RecordingFinalityTransport {
+    fn with_responses(
+        responses: Vec<Result<String, KolmeRuntimeCommitProviderError>>,
+    ) -> (Self, FinalityTransportCalls) {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        (
+            Self {
+                calls: calls.clone(),
+                responses: Rc::new(RefCell::new(VecDeque::from(responses))),
+            },
+            calls,
+        )
+    }
+}
+
+impl KolmeRuntimeCommitFinalityTransport for RecordingFinalityTransport {
+    fn fetch_runtime_commit_finality(
+        &mut self,
+        base_url: &str,
+        status_path: &str,
+        commit_id: &str,
+    ) -> Result<String, KolmeRuntimeCommitProviderError> {
+        self.calls.borrow_mut().push((
+            base_url.to_owned(),
+            status_path.to_owned(),
+            commit_id.to_owned(),
+        ));
+        self.responses.borrow_mut().pop_front().unwrap_or_else(|| {
+            Err(KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "no queued finality response".to_owned(),
+            })
+        })
     }
 }
 
@@ -605,5 +649,125 @@ fn regression_live_provider_normalizes_backend_finality_aliases() {
             commit_id: "kolme-commit:ab12cd34:h42".to_owned(),
             finality: KolmeCommitReceiptFinality::Pending,
         })
+    );
+}
+
+#[test]
+fn unit_finality_checker_rejects_empty_endpoint_or_status_path() {
+    let (transport, _calls) = RecordingFinalityTransport::with_responses(Vec::new());
+    assert!(
+        matches!(
+            KolmeRuntimeCommitFinalityChecker::new("", "/commit/finality", transport),
+            Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_base_url",
+                reason: "must not be empty",
+            })
+        ),
+        "finality checker base URL should fail validation when empty"
+    );
+
+    let (transport, _calls) = RecordingFinalityTransport::with_responses(Vec::new());
+    assert!(
+        matches!(
+            KolmeRuntimeCommitFinalityChecker::new("http://127.0.0.1:3030", "", transport),
+            Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_status_path",
+                reason: "must not be empty",
+            })
+        ),
+        "finality checker status path should fail validation when empty"
+    );
+}
+
+#[test]
+fn functional_finality_checker_maps_confirmed_alias_to_final_receipt() {
+    let response = r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"confirmed"}"#.to_owned();
+    let (transport, calls) = RecordingFinalityTransport::with_responses(vec![Ok(response)]);
+    let mut checker = KolmeRuntimeCommitFinalityChecker::new(
+        "http://127.0.0.1:3030",
+        "/commit/finality",
+        transport,
+    )
+    .expect("checker should build");
+
+    let receipt = checker
+        .check_commit_finality("kolme-commit:ab12cd34:h42")
+        .expect("checker should parse finality response");
+    assert_eq!(
+        receipt,
+        KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-fork-local".to_owned(),
+            commit_id: "kolme-commit:ab12cd34:h42".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }
+    );
+
+    let calls = calls.borrow();
+    assert_eq!(calls.len(), 1, "finality transport should be called once");
+    assert_eq!(calls[0].0, "http://127.0.0.1:3030");
+    assert_eq!(calls[0].1, "/commit/finality");
+    assert_eq!(calls[0].2, "kolme-commit:ab12cd34:h42");
+}
+
+#[test]
+fn functional_finality_checker_polls_pending_then_final() {
+    let pending =
+        r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"pending"}"#.to_owned();
+    let confirmed =
+        r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"confirmed"}"#.to_owned();
+    let (transport, _calls) =
+        RecordingFinalityTransport::with_responses(vec![Ok(pending), Ok(confirmed)]);
+    let mut checker = KolmeRuntimeCommitFinalityChecker::new(
+        "http://127.0.0.1:3030",
+        "/commit/finality",
+        transport,
+    )
+    .expect("checker should build");
+
+    let receipt = checker
+        .poll_finality("kolme-commit:ab12cd34:h42", 2)
+        .expect("checker should return first non-pending finality");
+    assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Final);
+}
+
+#[test]
+fn regression_finality_checker_fails_closed_for_commit_id_mismatch() {
+    // Regression: #1413
+    let mismatch =
+        r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:other:h42","finality":"final"}"#.to_owned();
+    let (transport, _calls) = RecordingFinalityTransport::with_responses(vec![Ok(mismatch)]);
+    let mut checker = KolmeRuntimeCommitFinalityChecker::new(
+        "http://127.0.0.1:3030",
+        "/commit/finality",
+        transport,
+    )
+    .expect("checker should build");
+
+    assert!(
+        matches!(
+            checker.check_commit_finality("kolme-commit:ab12cd34:h42"),
+            Err(KolmeRuntimeCommitProviderError::MalformedResponse { .. })
+        ),
+        "checker must fail closed when response commit id mismatches requested commit id"
+    );
+}
+
+#[test]
+fn regression_finality_checker_times_out_when_pending_budget_exhausted() {
+    // Regression: #1413
+    let pending =
+        r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"pending"}"#.to_owned();
+    let (transport, _calls) =
+        RecordingFinalityTransport::with_responses(vec![Ok(pending.clone()), Ok(pending)]);
+    let mut checker = KolmeRuntimeCommitFinalityChecker::new(
+        "http://127.0.0.1:3030",
+        "/commit/finality",
+        transport,
+    )
+    .expect("checker should build");
+
+    assert_eq!(
+        checker.poll_finality("kolme-commit:ab12cd34:h42", 2),
+        Err(KolmeRuntimeCommitProviderError::Timeout)
     );
 }


### PR DESCRIPTION
## Summary
- Add `KolmeRuntimeCommitFinalityTransport` and `KolmeRuntimeCommitFinalityChecker` to `kamn-core` for deterministic live receipt finality checks.
- Implement fail-closed semantics for commit-id mismatch and pending-budget timeout during finality polling.
- Add red/green tests for checker validation, alias mapping, polling progression, mismatch rejection, and timeout behavior.

## Linked Issues
- Closes #1413
- Refs #1408
- Refs #1407

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A
