### PR TITLE
feat(sdk): add typescript live transport backend adapter mode (#1414)

### DIFF
--- a/packages/kamn-sdk/src/index.ts
+++ b/packages/kamn-sdk/src/index.ts
@@ -1,5 +1,9 @@
 export { KAMNClient, SDKError, TransportModeMismatchError } from "./memory_client.ts";
-export { LiveTransportConfig, LiveTransportKAMNClient } from "./live_transport_client.ts";
+export {
+  LiveTransportBackendAdapterError,
+  LiveTransportConfig,
+  LiveTransportKAMNClient,
+} from "./live_transport_client.ts";
 export { OpenClawConnector } from "./openclaw_connector.ts";
 
 export type {

--- a/packages/kamn-sdk/src/live_transport_client.ts
+++ b/packages/kamn-sdk/src/live_transport_client.ts
@@ -8,6 +8,43 @@ import type {
   TransportMode,
 } from "./types.ts";
 
+export type LiveTransportOperation =
+  | "register"
+  | "resolve"
+  | "send"
+  | "receive"
+  | "createTask"
+  | "acceptTask"
+  | "createEscrow"
+  | "releaseEscrow"
+  | "balance"
+  | "searchAgents"
+  | "getReputation";
+
+export interface LiveTransportBackendRequest {
+  endpoint: string;
+  operation: LiveTransportOperation;
+  payload: Record<string, unknown>;
+}
+
+export type LiveTransportBackendResponse =
+  | { status: "ok"; value: unknown }
+  | { status: "error"; reason: string };
+
+export interface LiveTransportBackendAdapter {
+  invoke(request: LiveTransportBackendRequest): LiveTransportBackendResponse;
+}
+
+export class LiveTransportBackendAdapterError extends SDKError {
+  readonly operation: LiveTransportOperation;
+
+  constructor(operation: LiveTransportOperation, reason: string) {
+    super(`backend adapter operation ${operation} failed: ${reason}`);
+    this.name = "LiveTransportBackendAdapterError";
+    this.operation = operation;
+  }
+}
+
 export class LiveTransportConfig {
   readonly endpoint: string;
 
@@ -25,9 +62,23 @@ export class LiveTransportConfig {
 
 export class LiveTransportKAMNClient {
   private static readonly endpointRegistry = new Map<string, KAMNClient>();
+  private static readonly backendAdapterRegistry = new Map<
+    string,
+    LiveTransportBackendAdapter
+  >();
 
   readonly config: LiveTransportConfig;
   private readonly delegate: KAMNClient;
+  private readonly backendAdapter?: LiveTransportBackendAdapter;
+
+  static registerBackendAdapter(endpoint: string, adapter: LiveTransportBackendAdapter): void {
+    const config = new LiveTransportConfig(endpoint);
+    LiveTransportKAMNClient.backendAdapterRegistry.set(config.endpoint, adapter);
+  }
+
+  static clearBackendAdapters(): void {
+    LiveTransportKAMNClient.backendAdapterRegistry.clear();
+  }
 
   constructor(endpoint: string) {
     this.config = new LiveTransportConfig(endpoint);
@@ -38,6 +89,7 @@ export class LiveTransportKAMNClient {
     if (!LiveTransportKAMNClient.endpointRegistry.has(this.config.endpoint)) {
       LiveTransportKAMNClient.endpointRegistry.set(this.config.endpoint, this.delegate);
     }
+    this.backendAdapter = LiveTransportKAMNClient.backendAdapterRegistry.get(this.config.endpoint);
   }
 
   transportMode(): TransportMode {
@@ -52,46 +104,228 @@ export class LiveTransportKAMNClient {
   }
 
   register(agentType: string, modelFamily: string, capabilities: string[]): string {
-    return this.delegate.register(agentType, modelFamily, capabilities);
+    return this.invokeWithAdapter(
+      "register",
+      { agentType, modelFamily, capabilities: [...capabilities] },
+      (value) => this.requireStringValue("register", value),
+      () => this.delegate.register(agentType, modelFamily, capabilities),
+    );
   }
 
   resolve(did: string): ResolveRecord {
-    return this.delegate.resolve(did);
+    return this.invokeWithAdapter(
+      "resolve",
+      { did },
+      (value) => this.requireResolveRecordValue("resolve", value),
+      () => this.delegate.resolve(did),
+    );
   }
 
   send(fromDid: string, toDid: string, body: string): string {
-    return this.delegate.send(fromDid, toDid, body);
+    return this.invokeWithAdapter(
+      "send",
+      { fromDid, toDid, body },
+      (value) => this.requireStringValue("send", value),
+      () => this.delegate.send(fromDid, toDid, body),
+    );
   }
 
   receive(did: string): InboxMessage[] {
-    return this.delegate.receive(did);
+    return this.invokeWithAdapter(
+      "receive",
+      { did },
+      (value) => this.requireInboxMessagesValue("receive", value),
+      () => this.delegate.receive(did),
+    );
   }
 
   createTask(creatorDid: string, taskType: string, description: string): string {
-    return this.delegate.createTask(creatorDid, taskType, description);
+    return this.invokeWithAdapter(
+      "createTask",
+      { creatorDid, taskType, description },
+      (value) => this.requireStringValue("createTask", value),
+      () => this.delegate.createTask(creatorDid, taskType, description),
+    );
   }
 
   acceptTask(taskId: string, assigneeDid: string): void {
-    this.delegate.acceptTask(taskId, assigneeDid);
+    this.invokeWithAdapter(
+      "acceptTask",
+      { taskId, assigneeDid },
+      () => undefined,
+      () => this.delegate.acceptTask(taskId, assigneeDid),
+    );
   }
 
   createEscrow(payerDid: string, payeeDid: string, amount: number): string {
-    return this.delegate.createEscrow(payerDid, payeeDid, amount);
+    return this.invokeWithAdapter(
+      "createEscrow",
+      { payerDid, payeeDid, amount },
+      (value) => this.requireStringValue("createEscrow", value),
+      () => this.delegate.createEscrow(payerDid, payeeDid, amount),
+    );
   }
 
   releaseEscrow(escrowId: string): void {
-    this.delegate.releaseEscrow(escrowId);
+    this.invokeWithAdapter(
+      "releaseEscrow",
+      { escrowId },
+      () => undefined,
+      () => this.delegate.releaseEscrow(escrowId),
+    );
   }
 
   balance(did: string): number {
-    return this.delegate.balance(did);
+    return this.invokeWithAdapter(
+      "balance",
+      { did },
+      (value) => this.requireNumberValue("balance", value),
+      () => this.delegate.balance(did),
+    );
   }
 
   searchAgents(query: SearchAgentsQuery = {}): SearchAgentResult[] {
-    return this.delegate.searchAgents(query);
+    return this.invokeWithAdapter(
+      "searchAgents",
+      { ...query },
+      (value) => this.requireSearchAgentsValue("searchAgents", value),
+      () => this.delegate.searchAgents(query),
+    );
   }
 
   getReputation(did: string): ReputationRecord {
-    return this.delegate.getReputation(did);
+    return this.invokeWithAdapter(
+      "getReputation",
+      { did },
+      (value) => this.requireReputationValue("getReputation", value),
+      () => this.delegate.getReputation(did),
+    );
+  }
+
+  private invokeWithAdapter<T>(
+    operation: LiveTransportOperation,
+    payload: Record<string, unknown>,
+    normalize: (value: unknown) => T,
+    fallback: () => T,
+  ): T {
+    if (!this.backendAdapter) {
+      return fallback();
+    }
+    const response = this.backendAdapter.invoke({
+      endpoint: this.config.endpoint,
+      operation,
+      payload,
+    });
+
+    if (response.status === "error") {
+      const reason =
+        typeof response.reason === "string" && response.reason.trim()
+          ? response.reason.trim()
+          : "backend adapter returned unknown error";
+      throw new LiveTransportBackendAdapterError(operation, reason);
+    }
+
+    if (response.status !== "ok") {
+      this.throwInvalidAdapterResponse(operation, "expected status ok|error");
+    }
+    return normalize(response.value);
+  }
+
+  private throwInvalidAdapterResponse(operation: LiveTransportOperation, reason: string): never {
+    throw new SDKError(`backend adapter invalid response for operation ${operation}: ${reason}`);
+  }
+
+  private requireStringValue(operation: LiveTransportOperation, value: unknown): string {
+    if (typeof value !== "string" || value.trim() === "") {
+      this.throwInvalidAdapterResponse(operation, "expected string value");
+    }
+    return value;
+  }
+
+  private requireNumberValue(operation: LiveTransportOperation, value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      this.throwInvalidAdapterResponse(operation, "expected numeric value");
+    }
+    return value;
+  }
+
+  private requireResolveRecordValue(
+    operation: LiveTransportOperation,
+    value: unknown,
+  ): ResolveRecord {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      typeof (value as { id?: unknown }).id !== "string" ||
+      typeof (value as { serviceEndpoint?: unknown }).serviceEndpoint !== "string"
+    ) {
+      this.throwInvalidAdapterResponse(operation, "expected resolve record");
+    }
+    return value as ResolveRecord;
+  }
+
+  private requireSearchAgentsValue(
+    operation: LiveTransportOperation,
+    value: unknown,
+  ): SearchAgentResult[] {
+    if (!Array.isArray(value)) {
+      this.throwInvalidAdapterResponse(operation, "expected search agent result array");
+    }
+    return value as SearchAgentResult[];
+  }
+
+  private requireReputationValue(
+    operation: LiveTransportOperation,
+    value: unknown,
+  ): ReputationRecord {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      typeof (value as { id?: unknown }).id !== "string" ||
+      typeof (value as { score?: unknown }).score !== "number"
+    ) {
+      this.throwInvalidAdapterResponse(operation, "expected reputation record");
+    }
+    return value as ReputationRecord;
+  }
+
+  private requireInboxMessagesValue(
+    operation: LiveTransportOperation,
+    value: unknown,
+  ): InboxMessage[] {
+    if (!Array.isArray(value)) {
+      this.throwInvalidAdapterResponse(operation, "expected inbox message array");
+    }
+    const normalized: InboxMessage[] = [];
+    for (const entry of value) {
+      if (typeof entry !== "object" || entry === null) {
+        this.throwInvalidAdapterResponse(operation, "expected inbox message object");
+      }
+
+      const candidate = entry as {
+        id?: unknown;
+        from?: unknown;
+        to?: unknown;
+        body?: unknown;
+        envelope?: unknown;
+      };
+      if (
+        typeof candidate.id !== "string" ||
+        typeof candidate.from !== "string" ||
+        typeof candidate.to !== "string" ||
+        typeof candidate.body !== "string"
+      ) {
+        this.throwInvalidAdapterResponse(operation, "expected inbox message string fields");
+      }
+
+      normalized.push({
+        id: candidate.id,
+        from: candidate.from,
+        to: candidate.to,
+        body: candidate.body,
+        envelope: (candidate.envelope ?? { id: candidate.id }) as InboxMessage["envelope"],
+      });
+    }
+    return normalized;
   }
 }

--- a/packages/kamn-sdk/tests/live_transport_client.test.ts
+++ b/packages/kamn-sdk/tests/live_transport_client.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   KAMNClient,
+  LiveTransportBackendAdapterError,
   LiveTransportConfig,
   LiveTransportKAMNClient,
   TransportModeMismatchError,
@@ -68,4 +69,84 @@ test("performance live transport contract lane stays within budget", () => {
     elapsedMillis < 300,
     `typescript sdk live transport contract lane exceeded budget: ${elapsedMillis}ms`,
   );
+});
+
+test("functional live transport backend adapter mode normalizes success payloads", () => {
+  const endpoint = "https://live.kamn.testnet/ts-backend-adapter";
+  const requests: string[] = [];
+
+  LiveTransportKAMNClient.registerBackendAdapter(endpoint, {
+    invoke(request) {
+      requests.push(request.operation);
+      if (request.operation === "register") {
+        return { status: "ok", value: "kamn:did:agent:backend-1" };
+      }
+      if (request.operation === "send") {
+        return { status: "ok", value: "msg_backend_1" };
+      }
+      if (request.operation === "receive") {
+        return {
+          status: "ok",
+          value: [
+            {
+              id: "msg_backend_1",
+              from: "kamn:did:agent:backend-1",
+              to: "kamn:did:agent:backend-2",
+              body: "backend hello",
+            },
+          ],
+        };
+      }
+      return { status: "ok", value: null };
+    },
+  });
+
+  try {
+    const client = new LiveTransportKAMNClient(endpoint);
+    const sender = client.register("autonomous", "claude-4", ["text"]);
+    assert.equal(sender, "kamn:did:agent:backend-1");
+
+    const messageId = client.send(
+      "kamn:did:agent:backend-1",
+      "kamn:did:agent:backend-2",
+      "backend hello",
+    );
+    assert.equal(messageId, "msg_backend_1");
+
+    const received = client.receive("kamn:did:agent:backend-2");
+    assert.equal(received.length, 1);
+    assert.equal(received[0].body, "backend hello");
+    assert.deepEqual(requests, ["register", "send", "receive"]);
+  } finally {
+    LiveTransportKAMNClient.clearBackendAdapters();
+  }
+});
+
+test("regression backend adapter errors and invalid payloads fail closed", () => {
+  // Regression: #1414
+  const endpoint = "https://live.kamn.testnet/ts-backend-adapter-fail";
+
+  LiveTransportKAMNClient.registerBackendAdapter(endpoint, {
+    invoke(request) {
+      if (request.operation === "register") {
+        return { status: "ok", value: 99 };
+      }
+      return { status: "error", reason: "backend_timeout" };
+    },
+  });
+
+  try {
+    const client = new LiveTransportKAMNClient(endpoint);
+    assert.throws(() => client.register("autonomous", "claude-4", ["text"]), {
+      name: "SDKError",
+      message: "backend adapter invalid response for operation register: expected string value",
+    });
+
+    assert.throws(
+      () => client.send("kamn:did:agent:x", "kamn:did:agent:y", "hello"),
+      LiveTransportBackendAdapterError,
+    );
+  } finally {
+    LiveTransportKAMNClient.clearBackendAdapters();
+  }
 });


### PR DESCRIPTION
## Summary
- Add backend-adapter mode to the TypeScript live transport client with operation-level request contracts.
- Add deterministic response normalization and fail-closed validation for backend adapter payloads.
- Add regression coverage for adapter error responses and invalid success payload shapes.

## Linked Issues
- Closes #1414
- Refs #1409
- Refs #1407

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A
