### PR TITLE
feat(sdk): add Python live transport backend adapter (#1415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,36 @@ bash scripts/sdk/check_live_transport_replay_tamper_policy.sh \
 # deep lane marker: deep_no_go_status=verified
 ```
 
+### Python Live Backend Adapter (Kolme)
+
+```python
+from kamn_sdk import LiveKAMNClient, LiveTransportBackendAdapterError
+
+class KolmeBackendAdapter:
+    def invoke(self, request):
+        # request = {"endpoint": str, "operation": str, "payload": {...}}
+        # Map operation/payload to your kolme_fork API surface.
+        return {"status": "ok", "value": "kamn:did:agent:backend-1"}
+
+endpoint = "https://live.kamn.testnet/python-backend-adapter"
+LiveKAMNClient.register_backend_adapter(endpoint, KolmeBackendAdapter())
+client = LiveKAMNClient(endpoint)
+
+try:
+    did = client.register("autonomous", "claude-4", ["text"])
+except LiveTransportBackendAdapterError as error:
+    print(error.operation, error.reason)
+finally:
+    LiveKAMNClient.clear_backend_adapters()
+```
+
+Validation commands:
+
+```bash
+python3 -m unittest tests/python/test_sdk.py
+bash scripts/sdk/run_live_transport_parity_contract_lane.sh
+```
+
 ### Troubleshoot Localhost Transport Failures
 
 - Troubleshooting taxonomy and remediation details:

--- a/docs/foundation/python-sdk-beta.md
+++ b/docs/foundation/python-sdk-beta.md
@@ -14,6 +14,8 @@ This document captures the first Python SDK implementation slice for MVP workflo
   - `LiveTransportConfig` endpoint contract.
   - `LiveKAMNClient` endpoint-scoped shared-state live path.
   - transport mode contracts (`TransportMode`) and mismatch rejection (`TransportModeMismatchError`, `Regression: #620`).
+  - Backend adapter mode via `LiveKAMNClient.register_backend_adapter(...)` and `LiveKAMNClient.clear_backend_adapters()`.
+  - Fail-closed backend adapter error taxonomy (`LiveTransportBackendAdapterError`) and invalid response rejection (`Regression: #1415`).
 - Added Python test coverage: `tests/python/test_sdk.py`.
 - Added scheduled deep-lane coverage: `tests/python/test_sdk_live_transport_deep.py`.
 
@@ -24,6 +26,7 @@ This document captures the first Python SDK implementation slice for MVP workflo
 - Escrow release is one-time and guarded against duplicate release.
 - Unknown DID/task/escrow access returns explicit `SDKError`.
 - Transport mode mismatch (`in-memory` vs `live`) is explicitly rejected to prevent cross-language contract drift (`Regression: #620`).
+- Backend adapter responses are fail-closed: malformed payloads raise `SDKError`; adapter errors surface deterministic operation+reason details via `LiveTransportBackendAdapterError`.
 
 ## Local Validation
 Run from repository root:

--- a/kamn_sdk.py
+++ b/kamn_sdk.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import AsyncIterator, Dict, List, Optional
+from typing import (
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    TypedDict,
+    TypeVar,
+)
 
 
 class SDKError(Exception):
@@ -33,6 +43,55 @@ class LiveTransportConfig:
             raise SDKError("transport endpoint must start with https:// or wss://")
         if len(normalized) <= len("https://a"):
             raise SDKError("transport endpoint must include host information")
+
+
+LiveTransportOperation = Literal[
+    "register",
+    "resolve",
+    "send",
+    "receive",
+    "createTask",
+    "acceptTask",
+    "createEscrow",
+    "releaseEscrow",
+    "balance",
+    "searchAgents",
+    "getReputation",
+]
+
+
+class LiveTransportBackendRequest(TypedDict):
+    endpoint: str
+    operation: LiveTransportOperation
+    payload: Dict[str, object]
+
+
+class LiveTransportBackendResponseOk(TypedDict):
+    status: Literal["ok"]
+    value: object
+
+
+class LiveTransportBackendResponseError(TypedDict):
+    status: Literal["error"]
+    reason: str
+
+
+LiveTransportBackendResponse = (
+    LiveTransportBackendResponseOk | LiveTransportBackendResponseError
+)
+
+
+class LiveTransportBackendAdapter(Protocol):
+    def invoke(
+        self, request: LiveTransportBackendRequest
+    ) -> LiveTransportBackendResponse: ...
+
+
+class LiveTransportBackendAdapterError(SDKError):
+    def __init__(self, operation: LiveTransportOperation, reason: str) -> None:
+        self.operation = operation
+        self.reason = reason
+        super().__init__(f"backend adapter operation {operation} failed: {reason}")
 
 
 @dataclass
@@ -218,8 +277,23 @@ class KAMNClient:
             raise SDKError(f"unknown did: {did}")
 
 
+_T = TypeVar("_T")
+
+
 class LiveKAMNClient:
     _live_endpoints: Dict[str, KAMNClient] = {}
+    _backend_adapters: Dict[str, LiveTransportBackendAdapter] = {}
+
+    @classmethod
+    def register_backend_adapter(
+        cls, endpoint: str, adapter: LiveTransportBackendAdapter
+    ) -> None:
+        config = LiveTransportConfig(endpoint=endpoint)
+        cls._backend_adapters[config.endpoint] = adapter
+
+    @classmethod
+    def clear_backend_adapters(cls) -> None:
+        cls._backend_adapters.clear()
 
     def __init__(self, endpoint: str) -> None:
         self.config = LiveTransportConfig(endpoint=endpoint)
@@ -227,6 +301,7 @@ class LiveKAMNClient:
         if self._endpoint not in self._live_endpoints:
             self._live_endpoints[self._endpoint] = KAMNClient()
         self._delegate = self._live_endpoints[self._endpoint]
+        self._backend_adapter = self._backend_adapters.get(self._endpoint)
 
     @property
     def endpoint(self) -> str:
@@ -240,5 +315,262 @@ class LiveKAMNClient:
         if found != expected:
             raise TransportModeMismatchError(expected, found)
 
+    def register(
+        self, agent_type: str, model_family: str, capabilities: List[str]
+    ) -> str:
+        return self._invoke_with_adapter(
+            "register",
+            {
+                "agentType": agent_type,
+                "modelFamily": model_family,
+                "capabilities": list(capabilities),
+            },
+            lambda value: self._require_string_value("register", value),
+            lambda: self._delegate.register(agent_type, model_family, capabilities),
+        )
+
+    def resolve(self, did: str) -> Dict[str, object]:
+        return self._invoke_with_adapter(
+            "resolve",
+            {"did": did},
+            lambda value: self._require_resolve_value("resolve", value),
+            lambda: self._delegate.resolve(did),
+        )
+
+    def send(self, from_did: str, to_did: str, body: str) -> str:
+        return self._invoke_with_adapter(
+            "send",
+            {"fromDid": from_did, "toDid": to_did, "body": body},
+            lambda value: self._require_string_value("send", value),
+            lambda: self._delegate.send(from_did, to_did, body),
+        )
+
+    def receive(self, did: str) -> List[Dict[str, object]]:
+        return self._invoke_with_adapter(
+            "receive",
+            {"did": did},
+            lambda value: self._require_inbox_messages_value("receive", value),
+            lambda: self._delegate.receive(did),
+        )
+
+    async def receive_stream(self, did: str) -> AsyncIterator[Dict[str, object]]:
+        for message in self.receive(did):
+            yield dict(message)
+
+    def create_task(self, creator_did: str, task_type: str, description: str) -> str:
+        return self._invoke_with_adapter(
+            "createTask",
+            {"creatorDid": creator_did, "taskType": task_type, "description": description},
+            lambda value: self._require_string_value("createTask", value),
+            lambda: self._delegate.create_task(creator_did, task_type, description),
+        )
+
+    def accept_task(self, task_id: str, assignee_did: str) -> None:
+        self._invoke_with_adapter(
+            "acceptTask",
+            {"taskId": task_id, "assigneeDid": assignee_did},
+            lambda _: None,
+            lambda: self._delegate.accept_task(task_id, assignee_did),
+        )
+
+    def create_escrow(self, payer_did: str, payee_did: str, amount: int) -> str:
+        return self._invoke_with_adapter(
+            "createEscrow",
+            {"payerDid": payer_did, "payeeDid": payee_did, "amount": amount},
+            lambda value: self._require_string_value("createEscrow", value),
+            lambda: self._delegate.create_escrow(payer_did, payee_did, amount),
+        )
+
+    def release_escrow(self, escrow_id: str) -> None:
+        self._invoke_with_adapter(
+            "releaseEscrow",
+            {"escrowId": escrow_id},
+            lambda _: None,
+            lambda: self._delegate.release_escrow(escrow_id),
+        )
+
+    def balance(self, did: str) -> int:
+        return self._invoke_with_adapter(
+            "balance",
+            {"did": did},
+            lambda value: self._require_int_value("balance", value),
+            lambda: self._delegate.balance(did),
+        )
+
+    def search_agents(
+        self, capability: Optional[str] = None, model_family: Optional[str] = None
+    ) -> List[Dict[str, object]]:
+        payload: Dict[str, object] = {}
+        if capability is not None:
+            payload["capability"] = capability
+        if model_family is not None:
+            payload["modelFamily"] = model_family
+        return self._invoke_with_adapter(
+            "searchAgents",
+            payload,
+            lambda value: self._require_search_agents_value("searchAgents", value),
+            lambda: self._delegate.search_agents(capability=capability, model_family=model_family),
+        )
+
+    def get_reputation(self, did: str) -> Dict[str, object]:
+        return self._invoke_with_adapter(
+            "getReputation",
+            {"did": did},
+            lambda value: self._require_reputation_value("getReputation", value),
+            lambda: self._delegate.get_reputation(did),
+        )
+
     def __getattr__(self, name: str):
         return getattr(self._delegate, name)
+
+    def _invoke_with_adapter(
+        self,
+        operation: LiveTransportOperation,
+        payload: Dict[str, object],
+        normalize: Callable[[object], _T],
+        fallback: Callable[[], _T],
+    ) -> _T:
+        if self._backend_adapter is None:
+            return fallback()
+
+        response = self._backend_adapter.invoke(
+            {"endpoint": self._endpoint, "operation": operation, "payload": payload}
+        )
+        if not isinstance(response, dict):
+            self._raise_invalid_adapter_response(operation, "expected mapping response")
+
+        status = response.get("status")
+        if status == "error":
+            reason_raw = response.get("reason")
+            reason = (
+                reason_raw.strip()
+                if isinstance(reason_raw, str) and reason_raw.strip()
+                else "backend adapter returned unknown error"
+            )
+            raise LiveTransportBackendAdapterError(operation, reason)
+
+        if status != "ok":
+            self._raise_invalid_adapter_response(operation, "expected status ok|error")
+        return normalize(response.get("value"))
+
+    def _raise_invalid_adapter_response(
+        self, operation: LiveTransportOperation, reason: str
+    ) -> None:
+        raise SDKError(
+            f"backend adapter invalid response for operation {operation}: {reason}"
+        )
+
+    def _require_string_value(
+        self, operation: LiveTransportOperation, value: object
+    ) -> str:
+        if not isinstance(value, str) or not value.strip():
+            self._raise_invalid_adapter_response(operation, "expected string value")
+        return value
+
+    def _require_int_value(self, operation: LiveTransportOperation, value: object) -> int:
+        if not isinstance(value, int) or isinstance(value, bool):
+            self._raise_invalid_adapter_response(operation, "expected integer value")
+        return value
+
+    def _require_resolve_value(
+        self, operation: LiveTransportOperation, value: object
+    ) -> Dict[str, object]:
+        if not isinstance(value, dict):
+            self._raise_invalid_adapter_response(operation, "expected resolve record")
+
+        agent_id = value.get("id")
+        service_endpoint = value.get("service_endpoint")
+        metadata = value.get("metadata", {})
+        if not isinstance(agent_id, str) or not isinstance(service_endpoint, str):
+            self._raise_invalid_adapter_response(operation, "expected resolve record")
+        if not isinstance(metadata, dict):
+            self._raise_invalid_adapter_response(operation, "expected resolve metadata map")
+        return {
+            "id": agent_id,
+            "metadata": dict(metadata),
+            "service_endpoint": service_endpoint,
+        }
+
+    def _require_inbox_messages_value(
+        self, operation: LiveTransportOperation, value: object
+    ) -> List[Dict[str, object]]:
+        if not isinstance(value, list):
+            self._raise_invalid_adapter_response(operation, "expected inbox message array")
+        normalized: List[Dict[str, object]] = []
+        for entry in value:
+            if not isinstance(entry, dict):
+                self._raise_invalid_adapter_response(
+                    operation, "expected inbox message object"
+                )
+
+            message_id = entry.get("id")
+            from_did = entry.get("from")
+            to_did = entry.get("to")
+            body = entry.get("body")
+            if not isinstance(message_id, str):
+                self._raise_invalid_adapter_response(
+                    operation, "expected inbox message string fields"
+                )
+            if not isinstance(from_did, str):
+                self._raise_invalid_adapter_response(
+                    operation, "expected inbox message string fields"
+                )
+            if not isinstance(to_did, str):
+                self._raise_invalid_adapter_response(
+                    operation, "expected inbox message string fields"
+                )
+            if not isinstance(body, str):
+                self._raise_invalid_adapter_response(
+                    operation, "expected inbox message string fields"
+                )
+
+            envelope = entry.get("envelope")
+            if envelope is None:
+                envelope = {"id": message_id}
+            normalized.append(
+                {
+                    "id": message_id,
+                    "from": from_did,
+                    "to": to_did,
+                    "body": body,
+                    "envelope": envelope,
+                }
+            )
+        return normalized
+
+    def _require_search_agents_value(
+        self, operation: LiveTransportOperation, value: object
+    ) -> List[Dict[str, object]]:
+        if not isinstance(value, list):
+            self._raise_invalid_adapter_response(
+                operation, "expected search agent result array"
+            )
+
+        normalized: List[Dict[str, object]] = []
+        for entry in value:
+            if not isinstance(entry, dict):
+                self._raise_invalid_adapter_response(
+                    operation, "expected search agent result object"
+                )
+            agent_id = entry.get("id")
+            metadata = entry.get("metadata", {})
+            if not isinstance(agent_id, str) or not isinstance(metadata, dict):
+                self._raise_invalid_adapter_response(
+                    operation, "expected search agent result object"
+                )
+            normalized.append({"id": agent_id, "metadata": dict(metadata)})
+        return normalized
+
+    def _require_reputation_value(
+        self, operation: LiveTransportOperation, value: object
+    ) -> Dict[str, object]:
+        if not isinstance(value, dict):
+            self._raise_invalid_adapter_response(operation, "expected reputation record")
+
+        agent_id = value.get("id")
+        score = value.get("score")
+        if not isinstance(agent_id, str):
+            self._raise_invalid_adapter_response(operation, "expected reputation record")
+        if not isinstance(score, (int, float)) or isinstance(score, bool):
+            self._raise_invalid_adapter_response(operation, "expected reputation record")
+        return {"id": agent_id, "score": score}

--- a/tests/python/test_sdk.py
+++ b/tests/python/test_sdk.py
@@ -4,6 +4,7 @@ import asyncio
 from kamn_sdk import (
     KAMNClient,
     LiveKAMNClient,
+    LiveTransportBackendAdapterError,
     SDKError,
     TransportMode,
     TransportModeMismatchError,
@@ -158,6 +159,91 @@ class PythonLiveTransportSDKTests(unittest.TestCase):
             client.send(sender, receiver, f"python-live-perf-{nonce}")
         received = client.receive(receiver)
         self.assertEqual(len(received), 256)
+
+    def test_functional_live_transport_backend_adapter_mode_normalizes_success_payloads(
+        self,
+    ) -> None:
+        endpoint = "https://live.kamn.testnet/python-backend-adapter"
+        operations: list[str] = []
+
+        class Adapter:
+            def invoke(self, request: dict[str, object]) -> dict[str, object]:
+                operation = str(request["operation"])
+                operations.append(operation)
+                if operation == "register":
+                    return {"status": "ok", "value": "kamn:did:agent:backend-1"}
+                if operation == "send":
+                    return {"status": "ok", "value": "msg_backend_1"}
+                if operation == "receive":
+                    return {
+                        "status": "ok",
+                        "value": [
+                            {
+                                "id": "msg_backend_1",
+                                "from": "kamn:did:agent:backend-1",
+                                "to": "kamn:did:agent:backend-2",
+                                "body": "backend hello",
+                            }
+                        ],
+                    }
+                return {"status": "ok", "value": None}
+
+        LiveKAMNClient.register_backend_adapter(endpoint, Adapter())
+        try:
+            client = LiveKAMNClient(endpoint)
+            sender = client.register("autonomous", "claude-4", ["text"])
+            self.assertEqual(sender, "kamn:did:agent:backend-1")
+
+            message_id = client.send(
+                "kamn:did:agent:backend-1",
+                "kamn:did:agent:backend-2",
+                "backend hello",
+            )
+            self.assertEqual(message_id, "msg_backend_1")
+
+            received = client.receive("kamn:did:agent:backend-2")
+            self.assertEqual(len(received), 1)
+            self.assertEqual(received[0]["body"], "backend hello")
+            self.assertEqual(operations, ["register", "send", "receive"])
+        finally:
+            LiveKAMNClient.clear_backend_adapters()
+
+    def test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed(
+        self,
+    ) -> None:
+        # Regression: #1415
+        endpoint = "https://live.kamn.testnet/python-backend-adapter-fail"
+
+        class Adapter:
+            def invoke(self, request: dict[str, object]) -> dict[str, object]:
+                operation = str(request["operation"])
+                if operation == "register":
+                    return {"status": "ok", "value": 42}
+                if operation == "send":
+                    return {"status": "error", "reason": "backend_timeout"}
+                return {"status": "error", "reason": "policy_denied"}
+
+        LiveKAMNClient.register_backend_adapter(endpoint, Adapter())
+        try:
+            client = LiveKAMNClient(endpoint)
+            with self.assertRaises(SDKError) as invalid_response:
+                client.register("autonomous", "claude-4", ["text"])
+            self.assertEqual(
+                str(invalid_response.exception),
+                "backend adapter invalid response for operation register: expected string value",
+            )
+
+            with self.assertRaises(LiveTransportBackendAdapterError) as timeout_error:
+                client.send("kamn:did:agent:x", "kamn:did:agent:y", "hello")
+            self.assertEqual(timeout_error.exception.operation, "send")
+            self.assertEqual(timeout_error.exception.reason, "backend_timeout")
+
+            with self.assertRaises(LiveTransportBackendAdapterError) as policy_error:
+                client.receive("kamn:did:agent:y")
+            self.assertEqual(policy_error.exception.operation, "receive")
+            self.assertEqual(policy_error.exception.reason, "policy_denied")
+        finally:
+            LiveKAMNClient.clear_backend_adapters()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds a Python live transport backend adapter mode for `LiveKAMNClient` so KAMN can route SDK operations to a live Kolme backend while preserving deterministic fail-closed behavior. This closes the gap where Python live transport was endpoint-scoped in-memory only.

Closes #1415

## Changes
- `kamn_sdk.py`: added backend adapter protocol/types, adapter registry, explicit live operation methods, fail-closed response normalization, and `LiveTransportBackendAdapterError`.
- `tests/python/test_sdk.py`: added TDD coverage for adapter success normalization and regression coverage for malformed response + timeout/policy failures.
- `README.md`: documented Python backend adapter usage and validation commands.
- `docs/foundation/python-sdk-beta.md`: updated delivered scope/error taxonomy for Python adapter mode.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
python3 -m unittest tests/python/test_sdk.py
```
Failure excerpt:
```text
ImportError: cannot import name 'LiveTransportBackendAdapterError' from 'kamn_sdk'
```

### 🟢 Green Phase
Commands:
```bash
python3 -m unittest tests/python/test_sdk.py
python3 -m unittest tests/python/test_sdk_live_transport_deep.py
```
Result summary:
```text
Ran 15 tests ... OK
Ran 1 test ... OK
```

### 🔁 Regression
Commands:
```bash
bash scripts/sdk/test_run_live_transport_parity_contract_lane.sh
bash scripts/sdk/test_run_live_transport_smoke_parity_contract_lane.sh
bash scripts/sdk/test_run_transport_profile_parity_matrix.sh
cargo test -p kamn-core --test python_sdk_beta_docs
cargo fmt --check
cargo clippy -- -D warnings
```
Result summary:
```text
...passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `tests/python/test_sdk.py::test_functional_live_transport_backend_adapter_mode_normalizes_success_payloads` (normalization assertions) | |
| Functional   | ✅ | `tests/python/test_sdk.py` live transport adapter flow | |
| Integration  | ✅ | `scripts/sdk/test_run_live_transport_parity_contract_lane.sh`, `scripts/sdk/test_run_live_transport_smoke_parity_contract_lane.sh` | |
| Regression   | ✅ | `tests/python/test_sdk.py::test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed` (`Regression: #1415`) | |
| Performance  | ✅ | Existing Python live transport performance lane in `tests/python/test_sdk.py` + deep lane `tests/python/test_sdk_live_transport_deep.py` | |

## Risks & Rollback
- No breaking API changes for in-memory clients; new adapter surface is opt-in.
- Rollback: revert this PR to restore previous delegate-only live behavior.

## Documentation Updates
- Updated `README.md`.
- Updated `docs/foundation/python-sdk-beta.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
