### PR TITLE
feat(sdk): enforce cross-SDK backend adapter parity contracts (#1416)

### DIFF
--- a/crates/kamn-core/tests/live_network_wave_docs.rs
+++ b/crates/kamn-core/tests/live_network_wave_docs.rs
@@ -56,6 +56,10 @@ fn live_network_wave_doc_contains_smoke_commands_and_schema() {
     assert!(LIVE_NETWORK_WAVE_DOC.contains("tamper_payload_detected"));
     assert!(LIVE_NETWORK_WAVE_DOC
         .contains("run_live_transport_replay_tamper_fast_lane.sh --output-report"));
+    assert!(LIVE_NETWORK_WAVE_DOC
+        .contains("run_transport_profile_parity_matrix.sh --languages python,typescript"));
+    assert!(LIVE_NETWORK_WAVE_DOC
+        .contains("fixtures/sdk_parity/live_backend_adapter_profile_expectations.json"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("test_dashboard_package_runtime_compat.sh"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("npx -y node@22"));
 }
@@ -155,6 +159,9 @@ fn regression_localhost_transport_demo_receipt_artifact_contract_is_documented()
     // Regression: #981
     assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #981`"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains("receipt artifact schema drift"));
+    // Regression: #1416
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #1416`"));
+    assert!(LIVE_NETWORK_WAVE_DOC.contains("backend adapter reason-code drift fails closed"));
     // Regression: #982
     assert!(LIVE_NETWORK_WAVE_DOC.contains("`Regression: #982`"));
     assert!(LIVE_NETWORK_WAVE_DOC.contains(

--- a/docs/planning/live-network-wave.md
+++ b/docs/planning/live-network-wave.md
@@ -68,6 +68,10 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `bash scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh --output-report /tmp/live-transport-replay-tamper-fast-report.json`
 - Live transport replay/tamper policy checker:
   - `bash scripts/sdk/check_live_transport_replay_tamper_policy.sh --bundle-file /tmp/live-transport-replay-tamper-fast-report.json`
+- Cross-SDK live backend adapter parity matrix:
+  - `bash scripts/sdk/run_transport_profile_parity_matrix.sh --languages python,typescript --output-json /tmp/sdk-transport-profile-parity-report.json`
+- Cross-SDK live backend adapter parity fixture:
+  - `fixtures/sdk_parity/live_backend_adapter_profile_expectations.json`
 - Stable shell wrappers:
   - `scripts/sdk/run_localhost_signed_integration_harness.sh`
   - `scripts/sdk/run_localhost_signed_integration_contract_lane.sh`
@@ -83,6 +87,9 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `scripts/sdk/localhost_signed_integration_evidence_policy_contract.py`
   - `scripts/sdk/live_transport_replay_tamper_contract.py`
   - `scripts/sdk/live_transport_replay_tamper_contract_lane_contract.py`
+  - `scripts/sdk/run_transport_profile_parity_matrix.py`
+  - `scripts/sdk/transport_profile_probe.py`
+  - `scripts/sdk/transport_profile_probe.ts`
 
 ## Bridge Replay/Redaction Lane Matrix
 
@@ -120,6 +127,14 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - `kamn.sdk.localhost-signed.demo-receipt-artifact.v1`
 - Live transport replay/tamper evidence schema:
   - `kamn.sdk.live-transport-replay-tamper-evidence.v1`
+- Cross-SDK transport profile parity report fields:
+  - `backend_adapter_register_id`
+  - `backend_adapter_message_id`
+  - `backend_adapter_receive_body`
+  - `backend_adapter_invalid_response_message`
+  - `backend_adapter_error_operation`
+  - `backend_adapter_error_reason`
+  - `backend_adapter_policy_reason`
 - Required localhost signed integration report fields:
   - `status`
   - `contract_key`
@@ -233,6 +248,8 @@ lane used to validate live-network pilot readiness while keeping PR cost low.
   - localhost signed integration harness and contract lane preserve deterministic evidence keys (`Regression: #899`).
 - Regression guard:
   - localhost signed demo receipt artifact schema drift and missing receipt reconciliation outcomes fail closed (`Regression: #981`).
+- Regression guard:
+  - cross-SDK backend adapter reason-code drift fails closed in transport profile parity matrix (`Regression: #1416`).
 - Regression guard:
   - stale/tampered federated handshake deep-lane summary artifacts fail closed under policy checks (`Regression: #1003`).
 - Regression guard:

--- a/fixtures/sdk_parity/live_backend_adapter_profile_expectations.json
+++ b/fixtures/sdk_parity/live_backend_adapter_profile_expectations.json
@@ -1,0 +1,9 @@
+{
+  "backend_adapter_register_id": "kamn:did:agent:backend-1",
+  "backend_adapter_message_id": "msg_backend_1",
+  "backend_adapter_receive_body": "backend hello",
+  "backend_adapter_invalid_response_message": "backend adapter invalid response for operation register: expected string value",
+  "backend_adapter_error_operation": "send",
+  "backend_adapter_error_reason": "backend_timeout",
+  "backend_adapter_policy_reason": "policy_denied"
+}

--- a/packages/kamn-sdk/src/live_transport_client.ts
+++ b/packages/kamn-sdk/src/live_transport_client.ts
@@ -37,11 +37,13 @@ export interface LiveTransportBackendAdapter {
 
 export class LiveTransportBackendAdapterError extends SDKError {
   readonly operation: LiveTransportOperation;
+  readonly reason: string;
 
   constructor(operation: LiveTransportOperation, reason: string) {
     super(`backend adapter operation ${operation} failed: ${reason}`);
     this.name = "LiveTransportBackendAdapterError";
     this.operation = operation;
+    this.reason = reason;
   }
 }
 

--- a/packages/kamn-sdk/tests/live_transport_client.test.ts
+++ b/packages/kamn-sdk/tests/live_transport_client.test.ts
@@ -142,10 +142,16 @@ test("regression backend adapter errors and invalid payloads fail closed", () =>
       message: "backend adapter invalid response for operation register: expected string value",
     });
 
-    assert.throws(
-      () => client.send("kamn:did:agent:x", "kamn:did:agent:y", "hello"),
-      LiveTransportBackendAdapterError,
-    );
+    let sendError: unknown;
+    try {
+      client.send("kamn:did:agent:x", "kamn:did:agent:y", "hello");
+      assert.fail("expected backend adapter send failure");
+    } catch (error: unknown) {
+      sendError = error;
+    }
+    assert.ok(sendError instanceof LiveTransportBackendAdapterError);
+    assert.equal(sendError.operation, "send");
+    assert.equal(sendError.reason, "backend_timeout");
   } finally {
     LiveTransportKAMNClient.clearBackendAdapters();
   }

--- a/scripts/sdk/run_transport_profile_parity_matrix.py
+++ b/scripts/sdk/run_transport_profile_parity_matrix.py
@@ -18,18 +18,41 @@ RUNNERS = {
         str(ROOT_DIR / "scripts/sdk/run_transport_profile_probe_typescript.sh"),
     ],
 }
+BACKEND_ADAPTER_PARITY_LANGUAGES = {"python", "typescript"}
+BACKEND_ADAPTER_EXPECTED_KEYS = (
+    "backend_adapter_register_id",
+    "backend_adapter_message_id",
+    "backend_adapter_receive_body",
+    "backend_adapter_invalid_response_message",
+    "backend_adapter_error_operation",
+    "backend_adapter_error_reason",
+    "backend_adapter_policy_reason",
+)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--languages", default="all")
     parser.add_argument("--output-json", default="")
+    parser.add_argument(
+        "--backend-adapter-fixture",
+        default=str(
+            ROOT_DIR / "fixtures/sdk_parity/live_backend_adapter_profile_expectations.json"
+        ),
+    )
     parser.add_argument("--expect-default-mode", default="in-memory")
     parser.add_argument("--expect-live-mode", default="live")
     parser.add_argument("--expect-memory-mismatch-expected", default="live")
     parser.add_argument("--expect-memory-mismatch-found", default="in-memory")
     parser.add_argument("--expect-live-mismatch-expected", default="in-memory")
     parser.add_argument("--expect-live-mismatch-found", default="live")
+    parser.add_argument("--expect-adapter-register-id", default="")
+    parser.add_argument("--expect-adapter-message-id", default="")
+    parser.add_argument("--expect-adapter-receive-body", default="")
+    parser.add_argument("--expect-adapter-invalid-response-message", default="")
+    parser.add_argument("--expect-adapter-error-operation", default="")
+    parser.add_argument("--expect-adapter-error-reason", default="")
+    parser.add_argument("--expect-adapter-policy-reason", default="")
     return parser.parse_args()
 
 
@@ -70,6 +93,34 @@ def sanitize(value: str) -> str:
     return value.replace("\n", " ").strip()
 
 
+def load_backend_adapter_fixture(path: str) -> Dict[str, str]:
+    fixture_path = Path(path)
+    try:
+        raw = fixture_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ValueError(f"unable to read backend adapter fixture: {error}") from error
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"invalid backend adapter fixture JSON: {error.msg}"
+        ) from error
+
+    if not isinstance(parsed, dict):
+        raise ValueError("backend adapter fixture must be a JSON object")
+
+    normalized: Dict[str, str] = {}
+    for key in BACKEND_ADAPTER_EXPECTED_KEYS:
+        value = parsed.get(key)
+        if not isinstance(value, str) or value == "":
+            raise ValueError(
+                f"backend adapter fixture missing non-empty string for key: {key}"
+            )
+        normalized[key] = value
+    return normalized
+
+
 def run_runner(language: str) -> Dict[str, str]:
     completed = subprocess.run(
         RUNNERS[language],
@@ -101,7 +152,27 @@ def run_runner(language: str) -> Dict[str, str]:
         "memory_mismatch_found": values.get("memory_mismatch_found", ""),
         "live_mismatch_expected": values.get("live_mismatch_expected", ""),
         "live_mismatch_found": values.get("live_mismatch_found", ""),
+        "backend_adapter_register_id": values.get("backend_adapter_register_id", ""),
+        "backend_adapter_message_id": values.get("backend_adapter_message_id", ""),
+        "backend_adapter_receive_body": values.get("backend_adapter_receive_body", ""),
+        "backend_adapter_invalid_response_message": values.get(
+            "backend_adapter_invalid_response_message", ""
+        ),
+        "backend_adapter_error_operation": values.get(
+            "backend_adapter_error_operation", ""
+        ),
+        "backend_adapter_error_reason": values.get("backend_adapter_error_reason", ""),
+        "backend_adapter_policy_reason": values.get("backend_adapter_policy_reason", ""),
     }
+
+
+def expected_for_language(
+    language: str, base_expected: Dict[str, str], adapter_expected: Dict[str, str]
+) -> Dict[str, str]:
+    expected = dict(base_expected)
+    if language in BACKEND_ADAPTER_PARITY_LANGUAGES:
+        expected.update(adapter_expected)
+    return expected
 
 
 def main() -> int:
@@ -112,13 +183,51 @@ def main() -> int:
         print(f"status=fail; reason={sanitize(str(error))}")
         return 2
 
-    expected = {
+    try:
+        backend_adapter_fixture = load_backend_adapter_fixture(
+            args.backend_adapter_fixture
+        )
+    except ValueError as error:
+        print(f"status=fail; reason={sanitize(str(error))}")
+        return 2
+
+    base_expected = {
         "default_transport_mode": args.expect_default_mode,
         "live_transport_mode": args.expect_live_mode,
         "memory_mismatch_expected": args.expect_memory_mismatch_expected,
         "memory_mismatch_found": args.expect_memory_mismatch_found,
         "live_mismatch_expected": args.expect_live_mismatch_expected,
         "live_mismatch_found": args.expect_live_mismatch_found,
+    }
+    adapter_expected = {
+        "backend_adapter_register_id": (
+            args.expect_adapter_register_id
+            or backend_adapter_fixture["backend_adapter_register_id"]
+        ),
+        "backend_adapter_message_id": (
+            args.expect_adapter_message_id
+            or backend_adapter_fixture["backend_adapter_message_id"]
+        ),
+        "backend_adapter_receive_body": (
+            args.expect_adapter_receive_body
+            or backend_adapter_fixture["backend_adapter_receive_body"]
+        ),
+        "backend_adapter_invalid_response_message": (
+            args.expect_adapter_invalid_response_message
+            or backend_adapter_fixture["backend_adapter_invalid_response_message"]
+        ),
+        "backend_adapter_error_operation": (
+            args.expect_adapter_error_operation
+            or backend_adapter_fixture["backend_adapter_error_operation"]
+        ),
+        "backend_adapter_error_reason": (
+            args.expect_adapter_error_reason
+            or backend_adapter_fixture["backend_adapter_error_reason"]
+        ),
+        "backend_adapter_policy_reason": (
+            args.expect_adapter_policy_reason
+            or backend_adapter_fixture["backend_adapter_policy_reason"]
+        ),
     }
 
     failed_reasons: List[str] = []
@@ -133,6 +242,7 @@ def main() -> int:
             )
             continue
 
+        expected = expected_for_language(language, base_expected, adapter_expected)
         for key, expected_value in expected.items():
             actual_value = result.get(key, "")
             if actual_value != expected_value:
@@ -141,23 +251,40 @@ def main() -> int:
                 )
 
     if len(languages) > 1:
-        reference_language = languages[0]
-        reference = results.get(reference_language, {})
-        for language in languages[1:]:
-            candidate = results.get(language, {})
-            if candidate.get("status") != "ok" or reference.get("status") != "ok":
+        for index, left_language in enumerate(languages):
+            left = results.get(left_language, {})
+            if left.get("status") != "ok":
                 continue
-            for key in expected:
-                if candidate.get(key, "") != reference.get(key, ""):
-                    failed_reasons.append(
-                        f"{language}: parity mismatch for {key} against {reference_language}"
-                    )
+            left_expected = expected_for_language(
+                left_language, base_expected, adapter_expected
+            )
+            for right_language in languages[index + 1 :]:
+                right = results.get(right_language, {})
+                if right.get("status") != "ok":
+                    continue
+                right_expected = expected_for_language(
+                    right_language, base_expected, adapter_expected
+                )
+                shared_keys = set(left_expected.keys()).intersection(
+                    right_expected.keys()
+                )
+                for key in sorted(shared_keys):
+                    if left.get(key, "") != right.get(key, ""):
+                        failed_reasons.append(
+                            f"{right_language}: parity mismatch for {key} against "
+                            f"{left_language}"
+                        )
 
     status = "pass" if not failed_reasons else "fail"
     report = {
         "status": status,
         "languages": languages,
-        "expected": expected,
+        "expected": {
+            "base": base_expected,
+            "backend_adapter": adapter_expected,
+            "backend_adapter_languages": sorted(BACKEND_ADAPTER_PARITY_LANGUAGES),
+            "backend_adapter_fixture": args.backend_adapter_fixture,
+        },
         "failed_reasons": failed_reasons,
         "results": results,
     }
@@ -169,7 +296,8 @@ def main() -> int:
         print(
             "status=pass; "
             f"languages={','.join(languages)}; "
-            f"checks={len(expected)}"
+            f"checks_base={len(base_expected)}; "
+            f"checks_backend_adapter={len(adapter_expected)}"
         )
         return 0
 

--- a/scripts/sdk/test_run_transport_profile_parity_matrix.sh
+++ b/scripts/sdk/test_run_transport_profile_parity_matrix.sh
@@ -3,9 +3,20 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/sdk/run_transport_profile_parity_matrix.sh"
+BACKEND_ADAPTER_FIXTURE="$ROOT_DIR/fixtures/sdk_parity/live_backend_adapter_profile_expectations.json"
 
 if [ ! -x "$SCRIPT" ]; then
   echo "expected transport profile parity matrix runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$BACKEND_ADAPTER_FIXTURE" ]; then
+  echo "expected backend adapter parity fixture to exist" >&2
+  exit 1
+fi
+
+if ! grep -q '"backend_adapter_error_reason"' "$BACKEND_ADAPTER_FIXTURE"; then
+  echo "expected backend adapter parity fixture to define reason-code contract key" >&2
   exit 1
 fi
 
@@ -31,6 +42,11 @@ if ! grep -q '"status": "pass"' "$SUBSET_REPORT"; then
   exit 1
 fi
 
+if ! grep -q '"backend_adapter_error_reason": "backend_timeout"' "$SUBSET_REPORT"; then
+  echo "expected adapter reason-code parity evidence in subset report" >&2
+  exit 1
+fi
+
 set +e
 bash "$SCRIPT" --expect-default-mode live >"$TMP_DIR/fail.out" 2>&1
 fail_code=$?
@@ -44,6 +60,21 @@ fi
 # Regression: #679
 if ! grep -q "status=fail" "$TMP_DIR/fail.out"; then
   echo "expected transport profile parity matrix mismatch to emit fail status" >&2
+  exit 1
+fi
+
+set +e
+bash "$SCRIPT" --languages python,typescript --expect-adapter-error-reason policy_denied >"$TMP_DIR/fail-adapter.out" 2>&1
+adapter_fail_code=$?
+set -e
+
+if [ "$adapter_fail_code" -eq 0 ]; then
+  echo "expected transport profile parity matrix to fail for adapter reason-code drift" >&2
+  exit 1
+fi
+
+if ! grep -q "backend_adapter_error_reason" "$TMP_DIR/fail-adapter.out"; then
+  echo "expected adapter reason-code drift failure details in output" >&2
   exit 1
 fi
 

--- a/scripts/sdk/transport_profile_probe.py
+++ b/scripts/sdk/transport_profile_probe.py
@@ -11,6 +11,7 @@ if str(ROOT_DIR) not in sys.path:
 from kamn_sdk import (  # noqa: E402
     KAMNClient,
     LiveKAMNClient,
+    LiveTransportBackendAdapterError,
     SDKError,
     TransportMode,
     TransportModeMismatchError,
@@ -46,6 +47,88 @@ def main() -> int:
             print("error=live client unexpectedly accepted in-memory mode assertion")
             return 1
 
+        success_endpoint = "https://live.kamn.testnet/profile-probe-python-adapter"
+
+        class SuccessAdapter:
+            def invoke(self, request: dict[str, object]) -> dict[str, object]:
+                operation = str(request.get("operation", ""))
+                if operation == "register":
+                    return {"status": "ok", "value": "kamn:did:agent:backend-1"}
+                if operation == "send":
+                    return {"status": "ok", "value": "msg_backend_1"}
+                if operation == "receive":
+                    return {
+                        "status": "ok",
+                        "value": [
+                            {
+                                "id": "msg_backend_1",
+                                "from": "kamn:did:agent:backend-1",
+                                "to": "kamn:did:agent:backend-2",
+                                "body": "backend hello",
+                            }
+                        ],
+                    }
+                return {"status": "ok", "value": None}
+
+        LiveKAMNClient.register_backend_adapter(success_endpoint, SuccessAdapter())
+        try:
+            adapter_client = LiveKAMNClient(success_endpoint)
+            backend_register_id = adapter_client.register("autonomous", "claude-4", ["text"])
+            backend_message_id = adapter_client.send(
+                "kamn:did:agent:backend-1",
+                "kamn:did:agent:backend-2",
+                "backend hello",
+            )
+            backend_messages = adapter_client.receive("kamn:did:agent:backend-2")
+            if len(backend_messages) != 1:
+                print("status=error")
+                print("error=backend adapter receive returned unexpected message count")
+                return 1
+            backend_receive_body = str(backend_messages[0].get("body", ""))
+        finally:
+            LiveKAMNClient.clear_backend_adapters()
+
+        failure_endpoint = "https://live.kamn.testnet/profile-probe-python-adapter-fail"
+
+        class FailureAdapter:
+            def invoke(self, request: dict[str, object]) -> dict[str, object]:
+                operation = str(request.get("operation", ""))
+                if operation == "register":
+                    return {"status": "ok", "value": 7}
+                if operation == "send":
+                    return {"status": "error", "reason": "backend_timeout"}
+                return {"status": "error", "reason": "policy_denied"}
+
+        LiveKAMNClient.register_backend_adapter(failure_endpoint, FailureAdapter())
+        try:
+            failing_client = LiveKAMNClient(failure_endpoint)
+            try:
+                failing_client.register("autonomous", "claude-4", ["text"])
+                print("status=error")
+                print("error=failing adapter unexpectedly accepted invalid register payload")
+                return 1
+            except SDKError as error:
+                backend_invalid_response_message = str(error)
+
+            try:
+                failing_client.send("kamn:did:agent:x", "kamn:did:agent:y", "hello")
+                print("status=error")
+                print("error=failing adapter unexpectedly accepted send operation")
+                return 1
+            except LiveTransportBackendAdapterError as error:
+                backend_error_operation = error.operation
+                backend_error_reason = error.reason
+
+            try:
+                failing_client.receive("kamn:did:agent:y")
+                print("status=error")
+                print("error=failing adapter unexpectedly accepted receive operation")
+                return 1
+            except LiveTransportBackendAdapterError as error:
+                backend_policy_reason = error.reason
+        finally:
+            LiveKAMNClient.clear_backend_adapters()
+
         print("status=ok")
         print(f"default_transport_mode={memory.transport_mode().value}")
         print(f"live_transport_mode={live.transport_mode().value}")
@@ -53,6 +136,16 @@ def main() -> int:
         print(f"memory_mismatch_found={memory_found}")
         print(f"live_mismatch_expected={live_expected}")
         print(f"live_mismatch_found={live_found}")
+        print(f"backend_adapter_register_id={backend_register_id}")
+        print(f"backend_adapter_message_id={backend_message_id}")
+        print(f"backend_adapter_receive_body={backend_receive_body}")
+        print(
+            "backend_adapter_invalid_response_message="
+            f"{sanitize(backend_invalid_response_message)}"
+        )
+        print(f"backend_adapter_error_operation={backend_error_operation}")
+        print(f"backend_adapter_error_reason={backend_error_reason}")
+        print(f"backend_adapter_policy_reason={backend_policy_reason}")
         return 0
     except SDKError as error:
         print("status=error")

--- a/scripts/sdk/transport_profile_probe.ts
+++ b/scripts/sdk/transport_profile_probe.ts
@@ -1,5 +1,6 @@
 import {
   KAMNClient,
+  LiveTransportBackendAdapterError,
   LiveTransportKAMNClient,
   SDKError,
   TransportModeMismatchError,
@@ -51,6 +52,112 @@ try {
     }
   }
 
+  const successEndpoint = "https://live.kamn.testnet/profile-probe-ts-adapter";
+  LiveTransportKAMNClient.registerBackendAdapter(successEndpoint, {
+    invoke(request) {
+      if (request.operation === "register") {
+        return { status: "ok", value: "kamn:did:agent:backend-1" };
+      }
+      if (request.operation === "send") {
+        return { status: "ok", value: "msg_backend_1" };
+      }
+      if (request.operation === "receive") {
+        return {
+          status: "ok",
+          value: [
+            {
+              id: "msg_backend_1",
+              from: "kamn:did:agent:backend-1",
+              to: "kamn:did:agent:backend-2",
+              body: "backend hello",
+            },
+          ],
+        };
+      }
+      return { status: "ok", value: null };
+    },
+  });
+
+  let backendAdapterRegisterId = "";
+  let backendAdapterMessageId = "";
+  let backendAdapterReceiveBody = "";
+  try {
+    const adapterClient = new LiveTransportKAMNClient(successEndpoint);
+    backendAdapterRegisterId = adapterClient.register("autonomous", "claude-4", ["text"]);
+    backendAdapterMessageId = adapterClient.send(
+      "kamn:did:agent:backend-1",
+      "kamn:did:agent:backend-2",
+      "backend hello",
+    );
+    const received = adapterClient.receive("kamn:did:agent:backend-2");
+    if (received.length !== 1) {
+      fail("backend adapter receive returned unexpected message count");
+    }
+    backendAdapterReceiveBody = received[0].body;
+  } finally {
+    LiveTransportKAMNClient.clearBackendAdapters();
+  }
+
+  const failureEndpoint = "https://live.kamn.testnet/profile-probe-ts-adapter-fail";
+  LiveTransportKAMNClient.registerBackendAdapter(failureEndpoint, {
+    invoke(request) {
+      if (request.operation === "register") {
+        return { status: "ok", value: 7 };
+      }
+      if (request.operation === "send") {
+        return { status: "error", reason: "backend_timeout" };
+      }
+      return { status: "error", reason: "policy_denied" };
+    },
+  });
+
+  let backendAdapterInvalidResponseMessage = "";
+  let backendAdapterErrorOperation = "";
+  let backendAdapterErrorReason = "";
+  let backendAdapterPolicyReason = "";
+  try {
+    const failingClient = new LiveTransportKAMNClient(failureEndpoint);
+    try {
+      failingClient.register("autonomous", "claude-4", ["text"]);
+      fail("failing adapter unexpectedly accepted invalid register payload");
+    } catch (error: unknown) {
+      if (error instanceof SDKError || error instanceof Error) {
+        backendAdapterInvalidResponseMessage = error.message;
+      } else {
+        fail("unknown adapter register failure");
+      }
+    }
+
+    try {
+      failingClient.send("kamn:did:agent:x", "kamn:did:agent:y", "hello");
+      fail("failing adapter unexpectedly accepted send operation");
+    } catch (error: unknown) {
+      if (error instanceof LiveTransportBackendAdapterError) {
+        backendAdapterErrorOperation = error.operation;
+        backendAdapterErrorReason = error.reason;
+      } else if (error instanceof Error) {
+        fail(error.message);
+      } else {
+        fail("unknown adapter send failure");
+      }
+    }
+
+    try {
+      failingClient.receive("kamn:did:agent:y");
+      fail("failing adapter unexpectedly accepted receive operation");
+    } catch (error: unknown) {
+      if (error instanceof LiveTransportBackendAdapterError) {
+        backendAdapterPolicyReason = error.reason;
+      } else if (error instanceof Error) {
+        fail(error.message);
+      } else {
+        fail("unknown adapter receive failure");
+      }
+    }
+  } finally {
+    LiveTransportKAMNClient.clearBackendAdapters();
+  }
+
   console.log("status=ok");
   console.log(`default_transport_mode=${memory.transportMode()}`);
   console.log(`live_transport_mode=${live.transportMode()}`);
@@ -58,6 +165,15 @@ try {
   console.log(`memory_mismatch_found=${memoryFound}`);
   console.log(`live_mismatch_expected=${liveExpected}`);
   console.log(`live_mismatch_found=${liveFound}`);
+  console.log(`backend_adapter_register_id=${backendAdapterRegisterId}`);
+  console.log(`backend_adapter_message_id=${backendAdapterMessageId}`);
+  console.log(`backend_adapter_receive_body=${backendAdapterReceiveBody}`);
+  console.log(
+    `backend_adapter_invalid_response_message=${sanitize(backendAdapterInvalidResponseMessage)}`,
+  );
+  console.log(`backend_adapter_error_operation=${backendAdapterErrorOperation}`);
+  console.log(`backend_adapter_error_reason=${backendAdapterErrorReason}`);
+  console.log(`backend_adapter_policy_reason=${backendAdapterPolicyReason}`);
 } catch (error: unknown) {
   if (error instanceof SDKError || error instanceof Error) {
     fail(error.message);


### PR DESCRIPTION
## Summary
Extends cross-SDK live transport parity checks so Python and TypeScript backend adapter behavior is validated under a shared deterministic contract. This adds fail-closed reason-code drift detection for backend adapter errors while keeping lanes bounded and local-cost efficient.

Closes #1416

## Changes
- `fixtures/sdk_parity/live_backend_adapter_profile_expectations.json`: shared backend adapter parity fixture.
- `scripts/sdk/transport_profile_probe.py`: emits backend adapter success/error parity markers.
- `scripts/sdk/transport_profile_probe.ts`: emits equivalent backend adapter parity markers for TS SDK.
- `scripts/sdk/run_transport_profile_parity_matrix.py`: validates backend adapter parity fields for Python/TypeScript (with fixture-backed defaults), keeps base transport checks for all SDKs, and fails closed on reason-code drift.
- `scripts/sdk/test_run_transport_profile_parity_matrix.sh`: added regression checks for backend adapter parity evidence + drift failures.
- `packages/kamn-sdk/src/live_transport_client.ts`: exposes `reason` on `LiveTransportBackendAdapterError`.
- `packages/kamn-sdk/tests/live_transport_client.test.ts`: validates `operation` + `reason` on backend adapter failures.
- `docs/planning/live-network-wave.md`: documented backend adapter parity lane + fixture + regression marker.
- `crates/kamn-core/tests/live_network_wave_docs.rs`: doc contract assertions for new commands/fixture/regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/sdk/test_run_transport_profile_parity_matrix.sh
```
Failure excerpt:
```text
expected adapter reason-code parity evidence in subset report
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/sdk/test_run_transport_profile_parity_matrix.sh
bash scripts/sdk/run_transport_profile_probe_python.sh
bash scripts/sdk/run_transport_profile_probe_typescript.sh
bash scripts/sdk/run_transport_profile_parity_matrix.sh --languages python,typescript
```
Result summary:
```text
transport profile parity matrix tests passed.
status=ok ... backend_adapter_error_reason=backend_timeout
status=pass; languages=python,typescript; checks_base=6; checks_backend_adapter=7
```

### 🔁 Regression
Commands:
```bash
python3 -m unittest tests/python/test_sdk.py
npm --prefix packages/kamn-sdk test
bash scripts/sdk/test_run_live_transport_parity_contract_lane.sh
bash scripts/sdk/test_run_live_transport_smoke_parity_contract_lane.sh
cargo test -p kamn-core --test live_network_wave_docs
cargo fmt --check
cargo clippy -- -D warnings
```
Result summary:
```text
...passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/sdk/test_run_transport_profile_parity_matrix.sh`, `packages/kamn-sdk/tests/live_transport_client.test.ts` | |
| Functional   | ✅ | `scripts/sdk/transport_profile_probe.py`, `scripts/sdk/transport_profile_probe.ts` | |
| Integration  | ✅ | `scripts/sdk/run_transport_profile_parity_matrix.py`, `scripts/sdk/test_run_live_transport_parity_contract_lane.sh`, `scripts/sdk/test_run_live_transport_smoke_parity_contract_lane.sh` | |
| Regression   | ✅ | adapter reason-code drift guard in matrix + docs regression marker (`Regression: #1416`) | |
| Performance  | ✅ | reused bounded parity contract lanes (no deep/heavy CI expansion) | |

## Risks & Rollback
- Low risk; changes are additive and fail-closed for parity drift.
- Rollback: revert this PR to restore prior transport profile matrix behavior.

## Documentation Updates
- Updated `docs/planning/live-network-wave.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
