### PR TITLE
feat(kolme): add deterministic local api probe lane (#1439)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -42,6 +42,13 @@ fn plan_contains_local_fork_smoke_evidence_lane() {
 }
 
 #[test]
+fn plan_contains_local_kolme_api_probe_lane() {
+    assert!(PLAN.contains("## Deterministic Local Kolme API Probe Lane"));
+    assert!(PLAN.contains("run_local_kolme_api_probe_lane.sh"));
+    assert!(PLAN.contains("kamn.kolme.local-api-probe-summary.v1"));
+}
+
+#[test]
 fn plan_contains_local_only_heavy_validation_matrix() {
     assert!(PLAN.contains("## Local-Only Heavy Kolme Validation Matrix"));
     assert!(PLAN.contains("run_local_heavy_validation_matrix.sh"));
@@ -119,5 +126,13 @@ fn regression_requires_local_fork_smoke_evidence_guard_marker() {
     // Regression: #1430
     assert!(PLAN.contains(
         "local fork smoke evidence lane fails closed on missing local opt-in, metadata sync failure, command timeout, and smoke-command errors (`Regression: #1430`)."
+    ));
+}
+
+#[test]
+fn regression_requires_local_kolme_api_probe_guard_marker() {
+    // Regression: #1439
+    assert!(PLAN.contains(
+        "local Kolme API probe lane fails closed on unavailable health endpoint, invalid fork-info payload, and runtime budget overruns (`Regression: #1439`)."
     ));
 }

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -79,6 +79,20 @@ runtime roles (processor/listener/approver) and its CI-compatible validation.
   - run mode fails closed without explicit local-only opt-in.
   - smoke command timeout/exceeded budget is reported as `fork_smoke_command_timeout`.
 
+## Deterministic Local Kolme API Probe Lane (Issue #1439)
+
+- Local API probe runner:
+  - `bash scripts/kolme/run_local_kolme_api_probe_lane.sh --mode dry-run --base-url http://127.0.0.1:3000 --output-json /tmp/kolme-local-api-probe-summary.json`
+- Active local API probe:
+  - `bash scripts/kolme/run_local_kolme_api_probe_lane.sh --mode run --base-url http://127.0.0.1:3000 --max-seconds 30 --output-json /tmp/kolme-local-api-probe-summary.json`
+- Summary schema:
+  - `kamn.kolme.local-api-probe-summary.v1`
+- Deterministic checks include:
+  - `GET /healthz` response body matches expected health marker (`Healthy!` by default).
+  - `GET /fork-info` returns valid JSON object with integer `first_block` and `last_block`.
+- Cost policy:
+  - run mode enforces a deterministic runtime budget ceiling via `--max-seconds`.
+
 ## Deterministic Local Bootstrap Health Checks (Issue #1417)
 
 - Bootstrap health-check runner:
@@ -149,6 +163,7 @@ runtime roles (processor/listener/approver) and its CI-compatible validation.
 - local-only heavy validation matrix requires explicit opt-in and remains excluded from PR fast-gate workflows (`Regression: #1405`).
 - local fork metadata sync lane fails closed for checkout-path, remote-URL, ref, and dirty-checkout drift (`Regression: #1429`).
 - local fork smoke evidence lane fails closed on missing local opt-in, metadata sync failure, command timeout, and smoke-command errors (`Regression: #1430`).
+- local Kolme API probe lane fails closed on unavailable health endpoint, invalid fork-info payload, and runtime budget overruns (`Regression: #1439`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation
@@ -158,6 +173,7 @@ bash scripts/kolme/test_validate_triadic_devnet_smoke.sh
 bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh
 bash scripts/kolme/test_run_local_fork_sync_metadata_lane.sh
 bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh
+bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh
 bash scripts/kolme/test_run_local_bootstrap_health_checks.sh
 bash scripts/kolme/test_run_local_e2e_integration_lane.sh
 bash scripts/kolme/test_run_local_heavy_validation_matrix.sh

--- a/scripts/kolme/run_local_kolme_api_probe_lane.sh
+++ b/scripts/kolme/run_local_kolme_api_probe_lane.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="dry-run"
+OUTPUT_JSON="/tmp/kolme-local-api-probe-summary.json"
+BASE_URL="http://127.0.0.1:3000"
+HEALTHZ_PATH="/healthz"
+FORK_INFO_PATH="/fork-info"
+EXPECTED_HEALTHZ="Healthy!"
+MAX_SECONDS=30
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --mode" >&2
+        exit 1
+      fi
+      MODE="$2"
+      shift 2
+      ;;
+    --output-json)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --output-json" >&2
+        exit 1
+      fi
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --base-url)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --base-url" >&2
+        exit 1
+      fi
+      BASE_URL="$2"
+      shift 2
+      ;;
+    --healthz-path)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --healthz-path" >&2
+        exit 1
+      fi
+      HEALTHZ_PATH="$2"
+      shift 2
+      ;;
+    --fork-info-path)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --fork-info-path" >&2
+        exit 1
+      fi
+      FORK_INFO_PATH="$2"
+      shift 2
+      ;;
+    --expected-healthz)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --expected-healthz" >&2
+        exit 1
+      fi
+      EXPECTED_HEALTHZ="$2"
+      shift 2
+      ;;
+    --max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --max-seconds" >&2
+        exit 1
+      fi
+      MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: run_local_kolme_api_probe_lane.sh [options]
+
+Options:
+  --mode dry-run|run            Execute planned output or active endpoint checks.
+  --output-json <path>          Write deterministic summary JSON to this path.
+  --base-url <url>              Base URL for local Kolme API server.
+  --healthz-path <path>         Health endpoint path (default: /healthz).
+  --fork-info-path <path>       Fork-info endpoint path (default: /fork-info).
+  --expected-healthz <text>     Expected health endpoint body.
+  --max-seconds <n>             Max runtime budget in seconds for run mode.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$MODE" != "dry-run" ] && [ "$MODE" != "run" ]; then
+  echo "mode must be one of: dry-run, run" >&2
+  exit 1
+fi
+
+if [ -z "$BASE_URL" ]; then
+  echo "base-url must not be empty" >&2
+  exit 1
+fi
+
+if [ -z "$HEALTHZ_PATH" ] || [ -z "$FORK_INFO_PATH" ]; then
+  echo "endpoint paths must not be empty" >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$MAX_SECONDS" -le 0 ]; then
+  echo "max-seconds must be a positive integer" >&2
+  exit 1
+fi
+
+CHECK_FILE="$(mktemp)"
+HEALTHZ_BODY_FILE="$(mktemp)"
+FORK_INFO_BODY_FILE="$(mktemp)"
+FORK_INFO_VALUES_FILE="$(mktemp)"
+trap 'rm -f "$CHECK_FILE" "$HEALTHZ_BODY_FILE" "$FORK_INFO_BODY_FILE" "$FORK_INFO_VALUES_FILE"' EXIT
+
+record_check() {
+  local check_id="$1"
+  local command="$2"
+  local status="$3"
+  printf '%s\t%s\t%s\n' "$check_id" "$command" "$status" >>"$CHECK_FILE"
+}
+
+overall_status="ok"
+reason_code="dry_run_no_commands_executed"
+budget_status="not_run"
+elapsed_seconds=0
+fork_first_block=""
+fork_last_block=""
+
+healthz_url="${BASE_URL%/}${HEALTHZ_PATH}"
+fork_info_url="${BASE_URL%/}${FORK_INFO_PATH}"
+
+record_check "healthz_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${healthz_url}" "planned"
+record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "planned"
+
+if [ "$MODE" = "run" ]; then
+  : >"$CHECK_FILE"
+  start_epoch="$(date +%s)"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    record_check "healthz_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${healthz_url}" "fail"
+    record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "skipped"
+    overall_status="fail"
+    reason_code="http_client_missing"
+  else
+    if curl --silent --show-error --max-time "$MAX_SECONDS" "$healthz_url" >"$HEALTHZ_BODY_FILE" 2>/dev/null; then
+      observed_healthz="$(cat "$HEALTHZ_BODY_FILE")"
+      if [ "$observed_healthz" = "$EXPECTED_HEALTHZ" ]; then
+        record_check "healthz_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${healthz_url}" "pass"
+      else
+        record_check "healthz_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${healthz_url}" "fail"
+        record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "skipped"
+        overall_status="fail"
+        reason_code="healthz_unexpected_body"
+      fi
+    else
+      record_check "healthz_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${healthz_url}" "fail"
+      record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "skipped"
+      overall_status="fail"
+      reason_code="healthz_request_failed"
+    fi
+
+    if [ "$overall_status" = "ok" ]; then
+      if curl --silent --show-error --max-time "$MAX_SECONDS" "$fork_info_url" >"$FORK_INFO_BODY_FILE" 2>/dev/null; then
+        if python3 - "$FORK_INFO_BODY_FILE" "$FORK_INFO_VALUES_FILE" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+body_path = pathlib.Path(sys.argv[1])
+out_path = pathlib.Path(sys.argv[2])
+
+try:
+    payload = json.loads(body_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as error:
+    raise SystemExit(f"invalid json: {error.msg}") from error
+
+if not isinstance(payload, dict):
+    raise SystemExit("fork-info payload must be a JSON object")
+
+first_block = payload.get("first_block")
+last_block = payload.get("last_block")
+if not isinstance(first_block, int) or not isinstance(last_block, int):
+    raise SystemExit("fork-info payload must include integer first_block and last_block")
+
+out_path.write_text(
+    f"first_block={first_block}\nlast_block={last_block}\n",
+    encoding="utf-8",
+)
+PY
+        then
+          # shellcheck disable=SC1090
+          . "$FORK_INFO_VALUES_FILE"
+          fork_first_block="$first_block"
+          fork_last_block="$last_block"
+          record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "pass"
+          reason_code="probe_checks_passed"
+        else
+          record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "fail"
+          overall_status="fail"
+          reason_code="fork_info_invalid_payload"
+        fi
+      else
+        record_check "fork_info_endpoint" "curl --silent --show-error --max-time ${MAX_SECONDS} ${fork_info_url}" "fail"
+        overall_status="fail"
+        reason_code="fork_info_request_failed"
+      fi
+    fi
+  fi
+
+  end_epoch="$(date +%s)"
+  elapsed_seconds="$(( end_epoch - start_epoch ))"
+  if [ "$elapsed_seconds" -le "$MAX_SECONDS" ]; then
+    budget_status="within_budget"
+  else
+    budget_status="exceeded_budget"
+    if [ "$overall_status" = "ok" ]; then
+      overall_status="fail"
+      reason_code="probe_budget_exceeded"
+    fi
+  fi
+fi
+
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$BASE_URL" "$HEALTHZ_PATH" "$FORK_INFO_PATH" "$EXPECTED_HEALTHZ" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$fork_first_block" "$fork_last_block" "$CHECK_FILE" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1]).resolve()
+mode = sys.argv[2]
+status = sys.argv[3]
+reason_code = sys.argv[4]
+base_url = sys.argv[5]
+healthz_path = sys.argv[6]
+fork_info_path = sys.argv[7]
+expected_healthz = sys.argv[8]
+elapsed_seconds = int(sys.argv[9])
+max_seconds = int(sys.argv[10])
+budget_status = sys.argv[11]
+fork_first_block_raw = sys.argv[12]
+fork_last_block_raw = sys.argv[13]
+checks_path = pathlib.Path(sys.argv[14])
+
+checks = []
+for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.strip():
+        continue
+    parts = raw_line.split("\t")
+    if len(parts) != 3:
+        continue
+    check_id, command, check_status = parts
+    checks.append({"id": check_id, "command": command, "status": check_status})
+
+fork_info = {
+    "first_block": int(fork_first_block_raw) if fork_first_block_raw else None,
+    "last_block": int(fork_last_block_raw) if fork_last_block_raw else None,
+}
+
+summary = {
+    "schema_version": "kamn.kolme.local-api-probe-summary.v1",
+    "mode": mode,
+    "status": status,
+    "reason_code": reason_code,
+    "local_only_enforced": True,
+    "base_url": base_url,
+    "healthz_path": healthz_path,
+    "fork_info_path": fork_info_path,
+    "expected_healthz": expected_healthz,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "budget_status": budget_status,
+    "fork_info": fork_info,
+    "checks": checks,
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "status=$overall_status"
+echo "probe_mode=$MODE"
+echo "reason_code=$reason_code"
+echo "budget_status=$budget_status"
+echo "summary_file=$(realpath "$OUTPUT_JSON")"
+
+if [ "$overall_status" != "ok" ]; then
+  exit 1
+fi

--- a/scripts/kolme/test_run_local_kolme_api_probe_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_api_probe_lane.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_api_probe_lane.sh"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+TMP_DIR="$(mktemp -d)"
+TMP_REPORT="$(mktemp)"
+TMP_ERR="$(mktemp)"
+SERVER_PID=""
+trap 'rm -rf "$TMP_DIR"; rm -f "$TMP_REPORT" "$TMP_ERR"; if [ -n "$SERVER_PID" ]; then kill "$SERVER_PID" >/dev/null 2>&1 || true; wait "$SERVER_PID" 2>/dev/null || true; fi' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+}
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local Kolme API probe runner to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_api_probe_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local Kolme API probe runner" >&2
+  exit 1
+fi
+
+cat >"$TMP_DIR/mock_kolme_api.py" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(sys.argv[1])
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/healthz":
+            body = b"Healthy!"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if self.path == "/fork-info":
+            payload = {"first_block": 1, "last_block": 2}
+            body = json.dumps(payload, sort_keys=True).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        body = b"not found"
+        self.send_response(404)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+PY
+
+PORT="$(pick_port)"
+python3 "$TMP_DIR/mock_kolme_api.py" "$PORT" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID="$!"
+
+for _ in $(seq 1 40); do
+  if curl --silent --show-error "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+dry_run_output="$(
+  bash "$RUNNER" \
+    --mode dry-run \
+    --base-url "http://127.0.0.1:${PORT}" \
+    --output-json "$TMP_REPORT"
+)"
+
+assert_eq "$(extract_value "$dry_run_output" "status")" "ok" "expected dry-run probe lane to pass"
+assert_eq "$(extract_value "$dry_run_output" "probe_mode")" "dry-run" "expected dry-run mode marker"
+assert_eq "$(extract_value "$dry_run_output" "reason_code")" "dry_run_no_commands_executed" "expected dry-run reason code"
+assert_eq "$(extract_value "$dry_run_output" "budget_status")" "not_run" "expected dry-run budget marker"
+
+python3 - "$TMP_REPORT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("schema_version") != "kamn.kolme.local-api-probe-summary.v1":
+    raise SystemExit("unexpected local api probe summary schema")
+if report.get("mode") != "dry-run":
+    raise SystemExit("expected dry-run mode in summary")
+if report.get("local_only_enforced") is not True:
+    raise SystemExit("expected local_only_enforced=true")
+checks = report.get("checks")
+if not isinstance(checks, list) or len(checks) < 2:
+    raise SystemExit("expected deterministic probe checks")
+if not any(entry.get("id") == "healthz_endpoint" for entry in checks if isinstance(entry, dict)):
+    raise SystemExit("expected healthz_endpoint check in summary")
+PY
+
+run_output="$(
+  bash "$RUNNER" \
+    --mode run \
+    --base-url "http://127.0.0.1:${PORT}" \
+    --max-seconds 15 \
+    --output-json "$TMP_REPORT"
+)"
+
+assert_eq "$(extract_value "$run_output" "status")" "ok" "expected run probe lane to pass"
+assert_eq "$(extract_value "$run_output" "probe_mode")" "run" "expected run mode marker"
+assert_eq "$(extract_value "$run_output" "reason_code")" "probe_checks_passed" "expected success reason code"
+assert_eq "$(extract_value "$run_output" "budget_status")" "within_budget" "expected within_budget marker"
+
+python3 - "$TMP_REPORT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("mode") != "run":
+    raise SystemExit("expected run mode in summary")
+if report.get("status") != "ok":
+    raise SystemExit("expected ok status for run mode")
+if report.get("reason_code") != "probe_checks_passed":
+    raise SystemExit("expected probe_checks_passed reason code")
+fork_info = report.get("fork_info")
+if not isinstance(fork_info, dict):
+    raise SystemExit("expected fork_info object in summary")
+if fork_info.get("first_block") != 1 or fork_info.get("last_block") != 2:
+    raise SystemExit("unexpected fork_info values in summary")
+PY
+
+set +e
+bash "$RUNNER" \
+  --mode run \
+  --base-url "http://127.0.0.1:1" \
+  --max-seconds 5 \
+  --output-json "$TMP_REPORT" >"$TMP_ERR" 2>&1
+unreachable_code=$?
+set -e
+
+if [ "$unreachable_code" -eq 0 ]; then
+  echo "expected local API probe run mode to fail for unreachable base URL" >&2
+  exit 1
+fi
+
+if ! grep -q "reason_code=healthz_request_failed" "$TMP_ERR"; then
+  echo "expected healthz_request_failed reason marker for unreachable base URL" >&2
+  exit 1
+fi
+
+echo "local Kolme API probe lane tests passed."


### PR DESCRIPTION
## Summary
Add a deterministic local Kolme API probe lane that validates `healthz` and `fork-info` endpoint contracts and emits a machine-readable summary report. This establishes the first live local API proof step between KAMN and `njfio/kolme_fork` without expanding PR CI cost.

Closes #1439
Refs #1438
Refs #1437

## Changes
- `scripts/kolme/run_local_kolme_api_probe_lane.sh`: new dry-run/run probe lane with bounded runtime and deterministic reason codes.
- `scripts/kolme/test_run_local_kolme_api_probe_lane.sh`: new functional/integration lane tests using a local mock Kolme API server.
- `docs/planning/kolme-devnet-ops.md`: added probe lane runbook, schema contract, and `Regression: #1439` marker.
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`: added docs-contract assertions for probe lane and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh`
  - failed with: `expected local Kolme API probe runner to be executable`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
  - failed assertions for missing probe lane section and missing `Regression: #1439` marker

### 🟢 Green Phase
- `bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh` (pass)
- `cargo test -p kamn-core --test kolme_devnet_ops_docs` (pass)

### 🔁 Regression
- `bash scripts/ci/test_select_targets.sh` (pass)
- `bash scripts/ci/test_workflow_scope_policy.sh` (pass)
- `bash scripts/ci/test_ci_tools.sh` (pass)
- `cargo fmt --check` (pass)
- `cargo clippy -- -D warnings` (pass)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `cargo test -p kamn-core --test kolme_devnet_ops_docs` docs-contract parser/assertions | |
| Functional   | ✅     | `scripts/kolme/test_run_local_kolme_api_probe_lane.sh` dry-run/run behaviors | |
| Integration  | ✅     | `scripts/kolme/test_run_local_kolme_api_probe_lane.sh` mock local API server probe | |
| Regression   | ✅     | `Regression: #1439` marker + docs contract test | |
| Performance  | ✅     | `--max-seconds` runtime budget enforcement in probe runner | |

## Risks & Rollback
- None.
- Rollback: revert commit `a4eeab0`.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
