### PR TITLE
fix(foundation): harden runtime transport fail-closed regression paths (#1449)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -809,6 +809,11 @@ fn parse_authority(authority: &str) -> Result<(String, u16), KolmeRuntimeCommitP
             }
             return Ok((host.to_owned(), port));
         }
+        if !port_raw.is_empty() {
+            return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "base_url port is invalid".to_owned(),
+            });
+        }
     }
     Ok((authority.to_owned(), 80))
 }
@@ -900,6 +905,33 @@ fn parse_http_response(response_bytes: Vec<u8>) -> Result<String, KolmeRuntimeCo
             reason: format!("http response status indicates upstream failure: {status_code}"),
         });
     }
+
+    let mut declared_content_length = None;
+    for line in header_lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            let parsed = value.trim().parse::<usize>().map_err(|_| {
+                KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: "http response content-length is invalid".to_owned(),
+                }
+            })?;
+            declared_content_length = Some(parsed);
+            break;
+        }
+    }
+    if let Some(declared) = declared_content_length {
+        let observed = raw_body.len();
+        if declared != observed {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!(
+                    "http response content-length mismatch: declared {declared}, observed {observed}"
+                ),
+            });
+        }
+    }
+
     Ok(raw_body.to_owned())
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -83,6 +83,23 @@ fn spawn_single_request_server(
     format!("http://{addr}")
 }
 
+fn spawn_server_with_raw_response(
+    raw_response: String,
+    handler: impl Fn(String) + Send + 'static,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("connection should be accepted");
+        let request = read_http_request(&mut stream);
+        handler(request);
+        stream
+            .write_all(raw_response.as_bytes())
+            .expect("response should write");
+    });
+    format!("http://{addr}")
+}
+
 #[test]
 fn integration_http_transport_submit_and_response_mapping() {
     let wire_payload = "operation_id=op-1\nstate_root=state-1\n";
@@ -171,5 +188,54 @@ fn regression_http_transport_timeout_maps_to_provider_timeout() {
     assert_eq!(
         provider.submit_runtime_commit("operation_id=op-1\n", "idempotency-key-1"),
         Err(KolmeRuntimeCommitProviderError::Timeout)
+    );
+}
+
+#[test]
+fn regression_http_transport_rejects_invalid_port_before_network_io() {
+    let transport = KolmeRuntimeCommitHttpTransport::new(1).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "http://127.0.0.1:abc",
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    assert_eq!(
+        provider.submit_runtime_commit("operation_id=op-1\n", "idempotency-key-1"),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "base_url port is invalid".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_http_transport_fails_closed_on_content_length_mismatch() {
+    let body = "status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n";
+    let declared_length = body.len() + 9;
+    let raw_response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {declared_length}\r\nConnection: close\r\n\r\n{body}"
+    );
+
+    let base_url = spawn_server_with_raw_response(raw_response, |request| {
+        assert!(request.contains("POST /broadcast/runtime-commit HTTP/1.1"));
+    });
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(1).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        base_url.as_str(),
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    assert_eq!(
+        provider.submit_runtime_commit("operation_id=op-1\n", "idempotency-key-1"),
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: format!(
+                "http response content-length mismatch: declared {declared_length}, observed {}",
+                body.len()
+            ),
+        })
     );
 }


### PR DESCRIPTION
Closes #1449

## Summary
Extends deterministic transport regression coverage for the new concrete runtime-commit HTTP transport and hardens fail-closed behavior for two edge cases: invalid `base_url` port syntax and HTTP `Content-Length` mismatch.

## Changes
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`:
  - added regression tests for invalid port rejection before network I/O.
  - added regression tests for fail-closed content-length mismatch handling.
  - added helper for raw-response server fixtures.
- `crates/kamn-core/src/kolme_runtime_commit.rs`:
  - `parse_authority(...)` now fails closed on invalid non-numeric port markers.
  - `parse_http_response(...)` now validates `Content-Length` and rejects mismatches.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_http_transport`

Failing output:
- `regression_http_transport_rejects_invalid_port_before_network_io`
- `regression_http_transport_fails_closed_on_content_length_mismatch`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`

Result:
- all targeted suites pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
- both pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | authority parsing + HTTP response parsing edge paths | |
| Functional   | ✅     | concrete transport behavior under malformed protocol conditions | |
| Integration  | ✅     | local TCP-backed response fixtures for transport edge cases | |
| Regression   | ✅     | invalid-port and content-length mismatch fail-closed tests | |
| Performance  | N/A    | no throughput/path change; only edge-case validation hardening | bounded targeted scope |

## Risks & Rollback
- Risk: stricter input/response validation may surface malformed upstream behavior earlier.
- Rollback: revert this PR to restore previous permissive parsing behavior.

## Documentation Updates
- None required (no command-surface/API contract change).

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scoped suites)
- [x] Docs updated (or justified why not)
