### PR TITLE
feat(devops): add local runtime-commit live proof lane (#1450)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -56,6 +56,13 @@ fn plan_contains_local_kolme_api_smoke_lane() {
 }
 
 #[test]
+fn plan_contains_local_runtime_commit_live_lane() {
+    assert!(PLAN.contains("## Local Runtime Commit Live Proof Lane"));
+    assert!(PLAN.contains("run_local_runtime_commit_live_lane.sh"));
+    assert!(PLAN.contains("kamn.kolme.local-runtime-commit-live-summary.v1"));
+}
+
+#[test]
 fn plan_contains_local_only_heavy_validation_matrix() {
     assert!(PLAN.contains("## Local-Only Heavy Kolme Validation Matrix"));
     assert!(PLAN.contains("run_local_heavy_validation_matrix.sh"));
@@ -149,5 +156,13 @@ fn regression_requires_local_kolme_api_smoke_guard_marker() {
     // Regression: #1440
     assert!(PLAN.contains(
         "local Kolme API smoke lane fails closed without explicit local opt-in, probe prerequisite failure, smoke-command timeout, and smoke-command errors (`Regression: #1440`)."
+    ));
+}
+
+#[test]
+fn regression_requires_local_runtime_commit_live_guard_marker() {
+    // Regression: #1450
+    assert!(PLAN.contains(
+        "local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`)."
     ));
 }

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -108,6 +108,22 @@ runtime roles (processor/listener/approver) and its CI-compatible validation.
   - run mode fails closed without explicit local-only opt-in.
   - smoke command timeout/exceeded budget is reported as `smoke_command_timeout`.
 
+## Local Runtime Commit Live Proof Lane (Issue #1450)
+
+- Local runtime-commit live lane runner:
+  - `bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode dry-run --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
+- Explicit opt-in live execution:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --live-command "cargo test -p kamn-core --test kolme_runtime_commit_http_transport" --max-seconds 90 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
+- Summary schema:
+  - `kamn.kolme.local-runtime-commit-live-summary.v1`
+- Deterministic checkpoints include:
+  - explicit local-only opt-in marker (`KAMN_KOLME_LOCAL_HEAVY=1`)
+  - bounded live command timeout via `--max-seconds`
+  - machine-readable pass/fail reason codes for missing opt-in, command failure, and timeout
+- Cost policy:
+  - run mode fails closed without explicit local-only opt-in.
+  - live command timeout/exceeded budget is reported as `live_runtime_commit_command_timeout`.
+
 ## Deterministic Local Bootstrap Health Checks (Issue #1417)
 
 - Bootstrap health-check runner:
@@ -180,6 +196,7 @@ runtime roles (processor/listener/approver) and its CI-compatible validation.
 - local fork smoke evidence lane fails closed on missing local opt-in, metadata sync failure, command timeout, and smoke-command errors (`Regression: #1430`).
 - local Kolme API probe lane fails closed on unavailable health endpoint, invalid fork-info payload, and runtime budget overruns (`Regression: #1439`).
 - local Kolme API smoke lane fails closed without explicit local opt-in, probe prerequisite failure, smoke-command timeout, and smoke-command errors (`Regression: #1440`).
+- local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation
@@ -191,6 +208,7 @@ bash scripts/kolme/test_run_local_fork_sync_metadata_lane.sh
 bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh
 bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh
 bash scripts/kolme/test_run_local_kolme_api_smoke_lane.sh
+bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
 bash scripts/kolme/test_run_local_bootstrap_health_checks.sh
 bash scripts/kolme/test_run_local_e2e_integration_lane.sh
 bash scripts/kolme/test_run_local_heavy_validation_matrix.sh

--- a/scripts/kolme/run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="dry-run"
+OUTPUT_JSON="/tmp/kolme-local-runtime-commit-live-summary.json"
+LIVE_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-output.txt"
+LIVE_COMMAND=""
+MAX_SECONDS=90
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --mode" >&2
+        exit 1
+      fi
+      MODE="$2"
+      shift 2
+      ;;
+    --output-json)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --output-json" >&2
+        exit 1
+      fi
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --live-output-file)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --live-output-file" >&2
+        exit 1
+      fi
+      LIVE_OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    --live-command)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --live-command" >&2
+        exit 1
+      fi
+      LIVE_COMMAND="$2"
+      shift 2
+      ;;
+    --max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --max-seconds" >&2
+        exit 1
+      fi
+      MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: run_local_runtime_commit_live_lane.sh [options]
+
+Options:
+  --mode dry-run|run            Execute planned output or active local live lane.
+  --output-json <path>          Deterministic summary report output path.
+  --live-output-file <path>     Captured stdout/stderr for live command.
+  --live-command <command>      Runtime-commit submit/finality command for run mode.
+  --max-seconds <n>             Max runtime budget in seconds for run mode.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$MODE" != "dry-run" ] && [ "$MODE" != "run" ]; then
+  echo "mode must be one of: dry-run, run" >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$MAX_SECONDS" -le 0 ]; then
+  echo "max-seconds must be a positive integer" >&2
+  exit 1
+fi
+
+CHECK_FILE="$(mktemp)"
+trap 'rm -f "$CHECK_FILE"' EXIT
+
+record_check() {
+  local check_id="$1"
+  local command="$2"
+  local status="$3"
+  printf '%s\t%s\t%s\n' "$check_id" "$command" "$status" >>"$CHECK_FILE"
+}
+
+overall_status="ok"
+reason_code="dry_run_no_commands_executed"
+budget_status="not_run"
+elapsed_seconds=0
+local_only_enforced="true"
+
+planned_command="${LIVE_COMMAND:-<required-in-run-mode>}"
+record_check "runtime_commit_live_command" "$planned_command" "planned"
+
+if [ "$MODE" = "run" ]; then
+  : >"$CHECK_FILE"
+  start_epoch="$(date +%s)"
+
+  if [ "${KAMN_KOLME_LOCAL_HEAVY:-0}" != "1" ]; then
+    echo "run mode requires explicit local-only opt-in: KAMN_KOLME_LOCAL_HEAVY=1" >&2
+    record_check "runtime_commit_live_command" "$planned_command" "fail"
+    overall_status="fail"
+    reason_code="local_opt_in_missing"
+  elif [ -z "$LIVE_COMMAND" ]; then
+    echo "run mode requires --live-command for runtime-commit submit/finality proof execution" >&2
+    record_check "runtime_commit_live_command" "$planned_command" "fail"
+    overall_status="fail"
+    reason_code="live_command_missing"
+  else
+    mkdir -p "$(dirname "$LIVE_OUTPUT_FILE")"
+    command_exit_code=0
+    set +e
+    timeout "${MAX_SECONDS}" bash -lc "$LIVE_COMMAND" >"$LIVE_OUTPUT_FILE" 2>&1
+    command_exit_code=$?
+    set -e
+
+    if [ "$command_exit_code" -eq 0 ]; then
+      record_check "runtime_commit_live_command" "$LIVE_COMMAND" "pass"
+      reason_code="live_runtime_commit_command_passed"
+    elif [ "$command_exit_code" -eq 124 ]; then
+      record_check "runtime_commit_live_command" "$LIVE_COMMAND" "fail"
+      overall_status="fail"
+      reason_code="live_runtime_commit_command_timeout"
+    else
+      record_check "runtime_commit_live_command" "$LIVE_COMMAND" "fail"
+      overall_status="fail"
+      reason_code="live_runtime_commit_command_failed"
+    fi
+  fi
+
+  end_epoch="$(date +%s)"
+  elapsed_seconds="$(( end_epoch - start_epoch ))"
+  if [ "$elapsed_seconds" -le "$MAX_SECONDS" ] && [ "$reason_code" != "live_runtime_commit_command_timeout" ]; then
+    budget_status="within_budget"
+  else
+    budget_status="exceeded_budget"
+    if [ "$overall_status" = "ok" ]; then
+      overall_status="fail"
+      reason_code="live_runtime_commit_budget_exceeded"
+    fi
+  fi
+fi
+
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$CHECK_FILE" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1]).resolve()
+mode = sys.argv[2]
+status = sys.argv[3]
+reason_code = sys.argv[4]
+local_only_enforced = sys.argv[5] == "true"
+elapsed_seconds = int(sys.argv[6])
+max_seconds = int(sys.argv[7])
+budget_status = sys.argv[8]
+live_command = sys.argv[9]
+live_output_file = sys.argv[10]
+checks_path = pathlib.Path(sys.argv[11])
+
+checks = []
+for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.strip():
+        continue
+    parts = raw_line.split("\t")
+    if len(parts) != 3:
+        continue
+    check_id, command, check_status = parts
+    checks.append(
+        {
+            "id": check_id,
+            "command": command,
+            "status": check_status,
+        }
+    )
+
+summary = {
+    "schema_version": "kamn.kolme.local-runtime-commit-live-summary.v1",
+    "mode": mode,
+    "status": status,
+    "reason_code": reason_code,
+    "local_only_enforced": local_only_enforced,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "budget_status": budget_status,
+    "live_command": live_command,
+    "live_output_file": live_output_file,
+    "checks": checks,
+    "artifact_paths": [
+        live_output_file,
+    ],
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "status=$overall_status"
+echo "lane_mode=$MODE"
+echo "reason_code=$reason_code"
+echo "budget_status=$budget_status"
+echo "local_only_enforced=$local_only_enforced"
+echo "summary_file=$(realpath "$OUTPUT_JSON")"
+
+if [ "$overall_status" != "ok" ]; then
+  exit 1
+fi

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_runtime_commit_live_lane.sh"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+TMP_REPORT="$(mktemp)"
+TMP_OUTPUT="$(mktemp)"
+TMP_ERR="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_ERR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local runtime commit live lane runner to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_runtime_commit_live_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local runtime commit live lane runner" >&2
+  exit 1
+fi
+
+dry_run_output="$(
+  bash "$RUNNER" \
+    --mode dry-run \
+    --output-json "$TMP_REPORT" \
+    --live-output-file "$TMP_OUTPUT"
+)"
+
+assert_eq "$(extract_value "$dry_run_output" "status")" "ok" "expected dry-run live lane to pass"
+assert_eq "$(extract_value "$dry_run_output" "lane_mode")" "dry-run" "expected dry-run mode marker"
+assert_eq "$(extract_value "$dry_run_output" "reason_code")" "dry_run_no_commands_executed" "expected dry-run reason code"
+assert_eq "$(extract_value "$dry_run_output" "budget_status")" "not_run" "expected dry-run budget status"
+
+python3 - "$TMP_REPORT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("schema_version") != "kamn.kolme.local-runtime-commit-live-summary.v1":
+    raise SystemExit("unexpected live lane summary schema")
+if report.get("mode") != "dry-run":
+    raise SystemExit("expected dry-run mode")
+if report.get("local_only_enforced") is not True:
+    raise SystemExit("expected local_only_enforced=true")
+checks = report.get("checks")
+if not isinstance(checks, list) or not checks:
+    raise SystemExit("expected deterministic checks in summary")
+PY
+
+set +e
+bash "$RUNNER" \
+  --mode run \
+  --output-json "$TMP_REPORT" \
+  --live-output-file "$TMP_OUTPUT" >"$TMP_ERR" 2>&1
+run_without_opt_in_code=$?
+set -e
+
+if [ "$run_without_opt_in_code" -eq 0 ]; then
+  echo "expected run mode without opt-in to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "requires explicit local-only opt-in" "$TMP_ERR"; then
+  echo "expected explicit local opt-in failure message" >&2
+  exit 1
+fi
+
+run_output="$(
+  KAMN_KOLME_LOCAL_HEAVY=1 \
+    bash "$RUNNER" \
+      --mode run \
+      --live-command "printf 'status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n'" \
+      --max-seconds 5 \
+      --output-json "$TMP_REPORT" \
+      --live-output-file "$TMP_OUTPUT"
+)"
+
+assert_eq "$(extract_value "$run_output" "status")" "ok" "expected run mode to pass"
+assert_eq "$(extract_value "$run_output" "lane_mode")" "run" "expected run mode marker"
+assert_eq "$(extract_value "$run_output" "reason_code")" "live_runtime_commit_command_passed" "expected pass reason code"
+assert_eq "$(extract_value "$run_output" "budget_status")" "within_budget" "expected within_budget status"
+
+python3 - "$TMP_REPORT" "$TMP_OUTPUT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+live_output = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+if report.get("mode") != "run":
+    raise SystemExit("expected run mode in summary")
+if report.get("status") != "ok":
+    raise SystemExit("expected ok status in summary")
+if report.get("reason_code") != "live_runtime_commit_command_passed":
+    raise SystemExit("expected pass reason code in summary")
+if report.get("max_seconds") != 5:
+    raise SystemExit("expected max_seconds=5")
+if "status=submitted" not in live_output:
+    raise SystemExit("expected live command output marker")
+PY
+
+set +e
+KAMN_KOLME_LOCAL_HEAVY=1 \
+  bash "$RUNNER" \
+    --mode run \
+    --live-command "sleep 2" \
+    --max-seconds 1 \
+    --output-json "$TMP_REPORT" \
+    --live-output-file "$TMP_OUTPUT" >"$TMP_ERR" 2>&1
+timeout_code=$?
+set -e
+
+if [ "$timeout_code" -eq 0 ]; then
+  echo "expected run mode timeout to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "reason_code=live_runtime_commit_command_timeout" "$TMP_ERR"; then
+  echo "expected timeout reason marker" >&2
+  exit 1
+fi
+
+echo "local runtime commit live lane tests passed."


### PR DESCRIPTION
Closes #1450

## Summary
Adds a bounded local-only runtime-commit live proof lane command with deterministic summary artifacts and explicit local opt-in requirements, then wires contract tests and docs markers to keep it auditable and low-cost.

## Changes
- `scripts/kolme/run_local_runtime_commit_live_lane.sh`:
  - new lane runner with `--mode dry-run|run`
  - explicit run-mode gate: `KAMN_KOLME_LOCAL_HEAVY=1`
  - bounded runtime via `--max-seconds` and deterministic reason codes
  - machine-readable summary schema: `kamn.kolme.local-runtime-commit-live-summary.v1`
- `scripts/kolme/test_run_local_runtime_commit_live_lane.sh`:
  - new lane contract tests for dry-run, opt-in failure, run success, and timeout fail-closed behavior
- `docs/planning/kolme-devnet-ops.md`:
  - added local runtime-commit live lane runbook section and regression marker (`Regression: #1450`)
  - added local validation command entry
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`:
  - added doc-contract assertions for new lane section and regression marker

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh`

Failing output:
- `expected local runtime commit live lane runner to be executable`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`

Result:
- both pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
- both pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | lane arg/summary contract assertions via script checks | |
| Functional   | ✅     | dry-run/run/timeout/opt-in lane behavior | |
| Integration  | ✅     | docs contract integration via `kolme_devnet_ops_docs` | |
| Regression   | ✅     | explicit fail-closed marker + timeout/opt-in regressions | |
| Performance  | N/A    | no new CI-heavy workload; lane remains local-only and bounded | cost policy enforced |

## Risks & Rollback
- Risk: none beyond expected local command contract adoption.
- Rollback: revert this PR to remove the new lane and restore previous docs/test surface.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md` with lane runbook, schema, and regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scoped suites)
- [x] Docs updated (or justified why not)
