### PR TITLE
feat(foundation): add typed Kolme nonce/broadcast codec contracts (#1460)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -115,6 +115,131 @@ impl KolmeRuntimeCommitRequest {
     }
 }
 
+/// Typed nonce lookup request for Kolme `/get-next-nonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiNextNonceRequest {
+    /// Public key used to resolve next nonce and account identity.
+    pub pubkey: String,
+}
+
+impl KolmeApiNextNonceRequest {
+    /// Builds a deterministic nonce lookup request.
+    pub fn new(pubkey: &str) -> Result<Self, KolmeRuntimeCommitError> {
+        let trimmed = pubkey.trim();
+        if trimmed.is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "pubkey",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            pubkey: trimmed.to_owned(),
+        })
+    }
+
+    /// Returns encoded request path for the configured nonce endpoint.
+    pub fn query_path(&self, nonce_path: &str) -> String {
+        let base_path = if nonce_path.trim().is_empty() {
+            "/get-next-nonce".to_owned()
+        } else {
+            nonce_path.trim().to_owned()
+        };
+        let separator = if base_path.contains('?') { "&" } else { "?" };
+        format!(
+            "{base_path}{separator}pubkey={}",
+            percent_encode(self.pubkey.as_str())
+        )
+    }
+}
+
+/// Typed nonce lookup response for Kolme `/get-next-nonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiNextNonceResponse {
+    /// Monotonic next nonce for the provided public key.
+    pub next_nonce: u64,
+    /// Optional account identifier mapped to the provided public key.
+    pub account_id: Option<String>,
+}
+
+impl KolmeApiNextNonceResponse {
+    /// Parses one nonce lookup response JSON payload.
+    pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
+        let fields = parse_flat_json_value_fields(response)?;
+        let next_nonce = required_positive_u64_json_field(&fields, "next_nonce")?;
+        let account_id = optional_nullable_json_string_field(&fields, "account_id")?;
+        Ok(Self {
+            next_nonce,
+            account_id,
+        })
+    }
+}
+
+/// Typed broadcast request payload for Kolme `/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiBroadcastRequest {
+    /// Tagged transaction message payload.
+    pub message: String,
+    /// Chain signature for the transaction message payload.
+    pub signature: String,
+    /// Signature recovery identifier.
+    pub recovery_id: u8,
+}
+
+impl KolmeApiBroadcastRequest {
+    /// Builds a deterministic broadcast request payload.
+    pub fn new(
+        message: &str,
+        signature: &str,
+        recovery_id: u8,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        let message = message.trim();
+        if message.is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "message",
+                reason: "must not be empty",
+            });
+        }
+        let signature = signature.trim();
+        if signature.is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "signature",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            message: message.to_owned(),
+            signature: signature.to_owned(),
+            recovery_id,
+        })
+    }
+
+    /// Returns deterministic JSON payload in canonical field order.
+    pub fn to_json_payload(&self) -> String {
+        format!(
+            "{{\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
+            json_escape(self.message.as_str()),
+            json_escape(self.signature.as_str()),
+            self.recovery_id
+        )
+    }
+}
+
+/// Typed broadcast response payload for Kolme `/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiBroadcastResponse {
+    /// Transaction hash identifier from broadcast response.
+    pub txhash: String,
+}
+
+impl KolmeApiBroadcastResponse {
+    /// Parses one broadcast response JSON payload.
+    pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
+        let fields = parse_flat_json_value_fields(response)?;
+        let txhash = required_json_string_field(&fields, "txhash")?;
+        Ok(Self { txhash })
+    }
+}
+
 /// Finality classification for a runtime commit receipt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KolmeCommitReceiptFinality {
@@ -1077,6 +1202,182 @@ fn parse_flat_json_response_fields(
     Ok(fields)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FlatJsonValue {
+    String(String),
+    Number(String),
+    Boolean(bool),
+    Null,
+}
+
+fn parse_flat_json_value_fields(
+    response: &str,
+) -> Result<HashMap<String, FlatJsonValue>, KolmeRuntimeCommitProviderError> {
+    let body = response.trim();
+    if !(body.starts_with('{') && body.ends_with('}')) {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "json response must be an object".to_owned(),
+        });
+    }
+    let inner = &body[1..body.len() - 1];
+    if inner.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let entries = split_unquoted(inner, ',').map_err(|reason| {
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: format!("invalid json response: {reason}"),
+        }
+    })?;
+
+    let mut fields = HashMap::new();
+    for entry in entries {
+        let pair = split_unquoted(entry.as_str(), ':').map_err(|reason| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid json response pair: {reason}"),
+            }
+        })?;
+        if pair.len() != 2 {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "json response pair must contain exactly one ':'".to_owned(),
+            });
+        }
+
+        let key = parse_json_string(pair[0].trim()).map_err(|reason| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid json key: {reason}"),
+            }
+        })?;
+        let value = parse_json_value(pair[1].trim())?;
+        fields.insert(key, value);
+    }
+    Ok(fields)
+}
+
+fn parse_json_value(token: &str) -> Result<FlatJsonValue, KolmeRuntimeCommitProviderError> {
+    let trimmed = token.trim();
+    if trimmed.starts_with('"') {
+        let value = parse_json_string(trimmed).map_err(|reason| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid json value: {reason}"),
+            }
+        })?;
+        return Ok(FlatJsonValue::String(value));
+    }
+    if trimmed == "null" {
+        return Ok(FlatJsonValue::Null);
+    }
+    if trimmed == "true" {
+        return Ok(FlatJsonValue::Boolean(true));
+    }
+    if trimmed == "false" {
+        return Ok(FlatJsonValue::Boolean(false));
+    }
+    if is_json_number_literal(trimmed) {
+        return Ok(FlatJsonValue::Number(trimmed.to_owned()));
+    }
+    Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: "invalid json value token".to_owned(),
+    })
+}
+
+fn is_json_number_literal(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    let mut chars = token.chars();
+    let first = chars.next().unwrap_or_default();
+    if first == '-' {
+        let remainder = chars.as_str();
+        return !remainder.is_empty() && remainder.chars().all(|ch| ch.is_ascii_digit());
+    }
+    first.is_ascii_digit() && chars.as_str().chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn required_json_string_field(
+    fields: &HashMap<String, FlatJsonValue>,
+    field: &'static str,
+) -> Result<String, KolmeRuntimeCommitProviderError> {
+    let value =
+        fields
+            .get(field)
+            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("missing required field: {field}"),
+            })?;
+    let FlatJsonValue::String(raw) = value else {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: format!("field must be a string: {field}"),
+        });
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: format!("field must not be empty: {field}"),
+        });
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn optional_nullable_json_string_field(
+    fields: &HashMap<String, FlatJsonValue>,
+    field: &'static str,
+) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
+    let Some(value) = fields.get(field) else {
+        return Ok(None);
+    };
+    match value {
+        FlatJsonValue::Null => Ok(None),
+        FlatJsonValue::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: format!("field must not be empty: {field}"),
+                });
+            }
+            Ok(Some(trimmed.to_owned()))
+        }
+        _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: format!("field must be string|null: {field}"),
+        }),
+    }
+}
+
+fn required_positive_u64_json_field(
+    fields: &HashMap<String, FlatJsonValue>,
+    field: &'static str,
+) -> Result<u64, KolmeRuntimeCommitProviderError> {
+    let value =
+        fields
+            .get(field)
+            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("missing required field: {field}"),
+            })?;
+
+    let raw = match value {
+        FlatJsonValue::Number(value) => value.as_str(),
+        FlatJsonValue::String(value) => value.trim(),
+        _ => {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("field must be numeric: {field}"),
+            });
+        }
+    };
+
+    let parsed =
+        raw.parse::<i128>()
+            .map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid numeric field: {field}"),
+            })?;
+    if parsed <= 0 {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: format!("{field} must be positive"),
+        });
+    }
+    u64::try_from(parsed).map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: format!("invalid numeric field: {field}"),
+    })
+}
+
 fn split_unquoted(input: &str, delimiter: char) -> Result<Vec<String>, &'static str> {
     let mut parts = Vec::new();
     let mut current = String::new();
@@ -1155,6 +1456,21 @@ fn parse_json_string(token: &str) -> Result<String, &'static str> {
         return Err("unterminated escape sequence");
     }
     Ok(output)
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 fn required_response_field(

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -252,10 +252,12 @@ pub use key_lifecycle::{
 pub use key_recovery::{KeyRecoveryManager, RecoveryError, RecoveryState};
 pub use kolme_runtime_commit::{
     AdapterBackedKolmeRuntimeCommitClient, InMemoryKolmeRuntimeCommitClient,
-    KolmeCommitReceiptFinality, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
-    KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitFinalityTransport,
-    KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitOutcome,
-    KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
+    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiNextNonceRequest,
+    KolmeApiNextNonceResponse, KolmeCommitReceiptFinality, KolmeRuntimeCommitClient,
+    KolmeRuntimeCommitError, KolmeRuntimeCommitFinalityChecker,
+    KolmeRuntimeCommitFinalityTransport, KolmeRuntimeCommitHttpTransport,
+    KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
     KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderTransport,
     KolmeRuntimeCommitReceipt, KolmeRuntimeCommitRequest, KolmeRuntimeCommitTransportErrorKind,
     RuntimeCommitFinalityProjection, RuntimeCommitLifecycleRecord, RuntimeCommitLifecycleState,

--- a/crates/kamn-core/tests/kolme_api_codec_contracts.rs
+++ b/crates/kamn-core/tests/kolme_api_codec_contracts.rs
@@ -1,0 +1,105 @@
+use kamn_core::{
+    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiNextNonceRequest,
+    KolmeApiNextNonceResponse, KolmeRuntimeCommitError, KolmeRuntimeCommitProviderError,
+};
+
+#[test]
+fn unit_nonce_request_rejects_empty_pubkey() {
+    assert_eq!(
+        KolmeApiNextNonceRequest::new(""),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "pubkey",
+            reason: "must not be empty",
+        })
+    );
+}
+
+#[test]
+fn unit_nonce_request_builds_encoded_query_path() {
+    let request =
+        KolmeApiNextNonceRequest::new("pub:key/with space").expect("request should build");
+    assert_eq!(
+        request.query_path("/get-next-nonce"),
+        "/get-next-nonce?pubkey=pub%3Akey%2Fwith%20space"
+    );
+}
+
+#[test]
+fn functional_broadcast_request_serializes_canonical_json_payload() {
+    let request = KolmeApiBroadcastRequest::new("{\"messages\":[]}", "0xabc123", 1)
+        .expect("broadcast request should build");
+    assert_eq!(
+        request.to_json_payload(),
+        "{\"message\":\"{\\\"messages\\\":[]}\",\"signature\":\"0xabc123\",\"recovery_id\":1}"
+    );
+}
+
+#[test]
+fn functional_nonce_response_parses_numeric_next_nonce() {
+    let response =
+        KolmeApiNextNonceResponse::parse_json("{\"next_nonce\":12,\"account_id\":\"acct-1\"}")
+            .expect("nonce response should parse");
+    assert_eq!(response.next_nonce, 12);
+    assert_eq!(response.account_id, Some("acct-1".to_owned()));
+}
+
+#[test]
+fn functional_nonce_response_accepts_null_account_id() {
+    let response = KolmeApiNextNonceResponse::parse_json("{\"next_nonce\":7,\"account_id\":null}")
+        .expect("nonce response with null account should parse");
+    assert_eq!(response.next_nonce, 7);
+    assert_eq!(response.account_id, None);
+}
+
+#[test]
+fn functional_broadcast_response_parses_txhash() {
+    let response = KolmeApiBroadcastResponse::parse_json("{\"txhash\":\"abc123\"}")
+        .expect("broadcast response should parse");
+    assert_eq!(response.txhash, "abc123");
+}
+
+#[test]
+fn regression_nonce_response_rejects_non_positive_next_nonce() {
+    assert_eq!(
+        KolmeApiNextNonceResponse::parse_json("{\"next_nonce\":0,\"account_id\":null}"),
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "next_nonce must be positive".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn regression_broadcast_response_rejects_missing_txhash() {
+    assert_eq!(
+        KolmeApiBroadcastResponse::parse_json("{\"status\":\"ok\"}"),
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "missing required field: txhash".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn integration_nonce_and_broadcast_codec_contracts_are_compatible() {
+    let nonce_request =
+        KolmeApiNextNonceRequest::new("02abcd").expect("nonce request should build");
+    assert_eq!(
+        nonce_request.query_path("/get-next-nonce"),
+        "/get-next-nonce?pubkey=02abcd"
+    );
+
+    let nonce_response =
+        KolmeApiNextNonceResponse::parse_json("{\"next_nonce\":42,\"account_id\":\"acc-42\"}")
+            .expect("nonce response should parse");
+    assert_eq!(nonce_response.next_nonce, 42);
+
+    let broadcast_request =
+        KolmeApiBroadcastRequest::new("{\"nonce\":42}", "sig-42", 0).expect("request should build");
+    assert_eq!(
+        broadcast_request.to_json_payload(),
+        "{\"message\":\"{\\\"nonce\\\":42}\",\"signature\":\"sig-42\",\"recovery_id\":0}"
+    );
+
+    let broadcast_response = KolmeApiBroadcastResponse::parse_json("{\"txhash\":\"tx-42\"}")
+        .expect("response should parse");
+    assert_eq!(broadcast_response.txhash, "tx-42");
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -34,6 +34,24 @@ handling.
   - timeout mapping to `KolmeRuntimeCommitProviderError::Timeout`
   - network and protocol failures mapped fail-closed to provider transport errors
 
+## Typed Kolme Nonce/Broadcast Codecs
+
+- Added typed Kolme API codec contracts in `kamn-core`:
+  - `KolmeApiNextNonceRequest`
+  - `KolmeApiNextNonceResponse`
+  - `KolmeApiBroadcastRequest`
+  - `KolmeApiBroadcastResponse`
+- Deterministic nonce request behavior:
+  - `KolmeApiNextNonceRequest::query_path(...)` percent-encodes the `pubkey` query
+    value and preserves deterministic path composition.
+- Deterministic response parsing behavior:
+  - `KolmeApiNextNonceResponse::parse_json(...)` requires positive `next_nonce`
+    and supports nullable `account_id`.
+  - `KolmeApiBroadcastResponse::parse_json(...)` requires non-empty `txhash`.
+- Deterministic broadcast payload behavior:
+  - `KolmeApiBroadcastRequest::to_json_payload()` emits canonical JSON field order
+    (`message`, `signature`, `recovery_id`) and applies JSON string escaping.
+
 ## Deterministic Request Normalization Rules
 
 - Adapter submissions call provider transport with:


### PR DESCRIPTION
## Summary
Adds typed Kolme nonce and broadcast codec contracts to `kamn-core` so KAMN can model real `/get-next-nonce` and `/broadcast` JSON payloads with deterministic validation and error mapping. This closes the first task in the native API parity wave.

Closes #1460

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: adds `KolmeApiNextNonceRequest/Response` and `KolmeApiBroadcastRequest/Response` plus deterministic JSON parsing helpers.
- `crates/kamn-core/src/lib.rs`: exports new codec types.
- `crates/kamn-core/tests/kolme_api_codec_contracts.rs`: adds unit/functional/integration/regression codec coverage.
- `docs/foundation/kolme-runtime-commit-client.md`: documents typed nonce/broadcast codec contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_api_codec_contracts`
- Failure before implementation: unresolved imports for `KolmeApiNextNonceRequest`, `KolmeApiNextNonceResponse`, `KolmeApiBroadcastRequest`, `KolmeApiBroadcastResponse`.

### 🟢 Green Phase
- `cargo test -p kamn-core --test kolme_api_codec_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_api_codec_contracts` unit cases for nonce/broadcast request/response validation | |
| Functional   | ✅     | `kolme_api_codec_contracts` functional parse/serialization cases | |
| Integration  | ✅     | `kolme_api_codec_contracts` integration compatibility case + existing runtime commit integration tests | |
| Regression   | ✅     | `kolme_api_codec_contracts` regression cases for non-positive nonce and missing txhash | |
| Performance  | ✅     | Existing bounded runtime commit performance checks remain green (`kolme_runtime_commit_client`) | |

## Risks & Rollback
- None.
- Rollback: revert commit `83bb20c`.

## Documentation Updates
- Updated `docs/foundation/kolme-runtime-commit-client.md` with typed nonce/broadcast codec contract section.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
