### PR TITLE
fix(foundation): add TLS-backed HTTPS path for Kolme transport (#1471)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use std::fmt;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::time::Duration;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 /// Runtime commit submission request for the Kolme execution path.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -545,10 +547,26 @@ pub struct KolmeRuntimeCommitLiveProvider<T> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedHttpEndpoint {
+    scheme: HttpScheme,
     host: String,
     host_header: String,
     port: u16,
     target_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpScheme {
+    Http,
+    Https,
+}
+
+impl HttpScheme {
+    fn default_port(self) -> u16 {
+        match self {
+            Self::Http => 80,
+            Self::Https => 443,
+        }
+    }
 }
 
 /// Dependency-free HTTP transport implementation for runtime commit submit/finality calls.
@@ -592,17 +610,6 @@ impl KolmeRuntimeCommitHttpTransport {
         headers: &[(&str, &str)],
     ) -> Result<String, KolmeRuntimeCommitProviderError> {
         let endpoint = parse_http_endpoint(base_url, path)?;
-        let mut stream = TcpStream::connect((endpoint.host.as_str(), endpoint.port))
-            .map_err(map_transport_io_error)?;
-
-        let timeout = Duration::from_secs(self.timeout_seconds);
-        stream
-            .set_read_timeout(Some(timeout))
-            .map_err(map_transport_io_error)?;
-        stream
-            .set_write_timeout(Some(timeout))
-            .map_err(map_transport_io_error)?;
-
         let payload = body.unwrap_or("");
         let mut request = format!(
             "{method} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n",
@@ -627,15 +634,113 @@ impl KolmeRuntimeCommitHttpTransport {
             request.push_str(payload);
         }
 
-        stream
-            .write_all(request.as_bytes())
+        let response_bytes = match endpoint.scheme {
+            HttpScheme::Http => self.execute_http_request(endpoint, request.as_bytes())?,
+            HttpScheme::Https => self.execute_https_request(endpoint, request.as_bytes())?,
+        };
+        parse_http_response(response_bytes)
+    }
+
+    fn execute_http_request(
+        &self,
+        endpoint: ParsedHttpEndpoint,
+        request: &[u8],
+    ) -> Result<Vec<u8>, KolmeRuntimeCommitProviderError> {
+        let mut stream = TcpStream::connect((endpoint.host.as_str(), endpoint.port))
             .map_err(map_transport_io_error)?;
+        let timeout = Duration::from_secs(self.timeout_seconds);
+        stream
+            .set_read_timeout(Some(timeout))
+            .map_err(map_transport_io_error)?;
+        stream
+            .set_write_timeout(Some(timeout))
+            .map_err(map_transport_io_error)?;
+        stream.write_all(request).map_err(map_transport_io_error)?;
 
         let mut response_bytes = Vec::new();
         stream
             .read_to_end(&mut response_bytes)
             .map_err(map_transport_io_error)?;
-        parse_http_response(response_bytes)
+        Ok(response_bytes)
+    }
+
+    fn execute_https_request(
+        &self,
+        endpoint: ParsedHttpEndpoint,
+        request: &[u8],
+    ) -> Result<Vec<u8>, KolmeRuntimeCommitProviderError> {
+        let connect_target = format!("{}:{}", endpoint.host, endpoint.port);
+        let mut command = Command::new("openssl");
+        command
+            .arg("s_client")
+            .arg("-quiet")
+            .arg("-verify_return_error")
+            .arg("-servername")
+            .arg(endpoint.host.as_str())
+            .arg("-connect")
+            .arg(connect_target.as_str())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        if let Some(ca_file) = configured_tls_ca_file()? {
+            command.arg("-CAfile").arg(ca_file);
+        }
+
+        let mut child =
+            command
+                .spawn()
+                .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
+                    reason: format!("tls command spawn failed: {error}"),
+                })?;
+        {
+            let mut stdin =
+                child
+                    .stdin
+                    .take()
+                    .ok_or_else(|| KolmeRuntimeCommitProviderError::Unavailable {
+                        reason: "tls command stdin unavailable".to_owned(),
+                    })?;
+            stdin.write_all(request).map_err(map_transport_io_error)?;
+        }
+
+        let timeout = Duration::from_secs(self.timeout_seconds);
+        let started = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) => {
+                    if started.elapsed() >= timeout {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(KolmeRuntimeCommitProviderError::Timeout);
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => {
+                    return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                        reason: format!("tls command wait failed: {error}"),
+                    });
+                }
+            }
+        }
+
+        let output = child.wait_with_output().map_err(map_transport_io_error)?;
+        let looks_like_http_response = output.stdout.starts_with(b"HTTP/1.")
+            && output.stdout.windows(4).any(|window| window == b"\r\n\r\n");
+        if !output.status.success() && !looks_like_http_response {
+            return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                reason: classify_tls_failure_reason(
+                    String::from_utf8_lossy(&output.stderr).as_ref(),
+                ),
+            });
+        }
+        if output.stdout.is_empty() {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "tls response body is empty".to_owned(),
+            });
+        }
+        Ok(output.stdout)
     }
 }
 
@@ -905,13 +1010,15 @@ fn parse_http_endpoint(
             reason: "base_url must not be empty".to_owned(),
         });
     }
-    if !base.starts_with("http://") {
+    let (scheme, remainder) = if let Some(remainder) = base.strip_prefix("http://") {
+        (HttpScheme::Http, remainder)
+    } else if let Some(remainder) = base.strip_prefix("https://") {
+        (HttpScheme::Https, remainder)
+    } else {
         return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "only http:// base_url is supported".to_owned(),
+            reason: "base_url scheme must be http:// or https://".to_owned(),
         });
-    }
-
-    let remainder = &base["http://".len()..];
+    };
     let (authority, base_path) = match remainder.split_once('/') {
         Some((left, right)) => (left, format!("/{}", right.trim_start_matches('/'))),
         None => (remainder, "/".to_owned()),
@@ -923,9 +1030,10 @@ fn parse_http_endpoint(
         });
     }
 
-    let (host, port) = parse_authority(authority)?;
+    let (host, port) = parse_authority(authority, scheme.default_port())?;
     let target_path = join_http_paths(base_path.as_str(), path);
     Ok(ParsedHttpEndpoint {
+        scheme,
         host,
         host_header: authority.to_owned(),
         port,
@@ -933,7 +1041,10 @@ fn parse_http_endpoint(
     })
 }
 
-fn parse_authority(authority: &str) -> Result<(String, u16), KolmeRuntimeCommitProviderError> {
+fn parse_authority(
+    authority: &str,
+    default_port: u16,
+) -> Result<(String, u16), KolmeRuntimeCommitProviderError> {
     if authority.starts_with('[') {
         return Err(KolmeRuntimeCommitProviderError::Unavailable {
             reason: "ipv6 host syntax is not supported".to_owned(),
@@ -959,7 +1070,7 @@ fn parse_authority(authority: &str) -> Result<(String, u16), KolmeRuntimeCommitP
             });
         }
     }
-    Ok((authority.to_owned(), 80))
+    Ok((authority.to_owned(), default_port))
 }
 
 fn parse_authorization_header(value: &str) -> Result<String, KolmeRuntimeCommitError> {
@@ -1017,6 +1128,48 @@ fn map_transport_io_error(error: std::io::Error) -> KolmeRuntimeCommitProviderEr
     KolmeRuntimeCommitProviderError::Unavailable {
         reason: format!("transport io error: {error}"),
     }
+}
+
+fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
+    let value = match std::env::var("KAMN_KOLME_TLS_CA_FILE") {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "KAMN_KOLME_TLS_CA_FILE must be valid utf-8".to_owned(),
+            });
+        }
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "KAMN_KOLME_TLS_CA_FILE must not be empty".to_owned(),
+        });
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
+fn classify_tls_failure_reason(stderr: &str) -> String {
+    let normalized = stderr.to_ascii_lowercase();
+    if normalized.contains("certificate verify failed")
+        || normalized.contains("self-signed certificate")
+        || normalized.contains("unable to get local issuer certificate")
+        || normalized.contains("unable to verify the first certificate")
+    {
+        return "tls certificate verification failed".to_owned();
+    }
+    if normalized.contains("handshake failure")
+        || normalized.contains("wrong version number")
+        || normalized.contains("tlsv")
+        || normalized.contains("ssl routines")
+    {
+        return "tls handshake failed".to_owned();
+    }
+    let first_line = stderr
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("tls request failed");
+    format!("tls request failed: {}", first_line.trim())
 }
 
 fn parse_http_response(response_bytes: Vec<u8>) -> Result<String, KolmeRuntimeCommitProviderError> {
@@ -1942,7 +2095,7 @@ fn lifecycle_record_from_outcome(
 
 #[cfg(test)]
 mod tests {
-    use super::{KolmeRuntimeCommitError, KolmeRuntimeCommitRequest};
+    use super::{classify_tls_failure_reason, KolmeRuntimeCommitError, KolmeRuntimeCommitRequest};
 
     #[test]
     fn deterministic_request_rejects_empty_operation_id() {
@@ -1959,5 +2112,20 @@ mod tests {
                 reason: "must not be empty",
             })
         );
+    }
+
+    #[test]
+    fn tls_failure_reason_classifier_detects_certificate_errors() {
+        let reason = classify_tls_failure_reason(
+            "verify error:num=18:self-signed certificate\ncertificate verify failed",
+        );
+        assert_eq!(reason, "tls certificate verification failed");
+    }
+
+    #[test]
+    fn tls_failure_reason_classifier_detects_handshake_errors() {
+        let reason =
+            classify_tls_failure_reason("ssl routines:ssl3_get_record:wrong version number");
+        assert_eq!(reason, "tls handshake failed");
     }
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -8,7 +8,14 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("KolmeRuntimeCommitProviderReceipt"));
     assert!(DOC.contains("KolmeRuntimeCommitProviderError"));
     assert!(DOC.contains("KolmeRuntimeCommitTransportErrorKind"));
+    assert!(DOC.contains("http://` and `https://"));
+    assert!(DOC.contains("KAMN_KOLME_TLS_CA_FILE"));
+    assert!(DOC.contains("tls certificate verification failed"));
+    assert!(DOC.contains("tls handshake failed"));
     assert!(DOC.contains("cargo test -p kamn-core --test kolme_runtime_commit_client"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact"
+    ));
     assert!(DOC.contains("scripts/kolme/run_runtime_commit_contract_lane.sh"));
 }
 
@@ -17,4 +24,5 @@ fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marke
     // Regression: #979
     assert!(DOC.contains("`Regression: #979`"));
     assert!(DOC.contains("provider mismatch/non-final receipts remain fail-closed"));
+    assert!(DOC.contains("`Regression: #1471`"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -3,10 +3,205 @@ use kamn_core::{
     KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
     KolmeRuntimeCommitProviderOutcome,
 };
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::{env, fs};
+
+const TLS_CA_FILE_ENV: &str = "KAMN_KOLME_TLS_CA_FILE";
+
+fn tls_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: Option<&str>) -> Self {
+        let previous = env::var(key).ok();
+        match value {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.as_deref() {
+            env::set_var(self.key, previous);
+        } else {
+            env::remove_var(self.key);
+        }
+    }
+}
+
+struct HttpsSingleRequestServer {
+    base_url: String,
+    cert_path: PathBuf,
+    child: Child,
+    temp_dir: PathBuf,
+}
+
+impl HttpsSingleRequestServer {
+    fn wait_for_exit(&mut self) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = self.child.kill();
+                        let _ = self.child.wait();
+                        panic!("https test server did not exit after handling request");
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to wait for https test server exit: {error}"),
+            }
+        }
+    }
+}
+
+impl Drop for HttpsSingleRequestServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = fs::remove_dir_all(&self.temp_dir);
+    }
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    let path = env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&path).expect("temporary directory should be created");
+    path
+}
+
+fn generate_self_signed_certificate(temp_dir: &Path) -> (PathBuf, PathBuf) {
+    let cert_path = temp_dir.join("cert.pem");
+    let key_path = temp_dir.join("key.pem");
+
+    let status = Command::new("openssl")
+        .arg("req")
+        .arg("-x509")
+        .arg("-newkey")
+        .arg("rsa:2048")
+        .arg("-keyout")
+        .arg(key_path.as_os_str())
+        .arg("-out")
+        .arg(cert_path.as_os_str())
+        .arg("-days")
+        .arg("1")
+        .arg("-nodes")
+        .arg("-subj")
+        .arg("/CN=127.0.0.1")
+        .arg("-addext")
+        .arg("subjectAltName = DNS:localhost,IP:127.0.0.1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("openssl should run");
+    assert!(
+        status.success(),
+        "openssl self-signed certificate generation should succeed"
+    );
+
+    (cert_path, key_path)
+}
+
+fn spawn_https_single_request_server(
+    status_code: u16,
+    response_body: &str,
+) -> HttpsSingleRequestServer {
+    let temp_dir = unique_temp_dir("kolme-https-server");
+    let (cert_path, key_path) = generate_self_signed_certificate(temp_dir.as_path());
+    let server_script = r#"
+import http.server
+import ssl
+import sys
+
+port = int(sys.argv[1])
+cert_file = sys.argv[2]
+key_file = sys.argv[3]
+status_code = int(sys.argv[4])
+response_body = sys.argv[5].encode("utf-8")
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def _reply(self):
+        if "Content-Length" in self.headers:
+            _ = self.rfile.read(int(self.headers["Content-Length"]))
+        self.send_response(status_code)
+        self.send_header("Content-Length", str(len(response_body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def do_POST(self):
+        self._reply()
+
+    def do_GET(self):
+        self._reply()
+
+    def log_message(self, _format, *args):
+        return
+
+httpd = http.server.HTTPServer(("127.0.0.1", port), Handler)
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+print(httpd.server_address[1], flush=True)
+httpd.handle_request()
+"#;
+
+    let mut child = Command::new("python3")
+        .arg("-u")
+        .arg("-c")
+        .arg(server_script)
+        .arg("0")
+        .arg(cert_path.as_os_str())
+        .arg(key_path.as_os_str())
+        .arg(status_code.to_string())
+        .arg(response_body)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("python https test server should spawn");
+
+    let stdout = child
+        .stdout
+        .take()
+        .expect("python https test server stdout should be piped");
+    let mut stdout_reader = BufReader::new(stdout);
+    let mut port_line = String::new();
+    stdout_reader
+        .read_line(&mut port_line)
+        .expect("python https test server should emit bound port");
+    child.stdout = Some(stdout_reader.into_inner());
+
+    let port = port_line
+        .trim()
+        .parse::<u16>()
+        .expect("python https test server should emit a valid port");
+    HttpsSingleRequestServer {
+        base_url: format!("https://127.0.0.1:{port}"),
+        cert_path,
+        child,
+        temp_dir,
+    }
+}
 
 fn read_http_request(stream: &mut std::net::TcpStream) -> String {
     let mut buffer = Vec::new();
@@ -320,6 +515,105 @@ fn regression_http_transport_maps_422_to_invalid_request_malformed_error() {
         provider.submit_runtime_commit("operation_id=op-1\n", "idempotency-key-1"),
         Err(KolmeRuntimeCommitProviderError::MalformedResponse {
             reason: "http response status indicates invalid request: 422".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn functional_https_transport_submit_with_trusted_ca_succeeds() {
+    let _guard = tls_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut server = spawn_https_single_request_server(
+        200,
+        "status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:https\nfinality=final\n",
+    );
+    let cert_path = server
+        .cert_path
+        .to_str()
+        .expect("temporary cert path should be valid utf-8")
+        .to_owned();
+    let _env_guard = EnvVarGuard::set(TLS_CA_FILE_ENV, Some(cert_path.as_str()));
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        server.base_url.as_str(),
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    let outcome = provider
+        .submit_runtime_commit("operation_id=op-https\n", "idempotency-key-https")
+        .expect("https submit should succeed");
+    match outcome {
+        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => {
+            assert_eq!(receipt.provider, "kolme-local");
+            assert_eq!(receipt.commit_id, "kolme-commit:https");
+            assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Final);
+        }
+        other => panic!("unexpected provider outcome: {other:?}"),
+    }
+
+    server.wait_for_exit();
+}
+
+#[test]
+fn regression_https_transport_maps_certificate_errors_to_unavailable() {
+    let _guard = tls_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut server = spawn_https_single_request_server(
+        200,
+        "status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:https\nfinality=final\n",
+    );
+    let _env_guard = EnvVarGuard::set(TLS_CA_FILE_ENV, None);
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        server.base_url.as_str(),
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    assert_eq!(
+        provider.submit_runtime_commit("operation_id=op-https\n", "idempotency-key-https"),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "tls certificate verification failed".to_owned(),
+        })
+    );
+
+    server.wait_for_exit();
+}
+
+#[test]
+fn regression_https_transport_maps_tls_handshake_failures_to_unavailable() {
+    let _guard = tls_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _env_guard = EnvVarGuard::set(TLS_CA_FILE_ENV, None);
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("connection should be accepted");
+        let _ = stream.read(&mut [0_u8; 64]);
+        let _ =
+            stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+    });
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        format!("https://{addr}").as_str(),
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    assert_eq!(
+        provider.submit_runtime_commit("operation_id=op-https\n", "idempotency-key-https"),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "tls handshake failed".to_owned(),
         })
     );
 }

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -26,12 +26,18 @@ handling.
 
 ## Concrete HTTP Transport
 
-- `KolmeRuntimeCommitHttpTransport` provides a dependency-free `http://` transport for:
+- `KolmeRuntimeCommitHttpTransport` provides deterministic `http://` and `https://` transport paths for:
   - `KolmeRuntimeCommitProviderTransport::submit_runtime_commit(...)`
   - `KolmeRuntimeCommitFinalityTransport::fetch_runtime_commit_finality(...)`
 - Optional auth-aware constructor:
   - `KolmeRuntimeCommitHttpTransport::new_with_authorization(...)`
   - emits `Authorization: <value>` header on submit/finality requests.
+- HTTPS/TLS behavior:
+  - `https://` requests execute through TLS-backed `openssl s_client` command wiring.
+  - optional custom CA trust file is read from `KAMN_KOLME_TLS_CA_FILE`.
+  - deterministic TLS failure mapping:
+    - certificate verification failures => `Unavailable("tls certificate verification failed")`
+    - handshake/protocol failures => `Unavailable("tls handshake failed")`
 - Deterministic runtime behavior:
   - query parameter encoding for `commit_id` in finality polling
   - timeout mapping to `KolmeRuntimeCommitProviderError::Timeout`
@@ -98,6 +104,8 @@ Run targeted checks first:
 ```bash
 cargo test -p kamn-core --test kolme_runtime_commit_client
 cargo test -p kamn-core --test kolme_runtime_commit_finality
+cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact
+cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact
 bash scripts/kolme/run_runtime_commit_contract_lane.sh
 ```
 
@@ -112,3 +120,4 @@ cargo test -p kamn-core
 - Mutated invalid runtime commit requests remain fail-closed (`Regression: #825`).
 - Replay/tamper mismatch policy remains fail-closed (`Regression: #827`).
 - Adapter provider mismatch/non-final receipts remain fail-closed (`Regression: #979`).
+- HTTPS TLS certificate/handshake drift remains fail-closed (`Regression: #1471`).


### PR DESCRIPTION
## Summary
Implements TLS-backed `https://` transport execution for Kolme runtime commit submit/finality calls while preserving existing `http://` behavior, and adds deterministic certificate/handshake failure mapping with integration coverage.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`:
  - Added `https://` endpoint parsing support alongside `http://`.
  - Added TLS execution path for transport requests using `openssl s_client`.
  - Added deterministic TLS error classification:
    - certificate verification failures -> `Unavailable("tls certificate verification failed")`
    - handshake/protocol failures -> `Unavailable("tls handshake failed")`
  - Added optional CA trust-file support via `KAMN_KOLME_TLS_CA_FILE`.
  - Added unit tests for TLS failure classifier.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`:
  - Added functional HTTPS success test with trusted local CA.
  - Added regression tests for certificate verification failure and handshake failure classification.
- `docs/foundation/kolme-runtime-commit-client.md`:
  - Updated transport contract to document HTTPS support, CA-file behavior, and deterministic TLS error mapping.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`:
  - Added docs-contract assertions for new HTTPS/TLS markers and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact`
  - failed with `Unavailable { reason: "only http:// base_url is supported" }`
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact`
  - failed with unsupported `http://`-only scheme path

### 🟢 Green Phase
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo test -p kamn-core --lib kolme_runtime_commit::tests::tls_failure_reason_classifier_detects_handshake_errors -- --exact`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `kolme_runtime_commit::tests::tls_failure_reason_classifier_*` | |
| Functional   | ✅ | `functional_https_transport_submit_with_trusted_ca_succeeds` | |
| Integration  | ✅ | HTTPS submit path over local TLS server in `kolme_runtime_commit_http_transport` | |
| Regression   | ✅ | certificate + handshake failure mapping tests | |
| Performance  | N/A | | HTTPS transport path coverage added; no additional lane/runtime budget contract changed in this subtask |

## Risks & Rollback
- Risk: transport now depends on `openssl` binary availability for `https://` execution path.
- Rollback: revert this PR to restore previous `http://`-only behavior.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1471
Closes #1461
