### PR TITLE
fix(ci): reconcile script-surface budget waiver drift (#1497)

### DIFF
--- a/.ci/script-surface-budget-waiver.json
+++ b/.ci/script-surface-budget-waiver.json
@@ -1,7 +1,8 @@
 {
-  "reason": "Temporary waiver for elevated shell script line surface while lane/evidence framework consolidation is scheduled; keep all other script budget metrics fail-closed.",
-  "expires_on": "2026-04-30",
+  "reason": "Temporary waiver for elevated shell script surface (`shell_line_total` + `script_count`) while lane/evidence framework consolidation is scheduled and tracked in #1497; keep all other script budget metrics fail-closed.",
+  "expires_on": "2026-03-31",
   "allow_metrics": [
-    "shell_line_total"
+    "shell_line_total",
+    "script_count"
   ]
 }

--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -79,4 +79,5 @@ fn regression_requires_make_and_selector_demo_contract_marker() {
     assert!(DOC.contains("Regression: #1483"));
     assert!(DOC.contains("Regression: #1462"));
     assert!(DOC.contains("Regression: #1466"));
+    assert!(DOC.contains("Regression: #1497"));
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -165,6 +165,7 @@ Regression policy:
 - local probe fork-info chain_version query and native parity broadcast method drift remains fail-closed (`Regression: #1482`).
 - nonce/broadcast parity matrix selector/docs/runtime-budget drift remains fail-closed (`Regression: #1462`).
 - fast-gate native Kolme API parity lane schema/routing/runtime-budget drift remains fail-closed (`Regression: #1466`).
+- script-surface budget temporary `script_count` waiver scope/expiry drift remains fail-closed (`Regression: #1497`).
 
 ## Budget Telemetry and Enforcement
 Both lanes call `scripts/ci/evaluate_budget.sh` at the end of the run to:

--- a/scripts/ci/test_check_script_duplication_budget.sh
+++ b/scripts/ci/test_check_script_duplication_budget.sh
@@ -75,7 +75,8 @@ fail_output="$(
   bash "$SCRIPT" \
     --scripts-root "$SCRIPTS_ROOT" \
     --budget-file "$FAIL_BUDGET" \
-    --baseline-file "$BASELINE_FILE" 2>&1
+    --baseline-file "$BASELINE_FILE" \
+    --waiver-file "$TMP_DIR/missing-waiver.json" 2>&1
 )"
 fail_code=$?
 set -e

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -102,6 +102,7 @@ required_snippets=(
   "Regression: #1483"
   "Regression: #1462"
   "Regression: #1466"
+  "Regression: #1497"
 )
 
 for snippet in "${required_snippets[@]}"; do


### PR DESCRIPTION
## Summary
Reconciles fast-gate script-surface policy drift by extending the existing temporary waiver to include `script_count` with a shorter explicit expiry and issue traceability. Adds a regression marker and contract assertions so waiver scope/expiry drift fails closed.

Closes #1497

## Changes
- `.ci/script-surface-budget-waiver.json`: added `script_count` to `allow_metrics`, shortened expiry to `2026-03-31`, and linked rationale to `#1497`.
- `docs/ci/strategy.md`: added regression policy marker for script-surface waiver drift (`Regression: #1497`).
- `scripts/ci/test_ci_strategy_contract.sh`: requires `Regression: #1497` snippet.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: requires `Regression: #1497` in docs contract test.
- `scripts/ci/test_check_script_duplication_budget.sh`: isolates fail-path from repo waiver by forcing a missing waiver file in the threshold-fail case.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/check_script_duplication_budget.sh --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file .ci/script-surface-budget-waiver.json --output-json /tmp/ci-script-surface-budget-1497-red.json
```
Observed failure:
```text
status=fail
violations=script_count,shell_line_total
waived=shell_line_total
pending=script_count
```

### 🟢 Green Phase
Command:
```bash
bash scripts/ci/check_script_duplication_budget.sh --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file .ci/script-surface-budget-waiver.json
```
Observed pass:
```text
status=pass
violations=script_count,shell_line_total
waived=script_count,shell_line_total
pending=none
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_check_script_duplication_budget.sh
bash scripts/ci/test_ci_strategy_contract.sh
cargo test -p kamn-core --test ci_strategy_docs
cargo fmt --check
cargo clippy -- -D warnings
```
Observed pass summary:
- script duplication budget checker tests passed.
- CI strategy contract tests passed.
- `ci_strategy_docs` tests passed.
- `cargo fmt --check` clean.
- `cargo clippy -- -D warnings` clean.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/ci/test_check_script_duplication_budget.sh` fail-path isolation update | |
| Functional   | ✅ | direct red/green execution of `check_script_duplication_budget.sh` | |
| Integration  | N/A | No cross-module runtime integration path changed | CI policy/config-only remediation |
| Regression   | ✅ | `scripts/ci/test_ci_strategy_contract.sh`, `crates/kamn-core/tests/ci_strategy_docs.rs` | |
| Performance  | ✅ | bounded temporary waiver with explicit expiry; no workflow expansion | |

## Risks & Rollback
- Risk: temporary waiver could outlive intended horizon if not tracked.
- Rollback plan: remove `script_count` from `.ci/script-surface-budget-waiver.json` once script-count reductions land.

## Documentation Updates
- Updated: `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: none (policy/config/tests only; affects fast-gate pass/fail decision path for script-surface budget step)
Expected runtime delta: negligible
Expected runner-minute delta: none to negligible
Rollback plan if CI cost/runtime regresses: remove `script_count` waiver entry and reopen policy gate while addressing script-count reduction in follow-up
