### PR TITLE
feat(kolme): align runtime commit submit profile with fork broadcast (#1502)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -612,7 +612,15 @@ pub trait KolmeRuntimeCommitProviderTransport {
 pub struct KolmeRuntimeCommitLiveProvider<T> {
     base_url: String,
     submit_path: String,
+    profile: KolmeRuntimeCommitSubmitProfile,
+    provider_hint: Option<String>,
     transport: T,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KolmeRuntimeCommitSubmitProfile {
+    LegacyRuntimeCommit,
+    KolmeForkBroadcast,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -870,6 +878,19 @@ impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "idempotency_key must not be empty".to_owned(),
             });
+        }
+        if is_kolme_broadcast_submit_path(submit_path) {
+            let payload = normalize_kolme_broadcast_payload(wire_payload, idempotency_key)?;
+            return self.execute_request(
+                base_url,
+                submit_path,
+                "PUT",
+                Some(payload.as_str()),
+                &[
+                    ("Content-Type", "application/json"),
+                    ("X-Idempotency-Key", idempotency_key),
+                ],
+            );
         }
         self.execute_request(
             base_url,
@@ -1388,8 +1409,29 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
         Ok(Self {
             base_url: base_url.trim().to_owned(),
             submit_path: submit_path.trim().to_owned(),
+            profile: KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit,
+            provider_hint: None,
             transport,
         })
+    }
+
+    /// Builds a live provider configured for `kolme_fork` broadcast semantics.
+    pub fn new_kolme_fork_broadcast_profile(
+        base_url: &str,
+        provider_hint: &str,
+        transport: T,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        let provider_hint = provider_hint.trim();
+        if provider_hint.is_empty() {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_hint",
+                reason: "must not be empty",
+            });
+        }
+        let mut provider = Self::new(base_url, "/broadcast", transport)?;
+        provider.profile = KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast;
+        provider.provider_hint = Some(provider_hint.to_owned());
+        Ok(provider)
     }
 }
 
@@ -1407,7 +1449,11 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitProvider
             wire_payload,
             idempotency_key,
         )?;
-        parse_live_provider_response(response.as_str())
+        let provider_hint = match self.profile {
+            KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast => self.provider_hint.as_deref(),
+            KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit => None,
+        };
+        parse_live_provider_response(response.as_str(), provider_hint)
     }
 }
 
@@ -2338,35 +2384,122 @@ fn percent_encode(value: &str) -> String {
     encoded
 }
 
+fn is_kolme_broadcast_submit_path(submit_path: &str) -> bool {
+    let trimmed = submit_path.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let without_query = trimmed
+        .split('?')
+        .next()
+        .unwrap_or(trimmed)
+        .trim_end_matches('/');
+    without_query == "/broadcast"
+}
+
+fn normalize_kolme_broadcast_payload(
+    wire_payload: &str,
+    idempotency_key: &str,
+) -> Result<String, KolmeRuntimeCommitProviderError> {
+    let payload = wire_payload.trim();
+    if payload.is_empty() {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "wire_payload must not be empty".to_owned(),
+        });
+    }
+    let idempotency_key = idempotency_key.trim();
+    if idempotency_key.is_empty() {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "idempotency_key must not be empty".to_owned(),
+        });
+    }
+
+    let fields = parse_key_value_response_fields(payload)?;
+    if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
+        let payload_idempotency_key = payload_idempotency_key.trim();
+        if payload_idempotency_key != idempotency_key {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "wire_payload idempotency_key does not match transport idempotency key"
+                    .to_owned(),
+            });
+        }
+    }
+
+    let request = KolmeApiBroadcastRequest::new(payload, idempotency_key, 1).map_err(|error| {
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: error.to_string(),
+        }
+    })?;
+    Ok(request.to_json_payload())
+}
+
 fn parse_live_provider_response(
     response: &str,
+    provider_hint: Option<&str>,
 ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
     let fields = parse_response_fields(response)?;
-    let status = required_response_field(&fields, "status")?;
-    match status.as_str() {
-        "submitted" | "duplicate" => {
-            let provider = required_response_field(&fields, "provider")?;
-            let commit_id = resolve_commit_id(&fields)?;
-            let finality_value = required_response_field(&fields, "finality")?;
-            let finality = parse_receipt_finality(finality_value.as_str())?;
-            let receipt = KolmeRuntimeCommitProviderReceipt {
+    if let Some(status_raw) = fields.get("status") {
+        let status = status_raw.trim();
+        if status.is_empty() {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "field must not be empty: status".to_owned(),
+            });
+        }
+        match status {
+            "submitted" | "duplicate" => {
+                let provider = required_response_field(&fields, "provider")?;
+                let commit_id = resolve_commit_id(&fields)?;
+                let finality_value = required_response_field(&fields, "finality")?;
+                let finality = parse_receipt_finality(finality_value.as_str())?;
+                let receipt = KolmeRuntimeCommitProviderReceipt {
+                    provider,
+                    commit_id,
+                    finality,
+                };
+                if status == "submitted" {
+                    Ok(KolmeRuntimeCommitProviderOutcome::Submitted(receipt))
+                } else {
+                    Ok(KolmeRuntimeCommitProviderOutcome::Duplicate(receipt))
+                }
+            }
+            "rejected" => {
+                let reason = required_response_field(&fields, "reason")?;
+                Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
+            }
+            _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid status value: {status}"),
+            }),
+        }
+    } else {
+        let has_tx_hash = fields.contains_key("txhash") || fields.contains_key("tx_hash");
+        if !has_tx_hash {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "missing required field: status".to_owned(),
+            });
+        }
+
+        let provider = optional_response_field(&fields, "provider").or_else(|| {
+            provider_hint
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        });
+        let provider =
+            provider.ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "missing required field: provider".to_owned(),
+            })?;
+        let commit_id = resolve_commit_id(&fields)?;
+        let finality = match optional_response_field(&fields, "finality") {
+            Some(raw_finality) => parse_receipt_finality(raw_finality.as_str())?,
+            None => KolmeCommitReceiptFinality::Pending,
+        };
+        Ok(KolmeRuntimeCommitProviderOutcome::Submitted(
+            KolmeRuntimeCommitProviderReceipt {
                 provider,
                 commit_id,
                 finality,
-            };
-            if status == "submitted" {
-                Ok(KolmeRuntimeCommitProviderOutcome::Submitted(receipt))
-            } else {
-                Ok(KolmeRuntimeCommitProviderOutcome::Duplicate(receipt))
-            }
-        }
-        "rejected" => {
-            let reason = required_response_field(&fields, "reason")?;
-            Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
-        }
-        _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("invalid status value: {status}"),
-        }),
+            },
+        ))
     }
 }
 
@@ -2754,6 +2887,18 @@ fn required_response_field(
         });
     }
     Ok(trimmed.to_owned())
+}
+
+fn optional_response_field(
+    fields: &HashMap<String, String>,
+    field: &'static str,
+) -> Option<String> {
+    let value = fields.get(field)?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_owned())
 }
 
 fn resolve_commit_id(

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -555,6 +555,43 @@ fn functional_live_provider_maps_submitted_json_response_to_provider_outcome() {
 }
 
 #[test]
+fn unit_kolme_fork_live_provider_maps_txhash_only_response_using_provider_hint() {
+    let response = r#"{"txhash":"ab12cd34"}"#.to_owned();
+    let (transport, calls) = RecordingTransport::with_result(Ok(response));
+    let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+        "http://127.0.0.1:3030",
+        "kolme-fork-local",
+        transport,
+    )
+    .expect("provider should build");
+
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-live-provider-1502-a",
+        "state:live",
+        "kamn:did:agent:live-provider-1502-a",
+        59,
+        "payload:live-provider",
+    )
+    .expect("request should build");
+
+    let outcome = provider
+        .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
+        .expect("provider should map txhash-only response");
+    assert_eq!(
+        outcome,
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-fork-local".to_owned(),
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: KolmeCommitReceiptFinality::Pending,
+        })
+    );
+
+    let calls = calls.borrow();
+    assert_eq!(calls.len(), 1, "provider transport should be called once");
+    assert_eq!(calls[0].1, "/broadcast");
+}
+
+#[test]
 fn regression_live_provider_fails_closed_for_malformed_response_shape() {
     // Regression: #1411
     let malformed_response =
@@ -582,6 +619,38 @@ fn regression_live_provider_fails_closed_for_malformed_response_shape() {
             Err(KolmeRuntimeCommitProviderError::MalformedResponse { .. })
         ),
         "provider must fail closed for malformed backend responses"
+    );
+}
+
+#[test]
+fn regression_live_provider_rejects_statusless_response_without_txhash() {
+    // Regression: #1502
+    let malformed_response =
+        r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:runtime:missing-status"}"#
+            .to_owned();
+    let (transport, _calls) = RecordingTransport::with_result(Ok(malformed_response));
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "http://127.0.0.1:3030",
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-live-provider-1502-b",
+        "state:live",
+        "kamn:did:agent:live-provider-1502-b",
+        60,
+        "payload:live-provider",
+    )
+    .expect("request should build");
+
+    assert!(
+        matches!(
+            provider.submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key()),
+            Err(KolmeRuntimeCommitProviderError::MalformedResponse { .. })
+        ),
+        "provider must fail closed when neither status nor txhash is present"
     );
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -617,3 +617,54 @@ fn regression_https_transport_maps_tls_handshake_failures_to_unavailable() {
         })
     );
 }
+
+#[test]
+fn functional_kolme_fork_submit_profile_uses_put_broadcast_and_maps_txhash_response() {
+    let wire_payload = "operation_id=op-1\nstate_root=state-1\n";
+    let idempotency_key = "kolme-runtime-commit:op-1:state-1:agent-1:1:payload-1";
+    let base_url = spawn_single_request_server(
+        "{\"txhash\":\"ab12cd34\"}".to_owned(),
+        "HTTP/1.1 200 OK",
+        move |request| {
+            assert!(request.contains("PUT /broadcast HTTP/1.1"));
+            assert!(request.contains("Content-Type: application/json"));
+            assert!(request.contains("X-Idempotency-Key: "));
+        },
+    );
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+        base_url.as_str(),
+        "kolme-fork-local",
+        transport,
+    )
+    .expect("provider should build");
+
+    let outcome = provider
+        .submit_runtime_commit(wire_payload, idempotency_key)
+        .expect("submit should succeed");
+    match outcome {
+        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => {
+            assert_eq!(receipt.provider, "kolme-fork-local");
+            assert_eq!(receipt.commit_id, "kolme-commit:ab12cd34");
+            assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Pending);
+        }
+        other => panic!("unexpected provider outcome: {other:?}"),
+    }
+}
+
+#[test]
+fn regression_kolme_fork_submit_profile_requires_non_empty_provider_hint() {
+    let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let error = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+        "http://127.0.0.1:3030",
+        "",
+        transport,
+    )
+    .expect_err("empty provider hint must fail validation");
+
+    assert_eq!(
+        error.to_string(),
+        "invalid runtime commit request provider_hint: must not be empty"
+    );
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -46,6 +46,12 @@ handling.
     - `401`/`403` => authorization failure (`Unavailable`)
     - `400`/`404`/`409`/`422` => invalid request (`MalformedResponse`)
     - `429` => rate limited (`Unavailable`)
+- Live submit profiles:
+  - `KolmeRuntimeCommitLiveProvider::new(...)` preserves legacy submit behavior and request shape.
+  - `KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(...)` targets `PUT /broadcast` for `njfio/kolme_fork`.
+  - `PUT /broadcast` requests are normalized to JSON using `KolmeApiBroadcastRequest`.
+  - txhash-only responses (`{"txhash":"..."}`) map to deterministic commit ids (`kolme-commit:<txhash>`) with default `Pending` finality when backend finality is absent.
+  - provider identity for txhash-only responses uses response `provider` when present, otherwise deterministic provider hint from profile construction.
 
 ## Typed Kolme Nonce/Broadcast Codecs
 
@@ -121,3 +127,4 @@ cargo test -p kamn-core
 - Replay/tamper mismatch policy remains fail-closed (`Regression: #827`).
 - Adapter provider mismatch/non-final receipts remain fail-closed (`Regression: #979`).
 - HTTPS TLS certificate/handshake drift remains fail-closed (`Regression: #1471`).
+- `kolme_fork` submit-profile drift for `PUT /broadcast` and txhash-only response mapping remains fail-closed (`Regression: #1502`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -174,7 +174,7 @@ runtime roles (processor/listener/approver) and its CI-compatible validation.
 - Deterministic checkpoints include:
   - `run_local_kolme_fork_bootstrap_readiness_lane.sh` run-mode validation for pinned checkout provenance and API readiness.
   - `run_local_kolme_live_api_conformance_harness.sh` run-mode validation for health/query/nonce/broadcast command contracts.
-  - explicit runtime-commit endpoint probe over `POST /broadcast/runtime-commit` with fail-closed reason codes.
+  - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
 - Cost policy:
   - run mode fails closed without explicit local-only opt-in.
   - lane default budget is bounded to 210 seconds with per-stage budget caps.

--- a/docs/planning/kolme-integration-roadmap.md
+++ b/docs/planning/kolme-integration-roadmap.md
@@ -38,6 +38,9 @@ across Kolme upgrades.
   - fixture: `fixtures/kolme_commit/runtime_commit_replay_tamper_cases.json`
 - Runtime commit adapter replay/finality contract lane:
   - `bash scripts/kolme/run_runtime_commit_adapter_contract_lane.sh`
+- `kolme_fork` submit-profile transport regression checks:
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_kolme_fork_submit_profile_uses_put_broadcast_and_maps_txhash_response -- --exact`
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_kolme_fork_submit_profile_requires_non_empty_provider_hint -- --exact`
 - Nonce/broadcast parity policy checker:
   - `python3 scripts/kolme/check_nonce_broadcast_parity_policy.py --case-id nonce-go-001 --operation nonce --http-status 200 --nonce-value 42 --broadcast-accepted false --duplicate-detected false --payload-valid true --authorization-present true --ci-fast-gate PASS --output-json /tmp/kolme-nonce-broadcast-policy.json`
 - Nonce/broadcast parity matrix command:
@@ -84,6 +87,7 @@ across Kolme upgrades.
 - Runtime commit replay/tamper mismatch policy emits fail-closed reason codes (`Regression: #827`).
 - Adapter provider mismatch and non-final receipt handling remain fail-closed (`Regression: #979`).
 - Adapter replay/finality reason-code drift remains fail-closed (`Regression: #980`).
+- `kolme_fork` `PUT /broadcast` submit profile and txhash-only response mapping remain fail-closed (`Regression: #1502`).
 - Fork release-tag drift remains fail-closed (`Regression: #1401`).
 - Fork compatibility policy mismatches and malformed evidence remain fail-closed (`Regression: #1402`).
 - Nonce/broadcast duplicate-idempotent, unauthorized, and malformed payload drift remains fail-closed (`Regression: #1462`).


### PR DESCRIPTION
## Summary
Aligns KAMN runtime commit live-provider submit behavior with `njfio/kolme_fork` broadcast semantics by adding a dedicated `PUT /broadcast` profile and txhash-only response mapping. Preserves legacy status-based submit parsing and fail-closed behavior while introducing deterministic provider-hint fallback for fork responses.

Closes #1502

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `KolmeRuntimeCommitSubmitProfile`, new `new_kolme_fork_broadcast_profile(...)` constructor, `PUT /broadcast` JSON normalization path, and txhash-only response parsing fallback with provider hint.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`: added fork-profile transport/response functional coverage and non-empty provider-hint regression coverage.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: added unit coverage for txhash-only mapping through provider hint and regression guard for statusless/non-txhash responses.
- `docs/foundation/kolme-runtime-commit-client.md`: documented live submit-profile behavior and fail-closed regression marker.
- `docs/planning/kolme-integration-roadmap.md`: added explicit #1502 transport regression commands and guard marker.
- `docs/planning/kolme-devnet-ops.md`: corrected runtime-commit probe contract to `PUT /broadcast`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_kolme_fork_submit_profile_uses_put_broadcast_and_maps_txhash_response -- --exact
```
Observed failure:
```text
error[E0599]: no function or associated item named `new_kolme_fork_broadcast_profile` found for struct `KolmeRuntimeCommitLiveProvider<_>`
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_kolme_fork_submit_profile_uses_put_broadcast_and_maps_txhash_response -- --exact
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo test -p kamn-core --test kolme_runtime_commit_client
```
Observed pass summary:
- `kolme_runtime_commit_http_transport`: 13 passed.
- `kolme_runtime_commit_client`: 21 passed.

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test kolme_runtime_commit_client --test kolme_runtime_commit_http_transport --test kolme_runtime_commit_client_docs --test kolme_integration_roadmap_docs --test kolme_devnet_ops_docs
cargo fmt --check
cargo clippy -- -D warnings
```
Observed pass summary:
- Runtime/docs regression bundle: all selected tests passed.
- `cargo fmt --check` clean.
- `cargo clippy -- -D warnings` clean.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `unit_kolme_fork_live_provider_maps_txhash_only_response_using_provider_hint` | |
| Functional   | ✅ | `functional_kolme_fork_submit_profile_uses_put_broadcast_and_maps_txhash_response` | |
| Integration  | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_http_transport` (fixture-backed HTTP server path) | |
| Regression   | ✅ | `regression_kolme_fork_submit_profile_requires_non_empty_provider_hint`; `regression_live_provider_rejects_statusless_response_without_txhash` | |
| Performance  | ✅ | No CI expansion; fast deterministic lanes only | |

## Risks & Rollback
- Risk: fallback parsing path could accept unintended statusless payload shapes if they contain txhash-like fields.
- Rollback plan: revert this PR to restore legacy-only submit profile behavior.

## Documentation Updates
- Updated: `docs/foundation/kolme-runtime-commit-client.md`
- Updated: `docs/planning/kolme-integration-roadmap.md`
- Updated: `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
