### PR TITLE
fix(kolme): require core transaction fields in direct signed payloads

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -2720,6 +2720,7 @@ fn normalize_kolme_broadcast_payload(
                 reason: "direct signed payload message must be a JSON object string".to_owned(),
             });
         }
+        validate_direct_signed_transaction_message(message.as_str())?;
 
         let request =
             KolmeApiBroadcastRequest::new(message.as_str(), signature.as_str(), recovery_id)
@@ -2746,6 +2747,70 @@ fn normalize_kolme_broadcast_payload(
         }
     })?;
     Ok(request.to_json_payload())
+}
+
+fn validate_direct_signed_transaction_message(
+    message: &str,
+) -> Result<(), KolmeRuntimeCommitProviderError> {
+    let required_string_fields = ["pubkey", "created"];
+    for field in required_string_fields {
+        let value = find_notification_string_field(message, field).map_err(|_| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("direct signed payload message field is invalid: {field}"),
+            }
+        })?;
+        if value.is_none() {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("direct signed payload message missing required field: {field}"),
+            });
+        }
+    }
+
+    let nonce = find_notification_u64_field(message, "nonce").map_err(|_| {
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "direct signed payload message field is invalid: nonce".to_owned(),
+        }
+    })?;
+    if nonce.is_none() {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "direct signed payload message missing required field: nonce".to_owned(),
+        });
+    }
+
+    let has_messages = has_json_array_field(message, "messages")
+        .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse { reason: error })?;
+    if !has_messages {
+        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "direct signed payload message missing required field: messages".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn has_json_array_field(payload: &str, field: &str) -> Result<bool, String> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        let Some(first) = payload.as_bytes().get(cursor).copied() else {
+            return Err(format!(
+                "direct signed payload message field must be array: {field}"
+            ));
+        };
+        if first == b'[' {
+            return Ok(true);
+        }
+        return Err(format!(
+            "direct signed payload message field must be array: {field}"
+        ));
+    }
+    Ok(false)
 }
 
 fn parse_live_provider_response(

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -800,3 +800,58 @@ fn regression_kolme_fork_direct_signed_payload_requires_json_message_shape() {
         })
     );
 }
+
+#[test]
+fn regression_kolme_fork_direct_signed_payload_requires_core_transaction_keys() {
+    // Regression: #1519
+    let missing_key_cases = [
+        (
+            "pubkey",
+            "{\"nonce\":1,\"created\":\"2026-02-11T00:00:00Z\",\"messages\":[],\"max_height\":null}",
+        ),
+        (
+            "nonce",
+            "{\"pubkey\":\"pk-direct\",\"created\":\"2026-02-11T00:00:00Z\",\"messages\":[],\"max_height\":null}",
+        ),
+        (
+            "created",
+            "{\"pubkey\":\"pk-direct\",\"nonce\":1,\"messages\":[],\"max_height\":null}",
+        ),
+        (
+            "messages",
+            "{\"pubkey\":\"pk-direct\",\"nonce\":1,\"created\":\"2026-02-11T00:00:00Z\",\"max_height\":null}",
+        ),
+    ];
+
+    for (missing_field, message_json) in missing_key_cases {
+        let wire_payload = format!(
+            "{{\"message\":\"{}\",\"signature\":\"sig-direct\",\"recovery_id\":1}}",
+            message_json.replace('\\', "\\\\").replace('\"', "\\\"")
+        );
+        let base_url = spawn_single_request_server(
+            "{\"txhash\":\"ab12cd34\"}".to_owned(),
+            "HTTP/1.1 200 OK",
+            |_raw_request| {},
+        );
+
+        let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+        let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+            base_url.as_str(),
+            "kolme-fork-local",
+            transport,
+        )
+        .expect("provider should build");
+
+        assert_eq!(
+            provider.submit_runtime_commit(
+                wire_payload.as_str(),
+                "kolme-runtime-commit:direct-required-fields:1"
+            ),
+            Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!(
+                    "direct signed payload message missing required field: {missing_field}"
+                ),
+            })
+        );
+    }
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -94,6 +94,7 @@ handling.
   - fork `/broadcast` normalization accepts signed envelope wire payloads only when `signer_key_id` is present and envelope message idempotency key matches the transport idempotency key.
   - fork `/broadcast` normalization also accepts direct pre-signed transaction JSON payloads (`message`, `signature`, `recovery_id`) when:
     - `message` is a JSON object string.
+    - `message` contains required Kolme transaction fields: `pubkey`, `nonce`, `created`, `messages`.
     - optional JSON `idempotency_key` matches the transport idempotency key.
     - malformed/non-JSON direct payload messages fail closed.
 
@@ -149,3 +150,4 @@ cargo test -p kamn-core
 - `kolme_fork` finality resolution drift for notifications + block fallback remains fail-closed (`Regression: #1503`).
 - signed translation envelope and signer custody precondition drift remains fail-closed (`Regression: #1506`).
 - direct signed transaction payload normalization drift remains fail-closed (`Regression: #1516`).
+- direct signed transaction required-field validation drift remains fail-closed (`Regression: #1519`).

--- a/docs/planning/kolme-integration-roadmap.md
+++ b/docs/planning/kolme-integration-roadmap.md
@@ -63,6 +63,7 @@ across Kolme upgrades.
   - `cargo test -p kamn-core --test kolme_api_codec_contracts unit_runtime_commit_signed_translation_rejects_message_mismatch -- --exact`
   - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_kolme_fork_signed_envelope_submit_maps_txhash_response -- --exact`
   - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_kolme_fork_direct_signed_payload_submit_maps_txhash_response -- --exact`
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_kolme_fork_direct_signed_payload_requires_core_transaction_keys -- --exact`
 - Nonce/broadcast parity policy checker:
   - `python3 scripts/kolme/check_nonce_broadcast_parity_policy.py --case-id nonce-go-001 --operation nonce --http-status 200 --nonce-value 42 --broadcast-accepted false --duplicate-detected false --payload-valid true --authorization-present true --ci-fast-gate PASS --output-json /tmp/kolme-nonce-broadcast-policy.json`
 - Nonce/broadcast parity matrix command:


### PR DESCRIPTION
## Summary
Hardens direct signed fork `/broadcast` normalization by requiring core Kolme transaction fields in the signed `message` JSON (`pubkey`, `nonce`, `created`, `messages`) and keeping deterministic fail-closed behavior.

Closes #1519
Closes #1520

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`:
  - Added direct signed message validation helper for required core transaction fields.
  - Added deterministic array-field validation for `messages`.
  - Kept existing envelope and direct signed success paths intact.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`:
  - Added regression test `regression_kolme_fork_direct_signed_payload_requires_core_transaction_keys`.
- `docs/foundation/kolme-runtime-commit-client.md`:
  - Documented required direct signed transaction fields and regression marker.
- `docs/planning/kolme-integration-roadmap.md`:
  - Added command coverage for required-field regression check.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_kolme_fork_direct_signed_payload_requires_core_transaction_keys -- --exact`
  - Failed with `Ok(Submitted(...))` (payload accepted when it should fail closed).

### 🟢 Green Phase
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`

### 🔁 Regression
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport --test kolme_runtime_commit_client_docs --test kolme_integration_roadmap_docs`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | required-field validation helper behavior exercised via transport suite | |
| Functional   | ✅     | missing required keys now rejected deterministically | |
| Integration  | ✅     | fork submit-profile HTTP transport suite remains green | |
| Regression   | ✅     | direct signed required-key regression test added | |
| Performance  | N/A    | no perf-path or benchmark behavior changes | no runtime benchmark changes |

## Risks & Rollback
- Risk: Low; additional validation only affects malformed direct signed payloads.
- Rollback: revert commit `489d7d9` if downstream callers need temporary compatibility window.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-integration-roadmap.md`
