### PR TITLE
test(runtime): add bounded lifecycle evidence property matrix

### DIFF
--- a/crates/kamn-core/tests/engineering_hardening_wave_docs.rs
+++ b/crates/kamn-core/tests/engineering_hardening_wave_docs.rs
@@ -12,12 +12,15 @@ fn engineering_hardening_wave_doc_declares_missing_docs_policy_contract() {
         ENGINEERING_HARDENING_WAVE_DOC.contains("run_kamn_core_rustdoc_artifact_contract_lane.sh")
     );
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("check_kamn_core_rustdoc_artifact_policy.sh"));
+    assert!(ENGINEERING_HARDENING_WAVE_DOC
+        .contains("cargo test -p kamn-core --test lifecycle_evidence_property_matrix"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("kamn-core"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("#![warn(missing_docs)]"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("docs/architecture/kamn-core-module-map.md"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC
         .contains("docs/architecture/kamn-core-module-map.md#contributor-entrypoint-matrix"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("docs/developer/rustdoc-publishing.md"));
+    assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("Regression: #1526"));
 }
 
 #[test]

--- a/crates/kamn-core/tests/lifecycle_evidence_property_matrix.rs
+++ b/crates/kamn-core/tests/lifecycle_evidence_property_matrix.rs
@@ -1,0 +1,312 @@
+use kamn_core::{
+    EscrowLifecycle, EscrowStatus, EscrowTransitionAction, PeerLifecycle, PeerLifecycleEvent,
+    PeerLifecycleState, RuntimeLifecycleError, TaskLifecycle, TaskState, TaskTransition,
+};
+
+const TASK_TRANSITIONS: [TaskTransition; 8] = [
+    TaskTransition::Accept,
+    TaskTransition::Delegate,
+    TaskTransition::StartWork,
+    TaskTransition::RequestInput,
+    TaskTransition::Block,
+    TaskTransition::Complete,
+    TaskTransition::Fail,
+    TaskTransition::Cancel,
+];
+
+const PEER_EVENTS: [PeerLifecycleEvent; 6] = [
+    PeerLifecycleEvent::StartConnect,
+    PeerLifecycleEvent::HandshakeSucceeded,
+    PeerLifecycleEvent::HeartbeatMissed,
+    PeerLifecycleEvent::HeartbeatRestored,
+    PeerLifecycleEvent::Disconnect,
+    PeerLifecycleEvent::Rejoin,
+];
+
+#[derive(Debug, Clone, Copy)]
+enum EscrowPropertyAction {
+    ReleaseOne,
+    ReleaseRemaining,
+    Dispute,
+    ResolveHalfSplit,
+    RefundRemaining,
+}
+
+const ESCROW_PROPERTY_ACTIONS: [EscrowPropertyAction; 5] = [
+    EscrowPropertyAction::ReleaseOne,
+    EscrowPropertyAction::ReleaseRemaining,
+    EscrowPropertyAction::Dispute,
+    EscrowPropertyAction::ResolveHalfSplit,
+    EscrowPropertyAction::RefundRemaining,
+];
+
+fn for_each_sequence<T: Copy>(alphabet: &[T], max_len: usize, mut f: impl FnMut(&[T])) {
+    fn recurse<T: Copy>(
+        alphabet: &[T],
+        target_len: usize,
+        current: &mut Vec<T>,
+        f: &mut impl FnMut(&[T]),
+    ) {
+        if current.len() == target_len {
+            f(current.as_slice());
+            return;
+        }
+
+        for item in alphabet {
+            current.push(*item);
+            recurse(alphabet, target_len, current, f);
+            current.pop();
+        }
+    }
+
+    let mut current = Vec::new();
+    for len in 1..=max_len {
+        recurse(alphabet, len, &mut current, &mut f);
+    }
+}
+
+fn is_legal_task_state_step(from: TaskState, to: TaskState) -> bool {
+    matches!(
+        (from, to),
+        (TaskState::Submitted, TaskState::Accepted)
+            | (TaskState::Submitted, TaskState::Cancelled)
+            | (TaskState::Accepted, TaskState::Delegated)
+            | (TaskState::Accepted, TaskState::InProgress)
+            | (TaskState::Accepted, TaskState::Cancelled)
+            | (TaskState::Delegated, TaskState::InProgress)
+            | (TaskState::Delegated, TaskState::Cancelled)
+            | (TaskState::InProgress, TaskState::Blocked)
+            | (TaskState::InProgress, TaskState::InputRequired)
+            | (TaskState::InProgress, TaskState::Completed)
+            | (TaskState::InProgress, TaskState::Failed)
+            | (TaskState::InProgress, TaskState::Cancelled)
+            | (TaskState::InputRequired, TaskState::InProgress)
+            | (TaskState::InputRequired, TaskState::Failed)
+            | (TaskState::InputRequired, TaskState::Cancelled)
+            | (TaskState::Blocked, TaskState::InProgress)
+            | (TaskState::Blocked, TaskState::Failed)
+            | (TaskState::Blocked, TaskState::Cancelled)
+    )
+}
+
+fn to_escrow_transition_action(
+    escrow: &EscrowLifecycle,
+    action: EscrowPropertyAction,
+) -> EscrowTransitionAction {
+    let remaining = escrow.remaining_amount();
+    match action {
+        EscrowPropertyAction::ReleaseOne => EscrowTransitionAction::Release { amount: 1 },
+        EscrowPropertyAction::ReleaseRemaining => EscrowTransitionAction::Release {
+            amount: remaining.max(1),
+        },
+        EscrowPropertyAction::Dispute => EscrowTransitionAction::Dispute,
+        EscrowPropertyAction::ResolveHalfSplit => {
+            let release_to_payee = remaining / 2;
+            let refund_to_payer = remaining.saturating_sub(release_to_payee);
+            EscrowTransitionAction::Resolve {
+                release_to_payee,
+                refund_to_payer,
+            }
+        }
+        EscrowPropertyAction::RefundRemaining => EscrowTransitionAction::RefundRemaining,
+    }
+}
+
+fn assert_escrow_amount_invariants(escrow: &EscrowLifecycle, total_amount: u128) {
+    let released = escrow.released_amount();
+    let refunded = escrow.refunded_amount();
+    let remaining = escrow.remaining_amount();
+    assert_eq!(released + refunded + remaining, total_amount);
+
+    match escrow.status() {
+        EscrowStatus::Funded => {
+            assert_eq!(released, 0);
+            assert_eq!(refunded, 0);
+        }
+        EscrowStatus::PartiallyReleased {
+            released: status_released,
+            remaining: status_remaining,
+        } => {
+            assert_eq!(status_released, released);
+            assert_eq!(status_remaining, remaining);
+            assert!(remaining > 0);
+        }
+        EscrowStatus::Released => {
+            assert_eq!(remaining, 0);
+            assert_eq!(refunded, 0);
+        }
+        EscrowStatus::Refunded | EscrowStatus::Resolved { .. } => {
+            assert_eq!(remaining, 0);
+        }
+        EscrowStatus::Disputed => {}
+    }
+}
+
+fn expected_peer_next_state(
+    from: PeerLifecycleState,
+    event: PeerLifecycleEvent,
+) -> Option<PeerLifecycleState> {
+    match (from, event) {
+        (PeerLifecycleState::Disconnected, PeerLifecycleEvent::StartConnect)
+        | (PeerLifecycleState::Disconnected, PeerLifecycleEvent::Rejoin) => {
+            Some(PeerLifecycleState::Connecting)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::HandshakeSucceeded) => {
+            Some(PeerLifecycleState::Active)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Active, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Degraded, PeerLifecycleEvent::Disconnect) => {
+            Some(PeerLifecycleState::Disconnected)
+        }
+        (PeerLifecycleState::Active, PeerLifecycleEvent::HeartbeatMissed) => {
+            Some(PeerLifecycleState::Degraded)
+        }
+        (PeerLifecycleState::Degraded, PeerLifecycleEvent::HeartbeatRestored) => {
+            Some(PeerLifecycleState::Active)
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn lifecycle_property_task_evidence_sequences_preserve_transition_contracts() {
+    // Regression: #1526
+    // Keep this lane bounded for fast, low-cost CI execution.
+    for_each_sequence(&TASK_TRANSITIONS, 4, |sequence| {
+        let mut lifecycle =
+            TaskLifecycle::new("task-evidence-property").expect("task property case should init");
+        for transition in sequence {
+            let before_state = lifecycle.state();
+            let before_history = lifecycle.history();
+            match lifecycle.transition_with_evidence(*transition) {
+                Ok(evidence) => {
+                    assert_eq!(evidence.from, before_state);
+                    assert_eq!(evidence.transition, *transition);
+                    assert_eq!(evidence.to, lifecycle.state());
+                    assert_eq!(evidence.reason_code, "task_transition_allowed");
+                    assert!(
+                        is_legal_task_state_step(before_state, evidence.to),
+                        "task evidence transition must be legal from {before_state:?} to {:?}",
+                        evidence.to
+                    );
+                    assert_eq!(lifecycle.history().len(), before_history.len() + 1);
+                }
+                Err(error) => {
+                    assert_eq!(lifecycle.state(), before_state);
+                    assert_eq!(lifecycle.history(), before_history);
+                    assert!(matches!(
+                        error.reason_code(),
+                        "task_transition_invalid_edge" | "task_transition_terminal_state"
+                    ));
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn lifecycle_property_escrow_evidence_sequences_preserve_amount_and_reason_invariants() {
+    // Regression: #1526
+    // Keep the matrix bounded so this property lane remains cheap in fast-gate CI.
+    for total_amount in [1_u128, 2, 3, 5, 8] {
+        for_each_sequence(&ESCROW_PROPERTY_ACTIONS, 4, |sequence| {
+            let mut escrow =
+                EscrowLifecycle::new(total_amount).expect("escrow property case should init");
+            assert_escrow_amount_invariants(&escrow, total_amount);
+
+            for action in sequence {
+                let before_status = escrow.status();
+                let before_released = escrow.released_amount();
+                let before_refunded = escrow.refunded_amount();
+                let before_remaining = escrow.remaining_amount();
+                let transition_action = to_escrow_transition_action(&escrow, *action);
+
+                match escrow.apply_transition_with_evidence(transition_action.clone()) {
+                    Ok(evidence) => {
+                        assert_eq!(evidence.from, before_status);
+                        assert_eq!(evidence.action, transition_action);
+                        assert_eq!(evidence.to, escrow.status());
+                        assert_eq!(evidence.reason_code, "escrow_transition_allowed");
+                        assert_escrow_amount_invariants(&escrow, total_amount);
+                    }
+                    Err(error) => {
+                        assert_eq!(escrow.status(), before_status);
+                        assert_eq!(escrow.released_amount(), before_released);
+                        assert_eq!(escrow.refunded_amount(), before_refunded);
+                        assert_eq!(escrow.remaining_amount(), before_remaining);
+                        assert!(matches!(
+                            error.reason_code(),
+                            "escrow_transition_invalid"
+                                | "escrow_amount_invalid"
+                                | "escrow_resolution_mismatch"
+                        ));
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[test]
+fn lifecycle_property_runtime_peer_sequences_match_transition_contract() {
+    // Regression: #1526
+    // Sequence depth is intentionally bounded for fast feedback while retaining broad coverage.
+    for_each_sequence(&PEER_EVENTS, 4, |sequence| {
+        let mut lifecycle = PeerLifecycle::new("peer-property").expect("peer property should init");
+        for event in sequence {
+            let before_state = lifecycle.state();
+            let expected_next = expected_peer_next_state(before_state, *event);
+            match (expected_next, lifecycle.transition(*event)) {
+                (Some(next_state), Ok(applied_state)) => {
+                    assert_eq!(next_state, applied_state);
+                    assert_eq!(lifecycle.state(), applied_state);
+                }
+                (
+                    None,
+                    Err(RuntimeLifecycleError::InvalidTransition {
+                        from,
+                        event: rejected_event,
+                    }),
+                ) => {
+                    assert_eq!(from, before_state);
+                    assert_eq!(rejected_event, *event);
+                    assert_eq!(lifecycle.state(), before_state);
+                }
+                (Some(_), Err(error)) => panic!(
+                    "expected successful runtime transition from {before_state:?} via {event:?}, \
+                     got {error:?}"
+                ),
+                (None, Ok(applied_state)) => panic!(
+                    "expected invalid runtime transition from {before_state:?} via {event:?}, \
+                     got {applied_state:?}"
+                ),
+                (None, Err(RuntimeLifecycleError::InvalidPeerId)) => {
+                    panic!("peer id is fixed and valid in this property lane")
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn lifecycle_property_runtime_peer_sequence_replay_is_deterministic() {
+    // Regression: #1526
+    // Keep this deterministic replay check bounded for fast CI.
+    for_each_sequence(&PEER_EVENTS, 4, |sequence| {
+        let mut run_a = PeerLifecycle::new("peer-replay-a").expect("peer replay A should init");
+        let mut outcomes_a = Vec::with_capacity(sequence.len());
+        for event in sequence {
+            outcomes_a.push(run_a.transition(*event));
+        }
+
+        let mut run_b = PeerLifecycle::new("peer-replay-b").expect("peer replay B should init");
+        let mut outcomes_b = Vec::with_capacity(sequence.len());
+        for event in sequence {
+            outcomes_b.push(run_b.transition(*event));
+        }
+
+        assert_eq!(outcomes_a, outcomes_b);
+        assert_eq!(run_a.state(), run_b.state());
+    });
+}

--- a/docs/planning/engineering-hardening-wave.md
+++ b/docs/planning/engineering-hardening-wave.md
@@ -29,6 +29,8 @@ default development loop green while tightening missing-doc policy controls for
   - `bash scripts/ci/test_ci_tools.sh`
 - Contract framework helper unit tests:
   - `bash scripts/framework/test_contract_framework.sh`
+- Bounded lifecycle evidence property matrix (runtime/task/escrow):
+  - `cargo test -p kamn-core --test lifecycle_evidence_property_matrix`
 
 ## Missing-Docs Policy Contract
 
@@ -108,3 +110,5 @@ default development loop green while tightening missing-doc policy controls for
 
 - `Regression: #896` — protect against missing-doc policy drift and undocumented
   checker/documentation command changes.
+- `Regression: #1526` — keep bounded lifecycle evidence property matrices
+  deterministic and fail-closed for runtime/task/escrow transition contracts.


### PR DESCRIPTION
## Summary
Adds bounded lifecycle evidence property coverage for task, escrow, and runtime peer transitions to strengthen deterministic low-cost reliability checks. Also updates hardening-wave documentation contracts so the new lane is tracked and fail-closed.

## Changes
- `crates/kamn-core/tests/lifecycle_evidence_property_matrix.rs`: new bounded property matrix tests for task transition evidence, escrow transition evidence, and runtime peer lifecycle sequences/replay determinism.
- `docs/planning/engineering-hardening-wave.md`: adds command surface entry for the new property matrix lane and `Regression: #1526` marker.
- `crates/kamn-core/tests/engineering_hardening_wave_docs.rs`: enforces doc references for the new command and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test lifecycle_evidence_property_matrix
error: no test target named `lifecycle_evidence_property_matrix` in `kamn-core` package
```

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test lifecycle_evidence_property_matrix
running 4 tests
... ok
```

### 🔁 Regression
```bash
cargo test -p kamn-core --test lifecycle_evidence_property_matrix
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `lifecycle_evidence_property_matrix.rs` reason-code and state invariants | |
| Functional   | ✅     | bounded generated transition sequences for task/escrow/runtime paths | |
| Integration  | ✅     | cross-domain lifecycle matrix lane in one deterministic target | |
| Regression   | ✅     | `Regression: #1526` markers + doc contract assertions | |
| Performance  | ✅     | bounded sequence depth keeps runtime cheap for fast-gate/local checks | |

## Risks & Rollback
- None.
- Rollback: revert commit `baa0ec0`.

## Documentation Updates
- `docs/planning/engineering-hardening-wave.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A

Closes #1526
Refs #1525
Refs #1522
