### PR TITLE
test(runtime): add deterministic task terminal concurrency lane

### DIFF
--- a/crates/kamn-core/tests/concurrency_task_terminal_race.rs
+++ b/crates/kamn-core/tests/concurrency_task_terminal_race.rs
@@ -1,0 +1,153 @@
+use kamn_core::{TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskState};
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
+
+type TaskTerminalRaceSummary = (
+    usize,
+    usize,
+    TaskState,
+    Option<String>,
+    Vec<TaskOperationNoticeKind>,
+);
+
+fn seed_in_progress_task(
+    task_id: &str,
+    requester: &str,
+    assignee: &str,
+) -> Arc<Mutex<TaskOperationEngine>> {
+    let engine = Arc::new(Mutex::new(TaskOperationEngine::new()));
+    let mut guard = engine.lock().expect("engine lock should initialize");
+    guard
+        .submit(task_id, requester, "Concurrent terminal transition guard")
+        .expect("submit should succeed");
+    guard
+        .accept(task_id, assignee)
+        .expect("accept should succeed");
+    guard
+        .start_work(task_id, assignee)
+        .expect("start_work should succeed");
+    drop(guard);
+    engine
+}
+
+fn run_task_complete_delegate_race(
+    task_id: &str,
+    requester: &str,
+    assignee: &str,
+    delegatee: &str,
+) -> TaskTerminalRaceSummary {
+    let engine = seed_in_progress_task(task_id, requester, assignee);
+    let barrier = Arc::new(Barrier::new(2));
+    let mut handles = Vec::new();
+
+    {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        let task_id = task_id.to_owned();
+        let assignee = assignee.to_owned();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            engine
+                .lock()
+                .expect("engine lock should acquire")
+                .complete(&task_id, &assignee)
+        }));
+    }
+
+    {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        let task_id = task_id.to_owned();
+        let assignee = assignee.to_owned();
+        let delegatee = delegatee.to_owned();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            engine
+                .lock()
+                .expect("engine lock should acquire")
+                .delegate(&task_id, &assignee, &delegatee)
+        }));
+    }
+
+    let mut success_count = 0_usize;
+    let mut lifecycle_error_count = 0_usize;
+    for handle in handles {
+        match handle
+            .join()
+            .expect("task terminal race thread should join")
+        {
+            Ok(()) => success_count += 1,
+            Err(TaskOperationError::Lifecycle(error)) => {
+                lifecycle_error_count += 1;
+                assert!(
+                    error.contains("invalid task transition") || error.contains("terminal state"),
+                    "lifecycle error should stay in transition/terminal guard surface: {error}"
+                );
+            }
+            Err(error) => panic!("unexpected task terminal race error: {error:?}"),
+        }
+    }
+
+    let guard = engine.lock().expect("engine lock should acquire");
+    let task = guard.task(task_id).expect("task should exist");
+    (
+        success_count,
+        lifecycle_error_count,
+        task.lifecycle.state(),
+        task.assignee.clone(),
+        guard.notices(task_id),
+    )
+}
+
+#[test]
+fn functional_task_complete_delegate_concurrency_race_preserves_terminal_snapshot() {
+    let requester = "kamn:did:agent:requester-terminal";
+    let assignee = "kamn:did:agent:worker-terminal";
+    let delegatee = "kamn:did:agent:worker-shadow";
+
+    let (success_count, lifecycle_error_count, final_state, assignee_after, notices) =
+        run_task_complete_delegate_race(
+            "task-terminal-race-functional",
+            requester,
+            assignee,
+            delegatee,
+        );
+
+    assert_eq!(success_count, 1);
+    assert_eq!(lifecycle_error_count, 1);
+    assert_eq!(final_state, TaskState::Completed);
+    assert_eq!(assignee_after.as_deref(), Some(assignee));
+    assert_eq!(
+        notices,
+        vec![
+            TaskOperationNoticeKind::Submitted,
+            TaskOperationNoticeKind::Accepted,
+            TaskOperationNoticeKind::Started,
+            TaskOperationNoticeKind::Completed,
+        ]
+    );
+}
+
+#[test]
+fn regression_task_complete_delegate_concurrency_replay_is_deterministic() {
+    // Regression: #1527
+    let requester = "kamn:did:agent:requester-replay";
+    let assignee = "kamn:did:agent:worker-replay";
+    let delegatee = "kamn:did:agent:worker-replay-shadow";
+
+    let mut baseline: Option<TaskTerminalRaceSummary> = None;
+
+    for round in 0..32 {
+        let task_id = format!("task-terminal-race-replay-{round}");
+        let summary =
+            run_task_complete_delegate_race(task_id.as_str(), requester, assignee, delegatee);
+        if let Some(expected) = baseline.as_ref() {
+            assert_eq!(
+                &summary, expected,
+                "task terminal race summary drifted in round {round}"
+            );
+        } else {
+            baseline = Some(summary);
+        }
+    }
+}

--- a/crates/kamn-core/tests/engineering_hardening_wave_docs.rs
+++ b/crates/kamn-core/tests/engineering_hardening_wave_docs.rs
@@ -14,6 +14,8 @@ fn engineering_hardening_wave_doc_declares_missing_docs_policy_contract() {
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("check_kamn_core_rustdoc_artifact_policy.sh"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC
         .contains("cargo test -p kamn-core --test lifecycle_evidence_property_matrix"));
+    assert!(ENGINEERING_HARDENING_WAVE_DOC
+        .contains("cargo test -p kamn-core --test concurrency_task_terminal_race"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("kamn-core"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("#![warn(missing_docs)]"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("docs/architecture/kamn-core-module-map.md"));
@@ -21,6 +23,7 @@ fn engineering_hardening_wave_doc_declares_missing_docs_policy_contract() {
         .contains("docs/architecture/kamn-core-module-map.md#contributor-entrypoint-matrix"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("docs/developer/rustdoc-publishing.md"));
     assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("Regression: #1526"));
+    assert!(ENGINEERING_HARDENING_WAVE_DOC.contains("Regression: #1527"));
 }
 
 #[test]

--- a/docs/planning/engineering-hardening-wave.md
+++ b/docs/planning/engineering-hardening-wave.md
@@ -31,6 +31,8 @@ default development loop green while tightening missing-doc policy controls for
   - `bash scripts/framework/test_contract_framework.sh`
 - Bounded lifecycle evidence property matrix (runtime/task/escrow):
   - `cargo test -p kamn-core --test lifecycle_evidence_property_matrix`
+- Deterministic task terminal concurrency mutation lane:
+  - `cargo test -p kamn-core --test concurrency_task_terminal_race`
 
 ## Missing-Docs Policy Contract
 
@@ -112,3 +114,5 @@ default development loop green while tightening missing-doc policy controls for
   checker/documentation command changes.
 - `Regression: #1526` — keep bounded lifecycle evidence property matrices
   deterministic and fail-closed for runtime/task/escrow transition contracts.
+- `Regression: #1527` — keep deterministic task terminal concurrency replay
+  coverage fail-closed for shared-state mutation races.


### PR DESCRIPTION
## Summary
Adds a deterministic multi-threaded task-terminal mutation regression lane to strengthen shared-state concurrency coverage at low cost. Updates hardening-wave docs/contracts so the new lane remains part of the fail-closed command surface.

## Changes
- `crates/kamn-core/tests/concurrency_task_terminal_race.rs`: new deterministic race lane for concurrent `complete` vs invalid `delegate` mutation on an in-progress task.
- `docs/planning/engineering-hardening-wave.md`: adds command and regression marker for the new concurrency lane.
- `crates/kamn-core/tests/engineering_hardening_wave_docs.rs`: enforces docs contain new command and `Regression: #1527` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test concurrency_task_terminal_race
error: no test target named `concurrency_task_terminal_race` in `kamn-core` package
```

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test concurrency_task_terminal_race
running 2 tests
... ok
```

### 🔁 Regression
```bash
cargo test -p kamn-core --test concurrency_task_terminal_race
cargo test -p kamn-core --test concurrency_state_mutation
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | deterministic summary assertions in `concurrency_task_terminal_race.rs` | |
| Functional   | ✅     | terminal snapshot invariants for concurrent mutation race | |
| Integration  | ✅     | multi-threaded shared-state task engine mutation path | |
| Regression   | ✅     | `Regression: #1527` replay determinism + docs contract guards | |
| Performance  | ✅     | bounded 32-round replay and low-cost local validation commands | |

## Risks & Rollback
- None.
- Rollback: revert commit `ee5cfbc`.

## Documentation Updates
- `docs/planning/engineering-hardening-wave.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A

Closes #1527
Refs #1525
Refs #1522
