### PR TITLE
feat(kolme): add local-only fork rust test matrix lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help check test smoke-live-network deep-live-network demo demo-localhost-transport ci-tools kolme-local-heavy
+.PHONY: help check test smoke-live-network deep-live-network demo demo-localhost-transport ci-tools kolme-local-heavy kolme-fork-rust-tests-local
 
 help:
 	@echo "KAMN developer lanes"
@@ -12,6 +12,7 @@ help:
 	@echo "  make demo-localhost-transport - explicit localhost sender/listener transport demo"
 	@echo "  make ci-tools - CI helper regression suite"
 	@echo "  make kolme-local-heavy - local-only Kolme heavy validation matrix (requires explicit opt-in for run mode)"
+	@echo "  make kolme-fork-rust-tests-local - local-only bounded kolme_fork Rust test matrix plan"
 	@echo "Deep/scheduled lanes remain opt-in via scripts/sdk/run_rust_live_transport_deep_lane.sh and related scripts."
 
 check:
@@ -38,3 +39,6 @@ ci-tools:
 
 kolme-local-heavy:
 	bash scripts/kolme/run_local_heavy_validation_matrix.sh --mode dry-run --output-json /tmp/kolme-local-heavy-validation-summary.json
+
+kolme-fork-rust-tests-local:
+	bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json

--- a/README.md
+++ b/README.md
@@ -308,6 +308,18 @@ bash scripts/kolme/run_local_fork_smoke_evidence_lane.sh --mode run --checkout-p
 # schema: kamn.kolme.local-fork-smoke-evidence-summary.v1
 ```
 
+### Run Local Fork Rust Test Matrix Lane (Kolme)
+
+```bash
+# deterministic local matrix plan (no command execution)
+bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json
+
+# explicit local-only bounded matrix execution against fork checkout
+KAMN_KOLME_LOCAL_HEAVY=1 \
+bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json
+# schema: kamn.kolme.local-fork-rust-test-matrix-summary.v1
+```
+
 ### Run Local Kolme API Probe Lane
 
 ```bash
@@ -439,6 +451,7 @@ Fast-gate validates only command surfaces:
 Local Kolme API probe/smoke lane contract tests:
 - `bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_api_smoke_lane.sh`
+- `bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_live_api_conformance_contract_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_fork_bootstrap_readiness_contract_lane.sh`
 - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -91,6 +91,22 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - run mode fails closed without explicit local-only opt-in.
   - smoke command timeout/exceeded budget is reported as `fork_smoke_command_timeout`.
 
+## Local-Only Fork Rust Test Matrix Lane (Issue #1537)
+
+- Local fork Rust test matrix runner:
+  - `bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json`
+- Explicit local-only Rust test matrix execution:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json`
+- Summary schema:
+  - `kamn.kolme.local-fork-rust-test-matrix-summary.v1`
+- Deterministic checkpoints include:
+  - `run_local_fork_sync_metadata_lane.sh` metadata validation prior to Rust command execution.
+  - bounded per-command timeout guard with deterministic pass/fail reason codes.
+  - per-command stdout/stderr artifact capture for audit review.
+- Cost policy:
+  - run mode fails closed without explicit local-only opt-in.
+  - run mode remains local/manual and is excluded from PR fast-gate workflow routing.
+
 ## Deterministic Local Kolme API Probe Lane (Issue #1439)
 
 - Local API probe runner:
@@ -329,6 +345,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local-only heavy validation matrix requires explicit opt-in and remains excluded from PR fast-gate workflows (`Regression: #1405`).
 - local fork metadata sync lane fails closed for checkout-path, remote-URL, ref, and dirty-checkout drift (`Regression: #1429`).
 - local fork smoke evidence lane fails closed on missing local opt-in, metadata sync failure, command timeout, and smoke-command errors (`Regression: #1430`).
+- local fork Rust test matrix lane fails closed on missing local opt-in, metadata sync drift, and per-command timeout/failure paths (`Regression: #1537`).
 - local Kolme API probe lane fails closed on unavailable health endpoint, invalid fork-info payload, and runtime budget overruns (`Regression: #1439`).
 - local Kolme API smoke lane fails closed without explicit local opt-in, probe prerequisite failure, smoke-command timeout, and smoke-command errors (`Regression: #1440`).
 - local live API conformance harness fails closed for probe/native parity prerequisite failures, runtime budget overruns, and endpoint contract drift (`Regression: #1483`).
@@ -349,6 +366,7 @@ bash scripts/kolme/test_validate_triadic_devnet_smoke.sh
 bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh
 bash scripts/kolme/test_run_local_fork_sync_metadata_lane.sh
 bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh
+bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
 bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh
 bash scripts/kolme/test_run_local_kolme_api_smoke_lane.sh
 bash scripts/kolme/test_run_local_kolme_live_api_conformance_contract_lane.sh

--- a/scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SYNC_RUNNER="$ROOT_DIR/scripts/kolme/run_local_fork_sync_metadata_lane.sh"
+
+MODE="dry-run"
+OUTPUT_JSON="/tmp/kolme-local-fork-rust-test-matrix-summary.json"
+METADATA_REPORT="/tmp/kolme-local-fork-sync-metadata-summary.json"
+COMMAND_OUTPUT_DIR="/tmp/kolme-local-fork-rust-test-logs"
+CHECKOUT_PATH="/tmp/kolme_fork"
+EXPECTED_REMOTE_URL="https://github.com/njfio/kolme_fork.git"
+EXPECTED_REF="refs/heads/main"
+MAX_SECONDS=120
+
+declare -a MATRIX_COMMANDS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --mode" >&2
+        exit 1
+      fi
+      MODE="$2"
+      shift 2
+      ;;
+    --output-json)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --output-json" >&2
+        exit 1
+      fi
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --metadata-report)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --metadata-report" >&2
+        exit 1
+      fi
+      METADATA_REPORT="$2"
+      shift 2
+      ;;
+    --command-output-dir)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --command-output-dir" >&2
+        exit 1
+      fi
+      COMMAND_OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --checkout-path)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --checkout-path" >&2
+        exit 1
+      fi
+      CHECKOUT_PATH="$2"
+      shift 2
+      ;;
+    --expected-remote-url)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --expected-remote-url" >&2
+        exit 1
+      fi
+      EXPECTED_REMOTE_URL="$2"
+      shift 2
+      ;;
+    --expected-ref)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --expected-ref" >&2
+        exit 1
+      fi
+      EXPECTED_REF="$2"
+      shift 2
+      ;;
+    --matrix-command)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --matrix-command" >&2
+        exit 1
+      fi
+      MATRIX_COMMANDS+=("$2")
+      shift 2
+      ;;
+    --max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --max-seconds" >&2
+        exit 1
+      fi
+      MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: run_local_kolme_fork_rust_test_matrix_lane.sh [options]
+
+Options:
+  --mode dry-run|run              Print planned matrix output or execute bounded test matrix.
+  --output-json <path>            Summary report output path.
+  --metadata-report <path>        Metadata lane report output path.
+  --command-output-dir <path>     Directory for per-command stdout/stderr files.
+  --checkout-path <path>          Local kolme_fork checkout path.
+  --expected-remote-url <url>     Expected origin URL for checkout validation.
+  --expected-ref <ref>            Expected symbolic HEAD ref.
+  --matrix-command <command>      Repeatable bounded command to run from checkout path.
+  --max-seconds <n>               Max runtime per matrix command.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$MODE" != "dry-run" ] && [ "$MODE" != "run" ]; then
+  echo "mode must be one of: dry-run, run" >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$MAX_SECONDS" -le 0 ]; then
+  echo "max-seconds must be a positive integer" >&2
+  exit 1
+fi
+
+if [ -z "$CHECKOUT_PATH" ]; then
+  echo "checkout path must not be empty" >&2
+  exit 1
+fi
+
+if [ -z "$EXPECTED_REMOTE_URL" ]; then
+  echo "expected remote URL must not be empty" >&2
+  exit 1
+fi
+
+if [ -z "$EXPECTED_REF" ]; then
+  echo "expected ref must not be empty" >&2
+  exit 1
+fi
+
+if [ "${#MATRIX_COMMANDS[@]}" -eq 0 ]; then
+  MATRIX_COMMANDS=(
+    "cargo test -p merkle-map --test version -- --exact load_from_zero_example"
+    "cargo test -p merkle-map --lib -- --exact insert_get"
+  )
+fi
+
+if [ "$MODE" = "run" ] && [ "${KAMN_KOLME_LOCAL_HEAVY:-0}" != "1" ]; then
+  echo "run mode requires explicit local-only opt-in: KAMN_KOLME_LOCAL_HEAVY=1" >&2
+  exit 1
+fi
+
+CHECK_FILE="$(mktemp)"
+trap 'rm -f "$CHECK_FILE"' EXIT
+
+overall_status="ok"
+reason_code="dry_run_no_commands_executed"
+budget_status="not_run"
+elapsed_seconds=0
+local_only_enforced="true"
+
+record_check() {
+  local check_id="$1"
+  local command="$2"
+  local status="$3"
+  local output_file="$4"
+  printf '%s\t%s\t%s\t%s\n' "$check_id" "$command" "$status" "$output_file" >>"$CHECK_FILE"
+}
+
+record_check \
+  "fork_sync_metadata" \
+  "bash scripts/kolme/run_local_fork_sync_metadata_lane.sh --mode run --checkout-path $CHECKOUT_PATH --expected-remote-url $EXPECTED_REMOTE_URL --expected-ref $EXPECTED_REF --output-json $METADATA_REPORT" \
+  "planned" \
+  "$METADATA_REPORT"
+
+for i in "${!MATRIX_COMMANDS[@]}"; do
+  index="$(( i + 1 ))"
+  record_check "matrix_command_$index" "${MATRIX_COMMANDS[$i]}" "planned" "$COMMAND_OUTPUT_DIR/command-$index.log"
+done
+
+if [ "$MODE" = "run" ]; then
+  : >"$CHECK_FILE"
+  mkdir -p "$COMMAND_OUTPUT_DIR"
+  start_epoch="$(date +%s)"
+
+  if [ ! -x "$SYNC_RUNNER" ]; then
+    record_check \
+      "fork_sync_metadata" \
+      "bash scripts/kolme/run_local_fork_sync_metadata_lane.sh --mode run --checkout-path $CHECKOUT_PATH --expected-remote-url $EXPECTED_REMOTE_URL --expected-ref $EXPECTED_REF --output-json $METADATA_REPORT" \
+      "fail" \
+      "$METADATA_REPORT"
+    for i in "${!MATRIX_COMMANDS[@]}"; do
+      index="$(( i + 1 ))"
+      record_check "matrix_command_$index" "${MATRIX_COMMANDS[$i]}" "skipped" "$COMMAND_OUTPUT_DIR/command-$index.log"
+    done
+    overall_status="fail"
+    reason_code="fork_metadata_runner_missing"
+  else
+    if bash "$SYNC_RUNNER" \
+      --mode run \
+      --checkout-path "$CHECKOUT_PATH" \
+      --expected-remote-url "$EXPECTED_REMOTE_URL" \
+      --expected-ref "$EXPECTED_REF" \
+      --output-json "$METADATA_REPORT" >/dev/null; then
+      record_check \
+        "fork_sync_metadata" \
+        "bash scripts/kolme/run_local_fork_sync_metadata_lane.sh --mode run --checkout-path $CHECKOUT_PATH --expected-remote-url $EXPECTED_REMOTE_URL --expected-ref $EXPECTED_REF --output-json $METADATA_REPORT" \
+        "pass" \
+        "$METADATA_REPORT"
+
+      command_failure="false"
+      timeout_failure="false"
+      stop_execution="false"
+
+      for i in "${!MATRIX_COMMANDS[@]}"; do
+        index="$(( i + 1 ))"
+        command="${MATRIX_COMMANDS[$i]}"
+        output_file="$COMMAND_OUTPUT_DIR/command-$index.log"
+
+        if [ "$stop_execution" = "true" ]; then
+          record_check "matrix_command_$index" "$command" "skipped" "$output_file"
+          continue
+        fi
+
+        mkdir -p "$(dirname "$output_file")"
+        command_exit_code=0
+        set +e
+        timeout "$MAX_SECONDS" bash -lc "cd \"$CHECKOUT_PATH\" && $command" >"$output_file" 2>&1
+        command_exit_code=$?
+        set -e
+
+        if [ "$command_exit_code" -eq 0 ]; then
+          record_check "matrix_command_$index" "$command" "pass" "$output_file"
+        elif [ "$command_exit_code" -eq 124 ]; then
+          record_check "matrix_command_$index" "$command" "fail" "$output_file"
+          timeout_failure="true"
+          command_failure="true"
+          stop_execution="true"
+        else
+          record_check "matrix_command_$index" "$command" "fail" "$output_file"
+          command_failure="true"
+          stop_execution="true"
+        fi
+      done
+
+      if [ "$command_failure" = "true" ]; then
+        overall_status="fail"
+        if [ "$timeout_failure" = "true" ]; then
+          reason_code="fork_rust_test_command_timeout"
+          budget_status="exceeded_budget"
+        else
+          reason_code="fork_rust_test_command_failed"
+          budget_status="within_budget"
+        fi
+      else
+        reason_code="fork_rust_test_matrix_passed"
+        budget_status="within_budget"
+      fi
+    else
+      record_check \
+        "fork_sync_metadata" \
+        "bash scripts/kolme/run_local_fork_sync_metadata_lane.sh --mode run --checkout-path $CHECKOUT_PATH --expected-remote-url $EXPECTED_REMOTE_URL --expected-ref $EXPECTED_REF --output-json $METADATA_REPORT" \
+        "fail" \
+        "$METADATA_REPORT"
+      for i in "${!MATRIX_COMMANDS[@]}"; do
+        index="$(( i + 1 ))"
+        record_check "matrix_command_$index" "${MATRIX_COMMANDS[$i]}" "skipped" "$COMMAND_OUTPUT_DIR/command-$index.log"
+      done
+      overall_status="fail"
+      reason_code="fork_metadata_sync_failed"
+      budget_status="within_budget"
+    fi
+  fi
+
+  end_epoch="$(date +%s)"
+  elapsed_seconds="$(( end_epoch - start_epoch ))"
+fi
+
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$METADATA_REPORT" "$COMMAND_OUTPUT_DIR" "$CHECK_FILE" "${MATRIX_COMMANDS[@]}" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1]).resolve()
+mode = sys.argv[2]
+status = sys.argv[3]
+reason_code = sys.argv[4]
+local_only_enforced = sys.argv[5] == "true"
+elapsed_seconds = int(sys.argv[6])
+max_seconds_per_command = int(sys.argv[7])
+budget_status = sys.argv[8]
+checkout_path = sys.argv[9]
+expected_remote_url = sys.argv[10]
+expected_ref = sys.argv[11]
+metadata_report = sys.argv[12]
+command_output_dir = sys.argv[13]
+checks_path = pathlib.Path(sys.argv[14])
+commands = sys.argv[15:]
+
+checkpoints = []
+for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.strip():
+        continue
+    parts = raw_line.split("\t")
+    if len(parts) != 4:
+        continue
+    check_id, command, check_status, output_file = parts
+    checkpoints.append(
+        {
+            "id": check_id,
+            "command": command,
+            "status": check_status,
+            "output_file": output_file,
+        }
+    )
+
+summary = {
+    "schema_version": "kamn.kolme.local-fork-rust-test-matrix-summary.v1",
+    "mode": mode,
+    "status": status,
+    "reason_code": reason_code,
+    "local_only_enforced": local_only_enforced,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds_per_command": max_seconds_per_command,
+    "command_count": len(commands),
+    "budget_status": budget_status,
+    "checkout_path": checkout_path,
+    "expected_remote_url": expected_remote_url,
+    "expected_ref": expected_ref,
+    "metadata_report": metadata_report,
+    "command_output_dir": command_output_dir,
+    "commands": commands,
+    "checkpoints": checkpoints,
+    "artifact_paths": [
+        metadata_report,
+        command_output_dir,
+    ],
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "status=$overall_status"
+echo "matrix_mode=$MODE"
+echo "reason_code=$reason_code"
+echo "budget_status=$budget_status"
+echo "local_only_enforced=$local_only_enforced"
+echo "summary_file=$(realpath "$OUTPUT_JSON")"
+
+if [ "$overall_status" != "ok" ]; then
+  exit 1
+fi

--- a/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+TMP_METADATA_REPORT="$(mktemp)"
+TMP_OUTPUT_DIR="$(mktemp -d)"
+TMP_ERR="$(mktemp)"
+TMP_REPO="$(mktemp -d)"
+trap 'rm -f "$TMP_REPORT" "$TMP_METADATA_REPORT" "$TMP_ERR"; rm -rf "$TMP_OUTPUT_DIR" "$TMP_REPO"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { print $2; exit }'
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local fork rust test matrix runner to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_fork_rust_test_matrix_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork rust test matrix runner" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_fork_rust_test_matrix_lane.sh" "$README_FILE"; then
+  echo "expected README to reference local fork rust test matrix runner" >&2
+  exit 1
+fi
+
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" checkout -q -b main
+git -C "$TMP_REPO" config user.email "ci@example.com"
+git -C "$TMP_REPO" config user.name "CI Runner"
+cat >"$TMP_REPO/README.md" <<'DOC'
+local fork rust test matrix fixture
+DOC
+git -C "$TMP_REPO" add README.md
+git -C "$TMP_REPO" commit -q -m "init fixture"
+git -C "$TMP_REPO" remote add origin "https://github.com/njfio/kolme_fork.git"
+
+dry_run_output="$(
+  bash "$RUNNER" \
+    --mode dry-run \
+    --checkout-path "$TMP_REPO" \
+    --expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+    --expected-ref "refs/heads/main" \
+    --matrix-command "printf matrix_ok_1" \
+    --matrix-command "printf matrix_ok_2" \
+    --output-json "$TMP_REPORT" \
+    --metadata-report "$TMP_METADATA_REPORT" \
+    --command-output-dir "$TMP_OUTPUT_DIR"
+)"
+
+assert_eq "$(extract_value "$dry_run_output" "status")" "ok" "expected dry-run matrix lane to pass"
+assert_eq "$(extract_value "$dry_run_output" "matrix_mode")" "dry-run" "expected dry-run mode marker"
+assert_eq "$(extract_value "$dry_run_output" "reason_code")" "dry_run_no_commands_executed" "expected dry-run reason code"
+assert_eq "$(extract_value "$dry_run_output" "budget_status")" "not_run" "expected dry-run budget status"
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-summary.v1":
+    raise SystemExit("unexpected local fork rust test matrix schema")
+if report.get("mode") != "dry-run":
+    raise SystemExit("expected dry-run mode in local fork rust test matrix summary")
+if report.get("local_only_enforced") is not True:
+    raise SystemExit("expected local_only_enforced=true in local fork rust test matrix summary")
+if report.get("command_count") != 2:
+    raise SystemExit("expected command_count=2 for dry-run matrix")
+checkpoints = report.get("checkpoints")
+if not isinstance(checkpoints, list) or len(checkpoints) < 3:
+    raise SystemExit("expected metadata + command checkpoint entries in matrix summary")
+PY
+
+set +e
+bash "$RUNNER" \
+  --mode run \
+  --checkout-path "$TMP_REPO" \
+  --expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+  --expected-ref "refs/heads/main" \
+  --matrix-command "printf matrix_ok" \
+  --output-json "$TMP_REPORT" \
+  --metadata-report "$TMP_METADATA_REPORT" \
+  --command-output-dir "$TMP_OUTPUT_DIR" >"$TMP_ERR" 2>&1
+run_without_opt_in_code=$?
+set -e
+
+if [ "$run_without_opt_in_code" -eq 0 ]; then
+  echo "expected matrix lane run mode without opt-in to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "requires explicit local-only opt-in" "$TMP_ERR"; then
+  echo "expected deterministic local-only opt-in failure message for matrix run mode" >&2
+  exit 1
+fi
+
+run_output="$(
+  KAMN_KOLME_LOCAL_HEAVY=1 \
+    bash "$RUNNER" \
+      --mode run \
+      --checkout-path "$TMP_REPO" \
+      --expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+      --expected-ref "refs/heads/main" \
+      --matrix-command "printf matrix_ok_1" \
+      --matrix-command "printf matrix_ok_2" \
+      --max-seconds 20 \
+      --output-json "$TMP_REPORT" \
+      --metadata-report "$TMP_METADATA_REPORT" \
+      --command-output-dir "$TMP_OUTPUT_DIR"
+)"
+
+assert_eq "$(extract_value "$run_output" "status")" "ok" "expected matrix lane run mode to pass"
+assert_eq "$(extract_value "$run_output" "matrix_mode")" "run" "expected run mode marker"
+assert_eq "$(extract_value "$run_output" "reason_code")" "fork_rust_test_matrix_passed" "expected pass reason code"
+assert_eq "$(extract_value "$run_output" "budget_status")" "within_budget" "expected within-budget marker"
+
+python3 - "$TMP_REPORT" "$TMP_OUTPUT_DIR" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+out_dir = pathlib.Path(sys.argv[2])
+if report.get("mode") != "run":
+    raise SystemExit("expected run mode in local fork rust test matrix summary")
+if report.get("status") != "ok":
+    raise SystemExit("expected ok status for run mode matrix summary")
+if report.get("budget_status") != "within_budget":
+    raise SystemExit("expected within_budget for run mode matrix summary")
+log_files = sorted(out_dir.glob("command-*.log"))
+if len(log_files) != 2:
+    raise SystemExit("expected two command output files in matrix output directory")
+for idx, marker in enumerate(("matrix_ok_1", "matrix_ok_2"), start=1):
+    content = (out_dir / f"command-{idx}.log").read_text(encoding="utf-8")
+    if marker not in content:
+        raise SystemExit(f"expected marker {marker} in command-{idx}.log")
+PY
+
+set +e
+KAMN_KOLME_LOCAL_HEAVY=1 \
+  bash "$RUNNER" \
+    --mode run \
+    --checkout-path "$TMP_REPO" \
+    --expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+    --expected-ref "refs/heads/main" \
+    --matrix-command "sleep 2" \
+    --max-seconds 1 \
+    --output-json "$TMP_REPORT" \
+    --metadata-report "$TMP_METADATA_REPORT" \
+    --command-output-dir "$TMP_OUTPUT_DIR" >"$TMP_ERR" 2>&1
+timeout_code=$?
+set -e
+
+if [ "$timeout_code" -eq 0 ]; then
+  echo "expected matrix lane to fail when command exceeds max-seconds budget" >&2
+  exit 1
+fi
+
+if ! grep -q "reason_code=fork_rust_test_command_timeout" "$TMP_ERR"; then
+  echo "expected fork_rust_test_command_timeout reason marker for command timeout failure" >&2
+  exit 1
+fi
+
+echo "local fork rust test matrix lane tests passed."


### PR DESCRIPTION
## Summary
Adds a local-only bounded `kolme_fork` Rust test matrix lane with deterministic JSON evidence so maintainers can run real fork-side Rust checks locally without expanding PR CI cost. The lane is fail-closed for missing local opt-in and metadata drift.

## Changes
- `scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh`: new bounded matrix runner with per-command timeout, metadata precheck, and deterministic summary output (`kamn.kolme.local-fork-rust-test-matrix-summary.v1`).
- `scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh`: contract test coverage for dry-run/run, local-only guard, timeout failure, and docs references.
- `README.md`: added command surface for local fork Rust test matrix lane.
- `docs/planning/kolme-devnet-ops.md`: added lane contract section, regression marker, and local validation command.
- `Makefile`: added `kolme-fork-rust-tests-local` dry-run convenience target.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
expected local fork rust test matrix runner to be executable
```

### 🟢 Green Phase
```bash
bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
```
Passes with: `local fork rust test matrix lane tests passed.`

### 🔁 Regression
```bash
bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-rust-test-matrix-summary-ci1.json
KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --matrix-command "printf matrix_run_ok_1" --matrix-command "printf matrix_run_ok_2" --max-seconds 20 --output-json /tmp/kolme-local-fork-rust-test-matrix-summary-ci2.json --command-output-dir /tmp/kolme-local-fork-rust-test-logs-ci2
bash scripts/kolme/test_run_local_fork_sync_metadata_lane.sh
bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh
make kolme-fork-rust-tests-local
cargo fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | runner option/mode/max-seconds validation via lane contract test | |
| Functional   | ✅     | dry-run/run success path checks in `test_run_local_kolme_fork_rust_test_matrix_lane.sh` | |
| Integration  | ✅     | temp git checkout + metadata sync + command-output artifact checks | |
| Regression   | ✅     | missing opt-in + timeout fail-closed checks (`Regression: #1537`) | |
| Performance  | ✅     | bounded matrix commands with per-command timeout and local-only execution | |

## Risks & Rollback
- None.
- Rollback: revert commit `d00356b`.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

Closes #1537
Refs #1536
Refs #1535
