### PR TITLE
feat(kolme): add fork rust matrix policy contract lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode dry-run 
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json
 # schema: kamn.kolme.local-fork-rust-test-matrix-summary.v1
+
+# policy checker contract
+python3 scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py --report-file /tmp/kolme-local-fork-rust-test-matrix-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json
+
+# bounded contract lane (dry-run + local-only run + fail-closed policy checks)
+bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json --policy-output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json
 ```
 
 ### Run Local Kolme API Probe Lane
@@ -452,6 +458,8 @@ Local Kolme API probe/smoke lane contract tests:
 - `bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_api_smoke_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh`
+- `bash scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh`
+- `bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_live_api_conformance_contract_lane.sh`
 - `bash scripts/kolme/test_run_local_kolme_fork_bootstrap_readiness_contract_lane.sh`
 - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -97,6 +97,10 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json`
 - Explicit local-only Rust test matrix execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json`
+- Policy checker command:
+  - `python3 scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py --report-file /tmp/kolme-local-fork-rust-test-matrix-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json`
+- Contract lane command:
+  - `bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json --policy-output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json`
 - Summary schema:
   - `kamn.kolme.local-fork-rust-test-matrix-summary.v1`
 - Deterministic checkpoints include:
@@ -346,6 +350,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local fork metadata sync lane fails closed for checkout-path, remote-URL, ref, and dirty-checkout drift (`Regression: #1429`).
 - local fork smoke evidence lane fails closed on missing local opt-in, metadata sync failure, command timeout, and smoke-command errors (`Regression: #1430`).
 - local fork Rust test matrix lane fails closed on missing local opt-in, metadata sync drift, and per-command timeout/failure paths (`Regression: #1537`).
+- local fork Rust test matrix policy and contract-lane checks fail closed on schema/decision/reason-code drift (`Regression: #1541`).
 - local Kolme API probe lane fails closed on unavailable health endpoint, invalid fork-info payload, and runtime budget overruns (`Regression: #1439`).
 - local Kolme API smoke lane fails closed without explicit local opt-in, probe prerequisite failure, smoke-command timeout, and smoke-command errors (`Regression: #1440`).
 - local live API conformance harness fails closed for probe/native parity prerequisite failures, runtime budget overruns, and endpoint contract drift (`Regression: #1483`).
@@ -367,6 +372,8 @@ bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh
 bash scripts/kolme/test_run_local_fork_sync_metadata_lane.sh
 bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh
 bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
+bash scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
+bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh
 bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh
 bash scripts/kolme/test_run_local_kolme_api_smoke_lane.sh
 bash scripts/kolme/test_run_local_kolme_live_api_conformance_contract_lane.sh

--- a/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate local fork Rust test matrix summary policy."
+    )
+    parser.add_argument("--report-file", required=True)
+    parser.add_argument("--expected-final-decision", required=True, choices=["GO", "NO-GO"])
+    parser.add_argument("--ci-fast-gate", required=True, choices=["PASS", "FAIL"])
+    parser.add_argument("--require-reason-code", action="append", default=[])
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, list[str]]:
+    reason_codes: list[str] = []
+
+    if report.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-summary.v1":
+        reason_codes.append("report_schema_invalid")
+
+    mode = report.get("mode")
+    if mode not in ("dry-run", "run"):
+        reason_codes.append("mode_invalid")
+
+    status = report.get("status")
+    if status not in ("ok", "fail"):
+        reason_codes.append("status_invalid")
+
+    reason_code = report.get("reason_code")
+    if not isinstance(reason_code, str) or not reason_code.strip():
+        reason_codes.append("reason_code_missing")
+
+    if report.get("local_only_enforced") is not True:
+        reason_codes.append("local_only_enforced_missing")
+
+    elapsed_seconds = report.get("elapsed_seconds")
+    if not isinstance(elapsed_seconds, int) or elapsed_seconds < 0:
+        reason_codes.append("elapsed_seconds_invalid")
+
+    max_seconds_per_command = report.get("max_seconds_per_command")
+    if not isinstance(max_seconds_per_command, int) or max_seconds_per_command <= 0:
+        reason_codes.append("max_seconds_per_command_invalid")
+
+    command_count = report.get("command_count")
+    if not isinstance(command_count, int) or command_count <= 0:
+        reason_codes.append("command_count_invalid")
+
+    budget_status = report.get("budget_status")
+    if budget_status not in ("not_run", "within_budget", "exceeded_budget"):
+        reason_codes.append("budget_status_invalid")
+
+    checkpoints = report.get("checkpoints")
+    if not isinstance(checkpoints, list) or not checkpoints:
+        reason_codes.append("checkpoints_missing")
+    else:
+        for idx, checkpoint in enumerate(checkpoints):
+            if not isinstance(checkpoint, dict):
+                reason_codes.append(f"checkpoint_not_object:{idx}")
+                continue
+            if not isinstance(checkpoint.get("id"), str) or not checkpoint["id"].strip():
+                reason_codes.append(f"checkpoint_id_missing:{idx}")
+            if not isinstance(checkpoint.get("command"), str) or not checkpoint["command"].strip():
+                reason_codes.append(f"checkpoint_command_missing:{idx}")
+            if checkpoint.get("status") not in ("planned", "pass", "fail", "skipped"):
+                reason_codes.append(f"checkpoint_status_invalid:{idx}")
+            if not isinstance(checkpoint.get("output_file"), str) or not checkpoint["output_file"].strip():
+                reason_codes.append(f"checkpoint_output_file_missing:{idx}")
+
+    if args.ci_fast_gate != "PASS":
+        reason_codes.append("ci_fast_gate_failed")
+
+    observed_final_decision = ""
+    if status == "ok":
+        observed_final_decision = "GO"
+        if reason_code not in ("dry_run_no_commands_executed", "fork_rust_test_matrix_passed"):
+            reason_codes.append("ok_status_reason_code_mismatch")
+        if budget_status == "exceeded_budget":
+            reason_codes.append("ok_status_budget_exceeded")
+        if mode == "dry-run" and reason_code != "dry_run_no_commands_executed":
+            reason_codes.append("dry_run_reason_code_mismatch")
+        if mode == "run" and reason_code != "fork_rust_test_matrix_passed":
+            reason_codes.append("run_reason_code_mismatch")
+    elif status == "fail":
+        observed_final_decision = "NO-GO"
+        if reason_code in ("dry_run_no_commands_executed", "fork_rust_test_matrix_passed"):
+            reason_codes.append("fail_status_reason_code_mismatch")
+
+    for required_reason_code in args.require_reason_code:
+        if reason_code != required_reason_code:
+            reason_codes.append(f"required_reason_code_missing:{required_reason_code}")
+
+    if observed_final_decision and observed_final_decision != args.expected_final_decision:
+        reason_codes.append("observed_final_decision_mismatch")
+
+    final_decision = "GO" if not reason_codes else "NO-GO"
+    return final_decision, reason_codes
+
+
+def main() -> int:
+    args = parse_args()
+    report_path = Path(args.report_file).resolve()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    observed_status = report.get("status")
+    observed_final_decision = ""
+    if observed_status == "ok":
+        observed_final_decision = "GO"
+    elif observed_status == "fail":
+        observed_final_decision = "NO-GO"
+
+    final_decision, reason_codes = evaluate(report, args)
+    output = {
+        "schema_version": "kamn.kolme.local-fork-rust-test-matrix-policy-report.v1",
+        "report_file": str(report_path),
+        "expected_final_decision": args.expected_final_decision,
+        "ci_fast_gate": args.ci_fast_gate,
+        "required_reason_codes": args.require_reason_code,
+        "observed_status": observed_status,
+        "observed_final_decision": observed_final_decision,
+        "observed_reason_code": report.get("reason_code"),
+        "reason_codes": reason_codes,
+        "final_decision": final_decision,
+    }
+
+    if args.output_json:
+        output_path = Path(args.output_json).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(output, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    status = "ok" if final_decision == "GO" else "fail"
+    failed_checks = ",".join(reason_codes) if reason_codes else "none"
+    print(f"status={status}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+
+    return 0 if final_decision == "GO" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh"
+CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+OUTPUT_JSON="/tmp/kolme-local-fork-rust-test-matrix-summary.json"
+POLICY_OUTPUT_JSON="/tmp/kolme-local-fork-rust-test-matrix-policy.json"
+MAX_SECONDS="${KAMN_KOLME_LOCAL_FORK_RUST_MATRIX_MAX_SECONDS:-120}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-json)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --output-json" >&2
+        exit 1
+      fi
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --policy-output-json)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --policy-output-json" >&2
+        exit 1
+      fi
+      POLICY_OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: run_local_kolme_fork_rust_test_matrix_contract_lane.sh [options]
+
+Options:
+  --output-json <path>         Matrix summary output.
+  --policy-output-json <path>  Policy report output.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$MAX_SECONDS" -le 0 ]; then
+  echo "KAMN_KOLME_LOCAL_FORK_RUST_MATRIX_MAX_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local fork rust test matrix lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected local fork rust test matrix policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$DOC_FILE" ]; then
+  echo "expected Kolme devnet ops documentation to exist" >&2
+  exit 1
+fi
+
+start_epoch="$(date +%s)"
+
+bash "$RUNNER" \
+  --mode dry-run \
+  --checkout-path /tmp/kolme_fork \
+  --max-seconds "$MAX_SECONDS" \
+  --output-json "$OUTPUT_JSON" \
+  >/dev/null
+
+python3 "$CHECKER" \
+  --report-file "$OUTPUT_JSON" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code dry_run_no_commands_executed \
+  --output-json "$POLICY_OUTPUT_JSON" \
+  >/dev/null
+
+KAMN_KOLME_LOCAL_HEAVY=1 \
+  bash "$RUNNER" \
+    --mode run \
+    --checkout-path /tmp/kolme_fork \
+    --matrix-command "printf 'matrix_contract_ok_1\\n'" \
+    --matrix-command "printf 'matrix_contract_ok_2\\n'" \
+    --max-seconds "$MAX_SECONDS" \
+    --output-json "$OUTPUT_JSON" \
+    >/dev/null
+
+python3 "$CHECKER" \
+  --report-file "$OUTPUT_JSON" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code fork_rust_test_matrix_passed \
+  --output-json "$POLICY_OUTPUT_JSON" \
+  >/dev/null
+
+if ! grep -q "run_local_kolme_fork_rust_test_matrix_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork rust test matrix lane runner" >&2
+  exit 1
+fi
+
+if ! grep -q "check_local_kolme_fork_rust_test_matrix_policy.py" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork rust test matrix policy checker" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork rust test matrix contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q "Regression: #1541" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include local fork rust test matrix regression marker" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$MAX_SECONDS" ]; then
+  echo "local fork rust test matrix contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+echo "local fork rust test matrix contract lane tests passed."

--- a/scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py"
+TMP_DIR="$(mktemp -d)"
+TMP_REPORT_OK="$TMP_DIR/ok-report.json"
+TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
+TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
+TMP_ERR="$TMP_DIR/error.log"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected local fork rust test matrix policy checker to be executable" >&2
+  exit 1
+fi
+
+cat >"$TMP_REPORT_OK" <<'JSON'
+{
+  "schema_version": "kamn.kolme.local-fork-rust-test-matrix-summary.v1",
+  "mode": "dry-run",
+  "status": "ok",
+  "reason_code": "dry_run_no_commands_executed",
+  "local_only_enforced": true,
+  "elapsed_seconds": 0,
+  "max_seconds_per_command": 120,
+  "command_count": 2,
+  "budget_status": "not_run",
+  "checkpoints": [
+    {
+      "id": "fork_sync_metadata",
+      "command": "echo planned",
+      "status": "planned",
+      "output_file": "/tmp/meta.json"
+    },
+    {
+      "id": "matrix_command_1",
+      "command": "echo c1",
+      "status": "planned",
+      "output_file": "/tmp/c1.log"
+    },
+    {
+      "id": "matrix_command_2",
+      "command": "echo c2",
+      "status": "planned",
+      "output_file": "/tmp/c2.log"
+    }
+  ]
+}
+JSON
+
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_OK" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code dry_run_no_commands_executed \
+  --output-json "$TMP_POLICY_OUT" >/dev/null
+
+python3 - "$TMP_POLICY_OUT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-policy-report.v1":
+    raise SystemExit("unexpected matrix policy report schema")
+if report.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision GO for valid dry-run report")
+if report.get("reason_codes") != []:
+    raise SystemExit("expected no failed checks for valid dry-run report")
+PY
+
+cat >"$TMP_REPORT_BAD" <<'JSON'
+{
+  "schema_version": "kamn.kolme.local-fork-rust-test-matrix-summary.v1",
+  "mode": "run",
+  "status": "fail",
+  "reason_code": "fork_rust_test_command_timeout",
+  "local_only_enforced": true,
+  "elapsed_seconds": 6,
+  "max_seconds_per_command": 5,
+  "command_count": 1,
+  "budget_status": "exceeded_budget",
+  "checkpoints": [
+    {
+      "id": "fork_sync_metadata",
+      "command": "echo pass",
+      "status": "pass",
+      "output_file": "/tmp/meta.json"
+    },
+    {
+      "id": "matrix_command_1",
+      "command": "sleep 2",
+      "status": "fail",
+      "output_file": "/tmp/c1.log"
+    }
+  ]
+}
+JSON
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_BAD" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+bad_exit_code=$?
+set -e
+
+if [ "$bad_exit_code" -eq 0 ]; then
+  echo "expected policy checker to fail for run report when expected decision is GO" >&2
+  exit 1
+fi
+
+if ! grep -q "final_decision=NO-GO" "$TMP_ERR"; then
+  echo "expected checker output to include final_decision=NO-GO for failing report" >&2
+  exit 1
+fi
+
+if ! grep -q "observed_final_decision_mismatch" "$TMP_ERR"; then
+  echo "expected mismatch reason code for failing policy decision" >&2
+  exit 1
+fi
+
+echo "local fork rust test matrix policy checker tests passed."

--- a/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh"
+CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+TMP_POLICY_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local fork rust test matrix contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected local fork rust test matrix policy checker to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference fork rust test matrix contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q "check_local_kolme_fork_rust_test_matrix_policy.py" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference fork rust test matrix policy checker" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" "$README_FILE"; then
+  echo "expected README to reference fork rust test matrix contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q "Regression: #1541" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fork rust test matrix regression marker" >&2
+  exit 1
+fi
+
+bash "$RUNNER" --output-json "$TMP_REPORT" --policy-output-json "$TMP_POLICY_REPORT" >/dev/null
+
+python3 - "$TMP_REPORT" "$TMP_POLICY_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if summary.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-summary.v1":
+    raise SystemExit("unexpected contract-lane summary schema")
+if summary.get("status") != "ok":
+    raise SystemExit("expected contract-lane summary status ok")
+if policy.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-policy-report.v1":
+    raise SystemExit("unexpected contract-lane policy schema")
+if policy.get("final_decision") != "GO":
+    raise SystemExit("expected contract-lane policy final_decision GO")
+PY
+
+echo "local fork rust test matrix contract lane tests passed."


### PR DESCRIPTION
## Summary
Adds a fail-closed policy checker and contract lane wrapper for the local-only `kolme_fork` Rust test matrix lane. This hardens deterministic GO/NO-GO evaluation and keeps heavy verification local/manual while preserving fast, low-cost CI behavior.

## Changes
- `scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py`: new policy checker for `kamn.kolme.local-fork-rust-test-matrix-summary.v1`.
- `scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh`: new contract lane wrapper for dry-run + local-only run and policy validation.
- `scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh`: checker contract tests.
- `scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh`: contract lane integration tests.
- `README.md`: added checker and contract lane command examples and test references.
- `docs/planning/kolme-devnet-ops.md`: added checker/contract lane commands, regression marker, and local validation commands.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
expected local fork rust test matrix policy checker to be executable
```

### 🟢 Green Phase
```bash
bash scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh
```
Both commands pass.

### 🔁 Regression
```bash
bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json /tmp/kolme-fork-rust-matrix-contract-summary.json --policy-output-json /tmp/kolme-fork-rust-matrix-contract-policy.json
bash scripts/kolme/test_run_local_fork_sync_metadata_lane.sh
bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh
cargo fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | policy checker field/reason-code validation in `test_check_local_kolme_fork_rust_test_matrix_policy.sh` | |
| Functional   | ✅     | checker GO/NO-GO decision paths and contract lane success flow | |
| Integration  | ✅     | contract lane executes runner + checker over local checkout and emits policy report | |
| Regression   | ✅     | fail-closed schema/decision/reason-code drift guard (`Regression: #1541`) | |
| Performance  | ✅     | bounded local-only contract lane with explicit max-seconds budget | |

## Risks & Rollback
- None.
- Rollback: revert commit `4b65880`.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

Closes #1541
Refs #1540
Refs #1539
