### PR TITLE
chore(ci): externalize kolme asymmetry policy source (#1569)

### DIFF
--- a/.ci/kolme-command-surface-asymmetry-policy.json
+++ b/.ci/kolme-command-surface-asymmetry-policy.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "kamn.ci.kolme-command-surface-asymmetry-policy.v1",
+  "fast_only": [
+    "scripts/kolme/test_check_snapshot_drift.sh",
+    "scripts/kolme/test_run_local_heavy_validation_matrix.sh",
+    "scripts/kolme/test_run_local_runtime_commit_live_lane.sh",
+    "scripts/kolme/test_run_snapshot_drift_contract_lane.sh",
+    "scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh",
+    "scripts/kolme/test_run_version_compatibility_contract_lane.sh",
+    "scripts/kolme/test_validate_version_compatibility.sh"
+  ],
+  "ci_tools_only": [
+    "scripts/kolme/test_check_nonce_broadcast_parity_policy.sh",
+    "scripts/kolme/test_check_runtime_commit_replay_policy.sh",
+    "scripts/kolme/test_run_block_fallback_reconciliation_contract_lane.sh",
+    "scripts/kolme/test_run_nonce_broadcast_parity_contract_lane.sh",
+    "scripts/kolme/test_run_notifications_consumer_contract_lane.sh",
+    "scripts/kolme/test_run_runtime_commit_contract_lane.sh",
+    "scripts/kolme/test_run_runtime_commit_replay_contract_lane.sh"
+  ]
+}

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -41,7 +41,7 @@ Fast-gate command contract coverage is intentionally split:
 - static command-surface parity (`scripts/ci/test_makefile_command_surface_contract.sh`)
 - dry-run execution parity (`scripts/ci/test_makefile_execution_contract.sh`) via `make -n` target resolution for bounded `check/test/demo` targets
 - Kolme missing-both coverage (`scripts/ci/test_kolme_command_surface_coverage_contract.sh`) ensures every `scripts/kolme/test_*.sh` appears in at least one CI command surface (`ci-fast-gate` or aggregate `scripts/ci/test_ci_tools.sh`).
-- Kolme asymmetry split coverage (`scripts/ci/test_kolme_command_surface_asymmetry_contract.sh`) enforces the approved `fast_only` and `ci_tools_only` script sets.
+- Kolme asymmetry split coverage (`scripts/ci/test_kolme_command_surface_asymmetry_contract.sh`) enforces the approved `fast_only` and `ci_tools_only` script sets from `.ci/kolme-command-surface-asymmetry-policy.json`.
 
 Selector routing remains bounded through `scripts/ci/select_targets.sh`:
 
@@ -204,6 +204,7 @@ Regression policy:
 - script-surface budget temporary `script_count` waiver scope/expiry drift remains fail-closed (`Regression: #1497`).
 - Kolme command-surface missing-both coverage drift remains fail-closed (`Regression: #1561`).
 - Kolme command-surface asymmetry split drift remains fail-closed (`Regression: #1565`).
+- Kolme command-surface asymmetry policy-file schema drift remains fail-closed (`Regression: #1569`).
 
 ## Budget Telemetry and Enforcement
 Both lanes call `scripts/ci/evaluate_budget.sh` at the end of the run to:

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -20,6 +20,7 @@ required_snippets=(
   "test_makefile_execution_contract.sh"
   "test_kolme_command_surface_coverage_contract.sh"
   "test_kolme_command_surface_asymmetry_contract.sh"
+  ".ci/kolme-command-surface-asymmetry-policy.json"
   "run_runtime_snapshot_contract_tests=true"
   "test_scope=runtime-contract"
   "run_localhost_signed_integration_contract_lane_tests"
@@ -131,6 +132,9 @@ required_snippets=(
   "Regression: #1462"
   "Regression: #1466"
   "Regression: #1497"
+  "Regression: #1561"
+  "Regression: #1565"
+  "Regression: #1569"
 )
 
 for snippet in "${required_snippets[@]}"; do

--- a/scripts/ci/test_kolme_command_surface_asymmetry_contract.sh
+++ b/scripts/ci/test_kolme_command_surface_asymmetry_contract.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_WORKFLOW="$ROOT_DIR/.github/workflows/ci-fast-gate.yml"
 CI_TOOLS_SCRIPT="$ROOT_DIR/scripts/ci/test_ci_tools.sh"
+POLICY_FILE="$ROOT_DIR/.ci/kolme-command-surface-asymmetry-policy.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -14,6 +15,11 @@ fi
 
 if [ ! -f "$CI_TOOLS_SCRIPT" ]; then
   echo "expected aggregate CI tools script to exist" >&2
+  exit 1
+fi
+
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "expected Kolme asymmetry policy file to exist at .ci/kolme-command-surface-asymmetry-policy.json" >&2
   exit 1
 fi
 
@@ -45,30 +51,42 @@ for script_path in "${kolme_tests[@]}"; do
   fi
 done
 
-expected_fast_only=(
-  "scripts/kolme/test_check_snapshot_drift.sh"
-  "scripts/kolme/test_run_local_heavy_validation_matrix.sh"
-  "scripts/kolme/test_run_local_runtime_commit_live_lane.sh"
-  "scripts/kolme/test_run_snapshot_drift_contract_lane.sh"
-  "scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh"
-  "scripts/kolme/test_run_version_compatibility_contract_lane.sh"
-  "scripts/kolme/test_validate_version_compatibility.sh"
-)
-
-expected_ci_tools_only=(
-  "scripts/kolme/test_check_nonce_broadcast_parity_policy.sh"
-  "scripts/kolme/test_check_runtime_commit_replay_policy.sh"
-  "scripts/kolme/test_run_block_fallback_reconciliation_contract_lane.sh"
-  "scripts/kolme/test_run_nonce_broadcast_parity_contract_lane.sh"
-  "scripts/kolme/test_run_notifications_consumer_contract_lane.sh"
-  "scripts/kolme/test_run_runtime_commit_contract_lane.sh"
-  "scripts/kolme/test_run_runtime_commit_replay_contract_lane.sh"
-)
-
 printf '%s\n' "${actual_fast_only[@]}" | sed '/^$/d' | sort >"$TMP_DIR/actual_fast_only.txt"
 printf '%s\n' "${actual_ci_tools_only[@]}" | sed '/^$/d' | sort >"$TMP_DIR/actual_ci_tools_only.txt"
-printf '%s\n' "${expected_fast_only[@]}" | sort >"$TMP_DIR/expected_fast_only.txt"
-printf '%s\n' "${expected_ci_tools_only[@]}" | sort >"$TMP_DIR/expected_ci_tools_only.txt"
+
+python3 - "$POLICY_FILE" "$TMP_DIR/expected_fast_only.txt" "$TMP_DIR/expected_ci_tools_only.txt" <<'PY'
+import json
+import pathlib
+import sys
+
+policy_path = pathlib.Path(sys.argv[1])
+expected_fast_only_path = pathlib.Path(sys.argv[2])
+expected_ci_tools_only_path = pathlib.Path(sys.argv[3])
+
+try:
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid Kolme asymmetry policy file: {exc}")
+
+if policy.get("schema_version") != "kamn.ci.kolme-command-surface-asymmetry-policy.v1":
+    raise SystemExit("unexpected Kolme asymmetry policy schema_version")
+
+def validate_array(name: str) -> list[str]:
+    value = policy.get(name)
+    if not isinstance(value, list) or len(value) == 0:
+        raise SystemExit(f"expected non-empty '{name}' array in Kolme asymmetry policy")
+    if not all(isinstance(item, str) and item for item in value):
+        raise SystemExit(f"expected '{name}' entries to be non-empty strings")
+    if len(set(value)) != len(value):
+        raise SystemExit(f"expected '{name}' entries to be unique")
+    return sorted(value)
+
+expected_fast_only = validate_array("fast_only")
+expected_ci_tools_only = validate_array("ci_tools_only")
+
+expected_fast_only_path.write_text("".join(f"{item}\n" for item in expected_fast_only), encoding="utf-8")
+expected_ci_tools_only_path.write_text("".join(f"{item}\n" for item in expected_ci_tools_only), encoding="utf-8")
+PY
 
 echo "kolme_fast_only_count_actual=$(wc -l <"$TMP_DIR/actual_fast_only.txt" | tr -d ' ')"
 echo "kolme_fast_only_count_expected=$(wc -l <"$TMP_DIR/expected_fast_only.txt" | tr -d ' ')"


### PR DESCRIPTION
## Summary
Externalizes Kolme command-surface asymmetry policy into a versioned JSON contract file and updates the asymmetry guard to parse and validate that policy fail-closed.

Closes #1569

## Changes
- Added `.ci/kolme-command-surface-asymmetry-policy.json` as policy source-of-truth.
- Updated `scripts/ci/test_kolme_command_surface_asymmetry_contract.sh` to:
  - require policy file presence
  - validate schema version and required keys/shape
  - enforce uniqueness and non-empty string entries
  - compare actual sets against policy-driven expected sets
- Updated `scripts/ci/test_ci_strategy_contract.sh` to require policy-file snippet and regression marker.
- Updated `docs/ci/strategy.md` to reference policy file and add `Regression: #1569` guard note.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/ci/test_kolme_command_surface_asymmetry_contract.sh`
  - failed: expected `.ci/kolme-command-surface-asymmetry-policy.json` to exist
- `bash scripts/ci/test_ci_strategy_contract.sh`
  - failed: missing snippet `.ci/kolme-command-surface-asymmetry-policy.json`

### 🟢 Green Phase
- `bash scripts/ci/test_kolme_command_surface_asymmetry_contract.sh` — passed
- `bash scripts/ci/test_kolme_command_surface_coverage_contract.sh` — passed
- `bash scripts/ci/test_ci_strategy_contract.sh` — passed
- `bash scripts/ci/test_ci_tools_command_surface_contract.sh` — passed

### 🔁 Regression
- `bash scripts/ci/test_ci_tools.sh` — passed
- `cargo fmt --check` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Shell contract + JSON policy wiring |
| Functional   | ✅     | `scripts/ci/test_kolme_command_surface_asymmetry_contract.sh` | |
| Integration  | ✅     | `scripts/ci/test_ci_tools.sh`, `scripts/ci/test_ci_strategy_contract.sh` | |
| Regression   | ✅     | policy-file presence/schema drift fail-closed checks | |
| Performance  | N/A    | None                 | Static parsing/diff checks only |

## Risks & Rollback
- Low risk: policy externalization with fail-closed checks.
- Rollback: revert commit `5cb4085`.

## Documentation Updates
- `docs/ci/strategy.md`: now references `.ci/kolme-command-surface-asymmetry-policy.json` and `Regression: #1569`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
