### PR TITLE
feat(devops): aggregate fork checkpoints in local kolme orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,8 @@ bash scripts/kolme/run_local_bootstrap_health_checks.sh --mode run --output-json
 # local-only heavy end-to-end lane plan (no command execution)
 bash scripts/kolme/run_local_e2e_integration_lane.sh --mode dry-run --output-json /tmp/kolme-local-e2e-integration-summary.json
 
-# local-only heavy end-to-end lane execution (bootstrap + runtime commit + sdk parity)
+# local-only heavy end-to-end lane execution
+# (bootstrap + runtime commit + sdk parity + fork rust matrix + live API conformance)
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_e2e_integration_lane.sh --mode run --output-json /tmp/kolme-local-e2e-integration-summary.json
 # schema: kamn.kolme.local-e2e-integration-summary.v1
@@ -443,7 +444,8 @@ bash scripts/kolme/run_local_e2e_integration_lane.sh --mode run --output-json /t
 # command surface + artifact schema validation (no heavy execution)
 bash scripts/kolme/run_local_heavy_validation_matrix.sh --mode dry-run --output-json /tmp/kolme-local-heavy-validation-summary.json
 
-# explicit local-only heavy execution (bootstrap preflight + deep replay)
+# explicit local-only heavy execution
+# (bootstrap preflight + deep replay + fork rust matrix contract + live API conformance contract)
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_heavy_validation_matrix.sh --mode run --output-json /tmp/kolme-local-heavy-validation-summary.json
 # schema: kamn.kolme.local-heavy-validation-summary.v1

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -308,6 +308,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `run_local_bootstrap_health_checks.sh`
   - `run_runtime_commit_adapter_contract_lane.sh`
   - `run_live_transport_parity_contract_lane.sh --languages python,typescript`
+  - `run_local_kolme_fork_rust_test_matrix_contract_lane.sh`
+  - `run_local_kolme_live_api_conformance_contract_lane.sh`
 - Cost policy:
   - lane enforces explicit local-only opt-in and a deterministic runtime budget ceiling.
 
@@ -322,6 +324,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Heavy command set includes:
   - `scripts/kolme/run_local_bootstrap_health_checks.sh`
   - `scripts/kolme/run_version_compatibility_replay_deep_lane.sh`
+  - `scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh`
+  - `scripts/kolme/run_local_kolme_live_api_conformance_contract_lane.sh`
 - Cost policy:
   - matrix execution remains local-only and is excluded from PR fast-gate workflow routing.
 

--- a/scripts/kolme/run_local_e2e_integration_lane.sh
+++ b/scripts/kolme/run_local_e2e_integration_lane.sh
@@ -66,21 +66,33 @@ if [ "$MODE" = "run" ] && [ "${KAMN_KOLME_LOCAL_HEAVY:-0}" != "1" ]; then
 fi
 
 BOOTSTRAP_REPORT="/tmp/kolme-local-bootstrap-summary.json"
+FORK_RUST_MATRIX_REPORT="/tmp/kolme-local-fork-rust-test-matrix-summary.json"
+FORK_RUST_MATRIX_POLICY_REPORT="/tmp/kolme-local-fork-rust-test-matrix-policy.json"
+LIVE_API_CONFORMANCE_REPORT="/tmp/kolme-local-live-api-conformance-summary.json"
+LIVE_API_CONFORMANCE_POLICY_REPORT="/tmp/kolme-local-live-api-conformance-policy.json"
 
 declare -a CHECKPOINT_IDS=(
   "bootstrap_health_checks"
   "runtime_commit_adapter"
   "sdk_live_transport_parity"
+  "fork_rust_test_matrix"
+  "fork_live_api_conformance"
 )
 
 declare -a CHECKPOINT_COMMANDS=(
   "bash scripts/kolme/run_local_bootstrap_health_checks.sh --mode run --output-json $BOOTSTRAP_REPORT"
   "bash scripts/kolme/run_runtime_commit_adapter_contract_lane.sh"
   "bash scripts/sdk/run_live_transport_parity_contract_lane.sh --languages python,typescript"
+  "bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json $FORK_RUST_MATRIX_REPORT --policy-output-json $FORK_RUST_MATRIX_POLICY_REPORT"
+  "bash scripts/kolme/run_local_kolme_live_api_conformance_contract_lane.sh --output-json $LIVE_API_CONFORMANCE_REPORT --policy-output-json $LIVE_API_CONFORMANCE_POLICY_REPORT"
 )
 
 declare -a ARTIFACTS=(
   "$BOOTSTRAP_REPORT"
+  "$FORK_RUST_MATRIX_REPORT"
+  "$FORK_RUST_MATRIX_POLICY_REPORT"
+  "$LIVE_API_CONFORMANCE_REPORT"
+  "$LIVE_API_CONFORMANCE_POLICY_REPORT"
 )
 
 CHECKPOINT_FILE="$(mktemp)"

--- a/scripts/kolme/run_local_heavy_validation_matrix.sh
+++ b/scripts/kolme/run_local_heavy_validation_matrix.sh
@@ -53,15 +53,25 @@ fi
 
 BOOTSTRAP_REPORT="/tmp/kolme-local-bootstrap-summary.json"
 DEEP_REPORT="/tmp/kolme-version-compatibility-report.json"
+FORK_RUST_MATRIX_REPORT="/tmp/kolme-local-fork-rust-test-matrix-summary.json"
+FORK_RUST_MATRIX_POLICY_REPORT="/tmp/kolme-local-fork-rust-test-matrix-policy.json"
+LIVE_API_CONFORMANCE_REPORT="/tmp/kolme-local-live-api-conformance-summary.json"
+LIVE_API_CONFORMANCE_POLICY_REPORT="/tmp/kolme-local-live-api-conformance-policy.json"
 
 declare -a COMMANDS=(
   "bash scripts/kolme/run_local_bootstrap_health_checks.sh --mode run --output-json $BOOTSTRAP_REPORT"
   "bash scripts/kolme/run_version_compatibility_replay_deep_lane.sh --output-json $DEEP_REPORT"
+  "bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json $FORK_RUST_MATRIX_REPORT --policy-output-json $FORK_RUST_MATRIX_POLICY_REPORT"
+  "bash scripts/kolme/run_local_kolme_live_api_conformance_contract_lane.sh --output-json $LIVE_API_CONFORMANCE_REPORT --policy-output-json $LIVE_API_CONFORMANCE_POLICY_REPORT"
 )
 
 declare -a ARTIFACTS=(
   "$BOOTSTRAP_REPORT"
   "$DEEP_REPORT"
+  "$FORK_RUST_MATRIX_REPORT"
+  "$FORK_RUST_MATRIX_POLICY_REPORT"
+  "$LIVE_API_CONFORMANCE_REPORT"
+  "$LIVE_API_CONFORMANCE_POLICY_REPORT"
 )
 
 if [ "$MODE" = "run" ]; then

--- a/scripts/kolme/test_run_local_e2e_integration_lane.sh
+++ b/scripts/kolme/test_run_local_e2e_integration_lane.sh
@@ -59,7 +59,7 @@ if report.get("status") != "ok":
 if report.get("local_only_enforced") is not True:
     raise SystemExit("expected local_only_enforced=true in e2e summary")
 checkpoints = report.get("checkpoints")
-if not isinstance(checkpoints, list) or len(checkpoints) < 3:
+if not isinstance(checkpoints, list) or len(checkpoints) < 5:
     raise SystemExit("expected deterministic checkpoint entries in e2e summary")
 checkpoint_ids = [
     entry.get("id")
@@ -70,6 +70,10 @@ if "runtime_commit_adapter" not in checkpoint_ids:
     raise SystemExit("expected runtime_commit_adapter checkpoint id")
 if "sdk_live_transport_parity" not in checkpoint_ids:
     raise SystemExit("expected sdk_live_transport_parity checkpoint id")
+if "fork_rust_test_matrix" not in checkpoint_ids:
+    raise SystemExit("expected fork_rust_test_matrix checkpoint id")
+if "fork_live_api_conformance" not in checkpoint_ids:
+    raise SystemExit("expected fork_live_api_conformance checkpoint id")
 PY
 
 set +e

--- a/scripts/kolme/test_run_local_heavy_validation_matrix.sh
+++ b/scripts/kolme/test_run_local_heavy_validation_matrix.sh
@@ -56,12 +56,16 @@ if report.get("mode") != "dry-run":
 if report.get("local_only_enforced") is not True:
     raise SystemExit("expected local_only_enforced=true in local heavy matrix summary")
 commands = report.get("commands")
-if not isinstance(commands, list) or len(commands) < 2:
+if not isinstance(commands, list) or len(commands) < 4:
     raise SystemExit("expected local heavy matrix summary to contain command entries")
 if not any("run_local_bootstrap_health_checks.sh" in cmd for cmd in commands):
     raise SystemExit("expected bootstrap health-check command marker in local heavy matrix summary")
 if not any("run_version_compatibility_replay_deep_lane.sh" in cmd for cmd in commands):
     raise SystemExit("expected deep replay command marker in local heavy matrix summary")
+if not any("run_local_kolme_fork_rust_test_matrix_contract_lane.sh" in cmd for cmd in commands):
+    raise SystemExit("expected local fork rust matrix contract-lane command marker in local heavy matrix summary")
+if not any("run_local_kolme_live_api_conformance_contract_lane.sh" in cmd for cmd in commands):
+    raise SystemExit("expected local live API conformance contract-lane command marker in local heavy matrix summary")
 PY
 
 # Regression: #1405


### PR DESCRIPTION
## Summary
Expand local-only Kolme orchestration so deterministic local verification now aggregates fork Rust matrix and live API conformance checkpoints in both the heavy matrix and E2E lane summaries. This keeps integration readiness evidence centralized while preserving CI cost policy.

## Changes
- `scripts/kolme/run_local_heavy_validation_matrix.sh`: add fork Rust matrix and live API conformance contract-lane commands plus output artifacts.
- `scripts/kolme/run_local_e2e_integration_lane.sh`: add `fork_rust_test_matrix` and `fork_live_api_conformance` checkpoints and artifacts.
- `scripts/kolme/test_run_local_heavy_validation_matrix.sh`: enforce expanded command coverage in summary schema assertions.
- `scripts/kolme/test_run_local_e2e_integration_lane.sh`: enforce expanded checkpoint coverage in summary schema assertions.
- `README.md`: update local heavy/E2E command descriptions to reflect expanded deterministic scope.
- `docs/planning/kolme-devnet-ops.md`: update deterministic checkpoint and heavy command-set documentation.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed generated dry-run summaries for local heavy matrix and local E2E lane to confirm fork checkpoint inclusion and local-only guard retention.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅  | summary/checkpoint schema assertions in updated Kolme runner tests |
| Functional  | ✅  | dry-run command/checkpoint outputs include fork Rust matrix + live conformance coverage |
| Integration | ✅  | `bash scripts/kolme/test_run_local_heavy_validation_matrix.sh`, `bash scripts/kolme/test_run_local_e2e_integration_lane.sh`, `bash scripts/ci/test_readme_contract.sh`, `cargo test -p kamn-core --test kolme_devnet_ops_docs`, `cargo test -p kamn-core --test ci_strategy_docs` |
| Regression  | ✅  | local-only opt-in enforcement retained and documented; no CI-fast-gate heavy run-mode expansion |

Closes #1577
Closes #1576
Closes #1575
