### PR TITLE
test(runtime): add threaded lifecycle transition contracts

### DIFF
--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -34,6 +34,15 @@ pub enum RuntimeLifecycleError {
     },
 }
 
+impl RuntimeLifecycleError {
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::InvalidPeerId => "runtime_peer_id_invalid",
+            Self::InvalidTransition { .. } => "runtime_peer_transition_invalid",
+        }
+    }
+}
+
 impl Display for RuntimeLifecycleError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/kamn-core/tests/lifecycle_concurrency_contracts.rs
+++ b/crates/kamn-core/tests/lifecycle_concurrency_contracts.rs
@@ -1,0 +1,155 @@
+use kamn_core::{
+    EscrowLifecycle, PeerLifecycle, PeerLifecycleEvent, TaskLifecycle, TaskState, TaskTransition,
+};
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
+
+fn in_progress_task(task_id: &str) -> TaskLifecycle {
+    let mut lifecycle =
+        TaskLifecycle::new(task_id).expect("task lifecycle should initialize for concurrency test");
+    lifecycle
+        .transition(TaskTransition::Accept)
+        .expect("task should accept");
+    lifecycle
+        .transition(TaskTransition::StartWork)
+        .expect("task should move in-progress");
+    lifecycle
+}
+
+#[test]
+fn regression_task_complete_transition_stays_fail_closed_under_concurrency() {
+    // Regression: #1597
+    let thread_count = 8;
+    let lifecycle = Arc::new(Mutex::new(in_progress_task("task-concurrency-1")));
+    let barrier = Arc::new(Barrier::new(thread_count));
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let lifecycle = Arc::clone(&lifecycle);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                lifecycle
+                    .lock()
+                    .expect("task lifecycle mutex poisoned")
+                    .transition(TaskTransition::Complete)
+            })
+        })
+        .collect();
+
+    let mut success_count = 0usize;
+    let mut terminal_error_count = 0usize;
+
+    for handle in handles {
+        match handle.join().expect("task transition thread should join") {
+            Ok(()) => success_count += 1,
+            Err(error) => {
+                if error.reason_code() == "task_transition_terminal_state" {
+                    terminal_error_count += 1;
+                } else {
+                    panic!("unexpected task transition error: {error}");
+                }
+            }
+        }
+    }
+
+    assert_eq!(success_count, 1);
+    assert_eq!(terminal_error_count, thread_count - 1);
+    assert_eq!(
+        lifecycle
+            .lock()
+            .expect("task lifecycle mutex poisoned")
+            .state(),
+        TaskState::Completed
+    );
+}
+
+#[test]
+fn regression_escrow_dispute_transition_stays_fail_closed_under_concurrency() {
+    // Regression: #1597
+    let thread_count = 8;
+    let lifecycle = Arc::new(Mutex::new(
+        EscrowLifecycle::new(42).expect("escrow lifecycle should initialize for concurrency test"),
+    ));
+    let barrier = Arc::new(Barrier::new(thread_count));
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let lifecycle = Arc::clone(&lifecycle);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                lifecycle
+                    .lock()
+                    .expect("escrow lifecycle mutex poisoned")
+                    .dispute()
+            })
+        })
+        .collect();
+
+    let mut success_count = 0usize;
+    let mut invalid_error_count = 0usize;
+
+    for handle in handles {
+        match handle.join().expect("escrow transition thread should join") {
+            Ok(()) => success_count += 1,
+            Err(error) => {
+                if error.reason_code() == "escrow_transition_invalid" {
+                    invalid_error_count += 1;
+                } else {
+                    panic!("unexpected escrow transition error: {error}");
+                }
+            }
+        }
+    }
+
+    assert_eq!(success_count, 1);
+    assert_eq!(invalid_error_count, thread_count - 1);
+}
+
+#[test]
+fn regression_peer_handshake_transition_rejects_parallel_invalid_edges() {
+    // Regression: #1597
+    let thread_count = 8;
+    let mut seed_lifecycle =
+        PeerLifecycle::new("peer-concurrency-1").expect("peer lifecycle should initialize");
+    seed_lifecycle
+        .transition(PeerLifecycleEvent::StartConnect)
+        .expect("peer should enter connecting state");
+
+    let lifecycle = Arc::new(Mutex::new(seed_lifecycle));
+    let barrier = Arc::new(Barrier::new(thread_count));
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let lifecycle = Arc::clone(&lifecycle);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                lifecycle
+                    .lock()
+                    .expect("peer lifecycle mutex poisoned")
+                    .transition(PeerLifecycleEvent::HandshakeSucceeded)
+            })
+        })
+        .collect();
+
+    let mut success_count = 0usize;
+    let mut invalid_error_count = 0usize;
+
+    for handle in handles {
+        match handle.join().expect("peer transition thread should join") {
+            Ok(_) => success_count += 1,
+            Err(error) => {
+                if error.reason_code() == "runtime_peer_transition_invalid" {
+                    invalid_error_count += 1;
+                } else {
+                    panic!("unexpected peer lifecycle transition error: {error}");
+                }
+            }
+        }
+    }
+
+    assert_eq!(success_count, 1);
+    assert_eq!(invalid_error_count, thread_count - 1);
+}

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -44,6 +44,11 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 - Concurrency lanes use replay fixtures and deterministic round-based checks to
   guard winner exclusivity and terminal-state safety, and emit replay metadata
   artifact key `concurrency_mutation_replay:v1`.
+- Threaded lifecycle transition regression coverage is anchored in
+  `crates/kamn-core/tests/lifecycle_concurrency_contracts.rs`, validating:
+  - task terminal-state fail-closed behavior under parallel completion attempts
+  - escrow invalid-transition rejection under parallel dispute attempts
+  - peer lifecycle invalid-edge rejection under parallel handshake attempts
 
 ## Evidence and Policy Contracts
 


### PR DESCRIPTION
## Summary
Added deterministic threaded lifecycle regression tests for task, escrow, and peer lifecycle transitions so fail-closed guards are validated under concurrent mutation attempts. Introduced `RuntimeLifecycleError::reason_code()` to support stable peer lifecycle error assertions in the new concurrency contracts.

## Changes
- `crates/kamn-core/tests/lifecycle_concurrency_contracts.rs`: new threaded regression tests covering concurrent task completion, escrow dispute attempts, and peer handshake transition contention.
- `crates/kamn-core/src/runtime.rs`: added `RuntimeLifecycleError::reason_code()` for deterministic invalid-transition classification.
- `docs/testing/invariant-and-fuzz-strategy.md`: documented threaded lifecycle regression coverage anchors.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test lifecycle_concurrency_contracts
```
Failing output:
```text
error[E0599]: no method named `reason_code` found for enum `RuntimeLifecycleError` in the current scope
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test lifecycle_concurrency_contracts
```
Passing output:
```text
running 3 tests
... ok
... ok
... ok

test result: ok. 3 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test lifecycle_concurrency_contracts
cargo test -p kamn-core --test task_escrow_transition_contracts
cargo test -p kamn-core unit_rejects_invalid_peer_lifecycle_transition --lib
cargo test -p kamn-core --test invariant_and_fuzz_strategy_docs
cargo clippy -p kamn-core --all-targets --all-features -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
Summary:
```text
All listed commands passed locally.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `lifecycle_concurrency_contracts` per-component threaded assertions | |
| Functional   | ✅ | Parallel lifecycle flows verify expected final-state / invalid-edge behavior | |
| Integration  | ✅ | Lifecycle regression tests + selector routing regression executed together | |
| Regression   | ✅ | `Regression: #1597` tests added for concurrent invalid/terminal transitions | |
| Performance  | N/A | | Test-only change with bounded local runtime |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to remove threaded lifecycle coverage and runtime reason-code helper.

## Documentation Updates
- `docs/testing/invariant-and-fuzz-strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant lifecycle and selector regression suites passed locally

Closes #1597
