### PR TITLE
docs(kamn-core): graduate task_lifecycle from missing-docs allowlist

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -103,7 +103,6 @@ pub mod smoke;
 pub mod state;
 #[allow(missing_docs)]
 pub mod task_artifacts;
-#[allow(missing_docs)]
 pub mod task_lifecycle;
 #[allow(missing_docs)]
 pub mod task_operations;

--- a/crates/kamn-core/src/task_lifecycle.rs
+++ b/crates/kamn-core/src/task_lifecycle.rs
@@ -1,38 +1,65 @@
+//! Task lifecycle state machine and transition evidence contracts.
+
 use std::fmt;
 
+/// Snapshot of task lifecycle state within the task state machine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TaskState {
+    /// Task has been created but not yet accepted.
     Submitted,
+    /// Task has been accepted by an assignee.
     Accepted,
+    /// Task has been delegated to another assignee.
     Delegated,
+    /// Task is actively being worked.
     InProgress,
+    /// Task is waiting for additional external input.
     InputRequired,
+    /// Task is temporarily blocked.
     Blocked,
+    /// Task completed successfully.
     Completed,
+    /// Task ended in failure.
     Failed,
+    /// Task has been cancelled.
     Cancelled,
 }
 
+/// Transition action applied to [`TaskLifecycle`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TaskTransition {
+    /// Accept a submitted task.
     Accept,
+    /// Delegate an accepted task.
     Delegate,
+    /// Start or resume work.
     StartWork,
+    /// Request additional input while in progress.
     RequestInput,
+    /// Mark an in-progress task as blocked.
     Block,
+    /// Complete work successfully.
     Complete,
+    /// Mark work as failed.
     Fail,
+    /// Cancel the task.
     Cancel,
 }
 
+/// Evidence record describing an allowed task transition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TaskTransitionEvidence {
+    /// Source state before transition application.
     pub from: TaskState,
+    /// Applied transition.
     pub transition: TaskTransition,
+    /// Destination state after transition application.
     pub to: TaskState,
+    /// Stable reason-code emitted for policy contracts.
     pub reason_code: &'static str,
 }
 
+/// Mutable task lifecycle state machine with replayable history.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskLifecycle {
     task_id: String,
@@ -41,6 +68,7 @@ pub struct TaskLifecycle {
 }
 
 impl TaskLifecycle {
+    /// Create a new lifecycle initialized in [`TaskState::Submitted`].
     pub fn new(task_id: &str) -> Result<Self, TaskLifecycleError> {
         if task_id.trim().is_empty() {
             return Err(TaskLifecycleError::EmptyTaskId);
@@ -52,18 +80,22 @@ impl TaskLifecycle {
         })
     }
 
+    /// Return the stable task identifier.
     pub fn task_id(&self) -> &str {
         &self.task_id
     }
 
+    /// Return the current lifecycle state.
     pub fn state(&self) -> TaskState {
         self.state
     }
 
+    /// Return the replay history as an owned state vector.
     pub fn history(&self) -> Vec<TaskState> {
         self.history.clone()
     }
 
+    /// Apply a transition and mutate lifecycle state if the edge is valid.
     pub fn transition(&mut self, transition: TaskTransition) -> Result<(), TaskLifecycleError> {
         if is_terminal(self.state) {
             return Err(TaskLifecycleError::TerminalState(self.state));
@@ -80,6 +112,7 @@ impl TaskLifecycle {
         Ok(())
     }
 
+    /// Apply a transition and emit deterministic transition evidence.
     pub fn transition_with_evidence(
         &mut self,
         transition: TaskTransition,
@@ -94,6 +127,7 @@ impl TaskLifecycle {
         })
     }
 
+    /// Restore a lifecycle from historical states after validating each edge.
     pub fn restore(task_id: &str, history: Vec<TaskState>) -> Result<Self, TaskLifecycleError> {
         if history.is_empty() {
             return Err(TaskLifecycleError::InvalidHistory(
@@ -127,18 +161,26 @@ impl TaskLifecycle {
     }
 }
 
+/// Error variants emitted by [`TaskLifecycle`] transition and restore operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskLifecycleError {
+    /// Provided task identifier is empty.
     EmptyTaskId,
+    /// Lifecycle history is malformed or not replayable.
     InvalidHistory(String),
+    /// Requested transition edge is invalid for current state.
     InvalidTransition {
+        /// Source state where invalid transition was requested.
         from: TaskState,
+        /// Transition that was rejected.
         transition: TaskTransition,
     },
+    /// Transition was requested from a terminal state.
     TerminalState(TaskState),
 }
 
 impl TaskLifecycleError {
+    /// Return deterministic reason-code used by contract lanes.
     pub fn reason_code(&self) -> &'static str {
         match self {
             Self::EmptyTaskId => "task_id_empty",

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -89,3 +89,21 @@ fn graduated_wave_two_modules_must_not_return_to_missing_docs_allowlist() {
         );
     }
 }
+
+#[test]
+fn graduated_wave_three_task_lifecycle_module_must_not_return_to_missing_docs_allowlist() {
+    // Regression: #1601
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == "task_lifecycle"),
+        "task_lifecycle must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected
+            .iter()
+            .any(|candidate| candidate == "task_lifecycle"),
+        "allowlist fixture must keep task_lifecycle removed"
+    );
+}

--- a/docs/planning/engineering-hardening-wave.md
+++ b/docs/planning/engineering-hardening-wave.md
@@ -40,6 +40,8 @@ default development loop green while tightening missing-doc policy controls for
 - Crate-wide `#![allow(missing_docs)]` is prohibited.
 - Legacy `#[allow(missing_docs)] pub mod ...` exemptions are tracked in:
   - `fixtures/ci/kamn_core_missing_docs_allowlist.txt`
+- Graduated modules that must remain outside the allow-list:
+  - `namespaces`, `bootstrap`, `kolme_runtime_commit`, `state`, `task_lifecycle`
 - Any allowlist drift fails closed via:
   - `scripts/ci/check_kamn_core_missing_docs_policy.sh`
 - Architecture/runtime flow and rustdoc publication docs are required:

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -45,7 +45,6 @@ signature_profile
 signer_backend
 smoke
 task_artifacts
-task_lifecycle
 task_operations
 task_payment
 telegram_bridge


### PR DESCRIPTION
## Summary
Graduated `task_lifecycle` from the `kamn-core` missing-docs allow-list by documenting its full public API and removing its module-level exemption in `lib.rs`. Added a dedicated regression guard to prevent `task_lifecycle` from re-entering the allow-list.

## Changes
- `crates/kamn-core/src/task_lifecycle.rs`: added Rustdoc coverage for all public states, transitions, evidence fields, lifecycle methods, and error semantics.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `task_lifecycle` module declaration.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `Regression: #1601` guard ensuring `task_lifecycle` stays graduated.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `task_lifecycle`.
- `docs/planning/engineering-hardening-wave.md`: documented graduated-module progress including `task_lifecycle`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Failing output:
```text
test graduated_wave_three_task_lifecycle_module_must_not_return_to_missing_docs_allowlist ... FAILED
...
task_lifecycle must stay graduated from #[allow(missing_docs)]
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Passing output:
```text
running 5 tests
... ok
... ok
... ok
... ok
... ok

test result: ok. 5 passed; 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test task_state_machine
cargo test -p kamn-core --test engineering_hardening_wave_docs
bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh
cargo fmt --all --check
cargo clippy -p kamn-core --all-targets --all-features -- -D warnings
```
Summary:
```text
All listed commands passed locally.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `missing_docs_policy` regression assertion for `task_lifecycle` | |
| Functional   | ✅ | `task_state_machine` lifecycle behavior remains unchanged | |
| Integration  | ✅ | missing-doc policy checker + clippy/lint suite | |
| Regression   | ✅ | `Regression: #1601` guard prevents allow-list reintroduction | |
| Performance  | N/A | | Documentation-only behavior change |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore previous allow-list state.

## Documentation Updates
- `crates/kamn-core/src/task_lifecycle.rs`
- `docs/planning/engineering-hardening-wave.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant policy and lifecycle suites passed locally

Closes #1601
