### PR TITLE
test(runtime): add deterministic lifecycle replay metadata contract

### DIFF
--- a/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
+++ b/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
@@ -15,3 +15,11 @@ fn regression_requires_live_transport_replay_tamper_contract_markers() {
     assert!(DOC.contains("/tmp/live-transport-replay-tamper-contract-report.json"));
     assert!(DOC.contains("bundle-file /tmp/live-transport-replay-tamper-contract-report.json"));
 }
+
+#[test]
+fn regression_requires_lifecycle_property_replay_metadata_markers() {
+    // Regression: #1605
+    assert!(DOC.contains("kamn.runtime.lifecycle-property-replay-metadata.v1"));
+    assert!(DOC.contains("generated_sequence_bounds"));
+    assert!(DOC.contains("executed_cases"));
+}

--- a/crates/kamn-core/tests/invariants_docs.rs
+++ b/crates/kamn-core/tests/invariants_docs.rs
@@ -5,6 +5,7 @@ fn doc_contains_runtime_invariant_harness_coverage_contract() {
     assert!(DOC.contains("## Runtime Invariant Harness Coverage (Issue #897)"));
     assert!(DOC.contains("run_lifecycle_property_contract_lane.sh"));
     assert!(DOC.contains("kamn.runtime.lifecycle-property-contract-report.v1"));
+    assert!(DOC.contains("kamn.runtime.lifecycle-property-replay-metadata.v1"));
     assert!(DOC.contains("lifecycle_property_replay:v1"));
     assert!(DOC.contains("run_input_mutation_contract_lane.sh"));
     assert!(DOC.contains("kamn.runtime.input-mutation-contract-report.v1"));
@@ -15,6 +16,14 @@ fn doc_contains_runtime_invariant_harness_coverage_contract() {
     assert!(DOC.contains("run_invariant_fuzz_concurrency_contract_lane.sh"));
     assert!(DOC.contains("check_invariant_fuzz_concurrency_policy.sh"));
     assert!(DOC.contains("kamn.runtime.invariant-fuzz-concurrency-contract-report.v1"));
+}
+
+#[test]
+fn regression_requires_lifecycle_property_replay_metadata_contract_markers() {
+    // Regression: #1605
+    assert!(DOC.contains("kamn.runtime.lifecycle-property-replay-metadata.v1"));
+    assert!(DOC.contains("generated_sequence_bounds"));
+    assert!(DOC.contains("executed_cases"));
 }
 
 #[test]

--- a/docs/foundation/invariants.md
+++ b/docs/foundation/invariants.md
@@ -28,8 +28,13 @@ This document defines the canonical transaction invariant catalog and error taxo
   - `bash scripts/runtime/run_lifecycle_property_contract_lane.sh --output-json /tmp/lifecycle-property-contract-report.json`
 - Lifecycle property report schema:
   - `kamn.runtime.lifecycle-property-contract-report.v1`
+- Lifecycle property replay metadata schema:
+  - `kamn.runtime.lifecycle-property-replay-metadata.v1`
 - Lifecycle property replay artifact key:
   - `lifecycle_property_replay:v1`
+- Lifecycle property replay metadata fields:
+  - `executed_cases`
+  - `generated_sequence_bounds`
 - Fuzz/mutation fail-closed lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh --output-json /tmp/input-mutation-contract-report.json`

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -54,6 +54,8 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 
 - Lifecycle property report schema:
   - `kamn.runtime.lifecycle-property-contract-report.v1`
+- Lifecycle property replay metadata schema:
+  - `kamn.runtime.lifecycle-property-replay-metadata.v1`
 - Lifecycle property replay artifact key:
   - `lifecycle_property_replay:v1`
 - Input mutation report schema:
@@ -83,6 +85,9 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `elapsed_seconds`
   - `max_seconds`
   - `reason_codes`
+- Lifecycle property replay metadata contract fields:
+  - `executed_cases`
+  - `generated_sequence_bounds`
 - Required pass reason code:
   - `none`
 - Live transport replay/tamper report schema:

--- a/scripts/runtime/run_lifecycle_property_contract_lane.sh
+++ b/scripts/runtime/run_lifecycle_property_contract_lane.sh
@@ -55,11 +55,13 @@ declare -a property_cases=(
 )
 
 executed_tests=()
+executed_cases=()
 for property_case in "${property_cases[@]}"; do
   test_target="${property_case%%:*}"
   test_name="${property_case#*:}"
   cargo test -p kamn-core --test "$test_target" "$test_name" -- --exact >/dev/null
   executed_tests+=("$test_name")
+  executed_cases+=("$test_target:$test_name")
 done
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
@@ -71,26 +73,42 @@ fi
 if [[ -n "$output_json" ]]; then
   mkdir -p "$(dirname "$output_json")"
   tests_file="$(mktemp)"
-  trap 'rm -f "$tests_file"' EXIT
+  cases_file="$(mktemp)"
+  trap 'rm -f "$tests_file" "$cases_file"' EXIT
   printf '%s\n' "${executed_tests[@]}" >"$tests_file"
+  printf '%s\n' "${executed_cases[@]}" >"$cases_file"
 
-  python3 - "$output_json" "$tests_file" "$elapsed_seconds" "$max_seconds" <<'PY'
+  python3 - "$output_json" "$tests_file" "$cases_file" "$elapsed_seconds" "$max_seconds" <<'PY'
 import json
 import pathlib
 import sys
 
 output_path = pathlib.Path(sys.argv[1])
 tests_path = pathlib.Path(sys.argv[2])
-elapsed_seconds = int(sys.argv[3])
-max_seconds = int(sys.argv[4])
+cases_path = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
 
 tests = [line.strip() for line in tests_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+cases = [line.strip() for line in cases_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+executed_cases = []
+for case in cases:
+    target, name = case.split(":", 1)
+    executed_cases.append({"target": target, "name": name})
+
 payload = {
     "schema_version": "kamn.runtime.lifecycle-property-contract-report.v1",
     "status": "pass",
     "suite": "lifecycle_property_contract_lane",
+    "replay_schema_version": "kamn.runtime.lifecycle-property-replay-metadata.v1",
     "replay_artifact_key": "lifecycle_property_replay:v1",
     "executed_tests": tests,
+    "executed_cases": executed_cases,
+    "generated_sequence_bounds": {
+        "task": {"alphabet_size": 8, "max_sequence_length": 4},
+        "escrow": {"alphabet_size": 5, "max_sequence_length": 4},
+        "peer": {"alphabet_size": 6, "max_sequence_length": 4},
+    },
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
     "reason_codes": ["none"],

--- a/scripts/runtime/test_run_lifecycle_property_contract_lane.sh
+++ b/scripts/runtime/test_run_lifecycle_property_contract_lane.sh
@@ -61,9 +61,18 @@ import sys
 report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert report["schema_version"] == "kamn.runtime.lifecycle-property-contract-report.v1"
 assert report["status"] == "pass"
+assert report["replay_schema_version"] == "kamn.runtime.lifecycle-property-replay-metadata.v1"
 assert report["replay_artifact_key"] == "lifecycle_property_replay:v1"
 assert report["reason_codes"] == ["none"]
 assert len(report["executed_tests"]) >= 12
+assert len(report["executed_cases"]) == len(report["executed_tests"])
+assert all("target" in case and "name" in case for case in report["executed_cases"])
+assert report["generated_sequence_bounds"]["task"]["alphabet_size"] == 8
+assert report["generated_sequence_bounds"]["task"]["max_sequence_length"] == 4
+assert report["generated_sequence_bounds"]["escrow"]["alphabet_size"] == 5
+assert report["generated_sequence_bounds"]["escrow"]["max_sequence_length"] == 4
+assert report["generated_sequence_bounds"]["peer"]["alphabet_size"] == 6
+assert report["generated_sequence_bounds"]["peer"]["max_sequence_length"] == 4
 assert "integration_dispute_refund_replay_traces_are_deterministic" in report["executed_tests"]
 assert "peer_lifecycle_property_sequence_replay_is_deterministic" in report["executed_tests"]
 PY


### PR DESCRIPTION
## Summary
Added deterministic replay metadata contracts to the lifecycle property contract lane so generated transition coverage is reproducible and auditable beyond plain test names. Updated lane tests and documentation contracts to enforce replay schema/version/bounds markers.

## Changes
- `scripts/runtime/run_lifecycle_property_contract_lane.sh`: emits replay metadata fields:
  - `replay_schema_version = kamn.runtime.lifecycle-property-replay-metadata.v1`
  - `executed_cases` (`target` + `name` pairs)
  - `generated_sequence_bounds` for task/escrow/peer generated alphabets and sequence depth
- `scripts/runtime/test_run_lifecycle_property_contract_lane.sh`: enforces new replay metadata fields and deterministic bounds.
- `docs/foundation/invariants.md`: documents lifecycle replay metadata schema + contract fields.
- `docs/testing/invariant-and-fuzz-strategy.md`: documents replay metadata schema + required replay fields.
- `crates/kamn-core/tests/invariants_docs.rs`: added regression guard for replay metadata markers (`Regression: #1605`).
- `crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs`: added regression guard for replay metadata markers (`Regression: #1605`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_run_lifecycle_property_contract_lane.sh
```
Failing output:
```text
KeyError: 'replay_schema_version'
```

### 🟢 Green Phase
Command:
```bash
bash scripts/runtime/test_run_lifecycle_property_contract_lane.sh
```
Passing output:
```text
runtime lifecycle property contract lane script tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/runtime/test_run_lifecycle_property_contract_lane.sh
cargo test -p kamn-core --test invariants_docs
cargo test -p kamn-core --test invariant_and_fuzz_strategy_docs
bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
cargo clippy -p kamn-core --all-targets --all-features -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
Summary:
```text
All listed commands passed locally.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | replay metadata assertions in `test_run_lifecycle_property_contract_lane.sh` | |
| Functional   | ✅ | lifecycle property lane emits deterministic replay metadata contract | |
| Integration  | ✅ | invariant/fuzz/concurrency lane and policy checker stay green | |
| Regression   | ✅ | docs contract markers enforced with `Regression: #1605` | |
| Performance  | ✅ | no runtime expansion; existing bounded sequence-depth unchanged | |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore previous lifecycle property report shape.

## Documentation Updates
- `docs/foundation/invariants.md`
- `docs/testing/invariant-and-fuzz-strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant runtime lane + policy suites passed locally

Closes #1605
