### PR TITLE
feat(runtime): add bounded envelope/did mutation smoke targets (#1607)

### DIFF
--- a/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
+++ b/crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs
@@ -23,3 +23,13 @@ fn regression_requires_lifecycle_property_replay_metadata_markers() {
     assert!(DOC.contains("generated_sequence_bounds"));
     assert!(DOC.contains("executed_cases"));
 }
+
+#[test]
+fn regression_requires_input_mutation_targeted_smoke_markers() {
+    // Regression: #1607
+    assert!(DOC.contains("--target envelope"));
+    assert!(DOC.contains("--target did"));
+    assert!(DOC.contains("kamn.runtime.input-mutation-replay-metadata.v1"));
+    assert!(DOC.contains("input_mutation_envelope_seed:v1"));
+    assert!(DOC.contains("input_mutation_did_seed:v1"));
+}

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -194,6 +194,11 @@ fn regression_requires_rejoin_and_overflow_rejection_rules() {
 fn doc_contains_mutation_fail_closed_contract_rules() {
     assert!(DOC.contains("All mutation corpus entries must fail closed"));
     assert!(DOC.contains("typed errors and stable reason strings"));
+    assert!(DOC.contains("--target envelope"));
+    assert!(DOC.contains("--target did"));
+    assert!(DOC.contains("kamn.runtime.input-mutation-replay-metadata.v1"));
+    assert!(DOC.contains("input_mutation_envelope_seed:v1"));
+    assert!(DOC.contains("input_mutation_did_seed:v1"));
     assert!(DOC.contains("Regression: #843"));
 }
 

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -138,6 +138,8 @@ This document captures the initial runtime-network foundation slice for peer lif
 - All mutation corpus entries must fail closed with explicit typed errors and stable reason strings.
 - Fast contract lane command:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
+  - `bash scripts/runtime/run_input_mutation_contract_lane.sh --target envelope --output-json /tmp/input-mutation-envelope-smoke-report.json`
+  - `bash scripts/runtime/run_input_mutation_contract_lane.sh --target did --output-json /tmp/input-mutation-did-smoke-report.json`
 - Processor proof admission guard lane command:
   - `bash scripts/runtime/run_processor_proof_admission_contract_lane.sh`
 - Processor proof admission fail-closed rules:
@@ -145,6 +147,11 @@ This document captures the initial runtime-network foundation slice for peer lif
   - payload commitment mismatch
   - invalid proof format
   - replayed artifact id
+- Input mutation replay metadata schema:
+  - `kamn.runtime.input-mutation-replay-metadata.v1`
+- Input mutation seed corpus keys:
+  - `input_mutation_envelope_seed:v1`
+  - `input_mutation_did_seed:v1`
 
 ## Deterministic Concurrency Harness Rules
 - Shared-state mutation harness in `crates/kamn-core/tests/concurrency_state_mutation.rs` must enforce:

--- a/docs/testing/invariant-and-fuzz-strategy.md
+++ b/docs/testing/invariant-and-fuzz-strategy.md
@@ -17,6 +17,10 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 - Mutation/fuzz smoke lane:
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh`
   - `bash scripts/runtime/run_input_mutation_contract_lane.sh --output-json /tmp/input-mutation-contract-report.json`
+  - local envelope-only bounded run:
+    - `bash scripts/runtime/run_input_mutation_contract_lane.sh --target envelope --output-json /tmp/input-mutation-envelope-smoke-report.json`
+  - local DID-only bounded run:
+    - `bash scripts/runtime/run_input_mutation_contract_lane.sh --target did --output-json /tmp/input-mutation-did-smoke-report.json`
 - Concurrency race lane:
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh`
   - `bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh --output-json /tmp/concurrency-mutation-contract-report.json`
@@ -60,8 +64,13 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
   - `lifecycle_property_replay:v1`
 - Input mutation report schema:
   - `kamn.runtime.input-mutation-contract-report.v1`
+- Input mutation replay metadata schema:
+  - `kamn.runtime.input-mutation-replay-metadata.v1`
 - Input mutation replay artifact key:
   - `input_mutation_replay:v1`
+  - seed corpus keys:
+    - `input_mutation_envelope_seed:v1`
+    - `input_mutation_did_seed:v1`
 - Concurrency mutation report schema:
   - `kamn.runtime.concurrency-mutation-contract-report.v1`
 - Concurrency mutation replay artifact key:
@@ -88,6 +97,9 @@ invariants, mutation/fuzz smoke checks, and concurrency race contracts.
 - Lifecycle property replay metadata contract fields:
   - `executed_cases`
   - `generated_sequence_bounds`
+- Input mutation replay metadata contract fields:
+  - `target`
+  - `seed_corpus_keys`
 - Required pass reason code:
   - `none`
 - Live transport replay/tamper report schema:

--- a/scripts/runtime/run_input_mutation_contract_lane.sh
+++ b/scripts/runtime/run_input_mutation_contract_lane.sh
@@ -5,6 +5,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   bash scripts/runtime/run_input_mutation_contract_lane.sh \
+    [--target <all|envelope|did>] \
     [--output-json <path>]
 USAGE
 }
@@ -15,10 +16,15 @@ ZK_WITNESS_MUTATION_DEEP_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation
 cd "$ROOT_DIR"
 
 output_json=""
+target_selector="all"
 max_seconds="${KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS:-120}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --target)
+      target_selector="${2:-}"
+      shift 2
+      ;;
     --output-json)
       output_json="${2:-}"
       shift 2
@@ -36,6 +42,11 @@ done
 
 if [[ ! "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
   echo "KAMN_RUNTIME_INPUT_MUTATION_MAX_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+
+if [[ "$target_selector" != "all" && "$target_selector" != "envelope" && "$target_selector" != "did" ]]; then
+  echo "--target must be one of: all, envelope, did" >&2
   exit 1
 fi
 
@@ -57,23 +68,37 @@ declare -a did_cases=(
 
 start_epoch="$(date +%s)"
 
-for case_name in "${envelope_cases[@]}"; do
-  cargo test -p kamn-core --test message_envelope_fuzz_smoke "$case_name" -- --exact >/dev/null
-done
+executed_envelope_cases=()
+executed_did_cases=()
 
-for case_name in "${did_cases[@]}"; do
-  cargo test -p kamn-core --test did_fuzz_smoke "$case_name" -- --exact >/dev/null
-done
-
-zk_lane_mode="fast"
-if [ "${KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP:-false}" = "true" ]; then
-  zk_lane_mode="deep"
-  bash "$ZK_WITNESS_MUTATION_DEEP_LANE" >/dev/null
-else
-  bash "$ZK_WITNESS_MUTATION_LANE" >/dev/null
+if [[ "$target_selector" != "did" ]]; then
+  for case_name in "${envelope_cases[@]}"; do
+    cargo test -p kamn-core --test message_envelope_fuzz_smoke "$case_name" -- --exact >/dev/null
+    executed_envelope_cases+=("$case_name")
+  done
 fi
 
-cargo test -p kamn-core --test runtime_network_docs doc_contains_mutation_fail_closed_contract_rules -- --exact >/dev/null
+if [[ "$target_selector" != "envelope" ]]; then
+  for case_name in "${did_cases[@]}"; do
+    cargo test -p kamn-core --test did_fuzz_smoke "$case_name" -- --exact >/dev/null
+    executed_did_cases+=("$case_name")
+  done
+fi
+
+zk_lane_mode="not-run"
+if [[ "$target_selector" == "all" ]]; then
+  zk_lane_mode="fast"
+  if [ "${KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP:-false}" = "true" ]; then
+    zk_lane_mode="deep"
+    bash "$ZK_WITNESS_MUTATION_DEEP_LANE" >/dev/null
+  else
+    bash "$ZK_WITNESS_MUTATION_LANE" >/dev/null
+  fi
+
+  cargo test -p kamn-core --test runtime_network_docs doc_contains_mutation_fail_closed_contract_rules -- --exact >/dev/null
+else
+  :
+fi
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
 if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
@@ -86,13 +111,14 @@ if [[ -n "$output_json" ]]; then
   envelope_cases_file="$(mktemp)"
   did_cases_file="$(mktemp)"
   trap 'rm -f "$envelope_cases_file" "$did_cases_file"' EXIT
-  printf '%s\n' "${envelope_cases[@]}" >"$envelope_cases_file"
-  printf '%s\n' "${did_cases[@]}" >"$did_cases_file"
+  printf '%s\n' "${executed_envelope_cases[@]}" >"$envelope_cases_file"
+  printf '%s\n' "${executed_did_cases[@]}" >"$did_cases_file"
 
   python3 - \
     "$output_json" \
     "$envelope_cases_file" \
     "$did_cases_file" \
+    "$target_selector" \
     "$zk_lane_mode" \
     "$elapsed_seconds" \
     "$max_seconds" <<'PY'
@@ -103,9 +129,10 @@ import sys
 output_path = pathlib.Path(sys.argv[1])
 envelope_cases_path = pathlib.Path(sys.argv[2])
 did_cases_path = pathlib.Path(sys.argv[3])
-zk_lane_mode = sys.argv[4]
-elapsed_seconds = int(sys.argv[5])
-max_seconds = int(sys.argv[6])
+target = sys.argv[4]
+zk_lane_mode = sys.argv[5]
+elapsed_seconds = int(sys.argv[6])
+max_seconds = int(sys.argv[7])
 
 envelope_cases = [
     line.strip()
@@ -122,7 +149,13 @@ payload = {
     "schema_version": "kamn.runtime.input-mutation-contract-report.v1",
     "status": "pass",
     "suite": "input_mutation_contract_lane",
+    "target": target,
+    "replay_schema_version": "kamn.runtime.input-mutation-replay-metadata.v1",
     "replay_artifact_key": "input_mutation_replay:v1",
+    "seed_corpus_keys": {
+        "envelope": "input_mutation_envelope_seed:v1",
+        "did": "input_mutation_did_seed:v1",
+    },
     "envelope_tests": envelope_cases,
     "did_tests": did_cases,
     "envelope_test_count": len(envelope_cases),

--- a/scripts/runtime/test_run_input_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_input_mutation_contract_lane.sh
@@ -41,6 +41,11 @@ if ! grep -q "KAMN_RUNTIME_ZK_WITNESS_MUTATION_DEEP" "$CONTRACT_LANE"; then
   exit 1
 fi
 
+if ! grep -q -- "--target" "$CONTRACT_LANE"; then
+  echo "expected mutation lane to expose --target selector for bounded local envelope/did smoke runs" >&2
+  exit 1
+fi
+
 report_file="$TMP_DIR/input-mutation-contract-report.json"
 lane_output="$(bash "$CONTRACT_LANE" --output-json "$report_file")"
 if ! printf '%s\n' "$lane_output" | grep -q "runtime input mutation contract lane tests passed."; then
@@ -61,10 +66,43 @@ import sys
 report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert report["schema_version"] == "kamn.runtime.input-mutation-contract-report.v1"
 assert report["status"] == "pass"
+assert report["target"] == "all"
+assert report["replay_schema_version"] == "kamn.runtime.input-mutation-replay-metadata.v1"
 assert report["replay_artifact_key"] == "input_mutation_replay:v1"
 assert report["reason_codes"] == ["none"]
 assert report["envelope_test_count"] >= 5
 assert report["did_test_count"] >= 5
+assert report["seed_corpus_keys"]["envelope"] == "input_mutation_envelope_seed:v1"
+assert report["seed_corpus_keys"]["did"] == "input_mutation_did_seed:v1"
+assert report["zk_witness_lane_mode"] in {"fast", "deep"}
+PY
+
+envelope_report_file="$TMP_DIR/input-mutation-envelope-smoke-report.json"
+bash "$CONTRACT_LANE" --target envelope --output-json "$envelope_report_file" >/dev/null
+python3 - "$envelope_report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["target"] == "envelope"
+assert report["envelope_test_count"] >= 5
+assert report["did_test_count"] == 0
+assert report["zk_witness_lane_mode"] == "not-run"
+PY
+
+did_report_file="$TMP_DIR/input-mutation-did-smoke-report.json"
+bash "$CONTRACT_LANE" --target did --output-json "$did_report_file" >/dev/null
+python3 - "$did_report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["target"] == "did"
+assert report["envelope_test_count"] == 0
+assert report["did_test_count"] >= 5
+assert report["zk_witness_lane_mode"] == "not-run"
 PY
 
 echo "runtime input mutation contract lane script tests passed."


### PR DESCRIPTION
## Summary
Add bounded local `--target` selectors to the runtime input mutation contract lane so envelope-only and DID-only fuzz smoke runs can execute cheaply without always running the full lane. Extend replay metadata and docs/contracts so targeted runs, deterministic seed corpus keys, and replay schema are explicit and test-enforced.

## Changes
- `scripts/runtime/run_input_mutation_contract_lane.sh`: add `--target <all|envelope|did>`, bounded target routing, selective execution accounting, replay metadata schema + seed corpus keys in JSON output.
- `scripts/runtime/test_run_input_mutation_contract_lane.sh`: add contract assertions for `--target` support and target-specific report invariants.
- `docs/testing/invariant-and-fuzz-strategy.md`: add envelope/DID targeted commands and replay metadata markers.
- `docs/foundation/runtime-network.md`: add targeted commands and replay metadata/seed corpus key markers.
- `crates/kamn-core/tests/invariant_and_fuzz_strategy_docs.rs`: add regression doc-contract assertions for targeted markers (`Regression: #1607`).
- `crates/kamn-core/tests/runtime_network_docs.rs`: extend mutation fail-closed doc-contract assertions with targeted/replay markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_run_input_mutation_contract_lane.sh
```
Output:
```text
expected mutation lane to expose --target selector for bounded local envelope/did smoke runs
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/runtime/test_run_input_mutation_contract_lane.sh
cargo test -p kamn-core --test runtime_network_docs doc_contains_mutation_fail_closed_contract_rules -- --exact
cargo test -p kamn-core --test invariant_and_fuzz_strategy_docs
```
All passed.

### 🔁 Regression
Commands:
```bash
bash scripts/runtime/test_run_invariant_fuzz_concurrency_contract_lane.sh
bash scripts/runtime/test_check_invariant_fuzz_concurrency_policy.sh
cargo fmt --all --check
cargo clippy -p kamn-core --all-targets --all-features -- -D warnings
bash scripts/ci/test_select_targets.sh
```
All passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing unit-level parser mutation cases are exercised via targeted lane execution paths. | |
| Functional   | ✅ | `scripts/runtime/test_run_input_mutation_contract_lane.sh` target-mode assertions (`all/envelope/did`). | |
| Integration  | ✅ | `runtime_network_docs` + selector/policy lane checks ensure command surface and docs remain aligned. | |
| Regression   | ✅ | New `Regression: #1607` doc-contract assertions in `invariant_and_fuzz_strategy_docs.rs`; fail-closed marker assertions retained/extended. | |
| Performance  | ✅ | Bounded local target routing avoids full-lane costs for envelope/DID smoke runs; runtime budget contract remains enforced. | |

## Risks & Rollback
- No breaking API changes outside lane CLI surface (`--target` added, default remains `all`).
- Rollback: revert this PR to restore previous full-lane-only behavior.

## Documentation Updates
- `docs/testing/invariant-and-fuzz-strategy.md`
- `docs/foundation/runtime-network.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Unit/Functional/Integration/Regression coverage addressed or justified

Closes #1607
