### PR TITLE
docs(kolme): codify localhost demo contract markers (#1612)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario replay-n
 bash scripts/sdk/run_localhost_signed_integration_harness.sh --scenario admission-guards
 ```
 
+Kolme local-operability alignment for this localhost demo path is documented in:
+`docs/planning/kolme-devnet-ops.md#localhost-two-process-signed-message-demo-contract-issue-1612`.
+
 ### Run Localhost Bridge Relay Demo Lane
 
 ```bash

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -208,6 +208,27 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - lane default budget is bounded to 210 seconds with per-stage budget caps.
   - local KAMN live runtime integration run-mode execution remains excluded from PR fast-gate workflow routing.
 
+## Localhost Two-Process Signed-Message Demo Contract (Issue #1612)
+
+- Makefile demo command:
+  - `make demo-localhost-transport`
+- Direct localhost sender/listener demo command:
+  - `bash scripts/sdk/run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json`
+- Demo artifact schema:
+  - `kamn.sdk.localhost-signed.demo-receipt-artifact.v1`
+- Localhost signed integration contract commands:
+  - `bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed-integration-contract-report.json`
+  - `bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json`
+- Integration contract schema:
+  - `kamn.sdk.localhost-signed.integration-contract.v1`
+- Deterministic success markers:
+  - `localhost signed message demo completed.`
+  - `localhost signed integration contract lane tests passed.`
+- Cost policy:
+  - two-process localhost sender/listener demo remains bounded local smoke usage.
+  - explicit local-heavy Kolme opt-in remains limited to heavy lanes and is not required for this demo path.
+  - demo contract markers remain deterministic to keep onboarding checks local-fast.
+
 ## Local Kolme Fork Process Lifecycle Integration Lane (Issue #1494)
 
 - Local fork process lifecycle runner:
@@ -372,6 +393,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - native parity fast/local command matrix docs drift remains fail-closed (`Regression: #1468`).
 - local probe fork-info query semantics and native parity broadcast method drift remain fail-closed (`Regression: #1482`).
 - block fallback stale-window and response-height drift remains fail-closed (`Regression: #1464`).
+- localhost two-process signed-demo command/schema markers remain fail-closed across README and Kolme devnet ops docs (`Regression: #1612`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -7,6 +7,7 @@ LOCAL_HEAVY_GUARD="$ROOT_DIR/scripts/framework/assert_local_heavy_opt_in.sh"
 CHECKER="$ROOT_DIR/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py"
 CONTRACT_LANE="$ROOT_DIR/scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT="$(mktemp)"
 TMP_POLICY="$(mktemp)"
@@ -78,6 +79,56 @@ fi
 
 if ! grep -q "run_local_kamn_live_runtime_integration_contract_lane.sh" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference local KAMN live runtime integration contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q "run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed demo artifact command" >&2
+  exit 1
+fi
+
+if ! grep -q "kamn.sdk.localhost-signed.demo-receipt-artifact.v1" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed demo artifact schema" >&2
+  exit 1
+fi
+
+if ! grep -q "run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed-integration-contract-report.json" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed integration contract lane command" >&2
+  exit 1
+fi
+
+if ! grep -q "check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed integration evidence policy command" >&2
+  exit 1
+fi
+
+if ! grep -q "kamn.sdk.localhost-signed.integration-contract.v1" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed integration contract schema" >&2
+  exit 1
+fi
+
+if ! grep -q "run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json" "$README_FILE"; then
+  echo "expected README to reference localhost signed demo artifact command" >&2
+  exit 1
+fi
+
+if ! grep -q "kamn.sdk.localhost-signed.demo-receipt-artifact.v1" "$README_FILE"; then
+  echo "expected README to reference localhost signed demo artifact schema" >&2
+  exit 1
+fi
+
+if ! grep -q "run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed-integration-contract-report.json" "$README_FILE"; then
+  echo "expected README to reference localhost signed integration contract lane command" >&2
+  exit 1
+fi
+
+if ! grep -q "check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json" "$README_FILE"; then
+  echo "expected README to reference localhost signed integration evidence policy command" >&2
+  exit 1
+fi
+
+if ! grep -q "kamn.sdk.localhost-signed.integration-contract.v1" "$README_FILE"; then
+  echo "expected README to reference localhost signed integration contract schema" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Codify the two-process localhost signed-message demo contract in `docs/planning/kolme-devnet-ops.md` and enforce drift checks against `README.md`. This closes a documentation-alignment gap for local KAMN + `kolme_fork` onboarding without expanding CI cost.

## Changes
- `docs/planning/kolme-devnet-ops.md`: add explicit localhost two-process demo command path, schema/success markers, and regression marker.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: add fail-closed assertions for localhost demo/integration command + schema markers in both devnet ops docs and README.
- `README.md`: add direct cross-reference to the Kolme devnet ops localhost demo contract section.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
```
Output:
```text
expected Kolme devnet ops doc to reference localhost signed demo artifact command
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
bash scripts/ci/test_readme_contract.sh
```
All passed.

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_tools.sh
cargo fmt --all --check
cargo clippy -p kamn-core --all-targets --all-features -- -D warnings
```
All passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Added deterministic marker assertions in `test_run_local_kamn_live_runtime_integration_contract_lane.sh` for docs command/schema strings. | |
| Functional   | ✅ | Contract-lane test validates expected localhost demo command path and markers. | |
| Integration  | ✅ | `test_ci_tools.sh` and `test_select_targets.sh` verify CI/docs/command-surface alignment remains green. | |
| Regression   | ✅ | New fail-closed checks for localhost demo marker drift plus `Regression: #1612` doc marker. | |
| Performance  | ✅ | Change is docs/contracts only and keeps local-fast bounded checks; no local-heavy CI expansion. | |

## Risks & Rollback
- Risk is low and limited to documentation/test-contract drift if markers are edited without synchronized updates.
- Rollback: revert this PR to restore prior docs/test expectations.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Unit/Functional/Integration/Regression coverage addressed or justified

Closes #1612
