### PR TITLE
feat(sdk): add localhost signed demo contract lane (#1609)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-
 CI fast-gate routes this lane when selector output
 `run_localhost_signed_integration_contract_lane_tests` is `true`.
 
+### Run Localhost Signed Demo Contract Lane
+
+```bash
+bash scripts/sdk/run_localhost_signed_demo_contract_lane.sh \
+  --output-json /tmp/localhost-signed-demo-contract-report.json
+# schema: kamn.sdk.localhost-signed.demo-contract.v1
+# localhost_signed_demo_status=pass
+# localhost_signed_integration_status=pass
+# localhost signed demo contract lane tests passed.
+```
+
 ### Run Live Transport Replay/Tamper Contract Lane
 
 ```bash

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -221,9 +221,15 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/sdk/check_localhost_signed_integration_evidence_policy.sh --report-file /tmp/localhost-signed-integration-contract-report.json`
 - Integration contract schema:
   - `kamn.sdk.localhost-signed.integration-contract.v1`
+- Localhost signed demo contract lane command:
+  - `bash scripts/sdk/run_localhost_signed_demo_contract_lane.sh --output-json /tmp/localhost-signed-demo-contract-report.json`
+- Demo contract lane schema:
+  - `kamn.sdk.localhost-signed.demo-contract.v1`
 - Deterministic success markers:
   - `localhost signed message demo completed.`
   - `localhost signed integration contract lane tests passed.`
+  - `localhost_signed_demo_status=pass`
+  - `localhost_signed_integration_status=pass`
 - Cost policy:
   - two-process localhost sender/listener demo remains bounded local smoke usage.
   - explicit local-heavy Kolme opt-in remains limited to heavy lanes and is not required for this demo path.
@@ -394,6 +400,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local probe fork-info query semantics and native parity broadcast method drift remain fail-closed (`Regression: #1482`).
 - block fallback stale-window and response-height drift remains fail-closed (`Regression: #1464`).
 - localhost two-process signed-demo command/schema markers remain fail-closed across README and Kolme devnet ops docs (`Regression: #1612`).
+- localhost signed demo contract-lane status markers remain fail-closed (`Regression: #1609`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -76,6 +76,7 @@ bash "$ROOT_DIR/scripts/ci/run_with_retry.sh" \
   --max-attempts 2 \
   -- bash "$ROOT_DIR/scripts/sdk/test_run_rust_live_transport_contract_lane.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_demo.sh"
+bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_integration_harness.sh"
 bash "$ROOT_DIR/scripts/sdk/test_check_localhost_signed_integration_evidence_policy.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh"

--- a/scripts/sdk/run_localhost_signed_demo_contract_lane.sh
+++ b/scripts/sdk/run_localhost_signed_demo_contract_lane.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF_USAGE'
+Usage: run_localhost_signed_demo_contract_lane.sh [options]
+
+Options:
+  --output-json <path>   Write localhost signed demo contract lane report JSON.
+  --max-seconds <n>      Runtime budget in seconds (default: 180 or env override).
+  --help                 Show this help output.
+
+Environment:
+  KAMN_LOCALHOST_SIGNED_DEMO_CONTRACT_MAX_SECONDS
+EOF_USAGE
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEMO_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_demo.sh"
+INTEGRATION_CONTRACT_LANE="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
+
+output_json=""
+max_seconds="${KAMN_LOCALHOST_SIGNED_DEMO_CONTRACT_MAX_SECONDS:-180}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      if [ -z "$output_json" ]; then
+        echo "missing value for --output-json" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      if [ -z "$max_seconds" ]; then
+        echo "missing value for --max-seconds" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "max-seconds must be a positive integer" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEMO_SCRIPT" ]; then
+  echo "expected localhost signed demo script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$INTEGRATION_CONTRACT_LANE" ]; then
+  echo "expected localhost signed integration contract lane script to be executable" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+demo_artifact="$TMP_DIR/localhost-signed-demo-artifact.json"
+integration_report="$TMP_DIR/localhost-signed-integration-contract-report.json"
+
+start_epoch="$(date +%s)"
+
+demo_output="$(bash "$DEMO_SCRIPT" --output-json "$demo_artifact")"
+if ! printf '%s\n' "$demo_output" | grep -q "localhost signed message demo completed."; then
+  echo "expected localhost signed demo completion marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$demo_output" | grep -q "artifact_schema=kamn.sdk.localhost-signed.demo-receipt-artifact.v1"; then
+  echo "expected localhost signed demo artifact schema marker" >&2
+  exit 1
+fi
+
+integration_output="$(bash "$INTEGRATION_CONTRACT_LANE" --output-json "$integration_report")"
+if ! printf '%s\n' "$integration_output" | grep -q "localhost signed integration contract lane tests passed."; then
+  echo "expected localhost signed integration contract lane completion marker" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "localhost signed demo contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+if [ -n "$output_json" ]; then
+  mkdir -p "$(dirname "$output_json")"
+  python3 - \
+    "$demo_artifact" \
+    "$integration_report" \
+    "$output_json" \
+    "$elapsed_seconds" \
+    "$max_seconds" <<'PY'
+import json
+import pathlib
+import sys
+
+demo_artifact_path = pathlib.Path(sys.argv[1])
+integration_report_path = pathlib.Path(sys.argv[2])
+output_path = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
+
+demo_artifact = json.loads(demo_artifact_path.read_text(encoding="utf-8"))
+integration_report = json.loads(integration_report_path.read_text(encoding="utf-8"))
+
+if demo_artifact.get("schema_version") != "kamn.sdk.localhost-signed.demo-receipt-artifact.v1":
+    raise SystemExit("unexpected localhost signed demo artifact schema")
+if demo_artifact.get("status") != "pass":
+    raise SystemExit("expected localhost signed demo artifact status=pass")
+
+if integration_report.get("schema_version") != "kamn.sdk.localhost-signed.integration-contract.v1":
+    raise SystemExit("unexpected localhost signed integration report schema")
+if integration_report.get("status") != "pass":
+    raise SystemExit("expected localhost signed integration report status=pass")
+
+payload = {
+    "schema_version": "kamn.sdk.localhost-signed.demo-contract.v1",
+    "status": "pass",
+    "suite": "localhost_signed_demo_contract_lane",
+    "demo_artifact_schema": "kamn.sdk.localhost-signed.demo-receipt-artifact.v1",
+    "integration_report_schema": "kamn.sdk.localhost-signed.integration-contract.v1",
+    "demo_status": "pass",
+    "integration_status": "pass",
+    "demo_success_marker": "localhost signed message demo completed.",
+    "integration_success_marker": "localhost signed integration contract lane tests passed.",
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "budget_status": "within_budget",
+    "reason_codes": ["none"],
+}
+output_path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+PY
+  echo "localhost_signed_demo_contract_report=$output_json"
+fi
+
+echo "localhost_signed_demo_status=pass"
+echo "localhost_signed_integration_status=pass"
+echo "localhost signed demo contract lane tests passed."

--- a/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_demo_contract_lane.sh"
+DEMO_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_demo.sh"
+INTEGRATION_CONTRACT_LANE="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
+INTEGRATION_POLICY="$ROOT_DIR/scripts/sdk/check_localhost_signed_integration_evidence_policy.sh"
+README_FILE="$ROOT_DIR/README.md"
+DEVNET_DOC="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected localhost signed demo contract lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEMO_SCRIPT" ]; then
+  echo "expected localhost signed demo script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$INTEGRATION_CONTRACT_LANE" ]; then
+  echo "expected localhost signed integration contract lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$INTEGRATION_POLICY" ]; then
+  echo "expected localhost signed integration evidence policy checker to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "run_localhost_signed_demo_contract_lane.sh" "$README_FILE"; then
+  echo "expected README to reference localhost signed demo contract lane command" >&2
+  exit 1
+fi
+
+if ! grep -q "/tmp/localhost-signed-demo-contract-report.json" "$README_FILE"; then
+  echo "expected README to reference localhost signed demo contract lane report path" >&2
+  exit 1
+fi
+
+if ! grep -q "run_localhost_signed_demo_contract_lane.sh" "$DEVNET_DOC"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed demo contract lane command" >&2
+  exit 1
+fi
+
+if ! grep -q "/tmp/localhost-signed-demo-contract-report.json" "$DEVNET_DOC"; then
+  echo "expected Kolme devnet ops doc to reference localhost signed demo contract lane report path" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/localhost-signed-demo-contract-report.json"
+lane_output="$(bash "$LANE_SCRIPT" --output-json "$report_file")"
+
+for marker in \
+  "localhost_signed_demo_status=pass" \
+  "localhost_signed_integration_status=pass" \
+  "localhost signed demo contract lane tests passed." \
+  "localhost_signed_demo_contract_report=$report_file"; do
+  if ! printf '%s\n' "$lane_output" | grep -q "$marker"; then
+    echo "expected localhost signed demo contract lane marker '$marker'" >&2
+    exit 1
+  fi
+done
+
+python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["schema_version"] == "kamn.sdk.localhost-signed.demo-contract.v1"
+assert report["status"] == "pass"
+assert report["reason_codes"] == ["none"]
+assert report["demo_artifact_schema"] == "kamn.sdk.localhost-signed.demo-receipt-artifact.v1"
+assert report["integration_report_schema"] == "kamn.sdk.localhost-signed.integration-contract.v1"
+assert report["demo_status"] == "pass"
+assert report["integration_status"] == "pass"
+assert report["budget_status"] == "within_budget"
+PY
+
+echo "localhost signed demo contract lane script tests passed."


### PR DESCRIPTION
## Summary
Add a deterministic localhost signed-demo contract lane that composes the two-process sender/listener demo with the localhost signed integration contract lane into one bounded local run. This closes the remaining story child task for a reproducible local demo path while keeping CI cost local-fast and bounded.

## Changes
- `scripts/sdk/run_localhost_signed_demo_contract_lane.sh`: new bounded contract lane wrapper; validates demo + integration success markers and emits report schema `kamn.sdk.localhost-signed.demo-contract.v1`.
- `scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`: new fail-closed lane test including README/devnet docs command-marker assertions.
- `scripts/ci/test_ci_tools.sh`: include new lane test in CI tools regression suite.
- `README.md`: add localhost signed demo contract lane command + schema markers.
- `docs/planning/kolme-devnet-ops.md`: add localhost signed demo contract lane command/schema/status markers and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh
```
Output:
```text
expected localhost signed demo contract lane script to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh
bash scripts/sdk/test_run_localhost_signed_demo.sh
bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
```
All passed.

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_readme_contract.sh
bash scripts/ci/test_select_targets.sh
bash scripts/ci/test_ci_tools.sh
cargo fmt --all --check
cargo clippy -p kamn-core --all-targets --all-features -- -D warnings
```
All passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Marker/report invariant assertions in `test_run_localhost_signed_demo_contract_lane.sh`. | |
| Functional   | ✅ | New lane runs deterministic two-process localhost demo and integration contract lane end-to-end. | |
| Integration  | ✅ | `test_ci_tools.sh` + `test_select_targets.sh` + README/devnet doc marker checks keep command surface aligned. | |
| Regression   | ✅ | Fail-closed checks for missing lane/doc markers + `Regression: #1609` doc marker. | |
| Performance  | ✅ | Lane enforces bounded runtime via `--max-seconds`/`KAMN_LOCALHOST_SIGNED_DEMO_CONTRACT_MAX_SECONDS`; no local-heavy CI expansion. | |

## Risks & Rollback
- Low risk; change is additive script/doc/test contracts.
- Rollback: revert this PR to remove the lane and marker checks.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Unit/Functional/Integration/Regression coverage addressed or justified

Closes #1609
