### PR TITLE
refactor(sdk): extract shared localhost signed report composer (#1617)

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -223,6 +223,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `kamn.sdk.localhost-signed.integration-contract.v1`
 - Localhost signed demo contract lane command:
   - `bash scripts/sdk/run_localhost_signed_demo_contract_lane.sh --output-json /tmp/localhost-signed-demo-contract-report.json`
+- Shared report composer helper:
+  - `scripts/sdk/localhost_signed_report_composer.py` (used by demo and integration contract wrappers to keep report schema/marker composition deterministic)
 - Demo contract lane schema:
   - `kamn.sdk.localhost-signed.demo-contract.v1`
 - Deterministic success markers:
@@ -401,6 +403,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - block fallback stale-window and response-height drift remains fail-closed (`Regression: #1464`).
 - localhost two-process signed-demo command/schema markers remain fail-closed across README and Kolme devnet ops docs (`Regression: #1612`).
 - localhost signed demo contract-lane status markers remain fail-closed (`Regression: #1609`).
+- localhost signed demo/integration report composition remains centralized via shared helper wiring (`Regression: #1617`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -75,6 +75,7 @@ bash "$ROOT_DIR/scripts/ci/run_with_retry.sh" \
   --label "sdk-rust-live-transport-contract-lane" \
   --max-attempts 2 \
   -- bash "$ROOT_DIR/scripts/sdk/test_run_rust_live_transport_contract_lane.sh"
+bash "$ROOT_DIR/scripts/sdk/test_localhost_signed_report_composer.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_demo.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_integration_harness.sh"

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -18,6 +18,9 @@ ROOT_DIR = SCRIPT_DIR.parent.parent
 sys.path.insert(0, str(SCRIPT_DIR.parent))
 
 from framework.contract_framework import ContractError, fail, load_json  # noqa: E402
+from localhost_signed_report_composer import (  # noqa: E402
+    compose_localhost_signed_integration_contract_report,
+)
 
 
 def _is_executable(path: Path) -> bool:
@@ -377,53 +380,17 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         session_expired_payload = load_json(session_expired_report)
         replay_payload = load_json(replay_report)
         admission_payload = load_json(admission_report)
-        summary = {
-            "schema_version": "kamn.sdk.localhost-signed.integration-contract.v1",
-            "status": "pass",
-            "final_decision": "GO",
-            "contract_key": "localhost_signed_integration_contract:v1",
-            "scenario_fixture_schema_version": fixture_schema_version,
-            "scenario_fixture_ids": scenario_fixture_ids,
-            "success_scenario_status": success_payload["status"],
-            "signature_mismatch_scenario_status": signature_payload["status"],
-            "malformed_signature_scenario_status": malformed_signature_payload["status"],
-            "timeout_scenario_status": timeout_payload["status"],
-            "session_expired_scenario_status": session_expired_payload["status"],
-            "replay_nonce_scenario_status": replay_payload["status"],
-            "admission_guards_scenario_status": admission_payload["status"],
-            "success_evidence_key": success_payload["evidence_key"],
-            "signature_mismatch_evidence_key": signature_payload["evidence_key"],
-            "malformed_signature_evidence_key": malformed_signature_payload["evidence_key"],
-            "timeout_evidence_key": timeout_payload["evidence_key"],
-            "session_expired_evidence_key": session_expired_payload["evidence_key"],
-            "replay_nonce_evidence_key": replay_payload["evidence_key"],
-            "admission_guards_evidence_key": admission_payload["evidence_key"],
-            "signature_mismatch_reason_code": signature_payload["reason_code"],
-            "malformed_signature_reason_code": malformed_signature_payload["reason_code"],
-            "timeout_reason_code": timeout_payload["reason_code"],
-            "session_expired_reason_code": session_expired_payload["reason_code"],
-            "replay_nonce_reason_code": replay_payload["reason_code"],
-            "admission_guards_reason_code": admission_payload["reason_code"],
-            "success_reason_key": success_payload["reason_key"],
-            "signature_mismatch_reason_key": signature_payload["reason_key"],
-            "malformed_signature_reason_key": malformed_signature_payload["reason_key"],
-            "timeout_reason_key": timeout_payload["reason_key"],
-            "session_expired_reason_key": session_expired_payload["reason_key"],
-            "replay_nonce_reason_key": replay_payload["reason_key"],
-            "admission_guards_reason_key": admission_payload["reason_key"],
-            "success_elapsed_seconds": success_payload["elapsed_seconds"],
-            "signature_mismatch_elapsed_seconds": signature_payload["elapsed_seconds"],
-            "malformed_signature_elapsed_seconds": malformed_signature_payload["elapsed_seconds"],
-            "timeout_elapsed_seconds": timeout_payload["elapsed_seconds"],
-            "session_expired_elapsed_seconds": session_expired_payload["elapsed_seconds"],
-            "replay_nonce_elapsed_seconds": replay_payload["elapsed_seconds"],
-            "admission_guards_elapsed_seconds": admission_payload["elapsed_seconds"],
-            "expiry_guard_status": session_expired_payload["expiry_guard_status"],
-            "replay_guard_status": replay_payload["replay_guard_status"],
-            "replay_rejected_nonce": replay_payload["replay_rejected_nonce"],
-            "admission_guard_status": admission_payload["admission_guard_status"],
-            "admission_reason_codes": admission_payload["admission_reason_codes"],
-        }
+        summary = compose_localhost_signed_integration_contract_report(
+            fixture_schema_version=fixture_schema_version,
+            scenario_fixture_ids=scenario_fixture_ids,
+            success_payload=success_payload,
+            signature_payload=signature_payload,
+            malformed_signature_payload=malformed_signature_payload,
+            timeout_payload=timeout_payload,
+            session_expired_payload=session_expired_payload,
+            replay_payload=replay_payload,
+            admission_payload=admission_payload,
+        )
         summary_report.write_text(
             json.dumps(summary, separators=(",", ":")),
             encoding="utf-8",

--- a/scripts/sdk/localhost_signed_report_composer.py
+++ b/scripts/sdk/localhost_signed_report_composer.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Shared localhost_signed_report_composer helpers for SDK contract lane reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import ContractError, fail, load_json  # noqa: E402
+
+DEMO_ARTIFACT_SCHEMA = "kamn.sdk.localhost-signed.demo-receipt-artifact.v1"
+INTEGRATION_REPORT_SCHEMA = "kamn.sdk.localhost-signed.integration-contract.v1"
+DEMO_CONTRACT_SCHEMA = "kamn.sdk.localhost-signed.demo-contract.v1"
+INTEGRATION_CONTRACT_SCHEMA = "kamn.sdk.localhost-signed.integration-contract.v1"
+
+
+def _require_string(payload: dict[str, Any], field: str, context: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value:
+        fail(f"{context}.{field} must be a non-empty string")
+    return value
+
+
+def _require_int(payload: dict[str, Any], field: str, context: str) -> int:
+    value = payload.get(field)
+    if not isinstance(value, int):
+        fail(f"{context}.{field} must be an integer")
+    return value
+
+
+def _require_string_list(payload: dict[str, Any], field: str, context: str) -> list[str]:
+    value = payload.get(field)
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        fail(f"{context}.{field} must be a list of non-empty strings")
+    return value
+
+
+def compose_localhost_signed_demo_contract_report(
+    *,
+    demo_artifact: dict[str, Any],
+    integration_report: dict[str, Any],
+    elapsed_seconds: int,
+    max_seconds: int,
+) -> dict[str, Any]:
+    """Compose stable localhost signed demo contract lane report payload."""
+    if demo_artifact.get("schema_version") != DEMO_ARTIFACT_SCHEMA:
+        fail("unexpected localhost signed demo artifact schema")
+    if demo_artifact.get("status") != "pass":
+        fail("expected localhost signed demo artifact status=pass")
+
+    if integration_report.get("schema_version") != INTEGRATION_REPORT_SCHEMA:
+        fail("unexpected localhost signed integration report schema")
+    if integration_report.get("status") != "pass":
+        fail("expected localhost signed integration report status=pass")
+
+    if elapsed_seconds < 0:
+        fail("elapsed_seconds must be non-negative")
+    if max_seconds <= 0:
+        fail("max_seconds must be positive")
+    if elapsed_seconds > max_seconds:
+        fail("elapsed_seconds exceeds max_seconds")
+
+    return {
+        "schema_version": DEMO_CONTRACT_SCHEMA,
+        "status": "pass",
+        "suite": "localhost_signed_demo_contract_lane",
+        "demo_artifact_schema": DEMO_ARTIFACT_SCHEMA,
+        "integration_report_schema": INTEGRATION_REPORT_SCHEMA,
+        "demo_status": "pass",
+        "integration_status": "pass",
+        "demo_success_marker": "localhost signed message demo completed.",
+        "integration_success_marker": "localhost signed integration contract lane tests passed.",
+        "elapsed_seconds": elapsed_seconds,
+        "max_seconds": max_seconds,
+        "budget_status": "within_budget",
+        "reason_codes": ["none"],
+    }
+
+
+def compose_localhost_signed_integration_contract_report(
+    *,
+    fixture_schema_version: str,
+    scenario_fixture_ids: list[str],
+    success_payload: dict[str, Any],
+    signature_payload: dict[str, Any],
+    malformed_signature_payload: dict[str, Any],
+    timeout_payload: dict[str, Any],
+    session_expired_payload: dict[str, Any],
+    replay_payload: dict[str, Any],
+    admission_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Compose stable localhost signed integration contract lane report payload."""
+    if not isinstance(fixture_schema_version, str) or not fixture_schema_version:
+        fail("fixture_schema_version must be a non-empty string")
+    if not isinstance(scenario_fixture_ids, list) or not all(
+        isinstance(item, str) and item for item in scenario_fixture_ids
+    ):
+        fail("scenario_fixture_ids must be a list of non-empty strings")
+
+    for context, payload in (
+        ("success_payload", success_payload),
+        ("signature_payload", signature_payload),
+        ("malformed_signature_payload", malformed_signature_payload),
+        ("timeout_payload", timeout_payload),
+        ("session_expired_payload", session_expired_payload),
+        ("replay_payload", replay_payload),
+        ("admission_payload", admission_payload),
+    ):
+        if not isinstance(payload, dict):
+            fail(f"{context} must be an object")
+        _require_string(payload, "status", context)
+        _require_string(payload, "evidence_key", context)
+        _require_string(payload, "reason_key", context)
+        _require_int(payload, "elapsed_seconds", context)
+
+    _require_string(signature_payload, "reason_code", "signature_payload")
+    _require_string(malformed_signature_payload, "reason_code", "malformed_signature_payload")
+    _require_string(timeout_payload, "reason_code", "timeout_payload")
+    _require_string(session_expired_payload, "reason_code", "session_expired_payload")
+    _require_string(replay_payload, "reason_code", "replay_payload")
+    _require_string(admission_payload, "reason_code", "admission_payload")
+    _require_string(session_expired_payload, "expiry_guard_status", "session_expired_payload")
+    _require_string(replay_payload, "replay_guard_status", "replay_payload")
+    replay_rejected_nonce = _require_int(replay_payload, "replay_rejected_nonce", "replay_payload")
+    _require_string(admission_payload, "admission_guard_status", "admission_payload")
+    admission_reason_codes = _require_string_list(
+        admission_payload,
+        "admission_reason_codes",
+        "admission_payload",
+    )
+
+    return {
+        "schema_version": INTEGRATION_CONTRACT_SCHEMA,
+        "status": "pass",
+        "final_decision": "GO",
+        "contract_key": "localhost_signed_integration_contract:v1",
+        "scenario_fixture_schema_version": fixture_schema_version,
+        "scenario_fixture_ids": scenario_fixture_ids,
+        "success_scenario_status": success_payload["status"],
+        "signature_mismatch_scenario_status": signature_payload["status"],
+        "malformed_signature_scenario_status": malformed_signature_payload["status"],
+        "timeout_scenario_status": timeout_payload["status"],
+        "session_expired_scenario_status": session_expired_payload["status"],
+        "replay_nonce_scenario_status": replay_payload["status"],
+        "admission_guards_scenario_status": admission_payload["status"],
+        "success_evidence_key": success_payload["evidence_key"],
+        "signature_mismatch_evidence_key": signature_payload["evidence_key"],
+        "malformed_signature_evidence_key": malformed_signature_payload["evidence_key"],
+        "timeout_evidence_key": timeout_payload["evidence_key"],
+        "session_expired_evidence_key": session_expired_payload["evidence_key"],
+        "replay_nonce_evidence_key": replay_payload["evidence_key"],
+        "admission_guards_evidence_key": admission_payload["evidence_key"],
+        "signature_mismatch_reason_code": signature_payload["reason_code"],
+        "malformed_signature_reason_code": malformed_signature_payload["reason_code"],
+        "timeout_reason_code": timeout_payload["reason_code"],
+        "session_expired_reason_code": session_expired_payload["reason_code"],
+        "replay_nonce_reason_code": replay_payload["reason_code"],
+        "admission_guards_reason_code": admission_payload["reason_code"],
+        "success_reason_key": success_payload["reason_key"],
+        "signature_mismatch_reason_key": signature_payload["reason_key"],
+        "malformed_signature_reason_key": malformed_signature_payload["reason_key"],
+        "timeout_reason_key": timeout_payload["reason_key"],
+        "session_expired_reason_key": session_expired_payload["reason_key"],
+        "replay_nonce_reason_key": replay_payload["reason_key"],
+        "admission_guards_reason_key": admission_payload["reason_key"],
+        "success_elapsed_seconds": success_payload["elapsed_seconds"],
+        "signature_mismatch_elapsed_seconds": signature_payload["elapsed_seconds"],
+        "malformed_signature_elapsed_seconds": malformed_signature_payload["elapsed_seconds"],
+        "timeout_elapsed_seconds": timeout_payload["elapsed_seconds"],
+        "session_expired_elapsed_seconds": session_expired_payload["elapsed_seconds"],
+        "replay_nonce_elapsed_seconds": replay_payload["elapsed_seconds"],
+        "admission_guards_elapsed_seconds": admission_payload["elapsed_seconds"],
+        "expiry_guard_status": session_expired_payload["expiry_guard_status"],
+        "replay_guard_status": replay_payload["replay_guard_status"],
+        "replay_rejected_nonce": replay_rejected_nonce,
+        "admission_guard_status": admission_payload["admission_guard_status"],
+        "admission_reason_codes": admission_reason_codes,
+    }
+
+
+def _handle_compose_demo(args: argparse.Namespace) -> int:
+    if args.elapsed_seconds < 0:
+        fail("--elapsed-seconds must be non-negative")
+    if args.max_seconds <= 0:
+        fail("--max-seconds must be positive")
+
+    demo_artifact = load_json(Path(args.demo_artifact))
+    integration_report = load_json(Path(args.integration_report))
+    summary = compose_localhost_signed_demo_contract_report(
+        demo_artifact=demo_artifact,
+        integration_report=integration_report,
+        elapsed_seconds=args.elapsed_seconds,
+        max_seconds=args.max_seconds,
+    )
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, separators=(",", ":")), encoding="utf-8")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compose localhost signed SDK contract lane reports."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    compose_demo = subparsers.add_parser(
+        "compose-demo",
+        help="Compose localhost signed demo contract lane summary report.",
+    )
+    compose_demo.add_argument("--demo-artifact", required=True)
+    compose_demo.add_argument("--integration-report", required=True)
+    compose_demo.add_argument("--output-json", required=True)
+    compose_demo.add_argument("--elapsed-seconds", required=True, type=int)
+    compose_demo.add_argument("--max-seconds", required=True, type=int)
+    compose_demo.set_defaults(handler=_handle_compose_demo)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = getattr(args, "handler", None)
+    if handler is None:
+        fail("no command selected")
+    return int(handler(args))
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/sdk/run_localhost_signed_demo_contract_lane.sh
+++ b/scripts/sdk/run_localhost_signed_demo_contract_lane.sh
@@ -18,6 +18,7 @@ EOF_USAGE
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEMO_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_demo.sh"
 INTEGRATION_CONTRACT_LANE="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
+REPORT_COMPOSER="$ROOT_DIR/scripts/sdk/localhost_signed_report_composer.py"
 
 output_json=""
 max_seconds="${KAMN_LOCALHOST_SIGNED_DEMO_CONTRACT_MAX_SECONDS:-180}"
@@ -67,6 +68,11 @@ if [ ! -x "$INTEGRATION_CONTRACT_LANE" ]; then
   exit 1
 fi
 
+if [ ! -x "$REPORT_COMPOSER" ]; then
+  echo "expected localhost signed report composer helper module to be executable" >&2
+  exit 1
+fi
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -99,52 +105,12 @@ fi
 
 if [ -n "$output_json" ]; then
   mkdir -p "$(dirname "$output_json")"
-  python3 - \
-    "$demo_artifact" \
-    "$integration_report" \
-    "$output_json" \
-    "$elapsed_seconds" \
-    "$max_seconds" <<'PY'
-import json
-import pathlib
-import sys
-
-demo_artifact_path = pathlib.Path(sys.argv[1])
-integration_report_path = pathlib.Path(sys.argv[2])
-output_path = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-
-demo_artifact = json.loads(demo_artifact_path.read_text(encoding="utf-8"))
-integration_report = json.loads(integration_report_path.read_text(encoding="utf-8"))
-
-if demo_artifact.get("schema_version") != "kamn.sdk.localhost-signed.demo-receipt-artifact.v1":
-    raise SystemExit("unexpected localhost signed demo artifact schema")
-if demo_artifact.get("status") != "pass":
-    raise SystemExit("expected localhost signed demo artifact status=pass")
-
-if integration_report.get("schema_version") != "kamn.sdk.localhost-signed.integration-contract.v1":
-    raise SystemExit("unexpected localhost signed integration report schema")
-if integration_report.get("status") != "pass":
-    raise SystemExit("expected localhost signed integration report status=pass")
-
-payload = {
-    "schema_version": "kamn.sdk.localhost-signed.demo-contract.v1",
-    "status": "pass",
-    "suite": "localhost_signed_demo_contract_lane",
-    "demo_artifact_schema": "kamn.sdk.localhost-signed.demo-receipt-artifact.v1",
-    "integration_report_schema": "kamn.sdk.localhost-signed.integration-contract.v1",
-    "demo_status": "pass",
-    "integration_status": "pass",
-    "demo_success_marker": "localhost signed message demo completed.",
-    "integration_success_marker": "localhost signed integration contract lane tests passed.",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-    "budget_status": "within_budget",
-    "reason_codes": ["none"],
-}
-output_path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
-PY
+  python3 "$REPORT_COMPOSER" compose-demo \
+    --demo-artifact "$demo_artifact" \
+    --integration-report "$integration_report" \
+    --output-json "$output_json" \
+    --elapsed-seconds "$elapsed_seconds" \
+    --max-seconds "$max_seconds"
   echo "localhost_signed_demo_contract_report=$output_json"
 fi
 

--- a/scripts/sdk/test_localhost_signed_report_composer.py
+++ b/scripts/sdk/test_localhost_signed_report_composer.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Unit tests for localhost signed report composition helpers."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import ContractError
+from localhost_signed_report_composer import (
+    compose_localhost_signed_demo_contract_report,
+    compose_localhost_signed_integration_contract_report,
+)
+
+
+class LocalhostSignedReportComposerTests(unittest.TestCase):
+    def test_compose_demo_contract_report_emits_expected_payload(self) -> None:
+        report = compose_localhost_signed_demo_contract_report(
+            demo_artifact={
+                "schema_version": "kamn.sdk.localhost-signed.demo-receipt-artifact.v1",
+                "status": "pass",
+            },
+            integration_report={
+                "schema_version": "kamn.sdk.localhost-signed.integration-contract.v1",
+                "status": "pass",
+            },
+            elapsed_seconds=2,
+            max_seconds=180,
+        )
+        self.assertEqual(report["schema_version"], "kamn.sdk.localhost-signed.demo-contract.v1")
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["reason_codes"], ["none"])
+        self.assertEqual(report["budget_status"], "within_budget")
+        self.assertEqual(report["elapsed_seconds"], 2)
+        self.assertEqual(report["max_seconds"], 180)
+
+    def test_compose_demo_contract_report_rejects_schema_drift(self) -> None:
+        with self.assertRaises(ContractError):
+            compose_localhost_signed_demo_contract_report(
+                demo_artifact={"schema_version": "bad.schema.v1", "status": "pass"},
+                integration_report={
+                    "schema_version": "kamn.sdk.localhost-signed.integration-contract.v1",
+                    "status": "pass",
+                },
+                elapsed_seconds=1,
+                max_seconds=60,
+            )
+
+    def test_compose_integration_contract_report_maps_expected_fields(self) -> None:
+        scenario_ids = ["success-v1", "signature-mismatch-v1", "timeout-v1"]
+        success_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:success:v1",
+            "reason_key": "localhost_signed_integration_reason:none:v1",
+            "elapsed_seconds": 1,
+        }
+        signature_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:signature-mismatch:v1",
+            "reason_code": "signature_mismatch_detected",
+            "reason_key": "localhost_signed_integration_reason:signature_mismatch_detected:v1",
+            "elapsed_seconds": 1,
+        }
+        malformed_signature_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:malformed-signature:v1",
+            "reason_code": "malformed_signature_detected",
+            "reason_key": "localhost_signed_integration_reason:malformed_signature_detected:v1",
+            "elapsed_seconds": 1,
+        }
+        timeout_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:timeout:v1",
+            "reason_code": "listener_timeout_detected",
+            "reason_key": "localhost_signed_integration_reason:listener_timeout_detected:v1",
+            "elapsed_seconds": 1,
+        }
+        session_expired_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:session-expired:v1",
+            "reason_code": "session_expired_detected",
+            "reason_key": "localhost_signed_integration_reason:session_expired_detected:v1",
+            "elapsed_seconds": 1,
+            "expiry_guard_status": "pass",
+        }
+        replay_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:replay-nonce:v1",
+            "reason_code": "replay_nonce_detected",
+            "reason_key": "localhost_signed_integration_reason:replay_nonce_detected:v1",
+            "elapsed_seconds": 1,
+            "replay_guard_status": "pass",
+            "replay_rejected_nonce": 7,
+        }
+        admission_payload = {
+            "status": "pass",
+            "evidence_key": "localhost_signed_integration:admission-guards:v1",
+            "reason_code": "session_admission_guards_detected",
+            "reason_key": "localhost_signed_integration_reason:session_admission_guards_detected:v1",
+            "elapsed_seconds": 1,
+            "admission_guard_status": "pass",
+            "admission_reason_codes": [
+                "stale_session_detected",
+                "unauthorized_sender_detected",
+                "malformed_payload_detected",
+            ],
+        }
+
+        report = compose_localhost_signed_integration_contract_report(
+            fixture_schema_version="kamn.sdk.localhost-signed.integration-fixtures.v1",
+            scenario_fixture_ids=scenario_ids,
+            success_payload=success_payload,
+            signature_payload=signature_payload,
+            malformed_signature_payload=malformed_signature_payload,
+            timeout_payload=timeout_payload,
+            session_expired_payload=session_expired_payload,
+            replay_payload=replay_payload,
+            admission_payload=admission_payload,
+        )
+
+        self.assertEqual(
+            report["schema_version"], "kamn.sdk.localhost-signed.integration-contract.v1"
+        )
+        self.assertEqual(report["final_decision"], "GO")
+        self.assertEqual(report["contract_key"], "localhost_signed_integration_contract:v1")
+        self.assertEqual(report["scenario_fixture_ids"], scenario_ids)
+        self.assertEqual(
+            report["signature_mismatch_reason_code"], "signature_mismatch_detected"
+        )
+        self.assertEqual(report["replay_rejected_nonce"], 7)
+        self.assertEqual(
+            report["admission_reason_codes"],
+            [
+                "stale_session_detected",
+                "unauthorized_sender_detected",
+                "malformed_payload_detected",
+            ],
+        )
+
+    def test_compose_integration_contract_report_rejects_missing_reason_key(self) -> None:
+        with self.assertRaises(ContractError):
+            compose_localhost_signed_integration_contract_report(
+                fixture_schema_version="kamn.sdk.localhost-signed.integration-fixtures.v1",
+                scenario_fixture_ids=["success-v1", "signature-mismatch-v1", "timeout-v1"],
+                success_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:success:v1",
+                    "elapsed_seconds": 1,
+                },
+                signature_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:signature-mismatch:v1",
+                    "reason_code": "signature_mismatch_detected",
+                    "reason_key": "localhost_signed_integration_reason:signature_mismatch_detected:v1",
+                    "elapsed_seconds": 1,
+                },
+                malformed_signature_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:malformed-signature:v1",
+                    "reason_code": "malformed_signature_detected",
+                    "reason_key": "localhost_signed_integration_reason:malformed_signature_detected:v1",
+                    "elapsed_seconds": 1,
+                },
+                timeout_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:timeout:v1",
+                    "reason_code": "listener_timeout_detected",
+                    "reason_key": "localhost_signed_integration_reason:listener_timeout_detected:v1",
+                    "elapsed_seconds": 1,
+                },
+                session_expired_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:session-expired:v1",
+                    "reason_code": "session_expired_detected",
+                    "reason_key": "localhost_signed_integration_reason:session_expired_detected:v1",
+                    "elapsed_seconds": 1,
+                    "expiry_guard_status": "pass",
+                },
+                replay_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:replay-nonce:v1",
+                    "reason_code": "replay_nonce_detected",
+                    "reason_key": "localhost_signed_integration_reason:replay_nonce_detected:v1",
+                    "elapsed_seconds": 1,
+                    "replay_guard_status": "pass",
+                    "replay_rejected_nonce": 7,
+                },
+                admission_payload={
+                    "status": "pass",
+                    "evidence_key": "localhost_signed_integration:admission-guards:v1",
+                    "reason_code": "session_admission_guards_detected",
+                    "reason_key": "localhost_signed_integration_reason:session_admission_guards_detected:v1",
+                    "elapsed_seconds": 1,
+                    "admission_guard_status": "pass",
+                    "admission_reason_codes": [
+                        "stale_session_detected",
+                        "unauthorized_sender_detected",
+                        "malformed_payload_detected",
+                    ],
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sdk/test_localhost_signed_report_composer.sh
+++ b/scripts/sdk/test_localhost_signed_report_composer.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 "$ROOT_DIR/scripts/sdk/test_localhost_signed_report_composer.py"
+
+echo "localhost signed report composer helper tests passed."

--- a/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh
@@ -6,6 +6,7 @@ LANE_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_demo_contract_lane.sh"
 DEMO_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_demo.sh"
 INTEGRATION_CONTRACT_LANE="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
 INTEGRATION_POLICY="$ROOT_DIR/scripts/sdk/check_localhost_signed_integration_evidence_policy.sh"
+REPORT_COMPOSER="$ROOT_DIR/scripts/sdk/localhost_signed_report_composer.py"
 README_FILE="$ROOT_DIR/README.md"
 DEVNET_DOC="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 TMP_DIR="$(mktemp -d)"
@@ -28,6 +29,11 @@ fi
 
 if [ ! -x "$INTEGRATION_POLICY" ]; then
   echo "expected localhost signed integration evidence policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$REPORT_COMPOSER" ]; then
+  echo "expected localhost signed report composer helper module to be executable" >&2
   exit 1
 fi
 
@@ -80,5 +86,15 @@ assert report["demo_status"] == "pass"
 assert report["integration_status"] == "pass"
 assert report["budget_status"] == "within_budget"
 PY
+
+if ! grep -Fq "localhost_signed_report_composer.py" "$LANE_SCRIPT"; then
+  echo "expected localhost signed demo contract lane to dispatch shared report composer helper" >&2
+  exit 1
+fi
+
+if ! grep -Fq "localhost_signed_report_composer" "$REPORT_COMPOSER"; then
+  echo "expected localhost signed report composer helper to expose stable module entrypoint" >&2
+  exit 1
+fi
 
 echo "localhost signed demo contract lane script tests passed."

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LANE_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/sdk/localhost_signed_integration_contract_lane_contract.py"
+REPORT_COMPOSER="$ROOT_DIR/scripts/sdk/localhost_signed_report_composer.py"
 FIXTURE_FILE="$ROOT_DIR/fixtures/runtime/localhost_signed_integration_cases.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -15,6 +16,11 @@ fi
 
 if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected localhost signed integration shared contract lane module to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$REPORT_COMPOSER" ]; then
+  echo "expected localhost signed report composer helper module to be executable" >&2
   exit 1
 fi
 
@@ -163,6 +169,11 @@ fi
 
 if ! grep -Fq "fixtures/runtime/localhost_signed_integration_cases.json" "$SHARED_CONTRACT"; then
   echo "expected localhost signed integration shared contract lane module to enforce fixture corpus contract" >&2
+  exit 1
+fi
+
+if ! grep -Fq "localhost_signed_report_composer" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to use shared report composer helper" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Extracted shared localhost signed report composition into a single helper module and migrated both localhost demo/integration contract lanes to use it. This reduces duplicated schema/marker assembly logic while preserving deterministic output contracts.

Closes #1617

## Changes
- `scripts/sdk/localhost_signed_report_composer.py`: added shared report composition helpers and `compose-demo` CLI entrypoint with strict schema/status validation.
- `scripts/sdk/run_localhost_signed_demo_contract_lane.sh`: replaced inline Python report composition with helper-backed `compose-demo` invocation.
- `scripts/sdk/localhost_signed_integration_contract_lane_contract.py`: replaced inline integration summary dict composition with shared helper function.
- `scripts/sdk/test_localhost_signed_report_composer.py`: added unit tests for helper payload assembly and validation-fail paths.
- `scripts/sdk/test_localhost_signed_report_composer.sh`: added helper unit test wrapper script.
- `scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`: added assertions for shared helper executable/dispatch wiring.
- `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`: added assertions for integration shared module helper usage.
- `scripts/ci/test_ci_tools.sh`: added helper unit test wrapper into ci-tools regression sequence.
- `docs/planning/kolme-devnet-ops.md`: documented shared helper usage in localhost demo/integration contract lane section and regression contract marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`

Failure:
- `expected localhost signed report composer helper module to be executable`

Command:
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`

Failure:
- `expected localhost signed report composer helper module to be executable`

### 🟢 Green Phase
Commands:
- `bash scripts/sdk/test_localhost_signed_report_composer.sh`
- `bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`

Result:
- All pass after helper extraction/migration.

### 🔁 Regression
Commands:
- `bash scripts/ci/test_readme_contract.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-core --all-targets --all-features -- -D warnings`

Result:
- All pass locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status     | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|------------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅         | `scripts/sdk/test_localhost_signed_report_composer.py`                               |                      |
| Functional   | ✅         | `scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`, `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh` |                      |
| Integration  | ✅         | `scripts/ci/test_ci_tools.sh`, `scripts/ci/test_select_targets.sh`, `scripts/ci/test_readme_contract.sh` |                      |
| Regression   | ✅         | Existing localhost demo/integration contract-lane assertions preserved; helper wiring assertions added |                      |
| Performance  | ✅         | Runtime budgets preserved and validated via existing lane budget checks in `test_ci_tools.sh` |                      |

## Risks & Rollback
- Breaking changes: None expected; report schema/markers are preserved.
- Rollback plan: Revert this PR commit to restore prior inline report composition paths.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md` with shared helper contract note.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
