### PR TITLE
refactor(sdk): bounded localhost timeout scenario runner helper (#1621)

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -225,6 +225,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/sdk/run_localhost_signed_demo_contract_lane.sh --output-json /tmp/localhost-signed-demo-contract-report.json`
 - Shared report composer helper:
   - `scripts/sdk/localhost_signed_report_composer.py` (used by demo and integration contract wrappers to keep report schema/marker composition deterministic)
+- Shared scenario runner helper:
+  - `scripts/sdk/localhost_signed_scenario_runner.py` (used by integration contract wrapper to keep scenario execution deterministic with bounded timeout-race retries)
 - Demo contract lane schema:
   - `kamn.sdk.localhost-signed.demo-contract.v1`
 - Deterministic success markers:
@@ -404,6 +406,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - localhost two-process signed-demo command/schema markers remain fail-closed across README and Kolme devnet ops docs (`Regression: #1612`).
 - localhost signed demo contract-lane status markers remain fail-closed (`Regression: #1609`).
 - localhost signed demo/integration report composition remains centralized via shared helper wiring (`Regression: #1617`).
+- localhost signed timeout-race handling remains bounded and fail-closed via shared scenario runner retries (`Regression: #1621`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -75,6 +75,7 @@ bash "$ROOT_DIR/scripts/ci/run_with_retry.sh" \
   --label "sdk-rust-live-transport-contract-lane" \
   --max-attempts 2 \
   -- bash "$ROOT_DIR/scripts/sdk/test_run_rust_live_transport_contract_lane.sh"
+bash "$ROOT_DIR/scripts/sdk/test_localhost_signed_scenario_runner.sh"
 bash "$ROOT_DIR/scripts/sdk/test_localhost_signed_report_composer.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_demo.sh"
 bash "$ROOT_DIR/scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh"

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -21,6 +21,14 @@ from framework.contract_framework import ContractError, fail, load_json  # noqa:
 from localhost_signed_report_composer import (  # noqa: E402
     compose_localhost_signed_integration_contract_report,
 )
+from localhost_signed_scenario_runner import (  # noqa: E402
+    ScenarioRunnerError,
+    run_harness_scenario_with_retry,
+)
+
+
+TIMEOUT_RACE_REASON_CODE = "unexpected_listener_completion"
+TIMEOUT_SCENARIO_MAX_ATTEMPTS = 2
 
 
 def _is_executable(path: Path) -> bool:
@@ -34,6 +42,39 @@ def _require_contains(text: str, marker: str, message: str) -> None:
 
 def _require_file_contains(path: Path, marker: str, message: str) -> None:
     _require_contains(path.read_text(encoding="utf-8"), marker, message)
+
+
+def _run_and_validate_scenario(
+    *,
+    harness_runner: Path,
+    scenario: str,
+    output_json: Path,
+    status_marker: str,
+    status_message: str,
+    reason_marker: str,
+    reason_message: str,
+    evidence_marker: str,
+    evidence_message: str,
+    timeout_seconds: int | None = None,
+    max_attempts: int = 1,
+    retry_reason_code: str | None = None,
+) -> str:
+    try:
+        run_result = run_harness_scenario_with_retry(
+            harness_runner=harness_runner,
+            scenario=scenario,
+            output_json=output_json,
+            timeout_seconds=timeout_seconds,
+            max_attempts=max_attempts,
+            retry_reason_code=retry_reason_code,
+        )
+    except ScenarioRunnerError as error:
+        fail(str(error))
+    output = run_result.combined_output
+    _require_contains(output, status_marker, status_message)
+    _require_contains(output, reason_marker, reason_message)
+    _require_contains(output, evidence_marker, evidence_message)
+    return output
 
 
 def _load_fixture_contract(
@@ -123,254 +164,91 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
         admission_report = tmp_dir / "admission-guards.json"
         summary_report = tmp_dir / "localhost-signed-integration-contract.json"
 
-        success_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "success",
-                "--output-json",
-                str(success_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if success_run.returncode != 0:
-            fail((success_run.stderr or success_run.stdout or "success scenario failed").strip())
-        success_output = success_run.stdout
-        _require_contains(
-            success_output,
-            "status=pass; scenario=success;",
-            "expected localhost signed integration success scenario status marker",
-        )
-        _require_contains(
-            success_output,
-            f"reason_code={fixture_by_scenario['success']['expected_reason_code']};",
-            "expected localhost signed integration success scenario reason code marker",
-        )
-        _require_contains(
-            success_output,
-            f"evidence_key={fixture_by_scenario['success']['expected_evidence_key']};",
-            "expected localhost signed integration success scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="success",
+            output_json=success_report,
+            status_marker="status=pass; scenario=success;",
+            status_message="expected localhost signed integration success scenario status marker",
+            reason_marker=f"reason_code={fixture_by_scenario['success']['expected_reason_code']};",
+            reason_message="expected localhost signed integration success scenario reason code marker",
+            evidence_marker=f"evidence_key={fixture_by_scenario['success']['expected_evidence_key']};",
+            evidence_message="expected localhost signed integration success scenario evidence key",
         )
 
-        signature_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "signature-mismatch",
-                "--output-json",
-                str(signature_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if signature_run.returncode != 0:
-            fail(
-                (
-                    signature_run.stderr
-                    or signature_run.stdout
-                    or "signature-mismatch scenario failed"
-                ).strip()
-            )
-        signature_output = signature_run.stdout
-        _require_contains(
-            signature_output,
-            "status=pass; scenario=signature-mismatch;",
-            "expected localhost signed integration signature mismatch scenario status marker",
-        )
-        _require_contains(
-            signature_output,
-            f"reason_code={fixture_by_scenario['signature-mismatch']['expected_reason_code']};",
-            "expected localhost signed integration signature mismatch scenario reason code marker",
-        )
-        _require_contains(
-            signature_output,
-            f"evidence_key={fixture_by_scenario['signature-mismatch']['expected_evidence_key']};",
-            "expected localhost signed integration signature mismatch scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="signature-mismatch",
+            output_json=signature_report,
+            status_marker="status=pass; scenario=signature-mismatch;",
+            status_message="expected localhost signed integration signature mismatch scenario status marker",
+            reason_marker=f"reason_code={fixture_by_scenario['signature-mismatch']['expected_reason_code']};",
+            reason_message="expected localhost signed integration signature mismatch scenario reason code marker",
+            evidence_marker=f"evidence_key={fixture_by_scenario['signature-mismatch']['expected_evidence_key']};",
+            evidence_message="expected localhost signed integration signature mismatch scenario evidence key",
         )
 
-        malformed_signature_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "malformed-signature",
-                "--output-json",
-                str(malformed_signature_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if malformed_signature_run.returncode != 0:
-            fail(
-                (
-                    malformed_signature_run.stderr
-                    or malformed_signature_run.stdout
-                    or "malformed-signature scenario failed"
-                ).strip()
-            )
-        malformed_signature_output = malformed_signature_run.stdout
-        _require_contains(
-            malformed_signature_output,
-            "status=pass; scenario=malformed-signature;",
-            "expected localhost signed integration malformed signature scenario status marker",
-        )
-        _require_contains(
-            malformed_signature_output,
-            "reason_code=malformed_signature_detected;",
-            "expected localhost signed integration malformed signature scenario reason code marker",
-        )
-        _require_contains(
-            malformed_signature_output,
-            "evidence_key=localhost_signed_integration:malformed-signature:v1;",
-            "expected localhost signed integration malformed signature scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="malformed-signature",
+            output_json=malformed_signature_report,
+            status_marker="status=pass; scenario=malformed-signature;",
+            status_message="expected localhost signed integration malformed signature scenario status marker",
+            reason_marker="reason_code=malformed_signature_detected;",
+            reason_message="expected localhost signed integration malformed signature scenario reason code marker",
+            evidence_marker="evidence_key=localhost_signed_integration:malformed-signature:v1;",
+            evidence_message="expected localhost signed integration malformed signature scenario evidence key",
         )
 
-        timeout_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "timeout",
-                "--timeout-seconds",
-                "1",
-                "--output-json",
-                str(timeout_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if timeout_run.returncode != 0:
-            fail((timeout_run.stderr or timeout_run.stdout or "timeout scenario failed").strip())
-        timeout_output = timeout_run.stdout
-        _require_contains(
-            timeout_output,
-            "status=pass; scenario=timeout;",
-            "expected localhost signed integration timeout scenario status marker",
-        )
-        _require_contains(
-            timeout_output,
-            f"reason_code={fixture_by_scenario['timeout']['expected_reason_code']};",
-            "expected localhost signed integration timeout scenario reason code marker",
-        )
-        _require_contains(
-            timeout_output,
-            f"evidence_key={fixture_by_scenario['timeout']['expected_evidence_key']};",
-            "expected localhost signed integration timeout scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="timeout",
+            output_json=timeout_report,
+            timeout_seconds=1,
+            max_attempts=TIMEOUT_SCENARIO_MAX_ATTEMPTS,
+            retry_reason_code=TIMEOUT_RACE_REASON_CODE,
+            status_marker="status=pass; scenario=timeout;",
+            status_message="expected localhost signed integration timeout scenario status marker",
+            reason_marker=f"reason_code={fixture_by_scenario['timeout']['expected_reason_code']};",
+            reason_message="expected localhost signed integration timeout scenario reason code marker",
+            evidence_marker=f"evidence_key={fixture_by_scenario['timeout']['expected_evidence_key']};",
+            evidence_message="expected localhost signed integration timeout scenario evidence key",
         )
 
-        session_expired_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "session-expired",
-                "--output-json",
-                str(session_expired_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if session_expired_run.returncode != 0:
-            fail(
-                (
-                    session_expired_run.stderr
-                    or session_expired_run.stdout
-                    or "session-expired scenario failed"
-                ).strip()
-            )
-        session_expired_output = session_expired_run.stdout
-        _require_contains(
-            session_expired_output,
-            "status=pass; scenario=session-expired;",
-            "expected localhost signed integration session-expired scenario status marker",
-        )
-        _require_contains(
-            session_expired_output,
-            "reason_code=session_expired_detected;",
-            "expected localhost signed integration session-expired scenario reason code marker",
-        )
-        _require_contains(
-            session_expired_output,
-            "evidence_key=localhost_signed_integration:session-expired:v1;",
-            "expected localhost signed integration session-expired scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="session-expired",
+            output_json=session_expired_report,
+            status_marker="status=pass; scenario=session-expired;",
+            status_message="expected localhost signed integration session-expired scenario status marker",
+            reason_marker="reason_code=session_expired_detected;",
+            reason_message="expected localhost signed integration session-expired scenario reason code marker",
+            evidence_marker="evidence_key=localhost_signed_integration:session-expired:v1;",
+            evidence_message="expected localhost signed integration session-expired scenario evidence key",
         )
 
-        replay_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "replay-nonce",
-                "--output-json",
-                str(replay_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if replay_run.returncode != 0:
-            fail((replay_run.stderr or replay_run.stdout or "replay-nonce scenario failed").strip())
-        replay_output = replay_run.stdout
-        _require_contains(
-            replay_output,
-            "status=pass; scenario=replay-nonce;",
-            "expected localhost signed integration replay nonce scenario status marker",
-        )
-        _require_contains(
-            replay_output,
-            "reason_code=replay_nonce_detected;",
-            "expected localhost signed integration replay nonce scenario reason code marker",
-        )
-        _require_contains(
-            replay_output,
-            "evidence_key=localhost_signed_integration:replay-nonce:v1;",
-            "expected localhost signed integration replay nonce scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="replay-nonce",
+            output_json=replay_report,
+            status_marker="status=pass; scenario=replay-nonce;",
+            status_message="expected localhost signed integration replay nonce scenario status marker",
+            reason_marker="reason_code=replay_nonce_detected;",
+            reason_message="expected localhost signed integration replay nonce scenario reason code marker",
+            evidence_marker="evidence_key=localhost_signed_integration:replay-nonce:v1;",
+            evidence_message="expected localhost signed integration replay nonce scenario evidence key",
         )
 
-        admission_run = subprocess.run(
-            [
-                "bash",
-                str(harness_runner),
-                "--scenario",
-                "admission-guards",
-                "--output-json",
-                str(admission_report),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if admission_run.returncode != 0:
-            fail(
-                (
-                    admission_run.stderr
-                    or admission_run.stdout
-                    or "admission-guards scenario failed"
-                ).strip()
-            )
-        admission_output = admission_run.stdout
-        _require_contains(
-            admission_output,
-            "status=pass; scenario=admission-guards;",
-            "expected localhost signed integration admission guards scenario status marker",
-        )
-        _require_contains(
-            admission_output,
-            "reason_code=session_admission_guards_detected;",
-            "expected localhost signed integration admission guards scenario reason code marker",
-        )
-        _require_contains(
-            admission_output,
-            "evidence_key=localhost_signed_integration:admission-guards:v1;",
-            "expected localhost signed integration admission guards scenario evidence key",
+        _run_and_validate_scenario(
+            harness_runner=harness_runner,
+            scenario="admission-guards",
+            output_json=admission_report,
+            status_marker="status=pass; scenario=admission-guards;",
+            status_message="expected localhost signed integration admission guards scenario status marker",
+            reason_marker="reason_code=session_admission_guards_detected;",
+            reason_message="expected localhost signed integration admission guards scenario reason code marker",
+            evidence_marker="evidence_key=localhost_signed_integration:admission-guards:v1;",
+            evidence_message="expected localhost signed integration admission guards scenario evidence key",
         )
 
         success_payload = load_json(success_report)

--- a/scripts/sdk/localhost_signed_scenario_runner.py
+++ b/scripts/sdk/localhost_signed_scenario_runner.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Shared localhost signed integration harness scenario runner helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import time
+from typing import Callable
+
+
+REASON_CODE_PATTERN = re.compile(r"reason_code=([a-z0-9_\\-]+);")
+
+
+class ScenarioRunnerError(RuntimeError):
+    """Raised when a localhost signed scenario run fails closed."""
+
+
+@dataclass(frozen=True)
+class ScenarioExecutionResult:
+    """Result payload for scenario harness execution."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    attempts: int
+
+    @property
+    def combined_output(self) -> str:
+        return f"{self.stdout}{self.stderr}"
+
+
+def extract_reason_code(output: str) -> str | None:
+    """Extract `reason_code=...;` marker from scenario output."""
+    match = REASON_CODE_PATTERN.search(output)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _default_run_command(command: list[str]) -> ScenarioExecutionResult:
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return ScenarioExecutionResult(
+        returncode=result.returncode,
+        stdout=result.stdout or "",
+        stderr=result.stderr or "",
+        attempts=1,
+    )
+
+
+def run_harness_scenario_with_retry(
+    *,
+    harness_runner: Path,
+    scenario: str,
+    output_json: Path,
+    timeout_seconds: int | None = None,
+    max_attempts: int = 1,
+    retry_reason_code: str | None = None,
+    retry_delay_seconds: float = 0.2,
+    run_command: Callable[[list[str]], ScenarioExecutionResult] | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> ScenarioExecutionResult:
+    """Run localhost integration harness scenario with bounded retry support."""
+    if max_attempts <= 0:
+        raise ScenarioRunnerError("max_attempts must be >= 1")
+
+    command = [
+        "bash",
+        str(harness_runner),
+        "--scenario",
+        scenario,
+        "--output-json",
+        str(output_json),
+    ]
+    if timeout_seconds is not None:
+        command.extend(["--timeout-seconds", str(timeout_seconds)])
+
+    execute = run_command or _default_run_command
+
+    for attempt in range(1, max_attempts + 1):
+        raw_result = execute(command)
+        result = ScenarioExecutionResult(
+            returncode=raw_result.returncode,
+            stdout=raw_result.stdout,
+            stderr=raw_result.stderr,
+            attempts=attempt,
+        )
+        if result.returncode == 0:
+            return result
+
+        combined_output = result.combined_output
+        reason_code = extract_reason_code(combined_output)
+        should_retry = (
+            retry_reason_code is not None
+            and reason_code == retry_reason_code
+            and attempt < max_attempts
+        )
+        if should_retry:
+            sleep_fn(retry_delay_seconds)
+            continue
+
+        failure_output = (result.stderr or result.stdout).strip()
+        if not failure_output:
+            failure_output = (
+                f"scenario '{scenario}' failed with exit code {result.returncode}"
+            )
+        raise ScenarioRunnerError(failure_output)
+
+    raise ScenarioRunnerError(f"scenario '{scenario}' exhausted retry budget")

--- a/scripts/sdk/test_localhost_signed_scenario_runner.py
+++ b/scripts/sdk/test_localhost_signed_scenario_runner.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for localhost signed scenario runner helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+import unittest
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from localhost_signed_scenario_runner import (  # type: ignore[import-not-found]
+    ScenarioRunnerError,
+    extract_reason_code,
+    run_harness_scenario_with_retry,
+)
+
+
+@dataclass
+class _StubRunResult:
+    returncode: int
+    stdout: str
+    stderr: str = ""
+
+
+class LocalhostSignedScenarioRunnerTests(unittest.TestCase):
+    def test_extract_reason_code_parses_expected_marker(self) -> None:
+        output = "status=fail; scenario=timeout; reason_code=unexpected_listener_completion; elapsed=1;"
+        self.assertEqual(extract_reason_code(output), "unexpected_listener_completion")
+
+    def test_extract_reason_code_returns_none_when_missing(self) -> None:
+        self.assertIsNone(extract_reason_code("status=ok; scenario=success;"))
+
+    def test_retry_retries_once_for_expected_timeout_race(self) -> None:
+        calls: list[list[str]] = []
+        responses = [
+            _StubRunResult(
+                returncode=1,
+                stdout=(
+                    "status=fail; scenario=timeout; "
+                    "reason_code=unexpected_listener_completion;"
+                ),
+            ),
+            _StubRunResult(
+                returncode=0,
+                stdout="status=pass; scenario=timeout; reason_code=listener_timeout_detected;",
+            ),
+        ]
+
+        def _runner(command: list[str]) -> _StubRunResult:
+            calls.append(command)
+            return responses[len(calls) - 1]
+
+        sleeps: list[float] = []
+
+        result = run_harness_scenario_with_retry(
+            harness_runner=Path("/tmp/fake-harness.sh"),
+            scenario="timeout",
+            output_json=Path("/tmp/fake-timeout.json"),
+            timeout_seconds=1,
+            max_attempts=2,
+            retry_reason_code="unexpected_listener_completion",
+            run_command=_runner,
+            sleep_fn=sleeps.append,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("listener_timeout_detected", result.stdout)
+        self.assertEqual(result.attempts, 2)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(sleeps, [0.2])
+
+    def test_retry_fails_closed_when_race_persists(self) -> None:
+        def _runner(_command: list[str]) -> _StubRunResult:
+            return _StubRunResult(
+                returncode=1,
+                stdout=(
+                    "status=fail; scenario=timeout; "
+                    "reason_code=unexpected_listener_completion;"
+                ),
+            )
+
+        with self.assertRaises(ScenarioRunnerError):
+            run_harness_scenario_with_retry(
+                harness_runner=Path("/tmp/fake-harness.sh"),
+                scenario="timeout",
+                output_json=Path("/tmp/fake-timeout.json"),
+                timeout_seconds=1,
+                max_attempts=2,
+                retry_reason_code="unexpected_listener_completion",
+                run_command=_runner,
+                sleep_fn=lambda _seconds: None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sdk/test_localhost_signed_scenario_runner.sh
+++ b/scripts/sdk/test_localhost_signed_scenario_runner.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 "$ROOT_DIR/scripts/sdk/test_localhost_signed_scenario_runner.py"
+
+echo "localhost signed scenario runner helper tests passed."

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LANE_SCRIPT="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/sdk/localhost_signed_integration_contract_lane_contract.py"
 REPORT_COMPOSER="$ROOT_DIR/scripts/sdk/localhost_signed_report_composer.py"
+SCENARIO_RUNNER_HELPER="$ROOT_DIR/scripts/sdk/localhost_signed_scenario_runner.py"
 FIXTURE_FILE="$ROOT_DIR/fixtures/runtime/localhost_signed_integration_cases.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -21,6 +22,11 @@ fi
 
 if [ ! -x "$REPORT_COMPOSER" ]; then
   echo "expected localhost signed report composer helper module to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$SCENARIO_RUNNER_HELPER" ]; then
+  echo "expected localhost signed scenario runner helper module to be executable" >&2
   exit 1
 fi
 
@@ -174,6 +180,16 @@ fi
 
 if ! grep -Fq "localhost_signed_report_composer" "$SHARED_CONTRACT"; then
   echo "expected localhost signed integration shared contract lane module to use shared report composer helper" >&2
+  exit 1
+fi
+
+if ! grep -Fq "localhost_signed_scenario_runner" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to use shared scenario runner helper" >&2
+  exit 1
+fi
+
+if ! grep -Fq "unexpected_listener_completion" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to enforce bounded timeout race retry reason-code handling" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Extracted a shared localhost signed scenario runner helper and migrated localhost integration contract-lane scenario orchestration to use it. Added deterministic, bounded retry handling for the known timeout race reason code to reduce flaky reruns without changing fail-closed contracts.

Closes #1621

## Changes
- `scripts/sdk/localhost_signed_scenario_runner.py`: added reusable scenario execution helper, reason-code extraction, and bounded retry orchestration.
- `scripts/sdk/localhost_signed_integration_contract_lane_contract.py`: replaced repeated inline subprocess scenario blocks with helper-backed `_run_and_validate_scenario` calls; added bounded timeout retry constants for `unexpected_listener_completion`.
- `scripts/sdk/test_localhost_signed_scenario_runner.py`: added unit tests for reason-code extraction and bounded retry behavior.
- `scripts/sdk/test_localhost_signed_scenario_runner.sh`: added shell wrapper for helper unit suite.
- `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`: added contract checks for new helper wiring and timeout race retry reason-code handling.
- `scripts/ci/test_ci_tools.sh`: added new helper test wrapper to CI tools regression lane.
- `docs/planning/kolme-devnet-ops.md`: documented shared scenario helper and bounded timeout retry regression contract.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/sdk/test_localhost_signed_scenario_runner.sh`

Failure:
- `ModuleNotFoundError: No module named 'localhost_signed_scenario_runner'`

Command:
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`

Failure:
- `expected localhost signed scenario runner helper module to be executable`

### 🟢 Green Phase
Commands:
- `bash scripts/sdk/test_localhost_signed_scenario_runner.sh`
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`
- `bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`

Result:
- All pass after helper extraction + bounded timeout retry wiring.
- One early run of demo contract lane surfaced an intermittent signature-mismatch scenario failure and passed on immediate rerun.

### 🔁 Regression
Commands:
- `bash scripts/ci/test_readme_contract.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-core --all-targets --all-features -- -D warnings`

Result:
- All pass locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status     | Tests Added/Modified | Justification if N/A |
|--------------|------------|----------------------|----------------------|
| Unit         | ✅         | `scripts/sdk/test_localhost_signed_scenario_runner.py` | |
| Functional   | ✅         | `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh` | |
| Integration  | ✅         | `scripts/ci/test_ci_tools.sh`, `scripts/ci/test_readme_contract.sh`, `scripts/ci/test_select_targets.sh` | |
| Regression   | ✅         | Existing localhost signed schema/marker contract checks remained green; added helper wiring/retry contract assertions | |
| Performance  | ✅         | Retry capped at 2 attempts for timeout race path; runtime budget checks remain active in lane + `test_ci_tools.sh` | |

## Risks & Rollback
- Breaking changes: None expected; schema/marker/reason-code contracts remain unchanged.
- Rollback plan: Revert this PR commit to restore prior inline scenario orchestration.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md` with bounded timeout-race retry helper contract note.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
