### PR TITLE
fix(sdk): bound replay-nonce listener-timeout retries (#1629)

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -226,7 +226,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Shared report composer helper:
   - `scripts/sdk/localhost_signed_report_composer.py` (used by demo and integration contract wrappers to keep report schema/marker composition deterministic)
 - Shared scenario runner helper:
-  - `scripts/sdk/localhost_signed_scenario_runner.py` (used by integration contract wrapper to keep scenario execution deterministic with bounded timeout-race retries and signature-mismatch bounded retries)
+  - `scripts/sdk/localhost_signed_scenario_runner.py` (used by integration contract wrapper to keep scenario execution deterministic with bounded timeout-race retries, signature-mismatch bounded retries, and replay-nonce bounded retries)
 - Demo contract lane schema:
   - `kamn.sdk.localhost-signed.demo-contract.v1`
 - Deterministic success markers:
@@ -408,6 +408,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - localhost signed demo/integration report composition remains centralized via shared helper wiring (`Regression: #1617`).
 - localhost signed timeout-race handling remains bounded and fail-closed via shared scenario runner retries (`Regression: #1621`).
 - localhost signed signature-mismatch bounded retries remain deterministic and fail-closed via shared scenario runner retries (`Regression: #1625`).
+- localhost signed replay-nonce bounded retries remain deterministic and fail-closed via shared scenario runner retries (`Regression: #1629`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -31,6 +31,8 @@ TIMEOUT_RACE_REASON_CODE = "unexpected_listener_completion"
 TIMEOUT_SCENARIO_MAX_ATTEMPTS = 2
 SIGNATURE_MISMATCH_RACE_REASON_CODE = "mismatch_not_detected_not_reported"
 SIGNATURE_MISMATCH_RACE_MAX_ATTEMPTS = 2
+REPLAY_NONCE_RACE_REASON_CODE = "listener_timeout"
+REPLAY_NONCE_RACE_MAX_ATTEMPTS = 2
 
 
 def _is_executable(path: Path) -> bool:
@@ -235,6 +237,8 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             harness_runner=harness_runner,
             scenario="replay-nonce",
             output_json=replay_report,
+            max_attempts=REPLAY_NONCE_RACE_MAX_ATTEMPTS,
+            retry_reason_code=REPLAY_NONCE_RACE_REASON_CODE,
             status_marker="status=pass; scenario=replay-nonce;",
             status_message="expected localhost signed integration replay nonce scenario status marker",
             reason_marker="reason_code=replay_nonce_detected;",

--- a/scripts/sdk/test_localhost_signed_scenario_runner.py
+++ b/scripts/sdk/test_localhost_signed_scenario_runner.py
@@ -132,6 +132,44 @@ class LocalhostSignedScenarioRunnerTests(unittest.TestCase):
         self.assertEqual(result.attempts, 2)
         self.assertEqual(len(calls), 2)
 
+    def test_retry_retries_once_for_replay_nonce_listener_timeout(self) -> None:
+        calls: list[list[str]] = []
+        responses = [
+            _StubRunResult(
+                returncode=1,
+                stdout=(
+                    "status=fail; scenario=replay-nonce; "
+                    "reason_code=listener_timeout;"
+                ),
+            ),
+            _StubRunResult(
+                returncode=0,
+                stdout=(
+                    "status=pass; scenario=replay-nonce; "
+                    "reason_code=replay_nonce_detected;"
+                ),
+            ),
+        ]
+
+        def _runner(command: list[str]) -> _StubRunResult:
+            calls.append(command)
+            return responses[len(calls) - 1]
+
+        result = run_harness_scenario_with_retry(
+            harness_runner=Path("/tmp/fake-harness.sh"),
+            scenario="replay-nonce",
+            output_json=Path("/tmp/fake-replay.json"),
+            max_attempts=2,
+            retry_reason_code="listener_timeout",
+            run_command=_runner,
+            sleep_fn=lambda _seconds: None,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("replay_nonce_detected", result.stdout)
+        self.assertEqual(result.attempts, 2)
+        self.assertEqual(len(calls), 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -204,8 +204,28 @@ if ! grep -Fq "SIGNATURE_MISMATCH_RACE_MAX_ATTEMPTS" "$SHARED_CONTRACT"; then
   exit 1
 fi
 
+if ! grep -Fq "REPLAY_NONCE_RACE_REASON_CODE" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to define replay-nonce bounded retry reason-code handling" >&2
+  exit 1
+fi
+
+if ! grep -Fq "REPLAY_NONCE_RACE_MAX_ATTEMPTS" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to define bounded replay-nonce retry attempts" >&2
+  exit 1
+fi
+
+if ! grep -Fq "listener_timeout" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to wire replay-nonce listener_timeout retry reason-code handling" >&2
+  exit 1
+fi
+
 if ! grep -Fq "signature-mismatch bounded retries" "$DEVNET_DOC"; then
   echo "expected Kolme devnet ops doc to document localhost signature-mismatch bounded retries contract" >&2
+  exit 1
+fi
+
+if ! grep -Fq "replay-nonce bounded retries" "$DEVNET_DOC"; then
+  echo "expected Kolme devnet ops doc to document localhost replay-nonce bounded retries contract" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Added bounded replay-nonce listener-timeout retry handling in localhost integration contract-lane orchestration. This reduces transient replay scenario flake while preserving fail-closed behavior and existing report contracts.

Closes #1629

## Changes
- `scripts/sdk/localhost_signed_integration_contract_lane_contract.py`: added replay-nonce retry constants and wired replay scenario execution through bounded retry policy.
- `scripts/sdk/test_localhost_signed_scenario_runner.py`: added replay-nonce retry unit coverage for `listener_timeout` transient path.
- `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`: added contract assertions for replay retry constants/reason-code wiring and docs marker.
- `docs/planning/kolme-devnet-ops.md`: documented replay-nonce bounded retry contract and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`

Failure:
- `expected localhost signed integration shared contract lane module to define replay-nonce bounded retry reason-code handling`

### 🟢 Green Phase
Commands:
- `bash scripts/sdk/test_localhost_signed_scenario_runner.sh`
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`
- `bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`

Result:
- All pass after replay retry wiring.

### 🔁 Regression
Commands:
- `bash scripts/ci/test_readme_contract.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-core --all-targets --all-features -- -D warnings`

Result:
- All pass locally.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status     | Tests Added/Modified | Justification if N/A |
|--------------|------------|----------------------|----------------------|
| Unit         | ✅         | `scripts/sdk/test_localhost_signed_scenario_runner.py` | |
| Functional   | ✅         | `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`, `scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh` | |
| Integration  | ✅         | `scripts/ci/test_ci_tools.sh`, `scripts/ci/test_readme_contract.sh`, `scripts/ci/test_select_targets.sh` | |
| Regression   | ✅         | Existing localhost signed schema/marker contracts remained green; replay retry contract assertions added | |
| Performance  | ✅         | Replay retry capped at 2 attempts; runtime budget policy unchanged | |

## Risks & Rollback
- Breaking changes: None expected; schemas/markers/reason-keys unchanged.
- Rollback plan: Revert this PR commit to remove replay-specific bounded retry wiring.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md` with replay-nonce bounded retry contract note.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
