### PR TITLE
fix(sdk): bound admission listener-timeout retries (#1632)

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -226,7 +226,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Shared report composer helper:
   - `scripts/sdk/localhost_signed_report_composer.py` (used by demo and integration contract wrappers to keep report schema/marker composition deterministic)
 - Shared scenario runner helper:
-  - `scripts/sdk/localhost_signed_scenario_runner.py` (used by integration contract wrapper to keep scenario execution deterministic with bounded timeout-race retries, signature-mismatch bounded retries, and replay-nonce bounded retries)
+  - `scripts/sdk/localhost_signed_scenario_runner.py` (used by integration contract wrapper to keep scenario execution deterministic with bounded timeout-race retries, signature-mismatch bounded retries, replay-nonce bounded retries, and admission bounded retries)
 - Demo contract lane schema:
   - `kamn.sdk.localhost-signed.demo-contract.v1`
 - Deterministic success markers:
@@ -409,6 +409,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - localhost signed timeout-race handling remains bounded and fail-closed via shared scenario runner retries (`Regression: #1621`).
 - localhost signed signature-mismatch bounded retries remain deterministic and fail-closed via shared scenario runner retries (`Regression: #1625`).
 - localhost signed replay-nonce bounded retries remain deterministic and fail-closed via shared scenario runner retries (`Regression: #1629`).
+- localhost signed admission bounded retries remain deterministic and fail-closed via shared scenario runner retries (`Regression: #1632`).
 - Failover/sync budget overruns and unscheduled deep-lane execution fail closed (`Regression: #788`).
 
 ## Local Validation

--- a/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
+++ b/scripts/sdk/localhost_signed_integration_contract_lane_contract.py
@@ -33,6 +33,8 @@ SIGNATURE_MISMATCH_RACE_REASON_CODE = "mismatch_not_detected_not_reported"
 SIGNATURE_MISMATCH_RACE_MAX_ATTEMPTS = 2
 REPLAY_NONCE_RACE_REASON_CODE = "listener_timeout"
 REPLAY_NONCE_RACE_MAX_ATTEMPTS = 2
+ADMISSION_GUARDS_RACE_REASON_CODE = "listener_timeout"
+ADMISSION_GUARDS_RACE_MAX_ATTEMPTS = 2
 
 
 def _is_executable(path: Path) -> bool:
@@ -251,6 +253,8 @@ def run_localhost_signed_integration_contract_lane(args: argparse.Namespace) -> 
             harness_runner=harness_runner,
             scenario="admission-guards",
             output_json=admission_report,
+            max_attempts=ADMISSION_GUARDS_RACE_MAX_ATTEMPTS,
+            retry_reason_code=ADMISSION_GUARDS_RACE_REASON_CODE,
             status_marker="status=pass; scenario=admission-guards;",
             status_message="expected localhost signed integration admission guards scenario status marker",
             reason_marker="reason_code=session_admission_guards_detected;",

--- a/scripts/sdk/test_localhost_signed_scenario_runner.py
+++ b/scripts/sdk/test_localhost_signed_scenario_runner.py
@@ -170,6 +170,44 @@ class LocalhostSignedScenarioRunnerTests(unittest.TestCase):
         self.assertEqual(result.attempts, 2)
         self.assertEqual(len(calls), 2)
 
+    def test_retry_retries_once_for_admission_listener_timeout(self) -> None:
+        calls: list[list[str]] = []
+        responses = [
+            _StubRunResult(
+                returncode=1,
+                stdout=(
+                    "status=fail; scenario=admission-guards; "
+                    "reason_code=listener_timeout;"
+                ),
+            ),
+            _StubRunResult(
+                returncode=0,
+                stdout=(
+                    "status=pass; scenario=admission-guards; "
+                    "reason_code=session_admission_guards_detected;"
+                ),
+            ),
+        ]
+
+        def _runner(command: list[str]) -> _StubRunResult:
+            calls.append(command)
+            return responses[len(calls) - 1]
+
+        result = run_harness_scenario_with_retry(
+            harness_runner=Path("/tmp/fake-harness.sh"),
+            scenario="admission-guards",
+            output_json=Path("/tmp/fake-admission.json"),
+            max_attempts=2,
+            retry_reason_code="listener_timeout",
+            run_command=_runner,
+            sleep_fn=lambda _seconds: None,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("session_admission_guards_detected", result.stdout)
+        self.assertEqual(result.attempts, 2)
+        self.assertEqual(len(calls), 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
+++ b/scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh
@@ -219,6 +219,21 @@ if ! grep -Fq "listener_timeout" "$SHARED_CONTRACT"; then
   exit 1
 fi
 
+if ! grep -Fq "ADMISSION_GUARDS_RACE_REASON_CODE" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to define admission bounded retry reason-code handling" >&2
+  exit 1
+fi
+
+if ! grep -Fq "ADMISSION_GUARDS_RACE_MAX_ATTEMPTS" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to define bounded admission retry attempts" >&2
+  exit 1
+fi
+
+if ! grep -Fq "session_admission_guards_detected" "$SHARED_CONTRACT"; then
+  echo "expected localhost signed integration shared contract lane module to wire admission scenario reason-code handling" >&2
+  exit 1
+fi
+
 if ! grep -Fq "signature-mismatch bounded retries" "$DEVNET_DOC"; then
   echo "expected Kolme devnet ops doc to document localhost signature-mismatch bounded retries contract" >&2
   exit 1
@@ -226,6 +241,11 @@ fi
 
 if ! grep -Fq "replay-nonce bounded retries" "$DEVNET_DOC"; then
   echo "expected Kolme devnet ops doc to document localhost replay-nonce bounded retries contract" >&2
+  exit 1
+fi
+
+if ! grep -Fq "admission bounded retries" "$DEVNET_DOC"; then
+  echo "expected Kolme devnet ops doc to document localhost admission bounded retries contract" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Added bounded admission `listener_timeout` retry handling in localhost integration contract-lane orchestration. This reduces transient admission scenario flake while preserving fail-closed behavior and existing report contracts.

Closes #1632

## Changes
- `scripts/sdk/localhost_signed_integration_contract_lane_contract.py`: added admission retry constants and wired admission scenario execution through bounded retry policy.
- `scripts/sdk/test_localhost_signed_scenario_runner.py`: added admission retry unit coverage for `listener_timeout` transient path.
- `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`: added contract assertions for admission retry constants/reason-code wiring and docs marker.
- `docs/planning/kolme-devnet-ops.md`: documented admission bounded retry contract and regression marker.

## TDD Evidence (Mandatory)
### Red Phase
Command:
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`

Failure:
- `expected localhost signed integration shared contract lane module to define admission bounded retry reason-code handling`

### Green Phase
Commands:
- `bash scripts/sdk/test_localhost_signed_scenario_runner.sh`
- `bash scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`
- `bash scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh`

Result:
- All pass after admission retry wiring.

### Regression
Commands:
- `bash scripts/ci/test_readme_contract.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-core --all-targets --all-features -- -D warnings`

Result:
- All pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/sdk/test_localhost_signed_scenario_runner.py` | |
| Functional   | ✅     | `scripts/sdk/test_run_localhost_signed_integration_contract_lane.sh`, `scripts/sdk/test_run_localhost_signed_demo_contract_lane.sh` | |
| Integration  | ✅     | `scripts/ci/test_ci_tools.sh`, `scripts/ci/test_readme_contract.sh`, `scripts/ci/test_select_targets.sh` | |
| Regression   | ✅     | Existing localhost signed schema/marker contracts remained green; admission retry contract assertions added | |
| Performance  | ✅     | Admission retry capped at 2 attempts; runtime budget policy unchanged | |

## Risks & Rollback
- Breaking changes: None expected; schemas/markers/reason-keys unchanged.
- Rollback plan: Revert this PR commit to remove admission-specific bounded retry wiring.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md` with admission bounded retry contract note.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
