### PR TITLE
fix(kolme): compose localhost-signed prerequisite in live runtime lane (#1636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-ru
 
 # explicit local-only runtime integration execution
 KAMN_KOLME_LOCAL_HEAVY=1 \
-bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 210 --bootstrap-max-seconds 90 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
+bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 210 --bootstrap-max-seconds 90 --localhost-signed-max-seconds 45 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
 
 # policy checker contract
 python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json

--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -89,6 +89,7 @@ fn plan_contains_local_kamn_live_runtime_integration_lane() {
     assert!(PLAN.contains("run_local_kamn_live_runtime_integration_lane.sh"));
     assert!(PLAN.contains("check_local_kamn_live_runtime_integration_policy.py"));
     assert!(PLAN.contains("run_local_kamn_live_runtime_integration_contract_lane.sh"));
+    assert!(PLAN.contains("run_localhost_signed_integration_contract_lane.sh"));
     assert!(PLAN.contains("kamn.kolme.local-kamn-live-runtime-integration-summary.v1"));
     assert!(PLAN.contains(
         "signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization."
@@ -301,7 +302,15 @@ fn regression_requires_local_fork_bootstrap_readiness_guard_marker() {
 fn regression_requires_local_kamn_live_runtime_integration_guard_marker() {
     // Regression: #1489
     assert!(PLAN.contains(
-        "local KAMN live runtime integration lane fails closed for bootstrap/conformance/runtime-commit prerequisite drift, runtime budget overruns, and missing local opt-in (`Regression: #1489`)."
+        "local KAMN live runtime integration lane fails closed for bootstrap/localhost-signed/conformance/runtime-commit prerequisite drift, runtime budget overruns, and missing local opt-in (`Regression: #1489`)."
+    ));
+}
+
+#[test]
+fn regression_requires_localhost_signed_runtime_integration_prerequisite_guard_marker() {
+    // Regression: #1636
+    assert!(PLAN.contains(
+        "local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`)."
     ));
 }
 

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -190,7 +190,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Local KAMN live runtime integration runner:
   - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Explicit local-only live runtime integration execution:
-  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 210 --bootstrap-max-seconds 90 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 210 --bootstrap-max-seconds 90 --localhost-signed-max-seconds 45 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Policy checker command:
   - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
 - Contract lane command:
@@ -199,6 +199,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `kamn.kolme.local-kamn-live-runtime-integration-summary.v1`
 - Deterministic checkpoints include:
   - `run_local_kolme_fork_bootstrap_readiness_lane.sh` run-mode validation for pinned checkout provenance and API readiness.
+  - `run_localhost_signed_integration_contract_lane.sh` run-mode validation of signed message admission/replay guards before Kolme runtime commit execution.
   - `run_local_kolme_live_api_conformance_harness.sh` run-mode validation for health/query/nonce/broadcast command contracts.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.
@@ -396,7 +397,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local Kolme API smoke lane fails closed without explicit local opt-in, probe prerequisite failure, smoke-command timeout, and smoke-command errors (`Regression: #1440`).
 - local live API conformance harness fails closed for probe/native parity prerequisite failures, runtime budget overruns, and endpoint contract drift (`Regression: #1483`).
 - local fork bootstrap/readiness lane fails closed for sync/probe prerequisite failures, runtime budget overruns, and missing local opt-in (`Regression: #1488`).
-- local KAMN live runtime integration lane fails closed for bootstrap/conformance/runtime-commit prerequisite drift, runtime budget overruns, and missing local opt-in (`Regression: #1489`).
+- local KAMN live runtime integration lane fails closed for bootstrap/localhost-signed/conformance/runtime-commit prerequisite drift, runtime budget overruns, and missing local opt-in (`Regression: #1489`).
+- local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`).
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - local native API parity live proof lane fails closed without local opt-in and on nonce/broadcast/finality timeout or command failures (`Regression: #1465`).

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -59,12 +59,21 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_commit_endpoint_mismatch")
         if contracts.get("runtime_commit_method") != "POST":
             reason_codes.append("runtime_commit_method_mismatch")
+        if contracts.get("runtime_commit_finality_primary_endpoint") != "/notifications":
+            reason_codes.append("runtime_commit_finality_primary_endpoint_mismatch")
+        if contracts.get("runtime_commit_finality_fallback_endpoint") != "/block/{height}":
+            reason_codes.append("runtime_commit_finality_fallback_endpoint_mismatch")
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:
         reason_codes.append("checks_missing")
     else:
-        expected_ids = {"bootstrap_readiness", "live_api_conformance", "runtime_commit_endpoint"}
+        expected_ids = {
+            "bootstrap_readiness",
+            "localhost_signed_integration",
+            "live_api_conformance",
+            "runtime_commit_endpoint",
+        }
         observed_ids: set[str] = set()
         for entry in checks:
             if not isinstance(entry, dict):

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -260,6 +260,7 @@ KAMN_KOLME_LOCAL_HEAVY=1 \
     --fork-chain-version "$FORK_CHAIN_VERSION" \
     --max-seconds "$MAX_SECONDS" \
     --bootstrap-max-seconds 90 \
+    --localhost-signed-max-seconds 45 \
     --conformance-max-seconds 180 \
     --runtime-commit-max-seconds 30 \
     --output-json "$OUTPUT_JSON" \
@@ -288,8 +289,18 @@ if ! grep -q "run_local_kamn_live_runtime_integration_contract_lane.sh" "$DOC_FI
   exit 1
 fi
 
+if ! grep -q -- "--localhost-signed-max-seconds 45" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to document localhost signed checkpoint runtime budget argument" >&2
+  exit 1
+fi
+
 if ! grep -q "Regression: #1489" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to include local KAMN live runtime integration regression marker" >&2
+  exit 1
+fi
+
+if ! grep -q "Regression: #1636" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include localhost signed runtime integration prerequisite regression marker" >&2
   exit 1
 fi
 

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BOOTSTRAP_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh"
 CONFORMANCE_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_live_api_conformance_harness.sh"
+LOCALHOST_SIGNED_INTEGRATION_RUNNER="$ROOT_DIR/scripts/sdk/run_localhost_signed_integration_contract_lane.sh"
 LOCAL_HEAVY_GUARD="$ROOT_DIR/scripts/framework/assert_local_heavy_opt_in.sh"
 
 MODE="dry-run"
 OUTPUT_JSON="/tmp/kolme-local-kamn-live-runtime-integration-summary.json"
 BOOTSTRAP_REPORT="/tmp/kolme-local-fork-bootstrap-readiness-summary.json"
 CONFORMANCE_REPORT="/tmp/kolme-local-live-api-conformance-summary.json"
+LOCALHOST_SIGNED_REPORT="/tmp/localhost-signed-integration-contract-report.json"
 RUNTIME_COMMIT_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-endpoint-output.txt"
 CHECKOUT_PATH="/tmp/kolme_fork"
 EXPECTED_REMOTE_URL="https://github.com/njfio/kolme_fork.git"
@@ -20,6 +22,7 @@ RUNTIME_COMMIT_COMMAND=""
 MAX_SECONDS=210
 BOOTSTRAP_MAX_SECONDS=90
 CONFORMANCE_MAX_SECONDS=180
+LOCALHOST_SIGNED_MAX_SECONDS=45
 RUNTIME_COMMIT_MAX_SECONDS=30
 
 while [ "$#" -gt 0 ]; do
@@ -54,6 +57,14 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       CONFORMANCE_REPORT="$2"
+      shift 2
+      ;;
+    --localhost-signed-report)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --localhost-signed-report" >&2
+        exit 1
+      fi
+      LOCALHOST_SIGNED_REPORT="$2"
       shift 2
       ;;
     --runtime-commit-output-file)
@@ -136,6 +147,14 @@ while [ "$#" -gt 0 ]; do
       CONFORMANCE_MAX_SECONDS="$2"
       shift 2
       ;;
+    --localhost-signed-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --localhost-signed-max-seconds" >&2
+        exit 1
+      fi
+      LOCALHOST_SIGNED_MAX_SECONDS="$2"
+      shift 2
+      ;;
     --runtime-commit-max-seconds)
       if [ "$#" -lt 2 ]; then
         echo "missing value for --runtime-commit-max-seconds" >&2
@@ -153,6 +172,7 @@ Options:
   --output-json <path>                  Deterministic summary report output path.
   --bootstrap-report <path>             Output path for bootstrap/readiness summary.
   --conformance-report <path>           Output path for live API conformance summary.
+  --localhost-signed-report <path>      Output path for localhost signed integration summary.
   --runtime-commit-output-file <path>   Captured stdout/stderr for runtime-commit endpoint command.
   --checkout-path <path>                Local kolme_fork checkout path.
   --expected-remote-url <url>           Expected origin URL for checkout validation.
@@ -163,6 +183,7 @@ Options:
   --max-seconds <n>                     Max total runtime budget for run mode.
   --bootstrap-max-seconds <n>           Max budget for bootstrap/readiness prerequisite.
   --conformance-max-seconds <n>         Max budget for live API conformance prerequisite.
+  --localhost-signed-max-seconds <n>    Max budget for localhost signed integration prerequisite.
   --runtime-commit-max-seconds <n>      Max budget for runtime-commit endpoint command.
 USAGE
       exit 0
@@ -189,7 +210,7 @@ if [ -z "$BASE_URL" ] || [ -z "$FORK_CHAIN_VERSION" ]; then
   exit 1
 fi
 
-for numeric_value in "$MAX_SECONDS" "$BOOTSTRAP_MAX_SECONDS" "$CONFORMANCE_MAX_SECONDS" "$RUNTIME_COMMIT_MAX_SECONDS"; do
+for numeric_value in "$MAX_SECONDS" "$BOOTSTRAP_MAX_SECONDS" "$CONFORMANCE_MAX_SECONDS" "$LOCALHOST_SIGNED_MAX_SECONDS" "$RUNTIME_COMMIT_MAX_SECONDS"; do
   if ! [[ "$numeric_value" =~ ^[0-9]+$ ]] || [ "$numeric_value" -le 0 ]; then
     echo "all max-second arguments must be positive integers" >&2
     exit 1
@@ -203,6 +224,11 @@ fi
 
 if [ ! -x "$CONFORMANCE_RUNNER" ]; then
   echo "expected local Kolme live API conformance harness runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$LOCALHOST_SIGNED_INTEGRATION_RUNNER" ]; then
+  echo "expected localhost signed integration contract runner to be executable" >&2
   exit 1
 fi
 
@@ -256,6 +282,7 @@ PY
 }
 
 bootstrap_command="bash scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --max-seconds ${BOOTSTRAP_MAX_SECONDS} --probe-max-seconds 20 --output-json ${BOOTSTRAP_REPORT}"
+localhost_signed_command="bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json ${LOCALHOST_SIGNED_REPORT}"
 conformance_command="bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --max-seconds ${CONFORMANCE_MAX_SECONDS} --probe-max-seconds 30 --native-max-seconds 120 --output-json ${CONFORMANCE_REPORT}"
 runtime_commit_command="$RUNTIME_COMMIT_COMMAND"
 
@@ -264,10 +291,12 @@ reason_code="dry_run_no_commands_executed"
 budget_status="not_run"
 elapsed_seconds=0
 bootstrap_reason_code="not_run"
+localhost_signed_reason_code="not_run"
 conformance_reason_code="not_run"
 runtime_commit_reason_code="not_run"
 
 record_check "bootstrap_readiness" "$bootstrap_command" "planned" "not_run"
+record_check "localhost_signed_integration" "$localhost_signed_command" "planned" "not_run"
 record_check "live_api_conformance" "$conformance_command" "planned" "not_run"
 record_check "runtime_commit_endpoint" "$runtime_commit_command" "planned" "not_run"
 
@@ -277,11 +306,13 @@ if [ "$MODE" = "run" ]; then
 
   if ! "$LOCAL_HEAVY_GUARD"; then
     record_check "bootstrap_readiness" "$bootstrap_command" "fail" "local_opt_in_missing"
+    record_check "localhost_signed_integration" "$localhost_signed_command" "skipped" "local_opt_in_missing"
     record_check "live_api_conformance" "$conformance_command" "skipped" "local_opt_in_missing"
     record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "local_opt_in_missing"
     overall_status="fail"
     reason_code="local_opt_in_missing"
     bootstrap_reason_code="local_opt_in_missing"
+    localhost_signed_reason_code="local_opt_in_missing"
     conformance_reason_code="local_opt_in_missing"
     runtime_commit_reason_code="local_opt_in_missing"
   else
@@ -300,12 +331,45 @@ if [ "$MODE" = "run" ]; then
     else
       bootstrap_reason_code="$(read_report_reason_code "$BOOTSTRAP_REPORT")"
       record_check "bootstrap_readiness" "$bootstrap_command" "fail" "$bootstrap_reason_code"
+      record_check "localhost_signed_integration" "$localhost_signed_command" "skipped" "bootstrap_readiness_failed"
       record_check "live_api_conformance" "$conformance_command" "skipped" "bootstrap_readiness_failed"
       record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "bootstrap_readiness_failed"
       overall_status="fail"
       reason_code="bootstrap_readiness_failed"
+      localhost_signed_reason_code="bootstrap_readiness_failed"
       conformance_reason_code="bootstrap_readiness_failed"
       runtime_commit_reason_code="bootstrap_readiness_failed"
+    fi
+
+    if [ "$overall_status" = "ok" ]; then
+      set +e
+      timeout "$LOCALHOST_SIGNED_MAX_SECONDS" bash "$LOCALHOST_SIGNED_INTEGRATION_RUNNER" \
+        --output-json "$LOCALHOST_SIGNED_REPORT" >/dev/null 2>&1
+      localhost_signed_exit_code=$?
+      set -e
+
+      if [ "$localhost_signed_exit_code" -eq 0 ]; then
+        record_check "localhost_signed_integration" "$localhost_signed_command" "pass" "localhost_signed_integration_passed"
+        localhost_signed_reason_code="localhost_signed_integration_passed"
+      elif [ "$localhost_signed_exit_code" -eq 124 ]; then
+        record_check "localhost_signed_integration" "$localhost_signed_command" "fail" "localhost_signed_integration_timeout"
+        record_check "live_api_conformance" "$conformance_command" "skipped" "localhost_signed_integration_failed"
+        record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "localhost_signed_integration_failed"
+        overall_status="fail"
+        reason_code="localhost_signed_integration_failed"
+        localhost_signed_reason_code="localhost_signed_integration_timeout"
+        conformance_reason_code="localhost_signed_integration_failed"
+        runtime_commit_reason_code="localhost_signed_integration_failed"
+      else
+        record_check "localhost_signed_integration" "$localhost_signed_command" "fail" "localhost_signed_integration_failed"
+        record_check "live_api_conformance" "$conformance_command" "skipped" "localhost_signed_integration_failed"
+        record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "localhost_signed_integration_failed"
+        overall_status="fail"
+        reason_code="localhost_signed_integration_failed"
+        localhost_signed_reason_code="localhost_signed_integration_failed"
+        conformance_reason_code="localhost_signed_integration_failed"
+        runtime_commit_reason_code="localhost_signed_integration_failed"
+      fi
     fi
 
     if [ "$overall_status" = "ok" ]; then
@@ -367,7 +431,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$BOOTSTRAP_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$CHECK_FILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$CHECK_FILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -389,11 +453,13 @@ budget_status = sys.argv[12]
 runtime_commit_command = sys.argv[13]
 runtime_commit_output_file = sys.argv[14]
 bootstrap_report = sys.argv[15]
-conformance_report = sys.argv[16]
-bootstrap_reason_code = sys.argv[17]
-conformance_reason_code = sys.argv[18]
-runtime_commit_reason_code = sys.argv[19]
-checks_path = pathlib.Path(sys.argv[20])
+localhost_signed_report = sys.argv[16]
+conformance_report = sys.argv[17]
+bootstrap_reason_code = sys.argv[18]
+localhost_signed_reason_code = sys.argv[19]
+conformance_reason_code = sys.argv[20]
+runtime_commit_reason_code = sys.argv[21]
+checks_path = pathlib.Path(sys.argv[22])
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -428,15 +494,19 @@ summary = {
     "fork_chain_version": fork_chain_version,
     "runtime_commit_command": runtime_commit_command,
     "bootstrap_reason_code": bootstrap_reason_code,
+    "localhost_signed_reason_code": localhost_signed_reason_code,
     "conformance_reason_code": conformance_reason_code,
     "runtime_commit_reason_code": runtime_commit_reason_code,
     "contracts": {
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",
+        "runtime_commit_finality_primary_endpoint": "/notifications",
+        "runtime_commit_finality_fallback_endpoint": "/block/{height}",
     },
     "checks": checks,
     "artifact_paths": [
         bootstrap_report,
+        localhost_signed_report,
         conformance_report,
         runtime_commit_output_file,
     ],

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -57,6 +57,11 @@ if ! grep -q "scripts/framework/assert_local_heavy_opt_in.sh" "$RUNNER"; then
   exit 1
 fi
 
+if ! grep -q "run_localhost_signed_integration_contract_lane.sh" "$RUNNER"; then
+  echo "expected local KAMN live runtime integration runner to invoke localhost signed integration contract lane prerequisite" >&2
+  exit 1
+fi
+
 if [ ! -x "$CHECKER" ]; then
   echo "expected local KAMN live runtime integration policy checker to be executable" >&2
   exit 1
@@ -82,6 +87,11 @@ if ! grep -q "run_local_kamn_live_runtime_integration_contract_lane.sh" "$DOC_FI
   exit 1
 fi
 
+if ! grep -q -- "--localhost-signed-max-seconds 45" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to document localhost signed checkpoint runtime budget argument" >&2
+  exit 1
+fi
+
 if ! grep -q "run_localhost_signed_demo.sh --output-json /tmp/localhost-signed-demo-artifact.json" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference localhost signed demo artifact command" >&2
   exit 1
@@ -104,6 +114,11 @@ fi
 
 if ! grep -q "kamn.sdk.localhost-signed.integration-contract.v1" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference localhost signed integration contract schema" >&2
+  exit 1
+fi
+
+if ! grep -q "Regression: #1636" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include localhost signed runtime integration prerequisite regression marker" >&2
   exit 1
 fi
 
@@ -356,6 +371,7 @@ run_output="$(
       --fork-chain-version "$FORK_CHAIN_VERSION" \
       --max-seconds 210 \
       --bootstrap-max-seconds 90 \
+      --localhost-signed-max-seconds 45 \
       --conformance-max-seconds 180 \
       --runtime-commit-max-seconds 30 \
       --output-json "$TMP_REPORT"
@@ -393,7 +409,12 @@ if report.get("status") != "ok":
 checks = report.get("checks")
 if not isinstance(checks, list):
     raise SystemExit("expected check list in run summary")
-for expected_id in ("bootstrap_readiness", "live_api_conformance", "runtime_commit_endpoint"):
+for expected_id in (
+    "bootstrap_readiness",
+    "localhost_signed_integration",
+    "live_api_conformance",
+    "runtime_commit_endpoint",
+):
     matching = [entry for entry in checks if isinstance(entry, dict) and entry.get("id") == expected_id]
     if not matching:
         raise SystemExit(f"missing check id: {expected_id}")
@@ -406,6 +427,10 @@ if contracts.get("runtime_commit_endpoint") != "/broadcast/runtime-commit":
     raise SystemExit("unexpected runtime commit endpoint contract marker")
 if contracts.get("runtime_commit_method") != "POST":
     raise SystemExit("unexpected runtime commit method contract marker")
+if contracts.get("runtime_commit_finality_primary_endpoint") != "/notifications":
+    raise SystemExit("unexpected runtime commit finality primary endpoint contract marker")
+if contracts.get("runtime_commit_finality_fallback_endpoint") != "/block/{height}":
+    raise SystemExit("unexpected runtime commit finality fallback endpoint contract marker")
 PY
 
 contract_output="$(


### PR DESCRIPTION
## Summary
Extended the local KAMN live runtime integration lane to include a bounded localhost signed integration prerequisite before live conformance/runtime-commit stages. This closes the gap between signed-message contract validation and Kolme runtime commit/finality path checks while keeping execution local-only and fail-closed.

Closes #1636

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
  - Added `localhost_signed_integration` checkpoint with bounded timeout (`--localhost-signed-max-seconds`, default `45`).
  - Added report field `localhost_signed_reason_code`.
  - Added finality contract markers in report contracts:
    - `runtime_commit_finality_primary_endpoint=/notifications`
    - `runtime_commit_finality_fallback_endpoint=/block/{height}`
  - Added localhost signed integration report artifact path to summary output.
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`
  - Requires new checkpoint id `localhost_signed_integration`.
  - Validates finality contract markers in `contracts`.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
  - Added Red/Green assertions for runner prerequisite wiring.
  - Added check-id and finality-marker assertions.
  - Added docs contract assertions for localhost-signed stage budget flag and new regression marker.
- `scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh`
  - Executes runner with `--localhost-signed-max-seconds 45`.
  - Enforces docs regression marker and command-surface drift checks.
- `docs/planning/kolme-devnet-ops.md`
  - Updated local runtime integration lane command surface and checkpoint list.
  - Added regression marker for localhost-signed prerequisite (`Regression: #1636`).
- `README.md`
  - Updated local runtime integration run command with `--localhost-signed-max-seconds 45`.
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
  - Updated/added doc-contract assertions for the new checkpoint and regression marker.

## TDD Evidence (Mandatory)
### Red Phase
Command:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`

Failure:
- `expected local KAMN live runtime integration runner to invoke localhost signed integration contract lane prerequisite`

### Green Phase
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/ci/test_readme_contract.sh`
- `bash scripts/ci/test_select_targets.sh`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`

Result:
- All pass after localhost signed checkpoint + policy/report/doc updates.

### Regression
Commands:
- `TMPDIR=/home/n/Code/kamn/.tmp bash scripts/ci/test_ci_tools.sh`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-core --all-targets --all-features -- -D warnings`

Result:
- All pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py` validation extensions covered via lane tests | |
| Functional   | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Integration  | ✅     | `scripts/ci/test_ci_tools.sh`, `scripts/ci/test_select_targets.sh`, `scripts/ci/test_readme_contract.sh` | |
| Regression   | ✅     | `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`, `docs/planning/kolme-devnet-ops.md` | |
| Performance  | ✅     | New stage is bounded with `--localhost-signed-max-seconds` (default `45`) and total lane budget remains capped | |

## Risks & Rollback
- Breaking changes: None expected; lane schema remains stable with additive fields/checkpoint.
- Rollback plan: Revert this PR commit to remove localhost-signed prerequisite stage and associated policy/docs assertions.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md` and `README.md` command surfaces and regression markers.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
