### PR TITLE
feat(kolme): gate wrapper lifecycle on self-test checkpoints

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -138,6 +138,8 @@ fn plan_contains_real_fork_local_process_wrapper_lane() {
     assert!(PLAN.contains("run_local_kolme_fork_real_process_contract_lane.sh"));
     assert!(PLAN.contains("run_local_kolme_fork_profile_preflight_lane.sh"));
     assert!(PLAN.contains("check_local_kolme_fork_profile_preflight_policy.py"));
+    assert!(PLAN.contains("run_local_kolme_fork_self_test_lane.sh"));
+    assert!(PLAN.contains("check_local_kolme_fork_self_test_policy.py"));
     assert!(PLAN.contains("check_local_kolme_fork_real_process_policy.py"));
     assert!(PLAN.contains("kamn.kolme.local-fork-real-process-summary.v1"));
 }
@@ -384,6 +386,6 @@ fn regression_requires_local_fork_self_test_guard_marker() {
 fn regression_requires_real_fork_local_process_wrapper_guard_marker() {
     // Regression: #1644
     assert!(PLAN.contains(
-        "real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`)."
+        "real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`)."
     ));
 }

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -323,24 +323,28 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Real-fork local wrapper runner:
   - `bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Explicit local-only real-fork wrapper execution:
-  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 360 --preflight-max-seconds 45 --lifecycle-max-seconds 300 --lifecycle-startup-max-seconds 45 --lifecycle-integration-max-seconds 240 --lifecycle-bootstrap-max-seconds 90 --lifecycle-conformance-max-seconds 180 --lifecycle-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-real-process-summary.json`
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 360 --preflight-max-seconds 45 --self-test-max-seconds 120 --self-test-matrix-max-seconds 60 --lifecycle-max-seconds 300 --lifecycle-startup-max-seconds 45 --lifecycle-integration-max-seconds 240 --lifecycle-bootstrap-max-seconds 90 --lifecycle-conformance-max-seconds 180 --lifecycle-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Default serve profile contract:
   - `cd <checkout-path> && cargo run --bin example-six-sigma -- serve api-server`
 - Profile preflight prerequisite commands:
   - `bash scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh --mode run --checkout-path /tmp/kolme_fork --max-seconds 45 --output-json /tmp/kolme-local-fork-profile-preflight-summary.json`
   - `python3 scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py --report-file /tmp/kolme-local-fork-profile-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code profile_preflight_passed --output-json /tmp/kolme-local-fork-profile-preflight-policy.json`
+- Local self-test prerequisite commands:
+  - `bash scripts/kolme/run_local_kolme_fork_self_test_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --matrix-max-seconds 60 --output-json /tmp/kolme-local-fork-self-test-summary.json`
+  - `python3 scripts/kolme/check_local_kolme_fork_self_test_policy.py --report-file /tmp/kolme-local-fork-self-test-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code fork_self_test_passed --output-json /tmp/kolme-local-fork-self-test-policy.json`
 - Policy checker command:
   - `python3 scripts/kolme/check_local_kolme_fork_real_process_policy.py --report-file /tmp/kolme-local-fork-real-process-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-real-process-policy.json`
 - Summary schema:
   - `kamn.kolme.local-fork-real-process-summary.v1`
 - Deterministic checkpoints include:
   - real-fork command profile validation for `example-six-sigma serve api-server`.
-  - `run_local_kolme_fork_profile_preflight_lane.sh` and policy verification execute before lifecycle orchestration.
+  - `run_local_kolme_fork_profile_preflight_lane.sh` and policy verification execute before self-test/lifecycle orchestration.
+  - `run_local_kolme_fork_self_test_lane.sh` and policy verification execute before lifecycle orchestration.
   - `run_local_kolme_fork_process_lifecycle_lane.sh` run-mode composition with bounded budgets.
   - `check_local_kolme_fork_process_lifecycle_policy.py` GO decision verification.
 - Cost policy:
   - run mode fails closed without explicit local-only opt-in.
-  - wrapper run mode enforces bounded preflight/lifecycle and total runtime budgets.
+  - wrapper run mode enforces bounded preflight/self-test/lifecycle and total runtime budgets.
   - wrapper run-mode execution remains excluded from PR fast-gate workflow routing.
 
 ## Local Runtime Commit Live Proof Lane (Issue #1450)
@@ -485,7 +489,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).
 - local fork profile preflight lane fails closed for local opt-in, checkout/profile contract drift, probe command failures, and runtime budget overruns (`Regression: #1648`).
 - local fork self-test lane fails closed for local opt-in, nested matrix/policy checkpoint failures, and runtime budget overruns (`Regression: #1652`).
-- real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`).
+- real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - local native API parity live proof lane fails closed without local opt-in and on nonce/broadcast/finality timeout or command failures (`Regression: #1465`).
 - native parity fast/local command matrix docs drift remains fail-closed (`Regression: #1468`).

--- a/scripts/kolme/check_local_kolme_fork_real_process_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_real_process_policy.py
@@ -73,6 +73,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("profile_preflight_runner_mismatch")
         if contracts.get("profile_preflight_checker") != "check_local_kolme_fork_profile_preflight_policy.py":
             reason_codes.append("profile_preflight_checker_mismatch")
+        if contracts.get("self_test_runner") != "run_local_kolme_fork_self_test_lane.sh":
+            reason_codes.append("self_test_runner_mismatch")
+        if contracts.get("self_test_checker") != "check_local_kolme_fork_self_test_policy.py":
+            reason_codes.append("self_test_checker_mismatch")
         if contracts.get("lifecycle_runner") != "run_local_kolme_fork_process_lifecycle_lane.sh":
             reason_codes.append("lifecycle_runner_mismatch")
         if contracts.get("lifecycle_checker") != "check_local_kolme_fork_process_lifecycle_policy.py":
@@ -86,6 +90,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             "real_fork_command_profile",
             "profile_preflight_lane",
             "profile_preflight_policy",
+            "self_test_lane",
+            "self_test_policy",
             "process_lifecycle_lane",
             "process_lifecycle_policy",
         }
@@ -113,7 +119,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append(f"check_missing:{missing_id}")
 
     artifacts = report.get("artifact_paths")
-    if not isinstance(artifacts, list) or len(artifacts) < 4:
+    if not isinstance(artifacts, list) or len(artifacts) < 6:
         reason_codes.append("artifact_paths_missing")
 
     if args.ci_fast_gate != "PASS":

--- a/scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PROFILE_PREFLIGHT_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh"
 PROFILE_PREFLIGHT_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py"
+SELF_TEST_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_self_test_lane.sh"
+SELF_TEST_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_self_test_policy.py"
 LIFECYCLE_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh"
 LIFECYCLE_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py"
 LOCAL_HEAVY_GUARD="$ROOT_DIR/scripts/framework/assert_local_heavy_opt_in.sh"
@@ -12,6 +14,8 @@ MODE="dry-run"
 OUTPUT_JSON="/tmp/kolme-local-fork-real-process-summary.json"
 PROFILE_PREFLIGHT_REPORT="/tmp/kolme-local-fork-profile-preflight-summary.json"
 PROFILE_PREFLIGHT_POLICY_REPORT="/tmp/kolme-local-fork-profile-preflight-policy.json"
+SELF_TEST_REPORT="/tmp/kolme-local-fork-self-test-summary.json"
+SELF_TEST_POLICY_REPORT="/tmp/kolme-local-fork-self-test-policy.json"
 LIFECYCLE_REPORT="/tmp/kolme-local-fork-process-lifecycle-summary.json"
 LIFECYCLE_POLICY_REPORT="/tmp/kolme-local-fork-process-lifecycle-policy.json"
 CHECKOUT_PATH="/tmp/kolme_fork"
@@ -23,12 +27,16 @@ SERVE_COMMAND=""
 ALLOW_NON_FORK_SERVE_COMMAND="false"
 MAX_SECONDS=360
 PROFILE_PREFLIGHT_MAX_SECONDS=45
+SELF_TEST_MAX_SECONDS=120
+SELF_TEST_MATRIX_MAX_SECONDS=60
 LIFECYCLE_MAX_SECONDS=300
 LIFECYCLE_STARTUP_MAX_SECONDS=45
 LIFECYCLE_INTEGRATION_MAX_SECONDS=240
 LIFECYCLE_BOOTSTRAP_MAX_SECONDS=90
 LIFECYCLE_CONFORMANCE_MAX_SECONDS=180
 LIFECYCLE_RUNTIME_COMMIT_MAX_SECONDS=30
+
+declare -a SELF_TEST_MATRIX_COMMANDS=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -70,6 +78,22 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       PROFILE_PREFLIGHT_POLICY_REPORT="$2"
+      shift 2
+      ;;
+    --self-test-report)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --self-test-report" >&2
+        exit 1
+      fi
+      SELF_TEST_REPORT="$2"
+      shift 2
+      ;;
+    --self-test-policy-report)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --self-test-policy-report" >&2
+        exit 1
+      fi
+      SELF_TEST_POLICY_REPORT="$2"
       shift 2
       ;;
     --lifecycle-policy-report)
@@ -148,6 +172,30 @@ while [ "$#" -gt 0 ]; do
       PROFILE_PREFLIGHT_MAX_SECONDS="$2"
       shift 2
       ;;
+    --self-test-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --self-test-max-seconds" >&2
+        exit 1
+      fi
+      SELF_TEST_MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --self-test-matrix-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --self-test-matrix-max-seconds" >&2
+        exit 1
+      fi
+      SELF_TEST_MATRIX_MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --self-test-matrix-command)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --self-test-matrix-command" >&2
+        exit 1
+      fi
+      SELF_TEST_MATRIX_COMMANDS+=("$2")
+      shift 2
+      ;;
     --lifecycle-max-seconds)
       if [ "$#" -lt 2 ]; then
         echo "missing value for --lifecycle-max-seconds" >&2
@@ -205,6 +253,8 @@ Options:
   --output-json <path>                            Deterministic summary output path.
   --preflight-report <path>                       Output path for local fork profile preflight report.
   --preflight-policy-report <path>                Output path for local fork profile preflight policy report.
+  --self-test-report <path>                       Output path for local fork self-test summary report.
+  --self-test-policy-report <path>                Output path for local fork self-test policy report.
   --lifecycle-report <path>                       Output path for local fork process lifecycle report.
   --lifecycle-policy-report <path>                Output path for local fork process lifecycle policy report.
   --checkout-path <path>                          Local kolme_fork checkout path.
@@ -216,6 +266,9 @@ Options:
   --allow-non-fork-serve-command                  Allow non-fork serve command override for local test harnesses.
   --max-seconds <n>                               Max total runtime budget for run mode.
   --preflight-max-seconds <n>                     Max runtime budget for nested profile-preflight lane.
+  --self-test-max-seconds <n>                     Max runtime budget for nested self-test lane.
+  --self-test-matrix-max-seconds <n>              Max per-command budget for nested self-test matrix runner.
+  --self-test-matrix-command <command>            Repeatable override command passed to nested self-test lane.
   --lifecycle-max-seconds <n>                     Max runtime budget for nested process-lifecycle lane.
   --lifecycle-startup-max-seconds <n>             Max startup readiness budget for nested lane.
   --lifecycle-integration-max-seconds <n>         Max integration budget for nested lane.
@@ -240,6 +293,8 @@ fi
 for numeric_value in \
   "$MAX_SECONDS" \
   "$PROFILE_PREFLIGHT_MAX_SECONDS" \
+  "$SELF_TEST_MAX_SECONDS" \
+  "$SELF_TEST_MATRIX_MAX_SECONDS" \
   "$LIFECYCLE_MAX_SECONDS" \
   "$LIFECYCLE_STARTUP_MAX_SECONDS" \
   "$LIFECYCLE_INTEGRATION_MAX_SECONDS" \
@@ -259,6 +314,16 @@ fi
 
 if [ ! -x "$PROFILE_PREFLIGHT_CHECKER" ]; then
   echo "expected local fork profile preflight policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$SELF_TEST_RUNNER" ]; then
+  echo "expected local fork self-test runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$SELF_TEST_CHECKER" ]; then
+  echo "expected local fork self-test policy checker to be executable" >&2
   exit 1
 fi
 
@@ -327,6 +392,8 @@ command_policy_error_message="serve-command must target checkout path and use ca
 command_profile_contract="default profile: cargo run --bin example-six-sigma -- serve api-server"
 preflight_command="bash scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --max-seconds ${PROFILE_PREFLIGHT_MAX_SECONDS} --output-json ${PROFILE_PREFLIGHT_REPORT}"
 preflight_policy_command="python3 scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py --report-file ${PROFILE_PREFLIGHT_REPORT} --expected-final-decision GO --ci-fast-gate PASS --require-reason-code profile_preflight_passed --output-json ${PROFILE_PREFLIGHT_POLICY_REPORT}"
+self_test_command="bash scripts/kolme/run_local_kolme_fork_self_test_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --max-seconds ${SELF_TEST_MAX_SECONDS} --matrix-max-seconds ${SELF_TEST_MATRIX_MAX_SECONDS} --output-json ${SELF_TEST_REPORT}"
+self_test_policy_command="python3 scripts/kolme/check_local_kolme_fork_self_test_policy.py --report-file ${SELF_TEST_REPORT} --expected-final-decision GO --ci-fast-gate PASS --require-reason-code fork_self_test_passed --output-json ${SELF_TEST_POLICY_REPORT}"
 lifecycle_command="bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --serve-command ${selected_serve_command} --max-seconds ${LIFECYCLE_MAX_SECONDS} --startup-max-seconds ${LIFECYCLE_STARTUP_MAX_SECONDS} --integration-max-seconds ${LIFECYCLE_INTEGRATION_MAX_SECONDS} --integration-bootstrap-max-seconds ${LIFECYCLE_BOOTSTRAP_MAX_SECONDS} --integration-conformance-max-seconds ${LIFECYCLE_CONFORMANCE_MAX_SECONDS} --integration-runtime-commit-max-seconds ${LIFECYCLE_RUNTIME_COMMIT_MAX_SECONDS} --output-json ${LIFECYCLE_REPORT}"
 policy_command="python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py --report-file ${LIFECYCLE_REPORT} --expected-final-decision GO --ci-fast-gate PASS --require-reason-code process_lifecycle_integration_passed --output-json ${LIFECYCLE_POLICY_REPORT}"
 
@@ -338,6 +405,8 @@ elapsed_seconds=0
 record_check "real_fork_command_profile" "$command_profile_contract" "planned" "not_run"
 record_check "profile_preflight_lane" "$preflight_command" "planned" "not_run"
 record_check "profile_preflight_policy" "$preflight_policy_command" "planned" "not_run"
+record_check "self_test_lane" "$self_test_command" "planned" "not_run"
+record_check "self_test_policy" "$self_test_policy_command" "planned" "not_run"
 record_check "process_lifecycle_lane" "$lifecycle_command" "planned" "not_run"
 record_check "process_lifecycle_policy" "$policy_command" "planned" "not_run"
 
@@ -349,6 +418,8 @@ if [ "$MODE" = "run" ]; then
     record_check "real_fork_command_profile" "$command_profile_contract" "fail" "local_opt_in_missing"
     record_check "profile_preflight_lane" "$preflight_command" "skipped" "local_opt_in_missing"
     record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "local_opt_in_missing"
+    record_check "self_test_lane" "$self_test_command" "skipped" "local_opt_in_missing"
+    record_check "self_test_policy" "$self_test_policy_command" "skipped" "local_opt_in_missing"
     record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "local_opt_in_missing"
     record_check "process_lifecycle_policy" "$policy_command" "skipped" "local_opt_in_missing"
     overall_status="fail"
@@ -363,6 +434,8 @@ if [ "$MODE" = "run" ]; then
     record_check "real_fork_command_profile" "$command_profile_contract" "fail" "command_policy_violation"
     record_check "profile_preflight_lane" "$preflight_command" "skipped" "command_policy_violation"
     record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "command_policy_violation"
+    record_check "self_test_lane" "$self_test_command" "skipped" "command_policy_violation"
+    record_check "self_test_policy" "$self_test_policy_command" "skipped" "command_policy_violation"
     record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "command_policy_violation"
     record_check "process_lifecycle_policy" "$policy_command" "skipped" "command_policy_violation"
     overall_status="fail"
@@ -389,6 +462,8 @@ if [ "$MODE" = "run" ]; then
     elif [ "$preflight_exit_code" -eq 124 ]; then
       record_check "profile_preflight_lane" "$preflight_command" "fail" "profile_preflight_lane_timeout"
       record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "profile_preflight_lane_failed"
+      record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_lane_failed"
+      record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_lane_failed"
       record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_lane_failed"
       record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_lane_failed"
       overall_status="fail"
@@ -397,6 +472,8 @@ if [ "$MODE" = "run" ]; then
       preflight_reason_code="$(read_reason_code "$PROFILE_PREFLIGHT_REPORT")"
       record_check "profile_preflight_lane" "$preflight_command" "fail" "$preflight_reason_code"
       record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "profile_preflight_lane_failed"
+      record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_lane_failed"
+      record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_lane_failed"
       record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_lane_failed"
       record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_lane_failed"
       overall_status="fail"
@@ -418,10 +495,73 @@ if [ "$MODE" = "run" ]; then
         record_check "profile_preflight_policy" "$preflight_policy_command" "pass" "profile_preflight_policy_passed"
       else
         record_check "profile_preflight_policy" "$preflight_policy_command" "fail" "profile_preflight_policy_failed"
+        record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_policy_failed"
+        record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_policy_failed"
         record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_policy_failed"
         record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_policy_failed"
         overall_status="fail"
         reason_code="checkpoint_failed_profile_preflight_policy"
+      fi
+    fi
+
+    if [ "$overall_status" = "ok" ]; then
+      self_test_args=(
+        --mode run
+        --checkout-path "$CHECKOUT_PATH"
+        --expected-remote-url "$EXPECTED_REMOTE_URL"
+        --expected-ref "$EXPECTED_REF"
+        --max-seconds "$SELF_TEST_MAX_SECONDS"
+        --matrix-max-seconds "$SELF_TEST_MATRIX_MAX_SECONDS"
+        --output-json "$SELF_TEST_REPORT"
+      )
+      for self_test_matrix_command in "${SELF_TEST_MATRIX_COMMANDS[@]}"; do
+        self_test_args+=(--matrix-command "$self_test_matrix_command")
+      done
+
+      set +e
+      timeout "$SELF_TEST_MAX_SECONDS" bash "$SELF_TEST_RUNNER" "${self_test_args[@]}" >/dev/null 2>&1
+      self_test_exit_code=$?
+      set -e
+
+      if [ "$self_test_exit_code" -eq 0 ]; then
+        record_check "self_test_lane" "$self_test_command" "pass" "self_test_lane_passed"
+      elif [ "$self_test_exit_code" -eq 124 ]; then
+        record_check "self_test_lane" "$self_test_command" "fail" "self_test_lane_timeout"
+        record_check "self_test_policy" "$self_test_policy_command" "skipped" "self_test_lane_failed"
+        record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "self_test_lane_failed"
+        record_check "process_lifecycle_policy" "$policy_command" "skipped" "self_test_lane_failed"
+        overall_status="fail"
+        reason_code="checkpoint_failed_self_test_lane"
+      else
+        self_test_reason_code="$(read_reason_code "$SELF_TEST_REPORT")"
+        record_check "self_test_lane" "$self_test_command" "fail" "$self_test_reason_code"
+        record_check "self_test_policy" "$self_test_policy_command" "skipped" "self_test_lane_failed"
+        record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "self_test_lane_failed"
+        record_check "process_lifecycle_policy" "$policy_command" "skipped" "self_test_lane_failed"
+        overall_status="fail"
+        reason_code="checkpoint_failed_self_test_lane"
+      fi
+    fi
+
+    if [ "$overall_status" = "ok" ]; then
+      set +e
+      python3 "$SELF_TEST_CHECKER" \
+        --report-file "$SELF_TEST_REPORT" \
+        --expected-final-decision GO \
+        --ci-fast-gate PASS \
+        --require-reason-code fork_self_test_passed \
+        --output-json "$SELF_TEST_POLICY_REPORT" >/dev/null 2>&1
+      self_test_policy_exit_code=$?
+      set -e
+
+      if [ "$self_test_policy_exit_code" -eq 0 ]; then
+        record_check "self_test_policy" "$self_test_policy_command" "pass" "self_test_policy_passed"
+      else
+        record_check "self_test_policy" "$self_test_policy_command" "fail" "self_test_policy_failed"
+        record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "self_test_policy_failed"
+        record_check "process_lifecycle_policy" "$policy_command" "skipped" "self_test_policy_failed"
+        overall_status="fail"
+        reason_code="checkpoint_failed_self_test_policy"
       fi
     fi
 
@@ -495,7 +635,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECK_FILE" "$selected_serve_command" "$ALLOW_NON_FORK_SERVE_COMMAND" "$PROFILE_PREFLIGHT_REPORT" "$PROFILE_PREFLIGHT_POLICY_REPORT" "$LIFECYCLE_REPORT" "$LIFECYCLE_POLICY_REPORT" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECK_FILE" "$selected_serve_command" "$ALLOW_NON_FORK_SERVE_COMMAND" "$PROFILE_PREFLIGHT_REPORT" "$PROFILE_PREFLIGHT_POLICY_REPORT" "$SELF_TEST_REPORT" "$SELF_TEST_POLICY_REPORT" "$LIFECYCLE_REPORT" "$LIFECYCLE_POLICY_REPORT" <<'PY'
 from __future__ import annotations
 
 import json
@@ -514,8 +654,10 @@ selected_serve_command = sys.argv[9]
 allow_non_fork_serve_command = sys.argv[10] == "true"
 profile_preflight_report = sys.argv[11]
 profile_preflight_policy_report = sys.argv[12]
-lifecycle_report = sys.argv[13]
-lifecycle_policy_report = sys.argv[14]
+self_test_report = sys.argv[13]
+self_test_policy_report = sys.argv[14]
+lifecycle_report = sys.argv[15]
+lifecycle_policy_report = sys.argv[16]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -551,6 +693,8 @@ summary = {
         "expected_component": "api-server",
         "profile_preflight_runner": "run_local_kolme_fork_profile_preflight_lane.sh",
         "profile_preflight_checker": "check_local_kolme_fork_profile_preflight_policy.py",
+        "self_test_runner": "run_local_kolme_fork_self_test_lane.sh",
+        "self_test_checker": "check_local_kolme_fork_self_test_policy.py",
         "lifecycle_runner": "run_local_kolme_fork_process_lifecycle_lane.sh",
         "lifecycle_checker": "check_local_kolme_fork_process_lifecycle_policy.py",
     },
@@ -558,6 +702,8 @@ summary = {
     "artifact_paths": [
         profile_preflight_report,
         profile_preflight_policy_report,
+        self_test_report,
+        self_test_policy_report,
         lifecycle_report,
         lifecycle_policy_report,
     ],

--- a/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
@@ -70,6 +70,16 @@ if ! grep -q "run_local_kolme_fork_profile_preflight_lane.sh" "$DOC_FILE"; then
   exit 1
 fi
 
+if ! grep -q "run_local_kolme_fork_self_test_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork self-test runner" >&2
+  exit 1
+fi
+
+if ! grep -q "check_local_kolme_fork_self_test_policy.py" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork self-test policy checker" >&2
+  exit 1
+fi
+
 if ! grep -q "run_local_kolme_fork_real_process_contract_lane.sh" "$README_FILE"; then
   echo "expected README to reference real-fork local process wrapper runner" >&2
   exit 1
@@ -117,6 +127,8 @@ for expected_id in (
     "real_fork_command_profile",
     "profile_preflight_lane",
     "profile_preflight_policy",
+    "self_test_lane",
+    "self_test_policy",
     "process_lifecycle_lane",
     "process_lifecycle_policy",
 ):
@@ -305,6 +317,10 @@ run_output="$(
       --allow-non-fork-serve-command \
       --max-seconds 360 \
       --preflight-max-seconds 45 \
+      --self-test-max-seconds 60 \
+      --self-test-matrix-max-seconds 20 \
+      --self-test-matrix-command "printf wrapper_self_test_ok_1" \
+      --self-test-matrix-command "printf wrapper_self_test_ok_2" \
       --lifecycle-max-seconds 240 \
       --lifecycle-startup-max-seconds 45 \
       --lifecycle-integration-max-seconds 180 \
@@ -348,6 +364,8 @@ for expected_id in (
     "real_fork_command_profile",
     "profile_preflight_lane",
     "profile_preflight_policy",
+    "self_test_lane",
+    "self_test_policy",
     "process_lifecycle_lane",
     "process_lifecycle_policy",
 ):


### PR DESCRIPTION
Closes #1656

## Summary
Updates the real-fork process wrapper lane so lifecycle execution is gated by both self-test lane and self-test policy checkpoints after profile preflight. This preserves local-only bounded execution while strengthening wrapper contract evidence ordering.

## Changes
- `scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh`: added self-test runner/checker dependencies, new CLI options, new checkpoint flow (`self_test_lane`, `self_test_policy`), and updated summary artifacts/contracts.
- `scripts/kolme/check_local_kolme_fork_real_process_policy.py`: validates new self-test contract keys/check IDs and expanded artifact set.
- `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`: red->green wrapper checkpoint assertions updated for self-test stage.
- `docs/planning/kolme-devnet-ops.md`, `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`: wrapper docs/regression marker updates for self-test prerequisite composition.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p kamn-core --all-targets --all-features -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: wrapper lane and prerequisite lanes executed locally in dry-run/run modes

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core --test kolme_devnet_ops_docs` |
| Functional  | ✅ | `bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh` |
| Integration | ✅ | `bash scripts/kolme/test_run_local_kolme_fork_self_test_lane.sh` |
| Regression  | ✅ | `TMPDIR=/tmp/kamn1656/.tmp bash scripts/ci/test_ci_tools.sh` |
