### PR TITLE
feat(kolme): enforce bootstrap-first wrapper orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,30 @@ bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh \
   --mode dry-run \
   --checkout-path /tmp/kolme_fork \
   --output-json /tmp/kolme-local-fork-real-process-summary.json
+KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh \
+  --mode run \
+  --checkout-path /tmp/kolme_fork \
+  --fork-remote-url https://github.com/njfio/kolme_fork.git \
+  --expected-remote-url https://github.com/njfio/kolme_fork.git \
+  --expected-ref refs/heads/main \
+  --max-seconds 360 \
+  --bootstrap-max-seconds 120 \
+  --preflight-max-seconds 45 \
+  --self-test-max-seconds 120 \
+  --self-test-matrix-max-seconds 60 \
+  --lifecycle-max-seconds 300 \
+  --lifecycle-startup-max-seconds 45 \
+  --lifecycle-integration-max-seconds 240 \
+  --lifecycle-bootstrap-max-seconds 90 \
+  --lifecycle-conformance-max-seconds 180 \
+  --lifecycle-runtime-commit-max-seconds 30 \
+  --output-json /tmp/kolme-local-fork-real-process-summary.json
 python3 scripts/kolme/check_local_kolme_fork_real_process_policy.py \
   --report-file /tmp/kolme-local-fork-real-process-summary.json \
   --expected-final-decision GO \
   --ci-fast-gate PASS \
   --output-json /tmp/kolme-local-fork-real-process-policy.json
+# run mode composes checkout bootstrap + policy prerequisites before preflight/self-test/lifecycle
 # schema: kamn.kolme.local-fork-real-process-summary.v1
 ```
 

--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -146,6 +146,8 @@ fn plan_contains_local_fork_checkout_bootstrap_lane() {
 fn plan_contains_real_fork_local_process_wrapper_lane() {
     assert!(PLAN.contains("## Real Fork Local Process Wrapper Contract Lane"));
     assert!(PLAN.contains("run_local_kolme_fork_real_process_contract_lane.sh"));
+    assert!(PLAN.contains("run_local_kolme_fork_checkout_bootstrap_lane.sh"));
+    assert!(PLAN.contains("check_local_kolme_fork_checkout_bootstrap_policy.py"));
     assert!(PLAN.contains("run_local_kolme_fork_profile_preflight_lane.sh"));
     assert!(PLAN.contains("check_local_kolme_fork_profile_preflight_policy.py"));
     assert!(PLAN.contains("run_local_kolme_fork_self_test_lane.sh"));
@@ -414,5 +416,13 @@ fn regression_requires_real_fork_local_process_wrapper_guard_marker() {
     // Regression: #1644
     assert!(PLAN.contains(
         "real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`)."
+    ));
+}
+
+#[test]
+fn regression_requires_real_fork_wrapper_bootstrap_prerequisite_guard_marker() {
+    // Regression: #1667
+    assert!(PLAN.contains(
+        "real-fork local process wrapper bootstrap-first prerequisite ordering remains fail-closed for bootstrap lane/policy checkpoint drift (`Regression: #1667`)."
     ));
 }

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -346,9 +346,12 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Real-fork local wrapper runner:
   - `bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Explicit local-only real-fork wrapper execution:
-  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 360 --preflight-max-seconds 45 --self-test-max-seconds 120 --self-test-matrix-max-seconds 60 --lifecycle-max-seconds 300 --lifecycle-startup-max-seconds 45 --lifecycle-integration-max-seconds 240 --lifecycle-bootstrap-max-seconds 90 --lifecycle-conformance-max-seconds 180 --lifecycle-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-real-process-summary.json`
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 360 --bootstrap-max-seconds 120 --preflight-max-seconds 45 --self-test-max-seconds 120 --self-test-matrix-max-seconds 60 --lifecycle-max-seconds 300 --lifecycle-startup-max-seconds 45 --lifecycle-integration-max-seconds 240 --lifecycle-bootstrap-max-seconds 90 --lifecycle-conformance-max-seconds 180 --lifecycle-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Default serve profile contract:
   - `cd <checkout-path> && cargo run --bin example-six-sigma -- serve api-server`
+- Checkout bootstrap prerequisite commands:
+  - `bash scripts/kolme/run_local_kolme_fork_checkout_bootstrap_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --output-json /tmp/kolme-local-fork-checkout-bootstrap-summary.json`
+  - `python3 scripts/kolme/check_local_kolme_fork_checkout_bootstrap_policy.py --report-file /tmp/kolme-local-fork-checkout-bootstrap-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code fork_checkout_bootstrap_passed --output-json /tmp/kolme-local-fork-checkout-bootstrap-policy.json`
 - Profile preflight prerequisite commands:
   - `bash scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh --mode run --checkout-path /tmp/kolme_fork --max-seconds 45 --output-json /tmp/kolme-local-fork-profile-preflight-summary.json`
   - `python3 scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py --report-file /tmp/kolme-local-fork-profile-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code profile_preflight_passed --output-json /tmp/kolme-local-fork-profile-preflight-policy.json`
@@ -361,6 +364,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `kamn.kolme.local-fork-real-process-summary.v1`
 - Deterministic checkpoints include:
   - real-fork command profile validation for `example-six-sigma serve api-server`.
+  - `run_local_kolme_fork_checkout_bootstrap_lane.sh` and policy verification execute before preflight/self-test/lifecycle orchestration.
   - `run_local_kolme_fork_profile_preflight_lane.sh` and policy verification execute before self-test/lifecycle orchestration.
   - `run_local_kolme_fork_self_test_lane.sh` and policy verification execute before lifecycle orchestration.
   - `run_local_kolme_fork_process_lifecycle_lane.sh` run-mode composition with bounded budgets.
@@ -514,6 +518,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local fork profile preflight lane fails closed for local opt-in, checkout/profile contract drift, probe command failures, and runtime budget overruns (`Regression: #1648`).
 - local fork self-test lane fails closed for local opt-in, nested matrix/policy checkpoint failures, and runtime budget overruns (`Regression: #1652`).
 - local fork checkout bootstrap lane fails closed for local opt-in, checkout provenance drift, diagnostics command failures, and runtime budget overruns (`Regression: #1663`).
+- real-fork local process wrapper bootstrap-first prerequisite ordering remains fail-closed for bootstrap lane/policy checkpoint drift (`Regression: #1667`).
 - real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - local native API parity live proof lane fails closed without local opt-in and on nonce/broadcast/finality timeout or command failures (`Regression: #1465`).

--- a/scripts/kolme/check_local_kolme_fork_real_process_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_real_process_policy.py
@@ -69,6 +69,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("expected_cargo_bin_mismatch")
         if contracts.get("expected_component") != "api-server":
             reason_codes.append("expected_component_mismatch")
+        if contracts.get("checkout_bootstrap_runner") != "run_local_kolme_fork_checkout_bootstrap_lane.sh":
+            reason_codes.append("checkout_bootstrap_runner_mismatch")
+        if contracts.get("checkout_bootstrap_checker") != "check_local_kolme_fork_checkout_bootstrap_policy.py":
+            reason_codes.append("checkout_bootstrap_checker_mismatch")
         if contracts.get("profile_preflight_runner") != "run_local_kolme_fork_profile_preflight_lane.sh":
             reason_codes.append("profile_preflight_runner_mismatch")
         if contracts.get("profile_preflight_checker") != "check_local_kolme_fork_profile_preflight_policy.py":
@@ -88,6 +92,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     else:
         expected_ids = {
             "real_fork_command_profile",
+            "checkout_bootstrap_lane",
+            "checkout_bootstrap_policy",
             "profile_preflight_lane",
             "profile_preflight_policy",
             "self_test_lane",
@@ -119,7 +125,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append(f"check_missing:{missing_id}")
 
     artifacts = report.get("artifact_paths")
-    if not isinstance(artifacts, list) or len(artifacts) < 6:
+    if not isinstance(artifacts, list) or len(artifacts) < 8:
         reason_codes.append("artifact_paths_missing")
 
     if args.ci_fast_gate != "PASS":

--- a/scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKOUT_BOOTSTRAP_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_checkout_bootstrap_lane.sh"
+CHECKOUT_BOOTSTRAP_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_checkout_bootstrap_policy.py"
 PROFILE_PREFLIGHT_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh"
 PROFILE_PREFLIGHT_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py"
 SELF_TEST_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_fork_self_test_lane.sh"
@@ -12,6 +14,8 @@ LOCAL_HEAVY_GUARD="$ROOT_DIR/scripts/framework/assert_local_heavy_opt_in.sh"
 
 MODE="dry-run"
 OUTPUT_JSON="/tmp/kolme-local-fork-real-process-summary.json"
+CHECKOUT_BOOTSTRAP_REPORT="/tmp/kolme-local-fork-checkout-bootstrap-summary.json"
+CHECKOUT_BOOTSTRAP_POLICY_REPORT="/tmp/kolme-local-fork-checkout-bootstrap-policy.json"
 PROFILE_PREFLIGHT_REPORT="/tmp/kolme-local-fork-profile-preflight-summary.json"
 PROFILE_PREFLIGHT_POLICY_REPORT="/tmp/kolme-local-fork-profile-preflight-policy.json"
 SELF_TEST_REPORT="/tmp/kolme-local-fork-self-test-summary.json"
@@ -19,6 +23,7 @@ SELF_TEST_POLICY_REPORT="/tmp/kolme-local-fork-self-test-policy.json"
 LIFECYCLE_REPORT="/tmp/kolme-local-fork-process-lifecycle-summary.json"
 LIFECYCLE_POLICY_REPORT="/tmp/kolme-local-fork-process-lifecycle-policy.json"
 CHECKOUT_PATH="/tmp/kolme_fork"
+FORK_REMOTE_URL="https://github.com/njfio/kolme_fork.git"
 EXPECTED_REMOTE_URL="https://github.com/njfio/kolme_fork.git"
 EXPECTED_REF="refs/heads/main"
 BASE_URL="http://127.0.0.1:3000"
@@ -26,6 +31,7 @@ FORK_CHAIN_VERSION="v0.15.2"
 SERVE_COMMAND=""
 ALLOW_NON_FORK_SERVE_COMMAND="false"
 MAX_SECONDS=360
+CHECKOUT_BOOTSTRAP_MAX_SECONDS=120
 PROFILE_PREFLIGHT_MAX_SECONDS=45
 SELF_TEST_MAX_SECONDS=120
 SELF_TEST_MATRIX_MAX_SECONDS=60
@@ -54,6 +60,22 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --bootstrap-report)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --bootstrap-report" >&2
+        exit 1
+      fi
+      CHECKOUT_BOOTSTRAP_REPORT="$2"
+      shift 2
+      ;;
+    --bootstrap-policy-report)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --bootstrap-policy-report" >&2
+        exit 1
+      fi
+      CHECKOUT_BOOTSTRAP_POLICY_REPORT="$2"
       shift 2
       ;;
     --lifecycle-report)
@@ -112,6 +134,14 @@ while [ "$#" -gt 0 ]; do
       CHECKOUT_PATH="$2"
       shift 2
       ;;
+    --fork-remote-url)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --fork-remote-url" >&2
+        exit 1
+      fi
+      FORK_REMOTE_URL="$2"
+      shift 2
+      ;;
     --expected-remote-url)
       if [ "$#" -lt 2 ]; then
         echo "missing value for --expected-remote-url" >&2
@@ -162,6 +192,14 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --bootstrap-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --bootstrap-max-seconds" >&2
+        exit 1
+      fi
+      CHECKOUT_BOOTSTRAP_MAX_SECONDS="$2"
       shift 2
       ;;
     --preflight-max-seconds)
@@ -251,6 +289,8 @@ Usage: run_local_kolme_fork_real_process_contract_lane.sh [options]
 Options:
   --mode dry-run|run                              Emit planned checks or execute wrapper checks.
   --output-json <path>                            Deterministic summary output path.
+  --bootstrap-report <path>                       Output path for checkout bootstrap report.
+  --bootstrap-policy-report <path>                Output path for checkout bootstrap policy report.
   --preflight-report <path>                       Output path for local fork profile preflight report.
   --preflight-policy-report <path>                Output path for local fork profile preflight policy report.
   --self-test-report <path>                       Output path for local fork self-test summary report.
@@ -258,6 +298,7 @@ Options:
   --lifecycle-report <path>                       Output path for local fork process lifecycle report.
   --lifecycle-policy-report <path>                Output path for local fork process lifecycle policy report.
   --checkout-path <path>                          Local kolme_fork checkout path.
+  --fork-remote-url <url-or-path>                 Fork clone/fetch source used by checkout bootstrap prerequisite.
   --expected-remote-url <url>                     Expected origin URL for checkout validation.
   --expected-ref <ref>                            Expected symbolic HEAD ref for checkout.
   --base-url <url>                                Base URL for local Kolme API server.
@@ -265,6 +306,7 @@ Options:
   --serve-command <command>                       Optional serve command override.
   --allow-non-fork-serve-command                  Allow non-fork serve command override for local test harnesses.
   --max-seconds <n>                               Max total runtime budget for run mode.
+  --bootstrap-max-seconds <n>                     Max runtime budget for nested checkout bootstrap lane.
   --preflight-max-seconds <n>                     Max runtime budget for nested profile-preflight lane.
   --self-test-max-seconds <n>                     Max runtime budget for nested self-test lane.
   --self-test-matrix-max-seconds <n>              Max per-command budget for nested self-test matrix runner.
@@ -292,6 +334,7 @@ fi
 
 for numeric_value in \
   "$MAX_SECONDS" \
+  "$CHECKOUT_BOOTSTRAP_MAX_SECONDS" \
   "$PROFILE_PREFLIGHT_MAX_SECONDS" \
   "$SELF_TEST_MAX_SECONDS" \
   "$SELF_TEST_MATRIX_MAX_SECONDS" \
@@ -309,6 +352,16 @@ done
 
 if [ ! -x "$PROFILE_PREFLIGHT_RUNNER" ]; then
   echo "expected local fork profile preflight runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKOUT_BOOTSTRAP_RUNNER" ]; then
+  echo "expected local fork checkout bootstrap runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKOUT_BOOTSTRAP_CHECKER" ]; then
+  echo "expected local fork checkout bootstrap policy checker to be executable" >&2
   exit 1
 fi
 
@@ -390,6 +443,8 @@ PY
 command_policy_error_message="serve-command must target checkout path and use cargo run for the local fork profile (or pass --allow-non-fork-serve-command for local harnesses)"
 
 command_profile_contract="default profile: cargo run --bin example-six-sigma -- serve api-server"
+checkout_bootstrap_command="bash scripts/kolme/run_local_kolme_fork_checkout_bootstrap_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --fork-remote-url ${FORK_REMOTE_URL} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --max-seconds ${CHECKOUT_BOOTSTRAP_MAX_SECONDS} --output-json ${CHECKOUT_BOOTSTRAP_REPORT}"
+checkout_bootstrap_policy_command="python3 scripts/kolme/check_local_kolme_fork_checkout_bootstrap_policy.py --report-file ${CHECKOUT_BOOTSTRAP_REPORT} --expected-final-decision GO --ci-fast-gate PASS --require-reason-code fork_checkout_bootstrap_passed --output-json ${CHECKOUT_BOOTSTRAP_POLICY_REPORT}"
 preflight_command="bash scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --max-seconds ${PROFILE_PREFLIGHT_MAX_SECONDS} --output-json ${PROFILE_PREFLIGHT_REPORT}"
 preflight_policy_command="python3 scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py --report-file ${PROFILE_PREFLIGHT_REPORT} --expected-final-decision GO --ci-fast-gate PASS --require-reason-code profile_preflight_passed --output-json ${PROFILE_PREFLIGHT_POLICY_REPORT}"
 self_test_command="bash scripts/kolme/run_local_kolme_fork_self_test_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --max-seconds ${SELF_TEST_MAX_SECONDS} --matrix-max-seconds ${SELF_TEST_MATRIX_MAX_SECONDS} --output-json ${SELF_TEST_REPORT}"
@@ -403,6 +458,8 @@ budget_status="not_run"
 elapsed_seconds=0
 
 record_check "real_fork_command_profile" "$command_profile_contract" "planned" "not_run"
+record_check "checkout_bootstrap_lane" "$checkout_bootstrap_command" "planned" "not_run"
+record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "planned" "not_run"
 record_check "profile_preflight_lane" "$preflight_command" "planned" "not_run"
 record_check "profile_preflight_policy" "$preflight_policy_command" "planned" "not_run"
 record_check "self_test_lane" "$self_test_command" "planned" "not_run"
@@ -416,6 +473,8 @@ if [ "$MODE" = "run" ]; then
 
   if ! "$LOCAL_HEAVY_GUARD"; then
     record_check "real_fork_command_profile" "$command_profile_contract" "fail" "local_opt_in_missing"
+    record_check "checkout_bootstrap_lane" "$checkout_bootstrap_command" "skipped" "local_opt_in_missing"
+    record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "skipped" "local_opt_in_missing"
     record_check "profile_preflight_lane" "$preflight_command" "skipped" "local_opt_in_missing"
     record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "local_opt_in_missing"
     record_check "self_test_lane" "$self_test_command" "skipped" "local_opt_in_missing"
@@ -432,6 +491,8 @@ if [ "$MODE" = "run" ]; then
   }; then
     echo "$command_policy_error_message" >&2
     record_check "real_fork_command_profile" "$command_profile_contract" "fail" "command_policy_violation"
+    record_check "checkout_bootstrap_lane" "$checkout_bootstrap_command" "skipped" "command_policy_violation"
+    record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "skipped" "command_policy_violation"
     record_check "profile_preflight_lane" "$preflight_command" "skipped" "command_policy_violation"
     record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "command_policy_violation"
     record_check "self_test_lane" "$self_test_command" "skipped" "command_policy_violation"
@@ -444,40 +505,107 @@ if [ "$MODE" = "run" ]; then
     record_check "real_fork_command_profile" "$command_profile_contract" "pass" "command_profile_validated"
 
     set +e
-    preflight_args=(
-      --mode run
-      --checkout-path "$CHECKOUT_PATH"
-      --max-seconds "$PROFILE_PREFLIGHT_MAX_SECONDS"
-      --output-json "$PROFILE_PREFLIGHT_REPORT"
-    )
-    if [ "$ALLOW_NON_FORK_SERVE_COMMAND" = "true" ]; then
-      preflight_args+=(--probe-command "bash -lc 'exit 0'" --allow-non-default-probe-command)
-    fi
-    timeout "$PROFILE_PREFLIGHT_MAX_SECONDS" bash "$PROFILE_PREFLIGHT_RUNNER" "${preflight_args[@]}" >/dev/null 2>&1
-    preflight_exit_code=$?
+    timeout "$CHECKOUT_BOOTSTRAP_MAX_SECONDS" bash "$CHECKOUT_BOOTSTRAP_RUNNER" \
+      --mode run \
+      --checkout-path "$CHECKOUT_PATH" \
+      --fork-remote-url "$FORK_REMOTE_URL" \
+      --expected-remote-url "$EXPECTED_REMOTE_URL" \
+      --expected-ref "$EXPECTED_REF" \
+      --max-seconds "$CHECKOUT_BOOTSTRAP_MAX_SECONDS" \
+      --output-json "$CHECKOUT_BOOTSTRAP_REPORT" >/dev/null 2>&1
+    checkout_bootstrap_exit_code=$?
     set -e
 
-    if [ "$preflight_exit_code" -eq 0 ]; then
-      record_check "profile_preflight_lane" "$preflight_command" "pass" "profile_preflight_lane_passed"
-    elif [ "$preflight_exit_code" -eq 124 ]; then
-      record_check "profile_preflight_lane" "$preflight_command" "fail" "profile_preflight_lane_timeout"
-      record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "profile_preflight_lane_failed"
-      record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_lane_failed"
-      record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_lane_failed"
-      record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_lane_failed"
-      record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_lane_failed"
+    if [ "$checkout_bootstrap_exit_code" -eq 0 ]; then
+      record_check "checkout_bootstrap_lane" "$checkout_bootstrap_command" "pass" "checkout_bootstrap_lane_passed"
+    elif [ "$checkout_bootstrap_exit_code" -eq 124 ]; then
+      record_check "checkout_bootstrap_lane" "$checkout_bootstrap_command" "fail" "checkout_bootstrap_lane_timeout"
+      record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "profile_preflight_lane" "$preflight_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "self_test_lane" "$self_test_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "self_test_policy" "$self_test_policy_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "process_lifecycle_policy" "$policy_command" "skipped" "checkout_bootstrap_lane_failed"
       overall_status="fail"
-      reason_code="checkpoint_failed_profile_preflight_lane"
+      reason_code="checkpoint_failed_checkout_bootstrap_lane"
     else
-      preflight_reason_code="$(read_reason_code "$PROFILE_PREFLIGHT_REPORT")"
-      record_check "profile_preflight_lane" "$preflight_command" "fail" "$preflight_reason_code"
-      record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "profile_preflight_lane_failed"
-      record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_lane_failed"
-      record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_lane_failed"
-      record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_lane_failed"
-      record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_lane_failed"
+      checkout_bootstrap_reason_code="$(read_reason_code "$CHECKOUT_BOOTSTRAP_REPORT")"
+      record_check "checkout_bootstrap_lane" "$checkout_bootstrap_command" "fail" "$checkout_bootstrap_reason_code"
+      record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "profile_preflight_lane" "$preflight_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "self_test_lane" "$self_test_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "self_test_policy" "$self_test_policy_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "checkout_bootstrap_lane_failed"
+      record_check "process_lifecycle_policy" "$policy_command" "skipped" "checkout_bootstrap_lane_failed"
       overall_status="fail"
-      reason_code="checkpoint_failed_profile_preflight_lane"
+      reason_code="checkpoint_failed_checkout_bootstrap_lane"
+    fi
+
+    if [ "$overall_status" = "ok" ]; then
+      set +e
+      python3 "$CHECKOUT_BOOTSTRAP_CHECKER" \
+        --report-file "$CHECKOUT_BOOTSTRAP_REPORT" \
+        --expected-final-decision GO \
+        --ci-fast-gate PASS \
+        --require-reason-code fork_checkout_bootstrap_passed \
+        --output-json "$CHECKOUT_BOOTSTRAP_POLICY_REPORT" >/dev/null 2>&1
+      checkout_bootstrap_policy_exit_code=$?
+      set -e
+
+      if [ "$checkout_bootstrap_policy_exit_code" -eq 0 ]; then
+        record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "pass" "checkout_bootstrap_policy_passed"
+      else
+        record_check "checkout_bootstrap_policy" "$checkout_bootstrap_policy_command" "fail" "checkout_bootstrap_policy_failed"
+        record_check "profile_preflight_lane" "$preflight_command" "skipped" "checkout_bootstrap_policy_failed"
+        record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "checkout_bootstrap_policy_failed"
+        record_check "self_test_lane" "$self_test_command" "skipped" "checkout_bootstrap_policy_failed"
+        record_check "self_test_policy" "$self_test_policy_command" "skipped" "checkout_bootstrap_policy_failed"
+        record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "checkout_bootstrap_policy_failed"
+        record_check "process_lifecycle_policy" "$policy_command" "skipped" "checkout_bootstrap_policy_failed"
+        overall_status="fail"
+        reason_code="checkpoint_failed_checkout_bootstrap_policy"
+      fi
+    fi
+
+    if [ "$overall_status" = "ok" ]; then
+      set +e
+      preflight_args=(
+        --mode run
+        --checkout-path "$CHECKOUT_PATH"
+        --max-seconds "$PROFILE_PREFLIGHT_MAX_SECONDS"
+        --output-json "$PROFILE_PREFLIGHT_REPORT"
+      )
+      if [ "$ALLOW_NON_FORK_SERVE_COMMAND" = "true" ]; then
+        preflight_args+=(--probe-command "bash -lc 'exit 0'" --allow-non-default-probe-command)
+      fi
+      timeout "$PROFILE_PREFLIGHT_MAX_SECONDS" bash "$PROFILE_PREFLIGHT_RUNNER" "${preflight_args[@]}" >/dev/null 2>&1
+      preflight_exit_code=$?
+      set -e
+
+      if [ "$preflight_exit_code" -eq 0 ]; then
+        record_check "profile_preflight_lane" "$preflight_command" "pass" "profile_preflight_lane_passed"
+      elif [ "$preflight_exit_code" -eq 124 ]; then
+        record_check "profile_preflight_lane" "$preflight_command" "fail" "profile_preflight_lane_timeout"
+        record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "profile_preflight_lane_failed"
+        record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_lane_failed"
+        record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_lane_failed"
+        record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_lane_failed"
+        record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_lane_failed"
+        overall_status="fail"
+        reason_code="checkpoint_failed_profile_preflight_lane"
+      else
+        preflight_reason_code="$(read_reason_code "$PROFILE_PREFLIGHT_REPORT")"
+        record_check "profile_preflight_lane" "$preflight_command" "fail" "$preflight_reason_code"
+        record_check "profile_preflight_policy" "$preflight_policy_command" "skipped" "profile_preflight_lane_failed"
+        record_check "self_test_lane" "$self_test_command" "skipped" "profile_preflight_lane_failed"
+        record_check "self_test_policy" "$self_test_policy_command" "skipped" "profile_preflight_lane_failed"
+        record_check "process_lifecycle_lane" "$lifecycle_command" "skipped" "profile_preflight_lane_failed"
+        record_check "process_lifecycle_policy" "$policy_command" "skipped" "profile_preflight_lane_failed"
+        overall_status="fail"
+        reason_code="checkpoint_failed_profile_preflight_lane"
+      fi
     fi
 
     if [ "$overall_status" = "ok" ]; then
@@ -635,7 +763,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECK_FILE" "$selected_serve_command" "$ALLOW_NON_FORK_SERVE_COMMAND" "$PROFILE_PREFLIGHT_REPORT" "$PROFILE_PREFLIGHT_POLICY_REPORT" "$SELF_TEST_REPORT" "$SELF_TEST_POLICY_REPORT" "$LIFECYCLE_REPORT" "$LIFECYCLE_POLICY_REPORT" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECK_FILE" "$selected_serve_command" "$ALLOW_NON_FORK_SERVE_COMMAND" "$CHECKOUT_BOOTSTRAP_REPORT" "$CHECKOUT_BOOTSTRAP_POLICY_REPORT" "$PROFILE_PREFLIGHT_REPORT" "$PROFILE_PREFLIGHT_POLICY_REPORT" "$SELF_TEST_REPORT" "$SELF_TEST_POLICY_REPORT" "$LIFECYCLE_REPORT" "$LIFECYCLE_POLICY_REPORT" <<'PY'
 from __future__ import annotations
 
 import json
@@ -652,12 +780,14 @@ budget_status = sys.argv[7]
 checks_path = pathlib.Path(sys.argv[8])
 selected_serve_command = sys.argv[9]
 allow_non_fork_serve_command = sys.argv[10] == "true"
-profile_preflight_report = sys.argv[11]
-profile_preflight_policy_report = sys.argv[12]
-self_test_report = sys.argv[13]
-self_test_policy_report = sys.argv[14]
-lifecycle_report = sys.argv[15]
-lifecycle_policy_report = sys.argv[16]
+checkout_bootstrap_report = sys.argv[11]
+checkout_bootstrap_policy_report = sys.argv[12]
+profile_preflight_report = sys.argv[13]
+profile_preflight_policy_report = sys.argv[14]
+self_test_report = sys.argv[15]
+self_test_policy_report = sys.argv[16]
+lifecycle_report = sys.argv[17]
+lifecycle_policy_report = sys.argv[18]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -691,6 +821,8 @@ summary = {
         "default_profile": "example-six-sigma:serve-api-server",
         "expected_cargo_bin": "example-six-sigma",
         "expected_component": "api-server",
+        "checkout_bootstrap_runner": "run_local_kolme_fork_checkout_bootstrap_lane.sh",
+        "checkout_bootstrap_checker": "check_local_kolme_fork_checkout_bootstrap_policy.py",
         "profile_preflight_runner": "run_local_kolme_fork_profile_preflight_lane.sh",
         "profile_preflight_checker": "check_local_kolme_fork_profile_preflight_policy.py",
         "self_test_runner": "run_local_kolme_fork_self_test_lane.sh",
@@ -700,6 +832,8 @@ summary = {
     },
     "checks": checks,
     "artifact_paths": [
+        checkout_bootstrap_report,
+        checkout_bootstrap_policy_report,
         profile_preflight_report,
         profile_preflight_policy_report,
         self_test_report,

--- a/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
@@ -70,6 +70,16 @@ if ! grep -q "run_local_kolme_fork_profile_preflight_lane.sh" "$DOC_FILE"; then
   exit 1
 fi
 
+if ! grep -q "run_local_kolme_fork_checkout_bootstrap_lane.sh" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork checkout bootstrap runner" >&2
+  exit 1
+fi
+
+if ! grep -q "check_local_kolme_fork_checkout_bootstrap_policy.py" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference local fork checkout bootstrap policy checker" >&2
+  exit 1
+fi
+
 if ! grep -q "run_local_kolme_fork_self_test_lane.sh" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference local fork self-test runner" >&2
   exit 1
@@ -125,6 +135,8 @@ if not isinstance(checks, list):
     raise SystemExit("expected checks list in summary")
 for expected_id in (
     "real_fork_command_profile",
+    "checkout_bootstrap_lane",
+    "checkout_bootstrap_policy",
     "profile_preflight_lane",
     "profile_preflight_policy",
     "self_test_lane",
@@ -155,17 +167,18 @@ if ! grep -q "requires explicit local-only opt-in" "$TMP_ERR"; then
 fi
 
 CHECKOUT_PATH="$TMP_DIR/kolme_fork"
-mkdir -p "$CHECKOUT_PATH"
-git -C "$CHECKOUT_PATH" init -q
-git -C "$CHECKOUT_PATH" checkout -q -b main
-git -C "$CHECKOUT_PATH" config user.email "ci@example.com"
-git -C "$CHECKOUT_PATH" config user.name "CI Runner"
-cat >"$CHECKOUT_PATH/README.md" <<'EOF'
-real-fork wrapper fixture checkout
+SOURCE_REPO="$TMP_DIR/source_fork"
+mkdir -p "$SOURCE_REPO"
+git -C "$SOURCE_REPO" init -q
+git -C "$SOURCE_REPO" checkout -q -b main
+git -C "$SOURCE_REPO" config user.email "ci@example.com"
+git -C "$SOURCE_REPO" config user.name "CI Runner"
+cat >"$SOURCE_REPO/README.md" <<'EOF'
+real-fork wrapper source fixture checkout
 EOF
-git -C "$CHECKOUT_PATH" add README.md
-git -C "$CHECKOUT_PATH" commit -q -m "init wrapper fixture"
-git -C "$CHECKOUT_PATH" remote add origin "https://github.com/njfio/kolme_fork.git"
+git -C "$SOURCE_REPO" add README.md
+git -C "$SOURCE_REPO" commit -q -m "init wrapper source fixture"
+git clone -q "$SOURCE_REPO" "$CHECKOUT_PATH"
 
 cat >"$TMP_DIR/mock_kolme_api.py" <<'PY'
 from __future__ import annotations
@@ -309,7 +322,8 @@ run_output="$(
     bash "$RUNNER" \
       --mode run \
       --checkout-path "$CHECKOUT_PATH" \
-      --expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+      --fork-remote-url "$SOURCE_REPO" \
+      --expected-remote-url "$SOURCE_REPO" \
       --expected-ref "refs/heads/main" \
       --base-url "$BASE_URL" \
       --fork-chain-version "$FORK_CHAIN_VERSION" \
@@ -362,6 +376,8 @@ if not isinstance(checks, list):
     raise SystemExit("expected checks list in run summary")
 for expected_id in (
     "real_fork_command_profile",
+    "checkout_bootstrap_lane",
+    "checkout_bootstrap_policy",
     "profile_preflight_lane",
     "profile_preflight_policy",
     "self_test_lane",
@@ -381,7 +397,63 @@ KAMN_KOLME_LOCAL_HEAVY=1 \
   bash "$RUNNER" \
     --mode run \
     --checkout-path "$CHECKOUT_PATH" \
-    --expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+    --fork-remote-url "$SOURCE_REPO" \
+    --expected-remote-url "$TMP_DIR/not-source" \
+    --expected-ref "refs/heads/main" \
+    --max-seconds 180 \
+    --output-json "$TMP_REPORT" >"$TMP_ERR" 2>&1
+bootstrap_mismatch_code=$?
+set -e
+
+if [ "$bootstrap_mismatch_code" -eq 0 ]; then
+  echo "expected bootstrap-first wrapper run to fail on checkout remote mismatch" >&2
+  exit 1
+fi
+
+if ! grep -q "reason_code=checkpoint_failed_checkout_bootstrap_lane" "$TMP_ERR"; then
+  echo "expected checkpoint_failed_checkout_bootstrap_lane marker for bootstrap mismatch failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("status") != "fail":
+    raise SystemExit("expected fail status for bootstrap mismatch summary")
+if report.get("reason_code") != "checkpoint_failed_checkout_bootstrap_lane":
+    raise SystemExit("expected checkpoint_failed_checkout_bootstrap_lane reason code")
+checks = report.get("checks")
+if not isinstance(checks, list):
+    raise SystemExit("expected checks list for bootstrap mismatch summary")
+
+def check_status(check_id: str) -> str:
+    for entry in checks:
+        if isinstance(entry, dict) and entry.get("id") == check_id:
+            value = entry.get("status")
+            if isinstance(value, str):
+                return value
+    raise SystemExit(f"missing check id in bootstrap mismatch summary: {check_id}")
+
+if check_status("checkout_bootstrap_lane") != "fail":
+    raise SystemExit("expected checkout_bootstrap_lane=fail for bootstrap mismatch")
+if check_status("checkout_bootstrap_policy") != "skipped":
+    raise SystemExit("expected checkout_bootstrap_policy=skipped for bootstrap mismatch")
+if check_status("profile_preflight_lane") != "skipped":
+    raise SystemExit("expected profile_preflight_lane=skipped for bootstrap mismatch")
+PY
+
+set +e
+KAMN_KOLME_LOCAL_HEAVY=1 \
+  bash "$RUNNER" \
+    --mode run \
+    --checkout-path "$CHECKOUT_PATH" \
+    --fork-remote-url "$SOURCE_REPO" \
+    --expected-remote-url "$SOURCE_REPO" \
     --expected-ref "refs/heads/main" \
     --base-url "$BASE_URL" \
     --fork-chain-version "$FORK_CHAIN_VERSION" \


### PR DESCRIPTION
## Summary
Compose checkout bootstrap as an explicit prerequisite in the local real-fork wrapper lane so checkout provenance is validated before preflight, self-test, and lifecycle stages. This closes the orchestration gap between bootstrap readiness and wrapper execution ordering.

Closes #1668

## Changes
- `scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh`: add bootstrap runner/checker prerequisites, checkpoint ordering, reason-code handling, artifacts, and CLI options (`--fork-remote-url`, `--bootstrap-max-seconds`, bootstrap report/policy outputs).
- `scripts/kolme/check_local_kolme_fork_real_process_policy.py`: require bootstrap contracts/checkpoint IDs/artifacts in wrapper policy validation.
- `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`: enforce bootstrap-first checkpoint IDs in dry-run/run, add bootstrap mismatch fail-closed scenario, and use local source fixture for deterministic bootstrap fetch path.
- `docs/planning/kolme-devnet-ops.md`: document bootstrap-first wrapper prerequisites and add regression marker (`Regression: #1667`).
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`: enforce wrapper docs include bootstrap prerequisites and regression marker.
- `README.md`: update wrapper run example to include bootstrap composition options.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`

Observed failing output:
`missing check id: checkout_bootstrap_lane`

### 🟢 Green Phase
Command:
`bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`

Observed passing output:
`real-fork local process wrapper contract lane tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/ci/test_readme_contract.sh`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `bash scripts/ci/test_select_targets.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Updated wrapper policy validation in `check_local_kolme_fork_real_process_policy.py` and exercised it via wrapper contract lane test assertions. | |
| Functional   | ✅ | Updated `test_run_local_kolme_fork_real_process_contract_lane.sh` for bootstrap-first checkpoints and fail-closed mismatch path. | |
| Integration  | ✅ | `cargo test -p kamn-core --test kolme_devnet_ops_docs`; docs + wrapper orchestration contract alignment. | |
| Regression   | ✅ | Added docs regression marker enforcement (`Regression: #1667`) in `kolme_devnet_ops_docs.rs`. | |
| Performance  | N/A | No new runtime class introduced; existing local-only bounded budgets are preserved. | bounded budget contracts unchanged |

## Risks & Rollback
- None.
- Rollback plan: revert commit `91e9ef1` if wrapper bootstrap composition introduces local orchestration regressions.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
