### PR TITLE
feat: scaffold kamn-kolme crate boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,10 @@ name = "kamn-core"
 version = "0.1.0"
 
 [[package]]
+name = "kamn-kolme"
+version = "0.1.0"
+
+[[package]]
 name = "kamn-node"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/kamn-core",
+  "crates/kamn-kolme",
   "crates/kamn-sdk",
   "crates/kamn-node",
 ]

--- a/crates/kamn-kolme/Cargo.toml
+++ b/crates/kamn-kolme/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kamn-kolme"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[lib]
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/kamn-kolme/src/codec.rs
+++ b/crates/kamn-kolme/src/codec.rs
@@ -1,0 +1,71 @@
+//! Codec contracts for Kolme runtime-commit payloads.
+
+use std::error::Error;
+use std::fmt;
+
+/// Codec-level error for Kolme payload transforms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeCodecError {
+    /// Payload is empty and cannot be encoded/decoded.
+    EmptyPayload,
+}
+
+impl fmt::Display for KolmeCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyPayload => f.write_str("payload must not be empty"),
+        }
+    }
+}
+
+impl Error for KolmeCodecError {}
+
+/// Minimal codec boundary used by the runtime-commit pipeline scaffold.
+pub trait KolmeWireCodec {
+    /// Encodes an internal payload into wire format.
+    fn encode(&self, payload: &[u8]) -> Result<Vec<u8>, KolmeCodecError>;
+
+    /// Decodes a wire payload into internal representation.
+    fn decode(&self, payload: &[u8]) -> Result<Vec<u8>, KolmeCodecError>;
+}
+
+/// A deterministic passthrough codec used for scaffold tests.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PassthroughCodec;
+
+impl KolmeWireCodec for PassthroughCodec {
+    fn encode(&self, payload: &[u8]) -> Result<Vec<u8>, KolmeCodecError> {
+        if payload.is_empty() {
+            return Err(KolmeCodecError::EmptyPayload);
+        }
+        Ok(payload.to_vec())
+    }
+
+    fn decode(&self, payload: &[u8]) -> Result<Vec<u8>, KolmeCodecError> {
+        if payload.is_empty() {
+            return Err(KolmeCodecError::EmptyPayload);
+        }
+        Ok(payload.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
+
+    #[test]
+    fn unit_passthrough_codec_rejects_empty_payload() {
+        let codec = PassthroughCodec;
+        assert_eq!(codec.encode(&[]), Err(KolmeCodecError::EmptyPayload));
+        assert_eq!(codec.decode(&[]), Err(KolmeCodecError::EmptyPayload));
+    }
+
+    #[test]
+    fn unit_passthrough_codec_roundtrips_non_empty_payload() {
+        let codec = PassthroughCodec;
+        let payload = b"runtime-commit";
+        let encoded = codec.encode(payload).expect("encode should succeed");
+        let decoded = codec.decode(&encoded).expect("decode should succeed");
+        assert_eq!(decoded, payload);
+    }
+}

--- a/crates/kamn-kolme/src/finality.rs
+++ b/crates/kamn-kolme/src/finality.rs
@@ -1,0 +1,88 @@
+//! Finality contracts for Kolme runtime-commit settlement.
+
+/// Finality status for a runtime-commit submission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinalityState {
+    /// Transaction has not yet reached the configured confirmation threshold.
+    Pending,
+    /// Transaction reached the configured confirmation threshold.
+    Confirmed,
+    /// Transaction is explicitly rejected.
+    Rejected,
+}
+
+/// Deterministic finality resolution snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FinalityResolution {
+    state: FinalityState,
+    confirmations: u64,
+    threshold: u64,
+}
+
+impl FinalityResolution {
+    /// Creates a new finality resolution.
+    pub fn new(state: FinalityState, confirmations: u64, threshold: u64) -> Self {
+        Self {
+            state,
+            confirmations,
+            threshold: threshold.max(1),
+        }
+    }
+
+    /// Returns the resolved finality state.
+    pub fn state(&self) -> FinalityState {
+        self.state
+    }
+
+    /// Returns observed confirmation count.
+    pub fn confirmations(&self) -> u64 {
+        self.confirmations
+    }
+
+    /// Returns configured confirmation threshold.
+    pub fn threshold(&self) -> u64 {
+        self.threshold
+    }
+
+    /// True when the state reached a terminal outcome.
+    pub fn is_final(&self) -> bool {
+        matches!(
+            self.state,
+            FinalityState::Confirmed | FinalityState::Rejected
+        )
+    }
+}
+
+/// Resolves finality from confirmations, threshold, and explicit rejection.
+pub fn resolve_finality(confirmations: u64, threshold: u64, rejected: bool) -> FinalityResolution {
+    let normalized_threshold = threshold.max(1);
+    let state = if rejected {
+        FinalityState::Rejected
+    } else if confirmations >= normalized_threshold {
+        FinalityState::Confirmed
+    } else {
+        FinalityState::Pending
+    };
+
+    FinalityResolution::new(state, confirmations, normalized_threshold)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_finality, FinalityState};
+
+    #[test]
+    fn unit_resolve_finality_marks_pending_below_threshold() {
+        let resolution = resolve_finality(1, 2, false);
+        assert_eq!(resolution.state(), FinalityState::Pending);
+        assert!(!resolution.is_final());
+    }
+
+    #[test]
+    fn unit_resolve_finality_normalizes_zero_threshold() {
+        let resolution = resolve_finality(1, 0, false);
+        assert_eq!(resolution.threshold(), 1);
+        assert_eq!(resolution.state(), FinalityState::Confirmed);
+        assert!(resolution.is_final());
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -1,0 +1,29 @@
+//! `kamn-kolme` hosts the extracted Kolme runtime-commit boundary.
+//!
+//! This initial scaffold keeps the API surface intentionally small while
+//! extraction from `kamn-core` is in flight.
+#![warn(missing_docs)]
+
+pub mod codec;
+pub mod finality;
+pub mod pipeline;
+pub mod transport;
+
+pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
+pub use finality::{resolve_finality, FinalityResolution, FinalityState};
+pub use pipeline::{PipelineError, RuntimeCommitPipeline};
+pub use transport::{
+    EchoTransport, KolmeTransport, TransportError, TransportRequest, TransportResponse,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_finality, FinalityState};
+
+    #[test]
+    fn unit_scaffold_exports_finality_resolution() {
+        let resolution = resolve_finality(1, 1, false);
+        assert_eq!(resolution.state(), FinalityState::Confirmed);
+        assert!(resolution.is_final());
+    }
+}

--- a/crates/kamn-kolme/src/pipeline.rs
+++ b/crates/kamn-kolme/src/pipeline.rs
@@ -1,0 +1,150 @@
+//! Runtime-commit pipeline scaffold for Kolme extraction.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::codec::{KolmeCodecError, KolmeWireCodec};
+use crate::finality::{resolve_finality, FinalityState};
+use crate::transport::{KolmeTransport, TransportError, TransportRequest};
+
+/// Pipeline-level error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PipelineError {
+    /// Codec conversion failed.
+    Codec(KolmeCodecError),
+    /// Transport submission failed.
+    Transport(TransportError),
+    /// Finality threshold not yet satisfied.
+    FinalityPending {
+        /// Observed confirmations.
+        confirmations: u64,
+        /// Required confirmations.
+        threshold: u64,
+    },
+    /// Finality was explicitly rejected.
+    FinalityRejected,
+}
+
+impl fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Codec(err) => write!(f, "codec error: {err}"),
+            Self::Transport(err) => write!(f, "transport error: {err}"),
+            Self::FinalityPending {
+                confirmations,
+                threshold,
+            } => write!(
+                f,
+                "finality pending: confirmations={confirmations}, threshold={threshold}"
+            ),
+            Self::FinalityRejected => f.write_str("finality rejected"),
+        }
+    }
+}
+
+impl Error for PipelineError {}
+
+impl From<KolmeCodecError> for PipelineError {
+    fn from(value: KolmeCodecError) -> Self {
+        Self::Codec(value)
+    }
+}
+
+impl From<TransportError> for PipelineError {
+    fn from(value: TransportError) -> Self {
+        Self::Transport(value)
+    }
+}
+
+/// Deterministic runtime-commit pipeline scaffold.
+pub struct RuntimeCommitPipeline<C, T> {
+    codec: C,
+    transport: T,
+    finality_threshold: u64,
+}
+
+impl<C, T> RuntimeCommitPipeline<C, T>
+where
+    C: KolmeWireCodec,
+    T: KolmeTransport,
+{
+    /// Creates a pipeline with default single-confirmation finality.
+    pub fn new(codec: C, transport: T) -> Self {
+        Self {
+            codec,
+            transport,
+            finality_threshold: 1,
+        }
+    }
+
+    /// Configures finality threshold used by submit.
+    pub fn with_finality_threshold(mut self, threshold: u64) -> Self {
+        self.finality_threshold = threshold.max(1);
+        self
+    }
+
+    /// Encodes payload, submits transport request, and validates finality.
+    pub fn submit(
+        &self,
+        endpoint: &str,
+        payload: &[u8],
+        confirmations: u64,
+        rejected: bool,
+    ) -> Result<Vec<u8>, PipelineError> {
+        let encoded = self.codec.encode(payload)?;
+        let response = self
+            .transport
+            .submit(TransportRequest::new(endpoint, encoded))?;
+
+        if response.status >= 400 {
+            return Err(PipelineError::Transport(TransportError::RejectedStatus(
+                response.status,
+            )));
+        }
+
+        let finality = resolve_finality(confirmations, self.finality_threshold, rejected);
+        match finality.state() {
+            FinalityState::Confirmed => self.codec.decode(&response.body).map_err(Into::into),
+            FinalityState::Pending => Err(PipelineError::FinalityPending {
+                confirmations: finality.confirmations(),
+                threshold: finality.threshold(),
+            }),
+            FinalityState::Rejected => Err(PipelineError::FinalityRejected),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PipelineError, RuntimeCommitPipeline};
+    use crate::codec::PassthroughCodec;
+    use crate::transport::EchoTransport;
+
+    #[test]
+    fn functional_pipeline_submit_roundtrips_payload_when_confirmed() {
+        let pipeline = RuntimeCommitPipeline::new(PassthroughCodec, EchoTransport);
+        let payload = b"signed-runtime-commit";
+        let output = pipeline
+            .submit("http://kolme.local/tx", payload, 1, false)
+            .expect("submit should succeed");
+        assert_eq!(output, payload);
+    }
+
+    #[test]
+    fn unit_pipeline_submit_fails_when_finality_pending() {
+        let pipeline =
+            RuntimeCommitPipeline::new(PassthroughCodec, EchoTransport).with_finality_threshold(2);
+
+        let error = pipeline
+            .submit("http://kolme.local/tx", b"payload", 1, false)
+            .expect_err("pending finality should fail");
+
+        assert_eq!(
+            error,
+            PipelineError::FinalityPending {
+                confirmations: 1,
+                threshold: 2
+            }
+        );
+    }
+}

--- a/crates/kamn-kolme/src/transport.rs
+++ b/crates/kamn-kolme/src/transport.rs
@@ -1,0 +1,107 @@
+//! Transport contracts for Kolme runtime-commit submissions.
+
+use std::error::Error;
+use std::fmt;
+
+/// Runtime-commit transport request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportRequest {
+    /// Target endpoint path or URL.
+    pub endpoint: String,
+    /// Serialized payload body.
+    pub body: Vec<u8>,
+}
+
+impl TransportRequest {
+    /// Creates a new request envelope.
+    pub fn new(endpoint: impl Into<String>, body: Vec<u8>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            body,
+        }
+    }
+}
+
+/// Runtime-commit transport response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportResponse {
+    /// Transport status code.
+    pub status: u16,
+    /// Response payload body.
+    pub body: Vec<u8>,
+}
+
+impl TransportResponse {
+    /// Creates a new transport response.
+    pub fn new(status: u16, body: Vec<u8>) -> Self {
+        Self { status, body }
+    }
+}
+
+/// Transport-level error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransportError {
+    /// Endpoint is missing.
+    EmptyEndpoint,
+    /// Upstream returned failure status.
+    RejectedStatus(u16),
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyEndpoint => f.write_str("transport endpoint must not be empty"),
+            Self::RejectedStatus(status) => write!(f, "transport rejected with status {status}"),
+        }
+    }
+}
+
+impl Error for TransportError {}
+
+/// Transport boundary for runtime-commit submissions.
+pub trait KolmeTransport {
+    /// Submits a request and returns a response envelope.
+    fn submit(&self, request: TransportRequest) -> Result<TransportResponse, TransportError>;
+}
+
+/// Deterministic in-memory transport used by scaffold tests.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EchoTransport;
+
+impl KolmeTransport for EchoTransport {
+    fn submit(&self, request: TransportRequest) -> Result<TransportResponse, TransportError> {
+        if request.endpoint.trim().is_empty() {
+            return Err(TransportError::EmptyEndpoint);
+        }
+        Ok(TransportResponse::new(200, request.body))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EchoTransport, KolmeTransport, TransportError, TransportRequest};
+
+    #[test]
+    fn unit_echo_transport_requires_endpoint() {
+        let transport = EchoTransport;
+        let request = TransportRequest::new("", b"payload".to_vec());
+        assert_eq!(
+            transport.submit(request),
+            Err(TransportError::EmptyEndpoint)
+        );
+    }
+
+    #[test]
+    fn unit_echo_transport_roundtrips_payload() {
+        let transport = EchoTransport;
+        let payload = b"bridge".to_vec();
+        let response = transport
+            .submit(TransportRequest::new(
+                "http://127.0.0.1:8080",
+                payload.clone(),
+            ))
+            .expect("submit should succeed");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, payload);
+    }
+}

--- a/crates/kamn-kolme/tests/scaffold_contracts.rs
+++ b/crates/kamn-kolme/tests/scaffold_contracts.rs
@@ -1,0 +1,20 @@
+use kamn_kolme::{
+    resolve_finality, EchoTransport, FinalityState, PassthroughCodec, RuntimeCommitPipeline,
+};
+
+#[test]
+fn integration_scaffold_pipeline_surface_is_callable() {
+    let pipeline = RuntimeCommitPipeline::new(PassthroughCodec, EchoTransport);
+    let output = pipeline
+        .submit("http://localhost/runtime-commit", b"hello-kolme", 1, false)
+        .expect("pipeline should succeed");
+    assert_eq!(output, b"hello-kolme");
+}
+
+#[test]
+fn regression_issue_1719_scaffold_finality_contract_is_stable() {
+    // Regression: #1719
+    let resolution = resolve_finality(0, 1, false);
+    assert_eq!(resolution.state(), FinalityState::Pending);
+    assert!(!resolution.is_final());
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -104,6 +104,22 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - Mediates external transport and settlement confirmations into normalized
     internal state mutations.
 
+### Kolme Extraction Boundary (In Progress)
+
+- Crate/module surface:
+  - `crates/kamn-core/src/kolme_runtime_commit.rs` (legacy compatibility shim
+    while extraction proceeds)
+  - `crates/kamn-kolme/src/codec.rs`, `crates/kamn-kolme/src/transport.rs`,
+    `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`
+- Ownership boundary:
+  - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
+    contracts. `kamn-core` retains temporary compatibility exports until full
+    migration is complete.
+- Runtime/data-flow ownership:
+  - New runtime-commit submissions should target `kamn-kolme` contracts first,
+    then map back to `kamn-core` compatibility paths only where migration is
+    still in progress.
+
 ### Cryptographic Signer and ZK Surface
 
 - Modules:
@@ -134,6 +150,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 | See ownership boundaries across core modules | `docs/architecture/kamn-core-module-map.md#ownership-matrix` | Canonical map for domain ownership and runtime/data-flow responsibilities. |
 | Understand high-level runtime path | `docs/architecture/kamn-core-module-map.md#runtime-flow-condensed` | Condensed sequence from identity checks to external receipts. |
 | Find exported public API surface | `crates/kamn-core/src/lib.rs` | Canonical `pub mod` and `pub use` inventory for `kamn-core`. |
+| Find extracted Kolme scaffold contracts | `crates/kamn-kolme/src/lib.rs` | Canonical crate boundary for runtime-commit codec, transport, finality, and pipeline scaffolding. |
 | Run missing-doc drift policy | `scripts/ci/check_kamn_core_missing_docs_policy.sh` | Fail-closed lint allowlist checker for docs hardening. |
 | Generate bounded rustdoc artifact evidence | `scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh` | Deterministic rustdoc report/artifact lane used in CI and local checks. |
 | Enforce rustdoc artifact policy schema | `scripts/ci/check_kamn_core_rustdoc_artifact_policy.sh` | Validates report schema, digest, artifact path, and runtime budget. |

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -312,6 +312,13 @@ assert_eq "$(extract_output "$core_lib_policy_output" "run_rust")" "true" "kamn-
 assert_eq "$(extract_output "$core_lib_policy_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "kamn-core lib changes must run missing-docs policy checks"
 assert_eq "$(extract_output "$core_lib_policy_output" "test_scope")" "targeted" "kamn-core lib changes should stay targeted"
 
+kolme_scaffold_output="$(run_selector $'crates/kamn-kolme/src/lib.rs')"
+assert_eq "$(extract_output "$kolme_scaffold_output" "run_rust")" "true" "kamn-kolme scaffold changes should run rust lane"
+assert_eq "$(extract_output "$kolme_scaffold_output" "test_scope")" "targeted" "kamn-kolme scaffold changes should stay targeted"
+assert_eq "$(extract_output "$kolme_scaffold_output" "run_kolme_version_compatibility_contract_tests")" "false" "kamn-kolme scaffold alone should not force legacy kamn-core Kolme lanes"
+assert_eq "$(extract_output "$kolme_scaffold_output" "run_kamn_core_missing_docs_policy_contract_tests")" "false" "kamn-kolme scaffold should not trigger kamn-core missing-docs policy checks"
+assert_eq "$(extract_output "$kolme_scaffold_output" "changed_manifests")" "crates/kamn-kolme/Cargo.toml" "kamn-kolme paths should resolve to the new crate manifest"
+
 test_cmd="$(extract_output "$targeted_output" "test_cmd")"
 if ! printf '%s\n' "$test_cmd" | grep -q "run_cargo_test_with_quarantine.sh"; then
   echo "targeted test command must use quarantine wrapper" >&2


### PR DESCRIPTION
## Summary
Introduces a new `kamn-kolme` crate scaffold as the first extraction boundary for Kolme runtime-commit work. This creates a deterministic compile/test surface before moving runtime logic out of `kamn-core`.

Closes #1719
Refs #1713

## Changes
- `Cargo.toml`, `Cargo.lock`: add workspace membership and lock entry for `kamn-kolme`
- `crates/kamn-kolme/Cargo.toml`: new crate manifest
- `crates/kamn-kolme/src/lib.rs`: public module surface and exports
- `crates/kamn-kolme/src/codec.rs`: codec contract + unit tests
- `crates/kamn-kolme/src/transport.rs`: transport contract + unit tests
- `crates/kamn-kolme/src/finality.rs`: finality resolution contract + unit tests
- `crates/kamn-kolme/src/pipeline.rs`: runtime-commit pipeline scaffold + functional/unit tests
- `crates/kamn-kolme/tests/scaffold_contracts.rs`: integration + regression contract tests
- `scripts/ci/test_select_targets.sh`: selector regression coverage for `crates/kamn-kolme` path routing
- `docs/architecture/kamn-core-module-map.md`: document in-progress `kamn-kolme` extraction boundary

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --lib`
- Failed before implementation with:
  - `error: package ID specification 'kamn-kolme' did not match any packages`

### 🟢 Green Phase
`cargo test -p kamn-kolme --lib`
- Pass: 9 tests, 0 failed

### 🔁 Regression
- `cargo test -p kamn-kolme` (pass: 11 tests, 0 failed)
- `cargo fmt --all --check` (pass)
- `cargo clippy -p kamn-kolme --all-targets -- -D warnings` (pass)
- `bash scripts/ci/test_select_targets.sh` (pass)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `codec`, `transport`, `finality`, `pipeline`, `lib` unit tests | |
| Functional   | ✅ | `pipeline::tests::functional_pipeline_submit_roundtrips_payload_when_confirmed` | |
| Integration  | ✅ | `crates/kamn-kolme/tests/scaffold_contracts.rs::integration_scaffold_pipeline_surface_is_callable` | |
| Regression   | ✅ | `crates/kamn-kolme/tests/scaffold_contracts.rs::regression_issue_1719_scaffold_finality_contract_is_stable` | |
| Performance  | N/A | | Scaffold-only crate; no runtime path moved yet |

## Risks & Rollback
- Breaking changes: None
- Rollback plan: revert this PR to remove crate scaffold and restore previous workspace state.

## Documentation Updates
- Updated `docs/architecture/kamn-core-module-map.md` with `kamn-kolme` extraction boundary notes and contributor entrypoint.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to changed crate: `cargo clippy -p kamn-kolme --all-targets -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Unit tests pass
- [x] Functional tests pass
- [x] Integration tests pass
- [x] Regression tests pass
