### PR TITLE
refactor: extract kolme finality and block-scan policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,9 @@ version = 4
 [[package]]
 name = "kamn-core"
 version = "0.1.0"
+dependencies = [
+ "kamn-kolme",
+]
 
 [[package]]
 name = "kamn-kolme"

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -7,5 +7,8 @@ license = "MIT"
 [lib]
 path = "src/lib.rs"
 
+[dependencies]
+kamn-kolme = { path = "../kamn-kolme" }
+
 [lints]
 workspace = true

--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1,6 +1,13 @@
 //! Deterministic runtime-commit request/receipt contracts for Kolme integration.
 
 use crate::AgentDid;
+use kamn_kolme::{
+    parse_receipt_finality as parse_kolme_receipt_finality,
+    render_block_path as render_kolme_block_path,
+    validate_block_identity as validate_kolme_block_identity,
+    validate_block_path_template as validate_kolme_block_path_template,
+    validate_lookup_window as validate_kolme_lookup_window, BlockScanPolicyError, ReceiptFinality,
+};
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{Read, Write};
@@ -1233,31 +1240,8 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 reason: "txhash must not be empty".to_owned(),
             });
         }
-        if from_height == 0 {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "from_height must be positive".to_owned(),
-            });
-        }
-        if latest_height == 0 {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "latest_height must be positive".to_owned(),
-            });
-        }
-        if latest_height < from_height {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "latest_height must be greater than or equal to from_height".to_owned(),
-            });
-        }
-
-        let lookup_span = latest_height - from_height + 1;
-        if lookup_span > self.max_block_lookups {
-            return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                reason: format!(
-                    "block fallback window exceeds max lookups: from_height={from_height} latest_height={latest_height} max_lookups={}",
-                    self.max_block_lookups
-                ),
-            });
-        }
+        validate_kolme_lookup_window(from_height, latest_height, self.max_block_lookups)
+            .map_err(map_lookup_window_error)?;
 
         for height in from_height..=latest_height {
             let response = self.transport.fetch_block_by_height(
@@ -1273,22 +1257,13 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 )
             })?;
 
-            if block.provider != self.provider {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: format!(
-                        "block fallback provider mismatch: expected {} observed {}",
-                        self.provider, block.provider
-                    ),
-                });
-            }
-            if block.block_height != height {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: format!(
-                        "block fallback response height mismatch: expected {height} observed {}",
-                        block.block_height
-                    ),
-                });
-            }
+            validate_kolme_block_identity(
+                self.provider.as_str(),
+                block.provider.as_str(),
+                height,
+                block.block_height,
+            )
+            .map_err(map_block_scan_policy_error_to_malformed)?;
 
             if block
                 .finalized_tx_hashes
@@ -1740,6 +1715,31 @@ fn map_provider_error(error: KolmeRuntimeCommitProviderError) -> KolmeRuntimeCom
     }
 }
 
+fn map_block_scan_policy_error_to_unavailable(
+    error: BlockScanPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::Unavailable {
+        reason: error.to_string(),
+    }
+}
+
+fn map_block_scan_policy_error_to_malformed(
+    error: BlockScanPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
+fn map_lookup_window_error(error: BlockScanPolicyError) -> KolmeRuntimeCommitProviderError {
+    match error {
+        BlockScanPolicyError::MaxLookupsExceeded { .. } => {
+            map_block_scan_policy_error_to_unavailable(error)
+        }
+        _ => map_block_scan_policy_error_to_malformed(error),
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
@@ -1816,28 +1816,16 @@ fn parse_authority(
 fn validate_block_path_template(
     block_path_template: &str,
 ) -> Result<(), KolmeRuntimeCommitProviderError> {
-    let trimmed = block_path_template.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "block_path_template must not be empty".to_owned(),
-        });
-    }
-    if !trimmed.contains("{height}") {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "block_path_template must include '{height}' placeholder".to_owned(),
-        });
-    }
-    Ok(())
+    validate_kolme_block_path_template(block_path_template)
+        .map_err(map_block_scan_policy_error_to_unavailable)
 }
 
 fn render_block_path(
     block_path_template: &str,
     height: u64,
 ) -> Result<String, KolmeRuntimeCommitProviderError> {
-    validate_block_path_template(block_path_template)?;
-    Ok(block_path_template
-        .trim()
-        .replace("{height}", height.to_string().as_str()))
+    render_kolme_block_path(block_path_template, height)
+        .map_err(map_block_scan_policy_error_to_unavailable)
 }
 
 fn parse_block_fallback_response(
@@ -3421,13 +3409,14 @@ fn txhash_from_commit_id(commit_id: &str) -> Result<String, KolmeRuntimeCommitPr
 fn parse_receipt_finality(
     value: &str,
 ) -> Result<KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderError> {
-    match value {
-        "pending" | "accepted" | "mempool" => Ok(KolmeCommitReceiptFinality::Pending),
-        "final" | "confirmed" | "finalized" => Ok(KolmeCommitReceiptFinality::Final),
-        "failed" | "rejected" => Ok(KolmeCommitReceiptFinality::Failed),
-        _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("invalid finality value: {value}"),
-        }),
+    match parse_kolme_receipt_finality(value).map_err(|error| {
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: error.to_string(),
+        }
+    })? {
+        ReceiptFinality::Pending => Ok(KolmeCommitReceiptFinality::Pending),
+        ReceiptFinality::Final => Ok(KolmeCommitReceiptFinality::Final),
+        ReceiptFinality::Failed => Ok(KolmeCommitReceiptFinality::Failed),
     }
 }
 

--- a/crates/kamn-kolme/src/block_scan_policy.rs
+++ b/crates/kamn-kolme/src/block_scan_policy.rs
@@ -1,0 +1,187 @@
+//! Block-scan policy contracts for Kolme fallback reconciliation.
+
+use std::error::Error;
+use std::fmt;
+
+/// Error raised by block-scan policy contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlockScanPolicyError {
+    /// `block_path_template` is empty.
+    EmptyBlockPathTemplate,
+    /// `block_path_template` is missing `{height}` placeholder.
+    MissingHeightPlaceholder,
+    /// `from_height` must be positive.
+    NonPositiveFromHeight,
+    /// `latest_height` must be positive.
+    NonPositiveLatestHeight,
+    /// `latest_height` must be >= `from_height`.
+    LatestBeforeFromHeight,
+    /// Block lookup span exceeds configured max.
+    MaxLookupsExceeded {
+        /// Lower bound of lookup window.
+        from_height: u64,
+        /// Upper bound of lookup window.
+        latest_height: u64,
+        /// Configured max lookups.
+        max_lookups: u64,
+    },
+    /// Observed provider does not match configured provider.
+    ProviderMismatch {
+        /// Expected provider value.
+        expected: String,
+        /// Observed provider value.
+        observed: String,
+    },
+    /// Observed block height does not match requested height.
+    HeightMismatch {
+        /// Expected block height.
+        expected: u64,
+        /// Observed block height.
+        observed: u64,
+    },
+}
+
+impl fmt::Display for BlockScanPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyBlockPathTemplate => f.write_str("block_path_template must not be empty"),
+            Self::MissingHeightPlaceholder => {
+                f.write_str("block_path_template must include '{height}' placeholder")
+            }
+            Self::NonPositiveFromHeight => f.write_str("from_height must be positive"),
+            Self::NonPositiveLatestHeight => f.write_str("latest_height must be positive"),
+            Self::LatestBeforeFromHeight => {
+                f.write_str("latest_height must be greater than or equal to from_height")
+            }
+            Self::MaxLookupsExceeded {
+                from_height,
+                latest_height,
+                max_lookups,
+            } => write!(
+                f,
+                "block fallback window exceeds max lookups: from_height={from_height} latest_height={latest_height} max_lookups={max_lookups}"
+            ),
+            Self::ProviderMismatch { expected, observed } => write!(
+                f,
+                "block fallback provider mismatch: expected {expected} observed {observed}"
+            ),
+            Self::HeightMismatch { expected, observed } => write!(
+                f,
+                "block fallback response height mismatch: expected {expected} observed {observed}"
+            ),
+        }
+    }
+}
+
+impl Error for BlockScanPolicyError {}
+
+/// Validates the configured block endpoint path template.
+pub fn validate_block_path_template(block_path_template: &str) -> Result<(), BlockScanPolicyError> {
+    let trimmed = block_path_template.trim();
+    if trimmed.is_empty() {
+        return Err(BlockScanPolicyError::EmptyBlockPathTemplate);
+    }
+    if !trimmed.contains("{height}") {
+        return Err(BlockScanPolicyError::MissingHeightPlaceholder);
+    }
+    Ok(())
+}
+
+/// Renders one block lookup path from template and concrete height.
+pub fn render_block_path(
+    block_path_template: &str,
+    height: u64,
+) -> Result<String, BlockScanPolicyError> {
+    validate_block_path_template(block_path_template)?;
+    Ok(block_path_template
+        .trim()
+        .replace("{height}", height.to_string().as_str()))
+}
+
+/// Validates one bounded block lookup window.
+pub fn validate_lookup_window(
+    from_height: u64,
+    latest_height: u64,
+    max_lookups: u64,
+) -> Result<(), BlockScanPolicyError> {
+    if from_height == 0 {
+        return Err(BlockScanPolicyError::NonPositiveFromHeight);
+    }
+    if latest_height == 0 {
+        return Err(BlockScanPolicyError::NonPositiveLatestHeight);
+    }
+    if latest_height < from_height {
+        return Err(BlockScanPolicyError::LatestBeforeFromHeight);
+    }
+    let lookup_span = latest_height - from_height + 1;
+    if lookup_span > max_lookups {
+        return Err(BlockScanPolicyError::MaxLookupsExceeded {
+            from_height,
+            latest_height,
+            max_lookups,
+        });
+    }
+    Ok(())
+}
+
+/// Validates provider + height identity for one scanned block response.
+pub fn validate_block_identity(
+    expected_provider: &str,
+    observed_provider: &str,
+    expected_height: u64,
+    observed_height: u64,
+) -> Result<(), BlockScanPolicyError> {
+    if observed_provider != expected_provider {
+        return Err(BlockScanPolicyError::ProviderMismatch {
+            expected: expected_provider.to_owned(),
+            observed: observed_provider.to_owned(),
+        });
+    }
+    if observed_height != expected_height {
+        return Err(BlockScanPolicyError::HeightMismatch {
+            expected: expected_height,
+            observed: observed_height,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        render_block_path, validate_block_identity, validate_block_path_template,
+        validate_lookup_window, BlockScanPolicyError,
+    };
+
+    #[test]
+    fn unit_validate_block_path_template_requires_height_placeholder() {
+        assert_eq!(
+            validate_block_path_template("/block/static"),
+            Err(BlockScanPolicyError::MissingHeightPlaceholder)
+        );
+        assert!(validate_block_path_template("/block/{height}").is_ok());
+    }
+
+    #[test]
+    fn unit_validate_lookup_window_requires_non_stale_bounds() {
+        assert_eq!(
+            validate_lookup_window(5, 4, 3),
+            Err(BlockScanPolicyError::LatestBeforeFromHeight)
+        );
+    }
+
+    #[test]
+    fn unit_validate_block_identity_rejects_mismatch() {
+        assert_eq!(
+            validate_block_identity("kolme-a", "kolme-b", 42, 42),
+            Err(BlockScanPolicyError::ProviderMismatch {
+                expected: "kolme-a".to_owned(),
+                observed: "kolme-b".to_owned(),
+            })
+        );
+        assert_eq!(
+            render_block_path("/block/{height}", 42).expect("render should pass"),
+            "/block/42"
+        );
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -4,14 +4,21 @@
 //! extraction from `kamn-core` is in flight.
 #![warn(missing_docs)]
 
+pub mod block_scan_policy;
 pub mod codec;
 pub mod finality;
 pub mod pipeline;
+pub mod receipt_finality;
 pub mod transport;
 
+pub use block_scan_policy::{
+    render_block_path, validate_block_identity, validate_block_path_template,
+    validate_lookup_window, BlockScanPolicyError,
+};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
+pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use transport::{
     EchoTransport, KolmeTransport, TransportError, TransportRequest, TransportResponse,
 };

--- a/crates/kamn-kolme/src/receipt_finality.rs
+++ b/crates/kamn-kolme/src/receipt_finality.rs
@@ -1,0 +1,73 @@
+//! Receipt finality parsing contracts shared by Kolme runtime components.
+
+use std::error::Error;
+use std::fmt;
+
+/// Runtime receipt finality classes returned by provider responses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiptFinality {
+    /// Receipt is pending confirmation.
+    Pending,
+    /// Receipt is finalized.
+    Final,
+    /// Receipt is terminally failed.
+    Failed,
+}
+
+/// Error raised while parsing a provider finality token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiptFinalityError {
+    /// Provider returned an unsupported finality token.
+    InvalidFinalityValue(String),
+}
+
+impl fmt::Display for ReceiptFinalityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFinalityValue(value) => write!(f, "invalid finality value: {value}"),
+        }
+    }
+}
+
+impl Error for ReceiptFinalityError {}
+
+/// Parses canonical provider finality aliases into deterministic classes.
+pub fn parse_receipt_finality(value: &str) -> Result<ReceiptFinality, ReceiptFinalityError> {
+    match value {
+        "pending" | "accepted" | "mempool" => Ok(ReceiptFinality::Pending),
+        "final" | "confirmed" | "finalized" => Ok(ReceiptFinality::Final),
+        "failed" | "rejected" => Ok(ReceiptFinality::Failed),
+        _ => Err(ReceiptFinalityError::InvalidFinalityValue(value.to_owned())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
+
+    #[test]
+    fn unit_parse_receipt_finality_maps_aliases() {
+        assert_eq!(
+            parse_receipt_finality("accepted").expect("accepted alias should parse"),
+            ReceiptFinality::Pending
+        );
+        assert_eq!(
+            parse_receipt_finality("finalized").expect("finalized alias should parse"),
+            ReceiptFinality::Final
+        );
+        assert_eq!(
+            parse_receipt_finality("failed").expect("failed alias should parse"),
+            ReceiptFinality::Failed
+        );
+    }
+
+    #[test]
+    fn unit_parse_receipt_finality_rejects_unknown_value() {
+        assert_eq!(
+            parse_receipt_finality("settled"),
+            Err(ReceiptFinalityError::InvalidFinalityValue(
+                "settled".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
+++ b/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
@@ -1,0 +1,49 @@
+use kamn_kolme::{
+    parse_receipt_finality, render_block_path, validate_block_identity,
+    validate_block_path_template, validate_lookup_window, ReceiptFinality,
+};
+
+#[test]
+fn unit_parse_receipt_finality_supports_runtime_aliases() {
+    assert_eq!(
+        parse_receipt_finality("pending").expect("pending alias should parse"),
+        ReceiptFinality::Pending
+    );
+    assert_eq!(
+        parse_receipt_finality("confirmed").expect("confirmed alias should parse"),
+        ReceiptFinality::Final
+    );
+    assert_eq!(
+        parse_receipt_finality("rejected").expect("rejected alias should parse"),
+        ReceiptFinality::Failed
+    );
+}
+
+#[test]
+fn functional_validate_lookup_window_rejects_stale_span() {
+    let error = validate_lookup_window(40, 44, 3).expect_err("stale span must fail");
+    assert_eq!(
+        error.to_string(),
+        "block fallback window exceeds max lookups: from_height=40 latest_height=44 max_lookups=3"
+    );
+}
+
+#[test]
+fn regression_issue_1720_block_identity_mismatch_fails_closed() {
+    // Regression: #1720
+    let error = validate_block_identity("kolme-fork-local", "tampered-provider", 42, 99)
+        .expect_err("provider/height mismatch must fail");
+    assert_eq!(
+        error.to_string(),
+        "block fallback provider mismatch: expected kolme-fork-local observed tampered-provider"
+    );
+
+    assert!(
+        validate_block_path_template("/block/{height}").is_ok(),
+        "block path template should accept height placeholder"
+    );
+    assert_eq!(
+        render_block_path("/block/{height}", 42).expect("render should work"),
+        "/block/42"
+    );
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -56,6 +56,7 @@ handling.
   - provider identity for txhash-only responses uses response `provider` when present, otherwise deterministic provider hint from profile construction.
 - Fork finality profile:
   - `KolmeRuntimeCommitForkFinalityResolver` composes websocket notifications (`/notifications`) with bounded block fallback scans (`/block/{height}`).
+  - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.
@@ -131,6 +132,9 @@ Run targeted checks first:
 ```bash
 cargo test -p kamn-core --test kolme_runtime_commit_client
 cargo test -p kamn-core --test kolme_runtime_commit_finality
+cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
+cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
+cargo test -p kamn-kolme --test finality_block_scan_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact


### PR DESCRIPTION
## Summary
Extracts receipt-finality parsing and block-scan policy contracts into `kamn-kolme`, then rewires `kamn-core` runtime-commit fallback/finality paths to use those shared contracts with parity-preserving error mapping. This is a focused extraction slice toward splitting `kolme_runtime_commit.rs` into dedicated modules.

Closes #1720
Refs #1714

## Changes
- `crates/kamn-kolme/src/receipt_finality.rs`: new receipt finality enum + parser contracts
- `crates/kamn-kolme/src/block_scan_policy.rs`: new block path/window/identity policy contracts
- `crates/kamn-kolme/src/lib.rs`: export extracted contracts
- `crates/kamn-kolme/tests/finality_block_scan_contracts.rs`: unit/functional/regression tests for extracted contracts
- `crates/kamn-core/Cargo.toml`: add `kamn-kolme` dependency
- `crates/kamn-core/src/kolme_runtime_commit.rs`: use extracted contracts for finality parsing and block-scan policy checks while preserving error strings/classes
- `docs/foundation/kolme-runtime-commit-client.md`: document extraction boundary and updated validation commands
- `Cargo.lock`: dependency graph update

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test finality_block_scan_contracts`
- Failed before implementation with unresolved imports:
  - `parse_receipt_finality`
  - `validate_lookup_window`
  - `validate_block_identity`
  - `validate_block_path_template`
  - `render_block_path`

### 🟢 Green Phase
`cargo test -p kamn-kolme --test finality_block_scan_contracts`
- Pass: 3 tests, 0 failed

### 🔁 Regression
- `cargo test -p kamn-kolme` (pass)
- `cargo test -p kamn-core --test kolme_runtime_commit_finality --test kolme_runtime_commit_block_fallback --test kolme_runtime_commit_fork_finality_resolver --test kolme_runtime_commit_client_docs` (pass)
- `cargo fmt --all --check` (pass)
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings` (pass)
- `bash scripts/ci/test_select_targets.sh` (pass)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `receipt_finality` + `block_scan_policy` unit tests | |
| Functional   | ✅ | `functional_validate_lookup_window_rejects_stale_span`; existing fallback/finality functional tests remain green | |
| Integration  | ✅ | `kolme_runtime_commit_*` integration tests in `kamn-core` remain green | |
| Regression   | ✅ | `regression_issue_1720_block_identity_mismatch_fails_closed` + existing fail-closed regressions remain green | |
| Performance  | N/A | | Policy extraction only; no throughput-path redesign in this slice |

## Risks & Rollback
- Breaking changes: None expected; behavior-parity guardrails are covered by existing fail-closed tests.
- Rollback plan: revert this PR to restore in-module policy logic in `kamn-core`.

## Documentation Updates
- Updated `docs/foundation/kolme-runtime-commit-client.md` with extracted `kamn-kolme` policy boundary and validation command additions.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Unit tests pass
- [x] Functional tests pass
- [x] Integration tests pass
- [x] Regression tests pass
