### PR TITLE
refactor: extract kolme api codec contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -6,7 +6,12 @@ use kamn_kolme::{
     render_block_path as render_kolme_block_path,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
-    validate_lookup_window as validate_kolme_lookup_window, BlockScanPolicyError, ReceiptFinality,
+    validate_lookup_window as validate_kolme_lookup_window, BlockScanPolicyError,
+    KolmeApiBroadcastRequest as KamnKolmeApiBroadcastRequest,
+    KolmeApiBroadcastResponse as KamnKolmeApiBroadcastResponse,
+    KolmeApiCodecError as KamnKolmeApiCodecError,
+    KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
+    KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse, ReceiptFinality,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -231,30 +236,19 @@ pub struct KolmeApiNextNonceRequest {
 impl KolmeApiNextNonceRequest {
     /// Builds a deterministic nonce lookup request.
     pub fn new(pubkey: &str) -> Result<Self, KolmeRuntimeCommitError> {
-        let trimmed = pubkey.trim();
-        if trimmed.is_empty() {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "pubkey",
-                reason: "must not be empty",
-            });
-        }
+        let extracted = KamnKolmeApiNextNonceRequest::new(pubkey)
+            .map_err(map_codec_error_to_invalid_request)?;
         Ok(Self {
-            pubkey: trimmed.to_owned(),
+            pubkey: extracted.pubkey,
         })
     }
 
     /// Returns encoded request path for the configured nonce endpoint.
     pub fn query_path(&self, nonce_path: &str) -> String {
-        let base_path = if nonce_path.trim().is_empty() {
-            "/get-next-nonce".to_owned()
-        } else {
-            nonce_path.trim().to_owned()
-        };
-        let separator = if base_path.contains('?') { "&" } else { "?" };
-        format!(
-            "{base_path}{separator}pubkey={}",
-            percent_encode(self.pubkey.as_str())
-        )
+        KamnKolmeApiNextNonceRequest {
+            pubkey: self.pubkey.clone(),
+        }
+        .query_path(nonce_path)
     }
 }
 
@@ -270,12 +264,11 @@ pub struct KolmeApiNextNonceResponse {
 impl KolmeApiNextNonceResponse {
     /// Parses one nonce lookup response JSON payload.
     pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
-        let fields = parse_flat_json_value_fields(response)?;
-        let next_nonce = required_positive_u64_json_field(&fields, "next_nonce")?;
-        let account_id = optional_nullable_json_string_field(&fields, "account_id")?;
+        let extracted = KamnKolmeApiNextNonceResponse::parse_json(response)
+            .map_err(map_codec_error_to_malformed_response)?;
         Ok(Self {
-            next_nonce,
-            account_id,
+            next_nonce: extracted.next_nonce,
+            account_id: extracted.account_id,
         })
     }
 }
@@ -298,35 +291,23 @@ impl KolmeApiBroadcastRequest {
         signature: &str,
         recovery_id: u8,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        let message = message.trim();
-        if message.is_empty() {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "message",
-                reason: "must not be empty",
-            });
-        }
-        let signature = signature.trim();
-        if signature.is_empty() {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "signature",
-                reason: "must not be empty",
-            });
-        }
+        let extracted = KamnKolmeApiBroadcastRequest::new(message, signature, recovery_id)
+            .map_err(map_codec_error_to_invalid_request)?;
         Ok(Self {
-            message: message.to_owned(),
-            signature: signature.to_owned(),
-            recovery_id,
+            message: extracted.message,
+            signature: extracted.signature,
+            recovery_id: extracted.recovery_id,
         })
     }
 
     /// Returns deterministic JSON payload in canonical field order.
     pub fn to_json_payload(&self) -> String {
-        format!(
-            "{{\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
-            json_escape(self.message.as_str()),
-            json_escape(self.signature.as_str()),
-            self.recovery_id
-        )
+        KamnKolmeApiBroadcastRequest {
+            message: self.message.clone(),
+            signature: self.signature.clone(),
+            recovery_id: self.recovery_id,
+        }
+        .to_json_payload()
     }
 }
 
@@ -340,9 +321,11 @@ pub struct KolmeApiBroadcastResponse {
 impl KolmeApiBroadcastResponse {
     /// Parses one broadcast response JSON payload.
     pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
-        let fields = parse_flat_json_value_fields(response)?;
-        let txhash = required_json_string_field(&fields, "txhash")?;
-        Ok(Self { txhash })
+        let extracted = KamnKolmeApiBroadcastResponse::parse_json(response)
+            .map_err(map_codec_error_to_malformed_response)?;
+        Ok(Self {
+            txhash: extracted.txhash,
+        })
     }
 }
 
@@ -1711,6 +1694,35 @@ fn map_provider_error(error: KolmeRuntimeCommitProviderError) -> KolmeRuntimeCom
                 kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
                 detail: reason,
             }
+        }
+    }
+}
+
+fn map_codec_error_to_invalid_request(error: KamnKolmeApiCodecError) -> KolmeRuntimeCommitError {
+    match error {
+        KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+            KolmeRuntimeCommitError::InvalidRequest { field, reason }
+        }
+        KamnKolmeApiCodecError::MalformedResponse { .. } => {
+            KolmeRuntimeCommitError::InvalidRequest {
+                field: "codec_payload",
+                reason: "must be valid json",
+            }
+        }
+    }
+}
+
+fn map_codec_error_to_malformed_response(
+    error: KamnKolmeApiCodecError,
+) -> KolmeRuntimeCommitProviderError {
+    match error {
+        KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: format!("invalid request {field}: {reason}"),
+            }
+        }
+        KamnKolmeApiCodecError::MalformedResponse { reason } => {
+            KolmeRuntimeCommitProviderError::MalformedResponse { reason }
         }
     }
 }
@@ -3126,30 +3138,6 @@ fn required_json_string_field(
         });
     }
     Ok(trimmed.to_owned())
-}
-
-fn optional_nullable_json_string_field(
-    fields: &HashMap<String, FlatJsonValue>,
-    field: &'static str,
-) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
-    let Some(value) = fields.get(field) else {
-        return Ok(None);
-    };
-    match value {
-        FlatJsonValue::Null => Ok(None),
-        FlatJsonValue::String(raw) => {
-            let trimmed = raw.trim();
-            if trimmed.is_empty() {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: format!("field must not be empty: {field}"),
-                });
-            }
-            Ok(Some(trimmed.to_owned()))
-        }
-        _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("field must be string|null: {field}"),
-        }),
-    }
 }
 
 fn required_positive_u64_json_field(

--- a/crates/kamn-kolme/src/api_codec.rs
+++ b/crates/kamn-kolme/src/api_codec.rs
@@ -1,0 +1,489 @@
+//! Typed codec contracts for Kolme nonce and broadcast APIs.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+/// Error raised while building or parsing Kolme API codec payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeApiCodecError {
+    /// Request payload failed validation.
+    InvalidRequest {
+        /// Field that failed validation.
+        field: &'static str,
+        /// Validation reason.
+        reason: &'static str,
+    },
+    /// Response payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeApiCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest { field, reason } => {
+                write!(f, "invalid request {field}: {reason}")
+            }
+            Self::MalformedResponse { reason } => write!(f, "malformed response: {reason}"),
+        }
+    }
+}
+
+impl Error for KolmeApiCodecError {}
+
+/// Typed nonce lookup request for Kolme `/get-next-nonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiNextNonceRequest {
+    /// Public key used to resolve next nonce and account identity.
+    pub pubkey: String,
+}
+
+impl KolmeApiNextNonceRequest {
+    /// Builds a deterministic nonce lookup request.
+    pub fn new(pubkey: &str) -> Result<Self, KolmeApiCodecError> {
+        let trimmed = pubkey.trim();
+        if trimmed.is_empty() {
+            return Err(KolmeApiCodecError::InvalidRequest {
+                field: "pubkey",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            pubkey: trimmed.to_owned(),
+        })
+    }
+
+    /// Returns encoded request path for the configured nonce endpoint.
+    pub fn query_path(&self, nonce_path: &str) -> String {
+        let base_path = if nonce_path.trim().is_empty() {
+            "/get-next-nonce".to_owned()
+        } else {
+            nonce_path.trim().to_owned()
+        };
+        let separator = if base_path.contains('?') { "&" } else { "?" };
+        format!(
+            "{base_path}{separator}pubkey={}",
+            percent_encode(self.pubkey.as_str())
+        )
+    }
+}
+
+/// Typed nonce lookup response for Kolme `/get-next-nonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiNextNonceResponse {
+    /// Monotonic next nonce for the provided public key.
+    pub next_nonce: u64,
+    /// Optional account identifier mapped to the provided public key.
+    pub account_id: Option<String>,
+}
+
+impl KolmeApiNextNonceResponse {
+    /// Parses one nonce lookup response JSON payload.
+    pub fn parse_json(response: &str) -> Result<Self, KolmeApiCodecError> {
+        let fields = parse_flat_json_value_fields(response)?;
+        let next_nonce = required_positive_u64_json_field(&fields, "next_nonce")?;
+        let account_id = optional_nullable_json_string_field(&fields, "account_id")?;
+        Ok(Self {
+            next_nonce,
+            account_id,
+        })
+    }
+}
+
+/// Typed broadcast request payload for Kolme `/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiBroadcastRequest {
+    /// Tagged transaction message payload.
+    pub message: String,
+    /// Chain signature for the transaction message payload.
+    pub signature: String,
+    /// Signature recovery identifier.
+    pub recovery_id: u8,
+}
+
+impl KolmeApiBroadcastRequest {
+    /// Builds a deterministic broadcast request payload.
+    pub fn new(
+        message: &str,
+        signature: &str,
+        recovery_id: u8,
+    ) -> Result<Self, KolmeApiCodecError> {
+        let message = message.trim();
+        if message.is_empty() {
+            return Err(KolmeApiCodecError::InvalidRequest {
+                field: "message",
+                reason: "must not be empty",
+            });
+        }
+        let signature = signature.trim();
+        if signature.is_empty() {
+            return Err(KolmeApiCodecError::InvalidRequest {
+                field: "signature",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            message: message.to_owned(),
+            signature: signature.to_owned(),
+            recovery_id,
+        })
+    }
+
+    /// Returns deterministic JSON payload in canonical field order.
+    pub fn to_json_payload(&self) -> String {
+        format!(
+            "{{\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
+            json_escape(self.message.as_str()),
+            json_escape(self.signature.as_str()),
+            self.recovery_id
+        )
+    }
+}
+
+/// Typed broadcast response payload for Kolme `/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiBroadcastResponse {
+    /// Transaction hash identifier from broadcast response.
+    pub txhash: String,
+}
+
+impl KolmeApiBroadcastResponse {
+    /// Parses one broadcast response JSON payload.
+    pub fn parse_json(response: &str) -> Result<Self, KolmeApiCodecError> {
+        let fields = parse_flat_json_value_fields(response)?;
+        let txhash = required_json_string_field(&fields, "txhash")?;
+        Ok(Self { txhash })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FlatJsonValue {
+    String(String),
+    Number(String),
+    Boolean,
+    Null,
+}
+
+fn parse_flat_json_value_fields(
+    response: &str,
+) -> Result<HashMap<String, FlatJsonValue>, KolmeApiCodecError> {
+    let body = response.trim();
+    if !(body.starts_with('{') && body.ends_with('}')) {
+        return Err(KolmeApiCodecError::MalformedResponse {
+            reason: "json response must be an object".to_owned(),
+        });
+    }
+    let inner = &body[1..body.len() - 1];
+    if inner.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let entries =
+        split_unquoted(inner, ',').map_err(|reason| KolmeApiCodecError::MalformedResponse {
+            reason: format!("invalid json response: {reason}"),
+        })?;
+
+    let mut fields = HashMap::new();
+    for entry in entries {
+        let pair = split_unquoted(entry.as_str(), ':').map_err(|reason| {
+            KolmeApiCodecError::MalformedResponse {
+                reason: format!("invalid json response pair: {reason}"),
+            }
+        })?;
+        if pair.len() != 2 {
+            return Err(KolmeApiCodecError::MalformedResponse {
+                reason: "json response pair must contain exactly one ':'".to_owned(),
+            });
+        }
+
+        let key = parse_json_string(pair[0].trim()).map_err(|reason| {
+            KolmeApiCodecError::MalformedResponse {
+                reason: format!("invalid json key: {reason}"),
+            }
+        })?;
+        let value = parse_json_value(pair[1].trim())?;
+        fields.insert(key, value);
+    }
+    Ok(fields)
+}
+
+fn parse_json_value(token: &str) -> Result<FlatJsonValue, KolmeApiCodecError> {
+    let trimmed = token.trim();
+    if trimmed.starts_with('"') {
+        let value =
+            parse_json_string(trimmed).map_err(|reason| KolmeApiCodecError::MalformedResponse {
+                reason: format!("invalid json value: {reason}"),
+            })?;
+        return Ok(FlatJsonValue::String(value));
+    }
+    if trimmed == "null" {
+        return Ok(FlatJsonValue::Null);
+    }
+    if trimmed == "true" {
+        return Ok(FlatJsonValue::Boolean);
+    }
+    if trimmed == "false" {
+        return Ok(FlatJsonValue::Boolean);
+    }
+    if is_json_number_literal(trimmed) {
+        return Ok(FlatJsonValue::Number(trimmed.to_owned()));
+    }
+    Err(KolmeApiCodecError::MalformedResponse {
+        reason: "invalid json value token".to_owned(),
+    })
+}
+
+fn is_json_number_literal(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    let mut chars = token.chars();
+    let first = chars.next().unwrap_or_default();
+    if first == '-' {
+        let remainder = chars.as_str();
+        return !remainder.is_empty() && remainder.chars().all(|ch| ch.is_ascii_digit());
+    }
+    first.is_ascii_digit() && chars.as_str().chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn required_json_string_field(
+    fields: &HashMap<String, FlatJsonValue>,
+    field: &'static str,
+) -> Result<String, KolmeApiCodecError> {
+    let value = fields
+        .get(field)
+        .ok_or_else(|| KolmeApiCodecError::MalformedResponse {
+            reason: format!("missing required field: {field}"),
+        })?;
+    let FlatJsonValue::String(raw) = value else {
+        return Err(KolmeApiCodecError::MalformedResponse {
+            reason: format!("field must be a string: {field}"),
+        });
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeApiCodecError::MalformedResponse {
+            reason: format!("field must not be empty: {field}"),
+        });
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn optional_nullable_json_string_field(
+    fields: &HashMap<String, FlatJsonValue>,
+    field: &'static str,
+) -> Result<Option<String>, KolmeApiCodecError> {
+    let Some(value) = fields.get(field) else {
+        return Ok(None);
+    };
+    match value {
+        FlatJsonValue::Null => Ok(None),
+        FlatJsonValue::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(KolmeApiCodecError::MalformedResponse {
+                    reason: format!("field must not be empty: {field}"),
+                });
+            }
+            Ok(Some(trimmed.to_owned()))
+        }
+        _ => Err(KolmeApiCodecError::MalformedResponse {
+            reason: format!("field must be string|null: {field}"),
+        }),
+    }
+}
+
+fn required_positive_u64_json_field(
+    fields: &HashMap<String, FlatJsonValue>,
+    field: &'static str,
+) -> Result<u64, KolmeApiCodecError> {
+    let value = fields
+        .get(field)
+        .ok_or_else(|| KolmeApiCodecError::MalformedResponse {
+            reason: format!("missing required field: {field}"),
+        })?;
+
+    let raw = match value {
+        FlatJsonValue::Number(value) => value.as_str(),
+        FlatJsonValue::String(value) => value.trim(),
+        _ => {
+            return Err(KolmeApiCodecError::MalformedResponse {
+                reason: format!("field must be numeric: {field}"),
+            })
+        }
+    };
+
+    let parsed = raw
+        .parse::<i128>()
+        .map_err(|_| KolmeApiCodecError::MalformedResponse {
+            reason: format!("invalid numeric field: {field}"),
+        })?;
+    if parsed <= 0 {
+        return Err(KolmeApiCodecError::MalformedResponse {
+            reason: format!("{field} must be positive"),
+        });
+    }
+    u64::try_from(parsed).map_err(|_| KolmeApiCodecError::MalformedResponse {
+        reason: format!("invalid numeric field: {field}"),
+    })
+}
+
+fn split_unquoted(input: &str, delimiter: char) -> Result<Vec<String>, &'static str> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escape = false;
+
+    for ch in input.chars() {
+        if escape {
+            current.push(ch);
+            escape = false;
+            continue;
+        }
+
+        if ch == '\\' && in_quotes {
+            current.push(ch);
+            escape = true;
+            continue;
+        }
+
+        if ch == '"' {
+            in_quotes = !in_quotes;
+            current.push(ch);
+            continue;
+        }
+
+        if ch == delimiter && !in_quotes {
+            if current.trim().is_empty() {
+                return Err("empty segment");
+            }
+            parts.push(current.trim().to_owned());
+            current.clear();
+            continue;
+        }
+
+        current.push(ch);
+    }
+
+    if in_quotes {
+        return Err("unterminated quoted string");
+    }
+    if current.trim().is_empty() {
+        return Err("empty trailing segment");
+    }
+    parts.push(current.trim().to_owned());
+    Ok(parts)
+}
+
+fn parse_json_string(token: &str) -> Result<String, &'static str> {
+    let trimmed = token.trim();
+    if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
+        return Err("token must be a quoted string");
+    }
+    let mut output = String::new();
+    let mut escape = false;
+    for ch in trimmed[1..trimmed.len() - 1].chars() {
+        if escape {
+            let mapped = match ch {
+                '\\' => '\\',
+                '"' => '"',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => return Err("unsupported escape sequence"),
+            };
+            output.push(mapped);
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        output.push(ch);
+    }
+    if escape {
+        return Err("unterminated escape sequence");
+    }
+    Ok(output)
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        let ch = byte as char;
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~') {
+            encoded.push(ch);
+        } else {
+            encoded.push('%');
+            encoded.push_str(format!("{byte:02X}").as_str());
+        }
+    }
+    encoded
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiCodecError,
+        KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
+    };
+
+    #[test]
+    fn unit_next_nonce_request_requires_pubkey() {
+        assert_eq!(
+            KolmeApiNextNonceRequest::new(""),
+            Err(KolmeApiCodecError::InvalidRequest {
+                field: "pubkey",
+                reason: "must not be empty",
+            })
+        );
+    }
+
+    #[test]
+    fn unit_broadcast_response_requires_txhash() {
+        assert_eq!(
+            KolmeApiBroadcastResponse::parse_json("{\"txhash\":\"\"}"),
+            Err(KolmeApiCodecError::MalformedResponse {
+                reason: "field must not be empty: txhash".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn unit_next_nonce_response_supports_nullable_account_id() {
+        let response =
+            KolmeApiNextNonceResponse::parse_json("{\"next_nonce\":7,\"account_id\":null}")
+                .expect("response should parse");
+        assert_eq!(response.next_nonce, 7);
+        assert_eq!(response.account_id, None);
+    }
+
+    #[test]
+    fn unit_broadcast_request_serializes_canonical_json_order() {
+        let request =
+            KolmeApiBroadcastRequest::new("{\"nonce\":42}", "sig-42", 0).expect("request");
+        assert_eq!(
+            request.to_json_payload(),
+            "{\"message\":\"{\\\"nonce\\\":42}\",\"signature\":\"sig-42\",\"recovery_id\":0}"
+        );
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -4,6 +4,7 @@
 //! extraction from `kamn-core` is in flight.
 #![warn(missing_docs)]
 
+pub mod api_codec;
 pub mod block_scan_policy;
 pub mod codec;
 pub mod finality;
@@ -11,6 +12,10 @@ pub mod pipeline;
 pub mod receipt_finality;
 pub mod transport;
 
+pub use api_codec::{
+    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiCodecError,
+    KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
+};
 pub use block_scan_policy::{
     render_block_path, validate_block_identity, validate_block_path_template,
     validate_lookup_window, BlockScanPolicyError,

--- a/crates/kamn-kolme/tests/api_codec_contracts.rs
+++ b/crates/kamn-kolme/tests/api_codec_contracts.rs
@@ -1,0 +1,45 @@
+use kamn_kolme::{
+    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiCodecError,
+    KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
+};
+
+#[test]
+fn functional_nonce_request_query_path_percent_encodes_pubkey() {
+    let request = KolmeApiNextNonceRequest::new("validator:pub/key").expect("request should build");
+    assert_eq!(
+        request.query_path("/get-next-nonce"),
+        "/get-next-nonce?pubkey=validator%3Apub%2Fkey"
+    );
+}
+
+#[test]
+fn functional_broadcast_request_serializes_canonical_json_order() {
+    let request =
+        KolmeApiBroadcastRequest::new("msg-payload", "sig-value", 1).expect("request should build");
+    assert_eq!(
+        request.to_json_payload(),
+        "{\"message\":\"msg-payload\",\"signature\":\"sig-value\",\"recovery_id\":1}"
+    );
+}
+
+#[test]
+fn regression_issue_1727_nonce_and_broadcast_parsing_fails_closed() {
+    // Regression: #1727
+    let nonce_error = KolmeApiNextNonceResponse::parse_json("{\"next_nonce\":0}")
+        .expect_err("zero nonce must fail");
+    assert_eq!(
+        nonce_error,
+        KolmeApiCodecError::MalformedResponse {
+            reason: "next_nonce must be positive".to_owned(),
+        }
+    );
+
+    let broadcast_error = KolmeApiBroadcastResponse::parse_json("{\"txhash\":\"\"}")
+        .expect_err("empty txhash must fail");
+    assert_eq!(
+        broadcast_error,
+        KolmeApiCodecError::MalformedResponse {
+            reason: "field must not be empty: txhash".to_owned(),
+        }
+    );
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -67,11 +67,14 @@ handling.
 
 ## Typed Kolme Nonce/Broadcast Codecs
 
-- Added typed Kolme API codec contracts in `kamn-core`:
+- Added typed Kolme API codec contracts in `kamn-core` (compatibility wrappers) with canonical ownership in `kamn-kolme`:
   - `KolmeApiNextNonceRequest`
   - `KolmeApiNextNonceResponse`
   - `KolmeApiBroadcastRequest`
   - `KolmeApiBroadcastResponse`
+- Canonical extraction boundary:
+  - `crates/kamn-kolme/src/api_codec.rs` owns deterministic nonce/broadcast codec constructors, query/payload serializers, and JSON parse contracts.
+  - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates codec behavior through compatibility wrappers to preserve existing core API surface.
 - Deterministic nonce request behavior:
   - `KolmeApiNextNonceRequest::query_path(...)` percent-encodes the `pubkey` query
     value and preserves deterministic path composition.
@@ -134,6 +137,7 @@ cargo test -p kamn-core --test kolme_runtime_commit_client
 cargo test -p kamn-core --test kolme_runtime_commit_finality
 cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
 cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
+cargo test -p kamn-kolme --test api_codec_contracts
 cargo test -p kamn-kolme --test finality_block_scan_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact


### PR DESCRIPTION
## Summary
Extracts Kolme API nonce/broadcast codec contracts into `kamn-kolme` and wires `kamn-core` runtime-commit codec methods as compatibility wrappers over those extracted contracts. This advances task `#1713` while preserving existing core behavior and test expectations.

Closes #1727
Refs #1713

## Changes
- `crates/kamn-kolme/src/api_codec.rs`: new canonical codec contracts
  - `KolmeApiNextNonceRequest`
  - `KolmeApiNextNonceResponse`
  - `KolmeApiBroadcastRequest`
  - `KolmeApiBroadcastResponse`
  - `KolmeApiCodecError`
- `crates/kamn-kolme/src/lib.rs`: export new codec contracts
- `crates/kamn-kolme/tests/api_codec_contracts.rs`: extraction contract tests (unit/functional/regression)
- `crates/kamn-core/src/kolme_runtime_commit.rs`: core compatibility wrappers now delegate to extracted `kamn-kolme` codec types
- `docs/foundation/kolme-runtime-commit-client.md`: document canonical codec ownership and validation commands

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test api_codec_contracts`
- Failed before implementation with unresolved imports:
  - `KolmeApiNextNonceRequest`
  - `KolmeApiNextNonceResponse`
  - `KolmeApiBroadcastRequest`
  - `KolmeApiBroadcastResponse`
  - `KolmeApiCodecError`

### 🟢 Green Phase
`cargo test -p kamn-kolme --test api_codec_contracts`
- Pass: 3 tests, 0 failed

### 🔁 Regression
- `cargo test -p kamn-kolme` (pass)
- `cargo test -p kamn-core --test kolme_api_codec_contracts --test kolme_runtime_commit_http_transport` (pass)
- `cargo test -p kamn-core --test kolme_runtime_commit_finality --test kolme_runtime_commit_block_fallback --test kolme_runtime_commit_fork_finality_resolver` (pass)
- `cargo fmt --all --check` (pass)
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings` (pass)
- `bash scripts/ci/test_select_targets.sh` (pass)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `api_codec` module unit tests | |
| Functional   | ✅ | `api_codec_contracts` encoding/serialization behavior tests | |
| Integration  | ✅ | `kolme_api_codec_contracts` + `kolme_runtime_commit_http_transport` in `kamn-core` | |
| Regression   | ✅ | `regression_issue_1727_nonce_and_broadcast_parsing_fails_closed` + existing fail-closed regressions | |
| Performance  | N/A | | Codec/type extraction only |

## Risks & Rollback
- Breaking changes: None expected; `kamn-core` keeps compatibility wrappers and behavior parity tests.
- Rollback plan: revert this PR to restore codec logic to in-module `kamn-core` implementations.

## Documentation Updates
- Updated `docs/foundation/kolme-runtime-commit-client.md` with `kamn-kolme` codec ownership and command matrix.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Unit tests pass
- [x] Functional tests pass
- [x] Integration tests pass
- [x] Regression tests pass
