### PR TITLE
refactor: extract kolme endpoint normalization policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -2,7 +2,10 @@
 
 use crate::AgentDid;
 use kamn_kolme::{
+    compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
+    parse_http_endpoint as parse_kolme_http_endpoint,
     parse_receipt_finality as parse_kolme_receipt_finality,
+    parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
@@ -11,7 +14,10 @@ use kamn_kolme::{
     KolmeApiBroadcastResponse as KamnKolmeApiBroadcastResponse,
     KolmeApiCodecError as KamnKolmeApiCodecError,
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
-    KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse, ReceiptFinality,
+    KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
+    KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
+    KolmeHttpScheme as KamnKolmeHttpScheme, KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
+    KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint, ReceiptFinality,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -710,23 +716,8 @@ enum KolmeRuntimeCommitSubmitProfile {
     KolmeForkBroadcast,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedHttpEndpoint {
-    scheme: HttpScheme,
-    host: String,
-    host_header: String,
-    port: u16,
-    target_path: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedWebsocketEndpoint {
-    secure: bool,
-    host: String,
-    host_header: String,
-    port: u16,
-    target_path: String,
-}
+type ParsedHttpEndpoint = KamnKolmeParsedHttpEndpoint;
+type ParsedWebsocketEndpoint = KamnKolmeParsedWebsocketEndpoint;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedBlockFallbackResponse {
@@ -736,20 +727,7 @@ struct ParsedBlockFallbackResponse {
     failed_tx_hashes: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HttpScheme {
-    Http,
-    Https,
-}
-
-impl HttpScheme {
-    fn default_port(self) -> u16 {
-        match self {
-            Self::Http => 80,
-            Self::Https => 443,
-        }
-    }
-}
+type HttpScheme = KamnKolmeHttpScheme;
 
 /// Dependency-free HTTP transport implementation for runtime commit submit/finality calls.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1752,77 +1730,19 @@ fn map_lookup_window_error(error: BlockScanPolicyError) -> KolmeRuntimeCommitPro
     }
 }
 
+fn map_endpoint_policy_error(
+    error: KamnKolmeEndpointPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::Unavailable {
+        reason: error.to_string(),
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
 ) -> Result<ParsedHttpEndpoint, KolmeRuntimeCommitProviderError> {
-    let base = base_url.trim();
-    if base.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "base_url must not be empty".to_owned(),
-        });
-    }
-    let (scheme, remainder) = if let Some(remainder) = base.strip_prefix("http://") {
-        (HttpScheme::Http, remainder)
-    } else if let Some(remainder) = base.strip_prefix("https://") {
-        (HttpScheme::Https, remainder)
-    } else {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "base_url scheme must be http:// or https://".to_owned(),
-        });
-    };
-    let (authority, base_path) = match remainder.split_once('/') {
-        Some((left, right)) => (left, format!("/{}", right.trim_start_matches('/'))),
-        None => (remainder, "/".to_owned()),
-    };
-
-    if authority.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "base_url host must not be empty".to_owned(),
-        });
-    }
-
-    let (host, port) = parse_authority(authority, scheme.default_port())?;
-    let target_path = join_http_paths(base_path.as_str(), path);
-    Ok(ParsedHttpEndpoint {
-        scheme,
-        host,
-        host_header: authority.to_owned(),
-        port,
-        target_path,
-    })
-}
-
-fn parse_authority(
-    authority: &str,
-    default_port: u16,
-) -> Result<(String, u16), KolmeRuntimeCommitProviderError> {
-    if authority.starts_with('[') {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "ipv6 host syntax is not supported".to_owned(),
-        });
-    }
-    if let Some((host, port_raw)) = authority.rsplit_once(':') {
-        if !port_raw.is_empty() && port_raw.chars().all(|ch| ch.is_ascii_digit()) {
-            let port = port_raw.parse::<u16>().map_err(|_| {
-                KolmeRuntimeCommitProviderError::Unavailable {
-                    reason: "base_url port is invalid".to_owned(),
-                }
-            })?;
-            if host.trim().is_empty() {
-                return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                    reason: "base_url host must not be empty".to_owned(),
-                });
-            }
-            return Ok((host.to_owned(), port));
-        }
-        if !port_raw.is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                reason: "base_url port is invalid".to_owned(),
-            });
-        }
-    }
-    Ok((authority.to_owned(), default_port))
+    parse_kolme_http_endpoint(base_url, path).map_err(map_endpoint_policy_error)
 }
 
 fn validate_block_path_template(
@@ -1973,59 +1893,14 @@ fn compose_notifications_websocket_url(
     base_url: &str,
     notifications_path: &str,
 ) -> Result<String, KolmeRuntimeCommitProviderError> {
-    if notifications_path.trim().is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "notifications_path must not be empty".to_owned(),
-        });
-    }
-    let endpoint = parse_http_endpoint(base_url, notifications_path)?;
-    let scheme = match endpoint.scheme {
-        HttpScheme::Http => "ws",
-        HttpScheme::Https => "wss",
-    };
-    Ok(format!(
-        "{scheme}://{}{}",
-        endpoint.host_header, endpoint.target_path
-    ))
+    compose_kolme_notifications_websocket_url(base_url, notifications_path)
+        .map_err(map_endpoint_policy_error)
 }
 
 fn parse_websocket_endpoint(
     notifications_url: &str,
 ) -> Result<ParsedWebsocketEndpoint, KolmeRuntimeCommitProviderError> {
-    let raw = notifications_url.trim();
-    if raw.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "notifications_url must not be empty".to_owned(),
-        });
-    }
-    let (secure, remainder) = if let Some(remainder) = raw.strip_prefix("ws://") {
-        (false, remainder)
-    } else if let Some(remainder) = raw.strip_prefix("wss://") {
-        (true, remainder)
-    } else {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "notifications_url scheme must be ws:// or wss://".to_owned(),
-        });
-    };
-
-    let (authority, target_path) = match remainder.split_once('/') {
-        Some((left, right)) => (left, format!("/{}", right.trim_start_matches('/'))),
-        None => (remainder, "/".to_owned()),
-    };
-    if authority.trim().is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "notifications_url host must not be empty".to_owned(),
-        });
-    }
-    let default_port = if secure { 443 } else { 80 };
-    let (host, port) = parse_authority(authority, default_port)?;
-    Ok(ParsedWebsocketEndpoint {
-        secure,
-        host,
-        host_header: authority.to_owned(),
-        port,
-        target_path,
-    })
+    parse_kolme_websocket_endpoint(notifications_url).map_err(map_endpoint_policy_error)
 }
 
 fn reconnect_exhausted_error(max_reconnect_attempts: u32) -> KolmeRuntimeCommitProviderError {
@@ -2471,34 +2346,6 @@ fn parse_authorization_header(value: &str) -> Result<String, KolmeRuntimeCommitE
         });
     }
     Ok(trimmed.to_owned())
-}
-
-fn join_http_paths(base_path: &str, request_path: &str) -> String {
-    let base = if base_path.trim().is_empty() {
-        "/".to_owned()
-    } else if base_path.starts_with('/') {
-        base_path.to_owned()
-    } else {
-        format!("/{base_path}")
-    };
-
-    let request = request_path.trim();
-    if request.is_empty() || request == "/" {
-        return base;
-    }
-
-    if request.starts_with('/') {
-        if base == "/" {
-            return request.to_owned();
-        }
-        return format!("{}{}", base.trim_end_matches('/'), request);
-    }
-
-    if base == "/" {
-        format!("/{request}")
-    } else {
-        format!("{}/{}", base.trim_end_matches('/'), request)
-    }
 }
 
 fn map_transport_io_error(error: std::io::Error) -> KolmeRuntimeCommitProviderError {

--- a/crates/kamn-kolme/src/endpoint_policy.rs
+++ b/crates/kamn-kolme/src/endpoint_policy.rs
@@ -1,0 +1,290 @@
+//! Endpoint normalization and validation contracts for Kolme transports.
+
+use std::error::Error;
+use std::fmt;
+
+/// Endpoint-policy error used by transport URL normalization contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeEndpointPolicyError {
+    /// Endpoint is unavailable because input validation failed.
+    Unavailable {
+        /// Deterministic validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeEndpointPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeEndpointPolicyError {}
+
+/// HTTP endpoint scheme for runtime-commit transport connections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KolmeHttpScheme {
+    /// Plaintext HTTP.
+    Http,
+    /// TLS-backed HTTPS.
+    Https,
+}
+
+impl KolmeHttpScheme {
+    /// Default port for the given scheme.
+    pub fn default_port(self) -> u16 {
+        match self {
+            Self::Http => 80,
+            Self::Https => 443,
+        }
+    }
+}
+
+/// Parsed HTTP endpoint used by runtime-commit transport execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeParsedHttpEndpoint {
+    /// Scheme selected from the base URL.
+    pub scheme: KolmeHttpScheme,
+    /// Host name used by socket dialing.
+    pub host: String,
+    /// Host header authority value.
+    pub host_header: String,
+    /// Port selected from authority/defaults.
+    pub port: u16,
+    /// Fully normalized request path.
+    pub target_path: String,
+}
+
+/// Parsed websocket endpoint used by notifications consumer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeParsedWebsocketEndpoint {
+    /// True when scheme is `wss://`.
+    pub secure: bool,
+    /// Host name used by socket dialing.
+    pub host: String,
+    /// Host header authority value.
+    pub host_header: String,
+    /// Port selected from authority/defaults.
+    pub port: u16,
+    /// Fully normalized request path.
+    pub target_path: String,
+}
+
+/// Parses and validates one HTTP endpoint.
+pub fn parse_http_endpoint(
+    base_url: &str,
+    path: &str,
+) -> Result<KolmeParsedHttpEndpoint, KolmeEndpointPolicyError> {
+    let base = base_url.trim();
+    if base.is_empty() {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "base_url must not be empty".to_owned(),
+        });
+    }
+    let (scheme, remainder) = if let Some(remainder) = base.strip_prefix("http://") {
+        (KolmeHttpScheme::Http, remainder)
+    } else if let Some(remainder) = base.strip_prefix("https://") {
+        (KolmeHttpScheme::Https, remainder)
+    } else {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "base_url scheme must be http:// or https://".to_owned(),
+        });
+    };
+
+    let (authority, base_path) = match remainder.split_once('/') {
+        Some((left, right)) => (left, format!("/{}", right.trim_start_matches('/'))),
+        None => (remainder, "/".to_owned()),
+    };
+
+    if authority.is_empty() {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "base_url host must not be empty".to_owned(),
+        });
+    }
+
+    let (host, port) = parse_authority(authority, scheme.default_port())?;
+    let target_path = join_http_paths(base_path.as_str(), path);
+
+    Ok(KolmeParsedHttpEndpoint {
+        scheme,
+        host,
+        host_header: authority.to_owned(),
+        port,
+        target_path,
+    })
+}
+
+/// Composes websocket notifications URL from HTTP base URL + notifications path.
+pub fn compose_notifications_websocket_url(
+    base_url: &str,
+    notifications_path: &str,
+) -> Result<String, KolmeEndpointPolicyError> {
+    if notifications_path.trim().is_empty() {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "notifications_path must not be empty".to_owned(),
+        });
+    }
+    let endpoint = parse_http_endpoint(base_url, notifications_path)?;
+    let scheme = match endpoint.scheme {
+        KolmeHttpScheme::Http => "ws",
+        KolmeHttpScheme::Https => "wss",
+    };
+    Ok(format!(
+        "{scheme}://{}{}",
+        endpoint.host_header, endpoint.target_path
+    ))
+}
+
+/// Parses and validates one websocket notifications endpoint URL.
+pub fn parse_websocket_endpoint(
+    notifications_url: &str,
+) -> Result<KolmeParsedWebsocketEndpoint, KolmeEndpointPolicyError> {
+    let raw = notifications_url.trim();
+    if raw.is_empty() {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "notifications_url must not be empty".to_owned(),
+        });
+    }
+
+    let (secure, remainder) = if let Some(remainder) = raw.strip_prefix("ws://") {
+        (false, remainder)
+    } else if let Some(remainder) = raw.strip_prefix("wss://") {
+        (true, remainder)
+    } else {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "notifications_url scheme must be ws:// or wss://".to_owned(),
+        });
+    };
+
+    let (authority, target_path) = match remainder.split_once('/') {
+        Some((left, right)) => (left, format!("/{}", right.trim_start_matches('/'))),
+        None => (remainder, "/".to_owned()),
+    };
+    if authority.trim().is_empty() {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "notifications_url host must not be empty".to_owned(),
+        });
+    }
+    let default_port = if secure { 443 } else { 80 };
+    let (host, port) = parse_authority(authority, default_port)?;
+
+    Ok(KolmeParsedWebsocketEndpoint {
+        secure,
+        host,
+        host_header: authority.to_owned(),
+        port,
+        target_path,
+    })
+}
+
+fn parse_authority(
+    authority: &str,
+    default_port: u16,
+) -> Result<(String, u16), KolmeEndpointPolicyError> {
+    if authority.starts_with('[') {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "ipv6 host syntax is not supported".to_owned(),
+        });
+    }
+    if let Some((host, port_raw)) = authority.rsplit_once(':') {
+        if !port_raw.is_empty() && port_raw.chars().all(|ch| ch.is_ascii_digit()) {
+            let port =
+                port_raw
+                    .parse::<u16>()
+                    .map_err(|_| KolmeEndpointPolicyError::Unavailable {
+                        reason: "base_url port is invalid".to_owned(),
+                    })?;
+            if host.trim().is_empty() {
+                return Err(KolmeEndpointPolicyError::Unavailable {
+                    reason: "base_url host must not be empty".to_owned(),
+                });
+            }
+            return Ok((host.to_owned(), port));
+        }
+        if !port_raw.is_empty() {
+            return Err(KolmeEndpointPolicyError::Unavailable {
+                reason: "base_url port is invalid".to_owned(),
+            });
+        }
+    }
+    Ok((authority.to_owned(), default_port))
+}
+
+fn join_http_paths(base_path: &str, request_path: &str) -> String {
+    let base = if base_path.trim().is_empty() {
+        "/".to_owned()
+    } else if base_path.starts_with('/') {
+        base_path.to_owned()
+    } else {
+        format!("/{base_path}")
+    };
+
+    let request = request_path.trim();
+    if request.is_empty() || request == "/" {
+        return base;
+    }
+
+    if request.starts_with('/') {
+        if base == "/" {
+            return request.to_owned();
+        }
+        return format!("{}{}", base.trim_end_matches('/'), request);
+    }
+
+    if base == "/" {
+        format!("/{request}")
+    } else {
+        format!("{}/{}", base.trim_end_matches('/'), request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compose_notifications_websocket_url, parse_http_endpoint, parse_websocket_endpoint,
+        KolmeEndpointPolicyError, KolmeHttpScheme,
+    };
+
+    #[test]
+    fn unit_parse_http_endpoint_rejects_invalid_scheme() {
+        assert_eq!(
+            parse_http_endpoint("ftp://kolme.local", "/status"),
+            Err(KolmeEndpointPolicyError::Unavailable {
+                reason: "base_url scheme must be http:// or https://".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn functional_compose_notifications_websocket_url_maps_https_to_wss() {
+        let url =
+            compose_notifications_websocket_url("https://kolme.local/runtime", "/notifications")
+                .expect("notifications url should compose");
+        assert_eq!(url, "wss://kolme.local/runtime/notifications");
+    }
+
+    #[test]
+    fn regression_parse_websocket_endpoint_rejects_non_websocket_scheme() {
+        // Regression: #1729
+        assert_eq!(
+            parse_websocket_endpoint("http://kolme.local/notifications"),
+            Err(KolmeEndpointPolicyError::Unavailable {
+                reason: "notifications_url scheme must be ws:// or wss://".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn unit_parse_http_endpoint_normalizes_host_port_path() {
+        let endpoint =
+            parse_http_endpoint("https://kolme.local:7443/base", "runtime-commit/status")
+                .expect("endpoint should parse");
+        assert_eq!(endpoint.scheme, KolmeHttpScheme::Https);
+        assert_eq!(endpoint.host, "kolme.local");
+        assert_eq!(endpoint.host_header, "kolme.local:7443");
+        assert_eq!(endpoint.port, 7443);
+        assert_eq!(endpoint.target_path, "/base/runtime-commit/status");
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod api_codec;
 pub mod block_scan_policy;
 pub mod codec;
+pub mod endpoint_policy;
 pub mod finality;
 pub mod pipeline;
 pub mod receipt_finality;
@@ -21,6 +22,11 @@ pub use block_scan_policy::{
     validate_lookup_window, BlockScanPolicyError,
 };
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
+pub use endpoint_policy::{
+    compose_notifications_websocket_url, parse_http_endpoint, parse_websocket_endpoint,
+    KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
+    KolmeParsedWebsocketEndpoint,
+};
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};

--- a/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
@@ -1,0 +1,40 @@
+use kamn_kolme::{
+    compose_notifications_websocket_url, parse_http_endpoint, parse_websocket_endpoint,
+    KolmeEndpointPolicyError, KolmeHttpScheme,
+};
+
+#[test]
+fn functional_parse_http_endpoint_normalizes_path_and_scheme() {
+    let endpoint = parse_http_endpoint("https://kolme.example/api", "runtime-commit/status")
+        .expect("endpoint should parse");
+    assert_eq!(endpoint.scheme, KolmeHttpScheme::Https);
+    assert_eq!(endpoint.host, "kolme.example");
+    assert_eq!(endpoint.port, 443);
+    assert_eq!(endpoint.target_path, "/api/runtime-commit/status");
+}
+
+#[test]
+fn functional_compose_notifications_websocket_url_maps_https_to_wss() {
+    let notifications_url =
+        compose_notifications_websocket_url("https://kolme.example/base", "/notifications")
+            .expect("notifications url should compose");
+    assert_eq!(notifications_url, "wss://kolme.example/base/notifications");
+}
+
+#[test]
+fn regression_issue_1729_endpoint_validation_fails_closed() {
+    // Regression: #1729
+    assert_eq!(
+        parse_http_endpoint("ftp://kolme.example", "/status"),
+        Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "base_url scheme must be http:// or https://".to_owned(),
+        })
+    );
+
+    assert_eq!(
+        parse_websocket_endpoint("http://kolme.example/notifications"),
+        Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "notifications_url scheme must be ws:// or wss://".to_owned(),
+        })
+    );
+}

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -31,6 +31,9 @@ handling.
   - `KolmeRuntimeCommitFinalityTransport::fetch_runtime_commit_finality(...)`
   - `KolmeRuntimeCommitHttpTransport::fetch_next_nonce(...)`
   - `KolmeRuntimeCommitHttpTransport::submit_broadcast_request(...)`
+- Endpoint normalization boundary:
+  - `crates/kamn-kolme/src/endpoint_policy.rs` owns HTTP/WebSocket endpoint parsing and URL composition contracts.
+  - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
 - Optional auth-aware constructor:
   - `KolmeRuntimeCommitHttpTransport::new_with_authorization(...)`
   - emits `Authorization: <value>` header on submit/finality requests.
@@ -139,6 +142,7 @@ cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
 cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
 cargo test -p kamn-kolme --test api_codec_contracts
 cargo test -p kamn-kolme --test finality_block_scan_contracts
+cargo test -p kamn-kolme --test endpoint_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact


### PR DESCRIPTION
## Summary
Extracts HTTP/WebSocket endpoint normalization contracts from `kamn-core` into `kamn-kolme`, and rewires runtime-commit transport/notifications wrappers in `kamn-core` to delegate to the extracted policy module. This reduces `kolme_runtime_commit.rs` transport parsing surface while preserving behavior parity.

Closes #1729
Refs #1714

## Changes
- `crates/kamn-kolme/src/endpoint_policy.rs`
  - Added endpoint policy contracts:
    - `parse_http_endpoint`
    - `parse_websocket_endpoint`
    - `compose_notifications_websocket_url`
    - `KolmeEndpointPolicyError`
    - `KolmeHttpScheme`
    - `KolmeParsedHttpEndpoint`
    - `KolmeParsedWebsocketEndpoint`
- `crates/kamn-kolme/src/lib.rs`
  - Exported endpoint policy contracts.
- `crates/kamn-kolme/tests/endpoint_policy_contracts.rs`
  - Added functional + regression extraction tests.
- `crates/kamn-core/src/kolme_runtime_commit.rs`
  - Delegated endpoint parsing/composition wrappers to extracted `kamn-kolme` contracts.
  - Removed local endpoint parser/authority/path-join implementation blocks.
- `docs/foundation/kolme-runtime-commit-client.md`
  - Documented endpoint normalization ownership in `kamn-kolme` and added test command.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test endpoint_policy_contracts`
- Failed before implementation with unresolved imports:
  - `parse_http_endpoint`
  - `parse_websocket_endpoint`
  - `compose_notifications_websocket_url`
  - `KolmeEndpointPolicyError`
  - `KolmeHttpScheme`

### 🟢 Green Phase
`cargo test -p kamn-kolme --test endpoint_policy_contracts`
- Pass: 3 tests, 0 failed

### 🔁 Regression
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport --test kolme_runtime_commit_notifications --test kolme_runtime_commit_fork_finality_resolver` (pass)
- `cargo fmt --all --check` (pass)
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings` (pass)
- `bash scripts/ci/test_select_targets.sh` (pass)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `endpoint_policy` unit tests in `kamn-kolme` | |
| Functional   | ✅ | `endpoint_policy_contracts` path/scheme composition tests | |
| Integration  | ✅ | `kolme_runtime_commit_http_transport`, `kolme_runtime_commit_notifications`, `kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅ | `regression_issue_1729_endpoint_validation_fails_closed` | |
| Performance  | N/A | | Policy extraction only |

## Risks & Rollback
- Breaking changes: None expected; core wrappers preserve call sites and tested behavior.
- Rollback plan: revert this PR to restore local endpoint parsing in `kamn-core`.

## Documentation Updates
- Updated `docs/foundation/kolme-runtime-commit-client.md` with endpoint-policy extraction boundary and validation command.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Unit tests pass
- [x] Functional tests pass
- [x] Integration tests pass
- [x] Regression tests pass
