### PR TITLE
refactor(kolme): extract finality status-path policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -2,6 +2,7 @@
 
 use crate::AgentDid;
 use kamn_kolme::{
+    compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_receipt_finality as parse_kolme_receipt_finality,
@@ -1022,14 +1023,8 @@ impl KolmeRuntimeCommitFinalityTransport for KolmeRuntimeCommitHttpTransport {
         status_path: &str,
         commit_id: &str,
     ) -> Result<String, KolmeRuntimeCommitProviderError> {
-        if commit_id.trim().is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "commit_id must not be empty".to_owned(),
-            });
-        }
-        let encoded_commit_id = percent_encode(commit_id);
-        let separator = if status_path.contains('?') { "&" } else { "?" };
-        let path = format!("{status_path}{separator}commit_id={encoded_commit_id}");
+        let path = compose_kolme_finality_status_path(status_path, commit_id)
+            .map_err(map_endpoint_policy_error_to_malformed)?;
         self.execute_request(base_url, path.as_str(), "GET", None, &[])
     }
 }
@@ -1734,6 +1729,14 @@ fn map_endpoint_policy_error(
     error: KamnKolmeEndpointPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
     KolmeRuntimeCommitProviderError::Unavailable {
+        reason: error.to_string(),
+    }
+}
+
+fn map_endpoint_policy_error_to_malformed(
+    error: KamnKolmeEndpointPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
         reason: error.to_string(),
     }
 }
@@ -2497,20 +2500,6 @@ fn map_http_client_status_error(status_code: u16) -> KolmeRuntimeCommitProviderE
             reason: format!("http response status indicates client failure: {status_code}"),
         },
     }
-}
-
-fn percent_encode(value: &str) -> String {
-    let mut encoded = String::new();
-    for byte in value.bytes() {
-        let ch = byte as char;
-        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~') {
-            encoded.push(ch);
-        } else {
-            encoded.push('%');
-            encoded.push_str(format!("{byte:02X}").as_str());
-        }
-    }
-    encoded
 }
 
 fn is_kolme_broadcast_submit_path(submit_path: &str) -> bool {

--- a/crates/kamn-kolme/src/endpoint_policy.rs
+++ b/crates/kamn-kolme/src/endpoint_policy.rs
@@ -137,6 +137,24 @@ pub fn compose_notifications_websocket_url(
     ))
 }
 
+/// Composes one finality status path by appending encoded `commit_id` query.
+pub fn compose_finality_status_path(
+    status_path: &str,
+    commit_id: &str,
+) -> Result<String, KolmeEndpointPolicyError> {
+    let commit_id = commit_id.trim();
+    if commit_id.is_empty() {
+        return Err(KolmeEndpointPolicyError::Unavailable {
+            reason: "commit_id must not be empty".to_owned(),
+        });
+    }
+    let encoded_commit_id = percent_encode(commit_id);
+    let separator = if status_path.contains('?') { "&" } else { "?" };
+    Ok(format!(
+        "{status_path}{separator}commit_id={encoded_commit_id}"
+    ))
+}
+
 /// Parses and validates one websocket notifications endpoint URL.
 pub fn parse_websocket_endpoint(
     notifications_url: &str,
@@ -240,11 +258,25 @@ fn join_http_paths(base_path: &str, request_path: &str) -> String {
     }
 }
 
+fn percent_encode(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        let ch = byte as char;
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~') {
+            encoded.push(ch);
+        } else {
+            encoded.push('%');
+            encoded.push_str(format!("{byte:02X}").as_str());
+        }
+    }
+    encoded
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        compose_notifications_websocket_url, parse_http_endpoint, parse_websocket_endpoint,
-        KolmeEndpointPolicyError, KolmeHttpScheme,
+        compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,
+        parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
     };
 
     #[test]
@@ -286,5 +318,15 @@ mod tests {
         assert_eq!(endpoint.host_header, "kolme.local:7443");
         assert_eq!(endpoint.port, 7443);
         assert_eq!(endpoint.target_path, "/base/runtime-commit/status");
+    }
+
+    #[test]
+    fn unit_compose_finality_status_path_rejects_empty_commit_id() {
+        assert_eq!(
+            compose_finality_status_path("/runtime-commit/status", " "),
+            Err(KolmeEndpointPolicyError::Unavailable {
+                reason: "commit_id must not be empty".to_owned(),
+            })
+        );
     }
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -23,8 +23,8 @@ pub use block_scan_policy::{
 };
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use endpoint_policy::{
-    compose_notifications_websocket_url, parse_http_endpoint, parse_websocket_endpoint,
-    KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
+    compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,
+    parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
     KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};

--- a/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
@@ -1,6 +1,6 @@
 use kamn_kolme::{
-    compose_notifications_websocket_url, parse_http_endpoint, parse_websocket_endpoint,
-    KolmeEndpointPolicyError, KolmeHttpScheme,
+    compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,
+    parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
 };
 
 #[test]
@@ -19,6 +19,23 @@ fn functional_compose_notifications_websocket_url_maps_https_to_wss() {
         compose_notifications_websocket_url("https://kolme.example/base", "/notifications")
             .expect("notifications url should compose");
     assert_eq!(notifications_url, "wss://kolme.example/base/notifications");
+}
+
+#[test]
+fn functional_compose_finality_status_path_encodes_commit_id_and_separator() {
+    assert_eq!(
+        compose_finality_status_path("/runtime-commit/status", "kolme-commit:ab12cd34:h42")
+            .expect("status path should compose"),
+        "/runtime-commit/status?commit_id=kolme-commit%3Aab12cd34%3Ah42"
+    );
+    assert_eq!(
+        compose_finality_status_path(
+            "/runtime-commit/status?provider=kolme-fork-local",
+            "kolme-commit:ff00"
+        )
+        .expect("status path should append query"),
+        "/runtime-commit/status?provider=kolme-fork-local&commit_id=kolme-commit%3Aff00"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Extract finality status-path composition into `kamn-kolme` endpoint policy contracts and remove duplicated composition logic from `kamn-core`.
This keeps finality query normalization/encoding policy in one crate and reduces transport-path drift.

## Changes
- `crates/kamn-kolme/src/endpoint_policy.rs`: add `compose_finality_status_path` contract and unit guard for empty commit IDs
- `crates/kamn-kolme/src/lib.rs`: export `compose_finality_status_path`
- `crates/kamn-kolme/tests/endpoint_policy_contracts.rs`: add functional coverage for encoding/separator behavior
- `crates/kamn-core/src/kolme_runtime_commit.rs`: consume extracted contract and remove duplicate local `percent_encode` helper

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to changed crates)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated finality path composition for plain and pre-query status paths

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test endpoint_policy_contracts` |
| Functional  | ✅     | finality-status path composition contract cases |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_http_transport` |
| Regression  | ✅     | endpoint-policy fail-closed regression coverage retained |

Closes #1731
