### PR TITLE
refactor(kolme): extract fork fallback txhash parse policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -4,6 +4,7 @@ use crate::AgentDid;
 use kamn_kolme::{
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
+    parse_fork_block_txhash as parse_kolme_fork_block_txhash,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_receipt_finality as parse_kolme_receipt_finality,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
@@ -1816,11 +1817,8 @@ fn parse_kolme_fork_block_fallback_response(
             reason: "expected block height must be positive".to_owned(),
         });
     }
-    let txhash = find_notification_string_field(response, "txhash")?.ok_or_else(|| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "missing required field: txhash".to_owned(),
-        }
-    })?;
+    let txhash = parse_kolme_fork_block_txhash(response)
+        .map_err(map_block_scan_policy_error_to_malformed)?;
 
     Ok(ParsedBlockFallbackResponse {
         provider: provider.to_owned(),

--- a/crates/kamn-kolme/src/block_scan_policy.rs
+++ b/crates/kamn-kolme/src/block_scan_policy.rs
@@ -39,6 +39,11 @@ pub enum BlockScanPolicyError {
         /// Observed block height.
         observed: u64,
     },
+    /// Fork block-fallback response is malformed.
+    MalformedForkFallbackResponse {
+        /// Deterministic parse/validation failure reason.
+        reason: String,
+    },
 }
 
 impl fmt::Display for BlockScanPolicyError {
@@ -69,6 +74,7 @@ impl fmt::Display for BlockScanPolicyError {
                 f,
                 "block fallback response height mismatch: expected {expected} observed {observed}"
             ),
+            Self::MalformedForkFallbackResponse { reason } => f.write_str(reason),
         }
     }
 }
@@ -146,11 +152,114 @@ pub fn validate_block_identity(
     Ok(())
 }
 
+/// Parses the required `txhash` field from a fork block-fallback payload.
+pub fn parse_fork_block_txhash(response: &str) -> Result<String, BlockScanPolicyError> {
+    find_string_field(response, "txhash")?.ok_or_else(|| {
+        BlockScanPolicyError::MalformedForkFallbackResponse {
+            reason: "missing required field: txhash".to_owned(),
+        }
+    })
+}
+
+fn find_string_field(payload: &str, field: &str) -> Result<Option<String>, BlockScanPolicyError> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b'"') {
+            continue;
+        }
+
+        let mut end = cursor + 1;
+        let mut escape = false;
+        while let Some(byte) = payload.as_bytes().get(end).copied() {
+            if escape {
+                escape = false;
+                end += 1;
+                continue;
+            }
+            if byte == b'\\' {
+                escape = true;
+                end += 1;
+                continue;
+            }
+            if byte == b'"' {
+                let token = &payload[cursor..=end];
+                let parsed = parse_json_string(token).map_err(|reason| {
+                    BlockScanPolicyError::MalformedForkFallbackResponse {
+                        reason: format!("notification field '{field}' is invalid: {reason}"),
+                    }
+                })?;
+                if parsed.trim().is_empty() {
+                    return Err(BlockScanPolicyError::MalformedForkFallbackResponse {
+                        reason: format!("notification field '{field}' must not be empty"),
+                    });
+                }
+                return Ok(Some(parsed));
+            }
+            end += 1;
+        }
+        return Err(BlockScanPolicyError::MalformedForkFallbackResponse {
+            reason: format!("notification field '{field}' is unterminated"),
+        });
+    }
+    Ok(None)
+}
+
+fn parse_json_string(token: &str) -> Result<String, &'static str> {
+    let trimmed = token.trim();
+    if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
+        return Err("token must be a quoted string");
+    }
+    let mut output = String::new();
+    let mut escape = false;
+    for ch in trimmed[1..trimmed.len() - 1].chars() {
+        if escape {
+            let mapped = match ch {
+                '\\' => '\\',
+                '"' => '"',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => return Err("unsupported escape sequence"),
+            };
+            output.push(mapped);
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        output.push(ch);
+    }
+    if escape {
+        return Err("unterminated escape sequence");
+    }
+    Ok(output)
+}
+
+fn skip_ascii_whitespace(value: &str, mut cursor: usize) -> usize {
+    while let Some(byte) = value.as_bytes().get(cursor).copied() {
+        if byte.is_ascii_whitespace() {
+            cursor += 1;
+            continue;
+        }
+        break;
+    }
+    cursor
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        render_block_path, validate_block_identity, validate_block_path_template,
-        validate_lookup_window, BlockScanPolicyError,
+        parse_fork_block_txhash, render_block_path, validate_block_identity,
+        validate_block_path_template, validate_lookup_window, BlockScanPolicyError,
     };
 
     #[test]
@@ -182,6 +291,16 @@ mod tests {
         assert_eq!(
             render_block_path("/block/{height}", 42).expect("render should pass"),
             "/block/42"
+        );
+    }
+
+    #[test]
+    fn unit_parse_fork_block_txhash_rejects_empty_txhash() {
+        assert_eq!(
+            parse_fork_block_txhash(r#"{"txhash":"   "}"#),
+            Err(BlockScanPolicyError::MalformedForkFallbackResponse {
+                reason: "notification field 'txhash' must not be empty".to_owned(),
+            })
         );
     }
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -18,8 +18,8 @@ pub use api_codec::{
     KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
 };
 pub use block_scan_policy::{
-    render_block_path, validate_block_identity, validate_block_path_template,
-    validate_lookup_window, BlockScanPolicyError,
+    parse_fork_block_txhash, render_block_path, validate_block_identity,
+    validate_block_path_template, validate_lookup_window, BlockScanPolicyError,
 };
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use endpoint_policy::{

--- a/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
+++ b/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
@@ -1,5 +1,5 @@
 use kamn_kolme::{
-    parse_receipt_finality, render_block_path, validate_block_identity,
+    parse_fork_block_txhash, parse_receipt_finality, render_block_path, validate_block_identity,
     validate_block_path_template, validate_lookup_window, ReceiptFinality,
 };
 
@@ -25,6 +25,15 @@ fn functional_validate_lookup_window_rejects_stale_span() {
     assert_eq!(
         error.to_string(),
         "block fallback window exceeds max lookups: from_height=40 latest_height=44 max_lookups=3"
+    );
+}
+
+#[test]
+fn functional_parse_fork_block_txhash_extracts_required_field() {
+    assert_eq!(
+        parse_fork_block_txhash(r#"{"height":42,"txhash":"0xabc123"}"#)
+            .expect("txhash should parse"),
+        "0xabc123"
     );
 }
 

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -110,7 +110,9 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `crates/kamn-core/src/kolme_runtime_commit.rs` (legacy compatibility shim
     while extraction proceeds)
   - `crates/kamn-kolme/src/codec.rs`, `crates/kamn-kolme/src/transport.rs`,
-    `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`
+    `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`,
+    `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
+    `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts. `kamn-core` retains temporary compatibility exports until full

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -59,7 +59,7 @@ handling.
   - provider identity for txhash-only responses uses response `provider` when present, otherwise deterministic provider hint from profile construction.
 - Fork finality profile:
   - `KolmeRuntimeCommitForkFinalityResolver` composes websocket notifications (`/notifications`) with bounded block fallback scans (`/block/{height}`).
-  - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
+  - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.


### PR DESCRIPTION
## Summary
Extract fork block-fallback `txhash` parsing policy into `kamn-kolme` and rewire `kamn-core` to consume the extracted contract.
This reduces parser ownership in `kolme_runtime_commit.rs` and keeps fallback policy boundaries explicit in the subcrate.

## Changes
- `crates/kamn-kolme/src/block_scan_policy.rs`: add `parse_fork_block_txhash` contract and deterministic malformed-response variant
- `crates/kamn-kolme/src/lib.rs`: export `parse_fork_block_txhash`
- `crates/kamn-kolme/tests/finality_block_scan_contracts.rs`: add functional contract test for fork fallback txhash extraction
- `crates/kamn-core/src/kolme_runtime_commit.rs`: use extracted contract in fork fallback parser path
- `docs/foundation/kolme-runtime-commit-client.md`: document extracted fork fallback parser contract
- `docs/architecture/kamn-core-module-map.md`: update extraction boundary module list

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-kolme --test finality_block_scan_contracts`

Observed failure (before implementation):
```
error[E0432]: unresolved import `kamn_kolme::parse_fork_block_txhash`
no `parse_fork_block_txhash` in the root
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test finality_block_scan_contracts`
- `cargo test -p kamn-kolme`

Result:
- All `kamn-kolme` unit + contract tests passed, including new fork fallback txhash extraction coverage.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback`
- `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`
- `bash scripts/ci/test_select_targets.sh`

Result:
- All listed regression and quality gates passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `block_scan_policy::unit_parse_fork_block_txhash_rejects_empty_txhash` | |
| Functional   | ✅     | `functional_parse_fork_block_txhash_extracts_required_field` | |
| Integration  | ✅     | `kolme_runtime_commit_block_fallback`, `kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅     | Existing fork resolver + block fallback fail-closed contracts rerun | |
| Performance  | N/A    | N/A                  | Parser extraction only; no new runtime loops/I/O |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore previous in-core fallback txhash parser path.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1733
