### PR TITLE
refactor(kolme): extract notification parse policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -6,6 +6,7 @@ use kamn_kolme::{
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     parse_fork_block_txhash as parse_kolme_fork_block_txhash,
     parse_http_endpoint as parse_kolme_http_endpoint,
+    parse_notification_event as parse_kolme_notification_event_contract,
     parse_receipt_finality as parse_kolme_receipt_finality,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
@@ -18,7 +19,9 @@ use kamn_kolme::{
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
-    KolmeHttpScheme as KamnKolmeHttpScheme, KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
+    KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
+    KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
+    KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint, ReceiptFinality,
 };
 use std::collections::HashMap;
@@ -1742,6 +1745,14 @@ fn map_endpoint_policy_error_to_malformed(
     }
 }
 
+fn map_notification_policy_error_to_malformed(
+    error: KamnKolmeNotificationPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
@@ -2110,51 +2121,27 @@ fn try_take_websocket_frame(
 fn parse_kolme_notification_event(
     payload: &str,
 ) -> Result<KolmeRuntimeCommitNotificationEvent, KolmeRuntimeCommitProviderError> {
-    let trimmed = payload.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "notification payload must not be empty".to_owned(),
-        });
-    }
-    if trimmed.contains("\"NewBlock\"") {
-        let block_height = find_notification_u64_field(trimmed, "height")?
-            .or(find_escaped_notification_u64_field(trimmed, "height")?);
-        if let Some(txhash) = find_notification_string_field(trimmed, "txhash")? {
-            return Ok(KolmeRuntimeCommitNotificationEvent::NewBlock {
-                txhash,
-                block_height,
-            });
-        }
-        if let Some(height) = block_height {
-            return Ok(KolmeRuntimeCommitNotificationEvent::LatestBlock { height });
-        }
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "notification txhash or height field is missing".to_owned(),
-        });
-    }
-    if trimmed.contains("\"FailedTransaction\"") {
-        let txhash = find_notification_string_field(trimmed, "txhash")?.ok_or_else(|| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "notification txhash field is missing".to_owned(),
-            }
-        })?;
-        let proposed_height = find_notification_u64_field(trimmed, "proposed_height")?;
-        return Ok(KolmeRuntimeCommitNotificationEvent::FailedTransaction {
+    let event = parse_kolme_notification_event_contract(payload)
+        .map_err(map_notification_policy_error_to_malformed)?;
+    match event {
+        KamnKolmeNotificationEvent::NewBlock {
+            txhash,
+            block_height,
+        } => Ok(KolmeRuntimeCommitNotificationEvent::NewBlock {
+            txhash,
+            block_height,
+        }),
+        KamnKolmeNotificationEvent::FailedTransaction {
             txhash,
             proposed_height,
-        });
+        } => Ok(KolmeRuntimeCommitNotificationEvent::FailedTransaction {
+            txhash,
+            proposed_height,
+        }),
+        KamnKolmeNotificationEvent::LatestBlock { height } => {
+            Ok(KolmeRuntimeCommitNotificationEvent::LatestBlock { height })
+        }
     }
-    if trimmed.contains("\"LatestBlock\"") {
-        let height = find_notification_u64_field(trimmed, "height")?.ok_or_else(|| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "notification latest block height is missing".to_owned(),
-            }
-        })?;
-        return Ok(KolmeRuntimeCommitNotificationEvent::LatestBlock { height });
-    }
-    Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: "notification variant is unsupported".to_owned(),
-    })
 }
 
 fn find_notification_string_field(
@@ -2270,31 +2257,6 @@ fn find_notification_u64_field(
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: format!("notification field '{field}' must be a positive integer"),
             });
-        }
-        let token = &payload[cursor..end];
-        return parse_notification_positive_u64(token, field).map(Some);
-    }
-    Ok(None)
-}
-
-fn find_escaped_notification_u64_field(
-    payload: &str,
-    field: &str,
-) -> Result<Option<u64>, KolmeRuntimeCommitProviderError> {
-    let pattern = format!("\\\"{field}\\\":");
-    for (index, _) in payload.match_indices(pattern.as_str()) {
-        let mut cursor = index + pattern.len();
-        cursor = skip_ascii_whitespace(payload, cursor);
-        let mut end = cursor;
-        while let Some(byte) = payload.as_bytes().get(end).copied() {
-            if byte.is_ascii_digit() {
-                end += 1;
-                continue;
-            }
-            break;
-        }
-        if end == cursor {
-            continue;
         }
         let token = &payload[cursor..end];
         return parse_notification_positive_u64(token, field).map(Some);

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block_scan_policy;
 pub mod codec;
 pub mod endpoint_policy;
 pub mod finality;
+pub mod notification_policy;
 pub mod pipeline;
 pub mod receipt_finality;
 pub mod transport;
@@ -28,6 +29,9 @@ pub use endpoint_policy::{
     KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
+pub use notification_policy::{
+    parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
+};
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use transport::{

--- a/crates/kamn-kolme/src/notification_policy.rs
+++ b/crates/kamn-kolme/src/notification_policy.rs
@@ -1,0 +1,336 @@
+//! Notification event parsing contracts for Kolme websocket payloads.
+
+use std::error::Error;
+use std::fmt;
+
+/// Typed notification event variants emitted by Kolme websocket streams.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeNotificationEvent {
+    /// Finalized transaction notification emitted from a new block event.
+    NewBlock {
+        /// Transaction hash observed in the block payload.
+        txhash: String,
+        /// Optional block height where the transaction finalized.
+        block_height: Option<u64>,
+    },
+    /// Failed transaction notification emitted by processor execution path.
+    FailedTransaction {
+        /// Transaction hash observed in failed-transaction payload.
+        txhash: String,
+        /// Optional proposed block height for the failed transaction.
+        proposed_height: Option<u64>,
+    },
+    /// Latest block watermark notification.
+    LatestBlock {
+        /// Latest observed block height.
+        height: u64,
+    },
+}
+
+/// Error raised by notification parsing policy contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeNotificationPolicyError {
+    /// Notification payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeNotificationPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedResponse { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeNotificationPolicyError {}
+
+/// Parses one notification websocket payload into a typed event contract.
+pub fn parse_notification_event(
+    payload: &str,
+) -> Result<KolmeNotificationEvent, KolmeNotificationPolicyError> {
+    let trimmed = payload.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeNotificationPolicyError::MalformedResponse {
+            reason: "notification payload must not be empty".to_owned(),
+        });
+    }
+    if trimmed.contains("\"NewBlock\"") {
+        let block_height = find_notification_u64_field(trimmed, "height")?
+            .or(find_escaped_notification_u64_field(trimmed, "height")?);
+        if let Some(txhash) = find_notification_string_field(trimmed, "txhash")? {
+            return Ok(KolmeNotificationEvent::NewBlock {
+                txhash,
+                block_height,
+            });
+        }
+        if let Some(height) = block_height {
+            return Ok(KolmeNotificationEvent::LatestBlock { height });
+        }
+        return Err(KolmeNotificationPolicyError::MalformedResponse {
+            reason: "notification txhash or height field is missing".to_owned(),
+        });
+    }
+    if trimmed.contains("\"FailedTransaction\"") {
+        let txhash = find_notification_string_field(trimmed, "txhash")?.ok_or_else(|| {
+            KolmeNotificationPolicyError::MalformedResponse {
+                reason: "notification txhash field is missing".to_owned(),
+            }
+        })?;
+        let proposed_height = find_notification_u64_field(trimmed, "proposed_height")?;
+        return Ok(KolmeNotificationEvent::FailedTransaction {
+            txhash,
+            proposed_height,
+        });
+    }
+    if trimmed.contains("\"LatestBlock\"") {
+        let height = find_notification_u64_field(trimmed, "height")?.ok_or_else(|| {
+            KolmeNotificationPolicyError::MalformedResponse {
+                reason: "notification latest block height is missing".to_owned(),
+            }
+        })?;
+        return Ok(KolmeNotificationEvent::LatestBlock { height });
+    }
+    Err(KolmeNotificationPolicyError::MalformedResponse {
+        reason: "notification variant is unsupported".to_owned(),
+    })
+}
+
+fn find_notification_string_field(
+    payload: &str,
+    field: &str,
+) -> Result<Option<String>, KolmeNotificationPolicyError> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b'"') {
+            continue;
+        }
+        let mut end = cursor + 1;
+        let mut escape = false;
+        while let Some(byte) = payload.as_bytes().get(end).copied() {
+            if escape {
+                escape = false;
+                end += 1;
+                continue;
+            }
+            if byte == b'\\' {
+                escape = true;
+                end += 1;
+                continue;
+            }
+            if byte == b'"' {
+                let token = &payload[cursor..=end];
+                let parsed = parse_json_string(token).map_err(|reason| {
+                    KolmeNotificationPolicyError::MalformedResponse {
+                        reason: format!("notification field '{field}' is invalid: {reason}"),
+                    }
+                })?;
+                if parsed.trim().is_empty() {
+                    return Err(KolmeNotificationPolicyError::MalformedResponse {
+                        reason: format!("notification field '{field}' must not be empty"),
+                    });
+                }
+                return Ok(Some(parsed));
+            }
+            end += 1;
+        }
+        return Err(KolmeNotificationPolicyError::MalformedResponse {
+            reason: format!("notification field '{field}' is unterminated"),
+        });
+    }
+    Ok(None)
+}
+
+fn find_notification_u64_field(
+    payload: &str,
+    field: &str,
+) -> Result<Option<u64>, KolmeNotificationPolicyError> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        let Some(first) = payload.as_bytes().get(cursor).copied() else {
+            return Err(KolmeNotificationPolicyError::MalformedResponse {
+                reason: format!("notification field '{field}' value is missing"),
+            });
+        };
+
+        if first == b'"' {
+            let mut end = cursor + 1;
+            let mut escape = false;
+            while let Some(byte) = payload.as_bytes().get(end).copied() {
+                if escape {
+                    escape = false;
+                    end += 1;
+                    continue;
+                }
+                if byte == b'\\' {
+                    escape = true;
+                    end += 1;
+                    continue;
+                }
+                if byte == b'"' {
+                    let token = &payload[cursor..=end];
+                    let parsed = parse_json_string(token).map_err(|reason| {
+                        KolmeNotificationPolicyError::MalformedResponse {
+                            reason: format!("notification field '{field}' is invalid: {reason}"),
+                        }
+                    })?;
+                    return parse_notification_positive_u64(parsed.as_str(), field).map(Some);
+                }
+                end += 1;
+            }
+            return Err(KolmeNotificationPolicyError::MalformedResponse {
+                reason: format!("notification field '{field}' is unterminated"),
+            });
+        }
+
+        let mut end = cursor;
+        while let Some(byte) = payload.as_bytes().get(end).copied() {
+            if byte.is_ascii_digit() {
+                end += 1;
+                continue;
+            }
+            break;
+        }
+        if end == cursor {
+            return Err(KolmeNotificationPolicyError::MalformedResponse {
+                reason: format!("notification field '{field}' must be a positive integer"),
+            });
+        }
+        let token = &payload[cursor..end];
+        return parse_notification_positive_u64(token, field).map(Some);
+    }
+    Ok(None)
+}
+
+fn find_escaped_notification_u64_field(
+    payload: &str,
+    field: &str,
+) -> Result<Option<u64>, KolmeNotificationPolicyError> {
+    let pattern = format!("\\\"{field}\\\":");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        let mut end = cursor;
+        while let Some(byte) = payload.as_bytes().get(end).copied() {
+            if byte.is_ascii_digit() {
+                end += 1;
+                continue;
+            }
+            break;
+        }
+        if end == cursor {
+            continue;
+        }
+        let token = &payload[cursor..end];
+        return parse_notification_positive_u64(token, field).map(Some);
+    }
+    Ok(None)
+}
+
+fn parse_notification_positive_u64(
+    token: &str,
+    field: &str,
+) -> Result<u64, KolmeNotificationPolicyError> {
+    let trimmed = token.trim();
+    let parsed =
+        trimmed
+            .parse::<u64>()
+            .map_err(|_| KolmeNotificationPolicyError::MalformedResponse {
+                reason: format!("notification field '{field}' must be a positive integer"),
+            })?;
+    if parsed == 0 {
+        return Err(KolmeNotificationPolicyError::MalformedResponse {
+            reason: format!("notification field '{field}' must be a positive integer"),
+        });
+    }
+    Ok(parsed)
+}
+
+fn skip_ascii_whitespace(value: &str, mut cursor: usize) -> usize {
+    while let Some(byte) = value.as_bytes().get(cursor).copied() {
+        if byte.is_ascii_whitespace() {
+            cursor += 1;
+            continue;
+        }
+        break;
+    }
+    cursor
+}
+
+fn parse_json_string(token: &str) -> Result<String, &'static str> {
+    let trimmed = token.trim();
+    if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
+        return Err("token must be a quoted string");
+    }
+    let mut output = String::new();
+    let mut escape = false;
+    for ch in trimmed[1..trimmed.len() - 1].chars() {
+        if escape {
+            let mapped = match ch {
+                '\\' => '\\',
+                '"' => '"',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => return Err("unsupported escape sequence"),
+            };
+            output.push(mapped);
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        output.push(ch);
+    }
+    if escape {
+        return Err("unterminated escape sequence");
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError};
+
+    #[test]
+    fn unit_parse_notification_event_rejects_empty_payload() {
+        assert_eq!(
+            parse_notification_event(" "),
+            Err(KolmeNotificationPolicyError::MalformedResponse {
+                reason: "notification payload must not be empty".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn functional_parse_notification_event_maps_failed_transaction_variant() {
+        assert_eq!(
+            parse_notification_event(
+                r#"{"event":"FailedTransaction","txhash":"0xdeadbeef","proposed_height":44}"#
+            )
+            .expect("failed transaction should parse"),
+            KolmeNotificationEvent::FailedTransaction {
+                txhash: "0xdeadbeef".to_owned(),
+                proposed_height: Some(44),
+            }
+        );
+    }
+}

--- a/crates/kamn-kolme/tests/notification_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/notification_policy_contracts.rs
@@ -1,0 +1,22 @@
+use kamn_kolme::{parse_notification_event, KolmeNotificationEvent};
+
+#[test]
+fn functional_parse_notification_event_maps_new_block_variant() {
+    let event = parse_notification_event(r#"{"event":"NewBlock","txhash":"0xabc123","height":42}"#)
+        .expect("new block event should parse");
+    assert_eq!(
+        event,
+        KolmeNotificationEvent::NewBlock {
+            txhash: "0xabc123".to_owned(),
+            block_height: Some(42),
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1735_notification_parser_rejects_unsupported_variant() {
+    // Regression: #1735
+    let error = parse_notification_event(r#"{"event":"SomethingElse","txhash":"0xabc"}"#)
+        .expect_err("unsupported variant must fail");
+    assert_eq!(error.to_string(), "notification variant is unsupported");
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -112,7 +112,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `crates/kamn-kolme/src/codec.rs`, `crates/kamn-kolme/src/transport.rs`,
     `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`,
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
-    `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`
+    `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
+    `crates/kamn-kolme/src/notification_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts. `kamn-core` retains temporary compatibility exports until full

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -59,6 +59,7 @@ handling.
   - provider identity for txhash-only responses uses response `provider` when present, otherwise deterministic provider hint from profile construction.
 - Fork finality profile:
   - `KolmeRuntimeCommitForkFinalityResolver` composes websocket notifications (`/notifications`) with bounded block fallback scans (`/block/{height}`).
+  - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.


### PR DESCRIPTION
## Summary
Extract websocket notification event parsing policy from `kamn-core` into `kamn-kolme` and keep `kamn-core` as a compatibility mapper.
This reduces parser ownership in `kolme_runtime_commit.rs` while preserving fail-closed behavior and existing public core event types.

## Changes
- `crates/kamn-kolme/src/notification_policy.rs`: add typed notification event parser contracts + policy error type
- `crates/kamn-kolme/src/lib.rs`: export notification parser contracts
- `crates/kamn-kolme/tests/notification_policy_contracts.rs`: add functional/regression contract tests for extracted parser
- `crates/kamn-core/src/kolme_runtime_commit.rs`: route notification parsing through extracted `kamn-kolme` contract and map variants back to core compatibility enum
- `docs/foundation/kolme-runtime-commit-client.md`: document notification parser ownership in `kamn-kolme`
- `docs/architecture/kamn-core-module-map.md`: include `notification_policy` in extraction boundary map

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-kolme --test notification_policy_contracts`

Observed failure (before implementation):
```
error[E0432]: unresolved imports `kamn_kolme::parse_notification_event`, `kamn_kolme::KolmeNotificationEvent`
no `parse_notification_event` in the root
no `KolmeNotificationEvent` in the root
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test notification_policy_contracts`
- `cargo test -p kamn-kolme`

Result:
- New notification parser contract tests pass and full `kamn-kolme` suite remains green.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
- `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`
- `bash scripts/ci/test_select_targets.sh`

Result:
- All listed integration/regression and quality gates passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `notification_policy::unit_parse_notification_event_rejects_empty_payload` | |
| Functional   | ✅     | `functional_parse_notification_event_maps_new_block_variant`, `functional_parse_notification_event_maps_failed_transaction_variant` | |
| Integration  | ✅     | `kolme_runtime_commit_notifications`, `kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅     | `regression_issue_1735_notification_parser_rejects_unsupported_variant`; existing core notification regressions rerun | |
| Performance  | N/A    | N/A                  | Parser extraction only; no new I/O or polling loops |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore previous in-core notification parser implementation.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1735
