### PR TITLE
refactor(kolme): extract direct-signed validation policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -12,6 +12,7 @@ use kamn_kolme::{
     render_block_path as render_kolme_block_path,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
+    validate_direct_signed_transaction_message as validate_kolme_direct_signed_transaction_message,
     validate_lookup_window as validate_kolme_lookup_window, BlockScanPolicyError,
     KolmeApiBroadcastRequest as KamnKolmeApiBroadcastRequest,
     KolmeApiBroadcastResponse as KamnKolmeApiBroadcastResponse,
@@ -2144,156 +2145,6 @@ fn parse_kolme_notification_event(
     }
 }
 
-fn find_notification_string_field(
-    payload: &str,
-    field: &str,
-) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
-    let pattern = format!("\"{field}\"");
-    for (index, _) in payload.match_indices(pattern.as_str()) {
-        let mut cursor = index + pattern.len();
-        cursor = skip_ascii_whitespace(payload, cursor);
-        if payload.as_bytes().get(cursor).copied() != Some(b':') {
-            continue;
-        }
-        cursor += 1;
-        cursor = skip_ascii_whitespace(payload, cursor);
-        if payload.as_bytes().get(cursor).copied() != Some(b'"') {
-            continue;
-        }
-        let mut end = cursor + 1;
-        let mut escape = false;
-        while let Some(byte) = payload.as_bytes().get(end).copied() {
-            if escape {
-                escape = false;
-                end += 1;
-                continue;
-            }
-            if byte == b'\\' {
-                escape = true;
-                end += 1;
-                continue;
-            }
-            if byte == b'"' {
-                let token = &payload[cursor..=end];
-                let parsed = parse_json_string(token).map_err(|reason| {
-                    KolmeRuntimeCommitProviderError::MalformedResponse {
-                        reason: format!("notification field '{field}' is invalid: {reason}"),
-                    }
-                })?;
-                if parsed.trim().is_empty() {
-                    return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                        reason: format!("notification field '{field}' must not be empty"),
-                    });
-                }
-                return Ok(Some(parsed));
-            }
-            end += 1;
-        }
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("notification field '{field}' is unterminated"),
-        });
-    }
-    Ok(None)
-}
-
-fn find_notification_u64_field(
-    payload: &str,
-    field: &str,
-) -> Result<Option<u64>, KolmeRuntimeCommitProviderError> {
-    let pattern = format!("\"{field}\"");
-    for (index, _) in payload.match_indices(pattern.as_str()) {
-        let mut cursor = index + pattern.len();
-        cursor = skip_ascii_whitespace(payload, cursor);
-        if payload.as_bytes().get(cursor).copied() != Some(b':') {
-            continue;
-        }
-        cursor += 1;
-        cursor = skip_ascii_whitespace(payload, cursor);
-        let Some(first) = payload.as_bytes().get(cursor).copied() else {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("notification field '{field}' value is missing"),
-            });
-        };
-
-        if first == b'"' {
-            let mut end = cursor + 1;
-            let mut escape = false;
-            while let Some(byte) = payload.as_bytes().get(end).copied() {
-                if escape {
-                    escape = false;
-                    end += 1;
-                    continue;
-                }
-                if byte == b'\\' {
-                    escape = true;
-                    end += 1;
-                    continue;
-                }
-                if byte == b'"' {
-                    let token = &payload[cursor..=end];
-                    let parsed = parse_json_string(token).map_err(|reason| {
-                        KolmeRuntimeCommitProviderError::MalformedResponse {
-                            reason: format!("notification field '{field}' is invalid: {reason}"),
-                        }
-                    })?;
-                    return parse_notification_positive_u64(parsed.as_str(), field).map(Some);
-                }
-                end += 1;
-            }
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("notification field '{field}' is unterminated"),
-            });
-        }
-
-        let mut end = cursor;
-        while let Some(byte) = payload.as_bytes().get(end).copied() {
-            if byte.is_ascii_digit() {
-                end += 1;
-                continue;
-            }
-            break;
-        }
-        if end == cursor {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("notification field '{field}' must be a positive integer"),
-            });
-        }
-        let token = &payload[cursor..end];
-        return parse_notification_positive_u64(token, field).map(Some);
-    }
-    Ok(None)
-}
-
-fn parse_notification_positive_u64(
-    token: &str,
-    field: &str,
-) -> Result<u64, KolmeRuntimeCommitProviderError> {
-    let trimmed = token.trim();
-    let parsed =
-        trimmed
-            .parse::<u64>()
-            .map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("notification field '{field}' must be a positive integer"),
-            })?;
-    if parsed == 0 {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("notification field '{field}' must be a positive integer"),
-        });
-    }
-    Ok(parsed)
-}
-
-fn skip_ascii_whitespace(value: &str, mut cursor: usize) -> usize {
-    while let Some(byte) = value.as_bytes().get(cursor).copied() {
-        if byte.is_ascii_whitespace() {
-            cursor += 1;
-            continue;
-        }
-        break;
-    }
-    cursor
-}
-
 fn parse_authorization_header(value: &str) -> Result<String, KolmeRuntimeCommitError> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -2561,7 +2412,8 @@ fn normalize_kolme_broadcast_payload(
                 reason: "direct signed payload message must be a JSON object string".to_owned(),
             });
         }
-        validate_direct_signed_transaction_message(message.as_str())?;
+        validate_kolme_direct_signed_transaction_message(message.as_str())
+            .map_err(map_codec_error_to_malformed_response)?;
 
         let request =
             KolmeApiBroadcastRequest::new(message.as_str(), signature.as_str(), recovery_id)
@@ -2588,70 +2440,6 @@ fn normalize_kolme_broadcast_payload(
         }
     })?;
     Ok(request.to_json_payload())
-}
-
-fn validate_direct_signed_transaction_message(
-    message: &str,
-) -> Result<(), KolmeRuntimeCommitProviderError> {
-    let required_string_fields = ["pubkey", "created"];
-    for field in required_string_fields {
-        let value = find_notification_string_field(message, field).map_err(|_| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("direct signed payload message field is invalid: {field}"),
-            }
-        })?;
-        if value.is_none() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("direct signed payload message missing required field: {field}"),
-            });
-        }
-    }
-
-    let nonce = find_notification_u64_field(message, "nonce").map_err(|_| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "direct signed payload message field is invalid: nonce".to_owned(),
-        }
-    })?;
-    if nonce.is_none() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "direct signed payload message missing required field: nonce".to_owned(),
-        });
-    }
-
-    let has_messages = has_json_array_field(message, "messages")
-        .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse { reason: error })?;
-    if !has_messages {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "direct signed payload message missing required field: messages".to_owned(),
-        });
-    }
-
-    Ok(())
-}
-
-fn has_json_array_field(payload: &str, field: &str) -> Result<bool, String> {
-    let pattern = format!("\"{field}\"");
-    for (index, _) in payload.match_indices(pattern.as_str()) {
-        let mut cursor = index + pattern.len();
-        cursor = skip_ascii_whitespace(payload, cursor);
-        if payload.as_bytes().get(cursor).copied() != Some(b':') {
-            continue;
-        }
-        cursor += 1;
-        cursor = skip_ascii_whitespace(payload, cursor);
-        let Some(first) = payload.as_bytes().get(cursor).copied() else {
-            return Err(format!(
-                "direct signed payload message field must be array: {field}"
-            ));
-        };
-        if first == b'[' {
-            return Ok(true);
-        }
-        return Err(format!(
-            "direct signed payload message field must be array: {field}"
-        ));
-    }
-    Ok(false)
 }
 
 fn parse_live_provider_response(

--- a/crates/kamn-kolme/src/api_codec.rs
+++ b/crates/kamn-kolme/src/api_codec.rs
@@ -159,6 +159,47 @@ impl KolmeApiBroadcastResponse {
     }
 }
 
+/// Validates required direct-signed transaction message fields.
+pub fn validate_direct_signed_transaction_message(message: &str) -> Result<(), KolmeApiCodecError> {
+    let required_string_fields = ["pubkey", "created"];
+    for field in required_string_fields {
+        let value = find_json_string_field(message, field).map_err(|_| {
+            KolmeApiCodecError::MalformedResponse {
+                reason: format!("direct signed payload message field is invalid: {field}"),
+            }
+        })?;
+        if value.is_none() {
+            return Err(KolmeApiCodecError::MalformedResponse {
+                reason: format!("direct signed payload message missing required field: {field}"),
+            });
+        }
+    }
+
+    let nonce = find_json_u64_field(message, "nonce").map_err(|_| {
+        KolmeApiCodecError::MalformedResponse {
+            reason: "direct signed payload message field is invalid: nonce".to_owned(),
+        }
+    })?;
+    if nonce.is_none() {
+        return Err(KolmeApiCodecError::MalformedResponse {
+            reason: "direct signed payload message missing required field: nonce".to_owned(),
+        });
+    }
+
+    let has_messages = has_json_array_field(message, "messages").map_err(|_| {
+        KolmeApiCodecError::MalformedResponse {
+            reason: "direct signed payload message field is invalid: messages".to_owned(),
+        }
+    })?;
+    if !has_messages {
+        return Err(KolmeApiCodecError::MalformedResponse {
+            reason: "direct signed payload message missing required field: messages".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum FlatJsonValue {
     String(String),
@@ -378,6 +419,143 @@ fn split_unquoted(input: &str, delimiter: char) -> Result<Vec<String>, &'static 
     Ok(parts)
 }
 
+fn find_json_string_field(payload: &str, field: &str) -> Result<Option<String>, &'static str> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b'"') {
+            continue;
+        }
+        let mut end = cursor + 1;
+        let mut escape = false;
+        while let Some(byte) = payload.as_bytes().get(end).copied() {
+            if escape {
+                escape = false;
+                end += 1;
+                continue;
+            }
+            if byte == b'\\' {
+                escape = true;
+                end += 1;
+                continue;
+            }
+            if byte == b'"' {
+                let token = &payload[cursor..=end];
+                let parsed = parse_json_string(token)?;
+                if parsed.trim().is_empty() {
+                    return Err("field must not be empty");
+                }
+                return Ok(Some(parsed));
+            }
+            end += 1;
+        }
+        return Err("field value is unterminated");
+    }
+    Ok(None)
+}
+
+fn find_json_u64_field(payload: &str, field: &str) -> Result<Option<u64>, &'static str> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        let Some(first) = payload.as_bytes().get(cursor).copied() else {
+            return Err("field value is missing");
+        };
+        if first == b'"' {
+            let mut end = cursor + 1;
+            let mut escape = false;
+            while let Some(byte) = payload.as_bytes().get(end).copied() {
+                if escape {
+                    escape = false;
+                    end += 1;
+                    continue;
+                }
+                if byte == b'\\' {
+                    escape = true;
+                    end += 1;
+                    continue;
+                }
+                if byte == b'"' {
+                    let token = &payload[cursor..=end];
+                    let parsed = parse_json_string(token)?;
+                    return parse_positive_u64(parsed.as_str()).map(Some);
+                }
+                end += 1;
+            }
+            return Err("field value is unterminated");
+        }
+        let mut end = cursor;
+        while let Some(byte) = payload.as_bytes().get(end).copied() {
+            if byte.is_ascii_digit() {
+                end += 1;
+                continue;
+            }
+            break;
+        }
+        if end == cursor {
+            return Err("field must be a positive integer");
+        }
+        let token = &payload[cursor..end];
+        return parse_positive_u64(token).map(Some);
+    }
+    Ok(None)
+}
+
+fn parse_positive_u64(token: &str) -> Result<u64, &'static str> {
+    let trimmed = token.trim();
+    let parsed = trimmed
+        .parse::<u64>()
+        .map_err(|_| "field must be a positive integer")?;
+    if parsed == 0 {
+        return Err("field must be a positive integer");
+    }
+    Ok(parsed)
+}
+
+fn has_json_array_field(payload: &str, field: &str) -> Result<bool, &'static str> {
+    let pattern = format!("\"{field}\"");
+    for (index, _) in payload.match_indices(pattern.as_str()) {
+        let mut cursor = index + pattern.len();
+        cursor = skip_ascii_whitespace(payload, cursor);
+        if payload.as_bytes().get(cursor).copied() != Some(b':') {
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_ascii_whitespace(payload, cursor);
+        let Some(first) = payload.as_bytes().get(cursor).copied() else {
+            return Err("field must be array");
+        };
+        if first == b'[' {
+            return Ok(true);
+        }
+        return Err("field must be array");
+    }
+    Ok(false)
+}
+
+fn skip_ascii_whitespace(value: &str, mut cursor: usize) -> usize {
+    while let Some(byte) = value.as_bytes().get(cursor).copied() {
+        if byte.is_ascii_whitespace() {
+            cursor += 1;
+            continue;
+        }
+        break;
+    }
+    cursor
+}
+
 fn parse_json_string(token: &str) -> Result<String, &'static str> {
     let trimmed = token.trim();
     if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
@@ -443,8 +621,9 @@ fn json_escape(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiCodecError,
-        KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
+        validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
+        KolmeApiBroadcastResponse, KolmeApiCodecError, KolmeApiNextNonceRequest,
+        KolmeApiNextNonceResponse,
     };
 
     #[test]
@@ -484,6 +663,18 @@ mod tests {
         assert_eq!(
             request.to_json_payload(),
             "{\"message\":\"{\\\"nonce\\\":42}\",\"signature\":\"sig-42\",\"recovery_id\":0}"
+        );
+    }
+
+    #[test]
+    fn unit_validate_direct_signed_transaction_message_requires_messages_array() {
+        assert_eq!(
+            validate_direct_signed_transaction_message(
+                "{\"pubkey\":\"p\",\"nonce\":1,\"created\":\"c\",\"messages\":\"x\"}"
+            ),
+            Err(KolmeApiCodecError::MalformedResponse {
+                reason: "direct signed payload message field is invalid: messages".to_owned(),
+            })
         );
     }
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -15,8 +15,9 @@ pub mod receipt_finality;
 pub mod transport;
 
 pub use api_codec::{
-    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiCodecError,
-    KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
+    validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
+    KolmeApiBroadcastResponse, KolmeApiCodecError, KolmeApiNextNonceRequest,
+    KolmeApiNextNonceResponse,
 };
 pub use block_scan_policy::{
     parse_fork_block_txhash, render_block_path, validate_block_identity,

--- a/crates/kamn-kolme/tests/api_codec_contracts.rs
+++ b/crates/kamn-kolme/tests/api_codec_contracts.rs
@@ -1,6 +1,7 @@
 use kamn_kolme::{
-    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiCodecError,
-    KolmeApiNextNonceRequest, KolmeApiNextNonceResponse,
+    validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
+    KolmeApiBroadcastResponse, KolmeApiCodecError, KolmeApiNextNonceRequest,
+    KolmeApiNextNonceResponse,
 };
 
 #[test]
@@ -40,6 +41,29 @@ fn regression_issue_1727_nonce_and_broadcast_parsing_fails_closed() {
         broadcast_error,
         KolmeApiCodecError::MalformedResponse {
             reason: "field must not be empty: txhash".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn functional_validate_direct_signed_transaction_message_accepts_required_shape() {
+    validate_direct_signed_transaction_message(
+        r#"{"pubkey":"ed25519:abc","nonce":42,"created":"2026-02-11T00:00:00Z","messages":[{"kind":"transfer"}]}"#,
+    )
+    .expect("message shape should validate");
+}
+
+#[test]
+fn regression_issue_1737_direct_signed_message_validation_fails_closed() {
+    // Regression: #1737
+    let error = validate_direct_signed_transaction_message(
+        r#"{"pubkey":"ed25519:abc","nonce":42,"created":"2026-02-11T00:00:00Z","messages":"not-array"}"#,
+    )
+    .expect_err("non-array messages field must fail");
+    assert_eq!(
+        error,
+        KolmeApiCodecError::MalformedResponse {
+            reason: "direct signed payload message field is invalid: messages".to_owned(),
         }
     );
 }

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -116,8 +116,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/notification_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
-    contracts. `kamn-core` retains temporary compatibility exports until full
-    migration is complete.
+    contracts (including direct signed payload validation policy). `kamn-core`
+    retains temporary compatibility exports until full migration is complete.
 - Runtime/data-flow ownership:
   - New runtime-commit submissions should target `kamn-kolme` contracts first,
     then map back to `kamn-core` compatibility paths only where migration is

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -79,6 +79,7 @@ handling.
 - Canonical extraction boundary:
   - `crates/kamn-kolme/src/api_codec.rs` owns deterministic nonce/broadcast codec constructors, query/payload serializers, and JSON parse contracts.
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates codec behavior through compatibility wrappers to preserve existing core API surface.
+  - direct signed transaction message shape validation (`validate_direct_signed_transaction_message`) is sourced from `kamn-kolme` codec contracts.
 - Deterministic nonce request behavior:
   - `KolmeApiNextNonceRequest::query_path(...)` percent-encodes the `pubkey` query
     value and preserves deterministic path composition.


### PR DESCRIPTION
## Summary
Extract direct signed transaction message validation policy from `kamn-core` into `kamn-kolme` API codec contracts and keep core as compatibility wiring.
This removes duplicated field-parsing helper logic from `kolme_runtime_commit.rs` while preserving fail-closed validation behavior.

## Changes
- `crates/kamn-kolme/src/api_codec.rs`: add `validate_direct_signed_transaction_message` codec contract and supporting parser helpers
- `crates/kamn-kolme/src/lib.rs`: export direct signed validation contract
- `crates/kamn-kolme/tests/api_codec_contracts.rs`: add functional + regression contract tests for direct signed validation
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire direct signed payload normalization to use extracted contract; remove duplicated in-core parser helper block
- `docs/foundation/kolme-runtime-commit-client.md`: document direct signed validation contract ownership
- `docs/architecture/kamn-core-module-map.md`: clarify extraction boundary includes direct signed validation policy

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-kolme --test api_codec_contracts`

Observed failure (before implementation):
```
error[E0432]: unresolved import `kamn_kolme::validate_direct_signed_transaction_message`
no `validate_direct_signed_transaction_message` in the root
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test api_codec_contracts`
- `cargo test -p kamn-kolme`

Result:
- New direct signed validation contract tests pass and full `kamn-kolme` suite remains green.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`
- `bash scripts/ci/test_select_targets.sh`

Result:
- All listed integration/regression and quality gates passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_validate_direct_signed_transaction_message_requires_messages_array` | |
| Functional   | ✅     | `functional_validate_direct_signed_transaction_message_accepts_required_shape` | |
| Integration  | ✅     | `kolme_runtime_commit_http_transport` (fork direct-signed submit path) | |
| Regression   | ✅     | `regression_issue_1737_direct_signed_message_validation_fails_closed`; existing direct-signed core regressions rerun | |
| Performance  | N/A    | N/A                  | Parser extraction only; no additional I/O loops |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore previous in-core direct signed validation implementation.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1737
