### PR TITLE
refactor(kolme): extract websocket handshake/frame policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -4,17 +4,20 @@ use crate::AgentDid;
 use kamn_kolme::{
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
+    find_http_header_boundary as find_kolme_http_header_boundary,
     parse_fork_block_txhash as parse_kolme_fork_block_txhash,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_receipt_finality as parse_kolme_receipt_finality,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
+    try_take_websocket_frame as try_take_kolme_websocket_frame,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
     validate_direct_signed_transaction_message as validate_kolme_direct_signed_transaction_message,
-    validate_lookup_window as validate_kolme_lookup_window, BlockScanPolicyError,
-    KolmeApiBroadcastRequest as KamnKolmeApiBroadcastRequest,
+    validate_lookup_window as validate_kolme_lookup_window,
+    validate_websocket_handshake_response as validate_kolme_websocket_handshake_response,
+    BlockScanPolicyError, KolmeApiBroadcastRequest as KamnKolmeApiBroadcastRequest,
     KolmeApiBroadcastResponse as KamnKolmeApiBroadcastResponse,
     KolmeApiCodecError as KamnKolmeApiCodecError,
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
@@ -23,7 +26,9 @@ use kamn_kolme::{
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
-    KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint, ReceiptFinality,
+    KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint,
+    KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
+    KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -1292,9 +1297,11 @@ impl KolmeRuntimeCommitWebsocketConnection {
 impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketConnection {
     fn read_text_message(&mut self) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
         loop {
-            if let Some(frame) = try_take_websocket_frame(&mut self.read_buffer)? {
+            if let Some(frame) = try_take_kolme_websocket_frame(&mut self.read_buffer)
+                .map_err(map_websocket_policy_error)?
+            {
                 match frame {
-                    WebsocketFrame::Text(payload_bytes) => {
+                    KamnKolmeWebsocketFrame::Text(payload_bytes) => {
                         let payload = String::from_utf8(payload_bytes).map_err(|error| {
                             KolmeRuntimeCommitProviderError::MalformedResponse {
                                 reason: format!(
@@ -1304,8 +1311,8 @@ impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketCo
                         })?;
                         return Ok(Some(payload));
                     }
-                    WebsocketFrame::Close => return Ok(None),
-                    WebsocketFrame::Ping | WebsocketFrame::Pong => continue,
+                    KamnKolmeWebsocketFrame::Close => return Ok(None),
+                    KamnKolmeWebsocketFrame::Ping | KamnKolmeWebsocketFrame::Pong => continue,
                 }
             }
 
@@ -1754,6 +1761,19 @@ fn map_notification_policy_error_to_malformed(
     }
 }
 
+fn map_websocket_policy_error(
+    error: KamnKolmeWebsocketPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    match error {
+        KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+            KolmeRuntimeCommitProviderError::Unavailable { reason }
+        }
+        KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+            KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+        }
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
@@ -1929,16 +1949,10 @@ fn read_http_header_boundary(
     response_bytes: &mut Vec<u8>,
 ) -> Result<usize, KolmeRuntimeCommitProviderError> {
     loop {
-        if let Some(position) = response_bytes
-            .windows(4)
-            .position(|window| window == b"\r\n\r\n")
+        if let Some(position) =
+            find_kolme_http_header_boundary(response_bytes).map_err(map_websocket_policy_error)?
         {
             return Ok(position);
-        }
-        if response_bytes.len() > 32 * 1024 {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "websocket handshake response headers are too large".to_owned(),
-            });
         }
         let mut chunk = [0_u8; 1024];
         let read = stream.read(&mut chunk).map_err(map_transport_io_error)?;
@@ -1954,169 +1968,7 @@ fn read_http_header_boundary(
 fn validate_websocket_handshake_response(
     header_bytes: &[u8],
 ) -> Result<(), KolmeRuntimeCommitProviderError> {
-    let header_text = String::from_utf8(header_bytes.to_vec()).map_err(|error| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("websocket handshake response is not valid utf-8: {error}"),
-        }
-    })?;
-    let raw_headers = header_text
-        .split_once("\r\n\r\n")
-        .map(|(headers, _)| headers)
-        .unwrap_or(header_text.as_str());
-
-    let mut lines = raw_headers.lines();
-    let status_line =
-        lines
-            .next()
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "websocket handshake response missing status line".to_owned(),
-            })?;
-    let mut status_parts = status_line.split_whitespace();
-    let _http_version =
-        status_parts
-            .next()
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "websocket handshake status line is malformed".to_owned(),
-            })?;
-    let status_code_raw =
-        status_parts
-            .next()
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "websocket handshake status code is missing".to_owned(),
-            })?;
-    let status_code = status_code_raw.parse::<u16>().map_err(|_| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("websocket handshake status code is invalid: {status_code_raw}"),
-        }
-    })?;
-    if status_code != 101 {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: format!("websocket handshake rejected with status {status_code}"),
-        });
-    }
-
-    let mut has_upgrade_websocket = false;
-    let mut has_connection_upgrade = false;
-    for line in lines {
-        let Some((name, value)) = line.split_once(':') else {
-            continue;
-        };
-        if name.eq_ignore_ascii_case("Upgrade")
-            && value.trim().to_ascii_lowercase().contains("websocket")
-        {
-            has_upgrade_websocket = true;
-        }
-        if name.eq_ignore_ascii_case("Connection")
-            && value.trim().to_ascii_lowercase().contains("upgrade")
-        {
-            has_connection_upgrade = true;
-        }
-    }
-    if !has_upgrade_websocket || !has_connection_upgrade {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "websocket handshake response missing upgrade headers".to_owned(),
-        });
-    }
-    Ok(())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum WebsocketFrame {
-    Text(Vec<u8>),
-    Ping,
-    Pong,
-    Close,
-}
-
-fn try_take_websocket_frame(
-    read_buffer: &mut Vec<u8>,
-) -> Result<Option<WebsocketFrame>, KolmeRuntimeCommitProviderError> {
-    if read_buffer.len() < 2 {
-        return Ok(None);
-    }
-    let first = read_buffer[0];
-    let second = read_buffer[1];
-    let fin = (first & 0x80) != 0;
-    if !fin {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "fragmented websocket frames are not supported".to_owned(),
-        });
-    }
-    let opcode = first & 0x0f;
-    let masked = (second & 0x80) != 0;
-    let mut payload_len = usize::from(second & 0x7f);
-    let mut cursor = 2_usize;
-
-    if payload_len == 126 {
-        if read_buffer.len() < cursor + 2 {
-            return Ok(None);
-        }
-        payload_len = usize::from(u16::from_be_bytes([
-            read_buffer[cursor],
-            read_buffer[cursor + 1],
-        ]));
-        cursor += 2;
-    } else if payload_len == 127 {
-        if read_buffer.len() < cursor + 8 {
-            return Ok(None);
-        }
-        let raw = u64::from_be_bytes([
-            read_buffer[cursor],
-            read_buffer[cursor + 1],
-            read_buffer[cursor + 2],
-            read_buffer[cursor + 3],
-            read_buffer[cursor + 4],
-            read_buffer[cursor + 5],
-            read_buffer[cursor + 6],
-            read_buffer[cursor + 7],
-        ]);
-        payload_len = usize::try_from(raw).map_err(|_| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "websocket payload length exceeds platform limits".to_owned(),
-            }
-        })?;
-        cursor += 8;
-    }
-
-    let masking_key = if masked {
-        if read_buffer.len() < cursor + 4 {
-            return Ok(None);
-        }
-        let key = [
-            read_buffer[cursor],
-            read_buffer[cursor + 1],
-            read_buffer[cursor + 2],
-            read_buffer[cursor + 3],
-        ];
-        cursor += 4;
-        Some(key)
-    } else {
-        None
-    };
-
-    if read_buffer.len() < cursor + payload_len {
-        return Ok(None);
-    }
-    let mut payload = read_buffer[cursor..cursor + payload_len].to_vec();
-    if let Some(masking_key) = masking_key {
-        for (index, byte) in payload.iter_mut().enumerate() {
-            *byte ^= masking_key[index % 4];
-        }
-    }
-    read_buffer.drain(0..cursor + payload_len);
-
-    let frame = match opcode {
-        0x1 => WebsocketFrame::Text(payload),
-        0x8 => WebsocketFrame::Close,
-        0x9 => WebsocketFrame::Ping,
-        0xA => WebsocketFrame::Pong,
-        _ => {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("unsupported websocket opcode: {opcode}"),
-            })
-        }
-    };
-    Ok(Some(frame))
+    validate_kolme_websocket_handshake_response(header_bytes).map_err(map_websocket_policy_error)
 }
 
 fn parse_kolme_notification_event(

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -13,6 +13,7 @@ pub mod notification_policy;
 pub mod pipeline;
 pub mod receipt_finality;
 pub mod transport;
+pub mod websocket_policy;
 
 pub use api_codec::{
     validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
@@ -37,6 +38,10 @@ pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use transport::{
     EchoTransport, KolmeTransport, TransportError, TransportRequest, TransportResponse,
+};
+pub use websocket_policy::{
+    find_http_header_boundary, try_take_websocket_frame, validate_websocket_handshake_response,
+    KolmeWebsocketFrame, KolmeWebsocketPolicyError,
 };
 
 #[cfg(test)]

--- a/crates/kamn-kolme/src/websocket_policy.rs
+++ b/crates/kamn-kolme/src/websocket_policy.rs
@@ -1,0 +1,274 @@
+//! Websocket protocol policy contracts for Kolme notifications transport.
+
+use std::error::Error;
+use std::fmt;
+
+/// Websocket policy error used by handshake/frame parsing contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeWebsocketPolicyError {
+    /// Upstream returned an unavailable handshake state.
+    Unavailable {
+        /// Deterministic policy failure reason.
+        reason: String,
+    },
+    /// Payload/handshake bytes are malformed.
+    Malformed {
+        /// Deterministic malformed reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeWebsocketPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable { reason } => f.write_str(reason),
+            Self::Malformed { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeWebsocketPolicyError {}
+
+/// Parsed websocket frame variants supported by policy contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeWebsocketFrame {
+    /// UTF-8 text frame payload bytes.
+    Text(Vec<u8>),
+    /// Ping control frame.
+    Ping,
+    /// Pong control frame.
+    Pong,
+    /// Close control frame.
+    Close,
+}
+
+/// Returns the HTTP header boundary index if present.
+///
+/// Returns `Ok(None)` when more bytes are required.
+pub fn find_http_header_boundary(
+    response_bytes: &[u8],
+) -> Result<Option<usize>, KolmeWebsocketPolicyError> {
+    if let Some(position) = response_bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+    {
+        return Ok(Some(position));
+    }
+    if response_bytes.len() > 32 * 1024 {
+        return Err(KolmeWebsocketPolicyError::Malformed {
+            reason: "websocket handshake response headers are too large".to_owned(),
+        });
+    }
+    Ok(None)
+}
+
+/// Validates one websocket handshake response header block.
+pub fn validate_websocket_handshake_response(
+    header_bytes: &[u8],
+) -> Result<(), KolmeWebsocketPolicyError> {
+    let header_text = String::from_utf8(header_bytes.to_vec()).map_err(|error| {
+        KolmeWebsocketPolicyError::Malformed {
+            reason: format!("websocket handshake response is not valid utf-8: {error}"),
+        }
+    })?;
+    let raw_headers = header_text
+        .split_once("\r\n\r\n")
+        .map(|(headers, _)| headers)
+        .unwrap_or(header_text.as_str());
+
+    let mut lines = raw_headers.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| KolmeWebsocketPolicyError::Malformed {
+            reason: "websocket handshake response missing status line".to_owned(),
+        })?;
+    let mut status_parts = status_line.split_whitespace();
+    let _http_version =
+        status_parts
+            .next()
+            .ok_or_else(|| KolmeWebsocketPolicyError::Malformed {
+                reason: "websocket handshake status line is malformed".to_owned(),
+            })?;
+    let status_code_raw =
+        status_parts
+            .next()
+            .ok_or_else(|| KolmeWebsocketPolicyError::Malformed {
+                reason: "websocket handshake status code is missing".to_owned(),
+            })?;
+    let status_code =
+        status_code_raw
+            .parse::<u16>()
+            .map_err(|_| KolmeWebsocketPolicyError::Malformed {
+                reason: format!("websocket handshake status code is invalid: {status_code_raw}"),
+            })?;
+    if status_code != 101 {
+        return Err(KolmeWebsocketPolicyError::Unavailable {
+            reason: format!("websocket handshake rejected with status {status_code}"),
+        });
+    }
+
+    let mut has_upgrade_websocket = false;
+    let mut has_connection_upgrade = false;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("Upgrade")
+            && value.trim().to_ascii_lowercase().contains("websocket")
+        {
+            has_upgrade_websocket = true;
+        }
+        if name.eq_ignore_ascii_case("Connection")
+            && value.trim().to_ascii_lowercase().contains("upgrade")
+        {
+            has_connection_upgrade = true;
+        }
+    }
+    if !has_upgrade_websocket || !has_connection_upgrade {
+        return Err(KolmeWebsocketPolicyError::Malformed {
+            reason: "websocket handshake response missing upgrade headers".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Extracts one websocket frame from the read buffer.
+///
+/// Returns `Ok(None)` when more bytes are required to parse one full frame.
+pub fn try_take_websocket_frame(
+    read_buffer: &mut Vec<u8>,
+) -> Result<Option<KolmeWebsocketFrame>, KolmeWebsocketPolicyError> {
+    if read_buffer.len() < 2 {
+        return Ok(None);
+    }
+    let first = read_buffer[0];
+    let second = read_buffer[1];
+    let fin = (first & 0x80) != 0;
+    if !fin {
+        return Err(KolmeWebsocketPolicyError::Malformed {
+            reason: "fragmented websocket frames are not supported".to_owned(),
+        });
+    }
+    let opcode = first & 0x0f;
+    let masked = (second & 0x80) != 0;
+    let mut payload_len = usize::from(second & 0x7f);
+    let mut cursor = 2_usize;
+
+    if payload_len == 126 {
+        if read_buffer.len() < cursor + 2 {
+            return Ok(None);
+        }
+        payload_len = usize::from(u16::from_be_bytes([
+            read_buffer[cursor],
+            read_buffer[cursor + 1],
+        ]));
+        cursor += 2;
+    } else if payload_len == 127 {
+        if read_buffer.len() < cursor + 8 {
+            return Ok(None);
+        }
+        let raw = u64::from_be_bytes([
+            read_buffer[cursor],
+            read_buffer[cursor + 1],
+            read_buffer[cursor + 2],
+            read_buffer[cursor + 3],
+            read_buffer[cursor + 4],
+            read_buffer[cursor + 5],
+            read_buffer[cursor + 6],
+            read_buffer[cursor + 7],
+        ]);
+        payload_len = usize::try_from(raw).map_err(|_| KolmeWebsocketPolicyError::Malformed {
+            reason: "websocket payload length exceeds platform limits".to_owned(),
+        })?;
+        cursor += 8;
+    }
+
+    let masking_key = if masked {
+        if read_buffer.len() < cursor + 4 {
+            return Ok(None);
+        }
+        let key = [
+            read_buffer[cursor],
+            read_buffer[cursor + 1],
+            read_buffer[cursor + 2],
+            read_buffer[cursor + 3],
+        ];
+        cursor += 4;
+        Some(key)
+    } else {
+        None
+    };
+
+    if read_buffer.len() < cursor + payload_len {
+        return Ok(None);
+    }
+    let mut payload = read_buffer[cursor..cursor + payload_len].to_vec();
+    if let Some(masking_key) = masking_key {
+        for (index, byte) in payload.iter_mut().enumerate() {
+            *byte ^= masking_key[index % 4];
+        }
+    }
+    read_buffer.drain(0..cursor + payload_len);
+
+    let frame = match opcode {
+        0x1 => KolmeWebsocketFrame::Text(payload),
+        0x8 => KolmeWebsocketFrame::Close,
+        0x9 => KolmeWebsocketFrame::Ping,
+        0xA => KolmeWebsocketFrame::Pong,
+        _ => {
+            return Err(KolmeWebsocketPolicyError::Malformed {
+                reason: format!("unsupported websocket opcode: {opcode}"),
+            })
+        }
+    };
+    Ok(Some(frame))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        find_http_header_boundary, try_take_websocket_frame, validate_websocket_handshake_response,
+        KolmeWebsocketFrame, KolmeWebsocketPolicyError,
+    };
+
+    #[test]
+    fn unit_find_http_header_boundary_requires_more_bytes() {
+        assert_eq!(
+            find_http_header_boundary(b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket"),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn unit_validate_websocket_handshake_rejects_non_101_status() {
+        let header = b"HTTP/1.1 503 Service Unavailable\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n";
+        assert_eq!(
+            validate_websocket_handshake_response(header),
+            Err(KolmeWebsocketPolicyError::Unavailable {
+                reason: "websocket handshake rejected with status 503".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn unit_try_take_websocket_frame_rejects_fragmented_frame() {
+        let mut payload = vec![0x01, 0x01, b'x'];
+        assert_eq!(
+            try_take_websocket_frame(&mut payload),
+            Err(KolmeWebsocketPolicyError::Malformed {
+                reason: "fragmented websocket frames are not supported".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn functional_try_take_websocket_frame_parses_close_control_frame() {
+        let mut payload = vec![0x88, 0x00];
+        assert_eq!(
+            try_take_websocket_frame(&mut payload)
+                .expect("parsing should succeed")
+                .expect("frame should be available"),
+            KolmeWebsocketFrame::Close
+        );
+    }
+}

--- a/crates/kamn-kolme/tests/websocket_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/websocket_policy_contracts.rs
@@ -1,0 +1,26 @@
+use kamn_kolme::{
+    try_take_websocket_frame, validate_websocket_handshake_response, KolmeWebsocketFrame,
+};
+
+#[test]
+fn functional_websocket_frame_parser_maps_text_frame() {
+    let mut buffer = vec![0x81, 0x05, b'h', b'e', b'l', b'l', b'o'];
+    let frame = try_take_websocket_frame(&mut buffer)
+        .expect("frame parsing should succeed")
+        .expect("one frame should be available");
+    assert_eq!(frame, KolmeWebsocketFrame::Text(b"hello".to_vec()));
+    assert!(buffer.is_empty(), "frame bytes should be drained");
+}
+
+#[test]
+fn regression_issue_1739_handshake_validation_fails_closed() {
+    // Regression: #1739
+    let error = validate_websocket_handshake_response(
+        b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n",
+    )
+    .expect_err("missing connection upgrade header must fail");
+    assert_eq!(
+        error.to_string(),
+        "websocket handshake response missing upgrade headers"
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -113,7 +113,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`,
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
-    `crates/kamn-kolme/src/notification_policy.rs`
+    `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -59,6 +59,7 @@ handling.
   - provider identity for txhash-only responses uses response `provider` when present, otherwise deterministic provider hint from profile construction.
 - Fork finality profile:
   - `KolmeRuntimeCommitForkFinalityResolver` composes websocket notifications (`/notifications`) with bounded block fallback scans (`/block/{height}`).
+  - websocket handshake/frame parsing contracts are sourced from `kamn-kolme` (`find_http_header_boundary`, `validate_websocket_handshake_response`, `try_take_websocket_frame`) and mapped through `kamn-core` compatibility wrappers.
   - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - resolver consumes one notification event first:
@@ -145,6 +146,7 @@ cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
 cargo test -p kamn-kolme --test api_codec_contracts
 cargo test -p kamn-kolme --test finality_block_scan_contracts
 cargo test -p kamn-kolme --test endpoint_policy_contracts
+cargo test -p kamn-kolme --test websocket_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact


### PR DESCRIPTION
## Summary
Extract websocket handshake/frame parsing policy from `kamn-core` into `kamn-kolme` transport contracts and keep core focused on connector I/O orchestration.
This reduces policy density in `kolme_runtime_commit.rs` while preserving fail-closed behavior and notification integration parity.

## Changes
- `crates/kamn-kolme/src/websocket_policy.rs`: add websocket policy contracts (`find_http_header_boundary`, `validate_websocket_handshake_response`, `try_take_websocket_frame`) and typed frame/error enums
- `crates/kamn-kolme/src/lib.rs`: export websocket policy contracts
- `crates/kamn-kolme/tests/websocket_policy_contracts.rs`: add functional + regression tests for extracted websocket policies
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire websocket connection/connector helpers to use extracted websocket policy contracts; remove duplicated in-core frame/handshake policy implementations
- `docs/foundation/kolme-runtime-commit-client.md`: document websocket policy ownership in `kamn-kolme`
- `docs/architecture/kamn-core-module-map.md`: include `websocket_policy` in extraction boundary list

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-kolme --test websocket_policy_contracts`

Observed failure (before implementation):
```
error[E0432]: unresolved imports `kamn_kolme::try_take_websocket_frame`, `kamn_kolme::validate_websocket_handshake_response`, `kamn_kolme::KolmeWebsocketFrame`
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test websocket_policy_contracts`
- `cargo test -p kamn-kolme`

Result:
- New websocket contract tests pass and full `kamn-kolme` suite remains green.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
- `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`
- `bash scripts/ci/test_select_targets.sh`

Result:
- All listed integration/regression and quality gates passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | websocket policy unit guards for non-101 handshake, fragmented frames, incomplete header boundary | |
| Functional   | ✅     | `functional_websocket_frame_parser_maps_text_frame` | |
| Integration  | ✅     | `kolme_runtime_commit_notifications`, `kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅     | `regression_issue_1739_handshake_validation_fails_closed`; existing notification regressions rerun | |
| Performance  | N/A    | N/A                  | Policy extraction only; no new network operations |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore in-core websocket handshake/frame policy implementations.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1739
