### PR TITLE
refactor(kolme): extract http response parse policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -7,6 +7,7 @@ use kamn_kolme::{
     find_http_header_boundary as find_kolme_http_header_boundary,
     parse_fork_block_txhash as parse_kolme_fork_block_txhash,
     parse_http_endpoint as parse_kolme_http_endpoint,
+    parse_http_response_body as parse_kolme_http_response_body,
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_receipt_finality as parse_kolme_receipt_finality,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
@@ -23,6 +24,7 @@ use kamn_kolme::{
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
+    KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
@@ -854,7 +856,7 @@ impl KolmeRuntimeCommitHttpTransport {
             HttpScheme::Http => self.execute_http_request(endpoint, request.as_bytes())?,
             HttpScheme::Https => self.execute_https_request(endpoint, request.as_bytes())?,
         };
-        parse_http_response(response_bytes)
+        parse_kolme_http_response_body(response_bytes).map_err(map_http_response_policy_error)
     }
 
     fn execute_http_request(
@@ -1774,6 +1776,20 @@ fn map_websocket_policy_error(
     }
 }
 
+fn map_http_response_policy_error(
+    error: KamnKolmeHttpResponsePolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    match error {
+        KamnKolmeHttpResponsePolicyError::Timeout => KolmeRuntimeCommitProviderError::Timeout,
+        KamnKolmeHttpResponsePolicyError::Unavailable { reason } => {
+            KolmeRuntimeCommitProviderError::Unavailable { reason }
+        }
+        KamnKolmeHttpResponsePolicyError::Malformed { reason } => {
+            KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+        }
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
@@ -2066,103 +2082,6 @@ fn classify_tls_failure_reason(stderr: &str) -> String {
         .find(|line| !line.trim().is_empty())
         .unwrap_or("tls request failed");
     format!("tls request failed: {}", first_line.trim())
-}
-
-fn parse_http_response(response_bytes: Vec<u8>) -> Result<String, KolmeRuntimeCommitProviderError> {
-    let response_text = String::from_utf8(response_bytes).map_err(|error| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("http response body is not valid utf-8: {error}"),
-        }
-    })?;
-
-    let (raw_headers, raw_body) = response_text.split_once("\r\n\r\n").ok_or_else(|| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "http response missing header/body separator".to_owned(),
-        }
-    })?;
-
-    let mut header_lines = raw_headers.lines();
-    let status_line =
-        header_lines
-            .next()
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "http response missing status line".to_owned(),
-            })?;
-    let mut status_parts = status_line.split_whitespace();
-    let _http_version =
-        status_parts
-            .next()
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "http response status line is malformed".to_owned(),
-            })?;
-    let status_code_raw =
-        status_parts
-            .next()
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "http response status code is missing".to_owned(),
-            })?;
-    let status_code = status_code_raw.parse::<u16>().map_err(|_| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("http response status code is invalid: {status_code_raw}"),
-        }
-    })?;
-
-    if status_code == 408 || status_code == 504 {
-        return Err(KolmeRuntimeCommitProviderError::Timeout);
-    }
-    if status_code >= 500 {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: format!("http response status indicates upstream failure: {status_code}"),
-        });
-    }
-    if status_code >= 400 {
-        return Err(map_http_client_status_error(status_code));
-    }
-
-    let mut declared_content_length = None;
-    for line in header_lines {
-        let Some((name, value)) = line.split_once(':') else {
-            continue;
-        };
-        if name.eq_ignore_ascii_case("Content-Length") {
-            let parsed = value.trim().parse::<usize>().map_err(|_| {
-                KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: "http response content-length is invalid".to_owned(),
-                }
-            })?;
-            declared_content_length = Some(parsed);
-            break;
-        }
-    }
-    if let Some(declared) = declared_content_length {
-        let observed = raw_body.len();
-        if declared != observed {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!(
-                    "http response content-length mismatch: declared {declared}, observed {observed}"
-                ),
-            });
-        }
-    }
-
-    Ok(raw_body.to_owned())
-}
-
-fn map_http_client_status_error(status_code: u16) -> KolmeRuntimeCommitProviderError {
-    match status_code {
-        401 | 403 => KolmeRuntimeCommitProviderError::Unavailable {
-            reason: format!("http response status indicates authorization failure: {status_code}"),
-        },
-        400 | 404 | 409 | 422 => KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("http response status indicates invalid request: {status_code}"),
-        },
-        429 => KolmeRuntimeCommitProviderError::Unavailable {
-            reason: format!("http response status indicates rate limited: {status_code}"),
-        },
-        _ => KolmeRuntimeCommitProviderError::Unavailable {
-            reason: format!("http response status indicates client failure: {status_code}"),
-        },
-    }
 }
 
 fn is_kolme_broadcast_submit_path(submit_path: &str) -> bool {

--- a/crates/kamn-kolme/src/http_response_policy.rs
+++ b/crates/kamn-kolme/src/http_response_policy.rs
@@ -1,0 +1,160 @@
+//! HTTP response parsing policy contracts for Kolme transport paths.
+
+use std::error::Error;
+use std::fmt;
+
+/// HTTP response policy error variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeHttpResponsePolicyError {
+    /// Response status indicates timeout.
+    Timeout,
+    /// Response is unavailable due to upstream/client classification.
+    Unavailable {
+        /// Deterministic failure reason.
+        reason: String,
+    },
+    /// Response shape/content is malformed.
+    Malformed {
+        /// Deterministic malformed reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeHttpResponsePolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => f.write_str("provider request timed out"),
+            Self::Unavailable { reason } => f.write_str(reason),
+            Self::Malformed { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeHttpResponsePolicyError {}
+
+/// Parses raw HTTP response bytes and returns body for success statuses.
+pub fn parse_http_response_body(
+    response_bytes: Vec<u8>,
+) -> Result<String, KolmeHttpResponsePolicyError> {
+    let response_text = String::from_utf8(response_bytes).map_err(|error| {
+        KolmeHttpResponsePolicyError::Malformed {
+            reason: format!("http response body is not valid utf-8: {error}"),
+        }
+    })?;
+
+    let (raw_headers, raw_body) = response_text.split_once("\r\n\r\n").ok_or_else(|| {
+        KolmeHttpResponsePolicyError::Malformed {
+            reason: "http response missing header/body separator".to_owned(),
+        }
+    })?;
+
+    let mut header_lines = raw_headers.lines();
+    let status_line =
+        header_lines
+            .next()
+            .ok_or_else(|| KolmeHttpResponsePolicyError::Malformed {
+                reason: "http response missing status line".to_owned(),
+            })?;
+    let mut status_parts = status_line.split_whitespace();
+    let _http_version =
+        status_parts
+            .next()
+            .ok_or_else(|| KolmeHttpResponsePolicyError::Malformed {
+                reason: "http response status line is malformed".to_owned(),
+            })?;
+    let status_code_raw =
+        status_parts
+            .next()
+            .ok_or_else(|| KolmeHttpResponsePolicyError::Malformed {
+                reason: "http response status code is missing".to_owned(),
+            })?;
+    let status_code =
+        status_code_raw
+            .parse::<u16>()
+            .map_err(|_| KolmeHttpResponsePolicyError::Malformed {
+                reason: format!("http response status code is invalid: {status_code_raw}"),
+            })?;
+
+    if status_code == 408 || status_code == 504 {
+        return Err(KolmeHttpResponsePolicyError::Timeout);
+    }
+    if status_code >= 500 {
+        return Err(KolmeHttpResponsePolicyError::Unavailable {
+            reason: format!("http response status indicates upstream failure: {status_code}"),
+        });
+    }
+    if status_code >= 400 {
+        return Err(map_http_client_status_error(status_code));
+    }
+
+    let mut declared_content_length = None;
+    for line in header_lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            let parsed = value.trim().parse::<usize>().map_err(|_| {
+                KolmeHttpResponsePolicyError::Malformed {
+                    reason: "http response content-length is invalid".to_owned(),
+                }
+            })?;
+            declared_content_length = Some(parsed);
+            break;
+        }
+    }
+    if let Some(declared) = declared_content_length {
+        let observed = raw_body.len();
+        if declared != observed {
+            return Err(KolmeHttpResponsePolicyError::Malformed {
+                reason: format!(
+                    "http response content-length mismatch: declared {declared}, observed {observed}"
+                ),
+            });
+        }
+    }
+
+    Ok(raw_body.to_owned())
+}
+
+fn map_http_client_status_error(status_code: u16) -> KolmeHttpResponsePolicyError {
+    match status_code {
+        401 | 403 => KolmeHttpResponsePolicyError::Unavailable {
+            reason: format!("http response status indicates authorization failure: {status_code}"),
+        },
+        400 | 404 | 409 | 422 => KolmeHttpResponsePolicyError::Malformed {
+            reason: format!("http response status indicates invalid request: {status_code}"),
+        },
+        429 => KolmeHttpResponsePolicyError::Unavailable {
+            reason: format!("http response status indicates rate limited: {status_code}"),
+        },
+        _ => KolmeHttpResponsePolicyError::Unavailable {
+            reason: format!("http response status indicates client failure: {status_code}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_http_response_body, KolmeHttpResponsePolicyError};
+
+    #[test]
+    fn unit_parse_http_response_body_classifies_timeout_status() {
+        let error = parse_http_response_body(b"HTTP/1.1 504 Gateway Timeout\r\n\r\n".to_vec())
+            .expect_err("gateway timeout must map to timeout");
+        assert_eq!(error, KolmeHttpResponsePolicyError::Timeout);
+    }
+
+    #[test]
+    fn unit_parse_http_response_body_rejects_invalid_content_length() {
+        let error = parse_http_response_body(
+            b"HTTP/1.1 200 OK\r\nContent-Length: abc\r\n\r\nhello".to_vec(),
+        )
+        .expect_err("invalid content-length must fail");
+        assert_eq!(
+            error,
+            KolmeHttpResponsePolicyError::Malformed {
+                reason: "http response content-length is invalid".to_owned(),
+            }
+        );
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block_scan_policy;
 pub mod codec;
 pub mod endpoint_policy;
 pub mod finality;
+pub mod http_response_policy;
 pub mod notification_policy;
 pub mod pipeline;
 pub mod receipt_finality;
@@ -31,6 +32,7 @@ pub use endpoint_policy::{
     KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
+pub use http_response_policy::{parse_http_response_body, KolmeHttpResponsePolicyError};
 pub use notification_policy::{
     parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
 };

--- a/crates/kamn-kolme/tests/http_response_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/http_response_policy_contracts.rs
@@ -1,0 +1,23 @@
+use kamn_kolme::{parse_http_response_body, KolmeHttpResponsePolicyError};
+
+#[test]
+fn functional_parse_http_response_body_returns_body_for_2xx() {
+    let body =
+        parse_http_response_body(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello".to_vec())
+            .expect("response should parse");
+    assert_eq!(body, "hello");
+}
+
+#[test]
+fn regression_issue_1741_http_response_parser_fails_closed_on_length_mismatch() {
+    // Regression: #1741
+    let error =
+        parse_http_response_body(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nhello".to_vec())
+            .expect_err("content-length mismatch must fail");
+    assert_eq!(
+        error,
+        KolmeHttpResponsePolicyError::Malformed {
+            reason: "http response content-length mismatch: declared 4, observed 5".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -113,7 +113,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`,
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
-    `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`
+    `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
+    `crates/kamn-kolme/src/http_response_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -33,6 +33,7 @@ handling.
   - `KolmeRuntimeCommitHttpTransport::submit_broadcast_request(...)`
 - Endpoint normalization boundary:
   - `crates/kamn-kolme/src/endpoint_policy.rs` owns HTTP/WebSocket endpoint parsing and URL composition contracts.
+  - `crates/kamn-kolme/src/http_response_policy.rs` owns HTTP response status/content parsing contracts.
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
 - Optional auth-aware constructor:
   - `KolmeRuntimeCommitHttpTransport::new_with_authorization(...)`
@@ -147,6 +148,7 @@ cargo test -p kamn-kolme --test api_codec_contracts
 cargo test -p kamn-kolme --test finality_block_scan_contracts
 cargo test -p kamn-kolme --test endpoint_policy_contracts
 cargo test -p kamn-kolme --test websocket_policy_contracts
+cargo test -p kamn-kolme --test http_response_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact


### PR DESCRIPTION
## Summary
Extract HTTP response status/content parsing policy from `kamn-core` into `kamn-kolme` transport contracts and keep core focused on request execution/orchestration.
This reduces parser/classification policy in `kolme_runtime_commit.rs` while preserving timeout/unavailable/malformed behavior parity.

## Changes
- `crates/kamn-kolme/src/http_response_policy.rs`: add HTTP response parsing policy contracts and error classification
- `crates/kamn-kolme/src/lib.rs`: export HTTP response parsing policy contract
- `crates/kamn-kolme/tests/http_response_policy_contracts.rs`: add functional + regression contract tests
- `crates/kamn-core/src/kolme_runtime_commit.rs`: route HTTP response parsing through extracted contract and remove in-core duplicate parsing/status classification logic
- `docs/foundation/kolme-runtime-commit-client.md`: document HTTP response policy ownership in `kamn-kolme`
- `docs/architecture/kamn-core-module-map.md`: include `http_response_policy` in extraction boundary list

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-kolme --test http_response_policy_contracts`

Observed failure (before implementation):
```
error[E0432]: unresolved imports `kamn_kolme::parse_http_response_body`, `kamn_kolme::KolmeHttpResponsePolicyError`
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test http_response_policy_contracts`
- `cargo test -p kamn-kolme`

Result:
- New HTTP response policy contract tests pass and full `kamn-kolme` suite remains green.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`
- `bash scripts/ci/test_select_targets.sh`

Result:
- All listed integration/regression and quality gates passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | HTTP response policy unit guards for timeout/content-length invalid | |
| Functional   | ✅     | `functional_parse_http_response_body_returns_body_for_2xx` | |
| Integration  | ✅     | `kolme_runtime_commit_http_transport` | |
| Regression   | ✅     | `regression_issue_1741_http_response_parser_fails_closed_on_length_mismatch`; existing transport regressions rerun | |
| Performance  | N/A    | N/A                  | Policy extraction only; no additional network operations |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore in-core HTTP response parse/status classification implementation.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1741
