### PR TITLE
refactor(kolme): extract tls policy contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -2,6 +2,7 @@
 
 use crate::AgentDid;
 use kamn_kolme::{
+    classify_tls_failure_reason as classify_kolme_tls_failure_reason,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     find_http_header_boundary as find_kolme_http_header_boundary,
@@ -10,6 +11,7 @@ use kamn_kolme::{
     parse_http_response_body as parse_kolme_http_response_body,
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_receipt_finality as parse_kolme_receipt_finality,
+    parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
@@ -29,7 +31,7 @@ use kamn_kolme::{
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint,
-    KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
+    KolmeTlsPolicyError as KamnKolmeTlsPolicyError, KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
 };
 use std::collections::HashMap;
@@ -1790,6 +1792,14 @@ fn map_http_response_policy_error(
     }
 }
 
+fn map_tls_policy_error(error: KamnKolmeTlsPolicyError) -> KolmeRuntimeCommitProviderError {
+    match error {
+        KamnKolmeTlsPolicyError::Unavailable { reason } => {
+            KolmeRuntimeCommitProviderError::Unavailable { reason }
+        }
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
@@ -2044,7 +2054,7 @@ fn map_transport_io_error(error: std::io::Error) -> KolmeRuntimeCommitProviderEr
 
 fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
     let value = match std::env::var("KAMN_KOLME_TLS_CA_FILE") {
-        Ok(value) => value,
+        Ok(value) => Some(value),
         Err(std::env::VarError::NotPresent) => return Ok(None),
         Err(std::env::VarError::NotUnicode(_)) => {
             return Err(KolmeRuntimeCommitProviderError::Unavailable {
@@ -2052,36 +2062,11 @@ fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProvider
             });
         }
     };
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: "KAMN_KOLME_TLS_CA_FILE must not be empty".to_owned(),
-        });
-    }
-    Ok(Some(trimmed.to_owned()))
+    parse_kolme_tls_ca_file_env_value(value.as_deref()).map_err(map_tls_policy_error)
 }
 
 fn classify_tls_failure_reason(stderr: &str) -> String {
-    let normalized = stderr.to_ascii_lowercase();
-    if normalized.contains("certificate verify failed")
-        || normalized.contains("self-signed certificate")
-        || normalized.contains("unable to get local issuer certificate")
-        || normalized.contains("unable to verify the first certificate")
-    {
-        return "tls certificate verification failed".to_owned();
-    }
-    if normalized.contains("handshake failure")
-        || normalized.contains("wrong version number")
-        || normalized.contains("tlsv")
-        || normalized.contains("ssl routines")
-    {
-        return "tls handshake failed".to_owned();
-    }
-    let first_line = stderr
-        .lines()
-        .find(|line| !line.trim().is_empty())
-        .unwrap_or("tls request failed");
-    format!("tls request failed: {}", first_line.trim())
+    classify_kolme_tls_failure_reason(stderr)
 }
 
 fn is_kolme_broadcast_submit_path(submit_path: &str) -> bool {

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -13,6 +13,7 @@ pub mod http_response_policy;
 pub mod notification_policy;
 pub mod pipeline;
 pub mod receipt_finality;
+pub mod tls_policy;
 pub mod transport;
 pub mod websocket_policy;
 
@@ -38,6 +39,9 @@ pub use notification_policy::{
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
+pub use tls_policy::{
+    classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError,
+};
 pub use transport::{
     EchoTransport, KolmeTransport, TransportError, TransportRequest, TransportResponse,
 };

--- a/crates/kamn-kolme/src/tls_policy.rs
+++ b/crates/kamn-kolme/src/tls_policy.rs
@@ -1,0 +1,95 @@
+//! TLS policy contracts for Kolme HTTPS transport behavior.
+
+use std::error::Error;
+use std::fmt;
+
+/// TLS policy error variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeTlsPolicyError {
+    /// Configuration or policy makes TLS path unavailable.
+    Unavailable {
+        /// Deterministic unavailable reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeTlsPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeTlsPolicyError {}
+
+/// Parses optional CA-file environment value into deterministic policy output.
+pub fn parse_tls_ca_file_env_value(
+    value: Option<&str>,
+) -> Result<Option<String>, KolmeTlsPolicyError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeTlsPolicyError::Unavailable {
+            reason: "KAMN_KOLME_TLS_CA_FILE must not be empty".to_owned(),
+        });
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
+/// Classifies stderr output from TLS-backed transport into deterministic reason text.
+pub fn classify_tls_failure_reason(stderr: &str) -> String {
+    let normalized = stderr.to_ascii_lowercase();
+    if normalized.contains("certificate verify failed")
+        || normalized.contains("self-signed certificate")
+        || normalized.contains("unable to get local issuer certificate")
+        || normalized.contains("unable to verify the first certificate")
+    {
+        return "tls certificate verification failed".to_owned();
+    }
+    if normalized.contains("handshake failure")
+        || normalized.contains("wrong version number")
+        || normalized.contains("tlsv")
+        || normalized.contains("ssl routines")
+    {
+        return "tls handshake failed".to_owned();
+    }
+    let first_line = stderr
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("tls request failed");
+    format!("tls request failed: {}", first_line.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError};
+
+    #[test]
+    fn unit_parse_tls_ca_file_env_value_accepts_trimmed_path() {
+        assert_eq!(
+            parse_tls_ca_file_env_value(Some(" /etc/ssl/custom.pem ")),
+            Ok(Some("/etc/ssl/custom.pem".to_owned()))
+        );
+    }
+
+    #[test]
+    fn unit_parse_tls_ca_file_env_value_rejects_empty_value() {
+        assert_eq!(
+            parse_tls_ca_file_env_value(Some("  ")),
+            Err(KolmeTlsPolicyError::Unavailable {
+                reason: "KAMN_KOLME_TLS_CA_FILE must not be empty".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn functional_classify_tls_failure_reason_detects_handshake_pattern() {
+        assert_eq!(
+            classify_tls_failure_reason("ssl routines:ssl3_get_record:wrong version number"),
+            "tls handshake failed"
+        );
+    }
+}

--- a/crates/kamn-kolme/tests/tls_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/tls_policy_contracts.rs
@@ -1,0 +1,21 @@
+use kamn_kolme::{classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError};
+
+#[test]
+fn functional_tls_failure_reason_classifier_detects_certificate_errors() {
+    let reason = classify_tls_failure_reason(
+        "verify error:num=18:self-signed certificate\ncertificate verify failed",
+    );
+    assert_eq!(reason, "tls certificate verification failed");
+}
+
+#[test]
+fn regression_issue_1743_tls_ca_env_parser_fails_closed_on_empty_value() {
+    // Regression: #1743
+    let error = parse_tls_ca_file_env_value(Some("  ")).expect_err("empty CA env value must fail");
+    assert_eq!(
+        error,
+        KolmeTlsPolicyError::Unavailable {
+            reason: "KAMN_KOLME_TLS_CA_FILE must not be empty".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -114,7 +114,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
-    `crates/kamn-kolme/src/http_response_policy.rs`
+    `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -40,6 +40,7 @@ handling.
   - emits `Authorization: <value>` header on submit/finality requests.
 - HTTPS/TLS behavior:
   - `https://` requests execute through TLS-backed `openssl s_client` command wiring.
+  - `crates/kamn-kolme/src/tls_policy.rs` owns TLS CA-file env parsing and deterministic stderr failure classification contracts.
   - optional custom CA trust file is read from `KAMN_KOLME_TLS_CA_FILE`.
   - deterministic TLS failure mapping:
     - certificate verification failures => `Unavailable("tls certificate verification failed")`
@@ -149,6 +150,7 @@ cargo test -p kamn-kolme --test finality_block_scan_contracts
 cargo test -p kamn-kolme --test endpoint_policy_contracts
 cargo test -p kamn-kolme --test websocket_policy_contracts
 cargo test -p kamn-kolme --test http_response_policy_contracts
+cargo test -p kamn-kolme --test tls_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact


### PR DESCRIPTION
## Summary
Extract TLS policy behavior from `kamn-core` into `kamn-kolme` contracts while keeping core as compatibility wrapper.
This moves CA-file env parsing and TLS stderr failure classification into the dedicated Kolme policy crate and trims duplicated core policy logic.

## Changes
- `crates/kamn-kolme/src/tls_policy.rs`: add TLS policy contracts (`parse_tls_ca_file_env_value`, `classify_tls_failure_reason`) and error type
- `crates/kamn-kolme/src/lib.rs`: export TLS policy contracts
- `crates/kamn-kolme/tests/tls_policy_contracts.rs`: add functional + regression contract tests
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire TLS helper wrappers to consume extracted contracts
- `docs/foundation/kolme-runtime-commit-client.md`: document TLS policy ownership in `kamn-kolme`
- `docs/architecture/kamn-core-module-map.md`: include `tls_policy` in extraction boundary list

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-kolme --test tls_policy_contracts`

Observed failure (before implementation):
```
error[E0432]: unresolved imports `kamn_kolme::classify_tls_failure_reason`, `kamn_kolme::parse_tls_ca_file_env_value`, `kamn_kolme::KolmeTlsPolicyError`
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test tls_policy_contracts`
- `cargo test -p kamn-kolme`

Result:
- New TLS policy contract tests pass and full `kamn-kolme` suite remains green.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-core tls_failure_reason_classifier_detects_certificate_errors -- --exact`
- `cargo fmt --all --check`
- `cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings`
- `bash scripts/ci/test_select_targets.sh`

Result:
- All listed integration/regression and quality gates passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | TLS policy unit guards for CA env parsing and handshake-pattern classification | |
| Functional   | ✅     | `functional_tls_failure_reason_classifier_detects_certificate_errors` | |
| Integration  | ✅     | `kolme_runtime_commit_http_transport` HTTPS paths | |
| Regression   | ✅     | `regression_issue_1743_tls_ca_env_parser_fails_closed_on_empty_value`; existing TLS mapping tests rerun | |
| Performance  | N/A    | N/A                  | Policy extraction only; no additional network operations |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore in-core TLS policy implementation.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1743
