### PR TITLE
refactor(kolme): extract provider response parser contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -10,6 +10,8 @@ use kamn_kolme::{
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
     parse_notification_event as parse_kolme_notification_event_contract,
+    parse_provider_key_value_fields as parse_kolme_provider_key_value_fields,
+    parse_provider_response_fields as parse_kolme_provider_response_fields,
     parse_receipt_finality as parse_kolme_receipt_finality,
     parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
@@ -31,6 +33,7 @@ use kamn_kolme::{
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint,
+    KolmeProviderResponsePolicyError as KamnKolmeProviderResponsePolicyError,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError, KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
 };
@@ -1110,7 +1113,8 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
             self.status_path.as_str(),
             commit_id,
         )?;
-        let fields = parse_response_fields(response.as_str())?;
+        let fields = parse_kolme_provider_response_fields(response.as_str())
+            .map_err(map_provider_response_policy_error_to_malformed)?;
         let provider = required_response_field(&fields, "provider")?;
         let observed_commit_id = resolve_commit_id(&fields)?;
         if observed_commit_id != commit_id {
@@ -1765,6 +1769,14 @@ fn map_notification_policy_error_to_malformed(
     }
 }
 
+fn map_provider_response_policy_error_to_malformed(
+    error: KamnKolmeProviderResponsePolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
 fn map_websocket_policy_error(
     error: KamnKolmeWebsocketPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
@@ -1840,7 +1852,8 @@ fn parse_block_fallback_response(
         });
     }
 
-    let fields = parse_response_fields(trimmed)?;
+    let fields = parse_kolme_provider_response_fields(trimmed)
+        .map_err(map_provider_response_policy_error_to_malformed)?;
     let provider = required_response_field(&fields, "provider")?;
     let block_height = fields
         .get("block_height")
@@ -2144,7 +2157,8 @@ fn normalize_kolme_broadcast_payload(
                 reason: error.to_string(),
             })?;
 
-            let message_fields = parse_key_value_response_fields(envelope.message.as_str())?;
+            let message_fields = parse_kolme_provider_key_value_fields(envelope.message.as_str())
+                .map_err(map_provider_response_policy_error_to_malformed)?;
             let message_idempotency_key =
                 required_response_field(&message_fields, "idempotency_key")?;
             if message_idempotency_key != idempotency_key {
@@ -2179,7 +2193,8 @@ fn normalize_kolme_broadcast_payload(
         return Ok(request.to_json_payload());
     }
 
-    let fields = parse_key_value_response_fields(payload)?;
+    let fields = parse_kolme_provider_key_value_fields(payload)
+        .map_err(map_provider_response_policy_error_to_malformed)?;
     if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
         let payload_idempotency_key = payload_idempotency_key.trim();
         if payload_idempotency_key != idempotency_key {
@@ -2202,7 +2217,8 @@ fn parse_live_provider_response(
     response: &str,
     provider_hint: Option<&str>,
 ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
-    let fields = parse_response_fields(response)?;
+    let fields = parse_kolme_provider_response_fields(response)
+        .map_err(map_provider_response_policy_error_to_malformed)?;
     if let Some(status_raw) = fields.get("status") {
         let status = status_raw.trim();
         if status.is_empty() {
@@ -2266,102 +2282,6 @@ fn parse_live_provider_response(
             },
         ))
     }
-}
-
-fn parse_response_fields(
-    response: &str,
-) -> Result<HashMap<String, String>, KolmeRuntimeCommitProviderError> {
-    let trimmed = response.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "response body must not be empty".to_owned(),
-        });
-    }
-
-    if trimmed.starts_with('{') {
-        return parse_flat_json_response_fields(trimmed);
-    }
-
-    parse_key_value_response_fields(trimmed)
-}
-
-fn parse_key_value_response_fields(
-    response: &str,
-) -> Result<HashMap<String, String>, KolmeRuntimeCommitProviderError> {
-    let mut fields = HashMap::new();
-    for line in response.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let (key, value) = trimmed.split_once('=').ok_or_else(|| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid key/value response line: {trimmed}"),
-            }
-        })?;
-        let key = key.trim();
-        let value = value.trim();
-        if key.is_empty() || value.is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid key/value response line: {trimmed}"),
-            });
-        }
-        fields.insert(key.to_owned(), value.to_owned());
-    }
-    if fields.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "response body must contain at least one field".to_owned(),
-        });
-    }
-    Ok(fields)
-}
-
-fn parse_flat_json_response_fields(
-    response: &str,
-) -> Result<HashMap<String, String>, KolmeRuntimeCommitProviderError> {
-    let body = response.trim();
-    if !(body.starts_with('{') && body.ends_with('}')) {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "json response must be an object".to_owned(),
-        });
-    }
-    let inner = &body[1..body.len() - 1];
-    if inner.trim().is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    let entries = split_unquoted(inner, ',').map_err(|reason| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("invalid json response: {reason}"),
-        }
-    })?;
-
-    let mut fields = HashMap::new();
-    for entry in entries {
-        let pair = split_unquoted(entry.as_str(), ':').map_err(|reason| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid json response pair: {reason}"),
-            }
-        })?;
-        if pair.len() != 2 {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "json response pair must contain exactly one ':'".to_owned(),
-            });
-        }
-
-        let key = parse_json_string(pair[0].trim()).map_err(|reason| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid json key: {reason}"),
-            }
-        })?;
-        let value = parse_json_string(pair[1].trim()).map_err(|reason| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid json value: {reason}"),
-            }
-        })?;
-        fields.insert(key, value);
-    }
-    Ok(fields)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -12,6 +12,7 @@ pub mod finality;
 pub mod http_response_policy;
 pub mod notification_policy;
 pub mod pipeline;
+pub mod provider_response_policy;
 pub mod receipt_finality;
 pub mod tls_policy;
 pub mod transport;
@@ -38,6 +39,10 @@ pub use notification_policy::{
     parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
+pub use provider_response_policy::{
+    parse_provider_key_value_fields, parse_provider_response_fields,
+    KolmeProviderResponsePolicyError,
+};
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError,

--- a/crates/kamn-kolme/src/provider_response_policy.rs
+++ b/crates/kamn-kolme/src/provider_response_policy.rs
@@ -1,0 +1,203 @@
+//! Provider response parsing contracts for Kolme runtime-commit API calls.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+/// Error raised while parsing provider response payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeProviderResponsePolicyError {
+    /// Provider payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeProviderResponsePolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedResponse { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeProviderResponsePolicyError {}
+
+/// Parses provider response payload fields from key/value or flat JSON formats.
+pub fn parse_provider_response_fields(
+    response: &str,
+) -> Result<HashMap<String, String>, KolmeProviderResponsePolicyError> {
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: "response body must not be empty".to_owned(),
+        });
+    }
+
+    if trimmed.starts_with('{') {
+        return parse_flat_json_response_fields(trimmed);
+    }
+
+    parse_provider_key_value_fields(trimmed)
+}
+
+/// Parses a line-delimited key/value response payload into field pairs.
+pub fn parse_provider_key_value_fields(
+    response: &str,
+) -> Result<HashMap<String, String>, KolmeProviderResponsePolicyError> {
+    let mut fields = HashMap::new();
+    for line in response.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let (key, value) = trimmed.split_once('=').ok_or_else(|| {
+            KolmeProviderResponsePolicyError::MalformedResponse {
+                reason: format!("invalid key/value response line: {trimmed}"),
+            }
+        })?;
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() || value.is_empty() {
+            return Err(KolmeProviderResponsePolicyError::MalformedResponse {
+                reason: format!("invalid key/value response line: {trimmed}"),
+            });
+        }
+        fields.insert(key.to_owned(), value.to_owned());
+    }
+    if fields.is_empty() {
+        return Err(KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: "response body must contain at least one field".to_owned(),
+        });
+    }
+    Ok(fields)
+}
+
+fn parse_flat_json_response_fields(
+    response: &str,
+) -> Result<HashMap<String, String>, KolmeProviderResponsePolicyError> {
+    let body = response.trim();
+    if !(body.starts_with('{') && body.ends_with('}')) {
+        return Err(KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: "json response must be an object".to_owned(),
+        });
+    }
+    let inner = &body[1..body.len() - 1];
+    if inner.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let entries = split_unquoted(inner, ',').map_err(|reason| {
+        KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: format!("invalid json response: {reason}"),
+        }
+    })?;
+
+    let mut fields = HashMap::new();
+    for entry in entries {
+        let pair = split_unquoted(entry.as_str(), ':').map_err(|reason| {
+            KolmeProviderResponsePolicyError::MalformedResponse {
+                reason: format!("invalid json response pair: {reason}"),
+            }
+        })?;
+        if pair.len() != 2 {
+            return Err(KolmeProviderResponsePolicyError::MalformedResponse {
+                reason: "json response pair must contain exactly one ':'".to_owned(),
+            });
+        }
+
+        let key = parse_json_string(pair[0].trim()).map_err(|reason| {
+            KolmeProviderResponsePolicyError::MalformedResponse {
+                reason: format!("invalid json key: {reason}"),
+            }
+        })?;
+        let value = parse_json_string(pair[1].trim()).map_err(|reason| {
+            KolmeProviderResponsePolicyError::MalformedResponse {
+                reason: format!("invalid json value: {reason}"),
+            }
+        })?;
+        fields.insert(key, value);
+    }
+    Ok(fields)
+}
+
+fn split_unquoted(input: &str, delimiter: char) -> Result<Vec<String>, &'static str> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escape = false;
+
+    for ch in input.chars() {
+        if escape {
+            current.push(ch);
+            escape = false;
+            continue;
+        }
+
+        if ch == '\\' && in_quotes {
+            current.push(ch);
+            escape = true;
+            continue;
+        }
+
+        if ch == '"' {
+            in_quotes = !in_quotes;
+            current.push(ch);
+            continue;
+        }
+
+        if ch == delimiter && !in_quotes {
+            if current.trim().is_empty() {
+                return Err("empty segment");
+            }
+            parts.push(current.trim().to_owned());
+            current.clear();
+            continue;
+        }
+
+        current.push(ch);
+    }
+
+    if in_quotes {
+        return Err("unterminated quoted string");
+    }
+    if current.trim().is_empty() {
+        return Err("empty trailing segment");
+    }
+    parts.push(current.trim().to_owned());
+    Ok(parts)
+}
+
+fn parse_json_string(token: &str) -> Result<String, &'static str> {
+    let trimmed = token.trim();
+    if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
+        return Err("token must be a quoted string");
+    }
+    let mut output = String::new();
+    let mut escape = false;
+    for ch in trimmed[1..trimmed.len() - 1].chars() {
+        if escape {
+            let mapped = match ch {
+                '\\' => '\\',
+                '"' => '"',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => return Err("unsupported escape sequence"),
+            };
+            output.push(mapped);
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        output.push(ch);
+    }
+    if escape {
+        return Err("unterminated escape sequence");
+    }
+    Ok(output)
+}

--- a/crates/kamn-kolme/tests/provider_response_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_response_policy_contracts.rs
@@ -1,0 +1,61 @@
+use kamn_kolme::{
+    parse_provider_key_value_fields, parse_provider_response_fields,
+    KolmeProviderResponsePolicyError,
+};
+
+#[test]
+fn functional_parse_provider_response_fields_accepts_key_value_payload() {
+    let fields = parse_provider_response_fields("status=submitted\nprovider=kolme\n")
+        .expect("key/value payload should parse");
+    assert_eq!(fields.get("status"), Some(&"submitted".to_owned()));
+    assert_eq!(fields.get("provider"), Some(&"kolme".to_owned()));
+}
+
+#[test]
+fn functional_parse_provider_response_fields_accepts_flat_json_object() {
+    let fields = parse_provider_response_fields(
+        "{\"status\":\"duplicate\",\"provider\":\"kolme\",\"tx_hash\":\"ab12cd34\"}",
+    )
+    .expect("flat json payload should parse");
+    assert_eq!(fields.get("status"), Some(&"duplicate".to_owned()));
+    assert_eq!(fields.get("provider"), Some(&"kolme".to_owned()));
+    assert_eq!(fields.get("tx_hash"), Some(&"ab12cd34".to_owned()));
+}
+
+#[test]
+fn regression_issue_1745_parse_provider_response_fields_rejects_invalid_key_value_line() {
+    // Regression: #1745
+    let error = parse_provider_response_fields("status\nprovider=kolme")
+        .expect_err("invalid key/value line must fail");
+    assert_eq!(
+        error,
+        KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: "invalid key/value response line: status".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1745_parse_provider_response_fields_rejects_unterminated_json_entry() {
+    // Regression: #1745
+    let error = parse_provider_response_fields("{\"status\":\"submitted}")
+        .expect_err("unterminated json strings must fail");
+    assert_eq!(
+        error,
+        KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: "invalid json response: unterminated quoted string".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn unit_parse_provider_key_value_fields_rejects_empty_body() {
+    let error = parse_provider_key_value_fields("\n \n")
+        .expect_err("empty key/value payload must fail closed");
+    assert_eq!(
+        error,
+        KolmeProviderResponsePolicyError::MalformedResponse {
+            reason: "response body must contain at least one field".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -114,7 +114,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
-    `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`
+    `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
+    `crates/kamn-kolme/src/provider_response_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -34,6 +34,7 @@ handling.
 - Endpoint normalization boundary:
   - `crates/kamn-kolme/src/endpoint_policy.rs` owns HTTP/WebSocket endpoint parsing and URL composition contracts.
   - `crates/kamn-kolme/src/http_response_policy.rs` owns HTTP response status/content parsing contracts.
+  - `crates/kamn-kolme/src/provider_response_policy.rs` owns provider response field parsing contracts (key/value + flat JSON string object formats).
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
 - Optional auth-aware constructor:
   - `KolmeRuntimeCommitHttpTransport::new_with_authorization(...)`
@@ -64,6 +65,7 @@ handling.
   - websocket handshake/frame parsing contracts are sourced from `kamn-kolme` (`find_http_header_boundary`, `validate_websocket_handshake_response`, `try_take_websocket_frame`) and mapped through `kamn-core` compatibility wrappers.
   - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
+  - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.
@@ -151,6 +153,7 @@ cargo test -p kamn-kolme --test endpoint_policy_contracts
 cargo test -p kamn-kolme --test websocket_policy_contracts
 cargo test -p kamn-kolme --test http_response_policy_contracts
 cargo test -p kamn-kolme --test tls_policy_contracts
+cargo test -p kamn-kolme --test provider_response_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -177,3 +180,4 @@ cargo test -p kamn-core
 - direct signed transaction payload normalization drift remains fail-closed (`Regression: #1516`).
 - direct signed transaction required-field validation drift remains fail-closed (`Regression: #1519`).
 - typed nonce/broadcast HTTP helper mapping drift remains fail-closed (`Regression: #1533`).
+- provider response field parser extraction parity drift remains fail-closed (`Regression: #1745`).


### PR DESCRIPTION
## Summary
Extracts provider response field parser policy (key/value + flat JSON string-object parsing) from `kamn-core` into `kamn-kolme`, then rewires runtime-commit call sites to delegate through extracted contracts. This reduces policy duplication in `kolme_runtime_commit.rs` while preserving fail-closed behavior.

Closes #1745
Refs #1714

## Changes
- `crates/kamn-kolme/src/provider_response_policy.rs`: new provider response parser policy contracts and typed error.
- `crates/kamn-kolme/tests/provider_response_policy_contracts.rs`: unit/functional/regression contracts (`Regression: #1745`).
- `crates/kamn-kolme/src/lib.rs`: exports for provider response policy API.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegates provider response parsing to `kamn-kolme`; removes duplicated core parser helper block for this path.
- `docs/foundation/kolme-runtime-commit-client.md`: documents new extraction boundary and contract test command.
- `docs/architecture/kamn-core-module-map.md`: adds `provider_response_policy` to in-progress Kolme extraction map.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test provider_response_policy_contracts
```
Failed before implementation with unresolved imports:
- `no parse_provider_key_value_fields in the root`
- `no parse_provider_response_fields in the root`
- `no KolmeProviderResponsePolicyError in the root`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test provider_response_policy_contracts
```
Passes: `5 passed; 0 failed`.

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
cargo test -p kamn-kolme
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
All commands pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_parse_provider_key_value_fields_rejects_empty_body`; module unit paths in `kamn-kolme` | |
| Functional   | ✅     | provider response parser accepts key/value and flat JSON shapes; runtime HTTP transport suite | |
| Integration  | ✅     | `kolme_runtime_commit_http_transport`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_block_fallback` | |
| Regression   | ✅     | `regression_issue_1745_*` parser fail-closed tests + existing runtime regressions remain green | |
| Performance  | N/A    | Not a throughput-path change | Extraction is policy-only; CI cost kept low via targeted suites |

## Risks & Rollback
- None breaking; behavior intended to be parity-preserving.
- Rollback: revert this PR commit to restore in-core parser helpers.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
