### PR TITLE
refactor(kolme): extract flat json parser contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -6,6 +6,7 @@ use kamn_kolme::{
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     find_http_header_boundary as find_kolme_http_header_boundary,
+    parse_flat_json_value_fields as parse_kolme_flat_json_value_fields,
     parse_fork_block_txhash as parse_kolme_fork_block_txhash,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
@@ -16,6 +17,8 @@ use kamn_kolme::{
     parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
+    required_json_string_field as required_kolme_json_string_field,
+    required_positive_u64_json_field as required_kolme_positive_u64_json_field,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
@@ -28,6 +31,8 @@ use kamn_kolme::{
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
+    KolmeFlatJsonPolicyError as KamnKolmeFlatJsonPolicyError,
+    KolmeFlatJsonValue as KamnKolmeFlatJsonValue,
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
@@ -1777,6 +1782,14 @@ fn map_provider_response_policy_error_to_malformed(
     }
 }
 
+fn map_flat_json_policy_error_to_malformed(
+    error: KamnKolmeFlatJsonPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
 fn map_websocket_policy_error(
     error: KamnKolmeWebsocketPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
@@ -1839,8 +1852,10 @@ fn parse_block_fallback_response(
 ) -> Result<ParsedBlockFallbackResponse, KolmeRuntimeCommitProviderError> {
     let trimmed = response.trim();
     if trimmed.starts_with('{') {
-        let fields = parse_flat_json_value_fields(trimmed)?;
-        let provider = required_json_string_field(&fields, "provider")?;
+        let fields = parse_kolme_flat_json_value_fields(trimmed)
+            .map_err(map_flat_json_policy_error_to_malformed)?;
+        let provider = required_kolme_json_string_field(&fields, "provider")
+            .map_err(map_flat_json_policy_error_to_malformed)?;
         let block_height = required_block_height_json_field(&fields)?;
         let finalized_tx_hashes = optional_json_block_tx_hashes(&fields, "tx_hashes")?;
         let failed_tx_hashes = optional_json_block_tx_hashes(&fields, "failed_tx_hashes")?;
@@ -1932,13 +1947,15 @@ fn parse_tx_hash_list(
 }
 
 fn required_block_height_json_field(
-    fields: &HashMap<String, FlatJsonValue>,
+    fields: &HashMap<String, KamnKolmeFlatJsonValue>,
 ) -> Result<u64, KolmeRuntimeCommitProviderError> {
     if fields.contains_key("block_height") {
-        return required_positive_u64_json_field(fields, "block_height");
+        return required_kolme_positive_u64_json_field(fields, "block_height")
+            .map_err(map_flat_json_policy_error_to_malformed);
     }
     if fields.contains_key("height") {
-        return required_positive_u64_json_field(fields, "height");
+        return required_kolme_positive_u64_json_field(fields, "height")
+            .map_err(map_flat_json_policy_error_to_malformed);
     }
     Err(KolmeRuntimeCommitProviderError::MalformedResponse {
         reason: "missing required field: block_height".to_owned(),
@@ -1946,15 +1963,15 @@ fn required_block_height_json_field(
 }
 
 fn optional_json_block_tx_hashes(
-    fields: &HashMap<String, FlatJsonValue>,
+    fields: &HashMap<String, KamnKolmeFlatJsonValue>,
     field: &'static str,
 ) -> Result<Vec<String>, KolmeRuntimeCommitProviderError> {
     let Some(value) = fields.get(field) else {
         return Ok(Vec::new());
     };
     match value {
-        FlatJsonValue::Null => Ok(Vec::new()),
-        FlatJsonValue::String(raw) => parse_tx_hash_list(raw, field),
+        KamnKolmeFlatJsonValue::Null => Ok(Vec::new()),
+        KamnKolmeFlatJsonValue::String(raw) => parse_tx_hash_list(raw, field),
         _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
             reason: format!("field must be string|null: {field}"),
         }),
@@ -2113,10 +2130,11 @@ fn normalize_kolme_broadcast_payload(
     }
 
     if payload.starts_with('{') {
-        let fields = parse_flat_json_value_fields(payload)?;
+        let fields = parse_kolme_flat_json_value_fields(payload)
+            .map_err(map_flat_json_policy_error_to_malformed)?;
         if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
             let payload_idempotency_key = match payload_idempotency_key {
-                FlatJsonValue::String(value) => value.trim(),
+                KamnKolmeFlatJsonValue::String(value) => value.trim(),
                 _ => {
                     return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                         reason: "field must be a string: idempotency_key".to_owned(),
@@ -2136,9 +2154,12 @@ fn normalize_kolme_broadcast_payload(
             }
         }
 
-        let message = required_json_string_field(&fields, "message")?;
-        let signature = required_json_string_field(&fields, "signature")?;
-        let recovery_id_u64 = required_positive_u64_json_field(&fields, "recovery_id")?;
+        let message = required_kolme_json_string_field(&fields, "message")
+            .map_err(map_flat_json_policy_error_to_malformed)?;
+        let signature = required_kolme_json_string_field(&fields, "signature")
+            .map_err(map_flat_json_policy_error_to_malformed)?;
+        let recovery_id_u64 = required_kolme_positive_u64_json_field(&fields, "recovery_id")
+            .map_err(map_flat_json_policy_error_to_malformed)?;
         let recovery_id = u8::try_from(recovery_id_u64).map_err(|_| {
             KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "recovery_id must be within u8 range".to_owned(),
@@ -2146,7 +2167,8 @@ fn normalize_kolme_broadcast_payload(
         })?;
 
         if fields.contains_key("signer_key_id") {
-            let signer_key_id = required_json_string_field(&fields, "signer_key_id")?;
+            let signer_key_id = required_kolme_json_string_field(&fields, "signer_key_id")
+                .map_err(map_flat_json_policy_error_to_malformed)?;
             let envelope = KolmeRuntimeCommitSignedBroadcastEnvelope::new(
                 signer_key_id.as_str(),
                 message.as_str(),
@@ -2282,238 +2304,6 @@ fn parse_live_provider_response(
             },
         ))
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum FlatJsonValue {
-    String(String),
-    Number(String),
-    Boolean(bool),
-    Null,
-}
-
-fn parse_flat_json_value_fields(
-    response: &str,
-) -> Result<HashMap<String, FlatJsonValue>, KolmeRuntimeCommitProviderError> {
-    let body = response.trim();
-    if !(body.starts_with('{') && body.ends_with('}')) {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "json response must be an object".to_owned(),
-        });
-    }
-    let inner = &body[1..body.len() - 1];
-    if inner.trim().is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    let entries = split_unquoted(inner, ',').map_err(|reason| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("invalid json response: {reason}"),
-        }
-    })?;
-
-    let mut fields = HashMap::new();
-    for entry in entries {
-        let pair = split_unquoted(entry.as_str(), ':').map_err(|reason| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid json response pair: {reason}"),
-            }
-        })?;
-        if pair.len() != 2 {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "json response pair must contain exactly one ':'".to_owned(),
-            });
-        }
-
-        let key = parse_json_string(pair[0].trim()).map_err(|reason| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid json key: {reason}"),
-            }
-        })?;
-        let value = parse_json_value(pair[1].trim())?;
-        fields.insert(key, value);
-    }
-    Ok(fields)
-}
-
-fn parse_json_value(token: &str) -> Result<FlatJsonValue, KolmeRuntimeCommitProviderError> {
-    let trimmed = token.trim();
-    if trimmed.starts_with('"') {
-        let value = parse_json_string(trimmed).map_err(|reason| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid json value: {reason}"),
-            }
-        })?;
-        return Ok(FlatJsonValue::String(value));
-    }
-    if trimmed == "null" {
-        return Ok(FlatJsonValue::Null);
-    }
-    if trimmed == "true" {
-        return Ok(FlatJsonValue::Boolean(true));
-    }
-    if trimmed == "false" {
-        return Ok(FlatJsonValue::Boolean(false));
-    }
-    if is_json_number_literal(trimmed) {
-        return Ok(FlatJsonValue::Number(trimmed.to_owned()));
-    }
-    Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: "invalid json value token".to_owned(),
-    })
-}
-
-fn is_json_number_literal(token: &str) -> bool {
-    if token.is_empty() {
-        return false;
-    }
-    let mut chars = token.chars();
-    let first = chars.next().unwrap_or_default();
-    if first == '-' {
-        let remainder = chars.as_str();
-        return !remainder.is_empty() && remainder.chars().all(|ch| ch.is_ascii_digit());
-    }
-    first.is_ascii_digit() && chars.as_str().chars().all(|ch| ch.is_ascii_digit())
-}
-
-fn required_json_string_field(
-    fields: &HashMap<String, FlatJsonValue>,
-    field: &'static str,
-) -> Result<String, KolmeRuntimeCommitProviderError> {
-    let value =
-        fields
-            .get(field)
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("missing required field: {field}"),
-            })?;
-    let FlatJsonValue::String(raw) = value else {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("field must be a string: {field}"),
-        });
-    };
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("field must not be empty: {field}"),
-        });
-    }
-    Ok(trimmed.to_owned())
-}
-
-fn required_positive_u64_json_field(
-    fields: &HashMap<String, FlatJsonValue>,
-    field: &'static str,
-) -> Result<u64, KolmeRuntimeCommitProviderError> {
-    let value =
-        fields
-            .get(field)
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("missing required field: {field}"),
-            })?;
-
-    let raw = match value {
-        FlatJsonValue::Number(value) => value.as_str(),
-        FlatJsonValue::String(value) => value.trim(),
-        _ => {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("field must be numeric: {field}"),
-            });
-        }
-    };
-
-    let parsed =
-        raw.parse::<i128>()
-            .map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid numeric field: {field}"),
-            })?;
-    if parsed <= 0 {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("{field} must be positive"),
-        });
-    }
-    u64::try_from(parsed).map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: format!("invalid numeric field: {field}"),
-    })
-}
-
-fn split_unquoted(input: &str, delimiter: char) -> Result<Vec<String>, &'static str> {
-    let mut parts = Vec::new();
-    let mut current = String::new();
-    let mut in_quotes = false;
-    let mut escape = false;
-
-    for ch in input.chars() {
-        if escape {
-            current.push(ch);
-            escape = false;
-            continue;
-        }
-
-        if ch == '\\' && in_quotes {
-            current.push(ch);
-            escape = true;
-            continue;
-        }
-
-        if ch == '"' {
-            in_quotes = !in_quotes;
-            current.push(ch);
-            continue;
-        }
-
-        if ch == delimiter && !in_quotes {
-            if current.trim().is_empty() {
-                return Err("empty segment");
-            }
-            parts.push(current.trim().to_owned());
-            current.clear();
-            continue;
-        }
-
-        current.push(ch);
-    }
-
-    if in_quotes {
-        return Err("unterminated quoted string");
-    }
-    if current.trim().is_empty() {
-        return Err("empty trailing segment");
-    }
-    parts.push(current.trim().to_owned());
-    Ok(parts)
-}
-
-fn parse_json_string(token: &str) -> Result<String, &'static str> {
-    let trimmed = token.trim();
-    if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
-        return Err("token must be a quoted string");
-    }
-    let mut output = String::new();
-    let mut escape = false;
-    for ch in trimmed[1..trimmed.len() - 1].chars() {
-        if escape {
-            let mapped = match ch {
-                '\\' => '\\',
-                '"' => '"',
-                'n' => '\n',
-                'r' => '\r',
-                't' => '\t',
-                _ => return Err("unsupported escape sequence"),
-            };
-            output.push(mapped);
-            escape = false;
-            continue;
-        }
-        if ch == '\\' {
-            escape = true;
-            continue;
-        }
-        output.push(ch);
-    }
-    if escape {
-        return Err("unterminated escape sequence");
-    }
-    Ok(output)
 }
 
 fn json_escape(value: &str) -> String {

--- a/crates/kamn-kolme/src/flat_json_policy.rs
+++ b/crates/kamn-kolme/src/flat_json_policy.rs
@@ -1,0 +1,263 @@
+//! Flat JSON scalar/object parsing contracts for Kolme runtime-commit payloads.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+/// Typed scalar value parsed from a flat JSON object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeFlatJsonValue {
+    /// JSON string value.
+    String(String),
+    /// JSON integer number literal.
+    Number(String),
+    /// JSON boolean value.
+    Boolean(bool),
+    /// JSON null value.
+    Null,
+}
+
+/// Error raised by flat JSON parser policy contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeFlatJsonPolicyError {
+    /// JSON payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeFlatJsonPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedResponse { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeFlatJsonPolicyError {}
+
+/// Parses a flat JSON object into scalar field values.
+pub fn parse_flat_json_value_fields(
+    response: &str,
+) -> Result<HashMap<String, KolmeFlatJsonValue>, KolmeFlatJsonPolicyError> {
+    let body = response.trim();
+    if !(body.starts_with('{') && body.ends_with('}')) {
+        return Err(KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: "json response must be an object".to_owned(),
+        });
+    }
+    let inner = &body[1..body.len() - 1];
+    if inner.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let entries = split_unquoted(inner, ',').map_err(|reason| {
+        KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("invalid json response: {reason}"),
+        }
+    })?;
+
+    let mut fields = HashMap::new();
+    for entry in entries {
+        let pair = split_unquoted(entry.as_str(), ':').map_err(|reason| {
+            KolmeFlatJsonPolicyError::MalformedResponse {
+                reason: format!("invalid json response pair: {reason}"),
+            }
+        })?;
+        if pair.len() != 2 {
+            return Err(KolmeFlatJsonPolicyError::MalformedResponse {
+                reason: "json response pair must contain exactly one ':'".to_owned(),
+            });
+        }
+
+        let key = parse_json_string(pair[0].trim()).map_err(|reason| {
+            KolmeFlatJsonPolicyError::MalformedResponse {
+                reason: format!("invalid json key: {reason}"),
+            }
+        })?;
+        let value = parse_json_value(pair[1].trim())?;
+        fields.insert(key, value);
+    }
+    Ok(fields)
+}
+
+/// Extracts one non-empty string field from parsed flat JSON fields.
+pub fn required_json_string_field(
+    fields: &HashMap<String, KolmeFlatJsonValue>,
+    field: &'static str,
+) -> Result<String, KolmeFlatJsonPolicyError> {
+    let value = fields
+        .get(field)
+        .ok_or_else(|| KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("missing required field: {field}"),
+        })?;
+    let KolmeFlatJsonValue::String(raw) = value else {
+        return Err(KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("field must be a string: {field}"),
+        });
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("field must not be empty: {field}"),
+        });
+    }
+    Ok(trimmed.to_owned())
+}
+
+/// Extracts one positive `u64` field from parsed flat JSON fields.
+pub fn required_positive_u64_json_field(
+    fields: &HashMap<String, KolmeFlatJsonValue>,
+    field: &'static str,
+) -> Result<u64, KolmeFlatJsonPolicyError> {
+    let value = fields
+        .get(field)
+        .ok_or_else(|| KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("missing required field: {field}"),
+        })?;
+
+    let raw = match value {
+        KolmeFlatJsonValue::Number(value) => value.as_str(),
+        KolmeFlatJsonValue::String(value) => value.trim(),
+        _ => {
+            return Err(KolmeFlatJsonPolicyError::MalformedResponse {
+                reason: format!("field must be numeric: {field}"),
+            });
+        }
+    };
+
+    let parsed = raw
+        .parse::<i128>()
+        .map_err(|_| KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("invalid numeric field: {field}"),
+        })?;
+    if parsed <= 0 {
+        return Err(KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: format!("{field} must be positive"),
+        });
+    }
+    u64::try_from(parsed).map_err(|_| KolmeFlatJsonPolicyError::MalformedResponse {
+        reason: format!("invalid numeric field: {field}"),
+    })
+}
+
+fn parse_json_value(token: &str) -> Result<KolmeFlatJsonValue, KolmeFlatJsonPolicyError> {
+    let trimmed = token.trim();
+    if trimmed.starts_with('"') {
+        let value = parse_json_string(trimmed).map_err(|reason| {
+            KolmeFlatJsonPolicyError::MalformedResponse {
+                reason: format!("invalid json value: {reason}"),
+            }
+        })?;
+        return Ok(KolmeFlatJsonValue::String(value));
+    }
+    if trimmed == "null" {
+        return Ok(KolmeFlatJsonValue::Null);
+    }
+    if trimmed == "true" {
+        return Ok(KolmeFlatJsonValue::Boolean(true));
+    }
+    if trimmed == "false" {
+        return Ok(KolmeFlatJsonValue::Boolean(false));
+    }
+    if is_json_number_literal(trimmed) {
+        return Ok(KolmeFlatJsonValue::Number(trimmed.to_owned()));
+    }
+    Err(KolmeFlatJsonPolicyError::MalformedResponse {
+        reason: "invalid json value token".to_owned(),
+    })
+}
+
+fn is_json_number_literal(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    let mut chars = token.chars();
+    let first = chars.next().unwrap_or_default();
+    if first == '-' {
+        let remainder = chars.as_str();
+        return !remainder.is_empty() && remainder.chars().all(|ch| ch.is_ascii_digit());
+    }
+    first.is_ascii_digit() && chars.as_str().chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn split_unquoted(input: &str, delimiter: char) -> Result<Vec<String>, &'static str> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escape = false;
+
+    for ch in input.chars() {
+        if escape {
+            current.push(ch);
+            escape = false;
+            continue;
+        }
+
+        if ch == '\\' && in_quotes {
+            current.push(ch);
+            escape = true;
+            continue;
+        }
+
+        if ch == '"' {
+            in_quotes = !in_quotes;
+            current.push(ch);
+            continue;
+        }
+
+        if ch == delimiter && !in_quotes {
+            if current.trim().is_empty() {
+                return Err("empty segment");
+            }
+            parts.push(current.trim().to_owned());
+            current.clear();
+            continue;
+        }
+
+        current.push(ch);
+    }
+
+    if in_quotes {
+        return Err("unterminated quoted string");
+    }
+    if current.trim().is_empty() {
+        return Err("empty trailing segment");
+    }
+    parts.push(current.trim().to_owned());
+    Ok(parts)
+}
+
+fn parse_json_string(token: &str) -> Result<String, &'static str> {
+    let trimmed = token.trim();
+    if !(trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2) {
+        return Err("token must be a quoted string");
+    }
+    let mut output = String::new();
+    let mut escape = false;
+    for ch in trimmed[1..trimmed.len() - 1].chars() {
+        if escape {
+            let mapped = match ch {
+                '\\' => '\\',
+                '"' => '"',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => return Err("unsupported escape sequence"),
+            };
+            output.push(mapped);
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        output.push(ch);
+    }
+    if escape {
+        return Err("unterminated escape sequence");
+    }
+    Ok(output)
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block_scan_policy;
 pub mod codec;
 pub mod endpoint_policy;
 pub mod finality;
+pub mod flat_json_policy;
 pub mod http_response_policy;
 pub mod notification_policy;
 pub mod pipeline;
@@ -34,6 +35,10 @@ pub use endpoint_policy::{
     KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
+pub use flat_json_policy::{
+    parse_flat_json_value_fields, required_json_string_field, required_positive_u64_json_field,
+    KolmeFlatJsonPolicyError, KolmeFlatJsonValue,
+};
 pub use http_response_policy::{parse_http_response_body, KolmeHttpResponsePolicyError};
 pub use notification_policy::{
     parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,

--- a/crates/kamn-kolme/tests/flat_json_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/flat_json_policy_contracts.rs
@@ -1,0 +1,76 @@
+use kamn_kolme::{
+    parse_flat_json_value_fields, required_json_string_field, required_positive_u64_json_field,
+    KolmeFlatJsonPolicyError, KolmeFlatJsonValue,
+};
+
+#[test]
+fn functional_parse_flat_json_value_fields_accepts_mixed_scalar_values() {
+    let fields = parse_flat_json_value_fields(
+        "{\"provider\":\"kolme\",\"height\":72,\"ok\":true,\"meta\":null}",
+    )
+    .expect("flat json object should parse");
+    assert_eq!(
+        fields.get("provider"),
+        Some(&KolmeFlatJsonValue::String("kolme".to_owned()))
+    );
+    assert_eq!(
+        fields.get("height"),
+        Some(&KolmeFlatJsonValue::Number("72".to_owned()))
+    );
+    assert_eq!(fields.get("ok"), Some(&KolmeFlatJsonValue::Boolean(true)));
+    assert_eq!(fields.get("meta"), Some(&KolmeFlatJsonValue::Null));
+}
+
+#[test]
+fn functional_required_json_string_field_trims_whitespace() {
+    let fields = parse_flat_json_value_fields("{\"provider\":\"  kolme-fork  \"}")
+        .expect("parse should work");
+    let provider = required_json_string_field(&fields, "provider")
+        .expect("string field extraction should work");
+    assert_eq!(provider, "kolme-fork");
+}
+
+#[test]
+fn functional_required_positive_u64_json_field_accepts_string_and_number_tokens() {
+    let number_fields = parse_flat_json_value_fields("{\"height\":72}").expect("parse should work");
+    assert_eq!(
+        required_positive_u64_json_field(&number_fields, "height")
+            .expect("numeric token should parse"),
+        72
+    );
+
+    let string_fields =
+        parse_flat_json_value_fields("{\"height\":\"73\"}").expect("parse should work");
+    assert_eq!(
+        required_positive_u64_json_field(&string_fields, "height")
+            .expect("string token should parse"),
+        73
+    );
+}
+
+#[test]
+fn regression_issue_1747_parse_flat_json_value_fields_rejects_invalid_value_token() {
+    // Regression: #1747
+    let error = parse_flat_json_value_fields("{\"height\":7.2}")
+        .expect_err("unsupported number formats must fail");
+    assert_eq!(
+        error,
+        KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: "invalid json value token".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1747_required_positive_u64_json_field_rejects_zero() {
+    // Regression: #1747
+    let fields = parse_flat_json_value_fields("{\"height\":0}").expect("parse should work");
+    let error = required_positive_u64_json_field(&fields, "height")
+        .expect_err("zero values must fail closed");
+    assert_eq!(
+        error,
+        KolmeFlatJsonPolicyError::MalformedResponse {
+            reason: "height must be positive".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -115,7 +115,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
-    `crates/kamn-kolme/src/provider_response_policy.rs`
+    `crates/kamn-kolme/src/provider_response_policy.rs`, `crates/kamn-kolme/src/flat_json_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -34,6 +34,7 @@ handling.
 - Endpoint normalization boundary:
   - `crates/kamn-kolme/src/endpoint_policy.rs` owns HTTP/WebSocket endpoint parsing and URL composition contracts.
   - `crates/kamn-kolme/src/http_response_policy.rs` owns HTTP response status/content parsing contracts.
+  - `crates/kamn-kolme/src/flat_json_policy.rs` owns flat JSON scalar/object parsing contracts used by broadcast normalization and block-fallback field extraction.
   - `crates/kamn-kolme/src/provider_response_policy.rs` owns provider response field parsing contracts (key/value + flat JSON string object formats).
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
 - Optional auth-aware constructor:
@@ -66,6 +67,7 @@ handling.
   - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
+  - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.
@@ -154,6 +156,7 @@ cargo test -p kamn-kolme --test websocket_policy_contracts
 cargo test -p kamn-kolme --test http_response_policy_contracts
 cargo test -p kamn-kolme --test tls_policy_contracts
 cargo test -p kamn-kolme --test provider_response_policy_contracts
+cargo test -p kamn-kolme --test flat_json_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -181,3 +184,4 @@ cargo test -p kamn-core
 - direct signed transaction required-field validation drift remains fail-closed (`Regression: #1519`).
 - typed nonce/broadcast HTTP helper mapping drift remains fail-closed (`Regression: #1533`).
 - provider response field parser extraction parity drift remains fail-closed (`Regression: #1745`).
+- flat JSON parser extraction parity drift remains fail-closed (`Regression: #1747`).


### PR DESCRIPTION
## Summary
Extracts flat JSON scalar/object parsing helpers from `kamn-core` into `kamn-kolme` contracts and rewires runtime-commit call sites to delegate through extracted APIs. This removes another dense policy helper block from `kolme_runtime_commit.rs` while preserving fail-closed behavior.

Closes #1747
Refs #1714

## Changes
- `crates/kamn-kolme/src/flat_json_policy.rs`: new flat JSON parser policy contracts (`KolmeFlatJsonValue`, parser + required-field helpers, typed error).
- `crates/kamn-kolme/tests/flat_json_policy_contracts.rs`: unit/functional/regression coverage (`Regression: #1747`).
- `crates/kamn-kolme/src/lib.rs`: exports for flat JSON policy API.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegates flat JSON parsing/required-field extraction to `kamn-kolme`; removes duplicated local helper block.
- `docs/foundation/kolme-runtime-commit-client.md`: documents flat JSON extraction boundary and contract test command.
- `docs/architecture/kamn-core-module-map.md`: adds flat JSON policy module to Kolme extraction map.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test flat_json_policy_contracts
```
Failed before implementation with unresolved imports:
- `no parse_flat_json_value_fields in the root`
- `no required_json_string_field in the root`
- `no required_positive_u64_json_field in the root`
- `no KolmeFlatJsonPolicyError in the root`
- `no KolmeFlatJsonValue in the root`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test flat_json_policy_contracts
```
Passes: `5 passed; 0 failed`.

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
cargo test -p kamn-kolme
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
All commands pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | flat-json required-field extraction/unit parsing checks in `flat_json_policy_contracts` | |
| Functional   | ✅     | mixed scalar object parsing + runtime HTTP transport/block fallback functional suites | |
| Integration  | ✅     | `kolme_runtime_commit_http_transport`, `kolme_runtime_commit_block_fallback` | |
| Regression   | ✅     | `regression_issue_1747_*` fail-closed parser tests + existing runtime regressions remain green | |
| Performance  | N/A    | Not a throughput-path change | Policy-only extraction; CI cost bounded via targeted suites |

## Risks & Rollback
- None breaking; intended behavior is parity-preserving.
- Rollback: revert this PR commit to restore in-core parser helper block.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
