### PR TITLE
refactor(kolme): extract provider outcome parser contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -5,11 +5,13 @@ use kamn_kolme::{
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
+    deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     find_http_header_boundary as find_kolme_http_header_boundary,
     parse_flat_json_value_fields as parse_kolme_flat_json_value_fields,
     parse_fork_block_txhash as parse_kolme_fork_block_txhash,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
+    parse_live_provider_outcome as parse_kolme_live_provider_outcome,
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_provider_key_value_fields as parse_kolme_provider_key_value_fields,
     parse_provider_response_fields as parse_kolme_provider_response_fields,
@@ -20,6 +22,7 @@ use kamn_kolme::{
     required_json_string_field as required_kolme_json_string_field,
     required_positive_u64_json_field as required_kolme_positive_u64_json_field,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
+    txhash_from_commit_id as txhash_from_kolme_commit_id,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
     validate_direct_signed_transaction_message as validate_kolme_direct_signed_transaction_message,
@@ -38,6 +41,8 @@ use kamn_kolme::{
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeParsedWebsocketEndpoint as KamnKolmeParsedWebsocketEndpoint,
+    KolmeProviderOutcome as KamnKolmeProviderOutcome,
+    KolmeProviderOutcomePolicyError as KamnKolmeProviderOutcomePolicyError,
     KolmeProviderResponsePolicyError as KamnKolmeProviderResponsePolicyError,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError, KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
@@ -1782,6 +1787,14 @@ fn map_provider_response_policy_error_to_malformed(
     }
 }
 
+fn map_provider_outcome_policy_error_to_malformed(
+    error: KamnKolmeProviderOutcomePolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
 fn map_flat_json_policy_error_to_malformed(
     error: KamnKolmeFlatJsonPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
@@ -2239,70 +2252,34 @@ fn parse_live_provider_response(
     response: &str,
     provider_hint: Option<&str>,
 ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
-    let fields = parse_kolme_provider_response_fields(response)
-        .map_err(map_provider_response_policy_error_to_malformed)?;
-    if let Some(status_raw) = fields.get("status") {
-        let status = status_raw.trim();
-        if status.is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "field must not be empty: status".to_owned(),
-            });
-        }
-        match status {
-            "submitted" | "duplicate" => {
-                let provider = required_response_field(&fields, "provider")?;
-                let commit_id = resolve_commit_id(&fields)?;
-                let finality_value = required_response_field(&fields, "finality")?;
-                let finality = parse_receipt_finality(finality_value.as_str())?;
-                let receipt = KolmeRuntimeCommitProviderReceipt {
-                    provider,
-                    commit_id,
-                    finality,
-                };
-                if status == "submitted" {
-                    Ok(KolmeRuntimeCommitProviderOutcome::Submitted(receipt))
-                } else {
-                    Ok(KolmeRuntimeCommitProviderOutcome::Duplicate(receipt))
-                }
-            }
-            "rejected" => {
-                let reason = required_response_field(&fields, "reason")?;
-                Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
-            }
-            _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid status value: {status}"),
-            }),
-        }
-    } else {
-        let has_tx_hash = fields.contains_key("txhash") || fields.contains_key("tx_hash");
-        if !has_tx_hash {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "missing required field: status".to_owned(),
-            });
-        }
-
-        let provider = optional_response_field(&fields, "provider").or_else(|| {
-            provider_hint
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned)
-        });
-        let provider =
-            provider.ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "missing required field: provider".to_owned(),
-            })?;
-        let commit_id = resolve_commit_id(&fields)?;
-        let finality = match optional_response_field(&fields, "finality") {
-            Some(raw_finality) => parse_receipt_finality(raw_finality.as_str())?,
-            None => KolmeCommitReceiptFinality::Pending,
-        };
-        Ok(KolmeRuntimeCommitProviderOutcome::Submitted(
+    match parse_kolme_live_provider_outcome(response, provider_hint)
+        .map_err(map_provider_outcome_policy_error_to_malformed)?
+    {
+        KamnKolmeProviderOutcome::Submitted {
+            provider,
+            commit_id,
+            finality,
+        } => Ok(KolmeRuntimeCommitProviderOutcome::Submitted(
             KolmeRuntimeCommitProviderReceipt {
                 provider,
                 commit_id,
-                finality,
+                finality: map_extracted_receipt_finality(finality),
             },
-        ))
+        )),
+        KamnKolmeProviderOutcome::Duplicate {
+            provider,
+            commit_id,
+            finality,
+        } => Ok(KolmeRuntimeCommitProviderOutcome::Duplicate(
+            KolmeRuntimeCommitProviderReceipt {
+                provider,
+                commit_id,
+                finality: map_extracted_receipt_finality(finality),
+            },
+        )),
+        KamnKolmeProviderOutcome::Rejected { reason } => {
+            Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
+        }
     }
 }
 
@@ -2338,18 +2315,6 @@ fn required_response_field(
         });
     }
     Ok(trimmed.to_owned())
-}
-
-fn optional_response_field(
-    fields: &HashMap<String, String>,
-    field: &'static str,
-) -> Option<String> {
-    let value = fields.get(field)?;
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    Some(trimmed.to_owned())
 }
 
 fn resolve_commit_id(
@@ -2407,41 +2372,11 @@ fn parse_block_height(raw: &str) -> Result<u64, KolmeRuntimeCommitProviderError>
 }
 
 fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> String {
-    match block_height {
-        Some(height) => format!("kolme-commit:{tx_hash}:h{height}"),
-        None => format!("kolme-commit:{tx_hash}"),
-    }
+    deterministic_kolme_backend_commit_id(tx_hash, block_height)
 }
 
 fn txhash_from_commit_id(commit_id: &str) -> Result<String, KolmeRuntimeCommitProviderError> {
-    let commit_id = commit_id.trim();
-    if commit_id.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "commit_id must not be empty".to_owned(),
-        });
-    }
-    let without_prefix = commit_id.strip_prefix("kolme-commit:").ok_or_else(|| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "commit_id must start with 'kolme-commit:'".to_owned(),
-        }
-    })?;
-
-    let (txhash, block_suffix) = match without_prefix.split_once(":h") {
-        Some((txhash, suffix)) => (txhash, Some(suffix)),
-        None => (without_prefix, None),
-    };
-    let txhash = txhash.trim();
-    if txhash.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "commit_id txhash segment must not be empty".to_owned(),
-        });
-    }
-
-    if let Some(raw_height) = block_suffix {
-        parse_block_height(raw_height)?;
-    }
-
-    Ok(txhash.to_owned())
+    txhash_from_kolme_commit_id(commit_id).map_err(map_provider_outcome_policy_error_to_malformed)
 }
 
 fn parse_receipt_finality(
@@ -2455,6 +2390,14 @@ fn parse_receipt_finality(
         ReceiptFinality::Pending => Ok(KolmeCommitReceiptFinality::Pending),
         ReceiptFinality::Final => Ok(KolmeCommitReceiptFinality::Final),
         ReceiptFinality::Failed => Ok(KolmeCommitReceiptFinality::Failed),
+    }
+}
+
+fn map_extracted_receipt_finality(finality: ReceiptFinality) -> KolmeCommitReceiptFinality {
+    match finality {
+        ReceiptFinality::Pending => KolmeCommitReceiptFinality::Pending,
+        ReceiptFinality::Final => KolmeCommitReceiptFinality::Final,
+        ReceiptFinality::Failed => KolmeCommitReceiptFinality::Failed,
     }
 }
 

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -13,6 +13,7 @@ pub mod flat_json_policy;
 pub mod http_response_policy;
 pub mod notification_policy;
 pub mod pipeline;
+pub mod provider_outcome_policy;
 pub mod provider_response_policy;
 pub mod receipt_finality;
 pub mod tls_policy;
@@ -44,6 +45,10 @@ pub use notification_policy::{
     parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
+pub use provider_outcome_policy::{
+    deterministic_backend_commit_id, parse_live_provider_outcome, txhash_from_commit_id,
+    KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
+};
 pub use provider_response_policy::{
     parse_provider_key_value_fields, parse_provider_response_fields,
     KolmeProviderResponsePolicyError,

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -1,0 +1,273 @@
+//! Provider outcome parsing and commit-id helper contracts for runtime commits.
+
+use crate::{
+    parse_provider_response_fields, parse_receipt_finality, KolmeProviderResponsePolicyError,
+    ReceiptFinality, ReceiptFinalityError,
+};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+/// Typed provider outcome extracted from one live response payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeProviderOutcome {
+    /// Provider accepted a new request submission.
+    Submitted {
+        /// Provider identifier.
+        provider: String,
+        /// Deterministic backend commit id.
+        commit_id: String,
+        /// Parsed receipt finality.
+        finality: ReceiptFinality,
+    },
+    /// Provider detected duplicate idempotency key.
+    Duplicate {
+        /// Provider identifier.
+        provider: String,
+        /// Deterministic backend commit id.
+        commit_id: String,
+        /// Parsed receipt finality.
+        finality: ReceiptFinality,
+    },
+    /// Provider rejected request with explicit reason.
+    Rejected {
+        /// Rejection reason.
+        reason: String,
+    },
+}
+
+/// Error returned by provider outcome parser and commit-id helper contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeProviderOutcomePolicyError {
+    /// Response payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeProviderOutcomePolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedResponse { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeProviderOutcomePolicyError {}
+
+/// Parses a live provider response payload into one typed provider outcome.
+pub fn parse_live_provider_outcome(
+    response: &str,
+    provider_hint: Option<&str>,
+) -> Result<KolmeProviderOutcome, KolmeProviderOutcomePolicyError> {
+    let fields = parse_provider_response_fields(response).map_err(map_provider_response_error)?;
+    if let Some(status_raw) = fields.get("status") {
+        let status = status_raw.trim();
+        if status.is_empty() {
+            return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: "field must not be empty: status".to_owned(),
+            });
+        }
+        match status {
+            "submitted" | "duplicate" => {
+                let provider = required_response_field(&fields, "provider")?;
+                let commit_id = resolve_commit_id(&fields)?;
+                let finality_value = required_response_field(&fields, "finality")?;
+                let finality =
+                    parse_receipt_finality(finality_value.as_str()).map_err(map_finality_error)?;
+                if status == "submitted" {
+                    Ok(KolmeProviderOutcome::Submitted {
+                        provider,
+                        commit_id,
+                        finality,
+                    })
+                } else {
+                    Ok(KolmeProviderOutcome::Duplicate {
+                        provider,
+                        commit_id,
+                        finality,
+                    })
+                }
+            }
+            "rejected" => {
+                let reason = required_response_field(&fields, "reason")?;
+                Ok(KolmeProviderOutcome::Rejected { reason })
+            }
+            _ => Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: format!("invalid status value: {status}"),
+            }),
+        }
+    } else {
+        let has_tx_hash = fields.contains_key("txhash") || fields.contains_key("tx_hash");
+        if !has_tx_hash {
+            return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: "missing required field: status".to_owned(),
+            });
+        }
+
+        let provider = optional_response_field(&fields, "provider").or_else(|| {
+            provider_hint
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        });
+        let provider =
+            provider.ok_or_else(|| KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: "missing required field: provider".to_owned(),
+            })?;
+        let commit_id = resolve_commit_id(&fields)?;
+        let finality = match optional_response_field(&fields, "finality") {
+            Some(raw_finality) => {
+                parse_receipt_finality(raw_finality.as_str()).map_err(map_finality_error)?
+            }
+            None => ReceiptFinality::Pending,
+        };
+        Ok(KolmeProviderOutcome::Submitted {
+            provider,
+            commit_id,
+            finality,
+        })
+    }
+}
+
+/// Builds deterministic backend commit id from tx hash and optional block height.
+pub fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> String {
+    match block_height {
+        Some(height) => format!("kolme-commit:{tx_hash}:h{height}"),
+        None => format!("kolme-commit:{tx_hash}"),
+    }
+}
+
+/// Parses tx hash segment out of deterministic backend commit id format.
+pub fn txhash_from_commit_id(commit_id: &str) -> Result<String, KolmeProviderOutcomePolicyError> {
+    let commit_id = commit_id.trim();
+    if commit_id.is_empty() {
+        return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "commit_id must not be empty".to_owned(),
+        });
+    }
+    let without_prefix = commit_id.strip_prefix("kolme-commit:").ok_or_else(|| {
+        KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "commit_id must start with 'kolme-commit:'".to_owned(),
+        }
+    })?;
+
+    let (txhash, block_suffix) = match without_prefix.split_once(":h") {
+        Some((txhash, suffix)) => (txhash, Some(suffix)),
+        None => (without_prefix, None),
+    };
+    let txhash = txhash.trim();
+    if txhash.is_empty() {
+        return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "commit_id txhash segment must not be empty".to_owned(),
+        });
+    }
+
+    if let Some(raw_height) = block_suffix {
+        parse_block_height(raw_height)?;
+    }
+
+    Ok(txhash.to_owned())
+}
+
+fn required_response_field(
+    fields: &HashMap<String, String>,
+    field: &'static str,
+) -> Result<String, KolmeProviderOutcomePolicyError> {
+    let value =
+        fields
+            .get(field)
+            .ok_or_else(|| KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: format!("missing required field: {field}"),
+            })?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: format!("field must not be empty: {field}"),
+        });
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn optional_response_field(
+    fields: &HashMap<String, String>,
+    field: &'static str,
+) -> Option<String> {
+    let value = fields.get(field)?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_owned())
+}
+
+fn resolve_commit_id(
+    fields: &HashMap<String, String>,
+) -> Result<String, KolmeProviderOutcomePolicyError> {
+    if let Some(commit_id) = fields.get("commit_id") {
+        let trimmed = commit_id.trim();
+        if trimmed.is_empty() {
+            return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: "field must not be empty: commit_id".to_owned(),
+            });
+        }
+        return Ok(trimmed.to_owned());
+    }
+
+    let tx_hash = fields
+        .get("tx_hash")
+        .or_else(|| fields.get("txhash"))
+        .ok_or_else(|| KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "missing required field: commit_id".to_owned(),
+        })?;
+    let tx_hash = tx_hash.trim();
+    if tx_hash.is_empty() {
+        return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "field must not be empty: tx_hash".to_owned(),
+        });
+    }
+
+    let block_height = match fields.get("block_height") {
+        Some(raw_height) => Some(parse_block_height(raw_height.as_str())?),
+        None => None,
+    };
+    Ok(deterministic_backend_commit_id(tx_hash, block_height))
+}
+
+fn parse_block_height(raw: &str) -> Result<u64, KolmeProviderOutcomePolicyError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "field must not be empty: block_height".to_owned(),
+        });
+    }
+    let height =
+        trimmed
+            .parse::<u64>()
+            .map_err(|_| KolmeProviderOutcomePolicyError::MalformedResponse {
+                reason: format!("invalid block_height value: {trimmed}"),
+            })?;
+    if height == 0 {
+        return Err(KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "block_height must be positive".to_owned(),
+        });
+    }
+    Ok(height)
+}
+
+fn map_provider_response_error(
+    error: KolmeProviderResponsePolicyError,
+) -> KolmeProviderOutcomePolicyError {
+    match error {
+        KolmeProviderResponsePolicyError::MalformedResponse { reason } => {
+            KolmeProviderOutcomePolicyError::MalformedResponse { reason }
+        }
+    }
+}
+
+fn map_finality_error(error: ReceiptFinalityError) -> KolmeProviderOutcomePolicyError {
+    KolmeProviderOutcomePolicyError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,0 +1,71 @@
+use kamn_kolme::{
+    deterministic_backend_commit_id, parse_live_provider_outcome, txhash_from_commit_id,
+    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, ReceiptFinality,
+};
+
+#[test]
+fn functional_parse_live_provider_outcome_maps_submitted_status() {
+    let response =
+        "status=submitted\nprovider=kolme-fork\ncommit_id=kolme-commit:ab12cd34\nfinality=final\n";
+    let outcome = parse_live_provider_outcome(response, None).expect("response should parse");
+    assert_eq!(
+        outcome,
+        KolmeProviderOutcome::Submitted {
+            provider: "kolme-fork".to_owned(),
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: ReceiptFinality::Final,
+        }
+    );
+}
+
+#[test]
+fn functional_parse_live_provider_outcome_uses_provider_hint_for_txhash_only_shape() {
+    let outcome = parse_live_provider_outcome("{\"txhash\":\"ab12cd34\"}", Some("kolme-fork"))
+        .expect("txhash-only response should parse");
+    assert_eq!(
+        outcome,
+        KolmeProviderOutcome::Submitted {
+            provider: "kolme-fork".to_owned(),
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: ReceiptFinality::Pending,
+        }
+    );
+}
+
+#[test]
+fn unit_deterministic_backend_commit_id_includes_optional_height() {
+    assert_eq!(
+        deterministic_backend_commit_id("ab12cd34", Some(72)),
+        "kolme-commit:ab12cd34:h72".to_owned()
+    );
+    assert_eq!(
+        deterministic_backend_commit_id("ab12cd34", None),
+        "kolme-commit:ab12cd34".to_owned()
+    );
+}
+
+#[test]
+fn regression_issue_1749_parse_live_provider_outcome_rejects_missing_status_and_txhash() {
+    // Regression: #1749
+    let error = parse_live_provider_outcome("provider=kolme-fork\n", None)
+        .expect_err("missing status/txhash should fail closed");
+    assert_eq!(
+        error,
+        KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "missing required field: status".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1749_txhash_from_commit_id_rejects_invalid_prefix() {
+    // Regression: #1749
+    let error =
+        txhash_from_commit_id("commit:ab12cd34").expect_err("invalid commit_id prefix must fail");
+    assert_eq!(
+        error,
+        KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "commit_id must start with 'kolme-commit:'".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -115,7 +115,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
-    `crates/kamn-kolme/src/provider_response_policy.rs`, `crates/kamn-kolme/src/flat_json_policy.rs`
+    `crates/kamn-kolme/src/provider_response_policy.rs`, `crates/kamn-kolme/src/flat_json_policy.rs`,
+    `crates/kamn-kolme/src/provider_outcome_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -35,6 +35,7 @@ handling.
   - `crates/kamn-kolme/src/endpoint_policy.rs` owns HTTP/WebSocket endpoint parsing and URL composition contracts.
   - `crates/kamn-kolme/src/http_response_policy.rs` owns HTTP response status/content parsing contracts.
   - `crates/kamn-kolme/src/flat_json_policy.rs` owns flat JSON scalar/object parsing contracts used by broadcast normalization and block-fallback field extraction.
+  - `crates/kamn-kolme/src/provider_outcome_policy.rs` owns live provider outcome parsing and commit-id helper contracts.
   - `crates/kamn-kolme/src/provider_response_policy.rs` owns provider response field parsing contracts (key/value + flat JSON string object formats).
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
 - Optional auth-aware constructor:
@@ -68,6 +69,7 @@ handling.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
   - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
+  - provider outcome and commit-id helper contracts are sourced from `kamn-kolme` (`parse_live_provider_outcome`, `deterministic_backend_commit_id`, `txhash_from_commit_id`) and mapped through `kamn-core` compatibility wrappers.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.
@@ -157,6 +159,7 @@ cargo test -p kamn-kolme --test http_response_policy_contracts
 cargo test -p kamn-kolme --test tls_policy_contracts
 cargo test -p kamn-kolme --test provider_response_policy_contracts
 cargo test -p kamn-kolme --test flat_json_policy_contracts
+cargo test -p kamn-kolme --test provider_outcome_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -185,3 +188,4 @@ cargo test -p kamn-core
 - typed nonce/broadcast HTTP helper mapping drift remains fail-closed (`Regression: #1533`).
 - provider response field parser extraction parity drift remains fail-closed (`Regression: #1745`).
 - flat JSON parser extraction parity drift remains fail-closed (`Regression: #1747`).
+- provider outcome and commit-id parser extraction parity drift remains fail-closed (`Regression: #1749`).


### PR DESCRIPTION
## Summary
Extracts live provider outcome parsing and commit-id helper contracts from `kamn-core` into `kamn-kolme`, then rewires core runtime-commit adapters to delegate via extracted policies. This removes another high-density policy block from `kolme_runtime_commit.rs` while preserving fail-closed behavior.

Closes #1749
Refs #1714

## Changes
- `crates/kamn-kolme/src/provider_outcome_policy.rs`: new contracts for live provider outcome parsing + deterministic commit-id helpers.
- `crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs`: unit/functional/regression contract tests (`Regression: #1749`).
- `crates/kamn-kolme/src/lib.rs`: exports for provider outcome policy API.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegates live provider response parsing and commit-id helper behavior to `kamn-kolme`; removes duplicated core logic for this path.
- `docs/foundation/kolme-runtime-commit-client.md`: documents provider outcome policy extraction and contract lane command.
- `docs/architecture/kamn-core-module-map.md`: adds provider outcome policy module to Kolme extraction map.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test provider_outcome_policy_contracts
```
Failed before implementation with unresolved imports:
- `no deterministic_backend_commit_id in the root`
- `no parse_live_provider_outcome in the root`
- `no txhash_from_commit_id in the root`
- `no KolmeProviderOutcome in the root`
- `no KolmeProviderOutcomePolicyError in the root`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test provider_outcome_policy_contracts
```
Passes: `5 passed; 0 failed`.

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
All commands pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | deterministic commit-id helper tests in `provider_outcome_policy_contracts` | |
| Functional   | ✅     | submitted + txhash-only provider outcome parse behavior tests | |
| Integration  | ✅     | runtime suites: `kolme_runtime_commit_http_transport`, `kolme_runtime_commit_fork_finality_resolver`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_block_fallback` | |
| Regression   | ✅     | `regression_issue_1749_*` malformed parse fail-closed tests + existing runtime regressions green | |
| Performance  | N/A    | Not a throughput-path change | Policy extraction only; targeted validation keeps CI cost low |

## Risks & Rollback
- None breaking; behavior intended to be parity-preserving.
- Rollback: revert this PR commit to restore in-core provider outcome helper block.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
