### PR TITLE
refactor(kolme): extract block fallback parser contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -7,8 +7,9 @@ use kamn_kolme::{
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     find_http_header_boundary as find_kolme_http_header_boundary,
+    parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
     parse_flat_json_value_fields as parse_kolme_flat_json_value_fields,
-    parse_fork_block_txhash as parse_kolme_fork_block_txhash,
+    parse_fork_block_fallback_response as parse_kolme_fork_block_fallback_response_contract,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
     parse_live_provider_outcome as parse_kolme_live_provider_outcome,
@@ -33,6 +34,8 @@ use kamn_kolme::{
     KolmeApiCodecError as KamnKolmeApiCodecError,
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
+    KolmeBlockFallbackPolicyError as KamnKolmeBlockFallbackPolicyError,
+    KolmeBlockFallbackResponse as KamnKolmeBlockFallbackResponse,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
     KolmeFlatJsonPolicyError as KamnKolmeFlatJsonPolicyError,
     KolmeFlatJsonValue as KamnKolmeFlatJsonValue,
@@ -746,14 +749,7 @@ enum KolmeRuntimeCommitSubmitProfile {
 
 type ParsedHttpEndpoint = KamnKolmeParsedHttpEndpoint;
 type ParsedWebsocketEndpoint = KamnKolmeParsedWebsocketEndpoint;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedBlockFallbackResponse {
-    provider: String,
-    block_height: u64,
-    finalized_tx_hashes: Vec<String>,
-    failed_tx_hashes: Vec<String>,
-}
+type ParsedBlockFallbackResponse = KamnKolmeBlockFallbackResponse;
 
 type HttpScheme = KamnKolmeHttpScheme;
 
@@ -1755,6 +1751,14 @@ fn map_lookup_window_error(error: BlockScanPolicyError) -> KolmeRuntimeCommitPro
     }
 }
 
+fn map_block_fallback_policy_error_to_malformed(
+    error: KamnKolmeBlockFallbackPolicyError,
+) -> KolmeRuntimeCommitProviderError {
+    KolmeRuntimeCommitProviderError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
 fn map_endpoint_policy_error(
     error: KamnKolmeEndpointPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
@@ -1863,41 +1867,8 @@ fn render_block_path(
 fn parse_block_fallback_response(
     response: &str,
 ) -> Result<ParsedBlockFallbackResponse, KolmeRuntimeCommitProviderError> {
-    let trimmed = response.trim();
-    if trimmed.starts_with('{') {
-        let fields = parse_kolme_flat_json_value_fields(trimmed)
-            .map_err(map_flat_json_policy_error_to_malformed)?;
-        let provider = required_kolme_json_string_field(&fields, "provider")
-            .map_err(map_flat_json_policy_error_to_malformed)?;
-        let block_height = required_block_height_json_field(&fields)?;
-        let finalized_tx_hashes = optional_json_block_tx_hashes(&fields, "tx_hashes")?;
-        let failed_tx_hashes = optional_json_block_tx_hashes(&fields, "failed_tx_hashes")?;
-        return Ok(ParsedBlockFallbackResponse {
-            provider,
-            block_height,
-            finalized_tx_hashes,
-            failed_tx_hashes,
-        });
-    }
-
-    let fields = parse_kolme_provider_response_fields(trimmed)
-        .map_err(map_provider_response_policy_error_to_malformed)?;
-    let provider = required_response_field(&fields, "provider")?;
-    let block_height = fields
-        .get("block_height")
-        .or_else(|| fields.get("height"))
-        .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "missing required field: block_height".to_owned(),
-        })
-        .and_then(|value| parse_block_height(value.as_str()))?;
-    let finalized_tx_hashes = optional_block_tx_hashes(&fields, "tx_hashes")?;
-    let failed_tx_hashes = optional_block_tx_hashes(&fields, "failed_tx_hashes")?;
-    Ok(ParsedBlockFallbackResponse {
-        provider,
-        block_height,
-        finalized_tx_hashes,
-        failed_tx_hashes,
-    })
+    parse_kolme_block_fallback_response_contract(response)
+        .map_err(map_block_fallback_policy_error_to_malformed)
 }
 
 fn parse_kolme_fork_block_fallback_response(
@@ -1905,90 +1876,8 @@ fn parse_kolme_fork_block_fallback_response(
     provider: &str,
     expected_height: u64,
 ) -> Result<ParsedBlockFallbackResponse, KolmeRuntimeCommitProviderError> {
-    let provider = provider.trim();
-    if provider.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "provider must not be empty".to_owned(),
-        });
-    }
-    if expected_height == 0 {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "expected block height must be positive".to_owned(),
-        });
-    }
-    let txhash = parse_kolme_fork_block_txhash(response)
-        .map_err(map_block_scan_policy_error_to_malformed)?;
-
-    Ok(ParsedBlockFallbackResponse {
-        provider: provider.to_owned(),
-        block_height: expected_height,
-        finalized_tx_hashes: vec![txhash],
-        failed_tx_hashes: Vec::new(),
-    })
-}
-
-fn optional_block_tx_hashes(
-    fields: &HashMap<String, String>,
-    field: &'static str,
-) -> Result<Vec<String>, KolmeRuntimeCommitProviderError> {
-    let Some(value) = fields.get(field) else {
-        return Ok(Vec::new());
-    };
-    parse_tx_hash_list(value, field)
-}
-
-fn parse_tx_hash_list(
-    raw: &str,
-    field: &'static str,
-) -> Result<Vec<String>, KolmeRuntimeCommitProviderError> {
-    if raw.trim().is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("field must not be empty: {field}"),
-        });
-    }
-    let mut values = Vec::new();
-    for token in raw.split(',') {
-        let txhash = token.trim();
-        if txhash.is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("field contains empty tx hash token: {field}"),
-            });
-        }
-        values.push(txhash.to_owned());
-    }
-    Ok(values)
-}
-
-fn required_block_height_json_field(
-    fields: &HashMap<String, KamnKolmeFlatJsonValue>,
-) -> Result<u64, KolmeRuntimeCommitProviderError> {
-    if fields.contains_key("block_height") {
-        return required_kolme_positive_u64_json_field(fields, "block_height")
-            .map_err(map_flat_json_policy_error_to_malformed);
-    }
-    if fields.contains_key("height") {
-        return required_kolme_positive_u64_json_field(fields, "height")
-            .map_err(map_flat_json_policy_error_to_malformed);
-    }
-    Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: "missing required field: block_height".to_owned(),
-    })
-}
-
-fn optional_json_block_tx_hashes(
-    fields: &HashMap<String, KamnKolmeFlatJsonValue>,
-    field: &'static str,
-) -> Result<Vec<String>, KolmeRuntimeCommitProviderError> {
-    let Some(value) = fields.get(field) else {
-        return Ok(Vec::new());
-    };
-    match value {
-        KamnKolmeFlatJsonValue::Null => Ok(Vec::new()),
-        KamnKolmeFlatJsonValue::String(raw) => parse_tx_hash_list(raw, field),
-        _ => Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("field must be string|null: {field}"),
-        }),
-    }
+    parse_kolme_fork_block_fallback_response_contract(response, provider, expected_height)
+        .map_err(map_block_fallback_policy_error_to_malformed)
 }
 
 fn compose_notifications_websocket_url(

--- a/crates/kamn-kolme/src/block_fallback_policy.rs
+++ b/crates/kamn-kolme/src/block_fallback_policy.rs
@@ -1,0 +1,236 @@
+//! Block-fallback response parsing contracts for Kolme reconciliation flows.
+
+use crate::{
+    parse_flat_json_value_fields, parse_fork_block_txhash, parse_provider_response_fields,
+    required_json_string_field, required_positive_u64_json_field, BlockScanPolicyError,
+    KolmeFlatJsonPolicyError, KolmeFlatJsonValue, KolmeProviderResponsePolicyError,
+};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+/// Parsed block-fallback response used by reconciliation paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeBlockFallbackResponse {
+    /// Provider identifier.
+    pub provider: String,
+    /// Block height for this lookup response.
+    pub block_height: u64,
+    /// Finalized tx hash candidates observed in this block.
+    pub finalized_tx_hashes: Vec<String>,
+    /// Failed tx hash candidates observed in this block.
+    pub failed_tx_hashes: Vec<String>,
+}
+
+/// Error returned by block-fallback parsing contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeBlockFallbackPolicyError {
+    /// Response payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeBlockFallbackPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedResponse { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeBlockFallbackPolicyError {}
+
+/// Parses one block-fallback response payload into typed fallback fields.
+pub fn parse_block_fallback_response(
+    response: &str,
+) -> Result<KolmeBlockFallbackResponse, KolmeBlockFallbackPolicyError> {
+    let trimmed = response.trim();
+    if trimmed.starts_with('{') {
+        let fields = parse_flat_json_value_fields(trimmed).map_err(map_flat_json_error)?;
+        let provider =
+            required_json_string_field(&fields, "provider").map_err(map_flat_json_error)?;
+        let block_height = required_block_height_json_field(&fields)?;
+        let finalized_tx_hashes = optional_json_block_tx_hashes(&fields, "tx_hashes")?;
+        let failed_tx_hashes = optional_json_block_tx_hashes(&fields, "failed_tx_hashes")?;
+        return Ok(KolmeBlockFallbackResponse {
+            provider,
+            block_height,
+            finalized_tx_hashes,
+            failed_tx_hashes,
+        });
+    }
+
+    let fields = parse_provider_response_fields(trimmed).map_err(map_provider_response_error)?;
+    let provider = required_response_field(&fields, "provider")?;
+    let block_height = fields
+        .get("block_height")
+        .or_else(|| fields.get("height"))
+        .ok_or_else(|| KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "missing required field: block_height".to_owned(),
+        })
+        .and_then(|value| parse_block_height(value.as_str()))?;
+    let finalized_tx_hashes = optional_block_tx_hashes(&fields, "tx_hashes")?;
+    let failed_tx_hashes = optional_block_tx_hashes(&fields, "failed_tx_hashes")?;
+    Ok(KolmeBlockFallbackResponse {
+        provider,
+        block_height,
+        finalized_tx_hashes,
+        failed_tx_hashes,
+    })
+}
+
+/// Parses fork block fallback payload and maps txhash to finalized fallback fields.
+pub fn parse_fork_block_fallback_response(
+    response: &str,
+    provider: &str,
+    expected_height: u64,
+) -> Result<KolmeBlockFallbackResponse, KolmeBlockFallbackPolicyError> {
+    let provider = provider.trim();
+    if provider.is_empty() {
+        return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "provider must not be empty".to_owned(),
+        });
+    }
+    if expected_height == 0 {
+        return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "expected block height must be positive".to_owned(),
+        });
+    }
+
+    let txhash = parse_fork_block_txhash(response).map_err(map_block_scan_error)?;
+    Ok(KolmeBlockFallbackResponse {
+        provider: provider.to_owned(),
+        block_height: expected_height,
+        finalized_tx_hashes: vec![txhash],
+        failed_tx_hashes: Vec::new(),
+    })
+}
+
+fn optional_block_tx_hashes(
+    fields: &HashMap<String, String>,
+    field: &'static str,
+) -> Result<Vec<String>, KolmeBlockFallbackPolicyError> {
+    let Some(value) = fields.get(field) else {
+        return Ok(Vec::new());
+    };
+    parse_tx_hash_list(value, field)
+}
+
+fn parse_tx_hash_list(
+    raw: &str,
+    field: &'static str,
+) -> Result<Vec<String>, KolmeBlockFallbackPolicyError> {
+    if raw.trim().is_empty() {
+        return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: format!("field must not be empty: {field}"),
+        });
+    }
+    let mut values = Vec::new();
+    for token in raw.split(',') {
+        let txhash = token.trim();
+        if txhash.is_empty() {
+            return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+                reason: format!("field contains empty tx hash token: {field}"),
+            });
+        }
+        values.push(txhash.to_owned());
+    }
+    Ok(values)
+}
+
+fn required_block_height_json_field(
+    fields: &HashMap<String, KolmeFlatJsonValue>,
+) -> Result<u64, KolmeBlockFallbackPolicyError> {
+    if fields.contains_key("block_height") {
+        return required_positive_u64_json_field(fields, "block_height")
+            .map_err(map_flat_json_error);
+    }
+    if fields.contains_key("height") {
+        return required_positive_u64_json_field(fields, "height").map_err(map_flat_json_error);
+    }
+    Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+        reason: "missing required field: block_height".to_owned(),
+    })
+}
+
+fn optional_json_block_tx_hashes(
+    fields: &HashMap<String, KolmeFlatJsonValue>,
+    field: &'static str,
+) -> Result<Vec<String>, KolmeBlockFallbackPolicyError> {
+    let Some(value) = fields.get(field) else {
+        return Ok(Vec::new());
+    };
+    match value {
+        KolmeFlatJsonValue::Null => Ok(Vec::new()),
+        KolmeFlatJsonValue::String(raw) => parse_tx_hash_list(raw, field),
+        _ => Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: format!("field must be string|null: {field}"),
+        }),
+    }
+}
+
+fn required_response_field(
+    fields: &HashMap<String, String>,
+    field: &'static str,
+) -> Result<String, KolmeBlockFallbackPolicyError> {
+    let value =
+        fields
+            .get(field)
+            .ok_or_else(|| KolmeBlockFallbackPolicyError::MalformedResponse {
+                reason: format!("missing required field: {field}"),
+            })?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: format!("field must not be empty: {field}"),
+        });
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn parse_block_height(raw: &str) -> Result<u64, KolmeBlockFallbackPolicyError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "field must not be empty: block_height".to_owned(),
+        });
+    }
+    let height =
+        trimmed
+            .parse::<u64>()
+            .map_err(|_| KolmeBlockFallbackPolicyError::MalformedResponse {
+                reason: format!("invalid block_height value: {trimmed}"),
+            })?;
+    if height == 0 {
+        return Err(KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "block_height must be positive".to_owned(),
+        });
+    }
+    Ok(height)
+}
+
+fn map_block_scan_error(error: BlockScanPolicyError) -> KolmeBlockFallbackPolicyError {
+    KolmeBlockFallbackPolicyError::MalformedResponse {
+        reason: error.to_string(),
+    }
+}
+
+fn map_provider_response_error(
+    error: KolmeProviderResponsePolicyError,
+) -> KolmeBlockFallbackPolicyError {
+    match error {
+        KolmeProviderResponsePolicyError::MalformedResponse { reason } => {
+            KolmeBlockFallbackPolicyError::MalformedResponse { reason }
+        }
+    }
+}
+
+fn map_flat_json_error(error: KolmeFlatJsonPolicyError) -> KolmeBlockFallbackPolicyError {
+    match error {
+        KolmeFlatJsonPolicyError::MalformedResponse { reason } => {
+            KolmeBlockFallbackPolicyError::MalformedResponse { reason }
+        }
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -5,6 +5,7 @@
 #![warn(missing_docs)]
 
 pub mod api_codec;
+pub mod block_fallback_policy;
 pub mod block_scan_policy;
 pub mod codec;
 pub mod endpoint_policy;
@@ -24,6 +25,10 @@ pub use api_codec::{
     validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
     KolmeApiBroadcastResponse, KolmeApiCodecError, KolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse,
+};
+pub use block_fallback_policy::{
+    parse_block_fallback_response, parse_fork_block_fallback_response,
+    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
     parse_fork_block_txhash, render_block_path, validate_block_identity,

--- a/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
@@ -1,0 +1,60 @@
+use kamn_kolme::{
+    parse_block_fallback_response, parse_fork_block_fallback_response,
+    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
+};
+
+#[test]
+fn functional_parse_block_fallback_response_accepts_flat_json_shape() {
+    let response = parse_block_fallback_response(
+        "{\"provider\":\"kolme-fork-local\",\"block_height\":72,\"tx_hashes\":\"ab12cd34,ffee\",\"failed_tx_hashes\":\"deadbeef\"}",
+    )
+    .expect("flat json fallback response should parse");
+    assert_eq!(
+        response,
+        KolmeBlockFallbackResponse {
+            provider: "kolme-fork-local".to_owned(),
+            block_height: 72,
+            finalized_tx_hashes: vec!["ab12cd34".to_owned(), "ffee".to_owned()],
+            failed_tx_hashes: vec!["deadbeef".to_owned()],
+        }
+    );
+}
+
+#[test]
+fn functional_parse_fork_block_fallback_response_maps_txhash_to_finalized_bucket() {
+    let response =
+        parse_fork_block_fallback_response("{\"txhash\":\"ab12cd34\"}", "kolme-fork-local", 42)
+            .expect("fork fallback response should parse");
+    assert_eq!(response.provider, "kolme-fork-local");
+    assert_eq!(response.block_height, 42);
+    assert_eq!(response.finalized_tx_hashes, vec!["ab12cd34".to_owned()]);
+    assert!(response.failed_tx_hashes.is_empty());
+}
+
+#[test]
+fn regression_issue_1751_parse_block_fallback_response_rejects_empty_hash_token() {
+    // Regression: #1751
+    let error = parse_block_fallback_response(
+        "{\"provider\":\"kolme-fork-local\",\"block_height\":72,\"tx_hashes\":\"ab12cd34, ,ffee\"}",
+    )
+    .expect_err("empty tx hash list token must fail");
+    assert_eq!(
+        error,
+        KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "field contains empty tx hash token: tx_hashes".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1751_parse_fork_block_fallback_response_rejects_empty_provider() {
+    // Regression: #1751
+    let error = parse_fork_block_fallback_response("{\"txhash\":\"ab12cd34\"}", " ", 42)
+        .expect_err("empty provider must fail");
+    assert_eq!(
+        error,
+        KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "provider must not be empty".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -116,7 +116,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
     `crates/kamn-kolme/src/provider_response_policy.rs`, `crates/kamn-kolme/src/flat_json_policy.rs`,
-    `crates/kamn-kolme/src/provider_outcome_policy.rs`
+    `crates/kamn-kolme/src/provider_outcome_policy.rs`, `crates/kamn-kolme/src/block_fallback_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -35,6 +35,7 @@ handling.
   - `crates/kamn-kolme/src/endpoint_policy.rs` owns HTTP/WebSocket endpoint parsing and URL composition contracts.
   - `crates/kamn-kolme/src/http_response_policy.rs` owns HTTP response status/content parsing contracts.
   - `crates/kamn-kolme/src/flat_json_policy.rs` owns flat JSON scalar/object parsing contracts used by broadcast normalization and block-fallback field extraction.
+  - `crates/kamn-kolme/src/block_fallback_policy.rs` owns block-fallback response parsing contracts for key/value and flat-JSON payloads.
   - `crates/kamn-kolme/src/provider_outcome_policy.rs` owns live provider outcome parsing and commit-id helper contracts.
   - `crates/kamn-kolme/src/provider_response_policy.rs` owns provider response field parsing contracts (key/value + flat JSON string object formats).
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
@@ -69,6 +70,7 @@ handling.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
   - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
+  - block-fallback response parsing contracts are sourced from `kamn-kolme` (`parse_block_fallback_response`, `parse_fork_block_fallback_response`) and mapped through `kamn-core` compatibility wrappers.
   - provider outcome and commit-id helper contracts are sourced from `kamn-kolme` (`parse_live_provider_outcome`, `deterministic_backend_commit_id`, `txhash_from_commit_id`) and mapped through `kamn-core` compatibility wrappers.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
@@ -159,6 +161,7 @@ cargo test -p kamn-kolme --test http_response_policy_contracts
 cargo test -p kamn-kolme --test tls_policy_contracts
 cargo test -p kamn-kolme --test provider_response_policy_contracts
 cargo test -p kamn-kolme --test flat_json_policy_contracts
+cargo test -p kamn-kolme --test block_fallback_policy_contracts
 cargo test -p kamn-kolme --test provider_outcome_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
@@ -189,3 +192,4 @@ cargo test -p kamn-core
 - provider response field parser extraction parity drift remains fail-closed (`Regression: #1745`).
 - flat JSON parser extraction parity drift remains fail-closed (`Regression: #1747`).
 - provider outcome and commit-id parser extraction parity drift remains fail-closed (`Regression: #1749`).
+- block-fallback parser extraction parity drift remains fail-closed (`Regression: #1751`).


### PR DESCRIPTION
## Summary
Extracts block-fallback response parsing policy from `kamn-core` into `kamn-kolme`, then rewires core fallback wrappers to delegate through extracted contracts. This removes another parser helper cluster from `kolme_runtime_commit.rs` while preserving fail-closed behavior.

Closes #1751
Refs #1714

## Changes
- `crates/kamn-kolme/src/block_fallback_policy.rs`: new block-fallback parser contracts for key/value + flat-JSON payloads and fork fallback mapping.
- `crates/kamn-kolme/tests/block_fallback_policy_contracts.rs`: unit/functional/regression tests (`Regression: #1751`).
- `crates/kamn-kolme/src/lib.rs`: exports for block fallback policy API.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegates `parse_block_fallback_response` and fork fallback parser to `kamn-kolme`; removes duplicated helper cluster for this path.
- `docs/foundation/kolme-runtime-commit-client.md`: documents block-fallback policy extraction + contract test command.
- `docs/architecture/kamn-core-module-map.md`: adds `block_fallback_policy` module to Kolme extraction map.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test block_fallback_policy_contracts
```
Failed before implementation with unresolved imports:
- `no parse_block_fallback_response in the root`
- `no parse_fork_block_fallback_response in the root`
- `no KolmeBlockFallbackPolicyError in the root`
- `no KolmeBlockFallbackResponse in the root`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test block_fallback_policy_contracts
```
Passes: `4 passed; 0 failed`.

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_block_fallback
cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
All commands pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | hash-list + provider/height parser checks in `block_fallback_policy_contracts` | |
| Functional   | ✅     | valid flat-json and fork fallback parsing behavior tests | |
| Integration  | ✅     | runtime suites: `kolme_runtime_commit_block_fallback`, `kolme_runtime_commit_fork_finality_resolver`, `kolme_runtime_commit_http_transport` | |
| Regression   | ✅     | `regression_issue_1751_*` fail-closed parsing tests + existing runtime regressions remain green | |
| Performance  | N/A    | Not a throughput-path change | Policy-only extraction; targeted validation keeps CI costs low |

## Risks & Rollback
- None breaking; behavior is intended parity.
- Rollback: revert this PR commit to restore in-core fallback parser helpers.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
