### PR TITLE
refactor(kolme): reuse provider helper contracts in core

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -8,6 +8,7 @@ use kamn_kolme::{
     deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     find_http_header_boundary as find_kolme_http_header_boundary,
     parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
+    parse_commit_id_from_response_fields as parse_kolme_commit_id_from_response_fields,
     parse_flat_json_value_fields as parse_kolme_flat_json_value_fields,
     parse_fork_block_fallback_response as parse_kolme_fork_block_fallback_response_contract,
     parse_http_endpoint as parse_kolme_http_endpoint,
@@ -22,6 +23,7 @@ use kamn_kolme::{
     render_block_path as render_kolme_block_path,
     required_json_string_field as required_kolme_json_string_field,
     required_positive_u64_json_field as required_kolme_positive_u64_json_field,
+    required_provider_response_field as required_kolme_provider_response_field,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
     txhash_from_commit_id as txhash_from_kolme_commit_id,
     validate_block_identity as validate_kolme_block_identity,
@@ -1121,8 +1123,10 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
         )?;
         let fields = parse_kolme_provider_response_fields(response.as_str())
             .map_err(map_provider_response_policy_error_to_malformed)?;
-        let provider = required_response_field(&fields, "provider")?;
-        let observed_commit_id = resolve_commit_id(&fields)?;
+        let provider = required_kolme_provider_response_field(&fields, "provider")
+            .map_err(map_provider_outcome_policy_error_to_malformed)?;
+        let observed_commit_id = parse_kolme_commit_id_from_response_fields(&fields)
+            .map_err(map_provider_outcome_policy_error_to_malformed)?;
         if observed_commit_id != commit_id {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: format!(
@@ -1130,7 +1134,8 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
                 ),
             });
         }
-        let finality_value = required_response_field(&fields, "finality")?;
+        let finality_value = required_kolme_provider_response_field(&fields, "finality")
+            .map_err(map_provider_outcome_policy_error_to_malformed)?;
         let finality = parse_receipt_finality(finality_value.as_str())?;
         Ok(KolmeRuntimeCommitProviderReceipt {
             provider,
@@ -2084,7 +2089,8 @@ fn normalize_kolme_broadcast_payload(
             let message_fields = parse_kolme_provider_key_value_fields(envelope.message.as_str())
                 .map_err(map_provider_response_policy_error_to_malformed)?;
             let message_idempotency_key =
-                required_response_field(&message_fields, "idempotency_key")?;
+                required_kolme_provider_response_field(&message_fields, "idempotency_key")
+                    .map_err(map_provider_outcome_policy_error_to_malformed)?;
             if message_idempotency_key != idempotency_key {
                 return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                     reason:
@@ -2185,79 +2191,6 @@ fn json_escape(value: &str) -> String {
         }
     }
     escaped
-}
-
-fn required_response_field(
-    fields: &HashMap<String, String>,
-    field: &'static str,
-) -> Result<String, KolmeRuntimeCommitProviderError> {
-    let value =
-        fields
-            .get(field)
-            .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("missing required field: {field}"),
-            })?;
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: format!("field must not be empty: {field}"),
-        });
-    }
-    Ok(trimmed.to_owned())
-}
-
-fn resolve_commit_id(
-    fields: &HashMap<String, String>,
-) -> Result<String, KolmeRuntimeCommitProviderError> {
-    if let Some(commit_id) = fields.get("commit_id") {
-        let trimmed = commit_id.trim();
-        if trimmed.is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "field must not be empty: commit_id".to_owned(),
-            });
-        }
-        return Ok(trimmed.to_owned());
-    }
-
-    let tx_hash = fields
-        .get("tx_hash")
-        .or_else(|| fields.get("txhash"))
-        .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "missing required field: commit_id".to_owned(),
-        })?;
-    let tx_hash = tx_hash.trim();
-    if tx_hash.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "field must not be empty: tx_hash".to_owned(),
-        });
-    }
-
-    let block_height = match fields.get("block_height") {
-        Some(raw_height) => Some(parse_block_height(raw_height.as_str())?),
-        None => None,
-    };
-    Ok(deterministic_backend_commit_id(tx_hash, block_height))
-}
-
-fn parse_block_height(raw: &str) -> Result<u64, KolmeRuntimeCommitProviderError> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "field must not be empty: block_height".to_owned(),
-        });
-    }
-    let height =
-        trimmed
-            .parse::<u64>()
-            .map_err(|_| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid block_height value: {trimmed}"),
-            })?;
-    if height == 0 {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "block_height must be positive".to_owned(),
-        });
-    }
-    Ok(height)
 }
 
 fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> String {

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -51,7 +51,8 @@ pub use notification_policy::{
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
-    deterministic_backend_commit_id, parse_live_provider_outcome, txhash_from_commit_id,
+    deterministic_backend_commit_id, parse_commit_id_from_response_fields,
+    parse_live_provider_outcome, required_provider_response_field, txhash_from_commit_id,
     KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
 };
 pub use provider_response_policy::{

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -131,6 +131,21 @@ pub fn parse_live_provider_outcome(
     }
 }
 
+/// Extracts one required non-empty field from provider response field maps.
+pub fn required_provider_response_field(
+    fields: &HashMap<String, String>,
+    field: &'static str,
+) -> Result<String, KolmeProviderOutcomePolicyError> {
+    required_response_field(fields, field)
+}
+
+/// Resolves deterministic commit-id from provider response fields.
+pub fn parse_commit_id_from_response_fields(
+    fields: &HashMap<String, String>,
+) -> Result<String, KolmeProviderOutcomePolicyError> {
+    resolve_commit_id(fields)
+}
+
 /// Builds deterministic backend commit id from tx hash and optional block height.
 pub fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> String {
     match block_height {

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,7 +1,9 @@
 use kamn_kolme::{
-    deterministic_backend_commit_id, parse_live_provider_outcome, txhash_from_commit_id,
+    deterministic_backend_commit_id, parse_commit_id_from_response_fields,
+    parse_live_provider_outcome, required_provider_response_field, txhash_from_commit_id,
     KolmeProviderOutcome, KolmeProviderOutcomePolicyError, ReceiptFinality,
 };
+use std::collections::HashMap;
 
 #[test]
 fn functional_parse_live_provider_outcome_maps_submitted_status() {
@@ -66,6 +68,31 @@ fn regression_issue_1749_txhash_from_commit_id_rejects_invalid_prefix() {
         error,
         KolmeProviderOutcomePolicyError::MalformedResponse {
             reason: "commit_id must start with 'kolme-commit:'".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn functional_required_provider_response_field_trims_non_empty_values() {
+    let mut fields = HashMap::new();
+    fields.insert("provider".to_owned(), "  kolme-fork  ".to_owned());
+    let provider =
+        required_provider_response_field(&fields, "provider").expect("field should parse");
+    assert_eq!(provider, "kolme-fork");
+}
+
+#[test]
+fn regression_issue_1753_parse_commit_id_from_response_fields_rejects_zero_block_height() {
+    // Regression: #1753
+    let mut fields = HashMap::new();
+    fields.insert("tx_hash".to_owned(), "ab12cd34".to_owned());
+    fields.insert("block_height".to_owned(), "0".to_owned());
+    let error = parse_commit_id_from_response_fields(&fields)
+        .expect_err("zero block height must fail closed");
+    assert_eq!(
+        error,
+        KolmeProviderOutcomePolicyError::MalformedResponse {
+            reason: "block_height must be positive".to_owned(),
         }
     );
 }

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -71,7 +71,7 @@ handling.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
   - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
   - block-fallback response parsing contracts are sourced from `kamn-kolme` (`parse_block_fallback_response`, `parse_fork_block_fallback_response`) and mapped through `kamn-core` compatibility wrappers.
-  - provider outcome and commit-id helper contracts are sourced from `kamn-kolme` (`parse_live_provider_outcome`, `deterministic_backend_commit_id`, `txhash_from_commit_id`) and mapped through `kamn-core` compatibility wrappers.
+  - provider outcome and commit-id helper contracts are sourced from `kamn-kolme` (`parse_live_provider_outcome`, `required_provider_response_field`, `parse_commit_id_from_response_fields`, `deterministic_backend_commit_id`, `txhash_from_commit_id`) and mapped through `kamn-core` compatibility wrappers.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.
@@ -193,3 +193,4 @@ cargo test -p kamn-core
 - flat JSON parser extraction parity drift remains fail-closed (`Regression: #1747`).
 - provider outcome and commit-id parser extraction parity drift remains fail-closed (`Regression: #1749`).
 - block-fallback parser extraction parity drift remains fail-closed (`Regression: #1751`).
+- provider helper reuse extraction parity drift remains fail-closed (`Regression: #1753`).


### PR DESCRIPTION
## Summary
Promotes reusable provider helper contracts from `kamn-kolme` provider-outcome policy and rewires `kamn-core` to use them for finality/message parsing paths. This removes duplicated required-field/commit-id/block-height helper logic from `kolme_runtime_commit.rs` while preserving fail-closed behavior.

Closes #1753
Refs #1714

## Changes
- `crates/kamn-kolme/src/provider_outcome_policy.rs`: exports helper contracts:
  - `required_provider_response_field(...)`
  - `parse_commit_id_from_response_fields(...)`
- `crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs`: adds helper contract tests (`Regression: #1753`).
- `crates/kamn-kolme/src/lib.rs`: exports helper functions.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegates required-field and commit-id parsing to extracted helpers and removes duplicated local helper block.
- `docs/foundation/kolme-runtime-commit-client.md`: documents helper reuse boundary + regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test provider_outcome_policy_contracts
```
Failed before implementation with unresolved imports:
- `no parse_commit_id_from_response_fields in the root`
- `no required_provider_response_field in the root`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test provider_outcome_policy_contracts
```
Passes: `7 passed; 0 failed`.

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
All commands pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | helper contract tests in `provider_outcome_policy_contracts` | |
| Functional   | ✅     | required field trimming + commit-id parse behavior tests | |
| Integration  | ✅     | runtime suites: `kolme_runtime_commit_http_transport`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅     | `regression_issue_1753_*` helper fail-closed test + existing runtime regressions remain green | |
| Performance  | N/A    | Not a throughput-path change | Policy-only refactor with targeted validation |

## Risks & Rollback
- None breaking; behavior intended to be parity-preserving.
- Rollback: revert this PR commit to restore local core helper definitions.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
