### PR TITLE
refactor(kolme): extract transport request helper policy

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -7,6 +7,8 @@ use kamn_kolme::{
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     find_http_header_boundary as find_kolme_http_header_boundary,
+    is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
+    parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
     parse_commit_id_from_response_fields as parse_kolme_commit_id_from_response_fields,
     parse_flat_json_value_fields as parse_kolme_flat_json_value_fields,
@@ -49,7 +51,9 @@ use kamn_kolme::{
     KolmeProviderOutcome as KamnKolmeProviderOutcome,
     KolmeProviderOutcomePolicyError as KamnKolmeProviderOutcomePolicyError,
     KolmeProviderResponsePolicyError as KamnKolmeProviderResponsePolicyError,
-    KolmeTlsPolicyError as KamnKolmeTlsPolicyError, KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
+    KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
+    KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
+    KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
 };
 use std::collections::HashMap;
@@ -783,7 +787,10 @@ impl KolmeRuntimeCommitHttpTransport {
         authorization_header: &str,
     ) -> Result<Self, KolmeRuntimeCommitError> {
         let mut transport = Self::new(timeout_seconds)?;
-        transport.authorization_header = Some(parse_authorization_header(authorization_header)?);
+        transport.authorization_header = Some(
+            parse_kolme_authorization_header_value(authorization_header)
+                .map_err(map_transport_request_policy_error)?,
+        );
         Ok(transport)
     }
 
@@ -1015,7 +1022,7 @@ impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
                 reason: "idempotency_key must not be empty".to_owned(),
             });
         }
-        if is_kolme_broadcast_submit_path(submit_path) {
+        if is_kolme_broadcast_submit_path_contract(submit_path) {
             let payload = normalize_kolme_broadcast_payload(wire_payload, idempotency_key)?;
             return self.execute_request(
                 base_url,
@@ -1847,6 +1854,16 @@ fn map_tls_policy_error(error: KamnKolmeTlsPolicyError) -> KolmeRuntimeCommitPro
     }
 }
 
+fn map_transport_request_policy_error(
+    error: KamnKolmeTransportRequestPolicyError,
+) -> KolmeRuntimeCommitError {
+    match error {
+        KamnKolmeTransportRequestPolicyError::InvalidRequest { field, reason } => {
+            KolmeRuntimeCommitError::InvalidRequest { field, reason }
+        }
+    }
+}
+
 fn parse_http_endpoint(
     base_url: &str,
     path: &str,
@@ -1960,23 +1977,6 @@ fn parse_kolme_notification_event(
     }
 }
 
-fn parse_authorization_header(value: &str) -> Result<String, KolmeRuntimeCommitError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(KolmeRuntimeCommitError::InvalidRequest {
-            field: "transport_authorization_header",
-            reason: "must not be empty",
-        });
-    }
-    if trimmed.contains('\r') || trimmed.contains('\n') {
-        return Err(KolmeRuntimeCommitError::InvalidRequest {
-            field: "transport_authorization_header",
-            reason: "must be single-line",
-        });
-    }
-    Ok(trimmed.to_owned())
-}
-
 fn map_transport_io_error(error: std::io::Error) -> KolmeRuntimeCommitProviderError {
     if matches!(
         error.kind(),
@@ -2004,19 +2004,6 @@ fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProvider
 
 fn classify_tls_failure_reason(stderr: &str) -> String {
     classify_kolme_tls_failure_reason(stderr)
-}
-
-fn is_kolme_broadcast_submit_path(submit_path: &str) -> bool {
-    let trimmed = submit_path.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-    let without_query = trimmed
-        .split('?')
-        .next()
-        .unwrap_or(trimmed)
-        .trim_end_matches('/');
-    without_query == "/broadcast"
 }
 
 fn normalize_kolme_broadcast_payload(

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -19,6 +19,7 @@ pub mod provider_response_policy;
 pub mod receipt_finality;
 pub mod tls_policy;
 pub mod transport;
+pub mod transport_request_policy;
 pub mod websocket_policy;
 
 pub use api_codec::{
@@ -65,6 +66,9 @@ pub use tls_policy::{
 };
 pub use transport::{
     EchoTransport, KolmeTransport, TransportError, TransportRequest, TransportResponse,
+};
+pub use transport_request_policy::{
+    is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,
 };
 pub use websocket_policy::{
     find_http_header_boundary, try_take_websocket_frame, validate_websocket_handshake_response,

--- a/crates/kamn-kolme/src/transport_request_policy.rs
+++ b/crates/kamn-kolme/src/transport_request_policy.rs
@@ -1,0 +1,62 @@
+//! Transport request helper policies for Kolme runtime-commit transports.
+
+use std::error::Error;
+use std::fmt;
+
+/// Error raised by transport request helper policy contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeTransportRequestPolicyError {
+    /// Request field failed deterministic validation.
+    InvalidRequest {
+        /// Field name.
+        field: &'static str,
+        /// Validation reason.
+        reason: &'static str,
+    },
+}
+
+impl fmt::Display for KolmeTransportRequestPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest { field, reason } => {
+                write!(f, "invalid request {field}: {reason}")
+            }
+        }
+    }
+}
+
+impl Error for KolmeTransportRequestPolicyError {}
+
+/// Parses one authorization header value with deterministic trim + CRLF safeguards.
+pub fn parse_authorization_header_value(
+    value: &str,
+) -> Result<String, KolmeTransportRequestPolicyError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(KolmeTransportRequestPolicyError::InvalidRequest {
+            field: "transport_authorization_header",
+            reason: "must not be empty",
+        });
+    }
+    if trimmed.contains('\r') || trimmed.contains('\n') {
+        return Err(KolmeTransportRequestPolicyError::InvalidRequest {
+            field: "transport_authorization_header",
+            reason: "must be single-line",
+        });
+    }
+    Ok(trimmed.to_owned())
+}
+
+/// Returns whether submit path resolves to the Kolme fork `/broadcast` route.
+pub fn is_broadcast_submit_path(submit_path: &str) -> bool {
+    let trimmed = submit_path.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let without_query = trimmed
+        .split('?')
+        .next()
+        .unwrap_or(trimmed)
+        .trim_end_matches('/');
+    without_query == "/broadcast"
+}

--- a/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
@@ -1,0 +1,52 @@
+use kamn_kolme::{
+    is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,
+};
+
+#[test]
+fn functional_parse_authorization_header_value_trims_whitespace() {
+    let parsed = parse_authorization_header_value("  Bearer abc123  ")
+        .expect("authorization header should parse");
+    assert_eq!(parsed, "Bearer abc123");
+}
+
+#[test]
+fn functional_is_broadcast_submit_path_accepts_query_and_trailing_slash() {
+    assert!(is_broadcast_submit_path("/broadcast"));
+    assert!(is_broadcast_submit_path("/broadcast/"));
+    assert!(is_broadcast_submit_path("/broadcast?mode=sync"));
+}
+
+#[test]
+fn regression_issue_1755_parse_authorization_header_value_rejects_empty_header() {
+    // Regression: #1755
+    let error = parse_authorization_header_value("  ").expect_err("empty header must fail");
+    assert_eq!(
+        error,
+        KolmeTransportRequestPolicyError::InvalidRequest {
+            field: "transport_authorization_header",
+            reason: "must not be empty",
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1755_parse_authorization_header_value_rejects_crlf() {
+    // Regression: #1755
+    let error = parse_authorization_header_value("Bearer token\r\nX-Injected: 1")
+        .expect_err("CR/LF injection must fail");
+    assert_eq!(
+        error,
+        KolmeTransportRequestPolicyError::InvalidRequest {
+            field: "transport_authorization_header",
+            reason: "must be single-line",
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1755_is_broadcast_submit_path_rejects_non_broadcast_paths() {
+    // Regression: #1755
+    assert!(!is_broadcast_submit_path(""));
+    assert!(!is_broadcast_submit_path("/runtime-commit/submit"));
+    assert!(!is_broadcast_submit_path("/broadcasting"));
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -116,7 +116,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
     `crates/kamn-kolme/src/provider_response_policy.rs`, `crates/kamn-kolme/src/flat_json_policy.rs`,
-    `crates/kamn-kolme/src/provider_outcome_policy.rs`, `crates/kamn-kolme/src/block_fallback_policy.rs`
+    `crates/kamn-kolme/src/provider_outcome_policy.rs`, `crates/kamn-kolme/src/block_fallback_policy.rs`,
+    `crates/kamn-kolme/src/transport_request_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -36,6 +36,7 @@ handling.
   - `crates/kamn-kolme/src/http_response_policy.rs` owns HTTP response status/content parsing contracts.
   - `crates/kamn-kolme/src/flat_json_policy.rs` owns flat JSON scalar/object parsing contracts used by broadcast normalization and block-fallback field extraction.
   - `crates/kamn-kolme/src/block_fallback_policy.rs` owns block-fallback response parsing contracts for key/value and flat-JSON payloads.
+  - `crates/kamn-kolme/src/transport_request_policy.rs` owns authorization header validation and broadcast submit-path detection contracts.
   - `crates/kamn-kolme/src/provider_outcome_policy.rs` owns live provider outcome parsing and commit-id helper contracts.
   - `crates/kamn-kolme/src/provider_response_policy.rs` owns provider response field parsing contracts (key/value + flat JSON string object formats).
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
@@ -163,6 +164,7 @@ cargo test -p kamn-kolme --test provider_response_policy_contracts
 cargo test -p kamn-kolme --test flat_json_policy_contracts
 cargo test -p kamn-kolme --test block_fallback_policy_contracts
 cargo test -p kamn-kolme --test provider_outcome_policy_contracts
+cargo test -p kamn-kolme --test transport_request_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -194,3 +196,4 @@ cargo test -p kamn-core
 - provider outcome and commit-id parser extraction parity drift remains fail-closed (`Regression: #1749`).
 - block-fallback parser extraction parity drift remains fail-closed (`Regression: #1751`).
 - provider helper reuse extraction parity drift remains fail-closed (`Regression: #1753`).
+- transport request helper extraction parity drift remains fail-closed (`Regression: #1755`).


### PR DESCRIPTION
## Summary
Extracts transport request helper policy from `kamn-core` into `kamn-kolme` for authorization header validation and broadcast submit-path detection. Core transport wiring now delegates to extracted contracts, reducing compatibility helper logic in `kolme_runtime_commit.rs`.

Closes #1755
Refs #1714

## Changes
- `crates/kamn-kolme/src/transport_request_policy.rs`: new contracts:
  - `parse_authorization_header_value(...)`
  - `is_broadcast_submit_path(...)`
  - `KolmeTransportRequestPolicyError`
- `crates/kamn-kolme/tests/transport_request_policy_contracts.rs`: unit/functional/regression tests (`Regression: #1755`).
- `crates/kamn-kolme/src/lib.rs`: exports transport request policy API.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegates authorization header and broadcast submit-path checks to `kamn-kolme`; removes local helper implementations.
- `docs/foundation/kolme-runtime-commit-client.md`: documents transport request helper extraction and contract command.
- `docs/architecture/kamn-core-module-map.md`: adds `transport_request_policy` to extraction map.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test transport_request_policy_contracts
```
Failed before implementation with unresolved imports:
- `no is_broadcast_submit_path in the root`
- `no parse_authorization_header_value in the root`
- `no KolmeTransportRequestPolicyError in the root`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test transport_request_policy_contracts
```
Passes: `5 passed; 0 failed`.

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo fmt --all --check
bash scripts/ci/test_select_targets.sh
```
All commands pass locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | transport request helper unit checks in `transport_request_policy_contracts` | |
| Functional   | ✅     | authorization trim + broadcast path detection behavior tests | |
| Integration  | ✅     | runtime suites: `kolme_runtime_commit_http_transport`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅     | `regression_issue_1755_*` tests + existing runtime regressions remain green | |
| Performance  | N/A    | Not a throughput-path change | Policy-only extraction with targeted validation |

## Risks & Rollback
- None breaking; behavior is parity-preserving.
- Rollback: revert this PR commit to restore local helper logic in `kamn-core`.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
