### PR TITLE
refactor(kolme): extract broadcast payload normalization policy (#1757)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -8,29 +8,25 @@ use kamn_kolme::{
     deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
+    normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
     parse_commit_id_from_response_fields as parse_kolme_commit_id_from_response_fields,
-    parse_flat_json_value_fields as parse_kolme_flat_json_value_fields,
     parse_fork_block_fallback_response as parse_kolme_fork_block_fallback_response_contract,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
     parse_live_provider_outcome as parse_kolme_live_provider_outcome,
     parse_notification_event as parse_kolme_notification_event_contract,
-    parse_provider_key_value_fields as parse_kolme_provider_key_value_fields,
     parse_provider_response_fields as parse_kolme_provider_response_fields,
     parse_receipt_finality as parse_kolme_receipt_finality,
     parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
-    required_json_string_field as required_kolme_json_string_field,
-    required_positive_u64_json_field as required_kolme_positive_u64_json_field,
     required_provider_response_field as required_kolme_provider_response_field,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
     txhash_from_commit_id as txhash_from_kolme_commit_id,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
-    validate_direct_signed_transaction_message as validate_kolme_direct_signed_transaction_message,
     validate_lookup_window as validate_kolme_lookup_window,
     validate_websocket_handshake_response as validate_kolme_websocket_handshake_response,
     BlockScanPolicyError, KolmeApiBroadcastRequest as KamnKolmeApiBroadcastRequest,
@@ -40,9 +36,8 @@ use kamn_kolme::{
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeBlockFallbackPolicyError as KamnKolmeBlockFallbackPolicyError,
     KolmeBlockFallbackResponse as KamnKolmeBlockFallbackResponse,
+    KolmeBroadcastPayloadPolicyError as KamnKolmeBroadcastPayloadPolicyError,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
-    KolmeFlatJsonPolicyError as KamnKolmeFlatJsonPolicyError,
-    KolmeFlatJsonValue as KamnKolmeFlatJsonValue,
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
@@ -1811,8 +1806,8 @@ fn map_provider_outcome_policy_error_to_malformed(
     }
 }
 
-fn map_flat_json_policy_error_to_malformed(
-    error: KamnKolmeFlatJsonPolicyError,
+fn map_broadcast_payload_policy_error_to_malformed(
+    error: KamnKolmeBroadcastPayloadPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
     KolmeRuntimeCommitProviderError::MalformedResponse {
         reason: error.to_string(),
@@ -2010,124 +2005,8 @@ fn normalize_kolme_broadcast_payload(
     wire_payload: &str,
     idempotency_key: &str,
 ) -> Result<String, KolmeRuntimeCommitProviderError> {
-    let payload = wire_payload.trim();
-    if payload.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "wire_payload must not be empty".to_owned(),
-        });
-    }
-    let idempotency_key = idempotency_key.trim();
-    if idempotency_key.is_empty() {
-        return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: "idempotency_key must not be empty".to_owned(),
-        });
-    }
-
-    if payload.starts_with('{') {
-        let fields = parse_kolme_flat_json_value_fields(payload)
-            .map_err(map_flat_json_policy_error_to_malformed)?;
-        if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
-            let payload_idempotency_key = match payload_idempotency_key {
-                KamnKolmeFlatJsonValue::String(value) => value.trim(),
-                _ => {
-                    return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                        reason: "field must be a string: idempotency_key".to_owned(),
-                    });
-                }
-            };
-            if payload_idempotency_key.is_empty() {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: "field must not be empty: idempotency_key".to_owned(),
-                });
-            }
-            if payload_idempotency_key != idempotency_key {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: "wire_payload idempotency_key does not match transport idempotency key"
-                        .to_owned(),
-                });
-            }
-        }
-
-        let message = required_kolme_json_string_field(&fields, "message")
-            .map_err(map_flat_json_policy_error_to_malformed)?;
-        let signature = required_kolme_json_string_field(&fields, "signature")
-            .map_err(map_flat_json_policy_error_to_malformed)?;
-        let recovery_id_u64 = required_kolme_positive_u64_json_field(&fields, "recovery_id")
-            .map_err(map_flat_json_policy_error_to_malformed)?;
-        let recovery_id = u8::try_from(recovery_id_u64).map_err(|_| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "recovery_id must be within u8 range".to_owned(),
-            }
-        })?;
-
-        if fields.contains_key("signer_key_id") {
-            let signer_key_id = required_kolme_json_string_field(&fields, "signer_key_id")
-                .map_err(map_flat_json_policy_error_to_malformed)?;
-            let envelope = KolmeRuntimeCommitSignedBroadcastEnvelope::new(
-                signer_key_id.as_str(),
-                message.as_str(),
-                signature.as_str(),
-                recovery_id,
-            )
-            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: error.to_string(),
-            })?;
-
-            let message_fields = parse_kolme_provider_key_value_fields(envelope.message.as_str())
-                .map_err(map_provider_response_policy_error_to_malformed)?;
-            let message_idempotency_key =
-                required_kolme_provider_response_field(&message_fields, "idempotency_key")
-                    .map_err(map_provider_outcome_policy_error_to_malformed)?;
-            if message_idempotency_key != idempotency_key {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason:
-                        "signed message idempotency_key does not match transport idempotency key"
-                            .to_owned(),
-                });
-            }
-
-            let request = envelope.to_broadcast_request().map_err(|error| {
-                KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: error.to_string(),
-                }
-            })?;
-            return Ok(request.to_json_payload());
-        }
-
-        if !message.trim().starts_with('{') || !message.trim().ends_with('}') {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "direct signed payload message must be a JSON object string".to_owned(),
-            });
-        }
-        validate_kolme_direct_signed_transaction_message(message.as_str())
-            .map_err(map_codec_error_to_malformed_response)?;
-
-        let request =
-            KolmeApiBroadcastRequest::new(message.as_str(), signature.as_str(), recovery_id)
-                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: error.to_string(),
-                })?;
-        return Ok(request.to_json_payload());
-    }
-
-    let fields = parse_kolme_provider_key_value_fields(payload)
-        .map_err(map_provider_response_policy_error_to_malformed)?;
-    if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
-        let payload_idempotency_key = payload_idempotency_key.trim();
-        if payload_idempotency_key != idempotency_key {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "wire_payload idempotency_key does not match transport idempotency key"
-                    .to_owned(),
-            });
-        }
-    }
-
-    let request = KolmeApiBroadcastRequest::new(payload, idempotency_key, 1).map_err(|error| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: error.to_string(),
-        }
-    })?;
-    Ok(request.to_json_payload())
+    normalize_kolme_broadcast_payload_contract(wire_payload, idempotency_key)
+        .map_err(map_broadcast_payload_policy_error_to_malformed)
 }
 
 fn parse_live_provider_response(

--- a/crates/kamn-kolme/src/broadcast_payload_policy.rs
+++ b/crates/kamn-kolme/src/broadcast_payload_policy.rs
@@ -1,0 +1,178 @@
+//! `/broadcast` payload normalization policy contracts.
+
+use crate::{
+    parse_flat_json_value_fields, parse_provider_key_value_fields, required_json_string_field,
+    required_positive_u64_json_field, required_provider_response_field,
+    validate_direct_signed_transaction_message, KolmeApiBroadcastRequest, KolmeApiCodecError,
+    KolmeFlatJsonPolicyError, KolmeFlatJsonValue, KolmeProviderOutcomePolicyError,
+    KolmeProviderResponsePolicyError,
+};
+use std::error::Error;
+use std::fmt;
+
+/// Error raised by broadcast payload normalization policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeBroadcastPayloadPolicyError {
+    /// Payload failed deterministic parse/validation.
+    MalformedResponse {
+        /// Parse/validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeBroadcastPayloadPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedResponse { reason } => f.write_str(reason),
+        }
+    }
+}
+
+impl Error for KolmeBroadcastPayloadPolicyError {}
+
+/// Normalizes runtime commit wire payload into canonical Kolme `/broadcast` JSON payload.
+pub fn normalize_broadcast_payload(
+    wire_payload: &str,
+    idempotency_key: &str,
+) -> Result<String, KolmeBroadcastPayloadPolicyError> {
+    let payload = wire_payload.trim();
+    if payload.is_empty() {
+        return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+            reason: "wire_payload must not be empty".to_owned(),
+        });
+    }
+    let idempotency_key = idempotency_key.trim();
+    if idempotency_key.is_empty() {
+        return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+            reason: "idempotency_key must not be empty".to_owned(),
+        });
+    }
+
+    if payload.starts_with('{') {
+        let fields = parse_flat_json_value_fields(payload).map_err(map_flat_json_error)?;
+        if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
+            let payload_idempotency_key = match payload_idempotency_key {
+                KolmeFlatJsonValue::String(value) => value.trim(),
+                _ => {
+                    return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                        reason: "field must be a string: idempotency_key".to_owned(),
+                    });
+                }
+            };
+            if payload_idempotency_key.is_empty() {
+                return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                    reason: "field must not be empty: idempotency_key".to_owned(),
+                });
+            }
+            if payload_idempotency_key != idempotency_key {
+                return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                    reason: "wire_payload idempotency_key does not match transport idempotency key"
+                        .to_owned(),
+                });
+            }
+        }
+
+        let message =
+            required_json_string_field(&fields, "message").map_err(map_flat_json_error)?;
+        let signature =
+            required_json_string_field(&fields, "signature").map_err(map_flat_json_error)?;
+        let recovery_id_u64 = required_positive_u64_json_field(&fields, "recovery_id")
+            .map_err(map_flat_json_error)?;
+        let recovery_id = u8::try_from(recovery_id_u64).map_err(|_| {
+            KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                reason: "recovery_id must be within u8 range".to_owned(),
+            }
+        })?;
+
+        if fields.contains_key("signer_key_id") {
+            let _signer_key_id = required_json_string_field(&fields, "signer_key_id")
+                .map_err(map_flat_json_error)?;
+
+            let message_fields = parse_provider_key_value_fields(message.as_str())
+                .map_err(map_provider_response_error)?;
+            let message_idempotency_key =
+                required_provider_response_field(&message_fields, "idempotency_key")
+                    .map_err(map_provider_outcome_error)?;
+            if message_idempotency_key != idempotency_key {
+                return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                    reason:
+                        "signed message idempotency_key does not match transport idempotency key"
+                            .to_owned(),
+                });
+            }
+
+            let request =
+                KolmeApiBroadcastRequest::new(message.as_str(), signature.as_str(), recovery_id)
+                    .map_err(map_codec_error)?;
+            return Ok(request.to_json_payload());
+        }
+
+        if !message.trim().starts_with('{') || !message.trim().ends_with('}') {
+            return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                reason: "direct signed payload message must be a JSON object string".to_owned(),
+            });
+        }
+        validate_direct_signed_transaction_message(message.as_str()).map_err(map_codec_error)?;
+
+        let request =
+            KolmeApiBroadcastRequest::new(message.as_str(), signature.as_str(), recovery_id)
+                .map_err(map_codec_error)?;
+        return Ok(request.to_json_payload());
+    }
+
+    let fields = parse_provider_key_value_fields(payload).map_err(map_provider_response_error)?;
+    if let Some(payload_idempotency_key) = fields.get("idempotency_key") {
+        let payload_idempotency_key = payload_idempotency_key.trim();
+        if payload_idempotency_key != idempotency_key {
+            return Err(KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                reason: "wire_payload idempotency_key does not match transport idempotency key"
+                    .to_owned(),
+            });
+        }
+    }
+
+    let request =
+        KolmeApiBroadcastRequest::new(payload, idempotency_key, 1).map_err(map_codec_error)?;
+    Ok(request.to_json_payload())
+}
+
+fn map_flat_json_error(error: KolmeFlatJsonPolicyError) -> KolmeBroadcastPayloadPolicyError {
+    match error {
+        KolmeFlatJsonPolicyError::MalformedResponse { reason } => {
+            KolmeBroadcastPayloadPolicyError::MalformedResponse { reason }
+        }
+    }
+}
+
+fn map_provider_response_error(
+    error: KolmeProviderResponsePolicyError,
+) -> KolmeBroadcastPayloadPolicyError {
+    match error {
+        KolmeProviderResponsePolicyError::MalformedResponse { reason } => {
+            KolmeBroadcastPayloadPolicyError::MalformedResponse { reason }
+        }
+    }
+}
+
+fn map_provider_outcome_error(
+    error: KolmeProviderOutcomePolicyError,
+) -> KolmeBroadcastPayloadPolicyError {
+    match error {
+        KolmeProviderOutcomePolicyError::MalformedResponse { reason } => {
+            KolmeBroadcastPayloadPolicyError::MalformedResponse { reason }
+        }
+    }
+}
+
+fn map_codec_error(error: KolmeApiCodecError) -> KolmeBroadcastPayloadPolicyError {
+    match error {
+        KolmeApiCodecError::InvalidRequest { field, reason } => {
+            KolmeBroadcastPayloadPolicyError::MalformedResponse {
+                reason: format!("invalid request {field}: {reason}"),
+            }
+        }
+        KolmeApiCodecError::MalformedResponse { reason } => {
+            KolmeBroadcastPayloadPolicyError::MalformedResponse { reason }
+        }
+    }
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod api_codec;
 pub mod block_fallback_policy;
 pub mod block_scan_policy;
+pub mod broadcast_payload_policy;
 pub mod codec;
 pub mod endpoint_policy;
 pub mod finality;
@@ -35,6 +36,7 @@ pub use block_scan_policy::{
     parse_fork_block_txhash, render_block_path, validate_block_identity,
     validate_block_path_template, validate_lookup_window, BlockScanPolicyError,
 };
+pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use endpoint_policy::{
     compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,

--- a/crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs
@@ -1,0 +1,50 @@
+use kamn_kolme::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
+
+#[test]
+fn functional_normalize_broadcast_payload_maps_direct_signed_json() {
+    let payload = "{\"message\":\"{\\\"pubkey\\\":\\\"pk\\\",\\\"nonce\\\":1,\\\"created\\\":\\\"2026-02-11T00:00:00Z\\\",\\\"messages\\\":[],\\\"max_height\\\":null}\",\"signature\":\"sig-direct\",\"recovery_id\":1}";
+    let normalized = normalize_broadcast_payload(payload, "kolme-runtime-commit:direct:1")
+        .expect("direct signed payload should normalize");
+    assert!(normalized.contains("\"signature\":\"sig-direct\""));
+    assert!(normalized.contains("\"recovery_id\":1"));
+    assert!(normalized.contains("\\\"pubkey\\\":\\\"pk\\\""));
+}
+
+#[test]
+fn functional_normalize_broadcast_payload_maps_signed_envelope_payload() {
+    let payload = "{\"signer_key_id\":\"kamn:key:signer:1\",\"message\":\"operation_id=op\\nidempotency_key=abc\\n\",\"signature\":\"sig-envelope\",\"recovery_id\":1}";
+    let normalized = normalize_broadcast_payload(payload, "abc")
+        .expect("signed envelope payload should normalize");
+    assert!(normalized.contains("\"signature\":\"sig-envelope\""));
+    assert!(normalized.contains("\"recovery_id\":1"));
+    assert!(normalized.contains("operation_id=op"));
+    assert!(normalized.contains("idempotency_key=abc"));
+}
+
+#[test]
+fn regression_issue_1757_normalize_broadcast_payload_rejects_empty_signer_key_id() {
+    // Regression: #1757
+    let payload = "{\"signer_key_id\":\"\",\"message\":\"operation_id=op\\nidempotency_key=abc\\n\",\"signature\":\"sig\",\"recovery_id\":1}";
+    let error =
+        normalize_broadcast_payload(payload, "abc").expect_err("empty signer_key_id must fail");
+    assert_eq!(
+        error,
+        KolmeBroadcastPayloadPolicyError::MalformedResponse {
+            reason: "field must not be empty: signer_key_id".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1757_normalize_broadcast_payload_rejects_non_json_direct_message() {
+    // Regression: #1757
+    let payload = "{\"message\":\"operation_id=op\\nidempotency_key=abc\\n\",\"signature\":\"sig\",\"recovery_id\":1}";
+    let error =
+        normalize_broadcast_payload(payload, "abc").expect_err("non-json direct message must fail");
+    assert_eq!(
+        error,
+        KolmeBroadcastPayloadPolicyError::MalformedResponse {
+            reason: "direct signed payload message must be a JSON object string".to_owned(),
+        }
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -117,7 +117,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
     `crates/kamn-kolme/src/provider_response_policy.rs`, `crates/kamn-kolme/src/flat_json_policy.rs`,
     `crates/kamn-kolme/src/provider_outcome_policy.rs`, `crates/kamn-kolme/src/block_fallback_policy.rs`,
-    `crates/kamn-kolme/src/transport_request_policy.rs`
+    `crates/kamn-kolme/src/transport_request_policy.rs`, `crates/kamn-kolme/src/broadcast_payload_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation policy). `kamn-core`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -38,6 +38,7 @@ handling.
   - `crates/kamn-kolme/src/block_fallback_policy.rs` owns block-fallback response parsing contracts for key/value and flat-JSON payloads.
   - `crates/kamn-kolme/src/transport_request_policy.rs` owns authorization header validation and broadcast submit-path detection contracts.
   - `crates/kamn-kolme/src/provider_outcome_policy.rs` owns live provider outcome parsing and commit-id helper contracts.
+  - `crates/kamn-kolme/src/broadcast_payload_policy.rs` owns `/broadcast` payload normalization contracts (direct-signed, signed-envelope, and key/value fallback paths) with deterministic idempotency checks.
   - `crates/kamn-kolme/src/provider_response_policy.rs` owns provider response field parsing contracts (key/value + flat JSON string object formats).
   - `crates/kamn-core/src/kolme_runtime_commit.rs` delegates endpoint normalization through compatibility wrappers.
 - Optional auth-aware constructor:
@@ -73,6 +74,7 @@ handling.
   - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
   - block-fallback response parsing contracts are sourced from `kamn-kolme` (`parse_block_fallback_response`, `parse_fork_block_fallback_response`) and mapped through `kamn-core` compatibility wrappers.
   - provider outcome and commit-id helper contracts are sourced from `kamn-kolme` (`parse_live_provider_outcome`, `required_provider_response_field`, `parse_commit_id_from_response_fields`, `deterministic_backend_commit_id`, `txhash_from_commit_id`) and mapped through `kamn-core` compatibility wrappers.
+  - broadcast payload normalization contracts are sourced from `kamn-kolme` (`normalize_broadcast_payload`) and mapped through `kamn-core` compatibility wrappers.
   - resolver consumes one notification event first:
     - txhash-bearing `NewBlock` / `FailedTransaction` events map directly to receipts.
     - `LatestBlock` (or `NewBlock` payloads that carry height but no txhash) trigger bounded `/block/{height}` fallback reconciliation.
@@ -165,6 +167,7 @@ cargo test -p kamn-kolme --test flat_json_policy_contracts
 cargo test -p kamn-kolme --test block_fallback_policy_contracts
 cargo test -p kamn-kolme --test provider_outcome_policy_contracts
 cargo test -p kamn-kolme --test transport_request_policy_contracts
+cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -197,3 +200,4 @@ cargo test -p kamn-core
 - block-fallback parser extraction parity drift remains fail-closed (`Regression: #1751`).
 - provider helper reuse extraction parity drift remains fail-closed (`Regression: #1753`).
 - transport request helper extraction parity drift remains fail-closed (`Regression: #1755`).
+- broadcast payload normalization extraction parity drift remains fail-closed (`Regression: #1757`).


### PR DESCRIPTION
## Summary
Extracted Kolme `/broadcast` payload normalization policy from `kamn-core` into `kamn-kolme` as a dedicated contract module, then rewired `kamn-core` to delegate through compatibility wrappers. This reduces `kolme_runtime_commit` policy density while preserving fail-closed behavior and deterministic malformed-response mapping.

## Changes
- `crates/kamn-kolme/src/broadcast_payload_policy.rs`: added canonical normalization contract + typed error.
- `crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs`: added functional + regression coverage for direct-signed and signed-envelope paths.
- `crates/kamn-kolme/src/lib.rs`: exported `normalize_broadcast_payload` and `KolmeBroadcastPayloadPolicyError`.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed duplicated local normalization block and delegated to extracted contract.
- `docs/foundation/kolme-runtime-commit-client.md`: documented broadcast normalization extraction boundary, command surface, and regression marker.
- `docs/architecture/kamn-core-module-map.md`: added `broadcast_payload_policy` to Kolme extraction surface.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
```
Failing output (before implementation):
```text
error[E0432]: unresolved imports `kamn_kolme::normalize_broadcast_payload`, `kamn_kolme::KolmeBroadcastPayloadPolicyError`
 --> crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs:1:18
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
```
Passing summary:
```text
broadcast_payload_policy_contracts: 4 passed, 0 failed
kolme_runtime_commit_http_transport: 21 passed, 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-kolme -p kamn-core --all-targets -- -D warnings
cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
```
Result:
```text
all commands passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `broadcast_payload_policy_contracts` covers parser/validation branches | |
| Functional   | ✅ | direct-signed and signed-envelope normalization assertions | |
| Integration  | ✅ | `kolme_runtime_commit_http_transport` verifies core ↔ kolm policy delegation behavior | |
| Regression   | ✅ | `regression_issue_1757_*` tests for signer-key and non-JSON direct payload fail-closed paths | |
| Performance  | N/A | none | Not applicable for deterministic parsing/normalization refactor; kept validation targeted for CI cost control |

## Risks & Rollback
- None.
- Rollback: revert commit `86ac289` to restore in-core normalization implementation.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
