### PR TITLE
test(docs): enforce graduated missing-docs guard (#1723)

### DIFF
--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -1,6 +1,8 @@
 const CORE_LIB: &str = include_str!("../src/lib.rs");
 const ALLOWLIST_FIXTURE: &str =
     include_str!("../../../fixtures/ci/kamn_core_missing_docs_allowlist.txt");
+const GRADUATED_MODULES_FIXTURE: &str =
+    include_str!("../../../fixtures/ci/kamn_core_missing_docs_graduated_modules.txt");
 
 fn allowlisted_modules_from_core_lib(source: &str) -> Vec<String> {
     let mut allow_pending = false;
@@ -106,4 +108,23 @@ fn graduated_wave_three_task_lifecycle_module_must_not_return_to_missing_docs_al
             .any(|candidate| candidate == "task_lifecycle"),
         "allowlist fixture must keep task_lifecycle removed"
     );
+}
+
+#[test]
+fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
+    // Regression: #1723
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let graduated = allowlisted_modules_from_fixture(GRADUATED_MODULES_FIXTURE);
+
+    for module in graduated {
+        assert!(
+            !actual.iter().any(|candidate| candidate == &module),
+            "{module} must stay graduated from #[allow(missing_docs)]"
+        );
+        assert!(
+            !expected.iter().any(|candidate| candidate == &module),
+            "allowlist fixture must keep {module} removed"
+        );
+    }
 }

--- a/docs/developer/rustdoc-publishing.md
+++ b/docs/developer/rustdoc-publishing.md
@@ -40,6 +40,8 @@ without adding hosted-doc platform dependencies.
 
 - Missing-doc policy checker:
   - `bash scripts/ci/check_kamn_core_missing_docs_policy.sh`
+- Graduated-module guard fixture consumed by checker:
+  - `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`
 - Regression tests for checker behavior:
   - `bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh`
 - Rustdoc artifact contract lane (bounded):
@@ -64,3 +66,6 @@ without adding hosted-doc platform dependencies.
   builds in fast-gate lanes.
 - CI selector only routes this checker for missing-doc policy and docs-contract
   paths.
+- Graduated modules listed in `kamn_core_missing_docs_graduated_modules.txt`
+  cannot be re-added to `#[allow(missing_docs)]` without a fail-closed policy
+  break.

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -1,0 +1,5 @@
+bootstrap
+kolme_runtime_commit
+namespaces
+state
+task_lifecycle

--- a/scripts/ci/check_kamn_core_missing_docs_policy.sh
+++ b/scripts/ci/check_kamn_core_missing_docs_policy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CORE_LIB_PATH="${KAMN_CORE_LIB_PATH:-$ROOT_DIR/crates/kamn-core/src/lib.rs}"
 ALLOWLIST_PATH="${KAMN_CORE_MISSING_DOCS_ALLOWLIST_PATH:-$ROOT_DIR/fixtures/ci/kamn_core_missing_docs_allowlist.txt}"
+GRADUATED_MODULES_PATH="${KAMN_CORE_MISSING_DOCS_GRADUATED_MODULES_PATH:-$ROOT_DIR/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt}"
 README_PATH="${KAMN_README_PATH:-$ROOT_DIR/README.md}"
 PLAN_DOC_PATH="${KAMN_ENGINEERING_HARDENING_DOC_PATH:-$ROOT_DIR/docs/planning/engineering-hardening-wave.md}"
 ARCH_DOC_PATH="${KAMN_CORE_MODULE_MAP_DOC_PATH:-$ROOT_DIR/docs/architecture/kamn-core-module-map.md}"
@@ -20,6 +21,7 @@ require_file() {
 
 require_file "$CORE_LIB_PATH" "kamn-core lib"
 require_file "$ALLOWLIST_PATH" "missing-docs allowlist fixture"
+require_file "$GRADUATED_MODULES_PATH" "missing-docs graduated-modules fixture"
 require_file "$README_PATH" "README"
 require_file "$PLAN_DOC_PATH" "engineering hardening plan"
 require_file "$ARCH_DOC_PATH" "kamn-core module map"
@@ -63,6 +65,14 @@ expected_allowlisted_modules="$(
   ' "$ALLOWLIST_PATH" | sort
 )"
 
+expected_graduated_modules="$(
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    { print $1 }
+  ' "$GRADUATED_MODULES_PATH" | sort
+)"
+
 if ! diff -u \
   <(printf '%s\n' "$expected_allowlisted_modules") \
   <(printf '%s\n' "$actual_allowlisted_modules") >/dev/null; then
@@ -70,6 +80,17 @@ if ! diff -u \
   diff -u \
     <(printf '%s\n' "$expected_allowlisted_modules") \
     <(printf '%s\n' "$actual_allowlisted_modules") >&2
+  exit 1
+fi
+
+graduated_allowlist_overlap="$(
+  comm -12 \
+    <(printf '%s\n' "$expected_graduated_modules") \
+    <(printf '%s\n' "$actual_allowlisted_modules")
+)"
+if [ -n "$graduated_allowlist_overlap" ]; then
+  echo "missing-docs policy contract failed: graduated modules cannot be re-added to #[allow(missing_docs)] allowlist." >&2
+  echo "$graduated_allowlist_overlap" >&2
   exit 1
 fi
 

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -565,7 +565,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    crates/kamn-core/src/lib.rs|crates/kamn-core/tests/missing_docs_policy.rs|crates/kamn-core/tests/engineering_hardening_wave_docs.rs|fixtures/ci/kamn_core_missing_docs_allowlist.txt|scripts/ci/check_kamn_core_missing_docs_policy.sh|scripts/ci/test_check_kamn_core_missing_docs_policy.sh|scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh|scripts/ci/test_run_kamn_core_rustdoc_artifact_contract_lane.sh|scripts/ci/check_kamn_core_rustdoc_artifact_policy.sh|scripts/ci/test_check_kamn_core_rustdoc_artifact_policy.sh|docs/planning/engineering-hardening-wave.md|docs/architecture/kamn-core-module-map.md|docs/developer/rustdoc-publishing.md|README.md)
+    crates/kamn-core/src/lib.rs|crates/kamn-core/tests/missing_docs_policy.rs|crates/kamn-core/tests/engineering_hardening_wave_docs.rs|fixtures/ci/kamn_core_missing_docs_allowlist.txt|fixtures/ci/kamn_core_missing_docs_graduated_modules.txt|scripts/ci/check_kamn_core_missing_docs_policy.sh|scripts/ci/test_check_kamn_core_missing_docs_policy.sh|scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh|scripts/ci/test_run_kamn_core_rustdoc_artifact_contract_lane.sh|scripts/ci/check_kamn_core_rustdoc_artifact_policy.sh|scripts/ci/test_check_kamn_core_rustdoc_artifact_policy.sh|docs/planning/engineering-hardening-wave.md|docs/architecture/kamn-core-module-map.md|docs/developer/rustdoc-publishing.md|README.md)
       KAMN_CORE_MISSING_DOCS_POLICY_CHANGED=true
       classified=true
       ;;

--- a/scripts/ci/test_check_kamn_core_missing_docs_policy.sh
+++ b/scripts/ci/test_check_kamn_core_missing_docs_policy.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 CORE_LIB_FIXTURE="$TMP_DIR/lib.rs"
 ALLOWLIST_FIXTURE="$TMP_DIR/allowlist.txt"
+GRADUATED_MODULES_FIXTURE="$TMP_DIR/graduated-modules.txt"
 README_FIXTURE="$TMP_DIR/README.md"
 PLAN_DOC_FIXTURE="$TMP_DIR/engineering-hardening-wave.md"
 ARCH_DOC_FIXTURE="$TMP_DIR/kamn-core-module-map.md"
@@ -16,6 +17,7 @@ RUSTDOC_GUIDE_FIXTURE="$TMP_DIR/rustdoc-publishing.md"
 run_checker() {
   KAMN_CORE_LIB_PATH="$CORE_LIB_FIXTURE" \
   KAMN_CORE_MISSING_DOCS_ALLOWLIST_PATH="$ALLOWLIST_FIXTURE" \
+  KAMN_CORE_MISSING_DOCS_GRADUATED_MODULES_PATH="$GRADUATED_MODULES_FIXTURE" \
   KAMN_README_PATH="$README_FIXTURE" \
   KAMN_ENGINEERING_HARDENING_DOC_PATH="$PLAN_DOC_FIXTURE" \
   KAMN_CORE_MODULE_MAP_DOC_PATH="$ARCH_DOC_FIXTURE" \
@@ -26,6 +28,7 @@ run_checker() {
 reset_fixtures() {
   cp "$ROOT_DIR/crates/kamn-core/src/lib.rs" "$CORE_LIB_FIXTURE"
   cp "$ROOT_DIR/fixtures/ci/kamn_core_missing_docs_allowlist.txt" "$ALLOWLIST_FIXTURE"
+  cp "$ROOT_DIR/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt" "$GRADUATED_MODULES_FIXTURE"
   cp "$ROOT_DIR/README.md" "$README_FIXTURE"
   cp "$ROOT_DIR/docs/planning/engineering-hardening-wave.md" "$PLAN_DOC_FIXTURE"
   cp "$ROOT_DIR/docs/architecture/kamn-core-module-map.md" "$ARCH_DOC_FIXTURE"
@@ -73,5 +76,11 @@ expect_failure "rustdoc publishing command drift should fail"
 reset_fixtures
 sed -i '/docs\/developer\/rustdoc-publishing.md/d' "$README_FIXTURE"
 expect_failure "README rustdoc link drift should fail"
+
+# Regression: #1723
+reset_fixtures
+printf '\nkolme_runtime_commit\n' >>"$ALLOWLIST_FIXTURE"
+sed -i 's/^pub mod kolme_runtime_commit;/#[allow(missing_docs)]\npub mod kolme_runtime_commit;/' "$CORE_LIB_FIXTURE"
+expect_failure "graduated module allowlist bypass should fail"
 
 echo "kamn-core missing-docs policy checker tests passed."

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -312,6 +312,10 @@ assert_eq "$(extract_output "$core_lib_policy_output" "run_rust")" "true" "kamn-
 assert_eq "$(extract_output "$core_lib_policy_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "kamn-core lib changes must run missing-docs policy checks"
 assert_eq "$(extract_output "$core_lib_policy_output" "test_scope")" "targeted" "kamn-core lib changes should stay targeted"
 
+graduated_modules_fixture_output="$(run_selector $'fixtures/ci/kamn_core_missing_docs_graduated_modules.txt')"
+assert_eq "$(extract_output "$graduated_modules_fixture_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "graduated modules fixture changes must run missing-docs policy checks"
+assert_eq "$(extract_output "$graduated_modules_fixture_output" "test_scope")" "qa-doc-contract" "graduated modules fixture changes should stay in docs-contract scope"
+
 kolme_scaffold_output="$(run_selector $'crates/kamn-kolme/src/lib.rs')"
 assert_eq "$(extract_output "$kolme_scaffold_output" "run_rust")" "true" "kamn-kolme scaffold changes should run rust lane"
 assert_eq "$(extract_output "$kolme_scaffold_output" "test_scope")" "targeted" "kamn-kolme scaffold changes should stay targeted"


### PR DESCRIPTION
## Summary
Added a strict graduated-module guard to the `kamn-core` missing-docs policy checker so already-graduated modules cannot be re-added to `#[allow(missing_docs)]` even if allowlist fixture drift is attempted in tandem. Wired regression coverage and CI selector routing to keep the policy fail-closed and low-cost.

## Changes
- `scripts/ci/check_kamn_core_missing_docs_policy.sh`: added graduated-modules fixture input + overlap rejection check.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added canonical graduated module set (`bootstrap`, `kolme_runtime_commit`, `namespaces`, `state`, `task_lifecycle`).
- `scripts/ci/test_check_kamn_core_missing_docs_policy.sh`: added `#1723` regression for allowlist-bypass attempt and fixture wiring.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added fixture-driven regression test to ensure graduated modules never overlap allowlist.
- `scripts/ci/select_targets.sh` + `scripts/ci/test_select_targets.sh`: routed graduated fixture changes into docs policy contract checks.
- `docs/developer/rustdoc-publishing.md`: documented graduated-module guard fixture in contract enforcement.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh
```
Failing output before implementation:
```text
graduated module allowlist bypass should fail: expected failure but checker succeeded.
kamn-core missing-docs policy contract passed.
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/ci/check_kamn_core_missing_docs_policy.sh
bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh
cargo test -p kamn-core --test missing_docs_policy
```
Passing summary:
```text
kamn-core missing-docs policy contract passed.
kamn-core missing-docs policy checker tests passed.
missing_docs_policy: 6 passed, 0 failed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
bash scripts/ci/check_kamn_core_missing_docs_policy.sh
bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh
cargo test -p kamn-core --test missing_docs_policy
bash scripts/ci/test_select_targets.sh
cargo clippy -p kamn-core --tests -- -D warnings
```
Result:
```text
all commands passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `crates/kamn-core/tests/missing_docs_policy.rs` fixture-driven graduated-module overlap test | |
| Functional   | ✅ | `scripts/ci/test_check_kamn_core_missing_docs_policy.sh` checker-behavior regression for bypass attempt | |
| Integration  | ✅ | `scripts/ci/test_select_targets.sh` routing assertion for graduated fixture path | |
| Regression   | ✅ | `Regression: #1723` guard against re-allowlisting `kolme_runtime_commit` via fixture drift | |
| Performance  | N/A | none | Policy checker remains bounded shell/targeted test flow; no heavy lane added |

## Risks & Rollback
- None.
- Rollback: revert commit `835def1` to restore previous checker behavior.

## Documentation Updates
- `docs/developer/rustdoc-publishing.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #1723
