### PR TITLE
refactor(kolme): extract runtime lifecycle policy contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -3,11 +3,14 @@
 use crate::AgentDid;
 use kamn_kolme::{
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
+    commit_finality_label as commit_finality_label_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
+    lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
+    lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
@@ -37,6 +40,7 @@ use kamn_kolme::{
     KolmeBlockFallbackPolicyError as KamnKolmeBlockFallbackPolicyError,
     KolmeBlockFallbackResponse as KamnKolmeBlockFallbackResponse,
     KolmeBroadcastPayloadPolicyError as KamnKolmeBroadcastPayloadPolicyError,
+    KolmeCommitReceiptFinality as KamnKolmeCommitReceiptFinality,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
@@ -50,6 +54,7 @@ use kamn_kolme::{
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
     KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
+    RuntimeCommitLifecycleState as KamnKolmeRuntimeCommitLifecycleState,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -368,15 +373,7 @@ impl KolmeApiBroadcastResponse {
 }
 
 /// Finality classification for a runtime commit receipt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KolmeCommitReceiptFinality {
-    /// Commit has been submitted and is pending confirmation.
-    Pending,
-    /// Commit is fully finalized.
-    Final,
-    /// Commit failed validation/finality.
-    Failed,
-}
+pub type KolmeCommitReceiptFinality = KamnKolmeCommitReceiptFinality;
 
 /// Receipt emitted by the runtime commit client.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -404,15 +401,7 @@ pub enum KolmeRuntimeCommitOutcome {
 }
 
 /// Runtime lifecycle state projected from commit receipt outcomes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RuntimeCommitLifecycleState {
-    /// Commit is pending confirmation and should remain on requeue/watch.
-    Pending,
-    /// Commit has reached final confirmation.
-    Finalized,
-    /// Commit failed and should not be retried automatically.
-    Failed,
-}
+pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
 /// One runtime operation lifecycle record.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2354,27 +2343,15 @@ fn deterministic_commit_id(
 fn lifecycle_state_for_finality(
     finality: KolmeCommitReceiptFinality,
 ) -> RuntimeCommitLifecycleState {
-    match finality {
-        KolmeCommitReceiptFinality::Pending => RuntimeCommitLifecycleState::Pending,
-        KolmeCommitReceiptFinality::Final => RuntimeCommitLifecycleState::Finalized,
-        KolmeCommitReceiptFinality::Failed => RuntimeCommitLifecycleState::Failed,
-    }
+    lifecycle_state_for_finality_contract(finality)
 }
 
 fn lifecycle_state_label(state: RuntimeCommitLifecycleState) -> &'static str {
-    match state {
-        RuntimeCommitLifecycleState::Pending => "pending",
-        RuntimeCommitLifecycleState::Finalized => "finalized",
-        RuntimeCommitLifecycleState::Failed => "failed",
-    }
+    lifecycle_state_label_contract(state)
 }
 
 fn commit_finality_label(finality: KolmeCommitReceiptFinality) -> &'static str {
-    match finality {
-        KolmeCommitReceiptFinality::Pending => "pending",
-        KolmeCommitReceiptFinality::Final => "final",
-        KolmeCommitReceiptFinality::Failed => "failed",
-    }
+    commit_finality_label_contract(finality)
 }
 
 fn lifecycle_record_from_outcome(

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -8,6 +8,10 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("KolmeRuntimeCommitProviderReceipt"));
     assert!(DOC.contains("KolmeRuntimeCommitProviderError"));
     assert!(DOC.contains("KolmeRuntimeCommitForkFinalityResolver"));
+    assert!(DOC.contains("runtime_lifecycle_policy"));
+    assert!(DOC.contains("lifecycle_state_for_finality"));
+    assert!(DOC.contains("lifecycle_state_label"));
+    assert!(DOC.contains("commit_finality_label"));
     assert!(DOC.contains("translate_to_signed_broadcast_envelope"));
     assert!(DOC.contains("fetch_next_nonce"));
     assert!(DOC.contains("submit_broadcast_request"));
@@ -42,4 +46,5 @@ fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marke
     assert!(DOC.contains("`Regression: #1503`"));
     assert!(DOC.contains("`Regression: #1506`"));
     assert!(DOC.contains("`Regression: #1533`"));
+    assert!(DOC.contains("`Regression: #1775`"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -18,6 +18,7 @@ pub mod pipeline;
 pub mod provider_outcome_policy;
 pub mod provider_response_policy;
 pub mod receipt_finality;
+pub mod runtime_lifecycle_policy;
 pub mod tls_policy;
 pub mod transport;
 pub mod transport_request_policy;
@@ -63,6 +64,10 @@ pub use provider_response_policy::{
     KolmeProviderResponsePolicyError,
 };
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
+pub use runtime_lifecycle_policy::{
+    commit_finality_label, lifecycle_state_for_finality, lifecycle_state_label,
+    KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+};
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError,
 };

--- a/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
+++ b/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
@@ -1,0 +1,89 @@
+//! Runtime-commit lifecycle and finality policy contracts.
+
+/// Finality classification for a runtime commit receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KolmeCommitReceiptFinality {
+    /// Commit has been submitted and is pending confirmation.
+    Pending,
+    /// Commit is fully finalized.
+    Final,
+    /// Commit failed validation/finality.
+    Failed,
+}
+
+/// Runtime lifecycle state projected from commit receipt outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCommitLifecycleState {
+    /// Commit is pending confirmation and should remain on requeue/watch.
+    Pending,
+    /// Commit has reached final confirmation.
+    Finalized,
+    /// Commit failed and should not be retried automatically.
+    Failed,
+}
+
+/// Maps receipt finality to projected lifecycle state.
+pub fn lifecycle_state_for_finality(
+    finality: KolmeCommitReceiptFinality,
+) -> RuntimeCommitLifecycleState {
+    match finality {
+        KolmeCommitReceiptFinality::Pending => RuntimeCommitLifecycleState::Pending,
+        KolmeCommitReceiptFinality::Final => RuntimeCommitLifecycleState::Finalized,
+        KolmeCommitReceiptFinality::Failed => RuntimeCommitLifecycleState::Failed,
+    }
+}
+
+/// Renders deterministic lifecycle state labels for diagnostics and errors.
+pub fn lifecycle_state_label(state: RuntimeCommitLifecycleState) -> &'static str {
+    match state {
+        RuntimeCommitLifecycleState::Pending => "pending",
+        RuntimeCommitLifecycleState::Finalized => "finalized",
+        RuntimeCommitLifecycleState::Failed => "failed",
+    }
+}
+
+/// Renders deterministic receipt finality labels for diagnostics and errors.
+pub fn commit_finality_label(finality: KolmeCommitReceiptFinality) -> &'static str {
+    match finality {
+        KolmeCommitReceiptFinality::Pending => "pending",
+        KolmeCommitReceiptFinality::Final => "final",
+        KolmeCommitReceiptFinality::Failed => "failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        commit_finality_label, lifecycle_state_for_finality, lifecycle_state_label,
+        KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+    };
+
+    #[test]
+    fn unit_maps_finality_to_lifecycle_state() {
+        assert_eq!(
+            lifecycle_state_for_finality(KolmeCommitReceiptFinality::Pending),
+            RuntimeCommitLifecycleState::Pending
+        );
+        assert_eq!(
+            lifecycle_state_for_finality(KolmeCommitReceiptFinality::Final),
+            RuntimeCommitLifecycleState::Finalized
+        );
+        assert_eq!(
+            lifecycle_state_for_finality(KolmeCommitReceiptFinality::Failed),
+            RuntimeCommitLifecycleState::Failed
+        );
+    }
+
+    #[test]
+    fn regression_labels_remain_stable() {
+        // Regression: #1775
+        assert_eq!(
+            lifecycle_state_label(RuntimeCommitLifecycleState::Finalized),
+            "finalized"
+        );
+        assert_eq!(
+            commit_finality_label(KolmeCommitReceiptFinality::Final),
+            "final"
+        );
+    }
+}

--- a/crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs
@@ -1,0 +1,59 @@
+use kamn_kolme::{
+    commit_finality_label, lifecycle_state_for_finality, lifecycle_state_label,
+    KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+};
+
+#[test]
+fn unit_runtime_lifecycle_policy_maps_finality_to_state_contract() {
+    assert_eq!(
+        lifecycle_state_for_finality(KolmeCommitReceiptFinality::Pending),
+        RuntimeCommitLifecycleState::Pending
+    );
+    assert_eq!(
+        lifecycle_state_for_finality(KolmeCommitReceiptFinality::Final),
+        RuntimeCommitLifecycleState::Finalized
+    );
+    assert_eq!(
+        lifecycle_state_for_finality(KolmeCommitReceiptFinality::Failed),
+        RuntimeCommitLifecycleState::Failed
+    );
+}
+
+#[test]
+fn functional_runtime_lifecycle_policy_labels_are_deterministic() {
+    assert_eq!(
+        lifecycle_state_label(RuntimeCommitLifecycleState::Pending),
+        "pending"
+    );
+    assert_eq!(
+        lifecycle_state_label(RuntimeCommitLifecycleState::Finalized),
+        "finalized"
+    );
+    assert_eq!(
+        lifecycle_state_label(RuntimeCommitLifecycleState::Failed),
+        "failed"
+    );
+    assert_eq!(
+        commit_finality_label(KolmeCommitReceiptFinality::Pending),
+        "pending"
+    );
+    assert_eq!(
+        commit_finality_label(KolmeCommitReceiptFinality::Final),
+        "final"
+    );
+    assert_eq!(
+        commit_finality_label(KolmeCommitReceiptFinality::Failed),
+        "failed"
+    );
+}
+
+#[test]
+fn regression_runtime_lifecycle_policy_state_label_drift_remains_fail_closed() {
+    // Regression: #1775
+    assert_eq!(
+        lifecycle_state_label(lifecycle_state_for_finality(
+            KolmeCommitReceiptFinality::Final
+        )),
+        "finalized"
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -112,6 +112,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `crates/kamn-kolme/src/codec.rs`, `crates/kamn-kolme/src/transport.rs`,
     `crates/kamn-kolme/src/finality.rs`, `crates/kamn-kolme/src/pipeline.rs`,
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
+    `crates/kamn-kolme/src/runtime_lifecycle_policy.rs`,
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
@@ -120,7 +121,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/transport_request_policy.rs`, `crates/kamn-kolme/src/broadcast_payload_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
-    contracts (including direct signed payload validation policy). `kamn-core`
+    contracts (including direct signed payload validation and lifecycle/finality
+    projection policy). `kamn-core`
     retains temporary compatibility exports until full migration is complete.
 - Runtime/data-flow ownership:
   - New runtime-commit submissions should target `kamn-kolme` contracts first,

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -70,6 +70,7 @@ handling.
   - websocket handshake/frame parsing contracts are sourced from `kamn-kolme` (`find_http_header_boundary`, `validate_websocket_handshake_response`, `try_take_websocket_frame`) and mapped through `kamn-core` compatibility wrappers.
   - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
+  - runtime lifecycle/finality projection contracts are sourced from `kamn-kolme` (`lifecycle_state_for_finality`, `lifecycle_state_label`, `commit_finality_label`) and mapped through `kamn-core` compatibility wrappers.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
   - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
   - block-fallback response parsing contracts are sourced from `kamn-kolme` (`parse_block_fallback_response`, `parse_fork_block_fallback_response`) and mapped through `kamn-core` compatibility wrappers.
@@ -168,6 +169,7 @@ cargo test -p kamn-kolme --test block_fallback_policy_contracts
 cargo test -p kamn-kolme --test provider_outcome_policy_contracts
 cargo test -p kamn-kolme --test transport_request_policy_contracts
 cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
+cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -201,3 +203,4 @@ cargo test -p kamn-core
 - provider helper reuse extraction parity drift remains fail-closed (`Regression: #1753`).
 - transport request helper extraction parity drift remains fail-closed (`Regression: #1755`).
 - broadcast payload normalization extraction parity drift remains fail-closed (`Regression: #1757`).
+- runtime lifecycle/finality projection extraction parity drift remains fail-closed (`Regression: #1775`).


### PR DESCRIPTION
## Summary
Extract runtime-commit lifecycle/finality policy contracts from `kamn-core` into `kamn-kolme` and rewire `kamn-core` to consume the shared contracts via compatibility delegation. This reduces duplicate policy logic while preserving existing runtime behavior.

## Changes
- `crates/kamn-kolme/src/runtime_lifecycle_policy.rs`: added canonical lifecycle/finality enums and deterministic mapping/label helpers.
- `crates/kamn-kolme/src/lib.rs`: exported lifecycle/finality policy module and public contracts.
- `crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs`: added unit/functional/regression contract coverage for extracted policy behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: replaced duplicated enum/helper ownership with `kamn-kolme` type aliases and delegated helper wrappers.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: tightened doc-contract assertions for extraction boundary and regression marker.
- `docs/foundation/kolme-runtime-commit-client.md`: documented lifecycle/finality extraction boundary, added validation command, and regression marker.
- `docs/architecture/kamn-core-module-map.md`: updated Kolme extraction boundary ownership map.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
```

Expected failing output before implementation:
- unresolved imports in `kamn_kolme` for:
  - `KolmeCommitReceiptFinality`
  - `RuntimeCommitLifecycleState`
  - `lifecycle_state_for_finality`
  - `lifecycle_state_label`
  - `commit_finality_label`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
```

Passing summary:
- `runtime_lifecycle_policy_contracts`: 3 passed
- `kolme_runtime_commit_client_docs`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo fmt --check
cargo clippy -p kamn-core -p kamn-kolme --tests -- -D warnings
```

Passing summary:
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `cargo fmt --check`: clean
- strict clippy (touched crates): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `runtime_lifecycle_policy_contracts::unit_runtime_lifecycle_policy_maps_finality_to_state_contract` |                      |
| Functional   | ✅      | `runtime_lifecycle_policy_contracts::functional_runtime_lifecycle_policy_labels_are_deterministic` |                      |
| Integration  | ✅      | `kolme_runtime_commit_finality`, `kolme_runtime_commit_client`, `kolme_runtime_commit_client_docs` |                      |
| Regression   | ✅      | `runtime_lifecycle_policy_contracts::regression_runtime_lifecycle_policy_state_label_drift_remains_fail_closed` (`Regression: #1775`) |                      |
| Performance  | N/A     |                                                                     | Pure policy extraction; no runtime-path algorithm changes |

## Risks & Rollback
- None expected; behavior is parity-preserving via compatibility delegation.
- Rollback: revert this PR to restore previous `kamn-core` local policy ownership.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` and `kamn-kolme` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1775
Refs #1714
