### PR TITLE
refactor(kolme): extract receipt finality mapping policy contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -3,6 +3,7 @@
 use crate::AgentDid;
 use kamn_kolme::{
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
+    commit_finality_from_receipt_finality as commit_finality_from_receipt_finality_contract,
     commit_finality_label as commit_finality_label_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
@@ -2061,23 +2062,16 @@ fn txhash_from_commit_id(commit_id: &str) -> Result<String, KolmeRuntimeCommitPr
 fn parse_receipt_finality(
     value: &str,
 ) -> Result<KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderError> {
-    match parse_kolme_receipt_finality(value).map_err(|error| {
+    let finality = parse_kolme_receipt_finality(value).map_err(|error| {
         KolmeRuntimeCommitProviderError::MalformedResponse {
             reason: error.to_string(),
         }
-    })? {
-        ReceiptFinality::Pending => Ok(KolmeCommitReceiptFinality::Pending),
-        ReceiptFinality::Final => Ok(KolmeCommitReceiptFinality::Final),
-        ReceiptFinality::Failed => Ok(KolmeCommitReceiptFinality::Failed),
-    }
+    })?;
+    Ok(commit_finality_from_receipt_finality_contract(finality))
 }
 
 fn map_extracted_receipt_finality(finality: ReceiptFinality) -> KolmeCommitReceiptFinality {
-    match finality {
-        ReceiptFinality::Pending => KolmeCommitReceiptFinality::Pending,
-        ReceiptFinality::Final => KolmeCommitReceiptFinality::Final,
-        ReceiptFinality::Failed => KolmeCommitReceiptFinality::Failed,
-    }
+    commit_finality_from_receipt_finality_contract(finality)
 }
 
 fn map_provider_outcome(

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -9,6 +9,7 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("KolmeRuntimeCommitProviderError"));
     assert!(DOC.contains("KolmeRuntimeCommitForkFinalityResolver"));
     assert!(DOC.contains("runtime_lifecycle_policy"));
+    assert!(DOC.contains("commit_finality_from_receipt_finality"));
     assert!(DOC.contains("lifecycle_state_for_finality"));
     assert!(DOC.contains("lifecycle_state_label"));
     assert!(DOC.contains("commit_finality_label"));
@@ -51,4 +52,5 @@ fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marke
     assert!(DOC.contains("`Regression: #1533`"));
     assert!(DOC.contains("`Regression: #1775`"));
     assert!(DOC.contains("`Regression: #1777`"));
+    assert!(DOC.contains("`Regression: #1779`"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -66,8 +66,8 @@ pub use provider_response_policy::{
 };
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use runtime_lifecycle_policy::{
-    commit_finality_label, lifecycle_state_for_finality, lifecycle_state_label,
-    KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+    commit_finality_from_receipt_finality, commit_finality_label, lifecycle_state_for_finality,
+    lifecycle_state_label, KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
 };
 pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,

--- a/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
+++ b/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
@@ -1,5 +1,7 @@
 //! Runtime-commit lifecycle and finality policy contracts.
 
+use crate::ReceiptFinality;
+
 /// Finality classification for a runtime commit receipt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KolmeCommitReceiptFinality {
@@ -33,6 +35,17 @@ pub fn lifecycle_state_for_finality(
     }
 }
 
+/// Maps receipt finality aliases to runtime commit finality.
+pub fn commit_finality_from_receipt_finality(
+    finality: ReceiptFinality,
+) -> KolmeCommitReceiptFinality {
+    match finality {
+        ReceiptFinality::Pending => KolmeCommitReceiptFinality::Pending,
+        ReceiptFinality::Final => KolmeCommitReceiptFinality::Final,
+        ReceiptFinality::Failed => KolmeCommitReceiptFinality::Failed,
+    }
+}
+
 /// Renders deterministic lifecycle state labels for diagnostics and errors.
 pub fn lifecycle_state_label(state: RuntimeCommitLifecycleState) -> &'static str {
     match state {
@@ -54,9 +67,10 @@ pub fn commit_finality_label(finality: KolmeCommitReceiptFinality) -> &'static s
 #[cfg(test)]
 mod tests {
     use super::{
-        commit_finality_label, lifecycle_state_for_finality, lifecycle_state_label,
-        KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+        commit_finality_from_receipt_finality, commit_finality_label, lifecycle_state_for_finality,
+        lifecycle_state_label, KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
     };
+    use crate::ReceiptFinality;
 
     #[test]
     fn unit_maps_finality_to_lifecycle_state() {
@@ -84,6 +98,23 @@ mod tests {
         assert_eq!(
             commit_finality_label(KolmeCommitReceiptFinality::Final),
             "final"
+        );
+    }
+
+    #[test]
+    fn regression_receipt_finality_mapping_remains_stable() {
+        // Regression: #1779
+        assert_eq!(
+            commit_finality_from_receipt_finality(ReceiptFinality::Pending),
+            KolmeCommitReceiptFinality::Pending
+        );
+        assert_eq!(
+            commit_finality_from_receipt_finality(ReceiptFinality::Final),
+            KolmeCommitReceiptFinality::Final
+        );
+        assert_eq!(
+            commit_finality_from_receipt_finality(ReceiptFinality::Failed),
+            KolmeCommitReceiptFinality::Failed
         );
     }
 }

--- a/crates/kamn-kolme/tests/receipt_to_commit_finality_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/receipt_to_commit_finality_policy_contracts.rs
@@ -1,0 +1,50 @@
+use kamn_kolme::{
+    commit_finality_from_receipt_finality, commit_finality_label, parse_receipt_finality,
+    KolmeCommitReceiptFinality, ReceiptFinality,
+};
+
+#[test]
+fn unit_receipt_to_commit_finality_mapping_contract() {
+    assert_eq!(
+        commit_finality_from_receipt_finality(ReceiptFinality::Pending),
+        KolmeCommitReceiptFinality::Pending
+    );
+    assert_eq!(
+        commit_finality_from_receipt_finality(ReceiptFinality::Final),
+        KolmeCommitReceiptFinality::Final
+    );
+    assert_eq!(
+        commit_finality_from_receipt_finality(ReceiptFinality::Failed),
+        KolmeCommitReceiptFinality::Failed
+    );
+}
+
+#[test]
+fn functional_receipt_aliases_map_to_deterministic_commit_labels() {
+    let accepted = parse_receipt_finality("accepted").expect("accepted alias should parse");
+    let finalized = parse_receipt_finality("finalized").expect("finalized alias should parse");
+    let failed = parse_receipt_finality("failed").expect("failed alias should parse");
+
+    assert_eq!(
+        commit_finality_label(commit_finality_from_receipt_finality(accepted)),
+        "pending"
+    );
+    assert_eq!(
+        commit_finality_label(commit_finality_from_receipt_finality(finalized)),
+        "final"
+    );
+    assert_eq!(
+        commit_finality_label(commit_finality_from_receipt_finality(failed)),
+        "failed"
+    );
+}
+
+#[test]
+fn regression_receipt_to_commit_mapping_remains_parity_locked() {
+    // Regression: #1779
+    let pending = parse_receipt_finality("pending").expect("pending alias should parse");
+    assert_eq!(
+        commit_finality_from_receipt_finality(pending),
+        KolmeCommitReceiptFinality::Pending
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -122,8 +122,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/transport_request_policy.rs`, `crates/kamn-kolme/src/broadcast_payload_policy.rs`
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
-    contracts (including direct signed payload validation, lifecycle/finality,
-    and deterministic request identity
+    contracts (including direct signed payload validation, receipt-to-commit
+    finality mapping, lifecycle/finality, and deterministic request identity
     projection policy). `kamn-core`
     retains temporary compatibility exports until full migration is complete.
 - Runtime/data-flow ownership:

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -70,6 +70,7 @@ handling.
   - websocket handshake/frame parsing contracts are sourced from `kamn-kolme` (`find_http_header_boundary`, `validate_websocket_handshake_response`, `try_take_websocket_frame`) and mapped through `kamn-core` compatibility wrappers.
   - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
   - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
+  - receipt-finality to commit-finality mapping contracts are sourced from `kamn-kolme` (`commit_finality_from_receipt_finality`) and mapped through `kamn-core` compatibility wrappers.
   - runtime lifecycle/finality projection contracts are sourced from `kamn-kolme` (`lifecycle_state_for_finality`, `lifecycle_state_label`, `commit_finality_label`) and mapped through `kamn-core` compatibility wrappers.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
   - flat JSON scalar field parsing contracts are sourced from `kamn-kolme` (`parse_flat_json_value_fields`, `required_json_string_field`, `required_positive_u64_json_field`) and mapped through `kamn-core` compatibility wrappers.
@@ -174,6 +175,7 @@ cargo test -p kamn-kolme --test transport_request_policy_contracts
 cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
 cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
 cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts
+cargo test -p kamn-kolme --test receipt_to_commit_finality_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -209,3 +211,4 @@ cargo test -p kamn-core
 - broadcast payload normalization extraction parity drift remains fail-closed (`Regression: #1757`).
 - runtime lifecycle/finality projection extraction parity drift remains fail-closed (`Regression: #1775`).
 - runtime request identity extraction parity drift remains fail-closed (`Regression: #1777`).
+- receipt-finality mapping extraction parity drift remains fail-closed (`Regression: #1779`).


### PR DESCRIPTION
## Summary
Extract receipt-finality to runtime commit finality mapping contracts from `kamn-core` into `kamn-kolme` and rewire `kamn-core` to delegate to the shared helper. This removes duplicated mapping logic and keeps finality policy ownership centralized.

## Changes
- `crates/kamn-kolme/src/runtime_lifecycle_policy.rs`: added `commit_finality_from_receipt_finality` helper and regression coverage.
- `crates/kamn-kolme/src/lib.rs`: exported `commit_finality_from_receipt_finality`.
- `crates/kamn-kolme/tests/receipt_to_commit_finality_policy_contracts.rs`: added unit/functional/regression mapping contracts.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: replaced local `ReceiptFinality` mapping matches with delegation to `kamn-kolme` helper.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: tightened doc-contract checks for mapping helper + regression marker.
- `docs/foundation/kolme-runtime-commit-client.md`: documented extraction boundary, command, and regression marker.
- `docs/architecture/kamn-core-module-map.md`: updated ownership wording for extracted mapping policy.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test receipt_to_commit_finality_policy_contracts
```

Expected failing output before implementation:
- unresolved import in `kamn_kolme` for:
  - `commit_finality_from_receipt_finality`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test receipt_to_commit_finality_policy_contracts
cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
```

Passing summary:
- `receipt_to_commit_finality_policy_contracts`: 3 passed
- `runtime_lifecycle_policy_contracts`: 3 passed
- `kolme_runtime_commit_client_docs`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo fmt --check
cargo clippy -p kamn-core -p kamn-kolme --tests -- -D warnings
```

Passing summary:
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `cargo fmt --check`: clean
- strict clippy (touched crates): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `receipt_to_commit_finality_policy_contracts::unit_receipt_to_commit_finality_mapping_contract` |                      |
| Functional   | ✅      | `receipt_to_commit_finality_policy_contracts::functional_receipt_aliases_map_to_deterministic_commit_labels` |                      |
| Integration  | ✅      | `kolme_runtime_commit_finality`, `kolme_runtime_commit_client`, `kolme_runtime_commit_client_docs` |                      |
| Regression   | ✅      | `receipt_to_commit_finality_policy_contracts::regression_receipt_to_commit_mapping_remains_parity_locked` (`Regression: #1779`) |                      |
| Performance  | N/A     |                                                                     | Pure policy extraction; no runtime-path algorithm changes |

## Risks & Rollback
- None expected; behavior remains parity-preserving through compatibility delegation.
- Rollback: revert this PR to restore previous `kamn-core` local mapping helper logic.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` and `kamn-kolme` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1779
Refs #1714
