### PR TITLE
refactor(kolme): extract json escape helper policy contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -10,6 +10,7 @@ use kamn_kolme::{
     deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     deterministic_runtime_commit_id as deterministic_runtime_commit_id_contract,
     deterministic_runtime_commit_idempotency_key as deterministic_runtime_commit_idempotency_key_contract,
+    escape_json_string as escape_kolme_json_string,
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
@@ -253,9 +254,9 @@ impl KolmeRuntimeCommitSignedBroadcastEnvelope {
     pub fn to_wire_payload(&self) -> String {
         format!(
             "{{\"signer_key_id\":\"{}\",\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
-            json_escape(self.signer_key_id.as_str()),
-            json_escape(self.message.as_str()),
-            json_escape(self.signature.as_str()),
+            escape_kolme_json_string(self.signer_key_id.as_str()),
+            escape_kolme_json_string(self.message.as_str()),
+            escape_kolme_json_string(self.signature.as_str()),
             self.recovery_id
         )
     }
@@ -2034,21 +2035,6 @@ fn parse_live_provider_response(
             Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
         }
     }
-}
-
-fn json_escape(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '\\' => escaped.push_str("\\\\"),
-            '"' => escaped.push_str("\\\""),
-            '\n' => escaped.push_str("\\n"),
-            '\r' => escaped.push_str("\\r"),
-            '\t' => escaped.push_str("\\t"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
 }
 
 fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> String {

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -16,6 +16,7 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("runtime_request_identity_policy"));
     assert!(DOC.contains("deterministic_runtime_commit_idempotency_key"));
     assert!(DOC.contains("deterministic_runtime_commit_id"));
+    assert!(DOC.contains("escape_json_string"));
     assert!(DOC.contains("translate_to_signed_broadcast_envelope"));
     assert!(DOC.contains("fetch_next_nonce"));
     assert!(DOC.contains("submit_broadcast_request"));
@@ -53,4 +54,5 @@ fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marke
     assert!(DOC.contains("`Regression: #1775`"));
     assert!(DOC.contains("`Regression: #1777`"));
     assert!(DOC.contains("`Regression: #1779`"));
+    assert!(DOC.contains("`Regression: #1781`"));
 }

--- a/crates/kamn-kolme/src/api_codec.rs
+++ b/crates/kamn-kolme/src/api_codec.rs
@@ -136,8 +136,8 @@ impl KolmeApiBroadcastRequest {
     pub fn to_json_payload(&self) -> String {
         format!(
             "{{\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
-            json_escape(self.message.as_str()),
-            json_escape(self.signature.as_str()),
+            escape_json_string(self.message.as_str()),
+            escape_json_string(self.signature.as_str()),
             self.recovery_id
         )
     }
@@ -603,7 +603,8 @@ fn percent_encode(value: &str) -> String {
     encoded
 }
 
-fn json_escape(value: &str) -> String {
+/// Escapes one UTF-8 string for deterministic JSON string rendering.
+pub fn escape_json_string(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
         match ch {

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -26,7 +26,7 @@ pub mod transport_request_policy;
 pub mod websocket_policy;
 
 pub use api_codec::{
-    validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
+    escape_json_string, validate_direct_signed_transaction_message, KolmeApiBroadcastRequest,
     KolmeApiBroadcastResponse, KolmeApiCodecError, KolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse,
 };

--- a/crates/kamn-kolme/tests/json_escape_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/json_escape_policy_contracts.rs
@@ -1,0 +1,20 @@
+use kamn_kolme::escape_json_string;
+
+#[test]
+fn unit_json_escape_policy_escapes_control_and_quote_characters() {
+    let escaped = escape_json_string("a\"b\\c\nd\re\tf");
+    assert_eq!(escaped, "a\\\"b\\\\c\\nd\\re\\tf");
+}
+
+#[test]
+fn functional_json_escape_policy_preserves_plain_ascii() {
+    let escaped = escape_json_string("runtime-commit-123");
+    assert_eq!(escaped, "runtime-commit-123");
+}
+
+#[test]
+fn regression_json_escape_policy_remains_deterministic_for_repeated_input() {
+    // Regression: #1781
+    let value = "\"quoted\"\\slash\n";
+    assert_eq!(escape_json_string(value), escape_json_string(value));
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -123,8 +123,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation, receipt-to-commit
-    finality mapping, lifecycle/finality, and deterministic request identity
-    projection policy). `kamn-core`
+    finality mapping, lifecycle/finality, deterministic request identity, and
+    JSON escape serialization policy). `kamn-core`
     retains temporary compatibility exports until full migration is complete.
 - Runtime/data-flow ownership:
   - New runtime-commit submissions should target `kamn-kolme` contracts first,

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -115,6 +115,9 @@ handling.
 - Deterministic request identity contracts are sourced from `kamn-kolme`
   (`deterministic_runtime_commit_idempotency_key`, `deterministic_runtime_commit_id`)
   and mapped through `kamn-core` compatibility wrappers.
+- Deterministic JSON string escaping contracts for signed-envelope serialization are
+  sourced from `kamn-kolme` (`escape_json_string`) and mapped through
+  `kamn-core` compatibility wrappers.
 - The adapter preserves validation semantics from
   `KolmeRuntimeCommitRequest::validate()` before provider dispatch.
 - Signed translation model:
@@ -176,6 +179,7 @@ cargo test -p kamn-kolme --test broadcast_payload_policy_contracts
 cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
 cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts
 cargo test -p kamn-kolme --test receipt_to_commit_finality_policy_contracts
+cargo test -p kamn-kolme --test json_escape_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -212,3 +216,4 @@ cargo test -p kamn-core
 - runtime lifecycle/finality projection extraction parity drift remains fail-closed (`Regression: #1775`).
 - runtime request identity extraction parity drift remains fail-closed (`Regression: #1777`).
 - receipt-finality mapping extraction parity drift remains fail-closed (`Regression: #1779`).
+- JSON escape helper extraction parity drift remains fail-closed (`Regression: #1781`).


### PR DESCRIPTION
## Summary
Extract deterministic JSON escape helper policy from `kamn-core` into `kamn-kolme` and rewire signed-envelope serialization in `kamn-core` to delegate to the extracted helper. This removes duplicate escaping logic and keeps serialization policy ownership centralized.

## Changes
- `crates/kamn-kolme/src/api_codec.rs`: promoted canonical escape helper to public `escape_json_string`.
- `crates/kamn-kolme/src/lib.rs`: exported `escape_json_string` from the crate surface.
- `crates/kamn-kolme/tests/json_escape_policy_contracts.rs`: added unit/functional/regression escape-policy tests.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed local `json_escape` helper and delegated signed-envelope serialization escaping to `kamn-kolme`.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: tightened doc-contract assertions for escape helper extraction + regression marker.
- `docs/foundation/kolme-runtime-commit-client.md`: documented escape helper extraction boundary, command, and regression marker.
- `docs/architecture/kamn-core-module-map.md`: updated extraction ownership wording.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test json_escape_policy_contracts
```

Expected failing output before implementation:
- unresolved import in `kamn_kolme` for:
  - `escape_json_string`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test json_escape_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
```

Passing summary:
- `json_escape_policy_contracts`: 3 passed
- `kolme_runtime_commit_client_docs`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo fmt --check
cargo clippy -p kamn-core -p kamn-kolme --tests -- -D warnings
```

Passing summary:
- `runtime_request_identity_policy_contracts`: 3 passed
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `cargo fmt --check`: clean
- strict clippy (touched crates): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `json_escape_policy_contracts::unit_json_escape_policy_escapes_control_and_quote_characters` |                      |
| Functional   | ✅      | `json_escape_policy_contracts::functional_json_escape_policy_preserves_plain_ascii` |                      |
| Integration  | ✅      | `kolme_runtime_commit_client_docs`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_client` |                      |
| Regression   | ✅      | `json_escape_policy_contracts::regression_json_escape_policy_remains_deterministic_for_repeated_input` (`Regression: #1781`) |                      |
| Performance  | N/A     |                                                                     | Pure helper extraction; no runtime-path algorithm changes |

## Risks & Rollback
- None expected; behavior remains parity-preserving via compatibility delegation.
- Rollback: revert this PR to restore previous `kamn-core` local escape helper.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` and `kamn-kolme` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1781
Refs #1714
