### PR TITLE
refactor(kolme): extract commit finality parse helper contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -19,13 +19,13 @@ use kamn_kolme::{
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
     parse_commit_id_from_response_fields as parse_kolme_commit_id_from_response_fields,
+    parse_commit_receipt_finality as parse_kolme_commit_receipt_finality,
     parse_fork_block_fallback_response as parse_kolme_fork_block_fallback_response_contract,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
     parse_live_provider_outcome as parse_kolme_live_provider_outcome,
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_provider_response_fields as parse_kolme_provider_response_fields,
-    parse_receipt_finality as parse_kolme_receipt_finality,
     parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
@@ -2048,12 +2048,11 @@ fn txhash_from_commit_id(commit_id: &str) -> Result<String, KolmeRuntimeCommitPr
 fn parse_receipt_finality(
     value: &str,
 ) -> Result<KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderError> {
-    let finality = parse_kolme_receipt_finality(value).map_err(|error| {
+    parse_kolme_commit_receipt_finality(value).map_err(|error| {
         KolmeRuntimeCommitProviderError::MalformedResponse {
             reason: error.to_string(),
         }
-    })?;
-    Ok(commit_finality_from_receipt_finality_contract(finality))
+    })
 }
 
 fn map_extracted_receipt_finality(finality: ReceiptFinality) -> KolmeCommitReceiptFinality {

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -10,6 +10,7 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("KolmeRuntimeCommitForkFinalityResolver"));
     assert!(DOC.contains("runtime_lifecycle_policy"));
     assert!(DOC.contains("commit_finality_from_receipt_finality"));
+    assert!(DOC.contains("parse_commit_receipt_finality"));
     assert!(DOC.contains("lifecycle_state_for_finality"));
     assert!(DOC.contains("lifecycle_state_label"));
     assert!(DOC.contains("commit_finality_label"));
@@ -55,4 +56,5 @@ fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marke
     assert!(DOC.contains("`Regression: #1777`"));
     assert!(DOC.contains("`Regression: #1779`"));
     assert!(DOC.contains("`Regression: #1781`"));
+    assert!(DOC.contains("`Regression: #1783`"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -67,7 +67,8 @@ pub use provider_response_policy::{
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use runtime_lifecycle_policy::{
     commit_finality_from_receipt_finality, commit_finality_label, lifecycle_state_for_finality,
-    lifecycle_state_label, KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+    lifecycle_state_label, parse_commit_receipt_finality, KolmeCommitReceiptFinality,
+    RuntimeCommitLifecycleState,
 };
 pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,

--- a/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
+++ b/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
@@ -1,6 +1,6 @@
 //! Runtime-commit lifecycle and finality policy contracts.
 
-use crate::ReceiptFinality;
+use crate::receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 
 /// Finality classification for a runtime commit receipt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +46,14 @@ pub fn commit_finality_from_receipt_finality(
     }
 }
 
+/// Parses raw finality string and maps it into runtime commit finality.
+pub fn parse_commit_receipt_finality(
+    value: &str,
+) -> Result<KolmeCommitReceiptFinality, ReceiptFinalityError> {
+    let finality = parse_receipt_finality(value)?;
+    Ok(commit_finality_from_receipt_finality(finality))
+}
+
 /// Renders deterministic lifecycle state labels for diagnostics and errors.
 pub fn lifecycle_state_label(state: RuntimeCommitLifecycleState) -> &'static str {
     match state {
@@ -68,9 +76,10 @@ pub fn commit_finality_label(finality: KolmeCommitReceiptFinality) -> &'static s
 mod tests {
     use super::{
         commit_finality_from_receipt_finality, commit_finality_label, lifecycle_state_for_finality,
-        lifecycle_state_label, KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+        lifecycle_state_label, parse_commit_receipt_finality, KolmeCommitReceiptFinality,
+        RuntimeCommitLifecycleState,
     };
-    use crate::ReceiptFinality;
+    use crate::receipt_finality::{ReceiptFinality, ReceiptFinalityError};
 
     #[test]
     fn unit_maps_finality_to_lifecycle_state() {
@@ -115,6 +124,17 @@ mod tests {
         assert_eq!(
             commit_finality_from_receipt_finality(ReceiptFinality::Failed),
             KolmeCommitReceiptFinality::Failed
+        );
+    }
+
+    #[test]
+    fn regression_commit_finality_parse_remains_fail_closed() {
+        // Regression: #1783
+        assert_eq!(
+            parse_commit_receipt_finality("settled"),
+            Err(ReceiptFinalityError::InvalidFinalityValue(
+                "settled".to_owned()
+            ))
         );
     }
 }

--- a/crates/kamn-kolme/tests/commit_finality_parse_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/commit_finality_parse_policy_contracts.rs
@@ -1,0 +1,36 @@
+use kamn_kolme::{parse_commit_receipt_finality, KolmeCommitReceiptFinality, ReceiptFinalityError};
+
+#[test]
+fn unit_commit_finality_parse_maps_aliases_to_commit_finality_contract() {
+    assert_eq!(
+        parse_commit_receipt_finality("pending").expect("pending should parse"),
+        KolmeCommitReceiptFinality::Pending
+    );
+    assert_eq!(
+        parse_commit_receipt_finality("finalized").expect("finalized should parse"),
+        KolmeCommitReceiptFinality::Final
+    );
+    assert_eq!(
+        parse_commit_receipt_finality("failed").expect("failed should parse"),
+        KolmeCommitReceiptFinality::Failed
+    );
+}
+
+#[test]
+fn functional_commit_finality_parse_accepts_confirmed_alias() {
+    assert_eq!(
+        parse_commit_receipt_finality("confirmed").expect("confirmed alias should parse"),
+        KolmeCommitReceiptFinality::Final
+    );
+}
+
+#[test]
+fn regression_commit_finality_parse_rejects_unknown_values_fail_closed() {
+    // Regression: #1783
+    assert_eq!(
+        parse_commit_receipt_finality("settled"),
+        Err(ReceiptFinalityError::InvalidFinalityValue(
+            "settled".to_owned()
+        ))
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -123,8 +123,8 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 - Ownership boundary:
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation, receipt-to-commit
-    finality mapping, lifecycle/finality, deterministic request identity, and
-    JSON escape serialization policy). `kamn-core`
+    finality mapping and parse helpers, lifecycle/finality, deterministic
+    request identity, and JSON escape serialization policy). `kamn-core`
     retains temporary compatibility exports until full migration is complete.
 - Runtime/data-flow ownership:
   - New runtime-commit submissions should target `kamn-kolme` contracts first,

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -69,7 +69,7 @@ handling.
   - `KolmeRuntimeCommitForkFinalityResolver` composes websocket notifications (`/notifications`) with bounded block fallback scans (`/block/{height}`).
   - websocket handshake/frame parsing contracts are sourced from `kamn-kolme` (`find_http_header_boundary`, `validate_websocket_handshake_response`, `try_take_websocket_frame`) and mapped through `kamn-core` compatibility wrappers.
   - notification variant parsing contracts are sourced from `kamn-kolme` (`parse_notification_event`) and mapped through `kamn-core` compatibility wrappers.
-  - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
+  - finality alias parsing and block-scan policy contracts are sourced from `kamn-kolme` (`parse_receipt_finality`, `parse_commit_receipt_finality`, `validate_lookup_window`, `validate_block_identity`, `render_block_path`, `parse_fork_block_txhash`) so extraction boundaries stay explicit while `kamn-core` adapters are migrated.
   - receipt-finality to commit-finality mapping contracts are sourced from `kamn-kolme` (`commit_finality_from_receipt_finality`) and mapped through `kamn-core` compatibility wrappers.
   - runtime lifecycle/finality projection contracts are sourced from `kamn-kolme` (`lifecycle_state_for_finality`, `lifecycle_state_label`, `commit_finality_label`) and mapped through `kamn-core` compatibility wrappers.
   - provider response field parsing contracts are sourced from `kamn-kolme` (`parse_provider_response_fields`, `parse_provider_key_value_fields`) and mapped through `kamn-core` compatibility wrappers.
@@ -180,6 +180,7 @@ cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts
 cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts
 cargo test -p kamn-kolme --test receipt_to_commit_finality_policy_contracts
 cargo test -p kamn-kolme --test json_escape_policy_contracts
+cargo test -p kamn-kolme --test commit_finality_parse_policy_contracts
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_fetch_next_nonce_query_and_parse -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_broadcast_request_put_and_parse_txhash -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
@@ -217,3 +218,4 @@ cargo test -p kamn-core
 - runtime request identity extraction parity drift remains fail-closed (`Regression: #1777`).
 - receipt-finality mapping extraction parity drift remains fail-closed (`Regression: #1779`).
 - JSON escape helper extraction parity drift remains fail-closed (`Regression: #1781`).
+- commit-finality parse helper extraction parity drift remains fail-closed (`Regression: #1783`).


### PR DESCRIPTION
## Summary
Extract commit finality parse helper policy from `kamn-core` into `kamn-kolme` and rewire `kamn-core` to delegate parse+mapping behavior to the extracted helper. This removes local parse glue and keeps finality policy ownership centralized.

## Changes
- `crates/kamn-kolme/src/runtime_lifecycle_policy.rs`: added `parse_commit_receipt_finality` helper and regression coverage.
- `crates/kamn-kolme/src/lib.rs`: exported `parse_commit_receipt_finality`.
- `crates/kamn-kolme/tests/commit_finality_parse_policy_contracts.rs`: added unit/functional/regression parse helper contracts.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: replaced local parse glue with delegation to `kamn-kolme` parse helper.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: tightened doc-contract checks for parse helper extraction + regression marker.
- `docs/foundation/kolme-runtime-commit-client.md`: documented parse helper extraction boundary, command, and regression marker.
- `docs/architecture/kamn-core-module-map.md`: updated extraction ownership wording.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-kolme --test commit_finality_parse_policy_contracts
```

Expected failing output before implementation:
- unresolved import in `kamn_kolme` for:
  - `parse_commit_receipt_finality`

### 🟢 Green Phase
```bash
cargo test -p kamn-kolme --test commit_finality_parse_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
```

Passing summary:
- `commit_finality_parse_policy_contracts`: 3 passed
- `kolme_runtime_commit_client_docs`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-kolme --test receipt_to_commit_finality_policy_contracts
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo fmt --check
cargo clippy -p kamn-core -p kamn-kolme --tests -- -D warnings
```

Passing summary:
- `receipt_to_commit_finality_policy_contracts`: 3 passed
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `cargo fmt --check`: clean
- strict clippy (touched crates): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `commit_finality_parse_policy_contracts::unit_commit_finality_parse_maps_aliases_to_commit_finality_contract` |                      |
| Functional   | ✅      | `commit_finality_parse_policy_contracts::functional_commit_finality_parse_accepts_confirmed_alias` |                      |
| Integration  | ✅      | `kolme_runtime_commit_client_docs`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_client` |                      |
| Regression   | ✅      | `commit_finality_parse_policy_contracts::regression_commit_finality_parse_rejects_unknown_values_fail_closed` (`Regression: #1783`) |                      |
| Performance  | N/A     |                                                                     | Pure helper extraction; no runtime-path algorithm changes |

## Risks & Rollback
- None expected; behavior remains parity-preserving via compatibility delegation.
- Rollback: revert this PR to restore previous `kamn-core` local parse glue.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` and `kamn-kolme` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1783
Refs #1714
