### PR TITLE
refactor(kolme): remove remaining core finality glue wrappers

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -57,7 +57,7 @@ use kamn_kolme::{
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
     KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
-    KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError, ReceiptFinality,
+    KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError,
     RuntimeCommitLifecycleState as KamnKolmeRuntimeCommitLifecycleState,
 };
 use std::collections::HashMap;
@@ -1131,7 +1131,12 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
         }
         let finality_value = required_kolme_provider_response_field(&fields, "finality")
             .map_err(map_provider_outcome_policy_error_to_malformed)?;
-        let finality = parse_receipt_finality(finality_value.as_str())?;
+        let finality =
+            parse_kolme_commit_receipt_finality(finality_value.as_str()).map_err(|error| {
+                KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                }
+            })?;
         Ok(KolmeRuntimeCommitProviderReceipt {
             provider,
             commit_id: observed_commit_id,
@@ -2017,7 +2022,7 @@ fn parse_live_provider_response(
             KolmeRuntimeCommitProviderReceipt {
                 provider,
                 commit_id,
-                finality: map_extracted_receipt_finality(finality),
+                finality: commit_finality_from_receipt_finality_contract(finality),
             },
         )),
         KamnKolmeProviderOutcome::Duplicate {
@@ -2028,7 +2033,7 @@ fn parse_live_provider_response(
             KolmeRuntimeCommitProviderReceipt {
                 provider,
                 commit_id,
-                finality: map_extracted_receipt_finality(finality),
+                finality: commit_finality_from_receipt_finality_contract(finality),
             },
         )),
         KamnKolmeProviderOutcome::Rejected { reason } => {
@@ -2043,20 +2048,6 @@ fn deterministic_backend_commit_id(tx_hash: &str, block_height: Option<u64>) -> 
 
 fn txhash_from_commit_id(commit_id: &str) -> Result<String, KolmeRuntimeCommitProviderError> {
     txhash_from_kolme_commit_id(commit_id).map_err(map_provider_outcome_policy_error_to_malformed)
-}
-
-fn parse_receipt_finality(
-    value: &str,
-) -> Result<KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderError> {
-    parse_kolme_commit_receipt_finality(value).map_err(|error| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: error.to_string(),
-        }
-    })
-}
-
-fn map_extracted_receipt_finality(finality: ReceiptFinality) -> KolmeCommitReceiptFinality {
-    commit_finality_from_receipt_finality_contract(finality)
 }
 
 fn map_provider_outcome(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,0 +1,14 @@
+const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
+
+#[test]
+fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers() {
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_receipt_finality("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_extracted_receipt_finality("));
+}
+
+#[test]
+fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
+    // Regression: #1785
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
+    assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
+}


### PR DESCRIPTION
## Summary
Remove remaining local finality glue wrappers from `kamn-core` and delegate directly to extracted `kamn-kolme` helper contracts. This tightens the extraction boundary and reduces duplication without changing runtime behavior.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed local `parse_receipt_finality` and `map_extracted_receipt_finality` wrappers; rewired call sites to direct helper delegation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added extraction-boundary test coverage enforcing wrapper absence and direct helper delegation.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Expected failing output before implementation:
- `unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` failed because source still contained `fn parse_receipt_finality(...)`.

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Passing summary:
- `kolme_runtime_commit_extraction_boundary`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

Passing summary:
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `kolme_runtime_commit_client_docs`: 2 passed
- `cargo fmt --check`: clean
- strict clippy (`kamn-core` tests): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `kolme_runtime_commit_extraction_boundary::unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` |                      |
| Functional   | ✅      | `kolme_runtime_commit_finality::functional_pending_commit_receipt_sets_requeue_until_finalized` |                      |
| Integration  | ✅      | `kolme_runtime_commit_client`, `kolme_runtime_commit_client_docs`   |                      |
| Regression   | ✅      | `kolme_runtime_commit_extraction_boundary::regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation` (`Regression: #1785`) |                      |
| Performance  | N/A     |                                                                     | Pure wrapper-removal refactor |

## Risks & Rollback
- None expected; behavior remains parity-preserving via direct helper delegation.
- Rollback: revert this PR to restore previous local wrappers.

## Documentation Updates
- None required: user-facing behavior and documented extraction boundary semantics are unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1785
Refs #1714
