### PR TITLE
refactor(kolme): remove deterministic id delegate wrappers

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -99,7 +99,7 @@ impl KolmeRuntimeCommitRequest {
                 reason: "must be a valid KAMN DID",
             })?;
         let actor_did_value = actor_did.as_str().to_owned();
-        let idempotency_key = deterministic_idempotency_key(
+        let idempotency_key = deterministic_runtime_commit_idempotency_key_contract(
             operation_id,
             state_root,
             actor_did_value.as_str(),
@@ -2166,7 +2166,7 @@ impl KolmeRuntimeCommitClient for InMemoryKolmeRuntimeCommitClient {
 
         let receipt = KolmeRuntimeCommitReceipt {
             provider: self.provider.clone(),
-            commit_id: deterministic_commit_id(
+            commit_id: deterministic_runtime_commit_id_contract(
                 request.operation_id.as_str(),
                 request.actor_did.as_str(),
                 request.nonce,
@@ -2279,31 +2279,6 @@ impl fmt::Display for KolmeRuntimeCommitError {
 }
 
 impl std::error::Error for KolmeRuntimeCommitError {}
-
-fn deterministic_idempotency_key(
-    operation_id: &str,
-    state_root: &str,
-    actor_did: &str,
-    nonce: u64,
-    payload_hash: &str,
-) -> String {
-    deterministic_runtime_commit_idempotency_key_contract(
-        operation_id,
-        state_root,
-        actor_did,
-        nonce,
-        payload_hash,
-    )
-}
-
-fn deterministic_commit_id(
-    operation_id: &str,
-    actor_did: &str,
-    nonce: u64,
-    payload_hash: &str,
-) -> String {
-    deterministic_runtime_commit_id_contract(operation_id, actor_did, nonce, payload_hash)
-}
 
 fn lifecycle_record_from_outcome(
     request: &KolmeRuntimeCommitRequest,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -7,14 +7,18 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn lifecycle_state_for_finality("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn lifecycle_state_label("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn commit_finality_label("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn deterministic_idempotency_key("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn deterministic_commit_id("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1787
+    // Regression: #1790
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
 }


### PR DESCRIPTION
## Summary
Remove remaining deterministic ID delegate wrappers from `kamn-core` and call extracted `kamn-kolme` helper contracts directly. This reduces extraction-boundary noise while preserving behavior.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed local `deterministic_idempotency_key` and `deterministic_commit_id` wrappers; rewired call sites to direct helper contracts.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: extended extraction-boundary guards to fail if deterministic delegate wrappers are reintroduced.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Expected failing output before implementation:
- `unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` failed because source still contained `fn deterministic_idempotency_key(...)`.

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Passing summary:
- `kolme_runtime_commit_extraction_boundary`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

Passing summary:
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `kolme_runtime_commit_client_docs`: 2 passed
- `cargo fmt --check`: clean
- strict clippy (`kamn-core` tests): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `kolme_runtime_commit_extraction_boundary::unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` |                      |
| Functional   | ✅      | `kolme_runtime_commit_finality::functional_pending_commit_receipt_sets_requeue_until_finalized` |                      |
| Integration  | ✅      | `kolme_runtime_commit_client`, `kolme_runtime_commit_client_docs`   |                      |
| Regression   | ✅      | `kolme_runtime_commit_extraction_boundary::regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation` (`Regression: #1790`) |                      |
| Performance  | N/A     |                                                                     | Pure wrapper-removal refactor |

## Risks & Rollback
- None expected; behavior remains parity-preserving via direct helper delegation.
- Rollback: revert this PR to restore previous local delegate wrappers.

## Documentation Updates
- None required: behavior and documented extraction boundary semantics are unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1790
Refs #1714
