### PR TITLE
refactor(kolme): remove block path fallback delegate wrappers

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -42,7 +42,6 @@ use kamn_kolme::{
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeBlockFallbackPolicyError as KamnKolmeBlockFallbackPolicyError,
-    KolmeBlockFallbackResponse as KamnKolmeBlockFallbackResponse,
     KolmeBroadcastPayloadPolicyError as KamnKolmeBroadcastPayloadPolicyError,
     KolmeCommitReceiptFinality as KamnKolmeCommitReceiptFinality,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
@@ -741,7 +740,6 @@ enum KolmeRuntimeCommitSubmitProfile {
 }
 
 type ParsedHttpEndpoint = KamnKolmeParsedHttpEndpoint;
-type ParsedBlockFallbackResponse = KamnKolmeBlockFallbackResponse;
 
 type HttpScheme = KamnKolmeHttpScheme;
 
@@ -1060,7 +1058,8 @@ impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTranspor
                 reason: "block height must be positive".to_owned(),
             });
         }
-        let block_path = render_block_path(block_path_template, height)?;
+        let block_path = render_kolme_block_path(block_path_template, height)
+            .map_err(map_block_scan_policy_error_to_unavailable)?;
         self.execute_request(base_url, block_path.as_str(), "GET", None, &[])
     }
 }
@@ -1201,7 +1200,9 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 reason: "must be positive",
             });
         }
-        validate_block_path_template(block_path_template).map_err(map_provider_error)?;
+        validate_kolme_block_path_template(block_path_template)
+            .map_err(map_block_scan_policy_error_to_unavailable)
+            .map_err(map_provider_error)?;
         Ok(Self {
             base_url: base_url.trim().to_owned(),
             block_path_template: block_path_template.trim().to_owned(),
@@ -1233,13 +1234,16 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 self.block_path_template.as_str(),
                 height,
             )?;
-            let block = parse_block_fallback_response(response.as_str()).or_else(|_| {
-                parse_kolme_fork_block_fallback_response(
-                    response.as_str(),
-                    self.provider.as_str(),
-                    height,
-                )
-            })?;
+            let block = parse_kolme_block_fallback_response_contract(response.as_str())
+                .map_err(map_block_fallback_policy_error_to_malformed)
+                .or_else(|_| {
+                    parse_kolme_fork_block_fallback_response_contract(
+                        response.as_str(),
+                        self.provider.as_str(),
+                        height,
+                    )
+                    .map_err(map_block_fallback_policy_error_to_malformed)
+                })?;
 
             validate_kolme_block_identity(
                 self.provider.as_str(),
@@ -1860,37 +1864,6 @@ fn map_transport_request_policy_error(
             KolmeRuntimeCommitError::InvalidRequest { field, reason }
         }
     }
-}
-
-fn validate_block_path_template(
-    block_path_template: &str,
-) -> Result<(), KolmeRuntimeCommitProviderError> {
-    validate_kolme_block_path_template(block_path_template)
-        .map_err(map_block_scan_policy_error_to_unavailable)
-}
-
-fn render_block_path(
-    block_path_template: &str,
-    height: u64,
-) -> Result<String, KolmeRuntimeCommitProviderError> {
-    render_kolme_block_path(block_path_template, height)
-        .map_err(map_block_scan_policy_error_to_unavailable)
-}
-
-fn parse_block_fallback_response(
-    response: &str,
-) -> Result<ParsedBlockFallbackResponse, KolmeRuntimeCommitProviderError> {
-    parse_kolme_block_fallback_response_contract(response)
-        .map_err(map_block_fallback_policy_error_to_malformed)
-}
-
-fn parse_kolme_fork_block_fallback_response(
-    response: &str,
-    provider: &str,
-    expected_height: u64,
-) -> Result<ParsedBlockFallbackResponse, KolmeRuntimeCommitProviderError> {
-    parse_kolme_fork_block_fallback_response_contract(response, provider, expected_height)
-        .map_err(map_block_fallback_policy_error_to_malformed)
 }
 
 fn reconnect_exhausted_error(max_reconnect_attempts: u32) -> KolmeRuntimeCommitProviderError {

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -14,11 +14,15 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_http_endpoint("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_websocket_endpoint("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn compose_notifications_websocket_url("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_block_path_template("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn render_block_path("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_block_fallback_response("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_fork_block_fallback_response("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1794
+    // Regression: #1796
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -31,4 +35,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_notifications_websocket_url("));
+    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
+    assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_block_fallback_response_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_fork_block_fallback_response_contract("));
 }


### PR DESCRIPTION
## Summary
Remove block-path and block-fallback delegate wrappers from `kamn-core` and call extracted helper contracts directly. This reduces extraction-boundary clutter while preserving behavior.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed local `validate_block_path_template`, `render_block_path`, `parse_block_fallback_response`, and `parse_kolme_fork_block_fallback_response` wrappers; rewired call sites to direct extracted helper contracts with equivalent error mapping.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: extended extraction-boundary guards to fail if block-path/fallback wrappers are reintroduced.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Expected failing output before implementation:
- `unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` failed because source still contained `fn validate_block_path_template(...)`.

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Passing summary:
- `kolme_runtime_commit_extraction_boundary`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

Passing summary:
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `kolme_runtime_commit_client_docs`: 2 passed
- `cargo fmt --check`: clean
- strict clippy (`kamn-core` tests): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `kolme_runtime_commit_extraction_boundary::unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` |                      |
| Functional   | ✅      | `kolme_runtime_commit_finality::functional_pending_commit_receipt_sets_requeue_until_finalized` |                      |
| Integration  | ✅      | `kolme_runtime_commit_client`, `kolme_runtime_commit_client_docs`   |                      |
| Regression   | ✅      | `kolme_runtime_commit_extraction_boundary::regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation` (`Regression: #1796`) |                      |
| Performance  | N/A     |                                                                     | Pure wrapper-removal refactor |

## Risks & Rollback
- None expected; behavior remains parity-preserving via direct helper delegation.
- Rollback: revert this PR to restore previous local delegate wrappers.

## Documentation Updates
- None required: behavior and documented extraction boundary semantics are unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1796
Refs #1714
