### PR TITLE
refactor(kolme): remove tls payload delegate wrappers

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -953,7 +953,7 @@ impl KolmeRuntimeCommitHttpTransport {
             && output.stdout.windows(4).any(|window| window == b"\r\n\r\n");
         if !output.status.success() && !looks_like_http_response {
             return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                reason: classify_tls_failure_reason(
+                reason: classify_kolme_tls_failure_reason(
                     String::from_utf8_lossy(&output.stderr).as_ref(),
                 ),
             });
@@ -1008,7 +1008,8 @@ impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
             });
         }
         if is_kolme_broadcast_submit_path_contract(submit_path) {
-            let payload = normalize_kolme_broadcast_payload(wire_payload, idempotency_key)?;
+            let payload = normalize_kolme_broadcast_payload_contract(wire_payload, idempotency_key)
+                .map_err(map_broadcast_payload_policy_error_to_malformed)?;
             return self.execute_request(
                 base_url,
                 submit_path,
@@ -1952,18 +1953,6 @@ fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProvider
     parse_kolme_tls_ca_file_env_value(value.as_deref()).map_err(map_tls_policy_error)
 }
 
-fn classify_tls_failure_reason(stderr: &str) -> String {
-    classify_kolme_tls_failure_reason(stderr)
-}
-
-fn normalize_kolme_broadcast_payload(
-    wire_payload: &str,
-    idempotency_key: &str,
-) -> Result<String, KolmeRuntimeCommitProviderError> {
-    normalize_kolme_broadcast_payload_contract(wire_payload, idempotency_key)
-        .map_err(map_broadcast_payload_policy_error_to_malformed)
-}
-
 fn parse_live_provider_response(
     response: &str,
     provider_hint: Option<&str>,
@@ -2261,7 +2250,9 @@ fn lifecycle_record_from_outcome(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_tls_failure_reason, KolmeRuntimeCommitError, KolmeRuntimeCommitRequest};
+    use super::{
+        classify_kolme_tls_failure_reason, KolmeRuntimeCommitError, KolmeRuntimeCommitRequest,
+    };
 
     #[test]
     fn deterministic_request_rejects_empty_operation_id() {
@@ -2282,7 +2273,7 @@ mod tests {
 
     #[test]
     fn tls_failure_reason_classifier_detects_certificate_errors() {
-        let reason = classify_tls_failure_reason(
+        let reason = classify_kolme_tls_failure_reason(
             "verify error:num=18:self-signed certificate\ncertificate verify failed",
         );
         assert_eq!(reason, "tls certificate verification failed");
@@ -2291,7 +2282,7 @@ mod tests {
     #[test]
     fn tls_failure_reason_classifier_detects_handshake_errors() {
         let reason =
-            classify_tls_failure_reason("ssl routines:ssl3_get_record:wrong version number");
+            classify_kolme_tls_failure_reason("ssl routines:ssl3_get_record:wrong version number");
         assert_eq!(reason, "tls handshake failed");
     }
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -18,11 +18,13 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn render_block_path("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_block_fallback_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_fork_block_fallback_response("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1796
+    // Regression: #1798
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -39,4 +41,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_block_fallback_response_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_fork_block_fallback_response_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
 }


### PR DESCRIPTION
## Summary
Remove TLS/payload delegate wrappers from `kamn-core` and call extracted helper contracts directly. This reduces extraction-boundary clutter while preserving behavior.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed local `classify_tls_failure_reason` and `normalize_kolme_broadcast_payload` wrappers; rewired call sites to direct extracted helper contracts with equivalent error mapping.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: extended extraction-boundary guards to fail if TLS/payload wrappers are reintroduced.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Expected failing output before implementation:
- `unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` failed because source still contained `fn classify_tls_failure_reason(...)`.

### 🟢 Green Phase
```bash
cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary
```

Passing summary:
- `kolme_runtime_commit_extraction_boundary`: 2 passed

### 🔁 Regression
```bash
cargo test -p kamn-core --test kolme_runtime_commit_finality
cargo test -p kamn-core --test kolme_runtime_commit_client
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

Passing summary:
- `kolme_runtime_commit_finality`: 8 passed
- `kolme_runtime_commit_client`: 21 passed
- `kolme_runtime_commit_client_docs`: 2 passed
- `cargo fmt --check`: clean
- strict clippy (`kamn-core` tests): clean

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status  | Tests Added/Modified                                                | Justification if N/A |
|--------------|---------|---------------------------------------------------------------------|----------------------|
| Unit         | ✅      | `kolme_runtime_commit_extraction_boundary::unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers` |                      |
| Functional   | ✅      | `kolme_runtime_commit_finality::functional_pending_commit_receipt_sets_requeue_until_finalized` |                      |
| Integration  | ✅      | `kolme_runtime_commit_client`, `kolme_runtime_commit_client_docs`   |                      |
| Regression   | ✅      | `kolme_runtime_commit_extraction_boundary::regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation` (`Regression: #1798`) |                      |
| Performance  | N/A     |                                                                     | Pure wrapper-removal refactor |

## Risks & Rollback
- None expected; behavior remains parity-preserving via direct helper delegation.
- Rollback: revert this PR to restore previous local delegate wrappers.

## Documentation Updates
- None required: behavior and documented extraction boundary semantics are unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core` tests)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted suites)
- [x] Docs updated (or justified why not)

Closes #1798
Refs #1714
