### PR TITLE
refactor(kolme): remove websocket handshake delegate wrapper (#1800)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1396,7 +1396,8 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
         let mut response_bytes = Vec::new();
         let header_end = read_http_header_boundary(&mut stream, &mut response_bytes)?;
         let (header_bytes, trailing) = response_bytes.split_at(header_end + 4);
-        validate_websocket_handshake_response(header_bytes)?;
+        validate_kolme_websocket_handshake_response(header_bytes)
+            .map_err(map_websocket_policy_error)?;
         Ok(KolmeRuntimeCommitWebsocketConnection::new(
             stream,
             trailing.to_vec(),
@@ -1894,12 +1895,6 @@ fn read_http_header_boundary(
         }
         response_bytes.extend_from_slice(&chunk[..read]);
     }
-}
-
-fn validate_websocket_handshake_response(
-    header_bytes: &[u8],
-) -> Result<(), KolmeRuntimeCommitProviderError> {
-    validate_kolme_websocket_handshake_response(header_bytes).map_err(map_websocket_policy_error)
 }
 
 fn parse_kolme_notification_event(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -20,11 +20,12 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_fork_block_fallback_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1798
+    // Regression: #1800
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -43,4 +44,5 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_fork_block_fallback_response_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));
 }


### PR DESCRIPTION
## Summary
Removes the remaining thin websocket handshake delegate wrapper from `kolme_runtime_commit` and calls extraction policy helpers directly at the call site. This continues boundary cleanup under the `#1714` Kolme extraction task.

Closes #1800
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `validate_websocket_handshake_response` local wrapper.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: websocket connector now directly calls `validate_kolme_websocket_handshake_response(...).map_err(map_websocket_policy_error)`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertions for removed wrapper and direct helper presence (`Regression: #1800`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion that runtime source must not contain `fn validate_websocket_handshake_response(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after wrapper removal and direct helper call wiring.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | No standalone behavior change |
| Functional   | N/A    | None                 | No user-facing behavior change |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Integration guard verifies extraction boundary |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No perf path change |

## Risks & Rollback
- Risk: Low; equivalent helper call is inlined at existing call site.
- Rollback: Revert this PR to restore wrapper if any unexpected boundary behavior appears.

## Documentation Updates
- None required; internal extraction-boundary refactor only.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
