### PR TITLE
refactor(kolme): inline single-use transport tls mappers (#1802)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -772,8 +772,13 @@ impl KolmeRuntimeCommitHttpTransport {
     ) -> Result<Self, KolmeRuntimeCommitError> {
         let mut transport = Self::new(timeout_seconds)?;
         transport.authorization_header = Some(
-            parse_kolme_authorization_header_value(authorization_header)
-                .map_err(map_transport_request_policy_error)?,
+            parse_kolme_authorization_header_value(authorization_header).map_err(|error| {
+                match error {
+                    KamnKolmeTransportRequestPolicyError::InvalidRequest { field, reason } => {
+                        KolmeRuntimeCommitError::InvalidRequest { field, reason }
+                    }
+                }
+            })?,
         );
         Ok(transport)
     }
@@ -1850,24 +1855,6 @@ fn map_http_response_policy_error(
     }
 }
 
-fn map_tls_policy_error(error: KamnKolmeTlsPolicyError) -> KolmeRuntimeCommitProviderError {
-    match error {
-        KamnKolmeTlsPolicyError::Unavailable { reason } => {
-            KolmeRuntimeCommitProviderError::Unavailable { reason }
-        }
-    }
-}
-
-fn map_transport_request_policy_error(
-    error: KamnKolmeTransportRequestPolicyError,
-) -> KolmeRuntimeCommitError {
-    match error {
-        KamnKolmeTransportRequestPolicyError::InvalidRequest { field, reason } => {
-            KolmeRuntimeCommitError::InvalidRequest { field, reason }
-        }
-    }
-}
-
 fn reconnect_exhausted_error(max_reconnect_attempts: u32) -> KolmeRuntimeCommitProviderError {
     KolmeRuntimeCommitProviderError::Unavailable {
         reason: format!(
@@ -1945,7 +1932,11 @@ fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProvider
             });
         }
     };
-    parse_kolme_tls_ca_file_env_value(value.as_deref()).map_err(map_tls_policy_error)
+    parse_kolme_tls_ca_file_env_value(value.as_deref()).map_err(|error| match error {
+        KamnKolmeTlsPolicyError::Unavailable { reason } => {
+            KolmeRuntimeCommitProviderError::Unavailable { reason }
+        }
+    })
 }
 
 fn parse_live_provider_response(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -21,11 +21,13 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_tls_policy_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_request_policy_error("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1800
+    // Regression: #1802
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -45,4 +47,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_tls_ca_file_env_value("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
 }


### PR DESCRIPTION
## Summary
Inlines two single-use policy mapping delegates in `kolme_runtime_commit` and removes their wrapper functions. This keeps extraction-boundary cleanup progressing under `#1714` without changing behavior.

Closes #1802
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined transport request policy mapping in `new_with_authorization`.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined TLS CA env policy mapping in `configured_tls_ca_file`.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed local wrappers `map_transport_request_policy_error` and `map_tls_policy_error`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertions for removed wrappers and direct helper usage (`Regression: #1802`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_tls_policy_error(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after wrapper removal and inline mapping.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor only; no unit behavior changes |
| Functional   | N/A    | None                 | No feature-level behavior change |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary checks exercise integration-level source contract |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No performance-path changes |

## Risks & Rollback
- Risk: Low; inline mappings preserve prior match semantics.
- Rollback: Revert this PR to restore previous wrappers.

## Documentation Updates
- None required; internal boundary refactor only.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
