### PR TITLE
refactor(kolme): inline block scan policy mappers (#1804)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1064,8 +1064,11 @@ impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTranspor
                 reason: "block height must be positive".to_owned(),
             });
         }
-        let block_path = render_kolme_block_path(block_path_template, height)
-            .map_err(map_block_scan_policy_error_to_unavailable)?;
+        let block_path = render_kolme_block_path(block_path_template, height).map_err(|error| {
+            KolmeRuntimeCommitProviderError::Unavailable {
+                reason: error.to_string(),
+            }
+        })?;
         self.execute_request(base_url, block_path.as_str(), "GET", None, &[])
     }
 }
@@ -1207,7 +1210,9 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
             });
         }
         validate_kolme_block_path_template(block_path_template)
-            .map_err(map_block_scan_policy_error_to_unavailable)
+            .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
+                reason: error.to_string(),
+            })
             .map_err(map_provider_error)?;
         Ok(Self {
             base_url: base_url.trim().to_owned(),
@@ -1231,8 +1236,18 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 reason: "txhash must not be empty".to_owned(),
             });
         }
-        validate_kolme_lookup_window(from_height, latest_height, self.max_block_lookups)
-            .map_err(map_lookup_window_error)?;
+        validate_kolme_lookup_window(from_height, latest_height, self.max_block_lookups).map_err(
+            |error| match error {
+                BlockScanPolicyError::MaxLookupsExceeded { .. } => {
+                    KolmeRuntimeCommitProviderError::Unavailable {
+                        reason: error.to_string(),
+                    }
+                }
+                _ => KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                },
+            },
+        )?;
 
         for height in from_height..=latest_height {
             let response = self.transport.fetch_block_by_height(
@@ -1257,7 +1272,9 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 height,
                 block.block_height,
             )
-            .map_err(map_block_scan_policy_error_to_malformed)?;
+            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            })?;
 
             if block
                 .finalized_tx_hashes
@@ -1744,31 +1761,6 @@ fn map_codec_error_to_malformed_response(
         KamnKolmeApiCodecError::MalformedResponse { reason } => {
             KolmeRuntimeCommitProviderError::MalformedResponse { reason }
         }
-    }
-}
-
-fn map_block_scan_policy_error_to_unavailable(
-    error: BlockScanPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::Unavailable {
-        reason: error.to_string(),
-    }
-}
-
-fn map_block_scan_policy_error_to_malformed(
-    error: BlockScanPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
-    }
-}
-
-fn map_lookup_window_error(error: BlockScanPolicyError) -> KolmeRuntimeCommitProviderError {
-    match error {
-        BlockScanPolicyError::MaxLookupsExceeded { .. } => {
-            map_block_scan_policy_error_to_unavailable(error)
-        }
-        _ => map_block_scan_policy_error_to_malformed(error),
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -23,11 +23,14 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_tls_policy_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_request_policy_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_scan_policy_error_to_unavailable("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_scan_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_lookup_window_error("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1802
+    // Regression: #1804
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -49,4 +52,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_tls_ca_file_env_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
+    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
+    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
 }


### PR DESCRIPTION
## Summary
Inlines block-scan/lookup-window policy error mappings in runtime-commit call sites and removes three local delegate wrappers. This keeps extraction-boundary cleanup progressing under `#1714` with unchanged behavior.

Closes #1804
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined `BlockScanPolicyError` mapping in block-path rendering, template validation, lookup-window validation, and block identity validation paths.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `map_block_scan_policy_error_to_unavailable`, `map_block_scan_policy_error_to_malformed`, and `map_lookup_window_error`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertions for removed wrapper signatures and direct helper usage (`Regression: #1804`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_block_scan_policy_error_to_unavailable(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after inlining mappings and removing wrappers.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Internal refactor, no unit-level behavior changes |
| Functional   | N/A    | None                 | No feature behavior changes |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Source-boundary invariant validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No throughput/latency path changes |

## Risks & Rollback
- Risk: Low; mapping logic preserved and inlined.
- Rollback: Revert this PR to restore wrapper functions.

## Documentation Updates
- None required; internal extraction-boundary refactor.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
