### PR TITLE
refactor(kolme): inline single-use malformed mappers (#1806)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -42,16 +42,13 @@ use kamn_kolme::{
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeBlockFallbackPolicyError as KamnKolmeBlockFallbackPolicyError,
-    KolmeBroadcastPayloadPolicyError as KamnKolmeBroadcastPayloadPolicyError,
     KolmeCommitReceiptFinality as KamnKolmeCommitReceiptFinality,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
-    KolmeNotificationPolicyError as KamnKolmeNotificationPolicyError,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeProviderOutcome as KamnKolmeProviderOutcome,
     KolmeProviderOutcomePolicyError as KamnKolmeProviderOutcomePolicyError,
-    KolmeProviderResponsePolicyError as KamnKolmeProviderResponsePolicyError,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
     KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
@@ -1014,7 +1011,9 @@ impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
         }
         if is_kolme_broadcast_submit_path_contract(submit_path) {
             let payload = normalize_kolme_broadcast_payload_contract(wire_payload, idempotency_key)
-                .map_err(map_broadcast_payload_policy_error_to_malformed)?;
+                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                })?;
             return self.execute_request(
                 base_url,
                 submit_path,
@@ -1046,8 +1045,11 @@ impl KolmeRuntimeCommitFinalityTransport for KolmeRuntimeCommitHttpTransport {
         status_path: &str,
         commit_id: &str,
     ) -> Result<String, KolmeRuntimeCommitProviderError> {
-        let path = compose_kolme_finality_status_path(status_path, commit_id)
-            .map_err(map_endpoint_policy_error_to_malformed)?;
+        let path = compose_kolme_finality_status_path(status_path, commit_id).map_err(|error| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            }
+        })?;
         self.execute_request(base_url, path.as_str(), "GET", None, &[])
     }
 }
@@ -1123,8 +1125,11 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
             self.status_path.as_str(),
             commit_id,
         )?;
-        let fields = parse_kolme_provider_response_fields(response.as_str())
-            .map_err(map_provider_response_policy_error_to_malformed)?;
+        let fields = parse_kolme_provider_response_fields(response.as_str()).map_err(|error| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            }
+        })?;
         let provider = required_kolme_provider_response_field(&fields, "provider")
             .map_err(map_provider_outcome_policy_error_to_malformed)?;
         let observed_commit_id = parse_kolme_commit_id_from_response_fields(&fields)
@@ -1780,40 +1785,8 @@ fn map_endpoint_policy_error(
     }
 }
 
-fn map_endpoint_policy_error_to_malformed(
-    error: KamnKolmeEndpointPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
-    }
-}
-
-fn map_notification_policy_error_to_malformed(
-    error: KamnKolmeNotificationPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
-    }
-}
-
-fn map_provider_response_policy_error_to_malformed(
-    error: KamnKolmeProviderResponsePolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
-    }
-}
-
 fn map_provider_outcome_policy_error_to_malformed(
     error: KamnKolmeProviderOutcomePolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
-    }
-}
-
-fn map_broadcast_payload_policy_error_to_malformed(
-    error: KamnKolmeBroadcastPayloadPolicyError,
 ) -> KolmeRuntimeCommitProviderError {
     KolmeRuntimeCommitProviderError::MalformedResponse {
         reason: error.to_string(),
@@ -1879,8 +1852,11 @@ fn read_http_header_boundary(
 fn parse_kolme_notification_event(
     payload: &str,
 ) -> Result<KolmeRuntimeCommitNotificationEvent, KolmeRuntimeCommitProviderError> {
-    let event = parse_kolme_notification_event_contract(payload)
-        .map_err(map_notification_policy_error_to_malformed)?;
+    let event = parse_kolme_notification_event_contract(payload).map_err(|error| {
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: error.to_string(),
+        }
+    })?;
     match event {
         KamnKolmeNotificationEvent::NewBlock {
             txhash,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -26,11 +26,15 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_scan_policy_error_to_unavailable("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_scan_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_lookup_window_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_endpoint_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_notification_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_response_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_broadcast_payload_policy_error_to_malformed("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1804
+    // Regression: #1806
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -54,4 +58,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
+    assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_response_fields("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
 }


### PR DESCRIPTION
## Summary
Inlines four single-use malformed-response mapping delegates in `kolme_runtime_commit` and removes their wrapper functions. This reduces extraction-boundary indirection under `#1714` while preserving behavior.

Closes #1806
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined malformed mapping logic at call sites for broadcast payload normalization, finality status path composition, provider response field parsing, and notification event parsing.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed wrappers `map_endpoint_policy_error_to_malformed`, `map_notification_policy_error_to_malformed`, `map_provider_response_policy_error_to_malformed`, and `map_broadcast_payload_policy_error_to_malformed`.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed now-unused policy error imports.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: expanded anti-regression assertions for removed wrapper signatures and helper-call presence (`Regression: #1806`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_endpoint_policy_error_to_malformed(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after inlining/removing wrappers.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No user-facing behavior changes |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary contract validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; mappings are behavior-equivalent and now inline.
- Rollback: Revert this PR.

## Documentation Updates
- None required; internal extraction-boundary refactor.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
