### PR TITLE
refactor(kolme): inline block fallback malformed mapper (#1808)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -41,7 +41,6 @@ use kamn_kolme::{
     KolmeApiCodecError as KamnKolmeApiCodecError,
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
-    KolmeBlockFallbackPolicyError as KamnKolmeBlockFallbackPolicyError,
     KolmeCommitReceiptFinality as KamnKolmeCommitReceiptFinality,
     KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
@@ -1261,14 +1260,20 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 height,
             )?;
             let block = parse_kolme_block_fallback_response_contract(response.as_str())
-                .map_err(map_block_fallback_policy_error_to_malformed)
+                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                })
                 .or_else(|_| {
                     parse_kolme_fork_block_fallback_response_contract(
                         response.as_str(),
                         self.provider.as_str(),
                         height,
                     )
-                    .map_err(map_block_fallback_policy_error_to_malformed)
+                    .map_err(|error| {
+                        KolmeRuntimeCommitProviderError::MalformedResponse {
+                            reason: error.to_string(),
+                        }
+                    })
                 })?;
 
             validate_kolme_block_identity(
@@ -1766,14 +1771,6 @@ fn map_codec_error_to_malformed_response(
         KamnKolmeApiCodecError::MalformedResponse { reason } => {
             KolmeRuntimeCommitProviderError::MalformedResponse { reason }
         }
-    }
-}
-
-fn map_block_fallback_policy_error_to_malformed(
-    error: KamnKolmeBlockFallbackPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -26,6 +26,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_scan_policy_error_to_unavailable("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_scan_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_lookup_window_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_block_fallback_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_endpoint_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_notification_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_response_policy_error_to_malformed("));
@@ -34,7 +35,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1806
+    // Regression: #1808
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));


### PR DESCRIPTION
## Summary
Inlines block-fallback malformed-error mapping at its two call sites and removes the local wrapper function in `kolme_runtime_commit`. This continues extraction-boundary cleanup under `#1714` while preserving behavior.

Closes #1808
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined malformed mapping for both block fallback parser branches.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `map_block_fallback_policy_error_to_malformed` and now-unused policy import.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertion for removed wrapper signature (`Regression: #1808`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_block_fallback_policy_error_to_malformed(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after wrapper removal/inlining.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Internal refactor only |
| Functional   | N/A    | None                 | No user-facing behavior change |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariant validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; wrapper logic remains unchanged and is now inline.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
