### PR TITLE
refactor(kolme): inline endpoint websocket response mappers (#1810)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -42,7 +42,6 @@ use kamn_kolme::{
     KolmeApiNextNonceRequest as KamnKolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse as KamnKolmeApiNextNonceResponse,
     KolmeCommitReceiptFinality as KamnKolmeCommitReceiptFinality,
-    KolmeEndpointPolicyError as KamnKolmeEndpointPolicyError,
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
@@ -832,8 +831,11 @@ impl KolmeRuntimeCommitHttpTransport {
         body: Option<&str>,
         headers: &[(&str, &str)],
     ) -> Result<String, KolmeRuntimeCommitProviderError> {
-        let endpoint =
-            parse_kolme_http_endpoint(base_url, path).map_err(map_endpoint_policy_error)?;
+        let endpoint = parse_kolme_http_endpoint(base_url, path).map_err(|error| {
+            KolmeRuntimeCommitProviderError::Unavailable {
+                reason: error.to_string(),
+            }
+        })?;
         let payload = body.unwrap_or("");
         let mut request = format!(
             "{method} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n",
@@ -862,7 +864,15 @@ impl KolmeRuntimeCommitHttpTransport {
             HttpScheme::Http => self.execute_http_request(endpoint, request.as_bytes())?,
             HttpScheme::Https => self.execute_https_request(endpoint, request.as_bytes())?,
         };
-        parse_kolme_http_response_body(response_bytes).map_err(map_http_response_policy_error)
+        parse_kolme_http_response_body(response_bytes).map_err(|error| match error {
+            KamnKolmeHttpResponsePolicyError::Timeout => KolmeRuntimeCommitProviderError::Timeout,
+            KamnKolmeHttpResponsePolicyError::Unavailable { reason } => {
+                KolmeRuntimeCommitProviderError::Unavailable { reason }
+            }
+            KamnKolmeHttpResponsePolicyError::Malformed { reason } => {
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+            }
+        })
     }
 
     fn execute_http_request(
@@ -1352,9 +1362,16 @@ impl KolmeRuntimeCommitWebsocketConnection {
 impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketConnection {
     fn read_text_message(&mut self) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
         loop {
-            if let Some(frame) = try_take_kolme_websocket_frame(&mut self.read_buffer)
-                .map_err(map_websocket_policy_error)?
-            {
+            if let Some(frame) = try_take_kolme_websocket_frame(&mut self.read_buffer).map_err(
+                |error| match error {
+                    KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                        KolmeRuntimeCommitProviderError::Unavailable { reason }
+                    }
+                    KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                        KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                    }
+                },
+            )? {
                 match frame {
                     KamnKolmeWebsocketFrame::Text(payload_bytes) => {
                         let payload = String::from_utf8(payload_bytes).map_err(|error| {
@@ -1391,8 +1408,11 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
         &mut self,
         notifications_url: &str,
     ) -> Result<Self::Connection, KolmeRuntimeCommitProviderError> {
-        let endpoint =
-            parse_kolme_websocket_endpoint(notifications_url).map_err(map_endpoint_policy_error)?;
+        let endpoint = parse_kolme_websocket_endpoint(notifications_url).map_err(|error| {
+            KolmeRuntimeCommitProviderError::Unavailable {
+                reason: error.to_string(),
+            }
+        })?;
         if endpoint.secure {
             return Err(KolmeRuntimeCommitProviderError::Unavailable {
                 reason: "wss:// notifications are not supported by this transport".to_owned(),
@@ -1428,8 +1448,14 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
         let mut response_bytes = Vec::new();
         let header_end = read_http_header_boundary(&mut stream, &mut response_bytes)?;
         let (header_bytes, trailing) = response_bytes.split_at(header_end + 4);
-        validate_kolme_websocket_handshake_response(header_bytes)
-            .map_err(map_websocket_policy_error)?;
+        validate_kolme_websocket_handshake_response(header_bytes).map_err(|error| match error {
+            KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                KolmeRuntimeCommitProviderError::Unavailable { reason }
+            }
+            KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+            }
+        })?;
         Ok(KolmeRuntimeCommitWebsocketConnection::new(
             stream,
             trailing.to_vec(),
@@ -1475,7 +1501,9 @@ where
         }
         let notifications_url =
             compose_kolme_notifications_websocket_url(base_url, notifications_path)
-                .map_err(map_endpoint_policy_error)
+                .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
+                    reason: error.to_string(),
+                })
                 .map_err(map_provider_error)?;
         Ok(Self {
             notifications_url,
@@ -1774,46 +1802,11 @@ fn map_codec_error_to_malformed_response(
     }
 }
 
-fn map_endpoint_policy_error(
-    error: KamnKolmeEndpointPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::Unavailable {
-        reason: error.to_string(),
-    }
-}
-
 fn map_provider_outcome_policy_error_to_malformed(
     error: KamnKolmeProviderOutcomePolicyError,
 ) -> KolmeRuntimeCommitProviderError {
     KolmeRuntimeCommitProviderError::MalformedResponse {
         reason: error.to_string(),
-    }
-}
-
-fn map_websocket_policy_error(
-    error: KamnKolmeWebsocketPolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    match error {
-        KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
-            KolmeRuntimeCommitProviderError::Unavailable { reason }
-        }
-        KamnKolmeWebsocketPolicyError::Malformed { reason } => {
-            KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-        }
-    }
-}
-
-fn map_http_response_policy_error(
-    error: KamnKolmeHttpResponsePolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    match error {
-        KamnKolmeHttpResponsePolicyError::Timeout => KolmeRuntimeCommitProviderError::Timeout,
-        KamnKolmeHttpResponsePolicyError::Unavailable { reason } => {
-            KolmeRuntimeCommitProviderError::Unavailable { reason }
-        }
-        KamnKolmeHttpResponsePolicyError::Malformed { reason } => {
-            KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-        }
     }
 }
 
@@ -1831,7 +1824,14 @@ fn read_http_header_boundary(
 ) -> Result<usize, KolmeRuntimeCommitProviderError> {
     loop {
         if let Some(position) =
-            find_kolme_http_header_boundary(response_bytes).map_err(map_websocket_policy_error)?
+            find_kolme_http_header_boundary(response_bytes).map_err(|error| match error {
+                KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                    KolmeRuntimeCommitProviderError::Unavailable { reason }
+                }
+                KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                }
+            })?
         {
             return Ok(position);
         }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -31,11 +31,14 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_notification_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_response_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_broadcast_payload_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_endpoint_policy_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_websocket_policy_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_http_response_policy_error("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1808
+    // Regression: #1810
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -62,4 +65,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_response_fields("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
+    assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
 }


### PR DESCRIPTION
## Summary
Inlines endpoint/websocket/http-response policy mapping delegates directly at runtime-commit call sites and removes the three wrapper functions. This continues extraction-boundary simplification under `#1714` with unchanged behavior.

Closes #1810
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined endpoint unavailability mapping at HTTP/websocket parse and notifications URL composition call sites.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined websocket policy mapping at frame parse, handshake validation, and header-boundary scan call sites.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined HTTP response policy mapping at HTTP response parse call site.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed wrappers `map_endpoint_policy_error`, `map_websocket_policy_error`, and `map_http_response_policy_error`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertions preventing reintroduction of removed wrapper signatures (`Regression: #1810`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_endpoint_policy_error(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after call-site inlining and wrapper removal.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No user-facing behavior change |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariants validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; delegate logic preserved and moved inline.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
