### PR TITLE
refactor(kolme): inline codec error mappers (#1812)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -276,8 +276,17 @@ pub struct KolmeApiNextNonceRequest {
 impl KolmeApiNextNonceRequest {
     /// Builds a deterministic nonce lookup request.
     pub fn new(pubkey: &str) -> Result<Self, KolmeRuntimeCommitError> {
-        let extracted = KamnKolmeApiNextNonceRequest::new(pubkey)
-            .map_err(map_codec_error_to_invalid_request)?;
+        let extracted = KamnKolmeApiNextNonceRequest::new(pubkey).map_err(|error| match error {
+            KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                KolmeRuntimeCommitError::InvalidRequest { field, reason }
+            }
+            KamnKolmeApiCodecError::MalformedResponse { .. } => {
+                KolmeRuntimeCommitError::InvalidRequest {
+                    field: "codec_payload",
+                    reason: "must be valid json",
+                }
+            }
+        })?;
         Ok(Self {
             pubkey: extracted.pubkey,
         })
@@ -304,8 +313,17 @@ pub struct KolmeApiNextNonceResponse {
 impl KolmeApiNextNonceResponse {
     /// Parses one nonce lookup response JSON payload.
     pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
-        let extracted = KamnKolmeApiNextNonceResponse::parse_json(response)
-            .map_err(map_codec_error_to_malformed_response)?;
+        let extracted =
+            KamnKolmeApiNextNonceResponse::parse_json(response).map_err(|error| match error {
+                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse {
+                        reason: format!("invalid request {field}: {reason}"),
+                    }
+                }
+                KamnKolmeApiCodecError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                }
+            })?;
         Ok(Self {
             next_nonce: extracted.next_nonce,
             account_id: extracted.account_id,
@@ -332,7 +350,17 @@ impl KolmeApiBroadcastRequest {
         recovery_id: u8,
     ) -> Result<Self, KolmeRuntimeCommitError> {
         let extracted = KamnKolmeApiBroadcastRequest::new(message, signature, recovery_id)
-            .map_err(map_codec_error_to_invalid_request)?;
+            .map_err(|error| match error {
+                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                    KolmeRuntimeCommitError::InvalidRequest { field, reason }
+                }
+                KamnKolmeApiCodecError::MalformedResponse { .. } => {
+                    KolmeRuntimeCommitError::InvalidRequest {
+                        field: "codec_payload",
+                        reason: "must be valid json",
+                    }
+                }
+            })?;
         Ok(Self {
             message: extracted.message,
             signature: extracted.signature,
@@ -361,8 +389,17 @@ pub struct KolmeApiBroadcastResponse {
 impl KolmeApiBroadcastResponse {
     /// Parses one broadcast response JSON payload.
     pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
-        let extracted = KamnKolmeApiBroadcastResponse::parse_json(response)
-            .map_err(map_codec_error_to_malformed_response)?;
+        let extracted =
+            KamnKolmeApiBroadcastResponse::parse_json(response).map_err(|error| match error {
+                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse {
+                        reason: format!("invalid request {field}: {reason}"),
+                    }
+                }
+                KamnKolmeApiCodecError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                }
+            })?;
         Ok(Self {
             txhash: extracted.txhash,
         })
@@ -1769,35 +1806,6 @@ fn map_provider_error(error: KolmeRuntimeCommitProviderError) -> KolmeRuntimeCom
                 kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
                 detail: reason,
             }
-        }
-    }
-}
-
-fn map_codec_error_to_invalid_request(error: KamnKolmeApiCodecError) -> KolmeRuntimeCommitError {
-    match error {
-        KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
-            KolmeRuntimeCommitError::InvalidRequest { field, reason }
-        }
-        KamnKolmeApiCodecError::MalformedResponse { .. } => {
-            KolmeRuntimeCommitError::InvalidRequest {
-                field: "codec_payload",
-                reason: "must be valid json",
-            }
-        }
-    }
-}
-
-fn map_codec_error_to_malformed_response(
-    error: KamnKolmeApiCodecError,
-) -> KolmeRuntimeCommitProviderError {
-    match error {
-        KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: format!("invalid request {field}: {reason}"),
-            }
-        }
-        KamnKolmeApiCodecError::MalformedResponse { reason } => {
-            KolmeRuntimeCommitProviderError::MalformedResponse { reason }
         }
     }
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -34,11 +34,13 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_endpoint_policy_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_websocket_policy_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_http_response_policy_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_codec_error_to_invalid_request("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_codec_error_to_malformed_response("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1810
+    // Regression: #1812
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -67,4 +69,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
+    assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
+    assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
 }


### PR DESCRIPTION
## Summary
Inlines codec error mapping at runtime-commit parse call sites and removes two local codec mapping wrappers. This keeps extraction-boundary cleanup moving under `#1714` with no behavior change.

Closes #1812
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined `KamnKolmeApiCodecError` -> `KolmeRuntimeCommitError` mapping at nonce/broadcast request constructors.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined `KamnKolmeApiCodecError` -> `KolmeRuntimeCommitProviderError` mapping at nonce/broadcast response parsers.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed wrappers `map_codec_error_to_invalid_request` and `map_codec_error_to_malformed_response`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added regression assertions preventing wrapper reintroduction (`Regression: #1812`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_codec_error_to_invalid_request(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after call-site inlining and wrapper removal.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No feature-level behavior change |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariants validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Guards removed wrappers |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; wrapper logic preserved and moved inline.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
