### PR TITLE
refactor(kolme): inline provider outcome mappers (#1816)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1781,11 +1781,47 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
         request: &KolmeRuntimeCommitRequest,
     ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
         request.validate()?;
+        let expected_provider = self.expected_provider.as_str();
+        let map_provider_receipt = |receipt: KolmeRuntimeCommitProviderReceipt| {
+            if receipt.provider != expected_provider {
+                return Err(KolmeRuntimeCommitError::ProviderMismatch {
+                    expected: expected_provider.to_owned(),
+                    observed: receipt.provider,
+                });
+            }
+            if receipt.commit_id.trim().is_empty() {
+                return Err(KolmeRuntimeCommitError::InvalidRequest {
+                    field: "receipt_commit_id",
+                    reason: "must not be empty",
+                });
+            }
+            if !matches!(receipt.finality, KolmeCommitReceiptFinality::Final) {
+                return Err(KolmeRuntimeCommitError::NonFinalReceipt {
+                    commit_id: receipt.commit_id,
+                    finality: receipt.finality,
+                });
+            }
+            Ok(KolmeRuntimeCommitReceipt {
+                provider: receipt.provider,
+                commit_id: receipt.commit_id,
+                finality: receipt.finality,
+            })
+        };
         let provider_outcome = self
             .provider
             .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
             .map_err(map_provider_error)?;
-        map_provider_outcome(provider_outcome, self.expected_provider.as_str())
+        match provider_outcome {
+            KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => Ok(
+                KolmeRuntimeCommitOutcome::Submitted(map_provider_receipt(receipt)?),
+            ),
+            KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => Ok(
+                KolmeRuntimeCommitOutcome::Duplicate(map_provider_receipt(receipt)?),
+            ),
+            KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
+                Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
+            }
+        }
     }
 }
 
@@ -1945,54 +1981,6 @@ fn parse_live_provider_response(
             Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
         }
     }
-}
-
-fn map_provider_outcome(
-    outcome: KolmeRuntimeCommitProviderOutcome,
-    expected_provider: &str,
-) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
-    match outcome {
-        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => {
-            let runtime_receipt = map_provider_receipt(receipt, expected_provider)?;
-            Ok(KolmeRuntimeCommitOutcome::Submitted(runtime_receipt))
-        }
-        KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => {
-            let runtime_receipt = map_provider_receipt(receipt, expected_provider)?;
-            Ok(KolmeRuntimeCommitOutcome::Duplicate(runtime_receipt))
-        }
-        KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
-            Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
-        }
-    }
-}
-
-fn map_provider_receipt(
-    receipt: KolmeRuntimeCommitProviderReceipt,
-    expected_provider: &str,
-) -> Result<KolmeRuntimeCommitReceipt, KolmeRuntimeCommitError> {
-    if receipt.provider != expected_provider {
-        return Err(KolmeRuntimeCommitError::ProviderMismatch {
-            expected: expected_provider.to_owned(),
-            observed: receipt.provider,
-        });
-    }
-    if receipt.commit_id.trim().is_empty() {
-        return Err(KolmeRuntimeCommitError::InvalidRequest {
-            field: "receipt_commit_id",
-            reason: "must not be empty",
-        });
-    }
-    if !matches!(receipt.finality, KolmeCommitReceiptFinality::Final) {
-        return Err(KolmeRuntimeCommitError::NonFinalReceipt {
-            commit_id: receipt.commit_id,
-            finality: receipt.finality,
-        });
-    }
-    Ok(KolmeRuntimeCommitReceipt {
-        provider: receipt.provider,
-        commit_id: receipt.commit_id,
-        finality: receipt.finality,
-    })
 }
 
 /// Deterministic in-memory commit client used for contract tests and local development.

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -36,11 +36,13 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_http_response_policy_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_codec_error_to_invalid_request("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_codec_error_to_malformed_response("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_receipt("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1812
+    // Regression: #1816
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -71,4 +73,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
+    assert!(RUNTIME_COMMIT_SRC.contains("if receipt.provider != expected_provider"));
+    assert!(RUNTIME_COMMIT_SRC.contains("if receipt.commit_id.trim().is_empty()"));
 }


### PR DESCRIPTION
## Summary
Inlines provider outcome/receipt mapping logic into the adapter-backed runtime-commit submit path and removes two local wrapper delegates. This continues extraction-boundary cleanup under `#1714` while preserving fail-closed semantics.

Closes #1816
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined provider-outcome and receipt validation/mapping into `AdapterBackedKolmeRuntimeCommitClient::submit_commit`.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `map_provider_outcome` and `map_provider_receipt` wrappers.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertions for removed wrappers and required inline validation markers (`Regression: #1816`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_provider_outcome(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after inlining and wrapper removal.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No feature behavior change |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariants validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Prevents wrapper reintroduction |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; logic moved inline with equivalent checks.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
