### PR TITLE
refactor(kolme): inline provider transport mapper (#1818)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1264,7 +1264,26 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
             .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
                 reason: error.to_string(),
             })
-            .map_err(map_provider_error)?;
+            .map_err(|error| match error {
+                KolmeRuntimeCommitProviderError::Timeout => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+                        detail: "provider request timed out".to_owned(),
+                    }
+                }
+                KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                        detail: reason,
+                    }
+                }
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                        detail: reason,
+                    }
+                }
+            })?;
         Ok(Self {
             base_url: base_url.trim().to_owned(),
             block_path_template: block_path_template.trim().to_owned(),
@@ -1541,7 +1560,26 @@ where
                 .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
                     reason: error.to_string(),
                 })
-                .map_err(map_provider_error)?;
+                .map_err(|error| match error {
+                    KolmeRuntimeCommitProviderError::Timeout => {
+                        KolmeRuntimeCommitError::ProviderTransport {
+                            kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+                            detail: "provider request timed out".to_owned(),
+                        }
+                    }
+                    KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+                        KolmeRuntimeCommitError::ProviderTransport {
+                            kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                            detail: reason,
+                        }
+                    }
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+                        KolmeRuntimeCommitError::ProviderTransport {
+                            kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                            detail: reason,
+                        }
+                    }
+                })?;
         Ok(Self {
             notifications_url,
             provider: provider.trim().to_owned(),
@@ -1810,7 +1848,26 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
         let provider_outcome = self
             .provider
             .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
-            .map_err(map_provider_error)?;
+            .map_err(|error| match error {
+                KolmeRuntimeCommitProviderError::Timeout => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+                        detail: "provider request timed out".to_owned(),
+                    }
+                }
+                KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                        detail: reason,
+                    }
+                }
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                        detail: reason,
+                    }
+                }
+            })?;
         match provider_outcome {
             KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => Ok(
                 KolmeRuntimeCommitOutcome::Submitted(map_provider_receipt(receipt)?),
@@ -1820,27 +1877,6 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
             ),
             KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
                 Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
-            }
-        }
-    }
-}
-
-fn map_provider_error(error: KolmeRuntimeCommitProviderError) -> KolmeRuntimeCommitError {
-    match error {
-        KolmeRuntimeCommitProviderError::Timeout => KolmeRuntimeCommitError::ProviderTransport {
-            kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
-            detail: "provider request timed out".to_owned(),
-        },
-        KolmeRuntimeCommitProviderError::Unavailable { reason } => {
-            KolmeRuntimeCommitError::ProviderTransport {
-                kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
-                detail: reason,
-            }
-        }
-        KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
-            KolmeRuntimeCommitError::ProviderTransport {
-                kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
-                detail: reason,
             }
         }
     }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -38,11 +38,12 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_codec_error_to_malformed_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_receipt("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_error("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1816
+    // Regression: #1818
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -75,4 +76,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
     assert!(RUNTIME_COMMIT_SRC.contains("if receipt.provider != expected_provider"));
     assert!(RUNTIME_COMMIT_SRC.contains("if receipt.commit_id.trim().is_empty()"));
+    assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));
+    assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
 }


### PR DESCRIPTION
## Summary
Inlines provider transport error mapping at runtime-commit call sites and removes `map_provider_error`. This continues extraction-boundary cleanup under `#1714` while preserving timeout/unavailable/malformed fail-closed behavior.

Closes #1818
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: inlined provider transport mapping logic at all former `map_provider_error` call sites.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `map_provider_error` wrapper function.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertion preventing wrapper reintroduction (`Regression: #1818`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_provider_error(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after inlining and wrapper removal.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No feature behavior changes |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariants validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Guards removed wrapper signature |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; conversion logic preserved inlined at call sites.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit suite)
- [x] Docs updated (or justified why not)
