### PR TITLE
refactor(kolme): extract transport io classification contract (#1820)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -3,6 +3,7 @@
 use crate::AgentDid;
 use kamn_kolme::{
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
+    classify_transport_io_error as classify_kolme_transport_io_error,
     commit_finality_from_receipt_finality as commit_finality_from_receipt_finality_contract,
     commit_finality_label as commit_finality_label_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
@@ -48,6 +49,7 @@ use kamn_kolme::{
     KolmeProviderOutcome as KamnKolmeProviderOutcome,
     KolmeProviderOutcomePolicyError as KamnKolmeProviderOutcomePolicyError,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
+    KolmeTransportIoClassification as KamnKolmeTransportIoClassification,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
     KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError,
@@ -917,21 +919,35 @@ impl KolmeRuntimeCommitHttpTransport {
         endpoint: ParsedHttpEndpoint,
         request: &[u8],
     ) -> Result<Vec<u8>, KolmeRuntimeCommitProviderError> {
-        let mut stream = TcpStream::connect((endpoint.host.as_str(), endpoint.port))
-            .map_err(map_transport_io_error)?;
+        let mut stream =
+            TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
+                map_transport_io_classification_to_provider_error(
+                    classify_kolme_transport_io_error(&error),
+                )
+            })?;
         let timeout = Duration::from_secs(self.timeout_seconds);
-        stream
-            .set_read_timeout(Some(timeout))
-            .map_err(map_transport_io_error)?;
-        stream
-            .set_write_timeout(Some(timeout))
-            .map_err(map_transport_io_error)?;
-        stream.write_all(request).map_err(map_transport_io_error)?;
+        stream.set_read_timeout(Some(timeout)).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
+        stream.set_write_timeout(Some(timeout)).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
+        stream.write_all(request).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
 
         let mut response_bytes = Vec::new();
-        stream
-            .read_to_end(&mut response_bytes)
-            .map_err(map_transport_io_error)?;
+        stream.read_to_end(&mut response_bytes).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
         Ok(response_bytes)
     }
 
@@ -972,7 +988,11 @@ impl KolmeRuntimeCommitHttpTransport {
                     .ok_or_else(|| KolmeRuntimeCommitProviderError::Unavailable {
                         reason: "tls command stdin unavailable".to_owned(),
                     })?;
-            stdin.write_all(request).map_err(map_transport_io_error)?;
+            stdin.write_all(request).map_err(|error| {
+                map_transport_io_classification_to_provider_error(
+                    classify_kolme_transport_io_error(&error),
+                )
+            })?;
         }
 
         let timeout = Duration::from_secs(self.timeout_seconds);
@@ -996,7 +1016,11 @@ impl KolmeRuntimeCommitHttpTransport {
             }
         }
 
-        let output = child.wait_with_output().map_err(map_transport_io_error)?;
+        let output = child.wait_with_output().map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
         let looks_like_http_response = output.stdout.starts_with(b"HTTP/1.")
             && output.stdout.windows(4).any(|window| window == b"\r\n\r\n");
         if !output.status.success() && !looks_like_http_response {
@@ -1445,10 +1469,11 @@ impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketCo
             }
 
             let mut chunk = [0_u8; 1024];
-            let read = self
-                .stream
-                .read(&mut chunk)
-                .map_err(map_transport_io_error)?;
+            let read = self.stream.read(&mut chunk).map_err(|error| {
+                map_transport_io_classification_to_provider_error(
+                    classify_kolme_transport_io_error(&error),
+                )
+            })?;
             if read == 0 {
                 return Ok(None);
             }
@@ -1475,15 +1500,23 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
             });
         }
 
-        let mut stream = TcpStream::connect((endpoint.host.as_str(), endpoint.port))
-            .map_err(map_transport_io_error)?;
+        let mut stream =
+            TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
+                map_transport_io_classification_to_provider_error(
+                    classify_kolme_transport_io_error(&error),
+                )
+            })?;
         let timeout = Duration::from_secs(self.timeout_seconds);
-        stream
-            .set_read_timeout(Some(timeout))
-            .map_err(map_transport_io_error)?;
-        stream
-            .set_write_timeout(Some(timeout))
-            .map_err(map_transport_io_error)?;
+        stream.set_read_timeout(Some(timeout)).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
+        stream.set_write_timeout(Some(timeout)).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
 
         let handshake = format!(
             concat!(
@@ -1497,9 +1530,11 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
             ),
             endpoint.target_path, endpoint.host_header, "dGhlIHNhbXBsZSBub25jZQ=="
         );
-        stream
-            .write_all(handshake.as_bytes())
-            .map_err(map_transport_io_error)?;
+        stream.write_all(handshake.as_bytes()).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
 
         let mut response_bytes = Vec::new();
         let header_end = read_http_header_boundary(&mut stream, &mut response_bytes)?;
@@ -1916,7 +1951,11 @@ fn read_http_header_boundary(
             return Ok(position);
         }
         let mut chunk = [0_u8; 1024];
-        let read = stream.read(&mut chunk).map_err(map_transport_io_error)?;
+        let read = stream.read(&mut chunk).map_err(|error| {
+            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
+                &error,
+            ))
+        })?;
         if read == 0 {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "websocket handshake response is incomplete".to_owned(),
@@ -1955,15 +1994,14 @@ fn parse_kolme_notification_event(
     }
 }
 
-fn map_transport_io_error(error: std::io::Error) -> KolmeRuntimeCommitProviderError {
-    if matches!(
-        error.kind(),
-        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
-    ) {
-        return KolmeRuntimeCommitProviderError::Timeout;
-    }
-    KolmeRuntimeCommitProviderError::Unavailable {
-        reason: format!("transport io error: {error}"),
+fn map_transport_io_classification_to_provider_error(
+    classification: KamnKolmeTransportIoClassification,
+) -> KolmeRuntimeCommitProviderError {
+    match classification {
+        KamnKolmeTransportIoClassification::Timeout => KolmeRuntimeCommitProviderError::Timeout,
+        KamnKolmeTransportIoClassification::Unavailable { reason } => {
+            KolmeRuntimeCommitProviderError::Unavailable { reason }
+        }
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -39,11 +39,12 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_receipt("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_error("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1818
+    // Regression: #1820
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -78,4 +79,5 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("if receipt.commit_id.trim().is_empty()"));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
+    assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -13,6 +13,8 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("## Phase 1 - Transport and endpoint parsing extraction"));
     assert!(DOC.contains("## Phase 2 - Finality and block-fallback extraction"));
     assert!(DOC.contains("## Phase 3 - Adapter and lifecycle orchestration extraction"));
+    assert!(DOC.contains("## Phase 1 Progress"));
+    assert!(DOC.contains("#1820"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -77,7 +77,8 @@ pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError,
 };
 pub use transport::{
-    EchoTransport, KolmeTransport, TransportError, TransportRequest, TransportResponse,
+    classify_transport_io_error, EchoTransport, KolmeTransport, KolmeTransportIoClassification,
+    TransportError, TransportRequest, TransportResponse,
 };
 pub use transport_request_policy::{
     is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,

--- a/crates/kamn-kolme/src/transport.rs
+++ b/crates/kamn-kolme/src/transport.rs
@@ -58,6 +58,31 @@ impl fmt::Display for TransportError {
 
 impl Error for TransportError {}
 
+/// Deterministic classification for transport IO failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeTransportIoClassification {
+    /// IO timeout or would-block condition.
+    Timeout,
+    /// Other transport IO failures that should be treated as unavailable.
+    Unavailable {
+        /// Deterministic unavailability reason.
+        reason: String,
+    },
+}
+
+/// Classifies transport IO failures for runtime-commit transport paths.
+pub fn classify_transport_io_error(error: &std::io::Error) -> KolmeTransportIoClassification {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+    ) {
+        return KolmeTransportIoClassification::Timeout;
+    }
+    KolmeTransportIoClassification::Unavailable {
+        reason: format!("transport io error: {error}"),
+    }
+}
+
 /// Transport boundary for runtime-commit submissions.
 pub trait KolmeTransport {
     /// Submits a request and returns a response envelope.

--- a/crates/kamn-kolme/tests/transport_io_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_io_policy_contracts.rs
@@ -1,0 +1,30 @@
+use kamn_kolme::{
+    classify_transport_io_error, KolmeTransportIoClassification as TransportIoClassification,
+};
+use std::io;
+
+#[test]
+fn unit_classify_transport_io_error_maps_timeout_and_would_block_to_timeout() {
+    let timeout = io::Error::new(io::ErrorKind::TimedOut, "timed out");
+    assert_eq!(
+        classify_transport_io_error(&timeout),
+        TransportIoClassification::Timeout
+    );
+
+    let would_block = io::Error::new(io::ErrorKind::WouldBlock, "would block");
+    assert_eq!(
+        classify_transport_io_error(&would_block),
+        TransportIoClassification::Timeout
+    );
+}
+
+#[test]
+fn unit_classify_transport_io_error_maps_other_kinds_to_unavailable() {
+    let reset = io::Error::new(io::ErrorKind::ConnectionReset, "reset by peer");
+    assert_eq!(
+        classify_transport_io_error(&reset),
+        TransportIoClassification::Unavailable {
+            reason: "transport io error: reset by peer".to_owned(),
+        }
+    );
+}

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -25,6 +25,9 @@ Out of scope:
 - keep call-site behavior unchanged with extraction-boundary tests,
 - gate completion on strict `clippy` and runtime-commit transport regression tests.
 
+## Phase 1 Progress
+- #1820: extracted transport IO classification contract to `kamn-kolme` (`classify_transport_io_error`) and removed core-local transport IO classification ownership.
+
 ## Phase 2 - Finality and block-fallback extraction
 - move finality parsing and block-fallback conversion contracts behind `kamn-kolme` interfaces,
 - keep provider mismatch and commit-id mismatch fail-closed behavior in `kamn-core`,


### PR DESCRIPTION
## Summary
Extracts transport IO classification policy into `kamn-kolme` and rewires `kamn-core` runtime-commit transport paths to consume the extracted contract. This completes a concrete Phase 1 extraction slice from the runtime-commit extraction plan.

Closes #1820
Refs #1714

## Changes
- `crates/kamn-kolme/src/transport.rs`: added `KolmeTransportIoClassification` and `classify_transport_io_error(&std::io::Error)`.
- `crates/kamn-kolme/src/lib.rs`: exported transport IO classification contract.
- `crates/kamn-kolme/tests/transport_io_policy_contracts.rs`: added policy contract tests for timeout/would-block and unavailable classification.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed core-local `map_transport_io_error`; replaced call sites with `classify_kolme_transport_io_error` classification + provider mapping.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added extraction-boundary assertions for removed core-local transport IO classifier and required extracted classifier usage (`Regression: #1820`).
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added Phase 1 progress entry for #1820.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added doc-contract assertions for Phase 1 progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-kolme --test transport_io_policy_contracts`
- Result (before implementation): failed due unresolved imports `classify_transport_io_error` and `KolmeTransportIoClassification`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-kolme --test transport_io_policy_contracts`
- Result: pass after adding/exposing transport IO classification contract.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-kolme --test transport_io_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `transport_io_policy_contracts` | Extracted policy contract behavior covered |
| Functional   | N/A    | None                 | No feature-level behavior changes |
| Integration  | ✅     | runtime-commit and extraction-plan doc tests | Cross-crate contract wiring validated |
| Regression   | ✅     | extraction-boundary + transport policy contracts | Guards against classifier regressions/reintroduction |
| Performance  | N/A    | None                 | No throughput/latency changes |

## Risks & Rollback
- Risk: Low/Med; cross-crate policy extraction with behavior-equivalent mappings.
- Rollback: Revert this PR.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with Phase 1 progress note.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-kolme --tests`, `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
