### PR TITLE
refactor(kolme): remove transport classification wrapper (#1822)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -640,6 +640,17 @@ impl fmt::Display for KolmeRuntimeCommitProviderError {
 
 impl std::error::Error for KolmeRuntimeCommitProviderError {}
 
+impl From<KamnKolmeTransportIoClassification> for KolmeRuntimeCommitProviderError {
+    fn from(value: KamnKolmeTransportIoClassification) -> Self {
+        match value {
+            KamnKolmeTransportIoClassification::Timeout => Self::Timeout,
+            KamnKolmeTransportIoClassification::Unavailable { reason } => {
+                Self::Unavailable { reason }
+            }
+        }
+    }
+}
+
 /// Provider receipt payload returned by adapter-facing transport.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KolmeRuntimeCommitProviderReceipt {
@@ -921,32 +932,22 @@ impl KolmeRuntimeCommitHttpTransport {
     ) -> Result<Vec<u8>, KolmeRuntimeCommitProviderError> {
         let mut stream =
             TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
-                map_transport_io_classification_to_provider_error(
-                    classify_kolme_transport_io_error(&error),
-                )
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
             })?;
         let timeout = Duration::from_secs(self.timeout_seconds);
         stream.set_read_timeout(Some(timeout)).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
         stream.set_write_timeout(Some(timeout)).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
         stream.write_all(request).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
 
         let mut response_bytes = Vec::new();
         stream.read_to_end(&mut response_bytes).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
         Ok(response_bytes)
     }
@@ -989,9 +990,7 @@ impl KolmeRuntimeCommitHttpTransport {
                         reason: "tls command stdin unavailable".to_owned(),
                     })?;
             stdin.write_all(request).map_err(|error| {
-                map_transport_io_classification_to_provider_error(
-                    classify_kolme_transport_io_error(&error),
-                )
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
             })?;
         }
 
@@ -1017,9 +1016,7 @@ impl KolmeRuntimeCommitHttpTransport {
         }
 
         let output = child.wait_with_output().map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
         let looks_like_http_response = output.stdout.starts_with(b"HTTP/1.")
             && output.stdout.windows(4).any(|window| window == b"\r\n\r\n");
@@ -1470,9 +1467,7 @@ impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketCo
 
             let mut chunk = [0_u8; 1024];
             let read = self.stream.read(&mut chunk).map_err(|error| {
-                map_transport_io_classification_to_provider_error(
-                    classify_kolme_transport_io_error(&error),
-                )
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
             })?;
             if read == 0 {
                 return Ok(None);
@@ -1502,20 +1497,14 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
 
         let mut stream =
             TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
-                map_transport_io_classification_to_provider_error(
-                    classify_kolme_transport_io_error(&error),
-                )
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
             })?;
         let timeout = Duration::from_secs(self.timeout_seconds);
         stream.set_read_timeout(Some(timeout)).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
         stream.set_write_timeout(Some(timeout)).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
 
         let handshake = format!(
@@ -1531,9 +1520,7 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
             endpoint.target_path, endpoint.host_header, "dGhlIHNhbXBsZSBub25jZQ=="
         );
         stream.write_all(handshake.as_bytes()).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
 
         let mut response_bytes = Vec::new();
@@ -1952,9 +1939,7 @@ fn read_http_header_boundary(
         }
         let mut chunk = [0_u8; 1024];
         let read = stream.read(&mut chunk).map_err(|error| {
-            map_transport_io_classification_to_provider_error(classify_kolme_transport_io_error(
-                &error,
-            ))
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
         })?;
         if read == 0 {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
@@ -1990,17 +1975,6 @@ fn parse_kolme_notification_event(
         }),
         KamnKolmeNotificationEvent::LatestBlock { height } => {
             Ok(KolmeRuntimeCommitNotificationEvent::LatestBlock { height })
-        }
-    }
-}
-
-fn map_transport_io_classification_to_provider_error(
-    classification: KamnKolmeTransportIoClassification,
-) -> KolmeRuntimeCommitProviderError {
-    match classification {
-        KamnKolmeTransportIoClassification::Timeout => KolmeRuntimeCommitProviderError::Timeout,
-        KamnKolmeTransportIoClassification::Unavailable { reason } => {
-            KolmeRuntimeCommitProviderError::Unavailable { reason }
         }
     }
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -40,11 +40,12 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_receipt("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_classification_to_provider_error("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1820
+    // Regression: #1822
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
@@ -80,4 +81,5 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
+    assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }


### PR DESCRIPTION
## Summary
Removes the remaining transport-classification conversion wrapper in `kamn-core` by switching to direct `From<KamnKolmeTransportIoClassification>` conversion. This keeps the extracted `kamn-kolme` transport policy path explicit and reduces core indirection.

Closes #1822
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `impl From<KamnKolmeTransportIoClassification> for KolmeRuntimeCommitProviderError`.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: replaced wrapper-based conversion call sites with direct conversion.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `map_transport_io_classification_to_provider_error`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added regression assertion guarding wrapper removal and required `From` conversion presence (`Regression: #1822`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on assertions requiring removal of `map_transport_io_classification_to_provider_error` and presence of `impl From<KamnKolmeTransportIoClassification>`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after direct `From` conversion implementation and wrapper removal.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-kolme --test transport_io_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No feature behavior changes |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariants validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Guards wrapper reintroduction |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; conversion semantics are unchanged.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit scope)
- [x] Docs updated (or justified why not)
