### PR TITLE
refactor(kolme): inline provider outcome malformed mapper (#1824)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -47,7 +47,6 @@ use kamn_kolme::{
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeProviderOutcome as KamnKolmeProviderOutcome,
-    KolmeProviderOutcomePolicyError as KamnKolmeProviderOutcomePolicyError,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
     KolmeTransportIoClassification as KamnKolmeTransportIoClassification,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
@@ -1197,10 +1196,18 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
                 reason: error.to_string(),
             }
         })?;
-        let provider = required_kolme_provider_response_field(&fields, "provider")
-            .map_err(map_provider_outcome_policy_error_to_malformed)?;
-        let observed_commit_id = parse_kolme_commit_id_from_response_fields(&fields)
-            .map_err(map_provider_outcome_policy_error_to_malformed)?;
+        let provider =
+            required_kolme_provider_response_field(&fields, "provider").map_err(|error| {
+                KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                }
+            })?;
+        let observed_commit_id =
+            parse_kolme_commit_id_from_response_fields(&fields).map_err(|error| {
+                KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                }
+            })?;
         if observed_commit_id != commit_id {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: format!(
@@ -1208,8 +1215,12 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
                 ),
             });
         }
-        let finality_value = required_kolme_provider_response_field(&fields, "finality")
-            .map_err(map_provider_outcome_policy_error_to_malformed)?;
+        let finality_value =
+            required_kolme_provider_response_field(&fields, "finality").map_err(|error| {
+                KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                }
+            })?;
         let finality =
             parse_kolme_commit_receipt_finality(finality_value.as_str()).map_err(|error| {
                 KolmeRuntimeCommitProviderError::MalformedResponse {
@@ -1695,8 +1706,11 @@ where
         from_height: u64,
         latest_height: u64,
     ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        let expected_txhash = txhash_from_kolme_commit_id(commit_id)
-            .map_err(map_provider_outcome_policy_error_to_malformed)?;
+        let expected_txhash = txhash_from_kolme_commit_id(commit_id).map_err(|error| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            }
+        })?;
 
         match self.notifications_consumer.next_notification_event() {
             Ok(event) => match event {
@@ -1718,9 +1732,12 @@ where
                         .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
                             reason: "notification event did not carry receipt data".to_owned(),
                         })?;
-                    let observed_txhash =
-                        txhash_from_kolme_commit_id(receipt.commit_id.as_str())
-                            .map_err(map_provider_outcome_policy_error_to_malformed)?;
+                    let observed_txhash = txhash_from_kolme_commit_id(receipt.commit_id.as_str())
+                        .map_err(|error| {
+                        KolmeRuntimeCommitProviderError::MalformedResponse {
+                            reason: error.to_string(),
+                        }
+                    })?;
                     if observed_txhash != expected_txhash {
                         return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                             reason: format!(
@@ -1904,14 +1921,6 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
     }
 }
 
-fn map_provider_outcome_policy_error_to_malformed(
-    error: KamnKolmeProviderOutcomePolicyError,
-) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::MalformedResponse {
-        reason: error.to_string(),
-    }
-}
-
 fn reconnect_exhausted_error(max_reconnect_attempts: u32) -> KolmeRuntimeCommitProviderError {
     KolmeRuntimeCommitProviderError::Unavailable {
         reason: format!(
@@ -2000,9 +2009,11 @@ fn parse_live_provider_response(
     response: &str,
     provider_hint: Option<&str>,
 ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
-    match parse_kolme_live_provider_outcome(response, provider_hint)
-        .map_err(map_provider_outcome_policy_error_to_malformed)?
-    {
+    match parse_kolme_live_provider_outcome(response, provider_hint).map_err(|error| {
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: error.to_string(),
+        }
+    })? {
         KamnKolmeProviderOutcome::Submitted {
             provider,
             commit_id,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -41,11 +41,12 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_classification_to_provider_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome_policy_error_to_malformed("));
 }
 
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
-    // Regression: #1822
+    // Regression: #1824
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_commit_receipt_finality("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));


### PR DESCRIPTION
## Summary
Inlines provider-outcome malformed mapping at all runtime-commit call sites and removes the final local `map_*` delegate in `kolme_runtime_commit`. This completes the current boundary-cleanup arc under `#1714`.

Closes #1824
Refs #1714

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: replaced `.map_err(map_provider_outcome_policy_error_to_malformed)` with direct malformed mapping closures.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `map_provider_outcome_policy_error_to_malformed` helper and unused import.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added anti-regression assertion for removed helper (`Regression: #1824`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result (before implementation): failed on new assertion requiring absence of `fn map_provider_outcome_policy_error_to_malformed(`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- Result: pass after inlining and helper removal.

### 🔁 Regression
- `cargo fmt --check`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Refactor-only change |
| Functional   | N/A    | None                 | No feature behavior changes |
| Integration  | ✅     | `kolme_runtime_commit_extraction_boundary` | Boundary invariants validated |
| Regression   | ✅     | `kolme_runtime_commit_extraction_boundary` | Guards removed helper signature |
| Performance  | N/A    | None                 | No perf-path changes |

## Risks & Rollback
- Risk: Low; mapping logic remains behavior-equivalent.
- Rollback: Revert this PR.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (crate-scoped: `-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (runtime-commit scope)
- [x] Docs updated (or justified why not)
