### PR TITLE
docs(kamn-core): graduate key_recovery migrations smoke modules (#1828)

### DIFF
--- a/crates/kamn-core/src/key_recovery.rs
+++ b/crates/kamn-core/src/key_recovery.rs
@@ -1,31 +1,53 @@
+//! Recovery-state workflow for compromised agent signing keys.
+
 use std::collections::HashSet;
 
+/// Lifecycle state for key compromise and recovery operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecoveryState {
+    /// The active key can be used for normal signing operations.
     Active,
+    /// The active key is marked compromised and cannot be trusted.
     Compromised,
+    /// The compromised key has been revoked and recovery can begin.
     Revoked,
+    /// A recovery proposal is in progress and waiting for approvals.
     RecoveryPending,
 }
 
+/// Error surfaced by key recovery lifecycle operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecoveryError {
+    /// A required key identifier was empty.
     EmptyKeyId,
+    /// Recovery approval requirements are invalid for the configured approvers.
     InvalidRequiredApprovals {
+        /// Requested threshold of required approvals.
         required: usize,
+        /// Number of configured approvers available.
         approver_count: usize,
     },
+    /// Attempted transition is invalid for the current recovery state.
     InvalidTransition {
+        /// Current state where the transition was attempted.
         from: RecoveryState,
+        /// Operation name that triggered the invalid transition.
         action: &'static str,
     },
+    /// Recovery action was attempted by an untrusted approver.
     UnauthorizedApprover(String),
+    /// Finalization attempted without enough distinct approvals.
     InsufficientApprovals {
+        /// Required approval threshold.
         required: usize,
+        /// Number of approvals collected so far.
         actual: usize,
     },
+    /// Proposed key is known to be compromised.
     CompromisedKeyReuse(String),
+    /// Recovery nonce was already used by a prior finalized proposal.
     ReplayNonce(u64),
+    /// The same approver attempted to approve twice.
     DuplicateApproval(String),
 }
 
@@ -36,6 +58,7 @@ struct RecoveryProposal {
     approvals: HashSet<String>,
 }
 
+/// Manages emergency compromise, revocation, and multi-approver recovery.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyRecoveryManager {
     state: RecoveryState,
@@ -48,6 +71,7 @@ pub struct KeyRecoveryManager {
 }
 
 impl KeyRecoveryManager {
+    /// Creates a new recovery manager for the active key and approver set.
     pub fn new(
         current_key_id: &str,
         authorized_approvers: Vec<String>,
@@ -75,14 +99,17 @@ impl KeyRecoveryManager {
         })
     }
 
+    /// Returns the current recovery lifecycle state.
     pub fn state(&self) -> RecoveryState {
         self.state
     }
 
+    /// Returns the currently active key identifier.
     pub fn current_key_id(&self) -> &str {
         &self.current_key_id
     }
 
+    /// Marks the active key as compromised and enters compromised state.
     pub fn declare_compromised(&mut self, _reason: &str) -> Result<(), RecoveryError> {
         if self.state != RecoveryState::Active {
             return Err(RecoveryError::InvalidTransition {
@@ -96,6 +123,7 @@ impl KeyRecoveryManager {
         Ok(())
     }
 
+    /// Revokes the compromised key and opens recovery proposal flow.
     pub fn emergency_revoke(&mut self) -> Result<(), RecoveryError> {
         if self.state != RecoveryState::Compromised {
             return Err(RecoveryError::InvalidTransition {
@@ -107,6 +135,7 @@ impl KeyRecoveryManager {
         Ok(())
     }
 
+    /// Starts a recovery proposal with the first approver signature.
     pub fn propose_recovery(
         &mut self,
         candidate_key_id: &str,
@@ -145,6 +174,7 @@ impl KeyRecoveryManager {
         Ok(())
     }
 
+    /// Adds an approver vote to the in-flight recovery proposal.
     pub fn approve_recovery(&mut self, approver: &str) -> Result<(), RecoveryError> {
         if self.state != RecoveryState::RecoveryPending {
             return Err(RecoveryError::InvalidTransition {
@@ -171,6 +201,7 @@ impl KeyRecoveryManager {
         Ok(())
     }
 
+    /// Finalizes recovery and activates the proposed key once threshold is met.
     pub fn finalize_recovery(&mut self) -> Result<(), RecoveryError> {
         if self.state != RecoveryState::RecoveryPending {
             return Err(RecoveryError::InvalidTransition {
@@ -202,6 +233,7 @@ impl KeyRecoveryManager {
         Ok(())
     }
 
+    /// Rejects usage of keys that are recorded as compromised.
     pub fn verify_key_use(&self, key_id: &str) -> Result<(), RecoveryError> {
         if self.compromised_keys.contains(key_id) {
             return Err(RecoveryError::CompromisedKeyReuse(key_id.to_owned()));

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -58,7 +58,7 @@ pub mod instruction_verify;
 pub mod invariants;
 #[allow(missing_docs)]
 pub mod key_lifecycle;
-#[allow(missing_docs)]
+/// Key compromise and recovery lifecycle contracts.
 pub mod key_recovery;
 pub mod kolme_runtime_commit;
 #[allow(missing_docs)]
@@ -67,7 +67,7 @@ pub mod message_delivery_guards;
 pub mod message_envelope;
 #[allow(missing_docs)]
 pub mod message_lifecycle;
-#[allow(missing_docs)]
+/// State schema migration planning and validation contracts.
 pub mod migrations;
 pub mod namespaces;
 #[allow(missing_docs)]
@@ -98,7 +98,7 @@ pub mod service_marketplace;
 pub mod signature_profile;
 #[allow(missing_docs)]
 pub mod signer_backend;
-#[allow(missing_docs)]
+/// Deterministic triadic runtime smoke simulation contracts.
 pub mod smoke;
 pub mod state;
 #[allow(missing_docs)]

--- a/crates/kamn-core/src/migrations.rs
+++ b/crates/kamn-core/src/migrations.rs
@@ -1,17 +1,26 @@
+//! State-version migration planning and validation contracts.
+
 use std::fmt;
 
 use crate::state::StateVersion;
 
+/// Single migration step between two adjacent state versions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrationStep {
+    /// Stable step identifier used in audit and policy checks.
     pub id: &'static str,
+    /// Source state version for this step.
     pub from: StateVersion,
+    /// Destination state version reached by this step.
     pub to: StateVersion,
+    /// Human-readable description of the migration behavior.
     pub description: &'static str,
+    /// Namespaces affected by this migration step.
     pub namespaces: &'static [&'static str],
 }
 
 impl MigrationStep {
+    /// Builds a static migration step descriptor.
     pub const fn new(
         id: &'static str,
         from: StateVersion,
@@ -29,14 +38,19 @@ impl MigrationStep {
     }
 }
 
+/// Ordered migration plan from one version to another.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrationPlan {
+    /// Requested source version.
     pub from: StateVersion,
+    /// Requested target version.
     pub to: StateVersion,
+    /// Ordered steps required to reach the target version.
     pub steps: Vec<MigrationStep>,
 }
 
 impl MigrationPlan {
+    /// Validates continuity and target coverage of the migration plan.
     pub fn validate(&self) -> Result<(), MigrationError> {
         if self.from == self.to {
             if self.steps.is_empty() {
@@ -74,16 +88,19 @@ impl MigrationPlan {
     }
 }
 
+/// Registry of known migration steps keyed by their source version.
 #[derive(Debug, Clone, Default)]
 pub struct MigrationRegistry {
     steps: Vec<MigrationStep>,
 }
 
 impl MigrationRegistry {
+    /// Creates an empty migration registry.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Registers a new migration step after range and ID validation.
     pub fn register(&mut self, step: MigrationStep) -> Result<(), MigrationError> {
         if step.from >= step.to {
             return Err(MigrationError::InvalidStepRange {
@@ -102,6 +119,7 @@ impl MigrationRegistry {
         Ok(())
     }
 
+    /// Builds a contiguous migration plan from source to target version.
     pub fn build_plan(
         &self,
         from: StateVersion,
@@ -148,31 +166,51 @@ impl MigrationRegistry {
     }
 }
 
+/// Error returned when migration steps or plans are invalid.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MigrationError {
+    /// Step ID already exists in the registry.
     DuplicateStepId(String),
+    /// Step range is invalid because source is not lower than destination.
     InvalidStepRange {
+        /// Step identifier with invalid range.
         id: &'static str,
+        /// Source version supplied for the step.
         from: StateVersion,
+        /// Destination version supplied for the step.
         to: StateVersion,
     },
+    /// Requested plan range is invalid.
     InvalidPlanRange {
+        /// Source version requested by the caller.
         from: StateVersion,
+        /// Target version requested by the caller.
         to: StateVersion,
     },
+    /// Registry lacks a required step to continue toward the target.
     MissingStep {
+        /// Current version that requires a next step.
         from: StateVersion,
+        /// Final target version requested by the caller.
         to: StateVersion,
     },
+    /// Step sequence is not contiguous with prior step output.
     NonContiguousStep {
+        /// Expected source version based on previous step.
         expected_from: StateVersion,
+        /// Actual source version found on the next step.
         found_from: StateVersion,
     },
+    /// Step destination exceeds requested migration target.
     StepOvershootsTarget {
+        /// Step ID that overshoots the target.
         id: String,
+        /// Requested target version.
         target: StateVersion,
+        /// Step destination that exceeded the target.
         step_to: StateVersion,
     },
+    /// Plan includes steps even though source and target are equal.
     UnexpectedStepsForSameVersion,
 }
 

--- a/crates/kamn-core/src/smoke.rs
+++ b/crates/kamn-core/src/smoke.rs
@@ -1,31 +1,42 @@
+//! Deterministic triadic smoke network used by runtime contract tests.
+
 use std::fmt;
 
 use crate::config::NodeRole;
 use crate::transaction::{BaselineTransaction, TransactionGuardError, TransactionGuards};
 
+/// Block produced by the processor role during smoke simulation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProducedBlock {
+    /// Sequential block height.
     pub height: u64,
+    /// Producer role that emitted the block.
     pub producer: NodeRole,
+    /// Ordered transactions committed into the block.
     pub transactions: Vec<BaselineTransaction>,
 }
 
+/// In-memory role state tracked during smoke simulation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeSmokeState {
+    /// Node role represented by this state record.
     pub role: NodeRole,
     mempool: Vec<BaselineTransaction>,
     committed_tx_ids: Vec<String>,
 }
 
 impl NodeSmokeState {
+    /// Returns current number of pending mempool transactions.
     pub fn mempool_len(&self) -> usize {
         self.mempool.len()
     }
 
+    /// Returns number of committed transaction IDs.
     pub fn committed_len(&self) -> usize {
         self.committed_tx_ids.len()
     }
 
+    /// Returns true when the transaction appears in mempool or committed history.
     pub fn has_seen_transaction(&self, tx_id: &str) -> bool {
         self.mempool.iter().any(|tx| tx.id == tx_id)
             || self.committed_tx_ids.iter().any(|seen_id| seen_id == tx_id)
@@ -42,17 +53,23 @@ impl NodeSmokeState {
     }
 }
 
+/// Triadic runtime smoke network with processor/listener/approver roles.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoleSmokeNetwork {
+    /// Processor role state.
     pub processor: NodeSmokeState,
+    /// Listener role state.
     pub listener: NodeSmokeState,
+    /// Approver role state.
     pub approver: NodeSmokeState,
+    /// Enables transaction gossip from processor to listener/approver.
     pub gossip_enabled: bool,
     guards: TransactionGuards,
     next_height: u64,
 }
 
 impl RoleSmokeNetwork {
+    /// Creates a new triadic smoke network with optional gossip behavior.
     pub fn new(gossip_enabled: bool) -> Self {
         Self {
             processor: NodeSmokeState {
@@ -76,10 +93,12 @@ impl RoleSmokeNetwork {
         }
     }
 
+    /// Returns expected state hash required for the next accepted transaction.
     pub fn expected_state_hash(&self) -> &str {
         self.guards.expected_state_hash()
     }
 
+    /// Validates and submits a transaction into processor state.
     pub fn submit_transaction(&mut self, tx: BaselineTransaction) -> Result<(), SmokeError> {
         self.guards.validate_and_record(&tx)?;
 
@@ -92,6 +111,7 @@ impl RoleSmokeNetwork {
         Ok(())
     }
 
+    /// Produces a block from processor mempool and advances network height.
     pub fn produce_block(&mut self) -> Result<ProducedBlock, SmokeError> {
         if self.processor.mempool.is_empty() {
             return Err(SmokeError::EmptyMempool(NodeRole::Processor));
@@ -121,14 +141,18 @@ impl RoleSmokeNetwork {
         Ok(block)
     }
 
+    /// Returns true when listener and approver have both observed the transaction.
     pub fn gossip_reached_all_roles(&self, tx_id: &str) -> bool {
         self.listener.has_seen_transaction(tx_id) && self.approver.has_seen_transaction(tx_id)
     }
 }
 
+/// Smoke network error type surfaced by submit/produce operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SmokeError {
+    /// Attempted block production with an empty processor mempool.
     EmptyMempool(NodeRole),
+    /// Transaction guard rejected an operation.
     Guard(TransactionGuardError),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -111,6 +111,24 @@ fn graduated_wave_three_task_lifecycle_module_must_not_return_to_missing_docs_al
 }
 
 #[test]
+fn graduated_wave_four_runtime_safety_modules_must_not_return_to_allowlist() {
+    // Regression: #1828
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+
+    for module in ["key_recovery", "migrations", "smoke"] {
+        assert!(
+            !actual.iter().any(|candidate| candidate == module),
+            "{module} must stay graduated from #[allow(missing_docs)]"
+        );
+        assert!(
+            !expected.iter().any(|candidate| candidate == module),
+            "allowlist fixture must keep {module} removed"
+        );
+    }
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -154,6 +154,20 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 6. Bridge/adapters and signer/ZK surfaces emit external receipts and proof
    artifacts for reconciliation.
 
+## Missing-Docs Graduation Status
+
+- Graduated modules currently enforced outside the allow-list:
+  - `bootstrap`
+  - `key_recovery`
+  - `kolme_runtime_commit`
+  - `migrations`
+  - `namespaces`
+  - `smoke`
+  - `state`
+  - `task_lifecycle`
+- Regression marker:
+  - `Regression: #1828`
+
 ## Contributor Entrypoint Matrix
 
 | Contributor need | Entrypoint | Why it exists |

--- a/docs/developer/rustdoc-publishing.md
+++ b/docs/developer/rustdoc-publishing.md
@@ -42,6 +42,9 @@ without adding hosted-doc platform dependencies.
   - `bash scripts/ci/check_kamn_core_missing_docs_policy.sh`
 - Graduated-module guard fixture consumed by checker:
   - `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`
+- Current graduated modules:
+  - `bootstrap`, `key_recovery`, `kolme_runtime_commit`, `migrations`,
+    `namespaces`, `smoke`, `state`, `task_lifecycle`
 - Regression tests for checker behavior:
   - `bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh`
 - Rustdoc artifact contract lane (bounded):
@@ -69,3 +72,5 @@ without adding hosted-doc platform dependencies.
 - Graduated modules listed in `kamn_core_missing_docs_graduated_modules.txt`
   cannot be re-added to `#[allow(missing_docs)]` without a fail-closed policy
   break.
+- Graduation update marker:
+  - `Regression: #1828`

--- a/docs/planning/engineering-hardening-wave.md
+++ b/docs/planning/engineering-hardening-wave.md
@@ -44,7 +44,8 @@ default development loop green while tightening missing-doc policy controls for
 - Legacy `#[allow(missing_docs)] pub mod ...` exemptions are tracked in:
   - `fixtures/ci/kamn_core_missing_docs_allowlist.txt`
 - Graduated modules that must remain outside the allow-list:
-  - `namespaces`, `bootstrap`, `kolme_runtime_commit`, `state`, `task_lifecycle`
+  - `bootstrap`, `key_recovery`, `kolme_runtime_commit`, `migrations`,
+    `namespaces`, `smoke`, `state`, `task_lifecycle`
 - Graduated modules fixture:
   - `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`
 - Throughput visibility target:

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -24,11 +24,9 @@ group_channel_crypto
 instruction_verify
 invariants
 key_lifecycle
-key_recovery
 message_delivery_guards
 message_envelope
 message_lifecycle
-migrations
 observability
 operator_actions
 operator_binding
@@ -43,7 +41,6 @@ runtime
 service_marketplace
 signature_profile
 signer_backend
-smoke
 task_artifacts
 task_operations
 task_payment

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -1,5 +1,8 @@
 bootstrap
+key_recovery
 kolme_runtime_commit
+migrations
 namespaces
+smoke
 state
 task_lifecycle


### PR DESCRIPTION
## Summary
Graduates three additional `kamn-core` modules (`key_recovery`, `migrations`, `smoke`) from the missing-docs allow-list by adding full public rustdoc coverage and updating policy fixtures/docs. Adds regression coverage so these modules cannot drift back into `#[allow(missing_docs)]`.

Closes #1828

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `key_recovery`, `migrations`, and `smoke`; added module-level docs.
- `crates/kamn-core/src/key_recovery.rs`: added public API/variant/field rustdoc.
- `crates/kamn-core/src/migrations.rs`: added public API/variant/field rustdoc.
- `crates/kamn-core/src/smoke.rs`: added public API/variant/field rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `key_recovery`, `migrations`, `smoke`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `key_recovery`, `migrations`, `smoke`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard for newly graduated modules.
- `docs/planning/engineering-hardening-wave.md`, `docs/architecture/kamn-core-module-map.md`, `docs/developer/rustdoc-publishing.md`: updated graduation status references.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command (before docs graduation):
- `cargo clippy -p kamn-core -- -D warnings` (with `key_recovery` allow marker removed)

Failing output excerpt:
- `error: missing documentation for a module`
- `pub mod key_recovery;`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`
- `bash scripts/ci/check_kamn_core_missing_docs_policy.sh`
- `bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh`
- `bash scripts/ci/test_missing_docs_throughput_report_contract.sh`
- `bash scripts/ci/test_run_kamn_core_rustdoc_artifact_contract_lane.sh`
- `bash scripts/ci/test_check_kamn_core_rustdoc_artifact_policy.sh`

Result:
- All commands above passed.

### 🔁 Regression
- Added `graduated_wave_four_runtime_safety_modules_must_not_return_to_allowlist` in `crates/kamn-core/tests/missing_docs_policy.rs` with `Regression: #1828`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test missing_docs_policy` (new wave-four graduation guard) | |
| Functional   | ✅ | `cargo clippy -p kamn-core --tests -- -D warnings` against graduated modules | |
| Integration  | ✅ | `bash scripts/ci/check_kamn_core_missing_docs_policy.sh` + rustdoc artifact contract lane checks | |
| Regression   | ✅ | `bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh` and throughput contract checks | |
| Performance  | N/A | N/A | Docs-only graduation; no runtime hot-path behavior changes |

## Risks & Rollback
- Risk: incomplete rustdoc coverage could reintroduce missing-doc failures.
- Rollback plan: revert this PR to restore prior allow-list state.

## Documentation Updates
- `docs/planning/engineering-hardening-wave.md`
- `docs/architecture/kamn-core-module-map.md`
- `docs/developer/rustdoc-publishing.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (validated for touched crate scope: `kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant missing-doc policy/doc-contract suites)
- [x] Docs updated (or justified why not)
