### PR TITLE
feat(kolme): add preflighted local live-provider smoke lane (#1829)

### DIFF
--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -934,3 +934,63 @@ fn regression_kolme_fork_direct_signed_payload_requires_core_transaction_keys() 
         );
     }
 }
+
+#[test]
+#[ignore = "requires reachable local Kolme node and explicit local opt-in lane"]
+fn integration_kolme_fork_live_node_submit_reaches_endpoint() {
+    let base_url = env::var("KAMN_KOLME_LIVE_BASE_URL")
+        .expect("KAMN_KOLME_LIVE_BASE_URL must be set for live node smoke");
+    let provider_hint =
+        env::var("KAMN_KOLME_LIVE_PROVIDER_HINT").unwrap_or_else(|_| "kolme-fork-local".to_owned());
+    let authorization_header = env::var("KAMN_KOLME_LIVE_AUTHORIZATION").ok();
+
+    let transport = if let Some(value) = authorization_header {
+        KolmeRuntimeCommitHttpTransport::new_with_authorization(10, value.as_str())
+            .expect("transport with authorization should build")
+    } else {
+        KolmeRuntimeCommitHttpTransport::new(10).expect("transport should build")
+    };
+
+    let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+        base_url.as_str(),
+        provider_hint.as_str(),
+        transport,
+    )
+    .expect("provider should build");
+
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    let message_json = format!(
+        "{{\"pubkey\":\"pk-live-smoke-{unique_suffix}\",\"nonce\":1,\"created\":\"2026-02-11T00:00:00Z\",\"messages\":[],\"max_height\":null}}"
+    );
+    let wire_payload = format!(
+        "{{\"message\":\"{}\",\"signature\":\"sig-live-smoke-{unique_suffix}\",\"recovery_id\":1}}",
+        message_json.replace('\\', "\\\\").replace('\"', "\\\"")
+    );
+    let idempotency_key = format!("kolme-runtime-commit:live-smoke:{unique_suffix}");
+
+    let outcome = provider.submit_runtime_commit(wire_payload.as_str(), idempotency_key.as_str());
+    match outcome {
+        Ok(KolmeRuntimeCommitProviderOutcome::Submitted(receipt))
+        | Ok(KolmeRuntimeCommitProviderOutcome::Duplicate(receipt)) => {
+            assert!(!receipt.provider.trim().is_empty());
+            assert!(!receipt.commit_id.trim().is_empty());
+        }
+        Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason }) => {
+            assert!(!reason.trim().is_empty());
+        }
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse { reason }) => {
+            assert!(
+                reason.contains("invalid request")
+                    || reason.contains("missing required field")
+                    || reason.contains("txhash"),
+                "unexpected malformed response reason from live node: {reason}"
+            );
+        }
+        Err(other) => {
+            panic!("live node smoke expected endpoint reachability outcome, got error: {other:?}");
+        }
+    }
+}

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -209,7 +209,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `python3 scripts/kolme/check_local_kolme_fork_portability_preflight_policy.py --report-file /tmp/kolme-local-fork-portability-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code portability_preflight_passed --output-json /tmp/kolme-local-fork-portability-preflight-policy.json`
     - `bash scripts/kolme/run_local_kolme_fork_portability_preflight_contract_lane.sh --output-json /tmp/kolme-local-fork-portability-preflight-summary.json --policy-output-json /tmp/kolme-local-fork-portability-preflight-policy.json`
   - local runtime-commit live run-mode commands remain excluded from ci-fast-gate.
-    - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --live-command "cargo test -p kamn-core --test kolme_runtime_commit_http_transport" --max-seconds 90 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
+    - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
   - local native API parity live-proof run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_native_api_parity_live_proof_lane.sh --mode run --nonce-command "curl --silent --show-error --fail http://127.0.0.1:3000/get-next-nonce?pubkey=test-key" --broadcast-command "curl --silent --show-error --fail --request PUT --data '{\"message\":\"native-parity\",\"signature\":\"sig\",\"recovery_id\":1}' http://127.0.0.1:3000/broadcast" --finality-command "curl --silent --show-error --fail http://127.0.0.1:3000/block/1" --max-seconds 180 --output-json /tmp/kolme-local-native-api-parity-live-proof-summary.json`
   - heavy execution keeps explicit opt-in: `KAMN_KOLME_LOCAL_HEAVY=1`
@@ -307,6 +307,7 @@ Regression policy:
 - local KAMN live runtime integration run-mode exclusion parity remains fail-closed (`Regression: #1489`).
 - local fork process lifecycle integration run-mode exclusion parity remains fail-closed (`Regression: #1494`).
 - local runtime-commit live run-mode exclusion parity remains fail-closed (`Regression: #1451`).
+- local runtime-commit live preflight health-probe and default live-provider ignored-test dispatch parity remains fail-closed (`Regression: #1829`).
 - local native API parity live-proof run-mode exclusion parity remains fail-closed (`Regression: #1467`).
 - native parity fast/local command matrix docs parity remains fail-closed (`Regression: #1468`).
 - local probe fork-info chain_version query and native parity broadcast method drift remains fail-closed (`Regression: #1482`).

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -186,6 +186,8 @@ cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_h
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact
+bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode dry-run --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt
+KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt
 bash scripts/kolme/run_runtime_commit_contract_lane.sh
 ```
 
@@ -206,6 +208,7 @@ cargo test -p kamn-core
 - signed translation envelope and signer custody precondition drift remains fail-closed (`Regression: #1506`).
 - direct signed transaction payload normalization drift remains fail-closed (`Regression: #1516`).
 - direct signed transaction required-field validation drift remains fail-closed (`Regression: #1519`).
+- local live-node provider smoke preflight and ignored-test dispatch remain fail-closed (`Regression: #1829`).
 - typed nonce/broadcast HTTP helper mapping drift remains fail-closed (`Regression: #1533`).
 - provider response field parser extraction parity drift remains fail-closed (`Regression: #1745`).
 - flat JSON parser extraction parity drift remains fail-closed (`Regression: #1747`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -590,16 +590,20 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Local runtime-commit live lane runner:
   - `bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode dry-run --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
 - Explicit opt-in live execution:
-  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --live-command "cargo test -p kamn-core --test kolme_runtime_commit_http_transport" --max-seconds 90 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
+- Default live-provider smoke command executed by run mode:
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
 - Summary schema:
   - `kamn.kolme.local-runtime-commit-live-summary.v1`
 - Deterministic checkpoints include:
+  - bounded preflight probe against `<base-url>/healthz` before live submit execution (unless `--skip-preflight` is explicitly set)
   - explicit local-only opt-in marker (`KAMN_KOLME_LOCAL_HEAVY=1`)
   - bounded live command timeout via `--max-seconds`
-  - machine-readable pass/fail reason codes for missing opt-in, command failure, and timeout
+  - machine-readable pass/fail reason codes for missing opt-in, preflight failure/timeout, command failure, and command timeout
 - Cost policy:
   - run mode fails closed without explicit local-only opt-in.
   - live command timeout/exceeded budget is reported as `live_runtime_commit_command_timeout`.
+  - preflight failures are reported as `live_preflight_failed` or `live_preflight_timeout`.
 
 ## Local Native API Parity Live Proof Lane (Issue #1465)
 
@@ -766,6 +770,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`).
 - real-fork local process wrapper policy checker lane remains fail-closed for schema/contracts/checkpoint drift (`Regression: #1671`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
+- local runtime-commit live proof lane preflight health probe and default live-provider ignored-test dispatch remain fail-closed (`Regression: #1829`).
 - local native API parity live proof lane fails closed without local opt-in and on nonce/broadcast/finality timeout or command failures (`Regression: #1465`).
 - native parity fast/local command matrix docs drift remains fail-closed (`Regression: #1468`).
 - local probe fork-info query semantics and native parity broadcast method drift remain fail-closed (`Regression: #1482`).

--- a/scripts/kolme/run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane.sh
@@ -9,6 +9,26 @@ OUTPUT_JSON="/tmp/kolme-local-runtime-commit-live-summary.json"
 LIVE_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-output.txt"
 LIVE_COMMAND=""
 MAX_SECONDS=90
+BASE_URL="http://127.0.0.1:3000"
+PROVIDER_HINT="kolme-fork-local"
+AUTHORIZATION_HEADER=""
+PREFLIGHT_MAX_SECONDS=10
+SKIP_PREFLIGHT=0
+
+shell_escape() {
+  printf "%q" "$1"
+}
+
+default_live_command() {
+  local command
+  command="KAMN_KOLME_LIVE_BASE_URL=$(shell_escape "$BASE_URL")"
+  command="${command} KAMN_KOLME_LIVE_PROVIDER_HINT=$(shell_escape "$PROVIDER_HINT")"
+  if [ -n "$AUTHORIZATION_HEADER" ]; then
+    command="${command} KAMN_KOLME_LIVE_AUTHORIZATION=$(shell_escape "$AUTHORIZATION_HEADER")"
+  fi
+  command="${command} cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint"
+  printf '%s' "$command"
+}
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -52,6 +72,42 @@ while [ "$#" -gt 0 ]; do
       MAX_SECONDS="$2"
       shift 2
       ;;
+    --base-url)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --base-url" >&2
+        exit 1
+      fi
+      BASE_URL="$2"
+      shift 2
+      ;;
+    --provider-hint)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --provider-hint" >&2
+        exit 1
+      fi
+      PROVIDER_HINT="$2"
+      shift 2
+      ;;
+    --authorization-header)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --authorization-header" >&2
+        exit 1
+      fi
+      AUTHORIZATION_HEADER="$2"
+      shift 2
+      ;;
+    --preflight-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --preflight-max-seconds" >&2
+        exit 1
+      fi
+      PREFLIGHT_MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --skip-preflight)
+      SKIP_PREFLIGHT=1
+      shift
+      ;;
     --help|-h)
       cat <<'USAGE'
 Usage: run_local_runtime_commit_live_lane.sh [options]
@@ -62,6 +118,11 @@ Options:
   --live-output-file <path>     Captured stdout/stderr for live command.
   --live-command <command>      Runtime-commit submit/finality command for run mode.
   --max-seconds <n>             Max runtime budget in seconds for run mode.
+  --base-url <url>              Live Kolme base URL used by default smoke command.
+  --provider-hint <value>       Provider hint used by default live smoke command.
+  --authorization-header <str>  Optional Authorization header value for live smoke.
+  --preflight-max-seconds <n>   Max runtime budget for preflight health probe.
+  --skip-preflight              Bypass preflight health probe in run mode.
 USAGE
       exit 0
       ;;
@@ -82,10 +143,31 @@ if ! [[ "$MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$MAX_SECONDS" -le 0 ]; then
   exit 1
 fi
 
+if ! [[ "$PREFLIGHT_MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$PREFLIGHT_MAX_SECONDS" -le 0 ]; then
+  echo "preflight-max-seconds must be a positive integer" >&2
+  exit 1
+fi
+
+if [ -z "$BASE_URL" ]; then
+  echo "base-url must not be empty" >&2
+  exit 1
+fi
+
+if [ -z "$PROVIDER_HINT" ]; then
+  echo "provider-hint must not be empty" >&2
+  exit 1
+fi
+
 if [ ! -x "$LOCAL_HEAVY_GUARD" ]; then
   echo "expected shared local-heavy opt-in guard helper to be executable" >&2
   exit 1
 fi
+
+if [ -z "$LIVE_COMMAND" ]; then
+  LIVE_COMMAND="$(default_live_command)"
+fi
+
+preflight_command="curl --silent --show-error --fail --max-time ${PREFLIGHT_MAX_SECONDS} ${BASE_URL%/}/healthz"
 
 CHECK_FILE="$(mktemp)"
 trap 'rm -f "$CHECK_FILE"' EXIT
@@ -103,7 +185,8 @@ budget_status="not_run"
 elapsed_seconds=0
 local_only_enforced="true"
 
-planned_command="${LIVE_COMMAND:-<required-in-run-mode>}"
+planned_command="$LIVE_COMMAND"
+record_check "runtime_commit_live_preflight" "$preflight_command" "planned"
 record_check "runtime_commit_live_command" "$planned_command" "planned"
 
 if [ "$MODE" = "run" ]; then
@@ -114,12 +197,28 @@ if [ "$MODE" = "run" ]; then
     record_check "runtime_commit_live_command" "$planned_command" "fail"
     overall_status="fail"
     reason_code="local_opt_in_missing"
-  elif [ -z "$LIVE_COMMAND" ]; then
-    echo "run mode requires --live-command for runtime-commit submit/finality proof execution" >&2
-    record_check "runtime_commit_live_command" "$planned_command" "fail"
-    overall_status="fail"
-    reason_code="live_command_missing"
+  elif [ "$SKIP_PREFLIGHT" -eq 1 ]; then
+    record_check "runtime_commit_live_preflight" "$preflight_command" "skipped"
   else
+    set +e
+    timeout "${PREFLIGHT_MAX_SECONDS}" bash -lc "$preflight_command" >/dev/null 2>&1
+    preflight_exit_code=$?
+    set -e
+
+    if [ "$preflight_exit_code" -eq 0 ]; then
+      record_check "runtime_commit_live_preflight" "$preflight_command" "pass"
+    elif [ "$preflight_exit_code" -eq 124 ]; then
+      record_check "runtime_commit_live_preflight" "$preflight_command" "fail"
+      overall_status="fail"
+      reason_code="live_preflight_timeout"
+    else
+      record_check "runtime_commit_live_preflight" "$preflight_command" "fail"
+      overall_status="fail"
+      reason_code="live_preflight_failed"
+    fi
+  fi
+
+  if [ "$overall_status" = "ok" ]; then
     mkdir -p "$(dirname "$LIVE_OUTPUT_FILE")"
     command_exit_code=0
     set +e
@@ -154,7 +253,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$CHECK_FILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -171,7 +270,11 @@ max_seconds = int(sys.argv[7])
 budget_status = sys.argv[8]
 live_command = sys.argv[9]
 live_output_file = sys.argv[10]
-checks_path = pathlib.Path(sys.argv[11])
+base_url = sys.argv[11]
+provider_hint = sys.argv[12]
+preflight_max_seconds = int(sys.argv[13])
+skip_preflight = sys.argv[14] == "1"
+checks_path = pathlib.Path(sys.argv[15])
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -200,6 +303,10 @@ summary = {
     "budget_status": budget_status,
     "live_command": live_command,
     "live_output_file": live_output_file,
+    "base_url": base_url,
+    "provider_hint": provider_hint,
+    "preflight_enabled": not skip_preflight,
+    "preflight_max_seconds": preflight_max_seconds,
     "checks": checks,
     "artifact_paths": [
         live_output_file,

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -75,7 +75,34 @@ if report.get("local_only_enforced") is not True:
 checks = report.get("checks")
 if not isinstance(checks, list) or not checks:
     raise SystemExit("expected deterministic checks in summary")
+if not any(
+    check.get("id") == "runtime_commit_live_preflight" and check.get("status") == "planned"
+    for check in checks
+):
+    raise SystemExit("expected planned runtime commit live preflight check")
 PY
+
+set +e
+KAMN_KOLME_LOCAL_HEAVY=1 \
+  bash "$RUNNER" \
+    --mode run \
+    --live-command "printf 'status=submitted\n'" \
+    --max-seconds 5 \
+    --base-url "http://127.0.0.1:1" \
+    --output-json "$TMP_REPORT" \
+    --live-output-file "$TMP_OUTPUT" >"$TMP_ERR" 2>&1
+preflight_failure_code=$?
+set -e
+
+if [ "$preflight_failure_code" -eq 0 ]; then
+  echo "expected run mode preflight failure to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "reason_code=live_preflight_failed" "$TMP_ERR"; then
+  echo "expected preflight failure reason marker" >&2
+  exit 1
+fi
 
 set +e
 bash "$RUNNER" \
@@ -99,6 +126,7 @@ run_output="$(
   KAMN_KOLME_LOCAL_HEAVY=1 \
     bash "$RUNNER" \
       --mode run \
+      --skip-preflight \
       --live-command "printf 'status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n'" \
       --max-seconds 5 \
       --output-json "$TMP_REPORT" \
@@ -135,6 +163,7 @@ set +e
 KAMN_KOLME_LOCAL_HEAVY=1 \
   bash "$RUNNER" \
     --mode run \
+    --skip-preflight \
     --live-command "sleep 2" \
     --max-seconds 1 \
     --output-json "$TMP_REPORT" \


### PR DESCRIPTION
## Summary
Adds a deterministic local live-node smoke path for `KolmeRuntimeCommitLiveProvider` with explicit preflight health checks, local-only opt-in enforcement, and a default ignored live-provider transport test command. Keeps heavy live execution local/manual while preserving fast-gate cost posture.

Closes #1829

## Changes
- `scripts/kolme/run_local_runtime_commit_live_lane.sh`:
  - added run-mode preflight probe (`<base-url>/healthz`) with bounded timeout.
  - added `--skip-preflight` escape hatch for explicit local/manual workflows.
  - added default live-provider command when `--live-command` is omitted:
    - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
  - added configurable options: `--base-url`, `--provider-hint`, `--authorization-header`, `--preflight-max-seconds`.
  - added summary metadata fields for preflight and provider profile context.
- `scripts/kolme/test_run_local_runtime_commit_live_lane.sh`:
  - added red/green contract coverage for preflight planning, preflight failure reason code, and skip-preflight behavior.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`:
  - added ignored live-node smoke test: `integration_kolme_fork_live_node_submit_reaches_endpoint`.
- Docs updated:
  - `docs/foundation/kolme-runtime-commit-client.md`
  - `docs/ci/strategy.md`
  - `docs/planning/kolme-devnet-ops.md`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh`

Failing output:
- `expected planned runtime commit live preflight check`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_and_response_mapping -- --exact`
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`

Result:
- All commands above passed.

### 🔁 Regression
- Existing local runtime-commit live lane guard semantics retained and extended (opt-in fail-closed, timeout fail-closed) with new preflight fail-closed reason codes.
- Added live-provider smoke path regression marker in docs (`Regression: #1829`).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh` updates | |
| Functional   | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_http_transport_submit_and_response_mapping -- --exact` | |
| Integration  | ✅ | Added ignored live-node integration path `integration_kolme_fork_live_node_submit_reaches_endpoint` and wired default local lane command | |
| Regression   | ✅ | `cargo test -p kamn-core --test ci_strategy_docs`, `cargo test -p kamn-core --test kolme_devnet_ops_docs`, `bash scripts/ci/test_ci_strategy_contract.sh` | |
| Performance  | ✅ | Heavy live-node execution remains local-only and excluded from default fast-gate | |

## Risks & Rollback
- Risk: local environments without reachable Kolme node will fail run-mode preflight unless explicitly bypassed.
- Rollback plan: revert this PR to restore prior lane behavior.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (validated for touched crate scope: `kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant lane/doc-contract suites)
- [x] Docs updated (or justified why not)
