### PR TITLE
refactor(kolme): extract block fallback parse selection contract (#1836)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -18,12 +18,11 @@ use kamn_kolme::{
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
-    parse_block_fallback_response as parse_kolme_block_fallback_response_contract,
-    parse_fork_block_fallback_response as parse_kolme_fork_block_fallback_response_contract,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
     parse_live_provider_outcome as parse_kolme_live_provider_outcome,
     parse_notification_event as parse_kolme_notification_event_contract,
+    parse_provider_block_fallback_response as parse_kolme_provider_block_fallback_response_contract,
     parse_provider_finality_receipt as parse_kolme_provider_finality_receipt,
     parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
@@ -1323,22 +1322,14 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 self.block_path_template.as_str(),
                 height,
             )?;
-            let block = parse_kolme_block_fallback_response_contract(response.as_str())
-                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: error.to_string(),
-                })
-                .or_else(|_| {
-                    parse_kolme_fork_block_fallback_response_contract(
-                        response.as_str(),
-                        self.provider.as_str(),
-                        height,
-                    )
-                    .map_err(|error| {
-                        KolmeRuntimeCommitProviderError::MalformedResponse {
-                            reason: error.to_string(),
-                        }
-                    })
-                })?;
+            let block = parse_kolme_provider_block_fallback_response_contract(
+                response.as_str(),
+                self.provider.as_str(),
+                height,
+            )
+            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            })?;
 
             validate_kolme_block_identity(
                 self.provider.as_str(),

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -61,8 +61,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_notifications_websocket_url("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_block_fallback_response_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_fork_block_fallback_response_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_block_fallback_response_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -17,6 +17,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("## Phase 2 Progress"));
     assert!(DOC.contains("#1820"));
     assert!(DOC.contains("#1826"));
+    assert!(DOC.contains("#1836"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/block_fallback_policy.rs
+++ b/crates/kamn-kolme/src/block_fallback_policy.rs
@@ -108,6 +108,16 @@ pub fn parse_fork_block_fallback_response(
     })
 }
 
+/// Parses provider block-fallback payload by selecting canonical or fork profile shapes.
+pub fn parse_provider_block_fallback_response(
+    response: &str,
+    provider: &str,
+    expected_height: u64,
+) -> Result<KolmeBlockFallbackResponse, KolmeBlockFallbackPolicyError> {
+    parse_block_fallback_response(response)
+        .or_else(|_| parse_fork_block_fallback_response(response, provider, expected_height))
+}
+
 fn optional_block_tx_hashes(
     fields: &HashMap<String, String>,
     field: &'static str,

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -33,7 +33,8 @@ pub use api_codec::{
 };
 pub use block_fallback_policy::{
     parse_block_fallback_response, parse_fork_block_fallback_response,
-    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
+    parse_provider_block_fallback_response, KolmeBlockFallbackPolicyError,
+    KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
     parse_fork_block_txhash, render_block_path, validate_block_identity,

--- a/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
@@ -1,6 +1,7 @@
 use kamn_kolme::{
     parse_block_fallback_response, parse_fork_block_fallback_response,
-    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
+    parse_provider_block_fallback_response, KolmeBlockFallbackPolicyError,
+    KolmeBlockFallbackResponse,
 };
 
 #[test]
@@ -29,6 +30,50 @@ fn functional_parse_fork_block_fallback_response_maps_txhash_to_finalized_bucket
     assert_eq!(response.block_height, 42);
     assert_eq!(response.finalized_tx_hashes, vec!["ab12cd34".to_owned()]);
     assert!(response.failed_tx_hashes.is_empty());
+}
+
+#[test]
+fn functional_parse_provider_block_fallback_response_accepts_canonical_payload_shape() {
+    let response = parse_provider_block_fallback_response(
+        "{\"provider\":\"kolme-fork-local\",\"block_height\":72,\"tx_hashes\":\"ab12cd34,ffee\"}",
+        "kolme-fork-local",
+        72,
+    )
+    .expect("provider-aware canonical fallback response should parse");
+    assert_eq!(
+        response,
+        KolmeBlockFallbackResponse {
+            provider: "kolme-fork-local".to_owned(),
+            block_height: 72,
+            finalized_tx_hashes: vec!["ab12cd34".to_owned(), "ffee".to_owned()],
+            failed_tx_hashes: Vec::new(),
+        }
+    );
+}
+
+#[test]
+fn functional_parse_provider_block_fallback_response_falls_back_to_fork_shape() {
+    let response =
+        parse_provider_block_fallback_response("{\"txhash\":\"ab12cd34\"}", "kolme-fork-local", 42)
+            .expect("provider-aware parser should fall back to fork payload shape");
+    assert_eq!(response.provider, "kolme-fork-local");
+    assert_eq!(response.block_height, 42);
+    assert_eq!(response.finalized_tx_hashes, vec!["ab12cd34".to_owned()]);
+    assert!(response.failed_tx_hashes.is_empty());
+}
+
+#[test]
+fn regression_issue_1836_parse_provider_block_fallback_response_fails_closed_when_both_shapes_invalid(
+) {
+    // Regression: #1836
+    let error = parse_provider_block_fallback_response("{}", "kolme-fork-local", 42)
+        .expect_err("provider-aware parser must fail closed when payload is invalid");
+    assert_eq!(
+        error,
+        KolmeBlockFallbackPolicyError::MalformedResponse {
+            reason: "missing required field: txhash".to_owned(),
+        }
+    );
 }
 
 #[test]

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -35,6 +35,7 @@ Out of scope:
 
 ## Phase 2 Progress
 - #1826: extracted finality response-to-receipt parser contract to `kamn-kolme` (`parse_provider_finality_receipt`) and rewired `kamn-core` finality checker to consume the extracted contract.
+- #1836: extracted provider-aware block-fallback parse-selection contract to `kamn-kolme` (`parse_provider_block_fallback_response`) and rewired `kamn-core` block fallback reconciler delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted provider-aware block-fallback parse-selection glue from `kamn-core` into a dedicated `kamn-kolme` contract API. `KolmeRuntimeCommitBlockFallbackReconciler` now delegates canonical-vs-fork payload selection to `kamn-kolme`, reducing Phase 2 extraction leakage from core.

Closes #1836

## Changes
- `crates/kamn-kolme/src/block_fallback_policy.rs`
  - Added `parse_provider_block_fallback_response(response, provider, expected_height)`.
- `crates/kamn-kolme/src/lib.rs`
  - Exported new parser contract.
- `crates/kamn-kolme/tests/block_fallback_policy_contracts.rs`
  - Added functional tests for canonical and fork-shape selection.
  - Added regression test `Regression: #1836` for fail-closed invalid payload behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`
  - Replaced inline `parse_block_fallback_response` / `parse_fork_block_fallback_response` selection with delegated `parse_kolme_provider_block_fallback_response_contract`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`
  - Updated delegation contract assertion to require provider-aware helper usage.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`
  - Added Phase 2 progress marker for #1836.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`
  - Updated docs contract marker assertions.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
- `cargo test -p kamn-kolme --test block_fallback_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`

Observed failing output:
- unresolved import for `parse_provider_block_fallback_response` in `kamn-kolme` tests.
- extraction boundary assertion failed because `kolme_runtime_commit.rs` did not yet contain `parse_kolme_provider_block_fallback_response_contract(`.

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-kolme --test block_fallback_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback`
- `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`

Observed result:
- all commands passed.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

Observed result:
- all commands passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `crates/kamn-kolme/tests/block_fallback_policy_contracts.rs` provider-aware parser tests | |
| Functional   | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback` | |
| Integration  | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver` | |
| Regression   | ✅ | `regression_issue_1836_parse_provider_block_fallback_response_fails_closed_when_both_shapes_invalid` + extraction-boundary/docs guards | |
| Performance  | N/A | N/A | deterministic parser extraction with no runtime-path expansion |

## Risks & Rollback
- Scoped risk: block-fallback payload parse selection now delegated to `kamn-kolme` contract.
- Rollback: revert this PR to restore prior core-local selection glue.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A
