### PR TITLE
refactor(kolme): extract latest-block lookup upper-bound contract (#1840)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -28,6 +28,7 @@ use kamn_kolme::{
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
     require_commit_id_matches_expected_txhash as require_kolme_commit_id_matches_expected_txhash_contract,
+    resolve_lookup_upper_bound as resolve_kolme_lookup_upper_bound,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
     txhash_from_commit_id as txhash_from_kolme_commit_id,
     validate_block_identity as validate_kolme_block_identity,
@@ -1673,11 +1674,8 @@ where
         match self.notifications_consumer.next_notification_event() {
             Ok(event) => match event {
                 KolmeRuntimeCommitNotificationEvent::LatestBlock { height } => {
-                    let upper_bound = if height >= from_height {
-                        height.min(latest_height)
-                    } else {
-                        latest_height
-                    };
+                    let upper_bound =
+                        resolve_kolme_lookup_upper_bound(from_height, latest_height, height);
                     self.block_fallback_reconciler.reconcile_txhash(
                         expected_txhash.as_str(),
                         from_height,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -71,6 +71,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_tls_ca_file_env_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
+    assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_lookup_upper_bound("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -19,6 +19,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1826"));
     assert!(DOC.contains("#1836"));
     assert!(DOC.contains("#1838"));
+    assert!(DOC.contains("#1840"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/block_scan_policy.rs
+++ b/crates/kamn-kolme/src/block_scan_policy.rs
@@ -130,6 +130,19 @@ pub fn validate_lookup_window(
     Ok(())
 }
 
+/// Resolves block-fallback upper bound using one latest-block notification height.
+pub fn resolve_lookup_upper_bound(
+    from_height: u64,
+    latest_height: u64,
+    notification_height: u64,
+) -> u64 {
+    if notification_height >= from_height {
+        notification_height.min(latest_height)
+    } else {
+        latest_height
+    }
+}
+
 /// Validates provider + height identity for one scanned block response.
 pub fn validate_block_identity(
     expected_provider: &str,

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -37,8 +37,9 @@ pub use block_fallback_policy::{
     KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
-    parse_fork_block_txhash, render_block_path, validate_block_identity,
-    validate_block_path_template, validate_lookup_window, BlockScanPolicyError,
+    parse_fork_block_txhash, render_block_path, resolve_lookup_upper_bound,
+    validate_block_identity, validate_block_path_template, validate_lookup_window,
+    BlockScanPolicyError,
 };
 pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};

--- a/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
+++ b/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
@@ -1,6 +1,6 @@
 use kamn_kolme::{
-    parse_fork_block_txhash, parse_receipt_finality, render_block_path, validate_block_identity,
-    validate_block_path_template, validate_lookup_window, ReceiptFinality,
+    parse_fork_block_txhash, parse_receipt_finality, render_block_path, resolve_lookup_upper_bound,
+    validate_block_identity, validate_block_path_template, validate_lookup_window, ReceiptFinality,
 };
 
 #[test]
@@ -55,4 +55,17 @@ fn regression_issue_1720_block_identity_mismatch_fails_closed() {
         render_block_path("/block/{height}", 42).expect("render should work"),
         "/block/42"
     );
+}
+
+#[test]
+fn functional_resolve_lookup_upper_bound_honors_notification_height_within_window() {
+    let upper_bound = resolve_lookup_upper_bound(40, 45, 42);
+    assert_eq!(upper_bound, 42);
+}
+
+#[test]
+fn regression_issue_1840_resolve_lookup_upper_bound_falls_back_to_latest_when_notification_stale() {
+    // Regression: #1840
+    let upper_bound = resolve_lookup_upper_bound(40, 45, 39);
+    assert_eq!(upper_bound, 45);
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -37,6 +37,7 @@ Out of scope:
 - #1826: extracted finality response-to-receipt parser contract to `kamn-kolme` (`parse_provider_finality_receipt`) and rewired `kamn-core` finality checker to consume the extracted contract.
 - #1836: extracted provider-aware block-fallback parse-selection contract to `kamn-kolme` (`parse_provider_block_fallback_response`) and rewired `kamn-core` block fallback reconciler delegation.
 - #1838: extracted notification receipt txhash-correlation helper to `kamn-kolme` (`require_commit_id_matches_expected_txhash`) and rewired `kamn-core` fork finality resolver mismatch checking.
+- #1840: extracted latest-block upper-bound selection helper to `kamn-kolme` (`resolve_lookup_upper_bound`) and rewired `kamn-core` fork finality resolver block fallback bound selection.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract latest-block lookup upper-bound selection from `kamn-core` fork finality resolver into `kamn-kolme` block-scan policy and keep semantics unchanged.

Closes #1840

## Changes
- `crates/kamn-kolme/src/block_scan_policy.rs`: add `resolve_lookup_upper_bound` contract helper.
- `crates/kamn-kolme/src/lib.rs`: export the new helper.
- `crates/kamn-kolme/tests/finality_block_scan_contracts.rs`: add functional and regression tests for upper-bound semantics.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate `LatestBlock` upper-bound selection to the extracted helper.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation boundary marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: record Phase 2 progress marker for #1840.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1840 plan marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated stale/within-window notification upper-bound behavior through contract tests and fork-finality integration path.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test finality_block_scan_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver` |
| Regression  | ✅     | `Regression: #1840` in `finality_block_scan_contracts.rs`; boundary/docs guards in `kamn-core` tests |
