### PR TITLE
refactor(kolme): extract adapter receipt identity validation contract (#1842)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -34,6 +34,7 @@ use kamn_kolme::{
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
     validate_lookup_window as validate_kolme_lookup_window,
+    validate_provider_receipt_identity as validate_kolme_provider_receipt_identity_contract,
     validate_websocket_handshake_response as validate_kolme_websocket_handshake_response,
     BlockScanPolicyError, KolmeApiBroadcastRequest as KamnKolmeApiBroadcastRequest,
     KolmeApiBroadcastResponse as KamnKolmeApiBroadcastResponse,
@@ -45,6 +46,7 @@ use kamn_kolme::{
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
     KolmeProviderOutcome as KamnKolmeProviderOutcome,
+    KolmeProviderReceiptIdentityError as KamnKolmeProviderReceiptIdentityError,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
     KolmeTransportIoClassification as KamnKolmeTransportIoClassification,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
@@ -1812,18 +1814,22 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
         request.validate()?;
         let expected_provider = self.expected_provider.as_str();
         let map_provider_receipt = |receipt: KolmeRuntimeCommitProviderReceipt| {
-            if receipt.provider != expected_provider {
-                return Err(KolmeRuntimeCommitError::ProviderMismatch {
-                    expected: expected_provider.to_owned(),
-                    observed: receipt.provider,
-                });
-            }
-            if receipt.commit_id.trim().is_empty() {
-                return Err(KolmeRuntimeCommitError::InvalidRequest {
-                    field: "receipt_commit_id",
-                    reason: "must not be empty",
-                });
-            }
+            validate_kolme_provider_receipt_identity_contract(
+                expected_provider,
+                receipt.provider.as_str(),
+                receipt.commit_id.as_str(),
+            )
+            .map_err(|error| match error {
+                KamnKolmeProviderReceiptIdentityError::ProviderMismatch { expected, observed } => {
+                    KolmeRuntimeCommitError::ProviderMismatch { expected, observed }
+                }
+                KamnKolmeProviderReceiptIdentityError::EmptyCommitId => {
+                    KolmeRuntimeCommitError::InvalidRequest {
+                        field: "receipt_commit_id",
+                        reason: "must not be empty",
+                    }
+                }
+            })?;
             if !matches!(receipt.finality, KolmeCommitReceiptFinality::Final) {
                 return Err(KolmeRuntimeCommitError::NonFinalReceipt {
                     commit_id: receipt.commit_id,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -77,10 +77,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
+    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_provider_receipt_identity_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
-    assert!(RUNTIME_COMMIT_SRC.contains("if receipt.provider != expected_provider"));
-    assert!(RUNTIME_COMMIT_SRC.contains("if receipt.commit_id.trim().is_empty()"));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -20,6 +20,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1836"));
     assert!(DOC.contains("#1838"));
     assert!(DOC.contains("#1840"));
+    assert!(DOC.contains("#1842"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -65,8 +65,8 @@ pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
     deterministic_backend_commit_id, parse_commit_id_from_response_fields,
     parse_live_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id, KolmeProviderOutcome,
-    KolmeProviderOutcomePolicyError,
+    required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,
+    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
 };
 pub use provider_response_policy::{
     parse_provider_key_value_fields, parse_provider_response_fields,

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -56,6 +56,34 @@ impl fmt::Display for KolmeProviderOutcomePolicyError {
 
 impl Error for KolmeProviderOutcomePolicyError {}
 
+/// Error returned by provider receipt identity validation contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeProviderReceiptIdentityError {
+    /// Provider identifier differs from expected runtime provider.
+    ProviderMismatch {
+        /// Expected provider identifier.
+        expected: String,
+        /// Observed provider identifier from receipt.
+        observed: String,
+    },
+    /// Deterministic backend commit id is missing or empty.
+    EmptyCommitId,
+}
+
+impl fmt::Display for KolmeProviderReceiptIdentityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProviderMismatch { expected, observed } => write!(
+                f,
+                "provider mismatch: expected '{expected}' observed '{observed}'"
+            ),
+            Self::EmptyCommitId => f.write_str("receipt commit_id must not be empty"),
+        }
+    }
+}
+
+impl Error for KolmeProviderReceiptIdentityError {}
+
 /// Parses a live provider response payload into one typed provider outcome.
 pub fn parse_live_provider_outcome(
     response: &str,
@@ -204,6 +232,24 @@ pub fn require_commit_id_matches_expected_txhash(
                 "notification txhash mismatch: expected '{expected_txhash}' observed '{observed_txhash}'"
             ),
         });
+    }
+    Ok(())
+}
+
+/// Validates provider receipt identity tuple before adapter-level finality mapping.
+pub fn validate_provider_receipt_identity(
+    expected_provider: &str,
+    observed_provider: &str,
+    commit_id: &str,
+) -> Result<(), KolmeProviderReceiptIdentityError> {
+    if observed_provider != expected_provider {
+        return Err(KolmeProviderReceiptIdentityError::ProviderMismatch {
+            expected: expected_provider.to_owned(),
+            observed: observed_provider.to_owned(),
+        });
+    }
+    if commit_id.trim().is_empty() {
+        return Err(KolmeProviderReceiptIdentityError::EmptyCommitId);
     }
     Ok(())
 }

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,8 +1,10 @@
 use kamn_kolme::{
     deterministic_backend_commit_id, parse_commit_id_from_response_fields,
     parse_live_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id, KolmeProviderOutcome,
-    KolmeProviderOutcomePolicyError, ReceiptFinality,
+    required_provider_response_field, txhash_from_commit_id,
+    validate_provider_receipt_identity as validate_provider_receipt_identity_contract,
+    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    ReceiptFinality,
 };
 use std::collections::HashMap;
 
@@ -114,5 +116,37 @@ fn regression_issue_1838_require_commit_id_matches_expected_txhash_fails_closed_
         KolmeProviderOutcomePolicyError::MalformedResponse {
             reason: "notification txhash mismatch: expected 'ab12cd34' observed 'ff00'".to_owned(),
         }
+    );
+}
+
+#[test]
+fn functional_validate_provider_receipt_identity_accepts_matching_provider_and_commit_id() {
+    validate_provider_receipt_identity_contract("kolme-fork", "kolme-fork", "kolme-commit:ab12")
+        .expect("matching provider + non-empty commit id should pass");
+}
+
+#[test]
+fn regression_issue_1842_validate_provider_receipt_identity_rejects_mismatch_and_empty_commit_id() {
+    // Regression: #1842
+    let mismatch_error = validate_provider_receipt_identity_contract(
+        "kolme-local",
+        "kolme-remote",
+        "kolme-commit:a1",
+    )
+    .expect_err("provider mismatch must fail closed");
+    assert_eq!(
+        mismatch_error,
+        KolmeProviderReceiptIdentityError::ProviderMismatch {
+            expected: "kolme-local".to_owned(),
+            observed: "kolme-remote".to_owned(),
+        }
+    );
+
+    let empty_commit_id_error =
+        validate_provider_receipt_identity_contract("kolme-local", "kolme-local", "   ")
+            .expect_err("empty commit id must fail closed");
+    assert_eq!(
+        empty_commit_id_error,
+        KolmeProviderReceiptIdentityError::EmptyCommitId
     );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -38,6 +38,7 @@ Out of scope:
 - #1836: extracted provider-aware block-fallback parse-selection contract to `kamn-kolme` (`parse_provider_block_fallback_response`) and rewired `kamn-core` block fallback reconciler delegation.
 - #1838: extracted notification receipt txhash-correlation helper to `kamn-kolme` (`require_commit_id_matches_expected_txhash`) and rewired `kamn-core` fork finality resolver mismatch checking.
 - #1840: extracted latest-block upper-bound selection helper to `kamn-kolme` (`resolve_lookup_upper_bound`) and rewired `kamn-core` fork finality resolver block fallback bound selection.
+- #1842: extracted adapter receipt provider/commit-id identity validator to `kamn-kolme` (`validate_provider_receipt_identity`) and rewired `kamn-core` adapter receipt mapping checks.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract adapter receipt provider/commit-id identity validation from `kamn-core` into `kamn-kolme` as a typed contract helper and preserve existing fail-closed semantics.

Closes #1842

## Changes
- `crates/kamn-kolme/src/provider_outcome_policy.rs`: add `KolmeProviderReceiptIdentityError` and `validate_provider_receipt_identity`.
- `crates/kamn-kolme/src/lib.rs`: export the new helper and error.
- `crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs`: add functional and regression tests for provider mismatch and empty commit-id paths.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate adapter receipt identity checks to `validate_kolme_provider_receipt_identity_contract` and map typed errors to existing `KolmeRuntimeCommitError` variants.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce helper delegation marker and remove inline-branch marker checks.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1842.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1842 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated adapter receipt mismatch and empty commit-id fail-closed behavior through extracted `kamn-kolme` contract and `kamn-core` adapter pipeline tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test provider_outcome_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Regression  | ✅     | `Regression: #1842` in `provider_outcome_policy_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
