### PR TITLE
refactor(kolme): extract adapter finality guard contract (#1844)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -28,6 +28,7 @@ use kamn_kolme::{
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
     require_commit_id_matches_expected_txhash as require_kolme_commit_id_matches_expected_txhash_contract,
+    require_final_receipt_finality as require_kolme_final_receipt_finality_contract,
     resolve_lookup_upper_bound as resolve_kolme_lookup_upper_bound,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
     txhash_from_commit_id as txhash_from_kolme_commit_id,
@@ -53,6 +54,7 @@ use kamn_kolme::{
     KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError,
     RuntimeCommitLifecycleState as KamnKolmeRuntimeCommitLifecycleState,
+    RuntimeLifecyclePolicyError as KamnKolmeRuntimeLifecyclePolicyError,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -1830,12 +1832,16 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
                     }
                 }
             })?;
-            if !matches!(receipt.finality, KolmeCommitReceiptFinality::Final) {
-                return Err(KolmeRuntimeCommitError::NonFinalReceipt {
-                    commit_id: receipt.commit_id,
-                    finality: receipt.finality,
-                });
-            }
+            require_kolme_final_receipt_finality_contract(receipt.finality).map_err(|error| {
+                match error {
+                    KamnKolmeRuntimeLifecyclePolicyError::NonFinalReceipt { finality } => {
+                        KolmeRuntimeCommitError::NonFinalReceipt {
+                            commit_id: receipt.commit_id.clone(),
+                            finality,
+                        }
+                    }
+                }
+            })?;
             Ok(KolmeRuntimeCommitReceipt {
                 provider: receipt.provider,
                 commit_id: receipt.commit_id,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -78,6 +78,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_provider_receipt_identity_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("require_kolme_final_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -21,6 +21,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1838"));
     assert!(DOC.contains("#1840"));
     assert!(DOC.contains("#1842"));
+    assert!(DOC.contains("#1844"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -75,8 +75,8 @@ pub use provider_response_policy::{
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use runtime_lifecycle_policy::{
     commit_finality_from_receipt_finality, commit_finality_label, lifecycle_state_for_finality,
-    lifecycle_state_label, parse_commit_receipt_finality, KolmeCommitReceiptFinality,
-    RuntimeCommitLifecycleState,
+    lifecycle_state_label, parse_commit_receipt_finality, require_final_receipt_finality,
+    KolmeCommitReceiptFinality, RuntimeCommitLifecycleState, RuntimeLifecyclePolicyError,
 };
 pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,

--- a/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
+++ b/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
@@ -1,6 +1,8 @@
 //! Runtime-commit lifecycle and finality policy contracts.
 
 use crate::receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
+use std::error::Error;
+use std::fmt;
 
 /// Finality classification for a runtime commit receipt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,6 +25,30 @@ pub enum RuntimeCommitLifecycleState {
     /// Commit failed and should not be retried automatically.
     Failed,
 }
+
+/// Error returned by runtime lifecycle policy validation contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeLifecyclePolicyError {
+    /// Receipt did not reach final confirmation state.
+    NonFinalReceipt {
+        /// Observed receipt finality.
+        finality: KolmeCommitReceiptFinality,
+    },
+}
+
+impl fmt::Display for RuntimeLifecyclePolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonFinalReceipt { finality } => write!(
+                f,
+                "receipt finality must be final, observed {}",
+                commit_finality_label(*finality)
+            ),
+        }
+    }
+}
+
+impl Error for RuntimeLifecyclePolicyError {}
 
 /// Maps receipt finality to projected lifecycle state.
 pub fn lifecycle_state_for_finality(
@@ -70,6 +96,16 @@ pub fn commit_finality_label(finality: KolmeCommitReceiptFinality) -> &'static s
         KolmeCommitReceiptFinality::Final => "final",
         KolmeCommitReceiptFinality::Failed => "failed",
     }
+}
+
+/// Ensures one provider receipt finality is finalized before adapter acceptance.
+pub fn require_final_receipt_finality(
+    finality: KolmeCommitReceiptFinality,
+) -> Result<(), RuntimeLifecyclePolicyError> {
+    if finality != KolmeCommitReceiptFinality::Final {
+        return Err(RuntimeLifecyclePolicyError::NonFinalReceipt { finality });
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs
@@ -1,6 +1,7 @@
 use kamn_kolme::{
     commit_finality_label, lifecycle_state_for_finality, lifecycle_state_label,
-    KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
+    require_final_receipt_finality as require_final_receipt_finality_contract,
+    KolmeCommitReceiptFinality, RuntimeCommitLifecycleState, RuntimeLifecyclePolicyError,
 };
 
 #[test]
@@ -55,5 +56,24 @@ fn regression_runtime_lifecycle_policy_state_label_drift_remains_fail_closed() {
             KolmeCommitReceiptFinality::Final
         )),
         "finalized"
+    );
+}
+
+#[test]
+fn functional_runtime_lifecycle_policy_requires_final_receipt_finality() {
+    require_final_receipt_finality_contract(KolmeCommitReceiptFinality::Final)
+        .expect("final receipt finality should pass");
+}
+
+#[test]
+fn regression_issue_1844_runtime_lifecycle_policy_rejects_non_final_receipt_finality() {
+    // Regression: #1844
+    let error = require_final_receipt_finality_contract(KolmeCommitReceiptFinality::Pending)
+        .expect_err("pending receipt finality must fail closed");
+    assert_eq!(
+        error,
+        RuntimeLifecyclePolicyError::NonFinalReceipt {
+            finality: KolmeCommitReceiptFinality::Pending,
+        }
     );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -39,6 +39,7 @@ Out of scope:
 - #1838: extracted notification receipt txhash-correlation helper to `kamn-kolme` (`require_commit_id_matches_expected_txhash`) and rewired `kamn-core` fork finality resolver mismatch checking.
 - #1840: extracted latest-block upper-bound selection helper to `kamn-kolme` (`resolve_lookup_upper_bound`) and rewired `kamn-core` fork finality resolver block fallback bound selection.
 - #1842: extracted adapter receipt provider/commit-id identity validator to `kamn-kolme` (`validate_provider_receipt_identity`) and rewired `kamn-core` adapter receipt mapping checks.
+- #1844: extracted adapter non-final receipt guard to `kamn-kolme` (`require_final_receipt_finality`) and rewired `kamn-core` adapter receipt finality enforcement.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract adapter non-final receipt enforcement from `kamn-core` into a typed `kamn-kolme` lifecycle policy contract while preserving existing fail-closed `NonFinalReceipt` behavior.

Closes #1844

## Changes
- `crates/kamn-kolme/src/runtime_lifecycle_policy.rs`: add `RuntimeLifecyclePolicyError` and `require_final_receipt_finality`.
- `crates/kamn-kolme/src/lib.rs`: export the new lifecycle helper and error.
- `crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs`: add functional and regression coverage for final/non-final receipt finality validation.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate adapter non-final receipt guard to `require_kolme_final_receipt_finality_contract` and map contract errors to `KolmeRuntimeCommitError::NonFinalReceipt`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation marker for the extracted finality helper.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1844.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1844 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated adapter non-final receipt fail-closed behavior through extracted lifecycle contract and runtime commit adapter pipeline tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Regression  | ✅     | `Regression: #1844` in `runtime_lifecycle_policy_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
