### PR TITLE
refactor(kolme): extract live provider outcome finality normalization (#1846)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -4,7 +4,6 @@ use crate::AgentDid;
 use kamn_kolme::{
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
     classify_transport_io_error as classify_kolme_transport_io_error,
-    commit_finality_from_receipt_finality as commit_finality_from_receipt_finality_contract,
     commit_finality_label as commit_finality_label_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
@@ -20,7 +19,7 @@ use kamn_kolme::{
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
-    parse_live_provider_outcome as parse_kolme_live_provider_outcome,
+    parse_live_runtime_provider_outcome as parse_kolme_live_runtime_provider_outcome_contract,
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_provider_block_fallback_response as parse_kolme_provider_block_fallback_response_contract,
     parse_provider_finality_receipt as parse_kolme_provider_finality_receipt,
@@ -46,8 +45,8 @@ use kamn_kolme::{
     KolmeHttpResponsePolicyError as KamnKolmeHttpResponsePolicyError,
     KolmeHttpScheme as KamnKolmeHttpScheme, KolmeNotificationEvent as KamnKolmeNotificationEvent,
     KolmeParsedHttpEndpoint as KamnKolmeParsedHttpEndpoint,
-    KolmeProviderOutcome as KamnKolmeProviderOutcome,
     KolmeProviderReceiptIdentityError as KamnKolmeProviderReceiptIdentityError,
+    KolmeRuntimeProviderOutcome as KamnKolmeRuntimeProviderOutcome,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
     KolmeTransportIoClassification as KamnKolmeTransportIoClassification,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
@@ -1973,12 +1972,12 @@ fn parse_live_provider_response(
     response: &str,
     provider_hint: Option<&str>,
 ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
-    match parse_kolme_live_provider_outcome(response, provider_hint).map_err(|error| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
+    match parse_kolme_live_runtime_provider_outcome_contract(response, provider_hint).map_err(
+        |error| KolmeRuntimeCommitProviderError::MalformedResponse {
             reason: error.to_string(),
-        }
-    })? {
-        KamnKolmeProviderOutcome::Submitted {
+        },
+    )? {
+        KamnKolmeRuntimeProviderOutcome::Submitted {
             provider,
             commit_id,
             finality,
@@ -1986,10 +1985,10 @@ fn parse_live_provider_response(
             KolmeRuntimeCommitProviderReceipt {
                 provider,
                 commit_id,
-                finality: commit_finality_from_receipt_finality_contract(finality),
+                finality,
             },
         )),
-        KamnKolmeProviderOutcome::Duplicate {
+        KamnKolmeRuntimeProviderOutcome::Duplicate {
             provider,
             commit_id,
             finality,
@@ -1997,10 +1996,10 @@ fn parse_live_provider_response(
             KolmeRuntimeCommitProviderReceipt {
                 provider,
                 commit_id,
-                finality: commit_finality_from_receipt_finality_contract(finality),
+                finality,
             },
         )),
-        KamnKolmeProviderOutcome::Rejected { reason } => {
+        KamnKolmeRuntimeProviderOutcome::Rejected { reason } => {
             Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
         }
     }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -51,7 +51,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_COMMIT_SRC.contains("require_kolme_commit_id_matches_expected_txhash_contract(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_from_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_for_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
@@ -75,6 +74,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_provider_receipt_identity_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -22,6 +22,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1840"));
     assert!(DOC.contains("#1842"));
     assert!(DOC.contains("#1844"));
+    assert!(DOC.contains("#1846"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -64,9 +64,11 @@ pub use notification_policy::{
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
     deterministic_backend_commit_id, parse_commit_id_from_response_fields,
-    parse_live_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,
-    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
+    require_commit_id_matches_expected_txhash, required_provider_response_field,
+    txhash_from_commit_id, validate_provider_receipt_identity, KolmeProviderOutcome,
+    KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    KolmeRuntimeProviderOutcome,
 };
 pub use provider_response_policy::{
     parse_provider_key_value_fields, parse_provider_response_fields,

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -1,8 +1,9 @@
 //! Provider outcome parsing and commit-id helper contracts for runtime commits.
 
 use crate::{
-    parse_provider_response_fields, parse_receipt_finality, KolmeProviderResponsePolicyError,
-    ReceiptFinality, ReceiptFinalityError,
+    parse_provider_response_fields, parse_receipt_finality,
+    runtime_lifecycle_policy::{commit_finality_from_receipt_finality, KolmeCommitReceiptFinality},
+    KolmeProviderResponsePolicyError, ReceiptFinality, ReceiptFinalityError,
 };
 use std::collections::HashMap;
 use std::error::Error;
@@ -28,6 +29,35 @@ pub enum KolmeProviderOutcome {
         commit_id: String,
         /// Parsed receipt finality.
         finality: ReceiptFinality,
+    },
+    /// Provider rejected request with explicit reason.
+    Rejected {
+        /// Rejection reason.
+        reason: String,
+    },
+}
+
+/// Typed provider outcome extracted from one live response payload and normalized
+/// to runtime receipt finality variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeProviderOutcome {
+    /// Provider accepted a new request submission.
+    Submitted {
+        /// Provider identifier.
+        provider: String,
+        /// Deterministic backend commit id.
+        commit_id: String,
+        /// Runtime receipt finality.
+        finality: KolmeCommitReceiptFinality,
+    },
+    /// Provider detected duplicate idempotency key.
+    Duplicate {
+        /// Provider identifier.
+        provider: String,
+        /// Deterministic backend commit id.
+        commit_id: String,
+        /// Runtime receipt finality.
+        finality: KolmeCommitReceiptFinality,
     },
     /// Provider rejected request with explicit reason.
     Rejected {
@@ -156,6 +186,37 @@ pub fn parse_live_provider_outcome(
             commit_id,
             finality,
         })
+    }
+}
+
+/// Parses a live provider response payload and normalizes finality into runtime
+/// receipt finality variants.
+pub fn parse_live_runtime_provider_outcome(
+    response: &str,
+    provider_hint: Option<&str>,
+) -> Result<KolmeRuntimeProviderOutcome, KolmeProviderOutcomePolicyError> {
+    match parse_live_provider_outcome(response, provider_hint)? {
+        KolmeProviderOutcome::Submitted {
+            provider,
+            commit_id,
+            finality,
+        } => Ok(KolmeRuntimeProviderOutcome::Submitted {
+            provider,
+            commit_id,
+            finality: commit_finality_from_receipt_finality(finality),
+        }),
+        KolmeProviderOutcome::Duplicate {
+            provider,
+            commit_id,
+            finality,
+        } => Ok(KolmeRuntimeProviderOutcome::Duplicate {
+            provider,
+            commit_id,
+            finality: commit_finality_from_receipt_finality(finality),
+        }),
+        KolmeProviderOutcome::Rejected { reason } => {
+            Ok(KolmeRuntimeProviderOutcome::Rejected { reason })
+        }
     }
 }
 

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,12 +1,46 @@
 use kamn_kolme::{
     deterministic_backend_commit_id, parse_commit_id_from_response_fields,
-    parse_live_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id,
+    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
+    require_commit_id_matches_expected_txhash, required_provider_response_field,
+    txhash_from_commit_id,
     validate_provider_receipt_identity as validate_provider_receipt_identity_contract,
-    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
-    ReceiptFinality,
+    KolmeCommitReceiptFinality, KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
+    KolmeProviderReceiptIdentityError, KolmeRuntimeProviderOutcome, ReceiptFinality,
 };
 use std::collections::HashMap;
+
+#[test]
+fn functional_parse_live_runtime_provider_outcome_maps_finality_to_runtime_contract() {
+    let response =
+        "status=submitted\nprovider=kolme-fork\ncommit_id=kolme-commit:ab12cd34\nfinality=final\n";
+    let outcome =
+        parse_live_runtime_provider_outcome(response, None).expect("response should parse");
+    assert_eq!(
+        outcome,
+        KolmeRuntimeProviderOutcome::Submitted {
+            provider: "kolme-fork".to_owned(),
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1846_parse_live_runtime_provider_outcome_preserves_duplicate_shape() {
+    // Regression: #1846
+    let response =
+        "status=duplicate\nprovider=kolme-fork\ncommit_id=kolme-commit:ff00\nfinality=pending\n";
+    let outcome = parse_live_runtime_provider_outcome(response, None)
+        .expect("duplicate response should parse");
+    assert_eq!(
+        outcome,
+        KolmeRuntimeProviderOutcome::Duplicate {
+            provider: "kolme-fork".to_owned(),
+            commit_id: "kolme-commit:ff00".to_owned(),
+            finality: KolmeCommitReceiptFinality::Pending,
+        }
+    );
+}
 
 #[test]
 fn functional_parse_live_provider_outcome_maps_submitted_status() {

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -40,6 +40,7 @@ Out of scope:
 - #1840: extracted latest-block upper-bound selection helper to `kamn-kolme` (`resolve_lookup_upper_bound`) and rewired `kamn-core` fork finality resolver block fallback bound selection.
 - #1842: extracted adapter receipt provider/commit-id identity validator to `kamn-kolme` (`validate_provider_receipt_identity`) and rewired `kamn-core` adapter receipt mapping checks.
 - #1844: extracted adapter non-final receipt guard to `kamn-kolme` (`require_final_receipt_finality`) and rewired `kamn-core` adapter receipt finality enforcement.
+- #1846: extracted live provider outcome finality normalization to `kamn-kolme` (`parse_live_runtime_provider_outcome`) and rewired `kamn-core` live provider parsing delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract live provider outcome finality normalization from `kamn-core` into `kamn-kolme` by adding a normalized provider-outcome parser contract and delegating `parse_live_provider_response` to it.

Closes #1846

## Changes
- `crates/kamn-kolme/src/provider_outcome_policy.rs`: add `KolmeRuntimeProviderOutcome` and `parse_live_runtime_provider_outcome` to normalize finality into runtime receipt finality variants.
- `crates/kamn-kolme/src/lib.rs`: export new normalized provider outcome contract types/functions.
- `crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs`: add functional and regression tests for normalized submitted/duplicate provider outcome parsing.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire `parse_live_provider_response` to delegate normalization to `parse_kolme_live_runtime_provider_outcome_contract`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: assert delegation marker for new normalized parser contract and retire now-obsolete marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1846.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1846 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated submitted/duplicate live response parsing and finality normalization with extracted contract and runtime client tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test provider_outcome_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Regression  | ✅     | `Regression: #1846` in `provider_outcome_policy_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
