### PR TITLE
refactor(kolme): extract notification receipt mapping contract (#1848)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -16,6 +16,7 @@ use kamn_kolme::{
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
+    notification_event_to_receipt as notification_event_to_kolme_receipt_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
@@ -693,22 +694,31 @@ impl KolmeRuntimeCommitNotificationEvent {
         if provider.is_empty() {
             return None;
         }
-        match self {
+        let event = match self {
             Self::NewBlock {
                 txhash,
                 block_height,
-            } => Some(KolmeRuntimeCommitProviderReceipt {
-                provider: provider.to_owned(),
-                commit_id: deterministic_kolme_backend_commit_id(txhash.as_str(), *block_height),
-                finality: KolmeCommitReceiptFinality::Final,
-            }),
-            Self::FailedTransaction { txhash, .. } => Some(KolmeRuntimeCommitProviderReceipt {
-                provider: provider.to_owned(),
-                commit_id: deterministic_kolme_backend_commit_id(txhash.as_str(), None),
-                finality: KolmeCommitReceiptFinality::Failed,
-            }),
-            Self::LatestBlock { .. } => None,
-        }
+            } => KamnKolmeNotificationEvent::NewBlock {
+                txhash: txhash.clone(),
+                block_height: *block_height,
+            },
+            Self::FailedTransaction {
+                txhash,
+                proposed_height,
+            } => KamnKolmeNotificationEvent::FailedTransaction {
+                txhash: txhash.clone(),
+                proposed_height: *proposed_height,
+            },
+            Self::LatestBlock { height } => {
+                KamnKolmeNotificationEvent::LatestBlock { height: *height }
+            }
+        };
+        let receipt = notification_event_to_kolme_receipt_contract(&event)?;
+        Some(KolmeRuntimeCommitProviderReceipt {
+            provider: provider.to_owned(),
+            commit_id: receipt.commit_id,
+            finality: receipt.finality,
+        })
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -74,6 +74,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -23,6 +23,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1842"));
     assert!(DOC.contains("#1844"));
     assert!(DOC.contains("#1846"));
+    assert!(DOC.contains("#1848"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -59,7 +59,8 @@ pub use flat_json_policy::{
 };
 pub use http_response_policy::{parse_http_response_body, KolmeHttpResponsePolicyError};
 pub use notification_policy::{
-    parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
+    notification_event_to_receipt, parse_notification_event, KolmeNotificationEvent,
+    KolmeNotificationPolicyError, KolmeNotificationReceipt,
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{

--- a/crates/kamn-kolme/src/notification_policy.rs
+++ b/crates/kamn-kolme/src/notification_policy.rs
@@ -1,5 +1,7 @@
 //! Notification event parsing contracts for Kolme websocket payloads.
 
+use crate::provider_outcome_policy::deterministic_backend_commit_id;
+use crate::runtime_lifecycle_policy::KolmeCommitReceiptFinality;
 use std::error::Error;
 use std::fmt;
 
@@ -25,6 +27,15 @@ pub enum KolmeNotificationEvent {
         /// Latest observed block height.
         height: u64,
     },
+}
+
+/// Typed commit receipt projection derived from one notification event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeNotificationReceipt {
+    /// Deterministic backend commit id correlated from txhash/height fields.
+    pub commit_id: String,
+    /// Receipt finality projected from event class.
+    pub finality: KolmeCommitReceiptFinality,
 }
 
 /// Error raised by notification parsing policy contracts.
@@ -96,6 +107,28 @@ pub fn parse_notification_event(
     Err(KolmeNotificationPolicyError::MalformedResponse {
         reason: "notification variant is unsupported".to_owned(),
     })
+}
+
+/// Projects one parsed notification event into an optional commit receipt shape.
+pub fn notification_event_to_receipt(
+    event: &KolmeNotificationEvent,
+) -> Option<KolmeNotificationReceipt> {
+    match event {
+        KolmeNotificationEvent::NewBlock {
+            txhash,
+            block_height,
+        } => Some(KolmeNotificationReceipt {
+            commit_id: deterministic_backend_commit_id(txhash.as_str(), *block_height),
+            finality: KolmeCommitReceiptFinality::Final,
+        }),
+        KolmeNotificationEvent::FailedTransaction { txhash, .. } => {
+            Some(KolmeNotificationReceipt {
+                commit_id: deterministic_backend_commit_id(txhash.as_str(), None),
+                finality: KolmeCommitReceiptFinality::Failed,
+            })
+        }
+        KolmeNotificationEvent::LatestBlock { .. } => None,
+    }
 }
 
 fn find_notification_string_field(

--- a/crates/kamn-kolme/tests/notification_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/notification_policy_contracts.rs
@@ -1,4 +1,8 @@
-use kamn_kolme::{parse_notification_event, KolmeNotificationEvent};
+use kamn_kolme::{
+    notification_event_to_receipt as notification_event_to_receipt_contract,
+    parse_notification_event, KolmeCommitReceiptFinality, KolmeNotificationEvent,
+    KolmeNotificationReceipt,
+};
 
 #[test]
 fn functional_parse_notification_event_maps_new_block_variant() {
@@ -19,4 +23,43 @@ fn regression_issue_1735_notification_parser_rejects_unsupported_variant() {
     let error = parse_notification_event(r#"{"event":"SomethingElse","txhash":"0xabc"}"#)
         .expect_err("unsupported variant must fail");
     assert_eq!(error.to_string(), "notification variant is unsupported");
+}
+
+#[test]
+fn functional_notification_event_to_receipt_maps_new_block_and_failed_transaction() {
+    let new_block_receipt =
+        notification_event_to_receipt_contract(&KolmeNotificationEvent::NewBlock {
+            txhash: "0xabc123".to_owned(),
+            block_height: Some(42),
+        })
+        .expect("new block should map to receipt");
+    assert_eq!(
+        new_block_receipt,
+        KolmeNotificationReceipt {
+            commit_id: "kolme-commit:0xabc123:h42".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }
+    );
+
+    let failed_receipt =
+        notification_event_to_receipt_contract(&KolmeNotificationEvent::FailedTransaction {
+            txhash: "0xff00".to_owned(),
+            proposed_height: Some(44),
+        })
+        .expect("failed transaction should map to receipt");
+    assert_eq!(
+        failed_receipt,
+        KolmeNotificationReceipt {
+            commit_id: "kolme-commit:0xff00".to_owned(),
+            finality: KolmeCommitReceiptFinality::Failed,
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1848_notification_event_to_receipt_returns_none_for_latest_block() {
+    // Regression: #1848
+    let receipt =
+        notification_event_to_receipt_contract(&KolmeNotificationEvent::LatestBlock { height: 55 });
+    assert_eq!(receipt, None);
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -41,6 +41,7 @@ Out of scope:
 - #1842: extracted adapter receipt provider/commit-id identity validator to `kamn-kolme` (`validate_provider_receipt_identity`) and rewired `kamn-core` adapter receipt mapping checks.
 - #1844: extracted adapter non-final receipt guard to `kamn-kolme` (`require_final_receipt_finality`) and rewired `kamn-core` adapter receipt finality enforcement.
 - #1846: extracted live provider outcome finality normalization to `kamn-kolme` (`parse_live_runtime_provider_outcome`) and rewired `kamn-core` live provider parsing delegation.
+- #1848: extracted notification event-to-receipt projection to `kamn-kolme` (`notification_event_to_receipt`) and rewired `kamn-core` notification receipt conversion delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract deterministic notification event to receipt projection from `kamn-core` into `kamn-kolme` notification policy contracts and keep existing notification finality semantics unchanged.

Closes #1848

## Changes
- `crates/kamn-kolme/src/notification_policy.rs`: add `KolmeNotificationReceipt` and `notification_event_to_receipt` contract helper.
- `crates/kamn-kolme/src/lib.rs`: export notification receipt projection contract.
- `crates/kamn-kolme/tests/notification_policy_contracts.rs`: add functional and regression tests for `NewBlock`/`FailedTransaction` receipt mapping and `LatestBlock` no-receipt behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire `KolmeRuntimeCommitNotificationEvent::to_provider_receipt` to delegate deterministic commit-id/finality mapping to `notification_event_to_kolme_receipt_contract`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation marker for notification receipt mapping helper.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1848.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1848 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated notification receipt projections and fork finality notification paths through targeted contract and integration tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test notification_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver` |
| Regression  | ✅     | `Regression: #1848` in `notification_policy_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
