### PR TITLE
refactor(kolme): extract tls env resolution contract (#1850)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -24,12 +24,12 @@ use kamn_kolme::{
     parse_notification_event as parse_kolme_notification_event_contract,
     parse_provider_block_fallback_response as parse_kolme_provider_block_fallback_response_contract,
     parse_provider_finality_receipt as parse_kolme_provider_finality_receipt,
-    parse_tls_ca_file_env_value as parse_kolme_tls_ca_file_env_value,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
     render_block_path as render_kolme_block_path,
     require_commit_id_matches_expected_txhash as require_kolme_commit_id_matches_expected_txhash_contract,
     require_final_receipt_finality as require_kolme_final_receipt_finality_contract,
     resolve_lookup_upper_bound as resolve_kolme_lookup_upper_bound,
+    resolve_tls_ca_file_env_result as resolve_kolme_tls_ca_file_env_result_contract,
     try_take_websocket_frame as try_take_kolme_websocket_frame,
     txhash_from_commit_id as txhash_from_kolme_commit_id,
     validate_block_identity as validate_kolme_block_identity,
@@ -1962,20 +1962,13 @@ fn parse_kolme_notification_event(
 }
 
 fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
-    let value = match std::env::var("KAMN_KOLME_TLS_CA_FILE") {
-        Ok(value) => Some(value),
-        Err(std::env::VarError::NotPresent) => return Ok(None),
-        Err(std::env::VarError::NotUnicode(_)) => {
-            return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                reason: "KAMN_KOLME_TLS_CA_FILE must be valid utf-8".to_owned(),
-            });
-        }
-    };
-    parse_kolme_tls_ca_file_env_value(value.as_deref()).map_err(|error| match error {
-        KamnKolmeTlsPolicyError::Unavailable { reason } => {
-            KolmeRuntimeCommitProviderError::Unavailable { reason }
-        }
-    })
+    resolve_kolme_tls_ca_file_env_result_contract(std::env::var("KAMN_KOLME_TLS_CA_FILE")).map_err(
+        |error| match error {
+            KamnKolmeTlsPolicyError::Unavailable { reason } => {
+                KolmeRuntimeCommitProviderError::Unavailable { reason }
+            }
+        },
+    )
 }
 
 fn parse_live_provider_response(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -67,7 +67,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_tls_ca_file_env_value("));
+    assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_tls_ca_file_env_result_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
     assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_lookup_upper_bound("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -24,6 +24,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1844"));
     assert!(DOC.contains("#1846"));
     assert!(DOC.contains("#1848"));
+    assert!(DOC.contains("#1850"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -85,7 +85,8 @@ pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
 };
 pub use tls_policy::{
-    classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError,
+    classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,
+    KolmeTlsPolicyError,
 };
 pub use transport::{
     classify_transport_io_error, EchoTransport, KolmeTransport, KolmeTransportIoClassification,

--- a/crates/kamn-kolme/src/tls_policy.rs
+++ b/crates/kamn-kolme/src/tls_policy.rs
@@ -39,6 +39,19 @@ pub fn parse_tls_ca_file_env_value(
     Ok(Some(trimmed.to_owned()))
 }
 
+/// Resolves one `KAMN_KOLME_TLS_CA_FILE` environment read result into deterministic policy output.
+pub fn resolve_tls_ca_file_env_result(
+    value: Result<String, std::env::VarError>,
+) -> Result<Option<String>, KolmeTlsPolicyError> {
+    match value {
+        Ok(raw) => parse_tls_ca_file_env_value(Some(raw.as_str())),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(KolmeTlsPolicyError::Unavailable {
+            reason: "KAMN_KOLME_TLS_CA_FILE must be valid utf-8".to_owned(),
+        }),
+    }
+}
+
 /// Classifies stderr output from TLS-backed transport into deterministic reason text.
 pub fn classify_tls_failure_reason(stderr: &str) -> String {
     let normalized = stderr.to_ascii_lowercase();
@@ -65,7 +78,10 @@ pub fn classify_tls_failure_reason(stderr: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError};
+    use super::{
+        classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,
+        KolmeTlsPolicyError,
+    };
 
     #[test]
     fn unit_parse_tls_ca_file_env_value_accepts_trimmed_path() {
@@ -90,6 +106,31 @@ mod tests {
         assert_eq!(
             classify_tls_failure_reason("ssl routines:ssl3_get_record:wrong version number"),
             "tls handshake failed"
+        );
+    }
+
+    #[test]
+    fn functional_resolve_tls_ca_file_env_result_handles_not_present_and_valid_values() {
+        assert_eq!(
+            resolve_tls_ca_file_env_result(Err(std::env::VarError::NotPresent)),
+            Ok(None)
+        );
+        assert_eq!(
+            resolve_tls_ca_file_env_result(Ok("/etc/ssl/custom.pem".to_owned())),
+            Ok(Some("/etc/ssl/custom.pem".to_owned()))
+        );
+    }
+
+    #[test]
+    fn regression_tls_env_resolution_rejects_non_utf8_env_value() {
+        // Regression: #1850
+        assert_eq!(
+            resolve_tls_ca_file_env_result(Err(std::env::VarError::NotUnicode(
+                std::ffi::OsString::from("invalid"),
+            ))),
+            Err(KolmeTlsPolicyError::Unavailable {
+                reason: "KAMN_KOLME_TLS_CA_FILE must be valid utf-8".to_owned(),
+            })
         );
     }
 }

--- a/crates/kamn-kolme/tests/tls_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/tls_policy_contracts.rs
@@ -1,4 +1,7 @@
-use kamn_kolme::{classify_tls_failure_reason, parse_tls_ca_file_env_value, KolmeTlsPolicyError};
+use kamn_kolme::{
+    classify_tls_failure_reason, parse_tls_ca_file_env_value,
+    resolve_tls_ca_file_env_result as resolve_tls_ca_file_env_result_contract, KolmeTlsPolicyError,
+};
 
 #[test]
 fn functional_tls_failure_reason_classifier_detects_certificate_errors() {
@@ -16,6 +19,33 @@ fn regression_issue_1743_tls_ca_env_parser_fails_closed_on_empty_value() {
         error,
         KolmeTlsPolicyError::Unavailable {
             reason: "KAMN_KOLME_TLS_CA_FILE must not be empty".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn functional_resolve_tls_ca_file_env_result_supports_present_and_absent_values() {
+    let absent = resolve_tls_ca_file_env_result_contract(Err(std::env::VarError::NotPresent))
+        .expect("not-present env var should resolve to none");
+    assert_eq!(absent, None);
+
+    let present =
+        resolve_tls_ca_file_env_result_contract(Ok("/etc/ssl/certs/custom.pem".to_owned()))
+            .expect("present env var should resolve");
+    assert_eq!(present, Some("/etc/ssl/certs/custom.pem".to_owned()));
+}
+
+#[test]
+fn regression_issue_1850_tls_env_resolution_fails_closed_on_non_unicode() {
+    // Regression: #1850
+    let error = resolve_tls_ca_file_env_result_contract(Err(std::env::VarError::NotUnicode(
+        std::ffi::OsString::from("invalid"),
+    )))
+    .expect_err("non-unicode env value must fail closed");
+    assert_eq!(
+        error,
+        KolmeTlsPolicyError::Unavailable {
+            reason: "KAMN_KOLME_TLS_CA_FILE must be valid utf-8".to_owned(),
         }
     );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -42,6 +42,7 @@ Out of scope:
 - #1844: extracted adapter non-final receipt guard to `kamn-kolme` (`require_final_receipt_finality`) and rewired `kamn-core` adapter receipt finality enforcement.
 - #1846: extracted live provider outcome finality normalization to `kamn-kolme` (`parse_live_runtime_provider_outcome`) and rewired `kamn-core` live provider parsing delegation.
 - #1848: extracted notification event-to-receipt projection to `kamn-kolme` (`notification_event_to_receipt`) and rewired `kamn-core` notification receipt conversion delegation.
+- #1850: extracted TLS CA env-result resolver to `kamn-kolme` (`resolve_tls_ca_file_env_result`) and rewired `kamn-core` TLS CA configuration lookup delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract TLS CA env-var result resolution from `kamn-core` into `kamn-kolme` TLS policy contracts and preserve existing behavior for missing, non-UTF8, empty, and valid values.

Closes #1850

## Changes
- `crates/kamn-kolme/src/tls_policy.rs`: add `resolve_tls_ca_file_env_result(Result<String, VarError>)` contract helper and corresponding unit/regression tests.
- `crates/kamn-kolme/src/lib.rs`: export `resolve_tls_ca_file_env_result`.
- `crates/kamn-kolme/tests/tls_policy_contracts.rs`: add functional and regression tests for present/absent/non-unicode env result handling.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire `configured_tls_ca_file` to delegate env-result resolution to `resolve_kolme_tls_ca_file_env_result_contract`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: update delegation marker checks for TLS env-resolution helper.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1850.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1850 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated TLS env-resolution branches and HTTP transport TLS behavior through targeted contract and transport tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test tls_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_http_transport` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_http_transport` |
| Regression  | ✅     | `Regression: #1850` in `tls_policy_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
