### PR TITLE
refactor(kolme): extract provider notification receipt contract (#1852)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -16,7 +16,7 @@ use kamn_kolme::{
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
-    notification_event_to_receipt as notification_event_to_kolme_receipt_contract,
+    notification_event_to_provider_receipt as notification_event_to_kolme_provider_receipt_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_http_endpoint as parse_kolme_http_endpoint,
     parse_http_response_body as parse_kolme_http_response_body,
@@ -690,10 +690,6 @@ pub enum KolmeRuntimeCommitNotificationEvent {
 impl KolmeRuntimeCommitNotificationEvent {
     /// Converts notification event to a provider receipt when it carries tx finality information.
     pub fn to_provider_receipt(&self, provider: &str) -> Option<KolmeRuntimeCommitProviderReceipt> {
-        let provider = provider.trim();
-        if provider.is_empty() {
-            return None;
-        }
         let event = match self {
             Self::NewBlock {
                 txhash,
@@ -713,9 +709,9 @@ impl KolmeRuntimeCommitNotificationEvent {
                 KamnKolmeNotificationEvent::LatestBlock { height: *height }
             }
         };
-        let receipt = notification_event_to_kolme_receipt_contract(&event)?;
+        let receipt = notification_event_to_kolme_provider_receipt_contract(provider, &event)?;
         Some(KolmeRuntimeCommitProviderReceipt {
-            provider: provider.to_owned(),
+            provider: receipt.provider,
             commit_id: receipt.commit_id,
             finality: receipt.finality,
         })

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -74,7 +74,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_receipt_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -25,6 +25,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1846"));
     assert!(DOC.contains("#1848"));
     assert!(DOC.contains("#1850"));
+    assert!(DOC.contains("#1852"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -59,8 +59,9 @@ pub use flat_json_policy::{
 };
 pub use http_response_policy::{parse_http_response_body, KolmeHttpResponsePolicyError};
 pub use notification_policy::{
-    notification_event_to_receipt, parse_notification_event, KolmeNotificationEvent,
-    KolmeNotificationPolicyError, KolmeNotificationReceipt,
+    notification_event_to_provider_receipt, notification_event_to_receipt,
+    parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
+    KolmeNotificationReceipt, KolmeProviderNotificationReceipt,
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{

--- a/crates/kamn-kolme/src/notification_policy.rs
+++ b/crates/kamn-kolme/src/notification_policy.rs
@@ -38,6 +38,17 @@ pub struct KolmeNotificationReceipt {
     pub finality: KolmeCommitReceiptFinality,
 }
 
+/// Provider-scoped receipt projection derived from one notification event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeProviderNotificationReceipt {
+    /// Provider identifier normalized for adapter-facing receipts.
+    pub provider: String,
+    /// Deterministic backend commit id correlated from notification payload.
+    pub commit_id: String,
+    /// Receipt finality projected from notification variant.
+    pub finality: KolmeCommitReceiptFinality,
+}
+
 /// Error raised by notification parsing policy contracts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KolmeNotificationPolicyError {
@@ -129,6 +140,23 @@ pub fn notification_event_to_receipt(
         }
         KolmeNotificationEvent::LatestBlock { .. } => None,
     }
+}
+
+/// Projects (`provider`, `event`) into an optional provider-scoped receipt contract.
+pub fn notification_event_to_provider_receipt(
+    provider: &str,
+    event: &KolmeNotificationEvent,
+) -> Option<KolmeProviderNotificationReceipt> {
+    let provider = provider.trim();
+    if provider.is_empty() {
+        return None;
+    }
+    let receipt = notification_event_to_receipt(event)?;
+    Some(KolmeProviderNotificationReceipt {
+        provider: provider.to_owned(),
+        commit_id: receipt.commit_id,
+        finality: receipt.finality,
+    })
 }
 
 fn find_notification_string_field(

--- a/crates/kamn-kolme/tests/notification_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/notification_policy_contracts.rs
@@ -1,7 +1,8 @@
 use kamn_kolme::{
+    notification_event_to_provider_receipt as notification_event_to_provider_receipt_contract,
     notification_event_to_receipt as notification_event_to_receipt_contract,
     parse_notification_event, KolmeCommitReceiptFinality, KolmeNotificationEvent,
-    KolmeNotificationReceipt,
+    KolmeNotificationReceipt, KolmeProviderNotificationReceipt,
 };
 
 #[test]
@@ -61,5 +62,38 @@ fn regression_issue_1848_notification_event_to_receipt_returns_none_for_latest_b
     // Regression: #1848
     let receipt =
         notification_event_to_receipt_contract(&KolmeNotificationEvent::LatestBlock { height: 55 });
+    assert_eq!(receipt, None);
+}
+
+#[test]
+fn functional_notification_event_to_provider_receipt_normalizes_provider_and_maps_receipt() {
+    let receipt = notification_event_to_provider_receipt_contract(
+        "  kolme-fork  ",
+        &KolmeNotificationEvent::NewBlock {
+            txhash: "0xabc123".to_owned(),
+            block_height: Some(42),
+        },
+    )
+    .expect("new block + provider should map to provider receipt");
+    assert_eq!(
+        receipt,
+        KolmeProviderNotificationReceipt {
+            provider: "kolme-fork".to_owned(),
+            commit_id: "kolme-commit:0xabc123:h42".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1852_notification_event_to_provider_receipt_rejects_empty_provider() {
+    // Regression: #1852
+    let receipt = notification_event_to_provider_receipt_contract(
+        "   ",
+        &KolmeNotificationEvent::FailedTransaction {
+            txhash: "0xff00".to_owned(),
+            proposed_height: Some(44),
+        },
+    );
     assert_eq!(receipt, None);
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -43,6 +43,7 @@ Out of scope:
 - #1846: extracted live provider outcome finality normalization to `kamn-kolme` (`parse_live_runtime_provider_outcome`) and rewired `kamn-core` live provider parsing delegation.
 - #1848: extracted notification event-to-receipt projection to `kamn-kolme` (`notification_event_to_receipt`) and rewired `kamn-core` notification receipt conversion delegation.
 - #1850: extracted TLS CA env-result resolver to `kamn-kolme` (`resolve_tls_ca_file_env_result`) and rewired `kamn-core` TLS CA configuration lookup delegation.
+- #1852: extracted provider-scoped notification receipt projection to `kamn-kolme` (`notification_event_to_provider_receipt`) and rewired `kamn-core` notification conversion provider normalization + receipt assembly delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract provider-scoped notification receipt projection from `kamn-core` into `kamn-kolme` notification policy contracts while preserving notification semantics and empty-provider fail-closed behavior.

Closes #1852

## Changes
- `crates/kamn-kolme/src/notification_policy.rs`: add `KolmeProviderNotificationReceipt` and `notification_event_to_provider_receipt`.
- `crates/kamn-kolme/src/lib.rs`: export provider-scoped notification receipt projection helper/types.
- `crates/kamn-kolme/tests/notification_policy_contracts.rs`: add functional and regression tests for provider normalization and empty-provider fail-closed behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire `KolmeRuntimeCommitNotificationEvent::to_provider_receipt` to delegate provider normalization + receipt assembly to `notification_event_to_kolme_provider_receipt_contract`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: update extraction delegation marker for provider-scoped notification projection.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1852.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1852 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated notification provider-scope receipt projection and fork-finality notification behavior through contract + integration tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test notification_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver` |
| Regression  | ✅     | `Regression: #1852` in `notification_policy_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
