### PR TITLE
refactor(kolme): extract block-fallback receipt projection contract (#1854)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -4,10 +4,10 @@ use crate::AgentDid;
 use kamn_kolme::{
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
     classify_transport_io_error as classify_kolme_transport_io_error,
+    commit_finality_from_receipt_finality as commit_finality_from_receipt_finality_contract,
     commit_finality_label as commit_finality_label_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
-    deterministic_backend_commit_id as deterministic_kolme_backend_commit_id,
     deterministic_runtime_commit_id as deterministic_runtime_commit_id_contract,
     deterministic_runtime_commit_idempotency_key as deterministic_runtime_commit_idempotency_key_contract,
     escape_json_string as escape_kolme_json_string,
@@ -25,6 +25,8 @@ use kamn_kolme::{
     parse_provider_block_fallback_response as parse_kolme_provider_block_fallback_response_contract,
     parse_provider_finality_receipt as parse_kolme_provider_finality_receipt,
     parse_websocket_endpoint as parse_kolme_websocket_endpoint,
+    project_failed_block_txhash_receipt as project_kolme_failed_block_txhash_receipt_contract,
+    project_finalized_block_txhash_receipt as project_kolme_finalized_block_txhash_receipt_contract,
     render_block_path as render_kolme_block_path,
     require_commit_id_matches_expected_txhash as require_kolme_commit_id_matches_expected_txhash_contract,
     require_final_receipt_finality as require_kolme_final_receipt_finality_contract,
@@ -1357,17 +1359,20 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 .iter()
                 .any(|value| value == txhash)
             {
+                let projection =
+                    project_kolme_finalized_block_txhash_receipt_contract(txhash, height);
                 return Ok(KolmeRuntimeCommitProviderReceipt {
                     provider: self.provider.clone(),
-                    commit_id: deterministic_kolme_backend_commit_id(txhash, Some(height)),
-                    finality: KolmeCommitReceiptFinality::Final,
+                    commit_id: projection.commit_id,
+                    finality: commit_finality_from_receipt_finality_contract(projection.finality),
                 });
             }
             if block.failed_tx_hashes.iter().any(|value| value == txhash) {
+                let projection = project_kolme_failed_block_txhash_receipt_contract(txhash);
                 return Ok(KolmeRuntimeCommitProviderReceipt {
                     provider: self.provider.clone(),
-                    commit_id: deterministic_kolme_backend_commit_id(txhash, None),
-                    finality: KolmeCommitReceiptFinality::Failed,
+                    commit_id: projection.commit_id,
+                    finality: commit_finality_from_receipt_finality_contract(projection.finality),
                 });
             }
         }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -56,7 +56,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("deterministic_kolme_backend_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));
@@ -71,6 +70,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
     assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_lookup_upper_bound("));
+    assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_finalized_block_txhash_receipt_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_failed_block_txhash_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -26,6 +26,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1848"));
     assert!(DOC.contains("#1850"));
     assert!(DOC.contains("#1852"));
+    assert!(DOC.contains("#1854"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/block_scan_policy.rs
+++ b/crates/kamn-kolme/src/block_scan_policy.rs
@@ -1,5 +1,7 @@
 //! Block-scan policy contracts for Kolme fallback reconciliation.
 
+use crate::provider_outcome_policy::deterministic_backend_commit_id;
+use crate::receipt_finality::ReceiptFinality;
 use std::error::Error;
 use std::fmt;
 
@@ -81,6 +83,15 @@ impl fmt::Display for BlockScanPolicyError {
 
 impl Error for BlockScanPolicyError {}
 
+/// Deterministic receipt projection emitted from one block txhash match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockScanReceiptProjection {
+    /// Deterministic backend commit id.
+    pub commit_id: String,
+    /// Projected receipt finality.
+    pub finality: ReceiptFinality,
+}
+
 /// Validates the configured block endpoint path template.
 pub fn validate_block_path_template(block_path_template: &str) -> Result<(), BlockScanPolicyError> {
     let trimmed = block_path_template.trim();
@@ -140,6 +151,25 @@ pub fn resolve_lookup_upper_bound(
         notification_height.min(latest_height)
     } else {
         latest_height
+    }
+}
+
+/// Projects a finalized block match into deterministic receipt projection fields.
+pub fn project_finalized_block_txhash_receipt(
+    txhash: &str,
+    block_height: u64,
+) -> BlockScanReceiptProjection {
+    BlockScanReceiptProjection {
+        commit_id: deterministic_backend_commit_id(txhash, Some(block_height)),
+        finality: ReceiptFinality::Final,
+    }
+}
+
+/// Projects a failed block match into deterministic receipt projection fields.
+pub fn project_failed_block_txhash_receipt(txhash: &str) -> BlockScanReceiptProjection {
+    BlockScanReceiptProjection {
+        commit_id: deterministic_backend_commit_id(txhash, None),
+        finality: ReceiptFinality::Failed,
     }
 }
 

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -37,9 +37,10 @@ pub use block_fallback_policy::{
     KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
-    parse_fork_block_txhash, render_block_path, resolve_lookup_upper_bound,
+    parse_fork_block_txhash, project_failed_block_txhash_receipt,
+    project_finalized_block_txhash_receipt, render_block_path, resolve_lookup_upper_bound,
     validate_block_identity, validate_block_path_template, validate_lookup_window,
-    BlockScanPolicyError,
+    BlockScanPolicyError, BlockScanReceiptProjection,
 };
 pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};

--- a/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
+++ b/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
@@ -1,6 +1,10 @@
 use kamn_kolme::{
-    parse_fork_block_txhash, parse_receipt_finality, render_block_path, resolve_lookup_upper_bound,
-    validate_block_identity, validate_block_path_template, validate_lookup_window, ReceiptFinality,
+    parse_fork_block_txhash, parse_receipt_finality,
+    project_failed_block_txhash_receipt as project_failed_block_txhash_receipt_contract,
+    project_finalized_block_txhash_receipt as project_finalized_block_txhash_receipt_contract,
+    render_block_path, resolve_lookup_upper_bound, validate_block_identity,
+    validate_block_path_template, validate_lookup_window, BlockScanReceiptProjection,
+    ReceiptFinality,
 };
 
 #[test]
@@ -68,4 +72,29 @@ fn regression_issue_1840_resolve_lookup_upper_bound_falls_back_to_latest_when_no
     // Regression: #1840
     let upper_bound = resolve_lookup_upper_bound(40, 45, 39);
     assert_eq!(upper_bound, 45);
+}
+
+#[test]
+fn functional_project_finalized_block_txhash_receipt_maps_commit_id_and_finality() {
+    let receipt = project_finalized_block_txhash_receipt_contract("ab12cd34", 72);
+    assert_eq!(
+        receipt,
+        BlockScanReceiptProjection {
+            commit_id: "kolme-commit:ab12cd34:h72".to_owned(),
+            finality: ReceiptFinality::Final,
+        }
+    );
+}
+
+#[test]
+fn regression_issue_1854_project_failed_block_txhash_receipt_uses_heightless_commit_id() {
+    // Regression: #1854
+    let receipt = project_failed_block_txhash_receipt_contract("ab12cd34");
+    assert_eq!(
+        receipt,
+        BlockScanReceiptProjection {
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: ReceiptFinality::Failed,
+        }
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -44,6 +44,7 @@ Out of scope:
 - #1848: extracted notification event-to-receipt projection to `kamn-kolme` (`notification_event_to_receipt`) and rewired `kamn-core` notification receipt conversion delegation.
 - #1850: extracted TLS CA env-result resolver to `kamn-kolme` (`resolve_tls_ca_file_env_result`) and rewired `kamn-core` TLS CA configuration lookup delegation.
 - #1852: extracted provider-scoped notification receipt projection to `kamn-kolme` (`notification_event_to_provider_receipt`) and rewired `kamn-core` notification conversion provider normalization + receipt assembly delegation.
+- #1854: extracted block-fallback txhash-match receipt projection to `kamn-kolme` (`project_finalized_block_txhash_receipt` / `project_failed_block_txhash_receipt`) and rewired `kamn-core` fallback reconciler receipt projection delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract block-fallback txhash-match receipt projection from `kamn-core` into `kamn-kolme` block-scan contracts, preserving existing finalized/failed receipt shapes.

Closes #1854

## Changes
- `crates/kamn-kolme/src/block_scan_policy.rs`: add `BlockScanReceiptProjection`, `project_finalized_block_txhash_receipt`, and `project_failed_block_txhash_receipt`.
- `crates/kamn-kolme/src/lib.rs`: export new block-scan receipt projection contract types/functions.
- `crates/kamn-kolme/tests/finality_block_scan_contracts.rs`: add functional and regression tests for finalized/failed receipt projections.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire `KolmeRuntimeCommitBlockFallbackReconciler::reconcile_txhash` to delegate receipt projection to `kamn-kolme` helpers.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation markers for new projection helpers and retire obsolete marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1854.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1854 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated block fallback finalized/failed projection parity and downstream fork-finality behavior with focused contract/integration tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test finality_block_scan_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver` |
| Regression  | ✅     | `Regression: #1854` in `finality_block_scan_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
