### PR TITLE
refactor(kolme): extract fallback txhash validation contract (#1856)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -6,6 +6,7 @@ use kamn_kolme::{
     classify_transport_io_error as classify_kolme_transport_io_error,
     commit_finality_from_receipt_finality as commit_finality_from_receipt_finality_contract,
     commit_finality_label as commit_finality_label_contract,
+    compose_block_fallback_unresolved_reason as compose_kolme_block_fallback_unresolved_reason_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     deterministic_runtime_commit_id as deterministic_runtime_commit_id_contract,
@@ -36,6 +37,7 @@ use kamn_kolme::{
     txhash_from_commit_id as txhash_from_kolme_commit_id,
     validate_block_identity as validate_kolme_block_identity,
     validate_block_path_template as validate_kolme_block_path_template,
+    validate_lookup_txhash as validate_kolme_lookup_txhash_contract,
     validate_lookup_window as validate_kolme_lookup_window,
     validate_provider_receipt_identity as validate_kolme_provider_receipt_identity_contract,
     validate_websocket_handshake_response as validate_kolme_websocket_handshake_response,
@@ -1310,12 +1312,11 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
         from_height: u64,
         latest_height: u64,
     ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        let txhash = txhash.trim();
-        if txhash.is_empty() {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "txhash must not be empty".to_owned(),
-            });
-        }
+        let txhash = validate_kolme_lookup_txhash_contract(txhash).map_err(|error| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            }
+        })?;
         validate_kolme_lookup_window(from_height, latest_height, self.max_block_lookups).map_err(
             |error| match error {
                 BlockScanPolicyError::MaxLookupsExceeded { .. } => {
@@ -1357,18 +1358,23 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
             if block
                 .finalized_tx_hashes
                 .iter()
-                .any(|value| value == txhash)
+                .any(|value| value == txhash.as_str())
             {
                 let projection =
-                    project_kolme_finalized_block_txhash_receipt_contract(txhash, height);
+                    project_kolme_finalized_block_txhash_receipt_contract(txhash.as_str(), height);
                 return Ok(KolmeRuntimeCommitProviderReceipt {
                     provider: self.provider.clone(),
                     commit_id: projection.commit_id,
                     finality: commit_finality_from_receipt_finality_contract(projection.finality),
                 });
             }
-            if block.failed_tx_hashes.iter().any(|value| value == txhash) {
-                let projection = project_kolme_failed_block_txhash_receipt_contract(txhash);
+            if block
+                .failed_tx_hashes
+                .iter()
+                .any(|value| value == txhash.as_str())
+            {
+                let projection =
+                    project_kolme_failed_block_txhash_receipt_contract(txhash.as_str());
                 return Ok(KolmeRuntimeCommitProviderReceipt {
                     provider: self.provider.clone(),
                     commit_id: projection.commit_id,
@@ -1378,8 +1384,10 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
         }
 
         Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: format!(
-                "block fallback did not resolve txhash '{txhash}' between heights {from_height} and {latest_height}"
+            reason: compose_kolme_block_fallback_unresolved_reason_contract(
+                txhash.as_str(),
+                from_height,
+                latest_height,
             ),
         })
     }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -70,6 +70,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
     assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_lookup_upper_bound("));
+    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_txhash_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_block_fallback_unresolved_reason_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_finalized_block_txhash_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_failed_block_txhash_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -27,6 +27,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1850"));
     assert!(DOC.contains("#1852"));
     assert!(DOC.contains("#1854"));
+    assert!(DOC.contains("#1856"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/block_scan_policy.rs
+++ b/crates/kamn-kolme/src/block_scan_policy.rs
@@ -141,6 +141,17 @@ pub fn validate_lookup_window(
     Ok(())
 }
 
+/// Validates txhash request identity for block fallback reconciliation.
+pub fn validate_lookup_txhash(txhash: &str) -> Result<String, BlockScanPolicyError> {
+    let normalized = txhash.trim();
+    if normalized.is_empty() {
+        return Err(BlockScanPolicyError::MalformedForkFallbackResponse {
+            reason: "txhash must not be empty".to_owned(),
+        });
+    }
+    Ok(normalized.to_owned())
+}
+
 /// Resolves block-fallback upper bound using one latest-block notification height.
 pub fn resolve_lookup_upper_bound(
     from_height: u64,
@@ -171,6 +182,17 @@ pub fn project_failed_block_txhash_receipt(txhash: &str) -> BlockScanReceiptProj
         commit_id: deterministic_backend_commit_id(txhash, None),
         finality: ReceiptFinality::Failed,
     }
+}
+
+/// Renders deterministic fallback unresolved reason text.
+pub fn compose_block_fallback_unresolved_reason(
+    txhash: &str,
+    from_height: u64,
+    latest_height: u64,
+) -> String {
+    format!(
+        "block fallback did not resolve txhash '{txhash}' between heights {from_height} and {latest_height}"
+    )
 }
 
 /// Validates provider + height identity for one scanned block response.

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -37,10 +37,11 @@ pub use block_fallback_policy::{
     KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
-    parse_fork_block_txhash, project_failed_block_txhash_receipt,
-    project_finalized_block_txhash_receipt, render_block_path, resolve_lookup_upper_bound,
-    validate_block_identity, validate_block_path_template, validate_lookup_window,
-    BlockScanPolicyError, BlockScanReceiptProjection,
+    compose_block_fallback_unresolved_reason, parse_fork_block_txhash,
+    project_failed_block_txhash_receipt, project_finalized_block_txhash_receipt, render_block_path,
+    resolve_lookup_upper_bound, validate_block_identity, validate_block_path_template,
+    validate_lookup_txhash, validate_lookup_window, BlockScanPolicyError,
+    BlockScanReceiptProjection,
 };
 pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};

--- a/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
+++ b/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
@@ -1,10 +1,11 @@
 use kamn_kolme::{
+    compose_block_fallback_unresolved_reason as compose_block_fallback_unresolved_reason_contract,
     parse_fork_block_txhash, parse_receipt_finality,
     project_failed_block_txhash_receipt as project_failed_block_txhash_receipt_contract,
     project_finalized_block_txhash_receipt as project_finalized_block_txhash_receipt_contract,
     render_block_path, resolve_lookup_upper_bound, validate_block_identity,
-    validate_block_path_template, validate_lookup_window, BlockScanReceiptProjection,
-    ReceiptFinality,
+    validate_block_path_template, validate_lookup_txhash as validate_lookup_txhash_contract,
+    validate_lookup_window, BlockScanReceiptProjection, ReceiptFinality,
 };
 
 #[test]
@@ -96,5 +97,24 @@ fn regression_issue_1854_project_failed_block_txhash_receipt_uses_heightless_com
             commit_id: "kolme-commit:ab12cd34".to_owned(),
             finality: ReceiptFinality::Failed,
         }
+    );
+}
+
+#[test]
+fn functional_validate_lookup_txhash_normalizes_non_empty_input() {
+    let txhash = validate_lookup_txhash_contract("  ab12cd34  ").expect("txhash should normalize");
+    assert_eq!(txhash, "ab12cd34".to_owned());
+}
+
+#[test]
+fn regression_issue_1856_validate_lookup_txhash_rejects_empty_input_and_unresolved_reason_stable() {
+    // Regression: #1856
+    let error = validate_lookup_txhash_contract("   ").expect_err("empty txhash must fail");
+    assert_eq!(error.to_string(), "txhash must not be empty");
+
+    let reason = compose_block_fallback_unresolved_reason_contract("ab12cd34", 40, 45);
+    assert_eq!(
+        reason,
+        "block fallback did not resolve txhash 'ab12cd34' between heights 40 and 45".to_owned()
     );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -45,6 +45,7 @@ Out of scope:
 - #1850: extracted TLS CA env-result resolver to `kamn-kolme` (`resolve_tls_ca_file_env_result`) and rewired `kamn-core` TLS CA configuration lookup delegation.
 - #1852: extracted provider-scoped notification receipt projection to `kamn-kolme` (`notification_event_to_provider_receipt`) and rewired `kamn-core` notification conversion provider normalization + receipt assembly delegation.
 - #1854: extracted block-fallback txhash-match receipt projection to `kamn-kolme` (`project_finalized_block_txhash_receipt` / `project_failed_block_txhash_receipt`) and rewired `kamn-core` fallback reconciler receipt projection delegation.
+- #1856: extracted fallback txhash request validation + unresolved-reason composition to `kamn-kolme` (`validate_lookup_txhash` / `compose_block_fallback_unresolved_reason`) and rewired `kamn-core` fallback reconciler delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract fallback txhash request validation and unresolved-reason composition from `kamn-core` into `kamn-kolme` block-scan contracts while preserving existing fail-closed behavior and reason text.

Closes #1856

## Changes
- `crates/kamn-kolme/src/block_scan_policy.rs`: add `validate_lookup_txhash` and `compose_block_fallback_unresolved_reason`.
- `crates/kamn-kolme/src/lib.rs`: export new block-scan helper contracts.
- `crates/kamn-kolme/tests/finality_block_scan_contracts.rs`: add functional/regression tests for txhash validation and unresolved-reason composition.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewire `reconcile_txhash` to delegate txhash validation and unresolved reason composition to `kamn-kolme` helpers.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation markers for new helpers.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: add Phase 2 progress marker for #1856.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: assert #1856 marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated empty txhash fail-closed behavior and unresolved fallback reason parity with focused contract and fallback reconciler tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test finality_block_scan_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback` |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback` |
| Regression  | ✅     | `Regression: #1856` in `finality_block_scan_contracts.rs`; extraction boundary/docs guards in `kamn-core` |
