### PR TITLE
refactor(kolme): extract poll attempt budget contract (#1860)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -15,6 +15,7 @@ use kamn_kolme::{
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
     is_terminal_receipt_finality as is_kolme_terminal_receipt_finality_contract,
+    is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
@@ -1221,7 +1222,7 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
         commit_id: &str,
         max_attempts: u32,
     ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        if max_attempts == 0 {
+        if !is_kolme_valid_poll_attempt_budget_contract(max_attempts) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "max_attempts must be positive".to_owned(),
             });

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -55,6 +55,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("lifecycle_state_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_terminal_receipt_finality_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_poll_attempt_budget_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -29,6 +29,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1854"));
     assert!(DOC.contains("#1856"));
     assert!(DOC.contains("#1858"));
+    assert!(DOC.contains("#1860"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -81,9 +81,9 @@ pub use provider_response_policy::{
 pub use receipt_finality::{parse_receipt_finality, ReceiptFinality, ReceiptFinalityError};
 pub use runtime_lifecycle_policy::{
     commit_finality_from_receipt_finality, commit_finality_label, is_terminal_receipt_finality,
-    lifecycle_state_for_finality, lifecycle_state_label, parse_commit_receipt_finality,
-    require_final_receipt_finality, KolmeCommitReceiptFinality, RuntimeCommitLifecycleState,
-    RuntimeLifecyclePolicyError,
+    is_valid_poll_attempt_budget, lifecycle_state_for_finality, lifecycle_state_label,
+    parse_commit_receipt_finality, require_final_receipt_finality, KolmeCommitReceiptFinality,
+    RuntimeCommitLifecycleState, RuntimeLifecyclePolicyError,
 };
 pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,

--- a/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
+++ b/crates/kamn-kolme/src/runtime_lifecycle_policy.rs
@@ -113,6 +113,11 @@ pub fn is_terminal_receipt_finality(finality: KolmeCommitReceiptFinality) -> boo
     !matches!(finality, KolmeCommitReceiptFinality::Pending)
 }
 
+/// Validates polling attempt budget before runtime finality convergence loops.
+pub fn is_valid_poll_attempt_budget(max_attempts: u32) -> bool {
+    max_attempts > 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_lifecycle_policy_contracts.rs
@@ -1,5 +1,6 @@
 use kamn_kolme::{
     commit_finality_label, is_terminal_receipt_finality as is_terminal_receipt_finality_contract,
+    is_valid_poll_attempt_budget as is_valid_poll_attempt_budget_contract,
     lifecycle_state_for_finality, lifecycle_state_label,
     require_final_receipt_finality as require_final_receipt_finality_contract,
     KolmeCommitReceiptFinality, RuntimeCommitLifecycleState, RuntimeLifecyclePolicyError,
@@ -95,4 +96,16 @@ fn regression_issue_1858_runtime_lifecycle_policy_treats_failed_as_terminal() {
     assert!(is_terminal_receipt_finality_contract(
         KolmeCommitReceiptFinality::Failed
     ));
+}
+
+#[test]
+fn functional_runtime_lifecycle_policy_validates_positive_poll_attempt_budget() {
+    assert!(is_valid_poll_attempt_budget_contract(1));
+    assert!(is_valid_poll_attempt_budget_contract(3));
+}
+
+#[test]
+fn regression_issue_1860_runtime_lifecycle_policy_rejects_zero_poll_attempt_budget() {
+    // Regression: #1860
+    assert!(!is_valid_poll_attempt_budget_contract(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -47,6 +47,7 @@ Out of scope:
 - #1854: extracted block-fallback txhash-match receipt projection to `kamn-kolme` (`project_finalized_block_txhash_receipt` / `project_failed_block_txhash_receipt`) and rewired `kamn-core` fallback reconciler receipt projection delegation.
 - #1856: extracted fallback txhash request validation + unresolved-reason composition to `kamn-kolme` (`validate_lookup_txhash` / `compose_block_fallback_unresolved_reason`) and rewired `kamn-core` fallback reconciler delegation.
 - #1858: extracted terminal receipt-finality gate to `kamn-kolme` (`is_terminal_receipt_finality`) and rewired `kamn-core` finality poller convergence gating delegation.
+- #1860: extracted poll-attempt budget validation to `kamn-kolme` (`is_valid_poll_attempt_budget`) and rewired `kamn-core` finality poller budget guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract poll-attempt budget validation into `kamn-kolme` via `is_valid_poll_attempt_budget(max_attempts: u32) -> bool`.
- Rewire `KolmeRuntimeCommitFinalityChecker::poll_finality` to delegate budget validation to the extracted contract while preserving existing fail-closed error text.
- Extend extraction-boundary/doc-plan guards and lifecycle contract tests to cover issue marker `#1860`.

## Linked Issues
- Closes #1860

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test runtime_lifecycle_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1861
