### PR TITLE
refactor(kolme): extract finality commit-id guard contract (#1862)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -16,6 +16,7 @@ use kamn_kolme::{
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
     is_terminal_receipt_finality as is_kolme_terminal_receipt_finality_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
+    is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
@@ -1193,7 +1194,7 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
         &mut self,
         commit_id: &str,
     ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        if commit_id.trim().is_empty() {
+        if !is_kolme_valid_runtime_commit_id_request_contract(commit_id) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "commit_id must not be empty".to_owned(),
             });

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -56,6 +56,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_terminal_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_poll_attempt_budget_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_commit_id_request_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -30,6 +30,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1856"));
     assert!(DOC.contains("#1858"));
     assert!(DOC.contains("#1860"));
+    assert!(DOC.contains("#1862"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -87,6 +87,7 @@ pub use runtime_lifecycle_policy::{
 };
 pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
+    is_valid_runtime_commit_id_request,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -34,9 +34,17 @@ pub fn deterministic_runtime_commit_id(
     )
 }
 
+/// Validates runtime finality request commit identifier input.
+pub fn is_valid_runtime_commit_id_request(commit_id: &str) -> bool {
+    !commit_id.trim().is_empty()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key};
+    use super::{
+        deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
+        is_valid_runtime_commit_id_request,
+    };
 
     #[test]
     fn unit_renders_idempotency_key_contract() {
@@ -59,5 +67,13 @@ mod tests {
             deterministic_runtime_commit_id("op-x", "did:agent", 3, "abc"),
             deterministic_runtime_commit_id("op-x", "did:agent", 3, "xyz")
         );
+    }
+
+    #[test]
+    fn unit_validates_runtime_commit_id_request_input() {
+        assert!(is_valid_runtime_commit_id_request(
+            "kolme-commit:op:did:1:12"
+        ));
+        assert!(!is_valid_runtime_commit_id_request("   "));
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -1,4 +1,7 @@
-use kamn_kolme::{deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key};
+use kamn_kolme::{
+    deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
+    is_valid_runtime_commit_id_request,
+};
 
 #[test]
 fn unit_runtime_request_identity_policy_idempotency_key_contract() {
@@ -27,4 +30,18 @@ fn regression_runtime_request_identity_policy_payload_length_drift_remains_fail_
     let left = deterministic_runtime_commit_id("op-x", "did:agent", 3, "abc");
     let right = deterministic_runtime_commit_id("op-x", "did:agent", 3, "xyz");
     assert_eq!(left, right);
+}
+
+#[test]
+fn functional_runtime_request_identity_policy_accepts_non_empty_commit_id_request() {
+    assert!(is_valid_runtime_commit_id_request(
+        "kolme-commit:op-9:did:agent:beta:11:8"
+    ));
+}
+
+#[test]
+fn regression_issue_1862_runtime_request_identity_policy_rejects_empty_commit_id_request() {
+    // Regression: #1862
+    assert!(!is_valid_runtime_commit_id_request(""));
+    assert!(!is_valid_runtime_commit_id_request("   "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -48,6 +48,7 @@ Out of scope:
 - #1856: extracted fallback txhash request validation + unresolved-reason composition to `kamn-kolme` (`validate_lookup_txhash` / `compose_block_fallback_unresolved_reason`) and rewired `kamn-core` fallback reconciler delegation.
 - #1858: extracted terminal receipt-finality gate to `kamn-kolme` (`is_terminal_receipt_finality`) and rewired `kamn-core` finality poller convergence gating delegation.
 - #1860: extracted poll-attempt budget validation to `kamn-kolme` (`is_valid_poll_attempt_budget`) and rewired `kamn-core` finality poller budget guard delegation.
+- #1862: extracted finality check commit-id request guard to `kamn-kolme` (`is_valid_runtime_commit_id_request`) and rewired `kamn-core` finality checker input validation delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract finality request commit-id validation into `kamn-kolme` via `is_valid_runtime_commit_id_request`.
- Rewire `KolmeRuntimeCommitFinalityChecker::check_commit_finality` to delegate commit-id guard enforcement while preserving existing fail-closed malformed-response text.
- Extend extraction-boundary and extraction-plan guard coverage for issue marker `#1862`.

## Linked Issues
- Closes #1862

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1863
