### PR TITLE
refactor(kolme): extract finality endpoint guard contracts (#1864)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -15,6 +15,8 @@ use kamn_kolme::{
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
     is_terminal_receipt_finality as is_kolme_terminal_receipt_finality_contract,
+    is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
+    is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
@@ -1170,13 +1172,13 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
         status_path: &str,
         transport: T,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        if base_url.trim().is_empty() {
+        if !is_kolme_valid_finality_base_url_input_contract(base_url) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider_base_url",
                 reason: "must not be empty",
             });
         }
-        if status_path.trim().is_empty() {
+        if !is_kolme_valid_finality_status_path_input_contract(status_path) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider_status_path",
                 reason: "must not be empty",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -79,6 +79,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_failed_block_txhash_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_base_url_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_status_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -31,6 +31,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1858"));
     assert!(DOC.contains("#1860"));
     assert!(DOC.contains("#1862"));
+    assert!(DOC.contains("#1864"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/endpoint_policy.rs
+++ b/crates/kamn-kolme/src/endpoint_policy.rs
@@ -116,6 +116,16 @@ pub fn parse_http_endpoint(
     })
 }
 
+/// Validates finality checker base URL input before runtime-commit polling.
+pub fn is_valid_finality_base_url_input(base_url: &str) -> bool {
+    !base_url.trim().is_empty()
+}
+
+/// Validates finality checker status-path input before runtime-commit polling.
+pub fn is_valid_finality_status_path_input(status_path: &str) -> bool {
+    !status_path.trim().is_empty()
+}
+
 /// Composes websocket notifications URL from HTTP base URL + notifications path.
 pub fn compose_notifications_websocket_url(
     base_url: &str,
@@ -275,7 +285,8 @@ fn percent_encode(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,
+        compose_finality_status_path, compose_notifications_websocket_url,
+        is_valid_finality_base_url_input, is_valid_finality_status_path_input, parse_http_endpoint,
         parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
     };
 
@@ -328,5 +339,15 @@ mod tests {
                 reason: "commit_id must not be empty".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn unit_validates_finality_endpoint_inputs() {
+        assert!(is_valid_finality_base_url_input("https://kolme.local"));
+        assert!(!is_valid_finality_base_url_input(" "));
+        assert!(is_valid_finality_status_path_input(
+            "/runtime-commit/status"
+        ));
+        assert!(!is_valid_finality_status_path_input(" "));
     }
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -46,7 +46,8 @@ pub use block_scan_policy::{
 pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use endpoint_policy::{
-    compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,
+    compose_finality_status_path, compose_notifications_websocket_url,
+    is_valid_finality_base_url_input, is_valid_finality_status_path_input, parse_http_endpoint,
     parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
     KolmeParsedWebsocketEndpoint,
 };

--- a/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
@@ -1,5 +1,6 @@
 use kamn_kolme::{
-    compose_finality_status_path, compose_notifications_websocket_url, parse_http_endpoint,
+    compose_finality_status_path, compose_notifications_websocket_url,
+    is_valid_finality_base_url_input, is_valid_finality_status_path_input, parse_http_endpoint,
     parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
 };
 
@@ -54,4 +55,19 @@ fn regression_issue_1729_endpoint_validation_fails_closed() {
             reason: "notifications_url scheme must be ws:// or wss://".to_owned(),
         })
     );
+}
+
+#[test]
+fn functional_endpoint_policy_accepts_non_empty_finality_checker_inputs() {
+    assert!(is_valid_finality_base_url_input("https://kolme.example"));
+    assert!(is_valid_finality_status_path_input(
+        "/runtime-commit/status"
+    ));
+}
+
+#[test]
+fn regression_issue_1864_endpoint_policy_rejects_empty_finality_checker_inputs() {
+    // Regression: #1864
+    assert!(!is_valid_finality_base_url_input("   "));
+    assert!(!is_valid_finality_status_path_input(""));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -49,6 +49,7 @@ Out of scope:
 - #1858: extracted terminal receipt-finality gate to `kamn-kolme` (`is_terminal_receipt_finality`) and rewired `kamn-core` finality poller convergence gating delegation.
 - #1860: extracted poll-attempt budget validation to `kamn-kolme` (`is_valid_poll_attempt_budget`) and rewired `kamn-core` finality poller budget guard delegation.
 - #1862: extracted finality check commit-id request guard to `kamn-kolme` (`is_valid_runtime_commit_id_request`) and rewired `kamn-core` finality checker input validation delegation.
+- #1864: extracted finality checker constructor endpoint input guards to `kamn-kolme` (`is_valid_finality_base_url_input` / `is_valid_finality_status_path_input`) and rewired `kamn-core` constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract finality checker constructor endpoint guards into `kamn-kolme` endpoint-policy contracts (`is_valid_finality_base_url_input`, `is_valid_finality_status_path_input`).
- Rewire `KolmeRuntimeCommitFinalityChecker::new` in `kamn-core` to delegate guard validation while preserving invalid-request field/reason parity.
- Extend extraction boundary and extraction plan marker coverage for `#1864`.

## Linked Issues
- Closes #1864

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test endpoint_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1865
