### PR TITLE
refactor(kolme): extract block-fallback constructor guards (#1866)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -15,6 +15,9 @@ use kamn_kolme::{
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
     is_terminal_receipt_finality as is_kolme_terminal_receipt_finality_contract,
+    is_valid_block_fallback_base_url_input as is_kolme_valid_block_fallback_base_url_input_contract,
+    is_valid_block_fallback_lookup_budget as is_kolme_valid_block_fallback_lookup_budget_contract,
+    is_valid_block_fallback_provider_input as is_kolme_valid_block_fallback_provider_input_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
@@ -1259,19 +1262,19 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
         max_block_lookups: u64,
         transport: T,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        if base_url.trim().is_empty() {
+        if !is_kolme_valid_block_fallback_base_url_input_contract(base_url) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider_base_url",
                 reason: "must not be empty",
             });
         }
-        if provider.trim().is_empty() {
+        if !is_kolme_valid_block_fallback_provider_input_contract(provider) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider",
                 reason: "must not be empty",
             });
         }
-        if max_block_lookups == 0 {
+        if !is_kolme_valid_block_fallback_lookup_budget_contract(max_block_lookups) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "max_block_lookups",
                 reason: "must be positive",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -66,6 +66,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_block_fallback_response_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_base_url_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_provider_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_lookup_budget_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -32,6 +32,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1860"));
     assert!(DOC.contains("#1862"));
     assert!(DOC.contains("#1864"));
+    assert!(DOC.contains("#1866"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/block_fallback_policy.rs
+++ b/crates/kamn-kolme/src/block_fallback_policy.rs
@@ -118,6 +118,21 @@ pub fn parse_provider_block_fallback_response(
         .or_else(|_| parse_fork_block_fallback_response(response, provider, expected_height))
 }
 
+/// Validates block-fallback reconciler base URL input before provider lookups.
+pub fn is_valid_block_fallback_base_url_input(base_url: &str) -> bool {
+    !base_url.trim().is_empty()
+}
+
+/// Validates block-fallback reconciler provider input before provider lookups.
+pub fn is_valid_block_fallback_provider_input(provider: &str) -> bool {
+    !provider.trim().is_empty()
+}
+
+/// Validates block-fallback reconciler lookup budget input.
+pub fn is_valid_block_fallback_lookup_budget(max_block_lookups: u64) -> bool {
+    max_block_lookups > 0
+}
+
 fn optional_block_tx_hashes(
     fields: &HashMap<String, String>,
     field: &'static str,

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -32,9 +32,10 @@ pub use api_codec::{
     KolmeApiNextNonceResponse,
 };
 pub use block_fallback_policy::{
-    parse_block_fallback_response, parse_fork_block_fallback_response,
-    parse_provider_block_fallback_response, KolmeBlockFallbackPolicyError,
-    KolmeBlockFallbackResponse,
+    is_valid_block_fallback_base_url_input, is_valid_block_fallback_lookup_budget,
+    is_valid_block_fallback_provider_input, parse_block_fallback_response,
+    parse_fork_block_fallback_response, parse_provider_block_fallback_response,
+    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
     compose_block_fallback_unresolved_reason, parse_fork_block_txhash,

--- a/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
@@ -1,7 +1,8 @@
 use kamn_kolme::{
-    parse_block_fallback_response, parse_fork_block_fallback_response,
-    parse_provider_block_fallback_response, KolmeBlockFallbackPolicyError,
-    KolmeBlockFallbackResponse,
+    is_valid_block_fallback_base_url_input, is_valid_block_fallback_lookup_budget,
+    is_valid_block_fallback_provider_input, parse_block_fallback_response,
+    parse_fork_block_fallback_response, parse_provider_block_fallback_response,
+    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
 };
 
 #[test]
@@ -102,4 +103,21 @@ fn regression_issue_1751_parse_fork_block_fallback_response_rejects_empty_provid
             reason: "provider must not be empty".to_owned(),
         }
     );
+}
+
+#[test]
+fn functional_block_fallback_policy_accepts_valid_constructor_guard_inputs() {
+    assert!(is_valid_block_fallback_base_url_input(
+        "https://kolme.example"
+    ));
+    assert!(is_valid_block_fallback_provider_input("kolme-fork-local"));
+    assert!(is_valid_block_fallback_lookup_budget(5));
+}
+
+#[test]
+fn regression_issue_1866_block_fallback_policy_rejects_invalid_constructor_guard_inputs() {
+    // Regression: #1866
+    assert!(!is_valid_block_fallback_base_url_input(" "));
+    assert!(!is_valid_block_fallback_provider_input(""));
+    assert!(!is_valid_block_fallback_lookup_budget(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -50,6 +50,7 @@ Out of scope:
 - #1860: extracted poll-attempt budget validation to `kamn-kolme` (`is_valid_poll_attempt_budget`) and rewired `kamn-core` finality poller budget guard delegation.
 - #1862: extracted finality check commit-id request guard to `kamn-kolme` (`is_valid_runtime_commit_id_request`) and rewired `kamn-core` finality checker input validation delegation.
 - #1864: extracted finality checker constructor endpoint input guards to `kamn-kolme` (`is_valid_finality_base_url_input` / `is_valid_finality_status_path_input`) and rewired `kamn-core` constructor guard delegation.
+- #1866: extracted block-fallback constructor input guards to `kamn-kolme` (`is_valid_block_fallback_base_url_input` / `is_valid_block_fallback_provider_input` / `is_valid_block_fallback_lookup_budget`) and rewired `kamn-core` block-fallback constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract block-fallback reconciler constructor guard checks into `kamn-kolme` block-fallback policy contracts (`is_valid_block_fallback_base_url_input`, `is_valid_block_fallback_provider_input`, `is_valid_block_fallback_lookup_budget`).
- Rewire `KolmeRuntimeCommitBlockFallbackReconciler::new` in `kamn-core` to delegate constructor guard validation while preserving field/reason behavior parity.
- Extend extraction boundary and extraction-plan marker coverage for `#1866`.

## Linked Issues
- Closes #1866

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test block_fallback_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1867
