### PR TITLE
refactor(kolme): extract notifications guard contracts (#1868)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -20,6 +20,8 @@ use kamn_kolme::{
     is_valid_block_fallback_provider_input as is_kolme_valid_block_fallback_provider_input_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
+    is_valid_notifications_provider_input as is_kolme_valid_notifications_provider_input_contract,
+    is_valid_notifications_reconnect_budget as is_kolme_valid_notifications_reconnect_budget_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
@@ -1565,13 +1567,13 @@ where
         max_reconnect_attempts: u32,
         connector: C,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        if provider.trim().is_empty() {
+        if !is_kolme_valid_notifications_provider_input_contract(provider) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "notifications_provider",
                 reason: "must not be empty",
             });
         }
-        if max_reconnect_attempts == 0 {
+        if !is_kolme_valid_notifications_reconnect_budget_contract(max_reconnect_attempts) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "notifications_max_reconnect_attempts",
                 reason: "must be positive",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -84,6 +84,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_status_path_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_notifications_provider_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_notifications_reconnect_budget_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -33,6 +33,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1862"));
     assert!(DOC.contains("#1864"));
     assert!(DOC.contains("#1866"));
+    assert!(DOC.contains("#1868"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -63,6 +63,7 @@ pub use flat_json_policy::{
 };
 pub use http_response_policy::{parse_http_response_body, KolmeHttpResponsePolicyError};
 pub use notification_policy::{
+    is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
     notification_event_to_provider_receipt, notification_event_to_receipt,
     parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
     KolmeNotificationReceipt, KolmeProviderNotificationReceipt,

--- a/crates/kamn-kolme/src/notification_policy.rs
+++ b/crates/kamn-kolme/src/notification_policy.rs
@@ -159,6 +159,16 @@ pub fn notification_event_to_provider_receipt(
     })
 }
 
+/// Validates notifications consumer provider input.
+pub fn is_valid_notifications_provider_input(provider: &str) -> bool {
+    !provider.trim().is_empty()
+}
+
+/// Validates notifications consumer reconnect budget input.
+pub fn is_valid_notifications_reconnect_budget(max_reconnect_attempts: u32) -> bool {
+    max_reconnect_attempts > 0
+}
+
 fn find_notification_string_field(
     payload: &str,
     field: &str,
@@ -369,7 +379,10 @@ fn parse_json_string(token: &str) -> Result<String, &'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError};
+    use super::{
+        is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
+        parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
+    };
 
     #[test]
     fn unit_parse_notification_event_rejects_empty_payload() {
@@ -393,5 +406,13 @@ mod tests {
                 proposed_height: Some(44),
             }
         );
+    }
+
+    #[test]
+    fn unit_validates_notifications_consumer_guard_inputs() {
+        assert!(is_valid_notifications_provider_input("kolme-fork-local"));
+        assert!(!is_valid_notifications_provider_input(" "));
+        assert!(is_valid_notifications_reconnect_budget(2));
+        assert!(!is_valid_notifications_reconnect_budget(0));
     }
 }

--- a/crates/kamn-kolme/tests/notification_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/notification_policy_contracts.rs
@@ -1,4 +1,5 @@
 use kamn_kolme::{
+    is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
     notification_event_to_provider_receipt as notification_event_to_provider_receipt_contract,
     notification_event_to_receipt as notification_event_to_receipt_contract,
     parse_notification_event, KolmeCommitReceiptFinality, KolmeNotificationEvent,
@@ -96,4 +97,17 @@ fn regression_issue_1852_notification_event_to_provider_receipt_rejects_empty_pr
         },
     );
     assert_eq!(receipt, None);
+}
+
+#[test]
+fn functional_notification_policy_accepts_valid_notifications_consumer_inputs() {
+    assert!(is_valid_notifications_provider_input("kolme-fork-local"));
+    assert!(is_valid_notifications_reconnect_budget(2));
+}
+
+#[test]
+fn regression_issue_1868_notification_policy_rejects_invalid_notifications_consumer_inputs() {
+    // Regression: #1868
+    assert!(!is_valid_notifications_provider_input(" "));
+    assert!(!is_valid_notifications_reconnect_budget(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -51,6 +51,7 @@ Out of scope:
 - #1862: extracted finality check commit-id request guard to `kamn-kolme` (`is_valid_runtime_commit_id_request`) and rewired `kamn-core` finality checker input validation delegation.
 - #1864: extracted finality checker constructor endpoint input guards to `kamn-kolme` (`is_valid_finality_base_url_input` / `is_valid_finality_status_path_input`) and rewired `kamn-core` constructor guard delegation.
 - #1866: extracted block-fallback constructor input guards to `kamn-kolme` (`is_valid_block_fallback_base_url_input` / `is_valid_block_fallback_provider_input` / `is_valid_block_fallback_lookup_budget`) and rewired `kamn-core` block-fallback constructor guard delegation.
+- #1868: extracted notifications consumer constructor guard contracts to `kamn-kolme` (`is_valid_notifications_provider_input` / `is_valid_notifications_reconnect_budget`) and rewired `kamn-core` notifications consumer guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract notifications consumer constructor guard checks into `kamn-kolme` notification-policy contracts (`is_valid_notifications_provider_input`, `is_valid_notifications_reconnect_budget`).
- Rewire `KolmeRuntimeCommitNotificationsConsumer::new` in `kamn-core` to delegate constructor guard validation while preserving invalid-request field/reason parity.
- Extend extraction boundary and extraction-plan marker coverage for `#1868`.

## Linked Issues
- Closes #1868

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test notification_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
- `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1869
