### PR TITLE
refactor(kolme): extract websocket timeout guard contract (#1870)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -24,6 +24,7 @@ use kamn_kolme::{
     is_valid_notifications_reconnect_budget as is_kolme_valid_notifications_reconnect_budget_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
+    is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
@@ -1412,7 +1413,7 @@ pub struct KolmeRuntimeCommitWebsocketConnector {
 impl KolmeRuntimeCommitWebsocketConnector {
     /// Builds a websocket connector with deterministic timeout validation.
     pub fn new(timeout_seconds: u64) -> Result<Self, KolmeRuntimeCommitError> {
-        if timeout_seconds == 0 {
+        if !is_kolme_valid_websocket_timeout_seconds_contract(timeout_seconds) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "notifications_timeout_seconds",
                 reason: "must be positive",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -91,6 +91,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_websocket_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_provider_receipt_identity_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("require_kolme_final_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -34,6 +34,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1864"));
     assert!(DOC.contains("#1866"));
     assert!(DOC.contains("#1868"));
+    assert!(DOC.contains("#1870"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -104,8 +104,8 @@ pub use transport_request_policy::{
     is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,
 };
 pub use websocket_policy::{
-    find_http_header_boundary, try_take_websocket_frame, validate_websocket_handshake_response,
-    KolmeWebsocketFrame, KolmeWebsocketPolicyError,
+    find_http_header_boundary, is_valid_websocket_timeout_seconds, try_take_websocket_frame,
+    validate_websocket_handshake_response, KolmeWebsocketFrame, KolmeWebsocketPolicyError,
 };
 
 #[cfg(test)]

--- a/crates/kamn-kolme/src/websocket_policy.rs
+++ b/crates/kamn-kolme/src/websocket_policy.rs
@@ -224,11 +224,16 @@ pub fn try_take_websocket_frame(
     Ok(Some(frame))
 }
 
+/// Validates websocket connector timeout input in seconds.
+pub fn is_valid_websocket_timeout_seconds(timeout_seconds: u64) -> bool {
+    timeout_seconds > 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        find_http_header_boundary, try_take_websocket_frame, validate_websocket_handshake_response,
-        KolmeWebsocketFrame, KolmeWebsocketPolicyError,
+        find_http_header_boundary, is_valid_websocket_timeout_seconds, try_take_websocket_frame,
+        validate_websocket_handshake_response, KolmeWebsocketFrame, KolmeWebsocketPolicyError,
     };
 
     #[test]
@@ -270,5 +275,11 @@ mod tests {
                 .expect("frame should be available"),
             KolmeWebsocketFrame::Close
         );
+    }
+
+    #[test]
+    fn unit_validates_websocket_timeout_seconds_input() {
+        assert!(is_valid_websocket_timeout_seconds(2));
+        assert!(!is_valid_websocket_timeout_seconds(0));
     }
 }

--- a/crates/kamn-kolme/tests/websocket_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/websocket_policy_contracts.rs
@@ -1,5 +1,6 @@
 use kamn_kolme::{
-    try_take_websocket_frame, validate_websocket_handshake_response, KolmeWebsocketFrame,
+    is_valid_websocket_timeout_seconds, try_take_websocket_frame,
+    validate_websocket_handshake_response, KolmeWebsocketFrame,
 };
 
 #[test]
@@ -23,4 +24,16 @@ fn regression_issue_1739_handshake_validation_fails_closed() {
         error.to_string(),
         "websocket handshake response missing upgrade headers"
     );
+}
+
+#[test]
+fn functional_websocket_policy_accepts_positive_timeout_seconds() {
+    assert!(is_valid_websocket_timeout_seconds(1));
+    assert!(is_valid_websocket_timeout_seconds(5));
+}
+
+#[test]
+fn regression_issue_1870_websocket_policy_rejects_zero_timeout_seconds() {
+    // Regression: #1870
+    assert!(!is_valid_websocket_timeout_seconds(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -52,6 +52,7 @@ Out of scope:
 - #1864: extracted finality checker constructor endpoint input guards to `kamn-kolme` (`is_valid_finality_base_url_input` / `is_valid_finality_status_path_input`) and rewired `kamn-core` constructor guard delegation.
 - #1866: extracted block-fallback constructor input guards to `kamn-kolme` (`is_valid_block_fallback_base_url_input` / `is_valid_block_fallback_provider_input` / `is_valid_block_fallback_lookup_budget`) and rewired `kamn-core` block-fallback constructor guard delegation.
 - #1868: extracted notifications consumer constructor guard contracts to `kamn-kolme` (`is_valid_notifications_provider_input` / `is_valid_notifications_reconnect_budget`) and rewired `kamn-core` notifications consumer guard delegation.
+- #1870: extracted websocket connector timeout guard contract to `kamn-kolme` (`is_valid_websocket_timeout_seconds`) and rewired `kamn-core` websocket connector constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract websocket connector timeout guard into `kamn-kolme` websocket policy via `is_valid_websocket_timeout_seconds`.
- Rewire `KolmeRuntimeCommitWebsocketConnector::new` in `kamn-core` to delegate timeout guard validation while preserving invalid-request field/reason parity.
- Extend extraction boundary and extraction-plan marker coverage for `#1870`.

## Linked Issues
- Closes #1870

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test websocket_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1871
