### PR TITLE
refactor(kolme): extract live provider endpoint guards (#1872)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -20,6 +20,8 @@ use kamn_kolme::{
     is_valid_block_fallback_provider_input as is_kolme_valid_block_fallback_provider_input_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
+    is_valid_live_provider_base_url_input as is_kolme_valid_live_provider_base_url_input_contract,
+    is_valid_live_provider_submit_path_input as is_kolme_valid_live_provider_submit_path_input_contract,
     is_valid_notifications_provider_input as is_kolme_valid_notifications_provider_input_contract,
     is_valid_notifications_reconnect_budget as is_kolme_valid_notifications_reconnect_budget_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
@@ -1749,13 +1751,13 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
         submit_path: &str,
         transport: T,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        if base_url.trim().is_empty() {
+        if !is_kolme_valid_live_provider_base_url_input_contract(base_url) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider_base_url",
                 reason: "must not be empty",
             });
         }
-        if submit_path.trim().is_empty() {
+        if !is_kolme_valid_live_provider_submit_path_input_contract(submit_path) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider_submit_path",
                 reason: "must not be empty",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -62,6 +62,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_submit_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_notifications_websocket_url("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -35,6 +35,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1866"));
     assert!(DOC.contains("#1868"));
     assert!(DOC.contains("#1870"));
+    assert!(DOC.contains("#1872"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/endpoint_policy.rs
+++ b/crates/kamn-kolme/src/endpoint_policy.rs
@@ -126,6 +126,16 @@ pub fn is_valid_finality_status_path_input(status_path: &str) -> bool {
     !status_path.trim().is_empty()
 }
 
+/// Validates live provider base URL input before broadcast submit requests.
+pub fn is_valid_live_provider_base_url_input(base_url: &str) -> bool {
+    !base_url.trim().is_empty()
+}
+
+/// Validates live provider submit path input before broadcast submit requests.
+pub fn is_valid_live_provider_submit_path_input(submit_path: &str) -> bool {
+    !submit_path.trim().is_empty()
+}
+
 /// Composes websocket notifications URL from HTTP base URL + notifications path.
 pub fn compose_notifications_websocket_url(
     base_url: &str,
@@ -286,8 +296,9 @@ fn percent_encode(value: &str) -> String {
 mod tests {
     use super::{
         compose_finality_status_path, compose_notifications_websocket_url,
-        is_valid_finality_base_url_input, is_valid_finality_status_path_input, parse_http_endpoint,
-        parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
+        is_valid_finality_base_url_input, is_valid_finality_status_path_input,
+        is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
+        parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
     };
 
     #[test]
@@ -349,5 +360,15 @@ mod tests {
             "/runtime-commit/status"
         ));
         assert!(!is_valid_finality_status_path_input(" "));
+    }
+
+    #[test]
+    fn unit_validates_live_provider_endpoint_inputs() {
+        assert!(is_valid_live_provider_base_url_input("https://kolme.local"));
+        assert!(!is_valid_live_provider_base_url_input(" "));
+        assert!(is_valid_live_provider_submit_path_input(
+            "/broadcast/runtime-commit"
+        ));
+        assert!(!is_valid_live_provider_submit_path_input(""));
     }
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -48,9 +48,10 @@ pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPa
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use endpoint_policy::{
     compose_finality_status_path, compose_notifications_websocket_url,
-    is_valid_finality_base_url_input, is_valid_finality_status_path_input, parse_http_endpoint,
-    parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
-    KolmeParsedWebsocketEndpoint,
+    is_valid_finality_base_url_input, is_valid_finality_status_path_input,
+    is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
+    parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
+    KolmeParsedHttpEndpoint, KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
 pub use finality_receipt_policy::{

--- a/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
@@ -1,7 +1,8 @@
 use kamn_kolme::{
     compose_finality_status_path, compose_notifications_websocket_url,
-    is_valid_finality_base_url_input, is_valid_finality_status_path_input, parse_http_endpoint,
-    parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
+    is_valid_finality_base_url_input, is_valid_finality_status_path_input,
+    is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
+    parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
 };
 
 #[test]
@@ -70,4 +71,21 @@ fn regression_issue_1864_endpoint_policy_rejects_empty_finality_checker_inputs()
     // Regression: #1864
     assert!(!is_valid_finality_base_url_input("   "));
     assert!(!is_valid_finality_status_path_input(""));
+}
+
+#[test]
+fn functional_endpoint_policy_accepts_non_empty_live_provider_inputs() {
+    assert!(is_valid_live_provider_base_url_input(
+        "https://kolme.example"
+    ));
+    assert!(is_valid_live_provider_submit_path_input(
+        "/broadcast/runtime-commit"
+    ));
+}
+
+#[test]
+fn regression_issue_1872_endpoint_policy_rejects_empty_live_provider_inputs() {
+    // Regression: #1872
+    assert!(!is_valid_live_provider_base_url_input(""));
+    assert!(!is_valid_live_provider_submit_path_input("   "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -53,6 +53,7 @@ Out of scope:
 - #1866: extracted block-fallback constructor input guards to `kamn-kolme` (`is_valid_block_fallback_base_url_input` / `is_valid_block_fallback_provider_input` / `is_valid_block_fallback_lookup_budget`) and rewired `kamn-core` block-fallback constructor guard delegation.
 - #1868: extracted notifications consumer constructor guard contracts to `kamn-kolme` (`is_valid_notifications_provider_input` / `is_valid_notifications_reconnect_budget`) and rewired `kamn-core` notifications consumer guard delegation.
 - #1870: extracted websocket connector timeout guard contract to `kamn-kolme` (`is_valid_websocket_timeout_seconds`) and rewired `kamn-core` websocket connector constructor guard delegation.
+- #1872: extracted live provider constructor endpoint guard contracts to `kamn-kolme` (`is_valid_live_provider_base_url_input` / `is_valid_live_provider_submit_path_input`) and rewired `kamn-core` live provider constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract live provider constructor endpoint guards into `kamn-kolme` endpoint-policy contracts (`is_valid_live_provider_base_url_input`, `is_valid_live_provider_submit_path_input`).
- Rewire `KolmeRuntimeCommitLiveProvider::new` in `kamn-core` to delegate guard validation while preserving invalid-request field/reason parity.
- Extend extraction boundary and extraction-plan marker coverage for `#1872`.

## Linked Issues
- Closes #1872

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test endpoint_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1873
