### PR TITLE
refactor(kolme): extract http transport timeout guard contract (#1874)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -20,6 +20,7 @@ use kamn_kolme::{
     is_valid_block_fallback_provider_input as is_kolme_valid_block_fallback_provider_input_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
+    is_valid_http_transport_timeout_seconds as is_kolme_valid_http_transport_timeout_seconds_contract,
     is_valid_live_provider_base_url_input as is_kolme_valid_live_provider_base_url_input_contract,
     is_valid_live_provider_submit_path_input as is_kolme_valid_live_provider_submit_path_input_contract,
     is_valid_notifications_provider_input as is_kolme_valid_notifications_provider_input_contract,
@@ -821,7 +822,7 @@ pub struct KolmeRuntimeCommitHttpTransport {
 impl KolmeRuntimeCommitHttpTransport {
     /// Builds a concrete HTTP transport with deterministic timeout validation.
     pub fn new(timeout_seconds: u64) -> Result<Self, KolmeRuntimeCommitError> {
-        if timeout_seconds == 0 {
+        if !is_kolme_valid_http_transport_timeout_seconds_contract(timeout_seconds) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "transport_timeout_seconds",
                 reason: "must be positive",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -101,5 +101,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -36,6 +36,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1868"));
     assert!(DOC.contains("#1870"));
     assert!(DOC.contains("#1872"));
+    assert!(DOC.contains("#1874"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -297,6 +297,20 @@ fn spawn_server_with_raw_response(
 }
 
 #[test]
+fn unit_http_transport_rejects_zero_timeout_seconds() {
+    assert!(
+        matches!(
+            KolmeRuntimeCommitHttpTransport::new(0),
+            Err(kamn_core::KolmeRuntimeCommitError::InvalidRequest {
+                field: "transport_timeout_seconds",
+                reason: "must be positive",
+            })
+        ),
+        "http transport timeout must be positive"
+    );
+}
+
+#[test]
 fn integration_http_transport_submit_and_response_mapping() {
     let wire_payload = "operation_id=op-1\nstate_root=state-1\n";
     let idempotency_key = "kolme-runtime-commit:op-1:state-1:agent-1:1:payload-1";

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -98,8 +98,9 @@ pub use tls_policy::{
     KolmeTlsPolicyError,
 };
 pub use transport::{
-    classify_transport_io_error, EchoTransport, KolmeTransport, KolmeTransportIoClassification,
-    TransportError, TransportRequest, TransportResponse,
+    classify_transport_io_error, is_valid_http_transport_timeout_seconds, EchoTransport,
+    KolmeTransport, KolmeTransportIoClassification, TransportError, TransportRequest,
+    TransportResponse,
 };
 pub use transport_request_policy::{
     is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,

--- a/crates/kamn-kolme/src/transport.rs
+++ b/crates/kamn-kolme/src/transport.rs
@@ -83,6 +83,11 @@ pub fn classify_transport_io_error(error: &std::io::Error) -> KolmeTransportIoCl
     }
 }
 
+/// Validates HTTP transport timeout configuration in seconds.
+pub fn is_valid_http_transport_timeout_seconds(timeout_seconds: u64) -> bool {
+    timeout_seconds > 0
+}
+
 /// Transport boundary for runtime-commit submissions.
 pub trait KolmeTransport {
     /// Submits a request and returns a response envelope.
@@ -104,7 +109,10 @@ impl KolmeTransport for EchoTransport {
 
 #[cfg(test)]
 mod tests {
-    use super::{EchoTransport, KolmeTransport, TransportError, TransportRequest};
+    use super::{
+        is_valid_http_transport_timeout_seconds, EchoTransport, KolmeTransport, TransportError,
+        TransportRequest,
+    };
 
     #[test]
     fn unit_echo_transport_requires_endpoint() {
@@ -128,5 +136,11 @@ mod tests {
             .expect("submit should succeed");
         assert_eq!(response.status, 200);
         assert_eq!(response.body, payload);
+    }
+
+    #[test]
+    fn unit_validates_http_transport_timeout_seconds_input() {
+        assert!(is_valid_http_transport_timeout_seconds(1));
+        assert!(!is_valid_http_transport_timeout_seconds(0));
     }
 }

--- a/crates/kamn-kolme/tests/transport_io_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_io_policy_contracts.rs
@@ -1,5 +1,6 @@
 use kamn_kolme::{
-    classify_transport_io_error, KolmeTransportIoClassification as TransportIoClassification,
+    classify_transport_io_error, is_valid_http_transport_timeout_seconds,
+    KolmeTransportIoClassification as TransportIoClassification,
 };
 use std::io;
 
@@ -27,4 +28,16 @@ fn unit_classify_transport_io_error_maps_other_kinds_to_unavailable() {
             reason: "transport io error: reset by peer".to_owned(),
         }
     );
+}
+
+#[test]
+fn functional_transport_io_policy_accepts_positive_http_transport_timeout() {
+    assert!(is_valid_http_transport_timeout_seconds(1));
+    assert!(is_valid_http_transport_timeout_seconds(3));
+}
+
+#[test]
+fn regression_issue_1874_transport_io_policy_rejects_zero_http_transport_timeout() {
+    // Regression: #1874
+    assert!(!is_valid_http_transport_timeout_seconds(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -54,6 +54,7 @@ Out of scope:
 - #1868: extracted notifications consumer constructor guard contracts to `kamn-kolme` (`is_valid_notifications_provider_input` / `is_valid_notifications_reconnect_budget`) and rewired `kamn-core` notifications consumer guard delegation.
 - #1870: extracted websocket connector timeout guard contract to `kamn-kolme` (`is_valid_websocket_timeout_seconds`) and rewired `kamn-core` websocket connector constructor guard delegation.
 - #1872: extracted live provider constructor endpoint guard contracts to `kamn-kolme` (`is_valid_live_provider_base_url_input` / `is_valid_live_provider_submit_path_input`) and rewired `kamn-core` live provider constructor guard delegation.
+- #1874: extracted HTTP transport timeout guard contract to `kamn-kolme` (`is_valid_http_transport_timeout_seconds`) and rewired `kamn-core` HTTP transport constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract HTTP transport timeout guard into `kamn-kolme` transport policy via `is_valid_http_transport_timeout_seconds`.
- Rewire `KolmeRuntimeCommitHttpTransport::new` in `kamn-core` to delegate timeout validation while preserving invalid-request field/reason parity.
- Add a core regression guard test for zero-timeout construction and extend extraction boundary/doc markers for `#1874`.

## Linked Issues
- Closes #1874

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test transport_io_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1875
