### PR TITLE
refactor(kolme): extract block-fetch height guard contract (#1876)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -18,6 +18,7 @@ use kamn_kolme::{
     is_valid_block_fallback_base_url_input as is_kolme_valid_block_fallback_base_url_input_contract,
     is_valid_block_fallback_lookup_budget as is_kolme_valid_block_fallback_lookup_budget_contract,
     is_valid_block_fallback_provider_input as is_kolme_valid_block_fallback_provider_input_contract,
+    is_valid_block_lookup_height as is_kolme_valid_block_lookup_height_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
     is_valid_http_transport_timeout_seconds as is_kolme_valid_http_transport_timeout_seconds_contract,
@@ -1152,7 +1153,7 @@ impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTranspor
         block_path_template: &str,
         height: u64,
     ) -> Result<String, KolmeRuntimeCommitProviderError> {
-        if height == 0 {
+        if !is_kolme_valid_block_lookup_height_contract(height) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "block height must be positive".to_owned(),
             });

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -67,6 +67,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_notifications_websocket_url("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_lookup_height_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_block_fallback_response_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_provider_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -37,6 +37,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1870"));
     assert!(DOC.contains("#1872"));
     assert!(DOC.contains("#1874"));
+    assert!(DOC.contains("#1876"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -1,8 +1,8 @@
 use kamn_core::{
     KolmeApiBroadcastRequest, KolmeApiNextNonceRequest, KolmeCommitReceiptFinality,
-    KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitHttpTransport,
-    KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
-    KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitRequest,
+    KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitFinalityChecker,
+    KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitProvider,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitRequest,
 };
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
@@ -307,6 +307,17 @@ fn unit_http_transport_rejects_zero_timeout_seconds() {
             })
         ),
         "http transport timeout must be positive"
+    );
+}
+
+#[test]
+fn unit_http_transport_block_fetch_rejects_zero_height() {
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(1).expect("transport should build");
+    assert_eq!(
+        transport.fetch_block_by_height("http://127.0.0.1:3030", "/block/{height}", 0),
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "block height must be positive".to_owned(),
+        })
     );
 }
 

--- a/crates/kamn-kolme/src/block_scan_policy.rs
+++ b/crates/kamn-kolme/src/block_scan_policy.rs
@@ -152,6 +152,11 @@ pub fn validate_lookup_txhash(txhash: &str) -> Result<String, BlockScanPolicyErr
     Ok(normalized.to_owned())
 }
 
+/// Validates one concrete block lookup request height.
+pub fn is_valid_block_lookup_height(height: u64) -> bool {
+    height > 0
+}
+
 /// Resolves block-fallback upper bound using one latest-block notification height.
 pub fn resolve_lookup_upper_bound(
     from_height: u64,
@@ -323,8 +328,9 @@ fn skip_ascii_whitespace(value: &str, mut cursor: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_fork_block_txhash, render_block_path, validate_block_identity,
-        validate_block_path_template, validate_lookup_window, BlockScanPolicyError,
+        is_valid_block_lookup_height, parse_fork_block_txhash, render_block_path,
+        validate_block_identity, validate_block_path_template, validate_lookup_window,
+        BlockScanPolicyError,
     };
 
     #[test]
@@ -367,5 +373,11 @@ mod tests {
                 reason: "notification field 'txhash' must not be empty".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn unit_validates_block_lookup_height_input() {
+        assert!(is_valid_block_lookup_height(1));
+        assert!(!is_valid_block_lookup_height(0));
     }
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -38,11 +38,11 @@ pub use block_fallback_policy::{
     KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
-    compose_block_fallback_unresolved_reason, parse_fork_block_txhash,
-    project_failed_block_txhash_receipt, project_finalized_block_txhash_receipt, render_block_path,
-    resolve_lookup_upper_bound, validate_block_identity, validate_block_path_template,
-    validate_lookup_txhash, validate_lookup_window, BlockScanPolicyError,
-    BlockScanReceiptProjection,
+    compose_block_fallback_unresolved_reason, is_valid_block_lookup_height,
+    parse_fork_block_txhash, project_failed_block_txhash_receipt,
+    project_finalized_block_txhash_receipt, render_block_path, resolve_lookup_upper_bound,
+    validate_block_identity, validate_block_path_template, validate_lookup_txhash,
+    validate_lookup_window, BlockScanPolicyError, BlockScanReceiptProjection,
 };
 pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};

--- a/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
+++ b/crates/kamn-kolme/tests/finality_block_scan_contracts.rs
@@ -1,6 +1,6 @@
 use kamn_kolme::{
     compose_block_fallback_unresolved_reason as compose_block_fallback_unresolved_reason_contract,
-    parse_fork_block_txhash, parse_receipt_finality,
+    is_valid_block_lookup_height, parse_fork_block_txhash, parse_receipt_finality,
     project_failed_block_txhash_receipt as project_failed_block_txhash_receipt_contract,
     project_finalized_block_txhash_receipt as project_finalized_block_txhash_receipt_contract,
     render_block_path, resolve_lookup_upper_bound, validate_block_identity,
@@ -117,4 +117,16 @@ fn regression_issue_1856_validate_lookup_txhash_rejects_empty_input_and_unresolv
         reason,
         "block fallback did not resolve txhash 'ab12cd34' between heights 40 and 45".to_owned()
     );
+}
+
+#[test]
+fn functional_block_scan_policy_accepts_positive_block_lookup_height() {
+    assert!(is_valid_block_lookup_height(1));
+    assert!(is_valid_block_lookup_height(42));
+}
+
+#[test]
+fn regression_issue_1876_block_scan_policy_rejects_zero_block_lookup_height() {
+    // Regression: #1876
+    assert!(!is_valid_block_lookup_height(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -55,6 +55,7 @@ Out of scope:
 - #1870: extracted websocket connector timeout guard contract to `kamn-kolme` (`is_valid_websocket_timeout_seconds`) and rewired `kamn-core` websocket connector constructor guard delegation.
 - #1872: extracted live provider constructor endpoint guard contracts to `kamn-kolme` (`is_valid_live_provider_base_url_input` / `is_valid_live_provider_submit_path_input`) and rewired `kamn-core` live provider constructor guard delegation.
 - #1874: extracted HTTP transport timeout guard contract to `kamn-kolme` (`is_valid_http_transport_timeout_seconds`) and rewired `kamn-core` HTTP transport constructor guard delegation.
+- #1876: extracted HTTP block-fetch height guard contract to `kamn-kolme` (`is_valid_block_lookup_height`) and rewired `kamn-core` block-fetch transport height validation delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract block-fetch request height guard into `kamn-kolme` block-scan policy via `is_valid_block_lookup_height`.
- Rewire `KolmeRuntimeCommitHttpTransport::fetch_block_by_height` in `kamn-core` to delegate height guard validation while preserving malformed-response reason parity.
- Add a core regression test for zero-height block fetch and extend extraction boundary/doc markers for `#1876`.

## Linked Issues
- Closes #1876

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test finality_block_scan_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1877
