### PR TITLE
refactor(kolme): extract adapter expected-provider guard contract (#1878)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -19,6 +19,7 @@ use kamn_kolme::{
     is_valid_block_fallback_lookup_budget as is_kolme_valid_block_fallback_lookup_budget_contract,
     is_valid_block_fallback_provider_input as is_kolme_valid_block_fallback_provider_input_contract,
     is_valid_block_lookup_height as is_kolme_valid_block_lookup_height_contract,
+    is_valid_expected_provider_input as is_kolme_valid_expected_provider_input_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
     is_valid_http_transport_timeout_seconds as is_kolme_valid_http_transport_timeout_seconds_contract,
@@ -1826,7 +1827,7 @@ pub struct AdapterBackedKolmeRuntimeCommitClient<P> {
 impl<P: KolmeRuntimeCommitProvider> AdapterBackedKolmeRuntimeCommitClient<P> {
     /// Builds adapter-backed client with expected provider identifier.
     pub fn new(expected_provider: &str, provider: P) -> Result<Self, KolmeRuntimeCommitError> {
-        if expected_provider.trim().is_empty() {
+        if !is_kolme_valid_expected_provider_input_contract(expected_provider) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "expected_provider",
                 reason: "must not be empty",

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -515,6 +515,24 @@ fn unit_live_provider_rejects_empty_endpoint_or_submit_path() {
 }
 
 #[test]
+fn unit_adapter_backed_client_rejects_empty_expected_provider() {
+    let (provider, _calls) =
+        RecordingProvider::with_result(Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "unused".to_owned(),
+        }));
+    assert!(
+        matches!(
+            AdapterBackedKolmeRuntimeCommitClient::new(" ", provider),
+            Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "expected_provider",
+                reason: "must not be empty",
+            })
+        ),
+        "expected provider should fail validation when empty"
+    );
+}
+
+#[test]
 fn functional_live_provider_maps_submitted_json_response_to_provider_outcome() {
     let response = r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:runtime:55","finality":"final"}"#.to_owned();
     let (transport, calls) = RecordingTransport::with_result(Ok(response));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -64,6 +64,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_submit_path_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_expected_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_notifications_websocket_url("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -38,6 +38,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1872"));
     assert!(DOC.contains("#1874"));
     assert!(DOC.contains("#1876"));
+    assert!(DOC.contains("#1878"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -71,11 +71,11 @@ pub use notification_policy::{
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
-    deterministic_backend_commit_id, parse_commit_id_from_response_fields,
-    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
-    require_commit_id_matches_expected_txhash, required_provider_response_field,
-    txhash_from_commit_id, validate_provider_receipt_identity, KolmeProviderOutcome,
-    KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    deterministic_backend_commit_id, is_valid_expected_provider_input,
+    parse_commit_id_from_response_fields, parse_live_provider_outcome,
+    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
+    required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,
+    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
     KolmeRuntimeProviderOutcome,
 };
 pub use provider_response_policy::{

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -315,6 +315,11 @@ pub fn validate_provider_receipt_identity(
     Ok(())
 }
 
+/// Validates adapter expected-provider input before receipt identity enforcement.
+pub fn is_valid_expected_provider_input(expected_provider: &str) -> bool {
+    !expected_provider.trim().is_empty()
+}
+
 fn required_response_field(
     fields: &HashMap<String, String>,
     field: &'static str,

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,8 +1,8 @@
 use kamn_kolme::{
-    deterministic_backend_commit_id, parse_commit_id_from_response_fields,
-    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
-    require_commit_id_matches_expected_txhash, required_provider_response_field,
-    txhash_from_commit_id,
+    deterministic_backend_commit_id, is_valid_expected_provider_input,
+    parse_commit_id_from_response_fields, parse_live_provider_outcome,
+    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
+    required_provider_response_field, txhash_from_commit_id,
     validate_provider_receipt_identity as validate_provider_receipt_identity_contract,
     KolmeCommitReceiptFinality, KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
     KolmeProviderReceiptIdentityError, KolmeRuntimeProviderOutcome, ReceiptFinality,
@@ -183,4 +183,15 @@ fn regression_issue_1842_validate_provider_receipt_identity_rejects_mismatch_and
         empty_commit_id_error,
         KolmeProviderReceiptIdentityError::EmptyCommitId
     );
+}
+
+#[test]
+fn functional_provider_outcome_policy_accepts_non_empty_expected_provider_input() {
+    assert!(is_valid_expected_provider_input("kolme-fork"));
+}
+
+#[test]
+fn regression_issue_1878_provider_outcome_policy_rejects_empty_expected_provider_input() {
+    // Regression: #1878
+    assert!(!is_valid_expected_provider_input(" "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -56,6 +56,7 @@ Out of scope:
 - #1872: extracted live provider constructor endpoint guard contracts to `kamn-kolme` (`is_valid_live_provider_base_url_input` / `is_valid_live_provider_submit_path_input`) and rewired `kamn-core` live provider constructor guard delegation.
 - #1874: extracted HTTP transport timeout guard contract to `kamn-kolme` (`is_valid_http_transport_timeout_seconds`) and rewired `kamn-core` HTTP transport constructor guard delegation.
 - #1876: extracted HTTP block-fetch height guard contract to `kamn-kolme` (`is_valid_block_lookup_height`) and rewired `kamn-core` block-fetch transport height validation delegation.
+- #1878: extracted adapter expected-provider guard contract to `kamn-kolme` (`is_valid_expected_provider_input`) and rewired `kamn-core` adapter-backed client constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract adapter expected-provider constructor guard into `kamn-kolme` provider-outcome policy via `is_valid_expected_provider_input`.
- Rewire `AdapterBackedKolmeRuntimeCommitClient::new` in `kamn-core` to delegate expected-provider validation while preserving invalid-request field/reason parity.
- Add a core regression test for empty expected-provider rejection and extend extraction boundary/doc markers for `#1878`.

## Linked Issues
- Closes #1878

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test provider_outcome_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1879
