### PR TITLE
refactor(kolme): extract in-memory provider guard contract (#1880)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -29,6 +29,7 @@ use kamn_kolme::{
     is_valid_notifications_reconnect_budget as is_kolme_valid_notifications_reconnect_budget_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
+    is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
@@ -2045,7 +2046,7 @@ pub struct InMemoryKolmeRuntimeCommitClient {
 impl InMemoryKolmeRuntimeCommitClient {
     /// Constructs an in-memory commit client.
     pub fn new(provider: &str) -> Result<Self, KolmeRuntimeCommitError> {
-        if provider.trim().is_empty() {
+        if !is_kolme_valid_runtime_provider_input_contract(provider) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider",
                 reason: "must not be empty",

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -533,6 +533,20 @@ fn unit_adapter_backed_client_rejects_empty_expected_provider() {
 }
 
 #[test]
+fn unit_in_memory_client_rejects_empty_provider() {
+    assert!(
+        matches!(
+            InMemoryKolmeRuntimeCommitClient::new(""),
+            Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider",
+                reason: "must not be empty",
+            })
+        ),
+        "in-memory provider should fail validation when empty"
+    );
+}
+
+#[test]
 fn functional_live_provider_maps_submitted_json_response_to_provider_outcome() {
     let response = r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:runtime:55","finality":"final"}"#.to_owned();
     let (transport, calls) = RecordingTransport::with_result(Ok(response));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -104,5 +104,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -39,6 +39,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1874"));
     assert!(DOC.contains("#1876"));
     assert!(DOC.contains("#1878"));
+    assert!(DOC.contains("#1880"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -72,10 +72,11 @@ pub use notification_policy::{
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
-    parse_commit_id_from_response_fields, parse_live_provider_outcome,
-    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,
-    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    is_valid_runtime_provider_input, parse_commit_id_from_response_fields,
+    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
+    require_commit_id_matches_expected_txhash, required_provider_response_field,
+    txhash_from_commit_id, validate_provider_receipt_identity, KolmeProviderOutcome,
+    KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
     KolmeRuntimeProviderOutcome,
 };
 pub use provider_response_policy::{

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -317,7 +317,12 @@ pub fn validate_provider_receipt_identity(
 
 /// Validates adapter expected-provider input before receipt identity enforcement.
 pub fn is_valid_expected_provider_input(expected_provider: &str) -> bool {
-    !expected_provider.trim().is_empty()
+    is_valid_runtime_provider_input(expected_provider)
+}
+
+/// Validates runtime provider identifier input for provider-backed clients.
+pub fn is_valid_runtime_provider_input(provider: &str) -> bool {
+    !provider.trim().is_empty()
 }
 
 fn required_response_field(

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,8 +1,9 @@
 use kamn_kolme::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
-    parse_commit_id_from_response_fields, parse_live_provider_outcome,
-    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id,
+    is_valid_runtime_provider_input, parse_commit_id_from_response_fields,
+    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
+    require_commit_id_matches_expected_txhash, required_provider_response_field,
+    txhash_from_commit_id,
     validate_provider_receipt_identity as validate_provider_receipt_identity_contract,
     KolmeCommitReceiptFinality, KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
     KolmeProviderReceiptIdentityError, KolmeRuntimeProviderOutcome, ReceiptFinality,
@@ -194,4 +195,15 @@ fn functional_provider_outcome_policy_accepts_non_empty_expected_provider_input(
 fn regression_issue_1878_provider_outcome_policy_rejects_empty_expected_provider_input() {
     // Regression: #1878
     assert!(!is_valid_expected_provider_input(" "));
+}
+
+#[test]
+fn functional_provider_outcome_policy_accepts_non_empty_runtime_provider_input() {
+    assert!(is_valid_runtime_provider_input("kolme-local"));
+}
+
+#[test]
+fn regression_issue_1880_provider_outcome_policy_rejects_empty_runtime_provider_input() {
+    // Regression: #1880
+    assert!(!is_valid_runtime_provider_input(""));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -57,6 +57,7 @@ Out of scope:
 - #1874: extracted HTTP transport timeout guard contract to `kamn-kolme` (`is_valid_http_transport_timeout_seconds`) and rewired `kamn-core` HTTP transport constructor guard delegation.
 - #1876: extracted HTTP block-fetch height guard contract to `kamn-kolme` (`is_valid_block_lookup_height`) and rewired `kamn-core` block-fetch transport height validation delegation.
 - #1878: extracted adapter expected-provider guard contract to `kamn-kolme` (`is_valid_expected_provider_input`) and rewired `kamn-core` adapter-backed client constructor guard delegation.
+- #1880: extracted in-memory provider guard contract to `kamn-kolme` (`is_valid_runtime_provider_input`) and rewired `kamn-core` in-memory client constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
- Extract in-memory client provider guard into `kamn-kolme` provider-outcome policy via `is_valid_runtime_provider_input`.
- Rewire `InMemoryKolmeRuntimeCommitClient::new` in `kamn-core` to delegate provider validation while preserving invalid-request field/reason parity.
- Add a core regression test for empty in-memory provider rejection and extend extraction boundary/doc markers for `#1880`.

## Linked Issues
- Closes #1880

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Executed locally:
- `cargo test -p kamn-kolme --test provider_outcome_policy_contracts`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert PR #1881
