### PR TITLE
refactor(kolme): extract fork provider-hint guard contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -28,6 +28,7 @@ use kamn_kolme::{
     is_valid_notifications_provider_input as is_kolme_valid_notifications_provider_input_contract,
     is_valid_notifications_reconnect_budget as is_kolme_valid_notifications_reconnect_budget_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
+    is_valid_provider_hint_input as is_kolme_valid_provider_hint_input_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
@@ -1782,13 +1783,13 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
         provider_hint: &str,
         transport: T,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        let provider_hint = provider_hint.trim();
-        if provider_hint.is_empty() {
+        if !is_kolme_valid_provider_hint_input_contract(provider_hint) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "provider_hint",
                 reason: "must not be empty",
             });
         }
+        let provider_hint = provider_hint.trim();
         let mut provider = Self::new(base_url, "/broadcast", transport)?;
         provider.profile = KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast;
         provider.provider_hint = Some(provider_hint.to_owned());

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -105,5 +105,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -40,6 +40,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1876"));
     assert!(DOC.contains("#1878"));
     assert!(DOC.contains("#1880"));
+    assert!(DOC.contains("#1882"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -72,11 +72,11 @@ pub use notification_policy::{
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
-    is_valid_runtime_provider_input, parse_commit_id_from_response_fields,
-    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
-    require_commit_id_matches_expected_txhash, required_provider_response_field,
-    txhash_from_commit_id, validate_provider_receipt_identity, KolmeProviderOutcome,
-    KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    is_valid_provider_hint_input, is_valid_runtime_provider_input,
+    parse_commit_id_from_response_fields, parse_live_provider_outcome,
+    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
+    required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,
+    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
     KolmeRuntimeProviderOutcome,
 };
 pub use provider_response_policy::{

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -325,6 +325,11 @@ pub fn is_valid_runtime_provider_input(provider: &str) -> bool {
     !provider.trim().is_empty()
 }
 
+/// Validates provider hint input for `kolme_fork` submit profile configuration.
+pub fn is_valid_provider_hint_input(provider_hint: &str) -> bool {
+    is_valid_runtime_provider_input(provider_hint)
+}
+
 fn required_response_field(
     fields: &HashMap<String, String>,
     field: &'static str,

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,9 +1,9 @@
 use kamn_kolme::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
-    is_valid_runtime_provider_input, parse_commit_id_from_response_fields,
-    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
-    require_commit_id_matches_expected_txhash, required_provider_response_field,
-    txhash_from_commit_id,
+    is_valid_provider_hint_input, is_valid_runtime_provider_input,
+    parse_commit_id_from_response_fields, parse_live_provider_outcome,
+    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
+    required_provider_response_field, txhash_from_commit_id,
     validate_provider_receipt_identity as validate_provider_receipt_identity_contract,
     KolmeCommitReceiptFinality, KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
     KolmeProviderReceiptIdentityError, KolmeRuntimeProviderOutcome, ReceiptFinality,
@@ -206,4 +206,15 @@ fn functional_provider_outcome_policy_accepts_non_empty_runtime_provider_input()
 fn regression_issue_1880_provider_outcome_policy_rejects_empty_runtime_provider_input() {
     // Regression: #1880
     assert!(!is_valid_runtime_provider_input(""));
+}
+
+#[test]
+fn functional_provider_outcome_policy_accepts_non_empty_provider_hint_input() {
+    assert!(is_valid_provider_hint_input("kolme-fork"));
+}
+
+#[test]
+fn regression_issue_1882_provider_outcome_policy_rejects_empty_provider_hint_input() {
+    // Regression: #1882
+    assert!(!is_valid_provider_hint_input(" \t "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -58,6 +58,7 @@ Out of scope:
 - #1876: extracted HTTP block-fetch height guard contract to `kamn-kolme` (`is_valid_block_lookup_height`) and rewired `kamn-core` block-fetch transport height validation delegation.
 - #1878: extracted adapter expected-provider guard contract to `kamn-kolme` (`is_valid_expected_provider_input`) and rewired `kamn-core` adapter-backed client constructor guard delegation.
 - #1880: extracted in-memory provider guard contract to `kamn-kolme` (`is_valid_runtime_provider_input`) and rewired `kamn-core` in-memory client constructor guard delegation.
+- #1882: extracted fork provider-hint guard contract to `kamn-kolme` (`is_valid_provider_hint_input`) and rewired `kamn-core` fork broadcast profile provider-hint guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts kolme_fork provider-hint guard ownership from kamn-core into kamn-kolme provider-outcome policy contracts, preserving fail-closed InvalidRequest parity while reducing core-local guard logic.

## Changes
- crates/kamn-kolme/src/provider_outcome_policy.rs: add is_valid_provider_hint_input contract helper.
- crates/kamn-kolme/src/lib.rs: export provider-hint guard helper.
- crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs: add functional + regression tests for provider-hint input guard.
- crates/kamn-core/src/kolme_runtime_commit.rs: delegate fork broadcast profile provider_hint guard to kamn-kolme contract.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs: enforce delegation marker for provider-hint guard contract call.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs: require #1882 extraction marker.
- docs/planning/kolme_runtime_commit_extraction_plan.md: record #1882 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-commit suite)
- [x] Manual verification: Verified invalid provider_hint still fails with field=provider_hint and reason=must not be empty.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme provider outcome contracts |
| Functional  | ✅     | provider-hint input guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-commit http transport + extraction boundary/docs |
| Regression  | ✅     | #1882 guard extraction parity + plan marker assertions |

Closes #1882