### PR TITLE
refactor(kolme): extract transport idempotency-key guard contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -31,6 +31,7 @@ use kamn_kolme::{
     is_valid_provider_hint_input as is_kolme_valid_provider_hint_input_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
+    is_valid_transport_idempotency_key_input as is_kolme_valid_transport_idempotency_key_input_contract,
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
@@ -876,12 +877,12 @@ impl KolmeRuntimeCommitHttpTransport {
         request: &KolmeApiBroadcastRequest,
         idempotency_key: &str,
     ) -> Result<KolmeApiBroadcastResponse, KolmeRuntimeCommitProviderError> {
-        let idempotency_key = idempotency_key.trim();
-        if idempotency_key.is_empty() {
+        if !is_kolme_valid_transport_idempotency_key_input_contract(idempotency_key) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "idempotency_key must not be empty".to_owned(),
             });
         }
+        let idempotency_key = idempotency_key.trim();
         let submit_path = if submit_path.trim().is_empty() {
             "/broadcast"
         } else {
@@ -1099,7 +1100,7 @@ impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
                 reason: "wire_payload must not be empty".to_owned(),
             });
         }
-        if idempotency_key.trim().is_empty() {
+        if !is_kolme_valid_transport_idempotency_key_input_contract(idempotency_key) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "idempotency_key must not be empty".to_owned(),
             });

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -106,5 +106,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -41,6 +41,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1878"));
     assert!(DOC.contains("#1880"));
     assert!(DOC.contains("#1882"));
+    assert!(DOC.contains("#1884"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -509,6 +509,25 @@ fn regression_http_transport_rejects_invalid_port_before_network_io() {
 }
 
 #[test]
+fn regression_issue_1884_http_transport_rejects_empty_idempotency_key() {
+    // Regression: #1884
+    let transport = KolmeRuntimeCommitHttpTransport::new(1).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "http://127.0.0.1:1",
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    assert_eq!(
+        provider.submit_runtime_commit("operation_id=op-1\n", " "),
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "idempotency_key must not be empty".to_owned(),
+        })
+    );
+}
+
+#[test]
 fn regression_http_transport_fails_closed_on_content_length_mismatch() {
     let body = "status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n";
     let declared_length = body.len() + 9;

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -104,7 +104,8 @@ pub use transport::{
     TransportResponse,
 };
 pub use transport_request_policy::{
-    is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,
+    is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
+    parse_authorization_header_value, KolmeTransportRequestPolicyError,
 };
 pub use websocket_policy::{
     find_http_header_boundary, is_valid_websocket_timeout_seconds, try_take_websocket_frame,

--- a/crates/kamn-kolme/src/transport_request_policy.rs
+++ b/crates/kamn-kolme/src/transport_request_policy.rs
@@ -27,6 +27,11 @@ impl fmt::Display for KolmeTransportRequestPolicyError {
 
 impl Error for KolmeTransportRequestPolicyError {}
 
+/// Returns whether idempotency-key input is non-empty after trimming.
+pub fn is_valid_transport_idempotency_key_input(idempotency_key: &str) -> bool {
+    !idempotency_key.trim().is_empty()
+}
+
 /// Parses one authorization header value with deterministic trim + CRLF safeguards.
 pub fn parse_authorization_header_value(
     value: &str,

--- a/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
@@ -1,5 +1,6 @@
 use kamn_kolme::{
-    is_broadcast_submit_path, parse_authorization_header_value, KolmeTransportRequestPolicyError,
+    is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
+    parse_authorization_header_value, KolmeTransportRequestPolicyError,
 };
 
 #[test]
@@ -14,6 +15,13 @@ fn functional_is_broadcast_submit_path_accepts_query_and_trailing_slash() {
     assert!(is_broadcast_submit_path("/broadcast"));
     assert!(is_broadcast_submit_path("/broadcast/"));
     assert!(is_broadcast_submit_path("/broadcast?mode=sync"));
+}
+
+#[test]
+fn functional_transport_request_policy_accepts_non_empty_idempotency_key_input() {
+    assert!(is_valid_transport_idempotency_key_input(
+        "kolme-runtime-commit:op-1"
+    ));
 }
 
 #[test]
@@ -49,4 +57,10 @@ fn regression_issue_1755_is_broadcast_submit_path_rejects_non_broadcast_paths() 
     assert!(!is_broadcast_submit_path(""));
     assert!(!is_broadcast_submit_path("/runtime-commit/submit"));
     assert!(!is_broadcast_submit_path("/broadcasting"));
+}
+
+#[test]
+fn regression_issue_1884_transport_request_policy_rejects_empty_idempotency_key_input() {
+    // Regression: #1884
+    assert!(!is_valid_transport_idempotency_key_input(" \t "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -59,6 +59,7 @@ Out of scope:
 - #1878: extracted adapter expected-provider guard contract to `kamn-kolme` (`is_valid_expected_provider_input`) and rewired `kamn-core` adapter-backed client constructor guard delegation.
 - #1880: extracted in-memory provider guard contract to `kamn-kolme` (`is_valid_runtime_provider_input`) and rewired `kamn-core` in-memory client constructor guard delegation.
 - #1882: extracted fork provider-hint guard contract to `kamn-kolme` (`is_valid_provider_hint_input`) and rewired `kamn-core` fork broadcast profile provider-hint guard delegation.
+- #1884: extracted transport idempotency-key guard contract to `kamn-kolme` (`is_valid_transport_idempotency_key_input`) and rewired `kamn-core` HTTP transport submit-path idempotency guards.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts idempotency-key transport-input guard ownership from kamn-core into kamn-kolme transport-request policy contracts, preserving fail-closed malformed-response behavior while reducing core-local guard logic.

## Changes
- crates/kamn-kolme/src/transport_request_policy.rs: add is_valid_transport_idempotency_key_input helper.
- crates/kamn-kolme/src/lib.rs: export idempotency-key guard helper.
- crates/kamn-kolme/tests/transport_request_policy_contracts.rs: add functional + regression coverage for idempotency-key input guard.
- crates/kamn-core/src/kolme_runtime_commit.rs: delegate idempotency-key guards in submit_broadcast_request and submit_runtime_commit.
- crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs: add regression for empty idempotency-key rejection parity.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs: enforce helper-delegation marker for idempotency-key guard.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs: require #1884 plan marker.
- docs/planning/kolme_runtime_commit_extraction_plan.md: record #1884 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-commit suite)
- [x] Manual verification: Verified empty idempotency key still fails with malformed reason idempotency_key must not be empty.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme transport request policy contracts |
| Functional  | ✅     | idempotency-key guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-commit HTTP transport + extraction boundary/docs |
| Regression  | ✅     | #1884 malformed-response parity + plan marker assertions |

Closes #1884