### PR TITLE
refactor(kolme): extract transport wire-payload guard contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -32,6 +32,7 @@ use kamn_kolme::{
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
     is_valid_transport_idempotency_key_input as is_kolme_valid_transport_idempotency_key_input_contract,
+    is_valid_transport_wire_payload_input as is_kolme_valid_transport_wire_payload_input_contract,
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
@@ -1095,7 +1096,7 @@ impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
         wire_payload: &str,
         idempotency_key: &str,
     ) -> Result<String, KolmeRuntimeCommitProviderError> {
-        if wire_payload.trim().is_empty() {
+        if !is_kolme_valid_transport_wire_payload_input_contract(wire_payload) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "wire_payload must not be empty".to_owned(),
             });

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -107,5 +107,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_wire_payload_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -42,6 +42,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1880"));
     assert!(DOC.contains("#1882"));
     assert!(DOC.contains("#1884"));
+    assert!(DOC.contains("#1886"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -528,6 +528,25 @@ fn regression_issue_1884_http_transport_rejects_empty_idempotency_key() {
 }
 
 #[test]
+fn regression_issue_1886_http_transport_rejects_empty_wire_payload() {
+    // Regression: #1886
+    let transport = KolmeRuntimeCommitHttpTransport::new(1).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "http://127.0.0.1:1",
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    assert_eq!(
+        provider.submit_runtime_commit(" ", "idempotency-key-1"),
+        Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "wire_payload must not be empty".to_owned(),
+        })
+    );
+}
+
+#[test]
 fn regression_http_transport_fails_closed_on_content_length_mismatch() {
     let body = "status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n";
     let declared_length = body.len() + 9;

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -105,7 +105,8 @@ pub use transport::{
 };
 pub use transport_request_policy::{
     is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
-    parse_authorization_header_value, KolmeTransportRequestPolicyError,
+    is_valid_transport_wire_payload_input, parse_authorization_header_value,
+    KolmeTransportRequestPolicyError,
 };
 pub use websocket_policy::{
     find_http_header_boundary, is_valid_websocket_timeout_seconds, try_take_websocket_frame,

--- a/crates/kamn-kolme/src/transport_request_policy.rs
+++ b/crates/kamn-kolme/src/transport_request_policy.rs
@@ -32,6 +32,11 @@ pub fn is_valid_transport_idempotency_key_input(idempotency_key: &str) -> bool {
     !idempotency_key.trim().is_empty()
 }
 
+/// Returns whether wire-payload input is non-empty after trimming.
+pub fn is_valid_transport_wire_payload_input(wire_payload: &str) -> bool {
+    !wire_payload.trim().is_empty()
+}
+
 /// Parses one authorization header value with deterministic trim + CRLF safeguards.
 pub fn parse_authorization_header_value(
     value: &str,

--- a/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
@@ -1,6 +1,7 @@
 use kamn_kolme::{
     is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
-    parse_authorization_header_value, KolmeTransportRequestPolicyError,
+    is_valid_transport_wire_payload_input, parse_authorization_header_value,
+    KolmeTransportRequestPolicyError,
 };
 
 #[test]
@@ -22,6 +23,11 @@ fn functional_transport_request_policy_accepts_non_empty_idempotency_key_input()
     assert!(is_valid_transport_idempotency_key_input(
         "kolme-runtime-commit:op-1"
     ));
+}
+
+#[test]
+fn functional_transport_request_policy_accepts_non_empty_wire_payload_input() {
+    assert!(is_valid_transport_wire_payload_input("operation_id=op-1\n"));
 }
 
 #[test]
@@ -63,4 +69,10 @@ fn regression_issue_1755_is_broadcast_submit_path_rejects_non_broadcast_paths() 
 fn regression_issue_1884_transport_request_policy_rejects_empty_idempotency_key_input() {
     // Regression: #1884
     assert!(!is_valid_transport_idempotency_key_input(" \t "));
+}
+
+#[test]
+fn regression_issue_1886_transport_request_policy_rejects_empty_wire_payload_input() {
+    // Regression: #1886
+    assert!(!is_valid_transport_wire_payload_input(" \t "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -60,6 +60,7 @@ Out of scope:
 - #1880: extracted in-memory provider guard contract to `kamn-kolme` (`is_valid_runtime_provider_input`) and rewired `kamn-core` in-memory client constructor guard delegation.
 - #1882: extracted fork provider-hint guard contract to `kamn-kolme` (`is_valid_provider_hint_input`) and rewired `kamn-core` fork broadcast profile provider-hint guard delegation.
 - #1884: extracted transport idempotency-key guard contract to `kamn-kolme` (`is_valid_transport_idempotency_key_input`) and rewired `kamn-core` HTTP transport submit-path idempotency guards.
+- #1886: extracted transport wire-payload guard contract to `kamn-kolme` (`is_valid_transport_wire_payload_input`) and rewired `kamn-core` HTTP transport submit guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts transport wire-payload guard ownership from kamn-core into kamn-kolme transport-request policy contracts, preserving fail-closed malformed-response behavior while reducing core-local submit guard logic.

## Changes
- crates/kamn-kolme/src/transport_request_policy.rs: add is_valid_transport_wire_payload_input helper.
- crates/kamn-kolme/src/lib.rs: export wire-payload guard helper.
- crates/kamn-kolme/tests/transport_request_policy_contracts.rs: add functional + regression coverage for wire-payload guard.
- crates/kamn-core/src/kolme_runtime_commit.rs: delegate submit_runtime_commit wire_payload guard to kamn-kolme contract.
- crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs: add regression for empty wire-payload rejection parity.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs: enforce helper delegation marker for wire-payload guard.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs: require #1886 plan marker.
- docs/planning/kolme_runtime_commit_extraction_plan.md: record #1886 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-commit suite)
- [x] Manual verification: Verified empty wire_payload still fails with malformed reason wire_payload must not be empty.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme transport request policy contracts |
| Functional  | ✅     | wire-payload guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-commit HTTP transport + extraction boundary/docs |
| Regression  | ✅     | #1886 malformed-response parity + plan marker assertions |

Closes #1886