### PR TITLE
refactor(kolme): extract broadcast submit-path normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -37,6 +37,7 @@ use kamn_kolme::{
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
+    normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
     notification_event_to_provider_receipt as notification_event_to_kolme_provider_receipt_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_http_endpoint as parse_kolme_http_endpoint,
@@ -884,11 +885,7 @@ impl KolmeRuntimeCommitHttpTransport {
             });
         }
         let idempotency_key = idempotency_key.trim();
-        let submit_path = if submit_path.trim().is_empty() {
-            "/broadcast"
-        } else {
-            submit_path.trim()
-        };
+        let submit_path = normalize_kolme_broadcast_submit_path_input_contract(submit_path);
         let payload = request.to_json_payload();
         let response = self.execute_request(
             base_url,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -108,5 +108,6 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_wire_payload_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_submit_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -43,6 +43,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1882"));
     assert!(DOC.contains("#1884"));
     assert!(DOC.contains("#1886"));
+    assert!(DOC.contains("#1888"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -411,6 +411,31 @@ fn integration_http_transport_submit_broadcast_request_put_and_parse_txhash() {
 }
 
 #[test]
+fn regression_issue_1888_http_transport_submit_broadcast_defaults_empty_submit_path() {
+    // Regression: #1888
+    let broadcast_request = KolmeApiBroadcastRequest::new("{\"nonce\":8}", "sig-8", 1)
+        .expect("broadcast request should build");
+    let base_url = spawn_single_request_server(
+        "{\"txhash\":\"tx-typed-8\"}".to_owned(),
+        "HTTP/1.1 200 OK",
+        move |request| {
+            assert!(request.contains("PUT /broadcast HTTP/1.1"));
+        },
+    );
+
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let response = transport
+        .submit_broadcast_request(
+            base_url.as_str(),
+            "   ",
+            &broadcast_request,
+            "kolme-runtime-commit:typed-broadcast-8",
+        )
+        .expect("broadcast helper should default empty submit path");
+    assert_eq!(response.txhash, "tx-typed-8");
+}
+
+#[test]
 fn regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response() {
     let broadcast_request = KolmeApiBroadcastRequest::new("{\"nonce\":7}", "sig-7", 1)
         .expect("broadcast request should build");

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -105,8 +105,8 @@ pub use transport::{
 };
 pub use transport_request_policy::{
     is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
-    is_valid_transport_wire_payload_input, parse_authorization_header_value,
-    KolmeTransportRequestPolicyError,
+    is_valid_transport_wire_payload_input, normalize_broadcast_submit_path_input,
+    parse_authorization_header_value, KolmeTransportRequestPolicyError,
 };
 pub use websocket_policy::{
     find_http_header_boundary, is_valid_websocket_timeout_seconds, try_take_websocket_frame,

--- a/crates/kamn-kolme/src/transport_request_policy.rs
+++ b/crates/kamn-kolme/src/transport_request_policy.rs
@@ -37,6 +37,16 @@ pub fn is_valid_transport_wire_payload_input(wire_payload: &str) -> bool {
     !wire_payload.trim().is_empty()
 }
 
+/// Normalizes broadcast submit-path input, defaulting empty values to `/broadcast`.
+pub fn normalize_broadcast_submit_path_input(submit_path: &str) -> &str {
+    let trimmed = submit_path.trim();
+    if trimmed.is_empty() {
+        "/broadcast"
+    } else {
+        trimmed
+    }
+}
+
 /// Parses one authorization header value with deterministic trim + CRLF safeguards.
 pub fn parse_authorization_header_value(
     value: &str,

--- a/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
@@ -1,7 +1,7 @@
 use kamn_kolme::{
     is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
-    is_valid_transport_wire_payload_input, parse_authorization_header_value,
-    KolmeTransportRequestPolicyError,
+    is_valid_transport_wire_payload_input, normalize_broadcast_submit_path_input,
+    parse_authorization_header_value, KolmeTransportRequestPolicyError,
 };
 
 #[test]
@@ -28,6 +28,14 @@ fn functional_transport_request_policy_accepts_non_empty_idempotency_key_input()
 #[test]
 fn functional_transport_request_policy_accepts_non_empty_wire_payload_input() {
     assert!(is_valid_transport_wire_payload_input("operation_id=op-1\n"));
+}
+
+#[test]
+fn functional_transport_request_policy_normalizes_broadcast_submit_path_input() {
+    assert_eq!(
+        normalize_broadcast_submit_path_input(" /broadcast "),
+        "/broadcast"
+    );
 }
 
 #[test]
@@ -75,4 +83,10 @@ fn regression_issue_1884_transport_request_policy_rejects_empty_idempotency_key_
 fn regression_issue_1886_transport_request_policy_rejects_empty_wire_payload_input() {
     // Regression: #1886
     assert!(!is_valid_transport_wire_payload_input(" \t "));
+}
+
+#[test]
+fn regression_issue_1888_transport_request_policy_defaults_empty_submit_path_to_broadcast() {
+    // Regression: #1888
+    assert_eq!(normalize_broadcast_submit_path_input(" "), "/broadcast");
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -61,6 +61,7 @@ Out of scope:
 - #1882: extracted fork provider-hint guard contract to `kamn-kolme` (`is_valid_provider_hint_input`) and rewired `kamn-core` fork broadcast profile provider-hint guard delegation.
 - #1884: extracted transport idempotency-key guard contract to `kamn-kolme` (`is_valid_transport_idempotency_key_input`) and rewired `kamn-core` HTTP transport submit-path idempotency guards.
 - #1886: extracted transport wire-payload guard contract to `kamn-kolme` (`is_valid_transport_wire_payload_input`) and rewired `kamn-core` HTTP transport submit guard delegation.
+- #1888: extracted broadcast submit-path normalization contract to `kamn-kolme` (`normalize_broadcast_submit_path_input`) and rewired `kamn-core` broadcast helper submit-path normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts broadcast submit-path normalization ownership from kamn-core into kamn-kolme transport-request policy contracts, preserving behavior parity while reducing core-local transport policy logic.

## Changes
- crates/kamn-kolme/src/transport_request_policy.rs: add normalize_broadcast_submit_path_input helper.
- crates/kamn-kolme/src/lib.rs: export broadcast submit-path normalization helper.
- crates/kamn-kolme/tests/transport_request_policy_contracts.rs: add functional + regression coverage for submit-path normalization.
- crates/kamn-core/src/kolme_runtime_commit.rs: delegate submit_broadcast_request path normalization to kamn-kolme contract.
- crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs: add regression for empty submit-path defaulting to /broadcast.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs: enforce helper delegation marker for submit-path normalization.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs: require #1888 plan marker.
- docs/planning/kolme_runtime_commit_extraction_plan.md: record #1888 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-commit suite)
- [x] Manual verification: Verified empty/whitespace submit_path still defaults to /broadcast in submit_broadcast_request.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme transport request policy contracts |
| Functional  | ✅     | broadcast submit-path normalization contract coverage |
| Integration | ✅     | kamn-core runtime-commit HTTP transport + extraction boundary/docs |
| Regression  | ✅     | #1888 behavior parity + plan marker assertions |

Closes #1888