### PR TITLE
refactor(kolme): extract receipt-finality input guard contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -29,6 +29,8 @@ use kamn_kolme::{
     is_valid_notifications_reconnect_budget as is_kolme_valid_notifications_reconnect_budget_contract,
     is_valid_poll_attempt_budget as is_kolme_valid_poll_attempt_budget_contract,
     is_valid_provider_hint_input as is_kolme_valid_provider_hint_input_contract,
+    is_valid_receipt_commit_id_input as is_kolme_valid_receipt_commit_id_input_contract,
+    is_valid_receipt_provider_input as is_kolme_valid_receipt_provider_input_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
     is_valid_transport_idempotency_key_input as is_kolme_valid_transport_idempotency_key_input_contract,
@@ -528,13 +530,13 @@ impl RuntimeCommitPipeline {
         receipt_provider: &str,
         receipt_commit_id: &str,
     ) -> Result<RuntimeCommitLifecycleRecord, KolmeRuntimeCommitError> {
-        if receipt_provider.trim().is_empty() {
+        if !is_kolme_valid_receipt_provider_input_contract(receipt_provider) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "receipt_provider",
                 reason: "must not be empty",
             });
         }
-        if receipt_commit_id.trim().is_empty() {
+        if !is_kolme_valid_receipt_commit_id_input_contract(receipt_commit_id) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "receipt_commit_id",
                 reason: "must not be empty",

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -106,6 +106,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_provider_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_commit_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_wire_payload_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_submit_path_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -44,6 +44,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1884"));
     assert!(DOC.contains("#1886"));
     assert!(DOC.contains("#1888"));
+    assert!(DOC.contains("#1890"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_finality.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_finality.rs
@@ -143,6 +143,62 @@ fn regression_unknown_operation_finality_update_is_rejected() {
 }
 
 #[test]
+fn regression_issue_1890_empty_receipt_provider_is_rejected_fail_closed() {
+    // Regression: #1890
+    let mut client =
+        InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");
+    let mut pipeline = RuntimeCommitPipeline::new();
+    let request = request("op-empty-provider", 77);
+    let submitted = pipeline
+        .submit_with_client(&mut client, request.clone())
+        .expect("submit should succeed");
+
+    assert_eq!(
+        pipeline.apply_receipt_finality(
+            request.operation_id.as_str(),
+            KolmeCommitReceiptFinality::Final,
+            " ",
+            submitted
+                .receipt_commit_id
+                .as_deref()
+                .expect("submit must include receipt commit id"),
+        ),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "receipt_provider",
+            reason: "must not be empty",
+        })
+    );
+}
+
+#[test]
+fn regression_issue_1890_empty_receipt_commit_id_is_rejected_fail_closed() {
+    // Regression: #1890
+    let mut client =
+        InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");
+    let mut pipeline = RuntimeCommitPipeline::new();
+    let request = request("op-empty-commit-id", 78);
+    let submitted = pipeline
+        .submit_with_client(&mut client, request.clone())
+        .expect("submit should succeed");
+
+    assert_eq!(
+        pipeline.apply_receipt_finality(
+            request.operation_id.as_str(),
+            KolmeCommitReceiptFinality::Final,
+            submitted
+                .receipt_provider
+                .as_deref()
+                .expect("submit must include receipt provider"),
+            " ",
+        ),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "receipt_commit_id",
+            reason: "must not be empty",
+        })
+    );
+}
+
+#[test]
 fn regression_finalized_operation_cannot_regress_to_pending() {
     // Regression: #826
     let mut client =

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -72,7 +72,8 @@ pub use notification_policy::{
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
-    is_valid_provider_hint_input, is_valid_runtime_provider_input,
+    is_valid_provider_hint_input, is_valid_receipt_commit_id_input,
+    is_valid_receipt_provider_input, is_valid_runtime_provider_input,
     parse_commit_id_from_response_fields, parse_live_provider_outcome,
     parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
     required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -330,6 +330,16 @@ pub fn is_valid_provider_hint_input(provider_hint: &str) -> bool {
     is_valid_runtime_provider_input(provider_hint)
 }
 
+/// Validates receipt provider input for runtime lifecycle updates.
+pub fn is_valid_receipt_provider_input(receipt_provider: &str) -> bool {
+    is_valid_runtime_provider_input(receipt_provider)
+}
+
+/// Validates receipt commit identifier input for runtime lifecycle updates.
+pub fn is_valid_receipt_commit_id_input(receipt_commit_id: &str) -> bool {
+    !receipt_commit_id.trim().is_empty()
+}
+
 fn required_response_field(
     fields: &HashMap<String, String>,
     field: &'static str,

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -1,6 +1,7 @@
 use kamn_kolme::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
-    is_valid_provider_hint_input, is_valid_runtime_provider_input,
+    is_valid_provider_hint_input, is_valid_receipt_commit_id_input,
+    is_valid_receipt_provider_input, is_valid_runtime_provider_input,
     parse_commit_id_from_response_fields, parse_live_provider_outcome,
     parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
     required_provider_response_field, txhash_from_commit_id,
@@ -217,4 +218,17 @@ fn functional_provider_outcome_policy_accepts_non_empty_provider_hint_input() {
 fn regression_issue_1882_provider_outcome_policy_rejects_empty_provider_hint_input() {
     // Regression: #1882
     assert!(!is_valid_provider_hint_input(" \t "));
+}
+
+#[test]
+fn functional_provider_outcome_policy_accepts_non_empty_receipt_finality_update_inputs() {
+    assert!(is_valid_receipt_provider_input("kolme-local"));
+    assert!(is_valid_receipt_commit_id_input("kolme-commit:ab12"));
+}
+
+#[test]
+fn regression_issue_1890_provider_outcome_policy_rejects_empty_receipt_finality_update_inputs() {
+    // Regression: #1890
+    assert!(!is_valid_receipt_provider_input(" \t "));
+    assert!(!is_valid_receipt_commit_id_input(" \t "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -62,6 +62,7 @@ Out of scope:
 - #1884: extracted transport idempotency-key guard contract to `kamn-kolme` (`is_valid_transport_idempotency_key_input`) and rewired `kamn-core` HTTP transport submit-path idempotency guards.
 - #1886: extracted transport wire-payload guard contract to `kamn-kolme` (`is_valid_transport_wire_payload_input`) and rewired `kamn-core` HTTP transport submit guard delegation.
 - #1888: extracted broadcast submit-path normalization contract to `kamn-kolme` (`normalize_broadcast_submit_path_input`) and rewired `kamn-core` broadcast helper submit-path normalization delegation.
+- #1890: extracted receipt-finality update input guards to `kamn-kolme` (`is_valid_receipt_provider_input` / `is_valid_receipt_commit_id_input`) and rewired `kamn-core` runtime pipeline guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts receipt-finality update input guard ownership from kamn-core runtime pipeline into kamn-kolme contracts, preserving fail-closed InvalidRequest parity while reducing core-local guard logic.

## Changes
- crates/kamn-kolme/src/provider_outcome_policy.rs: add `is_valid_receipt_provider_input` and `is_valid_receipt_commit_id_input` helper contracts.
- crates/kamn-kolme/src/lib.rs: export new receipt-finality input guard helpers.
- crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs: add functional + regression coverage for receipt-finality update input guards.
- crates/kamn-core/src/kolme_runtime_commit.rs: delegate `apply_receipt_finality` provider/commit-id emptiness guards to kamn-kolme helper contracts.
- crates/kamn-core/tests/kolme_runtime_commit_finality.rs: add regressions for empty `receipt_provider` and empty `receipt_commit_id` fail-closed behavior.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs: enforce delegation markers for both new helper contracts.
- crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs: require #1890 extraction-plan marker.
- docs/planning/kolme_runtime_commit_extraction_plan.md: record #1890 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-finality + extraction suites)
- [x] Manual verification: Verified empty receipt provider/commit-id still return InvalidRequest field/reason parity.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme provider outcome policy contracts |
| Functional  | ✅     | receipt-finality guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-finality + extraction boundary/docs tests |
| Regression  | ✅     | #1890 InvalidRequest parity + plan marker assertions |

Closes #1890
