### PR TITLE
refactor(kolme): extract runtime request field guard contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -32,7 +32,10 @@ use kamn_kolme::{
     is_valid_receipt_commit_id_input as is_kolme_valid_receipt_commit_id_input_contract,
     is_valid_receipt_provider_input as is_kolme_valid_receipt_provider_input_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
+    is_valid_runtime_operation_id_input as is_kolme_valid_runtime_operation_id_input_contract,
+    is_valid_runtime_payload_hash_input as is_kolme_valid_runtime_payload_hash_input_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
+    is_valid_runtime_state_root_input as is_kolme_valid_runtime_state_root_input_contract,
     is_valid_transport_idempotency_key_input as is_kolme_valid_transport_idempotency_key_input_contract,
     is_valid_transport_wire_payload_input as is_kolme_valid_transport_wire_payload_input_contract,
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
@@ -186,13 +189,13 @@ impl KolmeRuntimeCommitRequest {
 
     /// Validates commit request schema and invariant boundaries.
     pub fn validate(&self) -> Result<(), KolmeRuntimeCommitError> {
-        if self.operation_id.trim().is_empty() {
+        if !is_kolme_valid_runtime_operation_id_input_contract(self.operation_id.as_str()) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "operation_id",
                 reason: "must not be empty",
             });
         }
-        if self.state_root.trim().is_empty() {
+        if !is_kolme_valid_runtime_state_root_input_contract(self.state_root.as_str()) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "state_root",
                 reason: "must not be empty",
@@ -204,7 +207,7 @@ impl KolmeRuntimeCommitRequest {
                 reason: "must be positive",
             });
         }
-        if self.payload_hash.trim().is_empty() {
+        if !is_kolme_valid_runtime_payload_hash_input_contract(self.payload_hash.as_str()) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "payload_hash",
                 reason: "must not be empty",

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -289,6 +289,54 @@ fn regression_submit_commit_fails_closed_for_mutated_invalid_request() {
 }
 
 #[test]
+fn regression_issue_1892_submit_commit_fails_closed_for_empty_operation_id() {
+    // Regression: #1892
+    let mut request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-1892-operation",
+        "state:op",
+        "kamn:did:agent:runtime-node-1892",
+        13,
+        "payload:op",
+    )
+    .expect("request should build");
+    request.operation_id.clear();
+
+    let mut client =
+        InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");
+    assert_eq!(
+        client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "operation_id",
+            reason: "must not be empty",
+        })
+    );
+}
+
+#[test]
+fn regression_issue_1892_submit_commit_fails_closed_for_empty_state_root() {
+    // Regression: #1892
+    let mut request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-1892-state-root",
+        "state:op",
+        "kamn:did:agent:runtime-node-1892",
+        14,
+        "payload:state",
+    )
+    .expect("request should build");
+    request.state_root.clear();
+
+    let mut client =
+        InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");
+    assert_eq!(
+        client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "state_root",
+            reason: "must not be empty",
+        })
+    );
+}
+
+#[test]
 fn performance_runtime_commit_contract_lane_stays_within_budget() {
     let mut client =
         InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -106,6 +106,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_operation_id_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_state_root_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_payload_hash_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_commit_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -45,6 +45,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1886"));
     assert!(DOC.contains("#1888"));
     assert!(DOC.contains("#1890"));
+    assert!(DOC.contains("#1892"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -93,7 +93,8 @@ pub use runtime_lifecycle_policy::{
 };
 pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
-    is_valid_runtime_commit_id_request,
+    is_valid_runtime_commit_id_request, is_valid_runtime_operation_id_input,
+    is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -39,11 +39,27 @@ pub fn is_valid_runtime_commit_id_request(commit_id: &str) -> bool {
     !commit_id.trim().is_empty()
 }
 
+/// Validates runtime commit request operation identifier input.
+pub fn is_valid_runtime_operation_id_input(operation_id: &str) -> bool {
+    !operation_id.trim().is_empty()
+}
+
+/// Validates runtime commit request state-root input.
+pub fn is_valid_runtime_state_root_input(state_root: &str) -> bool {
+    !state_root.trim().is_empty()
+}
+
+/// Validates runtime commit request payload-hash input.
+pub fn is_valid_runtime_payload_hash_input(payload_hash: &str) -> bool {
+    !payload_hash.trim().is_empty()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
-        is_valid_runtime_commit_id_request,
+        is_valid_runtime_commit_id_request, is_valid_runtime_operation_id_input,
+        is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
     };
 
     #[test]
@@ -75,5 +91,15 @@ mod tests {
             "kolme-commit:op:did:1:12"
         ));
         assert!(!is_valid_runtime_commit_id_request("   "));
+    }
+
+    #[test]
+    fn unit_validates_runtime_commit_request_field_inputs() {
+        assert!(is_valid_runtime_operation_id_input("op-123"));
+        assert!(is_valid_runtime_state_root_input("state:abc"));
+        assert!(is_valid_runtime_payload_hash_input("payload:hash"));
+        assert!(!is_valid_runtime_operation_id_input(" "));
+        assert!(!is_valid_runtime_state_root_input(" "));
+        assert!(!is_valid_runtime_payload_hash_input(" "));
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -1,6 +1,7 @@
 use kamn_kolme::{
     deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
-    is_valid_runtime_commit_id_request,
+    is_valid_runtime_commit_id_request, is_valid_runtime_operation_id_input,
+    is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
 };
 
 #[test]
@@ -44,4 +45,19 @@ fn regression_issue_1862_runtime_request_identity_policy_rejects_empty_commit_id
     // Regression: #1862
     assert!(!is_valid_runtime_commit_id_request(""));
     assert!(!is_valid_runtime_commit_id_request("   "));
+}
+
+#[test]
+fn functional_runtime_request_identity_policy_accepts_non_empty_request_fields() {
+    assert!(is_valid_runtime_operation_id_input("op-9"));
+    assert!(is_valid_runtime_state_root_input("state:beta"));
+    assert!(is_valid_runtime_payload_hash_input("payload:beta"));
+}
+
+#[test]
+fn regression_issue_1892_runtime_request_identity_policy_rejects_empty_request_fields() {
+    // Regression: #1892
+    assert!(!is_valid_runtime_operation_id_input(" "));
+    assert!(!is_valid_runtime_state_root_input(" "));
+    assert!(!is_valid_runtime_payload_hash_input(" "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -63,6 +63,7 @@ Out of scope:
 - #1886: extracted transport wire-payload guard contract to `kamn-kolme` (`is_valid_transport_wire_payload_input`) and rewired `kamn-core` HTTP transport submit guard delegation.
 - #1888: extracted broadcast submit-path normalization contract to `kamn-kolme` (`normalize_broadcast_submit_path_input`) and rewired `kamn-core` broadcast helper submit-path normalization delegation.
 - #1890: extracted receipt-finality update input guards to `kamn-kolme` (`is_valid_receipt_provider_input` / `is_valid_receipt_commit_id_input`) and rewired `kamn-core` runtime pipeline guard delegation.
+- #1892: extracted runtime-commit request field guards to `kamn-kolme` (`is_valid_runtime_operation_id_input` / `is_valid_runtime_state_root_input` / `is_valid_runtime_payload_hash_input`) and rewired `kamn-core` request validation delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts runtime-commit request field guard ownership from `kamn-core` into `kamn-kolme` runtime-request-identity contracts, preserving fail-closed `InvalidRequest` parity while reducing core-local guard logic.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: add `is_valid_runtime_operation_id_input`, `is_valid_runtime_state_root_input`, and `is_valid_runtime_payload_hash_input` helper contracts.
- `crates/kamn-kolme/src/lib.rs`: export new runtime-request field guard helpers.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: add functional + regression coverage for request field guards.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate `KolmeRuntimeCommitRequest::validate` emptiness guards for `operation_id`, `state_root`, and `payload_hash` to `kamn-kolme` helpers.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: add regressions for empty `operation_id` and empty `state_root` fail-closed behavior.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation markers for the new request-field guard helpers.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: require #1892 extraction-plan marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: record #1892 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-client + extraction suites)
- [x] Manual verification: Verified empty `operation_id` / `state_root` / `payload_hash` still return `InvalidRequest` with unchanged field/reason parity.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme runtime-request-identity contracts |
| Functional  | ✅     | request-field guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-client + extraction boundary/docs tests |
| Regression  | ✅     | #1892 InvalidRequest parity + plan marker assertions |

Closes #1892
