### PR TITLE
refactor(kolme): extract request single-line guard contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -2,6 +2,7 @@
 
 use crate::AgentDid;
 use kamn_kolme::{
+    are_runtime_commit_request_fields_single_line as are_kolme_runtime_commit_request_fields_single_line_contract,
     classify_tls_failure_reason as classify_kolme_tls_failure_reason,
     classify_transport_io_error as classify_kolme_transport_io_error,
     commit_finality_from_receipt_finality as commit_finality_from_receipt_finality_contract,
@@ -213,10 +214,11 @@ impl KolmeRuntimeCommitRequest {
                 reason: "must not be empty",
             });
         }
-        if self.operation_id.contains('\n')
-            || self.state_root.contains('\n')
-            || self.payload_hash.contains('\n')
-        {
+        if !are_kolme_runtime_commit_request_fields_single_line_contract(
+            self.operation_id.as_str(),
+            self.state_root.as_str(),
+            self.payload_hash.as_str(),
+        ) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "wire_payload",
                 reason: "fields must be single-line",

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -337,6 +337,30 @@ fn regression_issue_1892_submit_commit_fails_closed_for_empty_state_root() {
 }
 
 #[test]
+fn regression_issue_1894_submit_commit_fails_closed_for_multiline_operation_id() {
+    // Regression: #1894
+    let mut request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-1894-multiline",
+        "state:op",
+        "kamn:did:agent:runtime-node-1894",
+        15,
+        "payload:op",
+    )
+    .expect("request should build");
+    request.operation_id.push_str("\nwrapped");
+
+    let mut client =
+        InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");
+    assert_eq!(
+        client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "wire_payload",
+            reason: "fields must be single-line",
+        })
+    );
+}
+
+#[test]
 fn performance_runtime_commit_contract_lane_stays_within_budget() {
     let mut client =
         InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -109,6 +109,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_operation_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_state_root_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_payload_hash_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("are_kolme_runtime_commit_request_fields_single_line_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_commit_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -46,6 +46,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1888"));
     assert!(DOC.contains("#1890"));
     assert!(DOC.contains("#1892"));
+    assert!(DOC.contains("#1894"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -92,9 +92,10 @@ pub use runtime_lifecycle_policy::{
     RuntimeCommitLifecycleState, RuntimeLifecyclePolicyError,
 };
 pub use runtime_request_identity_policy::{
-    deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
-    is_valid_runtime_commit_id_request, is_valid_runtime_operation_id_input,
-    is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
+    are_runtime_commit_request_fields_single_line, deterministic_runtime_commit_id,
+    deterministic_runtime_commit_idempotency_key, is_valid_runtime_commit_id_request,
+    is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
+    is_valid_runtime_state_root_input,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -54,12 +54,22 @@ pub fn is_valid_runtime_payload_hash_input(payload_hash: &str) -> bool {
     !payload_hash.trim().is_empty()
 }
 
+/// Returns whether runtime commit request fields satisfy single-line constraints.
+pub fn are_runtime_commit_request_fields_single_line(
+    operation_id: &str,
+    state_root: &str,
+    payload_hash: &str,
+) -> bool {
+    !operation_id.contains('\n') && !state_root.contains('\n') && !payload_hash.contains('\n')
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
-        is_valid_runtime_commit_id_request, is_valid_runtime_operation_id_input,
-        is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
+        are_runtime_commit_request_fields_single_line, deterministic_runtime_commit_id,
+        deterministic_runtime_commit_idempotency_key, is_valid_runtime_commit_id_request,
+        is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
+        is_valid_runtime_state_root_input,
     };
 
     #[test]
@@ -101,5 +111,19 @@ mod tests {
         assert!(!is_valid_runtime_operation_id_input(" "));
         assert!(!is_valid_runtime_state_root_input(" "));
         assert!(!is_valid_runtime_payload_hash_input(" "));
+    }
+
+    #[test]
+    fn unit_validates_runtime_commit_request_fields_single_line() {
+        assert!(are_runtime_commit_request_fields_single_line(
+            "op-123",
+            "state:abc",
+            "payload:hash"
+        ));
+        assert!(!are_runtime_commit_request_fields_single_line(
+            "op-123\nwrapped",
+            "state:abc",
+            "payload:hash"
+        ));
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -1,7 +1,8 @@
 use kamn_kolme::{
-    deterministic_runtime_commit_id, deterministic_runtime_commit_idempotency_key,
-    is_valid_runtime_commit_id_request, is_valid_runtime_operation_id_input,
-    is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
+    are_runtime_commit_request_fields_single_line, deterministic_runtime_commit_id,
+    deterministic_runtime_commit_idempotency_key, is_valid_runtime_commit_id_request,
+    is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
+    is_valid_runtime_state_root_input,
 };
 
 #[test]
@@ -60,4 +61,33 @@ fn regression_issue_1892_runtime_request_identity_policy_rejects_empty_request_f
     assert!(!is_valid_runtime_operation_id_input(" "));
     assert!(!is_valid_runtime_state_root_input(" "));
     assert!(!is_valid_runtime_payload_hash_input(" "));
+}
+
+#[test]
+fn functional_runtime_request_identity_policy_accepts_single_line_request_fields() {
+    assert!(are_runtime_commit_request_fields_single_line(
+        "op-9",
+        "state:beta",
+        "payload:beta"
+    ));
+}
+
+#[test]
+fn regression_issue_1894_runtime_request_identity_policy_rejects_multiline_request_fields() {
+    // Regression: #1894
+    assert!(!are_runtime_commit_request_fields_single_line(
+        "op-9\nwrapped",
+        "state:beta",
+        "payload:beta"
+    ));
+    assert!(!are_runtime_commit_request_fields_single_line(
+        "op-9",
+        "state:beta\nwrapped",
+        "payload:beta"
+    ));
+    assert!(!are_runtime_commit_request_fields_single_line(
+        "op-9",
+        "state:beta",
+        "payload:beta\nwrapped"
+    ));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -64,6 +64,7 @@ Out of scope:
 - #1888: extracted broadcast submit-path normalization contract to `kamn-kolme` (`normalize_broadcast_submit_path_input`) and rewired `kamn-core` broadcast helper submit-path normalization delegation.
 - #1890: extracted receipt-finality update input guards to `kamn-kolme` (`is_valid_receipt_provider_input` / `is_valid_receipt_commit_id_input`) and rewired `kamn-core` runtime pipeline guard delegation.
 - #1892: extracted runtime-commit request field guards to `kamn-kolme` (`is_valid_runtime_operation_id_input` / `is_valid_runtime_state_root_input` / `is_valid_runtime_payload_hash_input`) and rewired `kamn-core` request validation delegation.
+- #1894: extracted runtime-commit request single-line field guard to `kamn-kolme` (`are_runtime_commit_request_fields_single_line`) and rewired `kamn-core` request validation newline checks delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts runtime-commit request single-line guard ownership from `kamn-core` into `kamn-kolme` runtime-request-identity contracts, preserving fail-closed `InvalidRequest` parity while reducing core-local request validation logic.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: add `are_runtime_commit_request_fields_single_line` helper contract.
- `crates/kamn-kolme/src/lib.rs`: export the runtime-request single-line guard helper.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: add functional + regression coverage for single-line request field validation.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate request newline checks in `KolmeRuntimeCommitRequest::validate` to `kamn-kolme` helper.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: add regression for multiline `operation_id` fail-closed behavior.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation marker for single-line request guard helper.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: require #1894 extraction-plan marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: record #1894 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-client + extraction suites)
- [x] Manual verification: Verified multiline request fields still return `InvalidRequest { field: "wire_payload", reason: "fields must be single-line" }`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme runtime-request-identity contracts |
| Functional  | ✅     | single-line guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-client + extraction boundary/docs tests |
| Regression  | ✅     | #1894 InvalidRequest parity + plan marker assertions |

Closes #1894
