### PR TITLE
refactor(kolme): extract signed envelope field guard contracts

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -37,6 +37,9 @@ use kamn_kolme::{
     is_valid_runtime_payload_hash_input as is_kolme_valid_runtime_payload_hash_input_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
     is_valid_runtime_state_root_input as is_kolme_valid_runtime_state_root_input_contract,
+    is_valid_signed_envelope_message_input as is_kolme_valid_signed_envelope_message_input_contract,
+    is_valid_signed_envelope_signature_input as is_kolme_valid_signed_envelope_signature_input_contract,
+    is_valid_signed_envelope_signer_key_id_input as is_kolme_valid_signed_envelope_signer_key_id_input_contract,
     is_valid_transport_idempotency_key_input as is_kolme_valid_transport_idempotency_key_input_contract,
     is_valid_transport_wire_payload_input as is_kolme_valid_transport_wire_payload_input_contract,
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
@@ -249,27 +252,27 @@ impl KolmeRuntimeCommitSignedBroadcastEnvelope {
         signature: &str,
         recovery_id: u8,
     ) -> Result<Self, KolmeRuntimeCommitError> {
-        let signer_key_id = signer_key_id.trim();
-        if signer_key_id.is_empty() {
+        if !is_kolme_valid_signed_envelope_signer_key_id_input_contract(signer_key_id) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "signer_key_id",
                 reason: "must not be empty",
             });
         }
-        let message = message.trim();
-        if message.is_empty() {
+        if !is_kolme_valid_signed_envelope_message_input_contract(message) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "signed_message",
                 reason: "must not be empty",
             });
         }
-        let signature = signature.trim();
-        if signature.is_empty() {
+        if !is_kolme_valid_signed_envelope_signature_input_contract(signature) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "signature",
                 reason: "must not be empty",
             });
         }
+        let signer_key_id = signer_key_id.trim();
+        let message = message.trim();
+        let signature = signature.trim();
         Ok(Self {
             signer_key_id: signer_key_id.to_owned(),
             message: message.to_owned(),

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -5,8 +5,8 @@ use kamn_core::{
     KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider,
     KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
     KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderTransport,
-    KolmeRuntimeCommitRequest, KolmeRuntimeCommitTransportErrorKind, RuntimeCommitLifecycleState,
-    RuntimeCommitPipeline,
+    KolmeRuntimeCommitRequest, KolmeRuntimeCommitSignedBroadcastEnvelope,
+    KolmeRuntimeCommitTransportErrorKind, RuntimeCommitLifecycleState, RuntimeCommitPipeline,
 };
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -356,6 +356,37 @@ fn regression_issue_1894_submit_commit_fails_closed_for_multiline_operation_id()
         Err(KolmeRuntimeCommitError::InvalidRequest {
             field: "wire_payload",
             reason: "fields must be single-line",
+        })
+    );
+}
+
+#[test]
+fn regression_issue_1896_signed_envelope_constructor_rejects_empty_fields() {
+    // Regression: #1896
+    assert_eq!(
+        KolmeRuntimeCommitSignedBroadcastEnvelope::new(" ", "operation_id=op\n", "sig-1", 1),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "signer_key_id",
+            reason: "must not be empty",
+        })
+    );
+    assert_eq!(
+        KolmeRuntimeCommitSignedBroadcastEnvelope::new("kamn:key:signer:1", " ", "sig-1", 1),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "signed_message",
+            reason: "must not be empty",
+        })
+    );
+    assert_eq!(
+        KolmeRuntimeCommitSignedBroadcastEnvelope::new(
+            "kamn:key:signer:1",
+            "operation_id=op\n",
+            " ",
+            1
+        ),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "signature",
+            reason: "must not be empty",
         })
     );
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -111,6 +111,11 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_payload_hash_input_contract("));
     assert!(RUNTIME_COMMIT_SRC
         .contains("are_kolme_runtime_commit_request_fields_single_line_contract("));
+    assert!(
+        RUNTIME_COMMIT_SRC.contains("is_kolme_valid_signed_envelope_signer_key_id_input_contract(")
+    );
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_signed_envelope_message_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_signed_envelope_signature_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_commit_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -47,6 +47,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1890"));
     assert!(DOC.contains("#1892"));
     assert!(DOC.contains("#1894"));
+    assert!(DOC.contains("#1896"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/broadcast_payload_policy.rs
+++ b/crates/kamn-kolme/src/broadcast_payload_policy.rs
@@ -30,6 +30,21 @@ impl fmt::Display for KolmeBroadcastPayloadPolicyError {
 
 impl Error for KolmeBroadcastPayloadPolicyError {}
 
+/// Returns whether signed-envelope signer key identifier input is non-empty after trimming.
+pub fn is_valid_signed_envelope_signer_key_id_input(signer_key_id: &str) -> bool {
+    !signer_key_id.trim().is_empty()
+}
+
+/// Returns whether signed-envelope message input is non-empty after trimming.
+pub fn is_valid_signed_envelope_message_input(message: &str) -> bool {
+    !message.trim().is_empty()
+}
+
+/// Returns whether signed-envelope signature input is non-empty after trimming.
+pub fn is_valid_signed_envelope_signature_input(signature: &str) -> bool {
+    !signature.trim().is_empty()
+}
+
 /// Normalizes runtime commit wire payload into canonical Kolme `/broadcast` JSON payload.
 pub fn normalize_broadcast_payload(
     wire_payload: &str,

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -44,7 +44,11 @@ pub use block_scan_policy::{
     validate_block_identity, validate_block_path_template, validate_lookup_txhash,
     validate_lookup_window, BlockScanPolicyError, BlockScanReceiptProjection,
 };
-pub use broadcast_payload_policy::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
+pub use broadcast_payload_policy::{
+    is_valid_signed_envelope_message_input, is_valid_signed_envelope_signature_input,
+    is_valid_signed_envelope_signer_key_id_input, normalize_broadcast_payload,
+    KolmeBroadcastPayloadPolicyError,
+};
 pub use codec::{KolmeCodecError, KolmeWireCodec, PassthroughCodec};
 pub use endpoint_policy::{
     compose_finality_status_path, compose_notifications_websocket_url,

--- a/crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs
@@ -1,4 +1,8 @@
-use kamn_kolme::{normalize_broadcast_payload, KolmeBroadcastPayloadPolicyError};
+use kamn_kolme::{
+    is_valid_signed_envelope_message_input, is_valid_signed_envelope_signature_input,
+    is_valid_signed_envelope_signer_key_id_input, normalize_broadcast_payload,
+    KolmeBroadcastPayloadPolicyError,
+};
 
 #[test]
 fn functional_normalize_broadcast_payload_maps_direct_signed_json() {
@@ -19,6 +23,15 @@ fn functional_normalize_broadcast_payload_maps_signed_envelope_payload() {
     assert!(normalized.contains("\"recovery_id\":1"));
     assert!(normalized.contains("operation_id=op"));
     assert!(normalized.contains("idempotency_key=abc"));
+}
+
+#[test]
+fn functional_broadcast_payload_policy_accepts_non_empty_signed_envelope_field_inputs() {
+    assert!(is_valid_signed_envelope_signer_key_id_input(
+        "kamn:key:signer:1"
+    ));
+    assert!(is_valid_signed_envelope_message_input("operation_id=op\n"));
+    assert!(is_valid_signed_envelope_signature_input("sig-1"));
 }
 
 #[test]
@@ -47,4 +60,12 @@ fn regression_issue_1757_normalize_broadcast_payload_rejects_non_json_direct_mes
             reason: "direct signed payload message must be a JSON object string".to_owned(),
         }
     );
+}
+
+#[test]
+fn regression_issue_1896_broadcast_payload_policy_rejects_empty_signed_envelope_field_inputs() {
+    // Regression: #1896
+    assert!(!is_valid_signed_envelope_signer_key_id_input(" "));
+    assert!(!is_valid_signed_envelope_message_input(" "));
+    assert!(!is_valid_signed_envelope_signature_input(" "));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -65,6 +65,7 @@ Out of scope:
 - #1890: extracted receipt-finality update input guards to `kamn-kolme` (`is_valid_receipt_provider_input` / `is_valid_receipt_commit_id_input`) and rewired `kamn-core` runtime pipeline guard delegation.
 - #1892: extracted runtime-commit request field guards to `kamn-kolme` (`is_valid_runtime_operation_id_input` / `is_valid_runtime_state_root_input` / `is_valid_runtime_payload_hash_input`) and rewired `kamn-core` request validation delegation.
 - #1894: extracted runtime-commit request single-line field guard to `kamn-kolme` (`are_runtime_commit_request_fields_single_line`) and rewired `kamn-core` request validation newline checks delegation.
+- #1896: extracted signed-envelope field guards to `kamn-kolme` (`is_valid_signed_envelope_signer_key_id_input` / `is_valid_signed_envelope_message_input` / `is_valid_signed_envelope_signature_input`) and rewired `kamn-core` signed-envelope constructor guard delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts signed-envelope field guard ownership from `kamn-core` into `kamn-kolme` broadcast-payload contracts, preserving fail-closed `InvalidRequest` parity while reducing core-local constructor guard logic.

## Changes
- `crates/kamn-kolme/src/broadcast_payload_policy.rs`: add `is_valid_signed_envelope_signer_key_id_input`, `is_valid_signed_envelope_message_input`, and `is_valid_signed_envelope_signature_input` helper contracts.
- `crates/kamn-kolme/src/lib.rs`: export new signed-envelope input guard helpers.
- `crates/kamn-kolme/tests/broadcast_payload_policy_contracts.rs`: add functional + regression coverage for signed-envelope field guard helpers.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate signed-envelope constructor guard checks to `kamn-kolme` helper contracts.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: add regression coverage for empty signed-envelope fields fail-closed behavior.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation markers for all three signed-envelope guard helpers.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: require #1896 extraction-plan marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: record #1896 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-client + extraction suites)
- [x] Manual verification: Verified empty signer/message/signature still return `InvalidRequest` with unchanged field/reason parity.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme broadcast-payload contracts |
| Functional  | ✅     | signed-envelope guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-client + extraction boundary/docs tests |
| Regression  | ✅     | #1896 InvalidRequest parity + plan marker assertions |

Closes #1896
