### PR TITLE
refactor(kolme): extract tls stdout guard contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -23,6 +23,7 @@ use kamn_kolme::{
     is_valid_expected_provider_input as is_kolme_valid_expected_provider_input_contract,
     is_valid_finality_base_url_input as is_kolme_valid_finality_base_url_input_contract,
     is_valid_finality_status_path_input as is_kolme_valid_finality_status_path_input_contract,
+    is_valid_http_response_bytes_input as is_kolme_valid_http_response_bytes_input_contract,
     is_valid_http_transport_timeout_seconds as is_kolme_valid_http_transport_timeout_seconds_contract,
     is_valid_live_provider_base_url_input as is_kolme_valid_live_provider_base_url_input_contract,
     is_valid_live_provider_submit_path_input as is_kolme_valid_live_provider_submit_path_input_contract,
@@ -1064,7 +1065,7 @@ impl KolmeRuntimeCommitHttpTransport {
                 ),
             });
         }
-        if output.stdout.is_empty() {
+        if !is_kolme_valid_http_response_bytes_input_contract(output.stdout.as_slice()) {
             return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
                 reason: "tls response body is empty".to_owned(),
             });

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -104,6 +104,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_response_bytes_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_operation_id_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -48,6 +48,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1892"));
     assert!(DOC.contains("#1894"));
     assert!(DOC.contains("#1896"));
+    assert!(DOC.contains("#1898"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/http_response_policy.rs
+++ b/crates/kamn-kolme/src/http_response_policy.rs
@@ -32,6 +32,11 @@ impl fmt::Display for KolmeHttpResponsePolicyError {
 
 impl Error for KolmeHttpResponsePolicyError {}
 
+/// Returns whether raw HTTP response bytes input is non-empty.
+pub fn is_valid_http_response_bytes_input(response_bytes: &[u8]) -> bool {
+    !response_bytes.is_empty()
+}
+
 /// Parses raw HTTP response bytes and returns body for success statuses.
 pub fn parse_http_response_body(
     response_bytes: Vec<u8>,

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -66,7 +66,9 @@ pub use flat_json_policy::{
     parse_flat_json_value_fields, required_json_string_field, required_positive_u64_json_field,
     KolmeFlatJsonPolicyError, KolmeFlatJsonValue,
 };
-pub use http_response_policy::{parse_http_response_body, KolmeHttpResponsePolicyError};
+pub use http_response_policy::{
+    is_valid_http_response_bytes_input, parse_http_response_body, KolmeHttpResponsePolicyError,
+};
 pub use notification_policy::{
     is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
     notification_event_to_provider_receipt, notification_event_to_receipt,

--- a/crates/kamn-kolme/tests/http_response_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/http_response_policy_contracts.rs
@@ -1,4 +1,6 @@
-use kamn_kolme::{parse_http_response_body, KolmeHttpResponsePolicyError};
+use kamn_kolme::{
+    is_valid_http_response_bytes_input, parse_http_response_body, KolmeHttpResponsePolicyError,
+};
 
 #[test]
 fn functional_parse_http_response_body_returns_body_for_2xx() {
@@ -6,6 +8,13 @@ fn functional_parse_http_response_body_returns_body_for_2xx() {
         parse_http_response_body(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello".to_vec())
             .expect("response should parse");
     assert_eq!(body, "hello");
+}
+
+#[test]
+fn functional_http_response_policy_accepts_non_empty_response_bytes_input() {
+    assert!(is_valid_http_response_bytes_input(
+        b"HTTP/1.1 200 OK\r\n\r\n"
+    ));
 }
 
 #[test]
@@ -20,4 +29,10 @@ fn regression_issue_1741_http_response_parser_fails_closed_on_length_mismatch() 
             reason: "http response content-length mismatch: declared 4, observed 5".to_owned(),
         }
     );
+}
+
+#[test]
+fn regression_issue_1898_http_response_policy_rejects_empty_response_bytes_input() {
+    // Regression: #1898
+    assert!(!is_valid_http_response_bytes_input(&[]));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -66,6 +66,7 @@ Out of scope:
 - #1892: extracted runtime-commit request field guards to `kamn-kolme` (`is_valid_runtime_operation_id_input` / `is_valid_runtime_state_root_input` / `is_valid_runtime_payload_hash_input`) and rewired `kamn-core` request validation delegation.
 - #1894: extracted runtime-commit request single-line field guard to `kamn-kolme` (`are_runtime_commit_request_fields_single_line`) and rewired `kamn-core` request validation newline checks delegation.
 - #1896: extracted signed-envelope field guards to `kamn-kolme` (`is_valid_signed_envelope_signer_key_id_input` / `is_valid_signed_envelope_message_input` / `is_valid_signed_envelope_signature_input`) and rewired `kamn-core` signed-envelope constructor guard delegation.
+- #1898: extracted HTTPS transport stdout non-empty guard to `kamn-kolme` (`is_valid_http_response_bytes_input`) and rewired `kamn-core` TLS response-byte validation delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts the HTTPS transport stdout non-empty guard from `kamn-core` into `kamn-kolme` HTTP response policy contracts, preserving fail-closed malformed-response parity while reducing core-local response guard logic.

## Changes
- `crates/kamn-kolme/src/http_response_policy.rs`: add `is_valid_http_response_bytes_input` helper contract.
- `crates/kamn-kolme/src/lib.rs`: export the response-bytes input guard helper.
- `crates/kamn-kolme/tests/http_response_policy_contracts.rs`: add functional + regression coverage for non-empty/empty response bytes input.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate HTTPS output stdout-empty check to `kamn-kolme` helper in `execute_https_request`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation marker for response-bytes guard helper.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: require #1898 extraction-plan marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: record #1898 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted HTTP transport + extraction suites)
- [x] Manual verification: Verified empty TLS stdout still returns `MalformedResponse { reason: "tls response body is empty" }`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme HTTP response policy contracts |
| Functional  | ✅     | response-bytes guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core HTTP transport + extraction boundary/docs tests |
| Regression  | ✅     | #1898 malformed-response parity + plan marker assertions |

Closes #1898
