### PR TITLE
refactor(kolme): extract runtime nonce guard contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -34,6 +34,7 @@ use kamn_kolme::{
     is_valid_receipt_commit_id_input as is_kolme_valid_receipt_commit_id_input_contract,
     is_valid_receipt_provider_input as is_kolme_valid_receipt_provider_input_contract,
     is_valid_runtime_commit_id_request as is_kolme_valid_runtime_commit_id_request_contract,
+    is_valid_runtime_nonce_input as is_kolme_valid_runtime_nonce_input_contract,
     is_valid_runtime_operation_id_input as is_kolme_valid_runtime_operation_id_input_contract,
     is_valid_runtime_payload_hash_input as is_kolme_valid_runtime_payload_hash_input_contract,
     is_valid_runtime_provider_input as is_kolme_valid_runtime_provider_input_contract,
@@ -206,7 +207,7 @@ impl KolmeRuntimeCommitRequest {
                 reason: "must not be empty",
             });
         }
-        if self.nonce == 0 {
+        if !is_kolme_valid_runtime_nonce_input_contract(self.nonce) {
             return Err(KolmeRuntimeCommitError::InvalidRequest {
                 field: "nonce",
                 reason: "must be positive",

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -392,6 +392,30 @@ fn regression_issue_1896_signed_envelope_constructor_rejects_empty_fields() {
 }
 
 #[test]
+fn regression_issue_1900_submit_commit_fails_closed_for_zero_nonce() {
+    // Regression: #1900
+    let mut request = KolmeRuntimeCommitRequest::deterministic(
+        "op-sync-1900-nonce",
+        "state:nonce",
+        "kamn:did:agent:runtime-node-1900",
+        1,
+        "payload:nonce",
+    )
+    .expect("request should build");
+    request.nonce = 0;
+
+    let mut client =
+        InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");
+    assert_eq!(
+        client.submit_commit(&request),
+        Err(KolmeRuntimeCommitError::InvalidRequest {
+            field: "nonce",
+            reason: "must be positive",
+        })
+    );
+}
+
+#[test]
 fn performance_runtime_commit_contract_lane_stays_within_budget() {
     let mut client =
         InMemoryKolmeRuntimeCommitClient::new("kolme-local").expect("client should build");

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -110,6 +110,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_operation_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_state_root_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_payload_hash_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_nonce_input_contract("));
     assert!(RUNTIME_COMMIT_SRC
         .contains("are_kolme_runtime_commit_request_fields_single_line_contract("));
     assert!(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -49,6 +49,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1894"));
     assert!(DOC.contains("#1896"));
     assert!(DOC.contains("#1898"));
+    assert!(DOC.contains("#1900"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -100,8 +100,8 @@ pub use runtime_lifecycle_policy::{
 pub use runtime_request_identity_policy::{
     are_runtime_commit_request_fields_single_line, deterministic_runtime_commit_id,
     deterministic_runtime_commit_idempotency_key, is_valid_runtime_commit_id_request,
-    is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-    is_valid_runtime_state_root_input,
+    is_valid_runtime_nonce_input, is_valid_runtime_operation_id_input,
+    is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -54,6 +54,11 @@ pub fn is_valid_runtime_payload_hash_input(payload_hash: &str) -> bool {
     !payload_hash.trim().is_empty()
 }
 
+/// Validates runtime commit request nonce input.
+pub fn is_valid_runtime_nonce_input(nonce: u64) -> bool {
+    nonce > 0
+}
+
 /// Returns whether runtime commit request fields satisfy single-line constraints.
 pub fn are_runtime_commit_request_fields_single_line(
     operation_id: &str,
@@ -68,8 +73,8 @@ mod tests {
     use super::{
         are_runtime_commit_request_fields_single_line, deterministic_runtime_commit_id,
         deterministic_runtime_commit_idempotency_key, is_valid_runtime_commit_id_request,
-        is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-        is_valid_runtime_state_root_input,
+        is_valid_runtime_nonce_input, is_valid_runtime_operation_id_input,
+        is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
     };
 
     #[test]
@@ -111,6 +116,12 @@ mod tests {
         assert!(!is_valid_runtime_operation_id_input(" "));
         assert!(!is_valid_runtime_state_root_input(" "));
         assert!(!is_valid_runtime_payload_hash_input(" "));
+    }
+
+    #[test]
+    fn unit_validates_runtime_commit_request_nonce_input() {
+        assert!(is_valid_runtime_nonce_input(1));
+        assert!(!is_valid_runtime_nonce_input(0));
     }
 
     #[test]

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -1,8 +1,8 @@
 use kamn_kolme::{
     are_runtime_commit_request_fields_single_line, deterministic_runtime_commit_id,
     deterministic_runtime_commit_idempotency_key, is_valid_runtime_commit_id_request,
-    is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-    is_valid_runtime_state_root_input,
+    is_valid_runtime_nonce_input, is_valid_runtime_operation_id_input,
+    is_valid_runtime_payload_hash_input, is_valid_runtime_state_root_input,
 };
 
 #[test]
@@ -56,6 +56,11 @@ fn functional_runtime_request_identity_policy_accepts_non_empty_request_fields()
 }
 
 #[test]
+fn functional_runtime_request_identity_policy_accepts_positive_nonce_input() {
+    assert!(is_valid_runtime_nonce_input(1));
+}
+
+#[test]
 fn regression_issue_1892_runtime_request_identity_policy_rejects_empty_request_fields() {
     // Regression: #1892
     assert!(!is_valid_runtime_operation_id_input(" "));
@@ -90,4 +95,10 @@ fn regression_issue_1894_runtime_request_identity_policy_rejects_multiline_reque
         "state:beta",
         "payload:beta\nwrapped"
     ));
+}
+
+#[test]
+fn regression_issue_1900_runtime_request_identity_policy_rejects_zero_nonce_input() {
+    // Regression: #1900
+    assert!(!is_valid_runtime_nonce_input(0));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -67,6 +67,7 @@ Out of scope:
 - #1894: extracted runtime-commit request single-line field guard to `kamn-kolme` (`are_runtime_commit_request_fields_single_line`) and rewired `kamn-core` request validation newline checks delegation.
 - #1896: extracted signed-envelope field guards to `kamn-kolme` (`is_valid_signed_envelope_signer_key_id_input` / `is_valid_signed_envelope_message_input` / `is_valid_signed_envelope_signature_input`) and rewired `kamn-core` signed-envelope constructor guard delegation.
 - #1898: extracted HTTPS transport stdout non-empty guard to `kamn-kolme` (`is_valid_http_response_bytes_input`) and rewired `kamn-core` TLS response-byte validation delegation.
+- #1900: extracted runtime request nonce guard to `kamn-kolme` (`is_valid_runtime_nonce_input`) and rewired `kamn-core` request validation nonce delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts runtime request nonce guard ownership from `kamn-core` into `kamn-kolme` runtime-request-identity contracts, preserving fail-closed `InvalidRequest` parity while reducing core-local request validation logic.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: add `is_valid_runtime_nonce_input` helper contract.
- `crates/kamn-kolme/src/lib.rs`: export runtime nonce guard helper.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: add functional + regression coverage for nonce input.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegate request nonce guard in `KolmeRuntimeCommitRequest::validate` to `kamn-kolme` helper.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: add regression for zero nonce fail-closed behavior.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: enforce delegation marker for runtime nonce helper.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: require #1900 extraction-plan marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: record #1900 Phase 2 extraction progress.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted crates)
- [x] Unit tests pass
- [x] Integration tests pass (targeted runtime-client + extraction suites)
- [x] Manual verification: Verified zero nonce still returns `InvalidRequest { field: "nonce", reason: "must be positive" }`.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | kamn-kolme runtime-request-identity contracts |
| Functional  | ✅     | runtime nonce guard acceptance/rejection coverage |
| Integration | ✅     | kamn-core runtime-client + extraction boundary/docs tests |
| Regression  | ✅     | #1900 InvalidRequest parity + plan marker assertions |

Closes #1900
