### PR TITLE
refactor(kolme): extract signed-envelope normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -50,6 +50,7 @@ use kamn_kolme::{
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
+    normalize_runtime_commit_signed_envelope_fields as normalize_kolme_runtime_commit_signed_envelope_fields_contract,
     notification_event_to_provider_receipt as notification_event_to_kolme_provider_receipt_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_http_endpoint as parse_kolme_http_endpoint,
@@ -276,13 +277,16 @@ impl KolmeRuntimeCommitSignedBroadcastEnvelope {
                 reason: "must not be empty",
             });
         }
-        let signer_key_id = signer_key_id.trim();
-        let message = message.trim();
-        let signature = signature.trim();
+        let (signer_key_id, message, signature) =
+            normalize_kolme_runtime_commit_signed_envelope_fields_contract(
+                signer_key_id,
+                message,
+                signature,
+            );
         Ok(Self {
-            signer_key_id: signer_key_id.to_owned(),
-            message: message.to_owned(),
-            signature: signature.to_owned(),
+            signer_key_id,
+            message,
+            signature,
             recovery_id,
         })
     }

--- a/crates/kamn-core/tests/kolme_api_codec_contracts.rs
+++ b/crates/kamn-core/tests/kolme_api_codec_contracts.rs
@@ -160,3 +160,33 @@ fn functional_runtime_commit_signed_translation_emits_canonical_signed_envelope(
     assert_eq!(broadcast_request.signature, "sig-1506-b");
     assert_eq!(broadcast_request.recovery_id, 2);
 }
+
+#[test]
+fn regression_issue_1904_runtime_commit_signed_translation_trims_outer_whitespace() {
+    // Regression: #1904
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-1506-c",
+        "state:1506",
+        "kamn:did:agent:codec-1506-c",
+        13,
+        "payload:1506-c",
+    )
+    .expect("request should build");
+    let canonical_message = request.to_wire_payload();
+
+    let envelope = request
+        .translate_to_signed_broadcast_envelope(
+            " kamn:key:signer:3 ",
+            canonical_message.as_str(),
+            " sig-1506-c ",
+            3,
+        )
+        .expect("signed envelope should build");
+
+    assert_eq!(envelope.signer_key_id, "kamn:key:signer:3");
+    assert_eq!(envelope.signature, "sig-1506-c");
+    let broadcast_request = envelope
+        .to_broadcast_request()
+        .expect("broadcast request should build");
+    assert_eq!(broadcast_request.signature, "sig-1506-c");
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -42,6 +42,9 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_classification_to_provider_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
 }
 
 #[test]
@@ -121,6 +124,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_signed_envelope_message_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_signed_envelope_signature_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("normalize_kolme_runtime_commit_signed_envelope_fields_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_receipt_commit_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_transport_idempotency_key_input_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -51,6 +51,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1898"));
     assert!(DOC.contains("#1900"));
     assert!(DOC.contains("#1902"));
+    assert!(DOC.contains("#1904"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -102,7 +102,7 @@ pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_idempotency_key, is_canonical_runtime_commit_signed_message,
     is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-    is_valid_runtime_state_root_input,
+    is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -76,6 +76,19 @@ pub fn is_canonical_runtime_commit_signed_message(
     signed_message == canonical_message
 }
 
+/// Normalizes signed-envelope fields for deterministic runtime commit wiring.
+pub fn normalize_runtime_commit_signed_envelope_fields(
+    signer_key_id: &str,
+    signed_message: &str,
+    signature: &str,
+) -> (String, String, String) {
+    (
+        signer_key_id.trim().to_owned(),
+        signed_message.trim().to_owned(),
+        signature.trim().to_owned(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -83,7 +96,7 @@ mod tests {
         deterministic_runtime_commit_idempotency_key, is_canonical_runtime_commit_signed_message,
         is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
         is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-        is_valid_runtime_state_root_input,
+        is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
     };
 
     #[test]
@@ -157,5 +170,22 @@ mod tests {
             "operation_id=op-1\nstate_root=state-1\n",
             "operation_id=op-2\nstate_root=state-1\n",
         ));
+    }
+
+    #[test]
+    fn unit_normalizes_runtime_commit_signed_envelope_fields() {
+        let normalized = normalize_runtime_commit_signed_envelope_fields(
+            " signer-key-1 ",
+            " canonical-payload ",
+            " signature-hex ",
+        );
+        assert_eq!(
+            normalized,
+            (
+                "signer-key-1".to_owned(),
+                "canonical-payload".to_owned(),
+                "signature-hex".to_owned(),
+            )
+        );
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -3,7 +3,7 @@ use kamn_kolme::{
     deterministic_runtime_commit_idempotency_key, is_canonical_runtime_commit_signed_message,
     is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-    is_valid_runtime_state_root_input,
+    is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
 };
 
 #[test]
@@ -87,6 +87,23 @@ fn functional_runtime_request_identity_policy_accepts_canonical_signed_message_m
 }
 
 #[test]
+fn functional_runtime_request_identity_policy_normalizes_signed_envelope_fields() {
+    let normalized = normalize_runtime_commit_signed_envelope_fields(
+        " signer-key-2 ",
+        " message-body ",
+        " signature-body ",
+    );
+    assert_eq!(
+        normalized,
+        (
+            "signer-key-2".to_owned(),
+            "message-body".to_owned(),
+            "signature-body".to_owned(),
+        )
+    );
+}
+
+#[test]
 fn regression_issue_1894_runtime_request_identity_policy_rejects_multiline_request_fields() {
     // Regression: #1894
     assert!(!are_runtime_commit_request_fields_single_line(
@@ -120,4 +137,22 @@ fn regression_issue_1902_runtime_request_identity_policy_rejects_noncanonical_si
     assert!(!is_canonical_runtime_commit_signed_message(
         canonical, tampered
     ));
+}
+
+#[test]
+fn regression_issue_1904_runtime_request_identity_policy_preserves_inner_whitespace() {
+    // Regression: #1904
+    let normalized = normalize_runtime_commit_signed_envelope_fields(
+        "\t signer-key-2\t",
+        " message value with spaces ",
+        "\n signature value \n",
+    );
+    assert_eq!(
+        normalized,
+        (
+            "signer-key-2".to_owned(),
+            "message value with spaces".to_owned(),
+            "signature value".to_owned(),
+        )
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -69,6 +69,7 @@ Out of scope:
 - #1898: extracted HTTPS transport stdout non-empty guard to `kamn-kolme` (`is_valid_http_response_bytes_input`) and rewired `kamn-core` TLS response-byte validation delegation.
 - #1900: extracted runtime request nonce guard to `kamn-kolme` (`is_valid_runtime_nonce_input`) and rewired `kamn-core` request validation nonce delegation.
 - #1902: extracted canonical signed-message match guard to `kamn-kolme` (`is_canonical_runtime_commit_signed_message`) and rewired `kamn-core` signed-envelope canonical payload match validation delegation.
+- #1904: extracted signed-envelope field normalization contract to `kamn-kolme` (`normalize_runtime_commit_signed_envelope_fields`) and rewired `kamn-core` signed-envelope construction normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract signed-envelope field normalization from `kamn-core` into a dedicated `kamn-kolme` runtime identity contract. This keeps runtime commit policy ownership inside the extracted crate while preserving existing envelope behavior.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: added `normalize_runtime_commit_signed_envelope_fields` plus unit coverage.
- `crates/kamn-kolme/src/lib.rs`: exported the new normalization contract.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: added functional and regression tests for normalization semantics.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired `KolmeRuntimeCommitSignedBroadcastEnvelope::new` to delegate normalization to `kamn-kolme`.
- `crates/kamn-core/tests/kolme_api_codec_contracts.rs`: added regression coverage for whitespace-trim behavior in signed translation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added marker assertions ensuring direct trim normalization no longer lives in `kamn-core` and delegated helper is used.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1904` plan marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged `#1904` in Phase 2 progress.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_runtime_commit_signed_envelope_fields`
 --> crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs:4:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts` (15 passed)
- `cargo test -p kamn-core --test kolme_api_codec_contracts` (12 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_normalizes_runtime_commit_signed_envelope_fields` | |
| Functional   | ✅     | `functional_runtime_request_identity_policy_normalizes_signed_envelope_fields` | |
| Integration  | ✅     | `regression_issue_1904_runtime_commit_signed_translation_trims_outer_whitespace` validates core↔kolme signed-envelope interaction | |
| Regression   | ✅     | `regression_issue_1904_runtime_request_identity_policy_preserves_inner_whitespace` | |
| Performance  | N/A    | None | Extraction-only policy move; no throughput/latency path change |

## Risks & Rollback
- None.
- Rollback: revert commit `53f68ef`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with Phase 2 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1904
