### PR TITLE
refactor(kolme): extract runtime-commit wire payload render contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -63,6 +63,7 @@ use kamn_kolme::{
     project_failed_block_txhash_receipt as project_kolme_failed_block_txhash_receipt_contract,
     project_finalized_block_txhash_receipt as project_kolme_finalized_block_txhash_receipt_contract,
     render_block_path as render_kolme_block_path,
+    render_runtime_commit_wire_payload as render_kolme_runtime_commit_wire_payload_contract,
     require_commit_id_matches_expected_txhash as require_kolme_commit_id_matches_expected_txhash_contract,
     require_final_receipt_finality as require_kolme_final_receipt_finality_contract,
     resolve_lookup_upper_bound as resolve_kolme_lookup_upper_bound,
@@ -155,14 +156,13 @@ impl KolmeRuntimeCommitRequest {
 
     /// Returns deterministic request payload in canonical field order.
     pub fn to_wire_payload(&self) -> String {
-        format!(
-            "operation_id={}\nstate_root={}\nactor_did={}\nnonce={}\npayload_hash={}\nidempotency_key={}\n",
-            self.operation_id,
-            self.state_root,
+        render_kolme_runtime_commit_wire_payload_contract(
+            self.operation_id.as_str(),
+            self.state_root.as_str(),
             self.actor_did.as_str(),
             self.nonce,
-            self.payload_hash,
-            self.idempotency_key
+            self.payload_hash.as_str(),
+            self.idempotency_key.as_str(),
         )
     }
 

--- a/crates/kamn-core/tests/kolme_api_codec_contracts.rs
+++ b/crates/kamn-core/tests/kolme_api_codec_contracts.rs
@@ -162,6 +162,24 @@ fn functional_runtime_commit_signed_translation_emits_canonical_signed_envelope(
 }
 
 #[test]
+fn regression_issue_1906_runtime_commit_wire_payload_order_remains_canonical() {
+    // Regression: #1906
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-1506-d",
+        "state:1506",
+        "kamn:did:agent:codec-1506-d",
+        14,
+        "payload:1506-d",
+    )
+    .expect("request should build");
+
+    assert_eq!(
+        request.to_wire_payload(),
+        "operation_id=op-1506-d\nstate_root=state:1506\nactor_did=kamn:did:agent:codec-1506-d\nnonce=14\npayload_hash=payload:1506-d\nidempotency_key=kolme-runtime-commit:op-1506-d:state:1506:kamn:did:agent:codec-1506-d:14:14\n"
+    );
+}
+
+#[test]
 fn regression_issue_1904_runtime_commit_signed_translation_trims_outer_whitespace() {
     // Regression: #1904
     let request = KolmeRuntimeCommitRequest::deterministic(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -45,6 +45,9 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
+    assert!(!RUNTIME_COMMIT_SRC.contains(
+        "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
+    ));
 }
 
 #[test]
@@ -62,6 +65,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_commit_id_request_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_runtime_commit_wire_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -52,6 +52,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1900"));
     assert!(DOC.contains("#1902"));
     assert!(DOC.contains("#1904"));
+    assert!(DOC.contains("#1906"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -103,6 +103,7 @@ pub use runtime_request_identity_policy::{
     is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
     is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
+    render_runtime_commit_wire_payload,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -18,6 +18,21 @@ pub fn deterministic_runtime_commit_idempotency_key(
     )
 }
 
+/// Renders runtime commit wire payload in canonical field order.
+pub fn render_runtime_commit_wire_payload(
+    operation_id: &str,
+    state_root: &str,
+    actor_did: &str,
+    nonce: u64,
+    payload_hash: &str,
+    idempotency_key: &str,
+) -> String {
+    format!(
+        "operation_id={}\nstate_root={}\nactor_did={}\nnonce={}\npayload_hash={}\nidempotency_key={}\n",
+        operation_id, state_root, actor_did, nonce, payload_hash, idempotency_key
+    )
+}
+
 /// Renders deterministic runtime commit identifier from request fields.
 pub fn deterministic_runtime_commit_id(
     operation_id: &str,
@@ -97,6 +112,7 @@ mod tests {
         is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
         is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
         is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
+        render_runtime_commit_wire_payload,
     };
 
     #[test]
@@ -186,6 +202,22 @@ mod tests {
                 "canonical-payload".to_owned(),
                 "signature-hex".to_owned(),
             )
+        );
+    }
+
+    #[test]
+    fn unit_renders_runtime_commit_wire_payload_contract() {
+        let payload = render_runtime_commit_wire_payload(
+            "op-11",
+            "state:gamma",
+            "did:kamn:agent:gamma",
+            4,
+            "payload:gamma",
+            "idempotency:gamma",
+        );
+        assert_eq!(
+            payload,
+            "operation_id=op-11\nstate_root=state:gamma\nactor_did=did:kamn:agent:gamma\nnonce=4\npayload_hash=payload:gamma\nidempotency_key=idempotency:gamma\n"
         );
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -4,6 +4,7 @@ use kamn_kolme::{
     is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
     is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
+    render_runtime_commit_wire_payload,
 };
 
 #[test]
@@ -104,6 +105,22 @@ fn functional_runtime_request_identity_policy_normalizes_signed_envelope_fields(
 }
 
 #[test]
+fn functional_runtime_request_identity_policy_renders_runtime_commit_wire_payload() {
+    let payload = render_runtime_commit_wire_payload(
+        "op-12",
+        "state:delta",
+        "did:kamn:agent:delta",
+        8,
+        "payload:delta",
+        "idempotency:delta",
+    );
+    assert_eq!(
+        payload,
+        "operation_id=op-12\nstate_root=state:delta\nactor_did=did:kamn:agent:delta\nnonce=8\npayload_hash=payload:delta\nidempotency_key=idempotency:delta\n"
+    );
+}
+
+#[test]
 fn regression_issue_1894_runtime_request_identity_policy_rejects_multiline_request_fields() {
     // Regression: #1894
     assert!(!are_runtime_commit_request_fields_single_line(
@@ -155,4 +172,19 @@ fn regression_issue_1904_runtime_request_identity_policy_preserves_inner_whitesp
             "signature value".to_owned(),
         )
     );
+}
+
+#[test]
+fn regression_issue_1906_runtime_request_identity_policy_wire_payload_field_order_is_stable() {
+    // Regression: #1906
+    let payload = render_runtime_commit_wire_payload(
+        "op-12",
+        "state:delta",
+        "did:kamn:agent:delta",
+        8,
+        "payload:delta",
+        "idempotency:delta",
+    );
+    assert!(payload.starts_with("operation_id=op-12\nstate_root=state:delta\n"));
+    assert!(payload.ends_with("idempotency_key=idempotency:delta\n"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -70,6 +70,7 @@ Out of scope:
 - #1900: extracted runtime request nonce guard to `kamn-kolme` (`is_valid_runtime_nonce_input`) and rewired `kamn-core` request validation nonce delegation.
 - #1902: extracted canonical signed-message match guard to `kamn-kolme` (`is_canonical_runtime_commit_signed_message`) and rewired `kamn-core` signed-envelope canonical payload match validation delegation.
 - #1904: extracted signed-envelope field normalization contract to `kamn-kolme` (`normalize_runtime_commit_signed_envelope_fields`) and rewired `kamn-core` signed-envelope construction normalization delegation.
+- #1906: extracted runtime-commit canonical wire-payload renderer to `kamn-kolme` (`render_runtime_commit_wire_payload`) and rewired `kamn-core` runtime request payload serialization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract canonical runtime-commit wire-payload rendering from `kamn-core` into `kamn-kolme` as an explicit request identity contract. This narrows `kamn-core` ownership to orchestration while preserving payload format and signed-translation compatibility.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: added `render_runtime_commit_wire_payload` contract and unit coverage.
- `crates/kamn-kolme/src/lib.rs`: exported runtime-commit wire payload renderer.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: added functional + regression coverage for canonical field-order/newline payload rendering.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired `KolmeRuntimeCommitRequest::to_wire_payload` to delegate to extracted renderer.
- `crates/kamn-core/tests/kolme_api_codec_contracts.rs`: added `#1906` regression asserting canonical payload ordering remains unchanged through delegated rendering.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary markers for delegated renderer and removed inline format ownership.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1906` plan marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged `#1906` in Phase 2 progress.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::render_runtime_commit_wire_payload`
 --> crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs:7:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts` (17 passed)
- `cargo test -p kamn-core --test kolme_api_codec_contracts` (13 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_renders_runtime_commit_wire_payload_contract` | |
| Functional   | ✅     | `functional_runtime_request_identity_policy_renders_runtime_commit_wire_payload` | |
| Integration  | ✅     | `regression_issue_1906_runtime_commit_wire_payload_order_remains_canonical` (core request -> payload contract path) | |
| Regression   | ✅     | `regression_issue_1906_runtime_request_identity_policy_wire_payload_field_order_is_stable` | |
| Performance  | N/A    | None | Extraction-only contract move; no performance-path expansion |

## Risks & Rollback
- None.
- Rollback: revert commit `a49d70d`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with `#1906` progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1906
