### PR TITLE
refactor(kolme): extract runtime request field normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -50,6 +50,7 @@ use kamn_kolme::{
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
+    normalize_runtime_commit_request_fields as normalize_kolme_runtime_commit_request_fields_contract,
     normalize_runtime_commit_signed_envelope_fields as normalize_kolme_runtime_commit_signed_envelope_fields_contract,
     notification_event_to_provider_receipt as notification_event_to_kolme_provider_receipt_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
@@ -133,21 +134,27 @@ impl KolmeRuntimeCommitRequest {
                 field: "actor_did",
                 reason: "must be a valid KAMN DID",
             })?;
+        let (operation_id, state_root, payload_hash) =
+            normalize_kolme_runtime_commit_request_fields_contract(
+                operation_id,
+                state_root,
+                payload_hash,
+            );
         let actor_did_value = actor_did.as_str().to_owned();
         let idempotency_key = deterministic_runtime_commit_idempotency_key_contract(
-            operation_id,
-            state_root,
+            operation_id.as_str(),
+            state_root.as_str(),
             actor_did_value.as_str(),
             nonce,
-            payload_hash,
+            payload_hash.as_str(),
         );
 
         let request = Self {
-            operation_id: operation_id.trim().to_owned(),
-            state_root: state_root.trim().to_owned(),
+            operation_id,
+            state_root,
             actor_did,
             nonce,
-            payload_hash: payload_hash.trim().to_owned(),
+            payload_hash,
             idempotency_key,
         };
         request.validate()?;

--- a/crates/kamn-core/tests/kolme_api_codec_contracts.rs
+++ b/crates/kamn-core/tests/kolme_api_codec_contracts.rs
@@ -180,6 +180,24 @@ fn regression_issue_1906_runtime_commit_wire_payload_order_remains_canonical() {
 }
 
 #[test]
+fn regression_issue_1908_runtime_commit_request_construction_trims_request_fields() {
+    // Regression: #1908
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        " op-1506-e ",
+        " state:1506 ",
+        "kamn:did:agent:codec-1506-e",
+        15,
+        " payload:1506-e ",
+    )
+    .expect("request should build");
+
+    assert_eq!(
+        request.to_wire_payload(),
+        "operation_id=op-1506-e\nstate_root=state:1506\nactor_did=kamn:did:agent:codec-1506-e\nnonce=15\npayload_hash=payload:1506-e\nidempotency_key=kolme-runtime-commit:op-1506-e:state:1506:kamn:did:agent:codec-1506-e:15:14\n"
+    );
+}
+
+#[test]
 fn regression_issue_1904_runtime_commit_signed_translation_trims_outer_whitespace() {
     // Regression: #1904
     let request = KolmeRuntimeCommitRequest::deterministic(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -45,6 +45,9 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("operation_id: operation_id.trim().to_owned(),"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("state_root: state_root.trim().to_owned(),"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("payload_hash: payload_hash.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
@@ -66,6 +69,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_runtime_commit_wire_payload_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_runtime_commit_request_fields_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -53,6 +53,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1902"));
     assert!(DOC.contains("#1904"));
     assert!(DOC.contains("#1906"));
+    assert!(DOC.contains("#1908"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -102,8 +102,8 @@ pub use runtime_request_identity_policy::{
     deterministic_runtime_commit_idempotency_key, is_canonical_runtime_commit_signed_message,
     is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-    is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
-    render_runtime_commit_wire_payload,
+    is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
+    normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -33,6 +33,19 @@ pub fn render_runtime_commit_wire_payload(
     )
 }
 
+/// Normalizes runtime commit request fields before deterministic identity/rendering.
+pub fn normalize_runtime_commit_request_fields(
+    operation_id: &str,
+    state_root: &str,
+    payload_hash: &str,
+) -> (String, String, String) {
+    (
+        operation_id.trim().to_owned(),
+        state_root.trim().to_owned(),
+        payload_hash.trim().to_owned(),
+    )
+}
+
 /// Renders deterministic runtime commit identifier from request fields.
 pub fn deterministic_runtime_commit_id(
     operation_id: &str,
@@ -111,8 +124,8 @@ mod tests {
         deterministic_runtime_commit_idempotency_key, is_canonical_runtime_commit_signed_message,
         is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
         is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-        is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
-        render_runtime_commit_wire_payload,
+        is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
+        normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
     };
 
     #[test]
@@ -218,6 +231,23 @@ mod tests {
         assert_eq!(
             payload,
             "operation_id=op-11\nstate_root=state:gamma\nactor_did=did:kamn:agent:gamma\nnonce=4\npayload_hash=payload:gamma\nidempotency_key=idempotency:gamma\n"
+        );
+    }
+
+    #[test]
+    fn unit_normalizes_runtime_commit_request_fields() {
+        let normalized = normalize_runtime_commit_request_fields(
+            " operation-42 ",
+            " state:epsilon ",
+            " payload:epsilon ",
+        );
+        assert_eq!(
+            normalized,
+            (
+                "operation-42".to_owned(),
+                "state:epsilon".to_owned(),
+                "payload:epsilon".to_owned(),
+            )
         );
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -3,8 +3,8 @@ use kamn_kolme::{
     deterministic_runtime_commit_idempotency_key, is_canonical_runtime_commit_signed_message,
     is_valid_runtime_commit_id_request, is_valid_runtime_nonce_input,
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
-    is_valid_runtime_state_root_input, normalize_runtime_commit_signed_envelope_fields,
-    render_runtime_commit_wire_payload,
+    is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
+    normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
 };
 
 #[test]
@@ -121,6 +121,20 @@ fn functional_runtime_request_identity_policy_renders_runtime_commit_wire_payloa
 }
 
 #[test]
+fn functional_runtime_request_identity_policy_normalizes_runtime_commit_request_fields() {
+    let normalized =
+        normalize_runtime_commit_request_fields(" op-19 ", " state:zeta ", " payload:zeta ");
+    assert_eq!(
+        normalized,
+        (
+            "op-19".to_owned(),
+            "state:zeta".to_owned(),
+            "payload:zeta".to_owned(),
+        )
+    );
+}
+
+#[test]
 fn regression_issue_1894_runtime_request_identity_policy_rejects_multiline_request_fields() {
     // Regression: #1894
     assert!(!are_runtime_commit_request_fields_single_line(
@@ -187,4 +201,19 @@ fn regression_issue_1906_runtime_request_identity_policy_wire_payload_field_orde
     );
     assert!(payload.starts_with("operation_id=op-12\nstate_root=state:delta\n"));
     assert!(payload.ends_with("idempotency_key=idempotency:delta\n"));
+}
+
+#[test]
+fn regression_issue_1908_runtime_request_identity_policy_trims_outer_request_whitespace() {
+    // Regression: #1908
+    let normalized =
+        normalize_runtime_commit_request_fields("\top-19\t", "\nstate:zeta\n", " payload:zeta ");
+    assert_eq!(
+        normalized,
+        (
+            "op-19".to_owned(),
+            "state:zeta".to_owned(),
+            "payload:zeta".to_owned(),
+        )
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -71,6 +71,7 @@ Out of scope:
 - #1902: extracted canonical signed-message match guard to `kamn-kolme` (`is_canonical_runtime_commit_signed_message`) and rewired `kamn-core` signed-envelope canonical payload match validation delegation.
 - #1904: extracted signed-envelope field normalization contract to `kamn-kolme` (`normalize_runtime_commit_signed_envelope_fields`) and rewired `kamn-core` signed-envelope construction normalization delegation.
 - #1906: extracted runtime-commit canonical wire-payload renderer to `kamn-kolme` (`render_runtime_commit_wire_payload`) and rewired `kamn-core` runtime request payload serialization delegation.
+- #1908: extracted runtime request field normalization contract to `kamn-kolme` (`normalize_runtime_commit_request_fields`) and rewired `kamn-core` deterministic request construction normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract runtime-commit request field normalization (`operation_id`, `state_root`, `payload_hash`) from `kamn-core` into `kamn-kolme` as a dedicated request identity contract. This further narrows `kamn-core` ownership to orchestration and error mapping.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: added `normalize_runtime_commit_request_fields` and unit coverage.
- `crates/kamn-kolme/src/lib.rs`: exported request field normalization contract.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: added functional + regression tests for request field normalization behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired deterministic request construction to use normalization contract and removed inline `trim` ownership.
- `crates/kamn-core/tests/kolme_api_codec_contracts.rs`: added `#1908` regression ensuring whitespace-padded inputs still produce canonical deterministic payload.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added assertions for removed inline trims and delegated helper marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1908` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added `#1908` Phase 2 progress entry.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_runtime_commit_request_fields`
 --> crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs:4:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts` (19 passed)
- `cargo test -p kamn-core --test kolme_api_codec_contracts` (14 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_normalizes_runtime_commit_request_fields` | |
| Functional   | ✅     | `functional_runtime_request_identity_policy_normalizes_runtime_commit_request_fields` | |
| Integration  | ✅     | `regression_issue_1908_runtime_commit_request_construction_trims_request_fields` validates core deterministic constructor → payload contract path | |
| Regression   | ✅     | `regression_issue_1908_runtime_request_identity_policy_trims_outer_request_whitespace` | |
| Performance  | N/A    | None | Extraction-only normalization move; no perf-path expansion |

## Risks & Rollback
- None.
- Rollback: revert commit `f290905`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1908` progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1908
