### PR TITLE
refactor(kolme): extract signed-envelope wire payload render contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -12,7 +12,6 @@ use kamn_kolme::{
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     deterministic_runtime_commit_id as deterministic_runtime_commit_id_contract,
     deterministic_runtime_commit_idempotency_key as deterministic_runtime_commit_idempotency_key_contract,
-    escape_json_string as escape_kolme_json_string,
     find_http_header_boundary as find_kolme_http_header_boundary,
     is_broadcast_submit_path as is_kolme_broadcast_submit_path_contract,
     is_canonical_runtime_commit_signed_message as is_kolme_canonical_runtime_commit_signed_message_contract,
@@ -65,6 +64,7 @@ use kamn_kolme::{
     project_finalized_block_txhash_receipt as project_kolme_finalized_block_txhash_receipt_contract,
     render_block_path as render_kolme_block_path,
     render_runtime_commit_wire_payload as render_kolme_runtime_commit_wire_payload_contract,
+    render_signed_envelope_wire_payload as render_kolme_signed_envelope_wire_payload_contract,
     require_commit_id_matches_expected_txhash as require_kolme_commit_id_matches_expected_txhash_contract,
     require_final_receipt_finality as require_kolme_final_receipt_finality_contract,
     resolve_lookup_upper_bound as resolve_kolme_lookup_upper_bound,
@@ -300,12 +300,11 @@ impl KolmeRuntimeCommitSignedBroadcastEnvelope {
 
     /// Returns canonical wire payload used by fork submit profile before normalization.
     pub fn to_wire_payload(&self) -> String {
-        format!(
-            "{{\"signer_key_id\":\"{}\",\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
-            escape_kolme_json_string(self.signer_key_id.as_str()),
-            escape_kolme_json_string(self.message.as_str()),
-            escape_kolme_json_string(self.signature.as_str()),
-            self.recovery_id
+        render_kolme_signed_envelope_wire_payload_contract(
+            self.signer_key_id.as_str(),
+            self.message.as_str(),
+            self.signature.as_str(),
+            self.recovery_id,
         )
     }
 

--- a/crates/kamn-core/tests/kolme_api_codec_contracts.rs
+++ b/crates/kamn-core/tests/kolme_api_codec_contracts.rs
@@ -1,7 +1,7 @@
 use kamn_core::{
     KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiNextNonceRequest,
     KolmeApiNextNonceResponse, KolmeRuntimeCommitError, KolmeRuntimeCommitProviderError,
-    KolmeRuntimeCommitRequest,
+    KolmeRuntimeCommitRequest, KolmeRuntimeCommitSignedBroadcastEnvelope,
 };
 
 #[test]
@@ -194,6 +194,22 @@ fn regression_issue_1908_runtime_commit_request_construction_trims_request_field
     assert_eq!(
         request.to_wire_payload(),
         "operation_id=op-1506-e\nstate_root=state:1506\nactor_did=kamn:did:agent:codec-1506-e\nnonce=15\npayload_hash=payload:1506-e\nidempotency_key=kolme-runtime-commit:op-1506-e:state:1506:kamn:did:agent:codec-1506-e:15:14\n"
+    );
+}
+
+#[test]
+fn regression_issue_1910_signed_envelope_wire_payload_escaping_remains_stable() {
+    // Regression: #1910
+    let envelope = KolmeRuntimeCommitSignedBroadcastEnvelope::new(
+        "signer:\"esc\"",
+        "message:\"esc\"",
+        "signature:\"esc\"",
+        1,
+    )
+    .expect("envelope should build");
+    assert_eq!(
+        envelope.to_wire_payload(),
+        "{\"signer_key_id\":\"signer:\\\"esc\\\"\",\"message\":\"message:\\\"esc\\\"\",\"signature\":\"signature:\\\"esc\\\"\",\"recovery_id\":1}"
     );
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -49,6 +49,9 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("state_root: state_root.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains("payload_hash: payload_hash.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
+        "\"{\\\"signer_key_id\\\":\\\"{}\\\",\\\"message\\\":\\\"{}\\\",\\\"signature\\\":\\\"{}\\\",\\\"recovery_id\\\":{}}\""
+    ));
+    assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
 }
@@ -69,6 +72,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_runtime_commit_wire_payload_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_signed_envelope_wire_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_runtime_commit_request_fields_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -54,6 +54,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1904"));
     assert!(DOC.contains("#1906"));
     assert!(DOC.contains("#1908"));
+    assert!(DOC.contains("#1910"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -104,6 +104,7 @@ pub use runtime_request_identity_policy::{
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
     is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
     normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
+    render_signed_envelope_wire_payload,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_request_identity_policy.rs
+++ b/crates/kamn-kolme/src/runtime_request_identity_policy.rs
@@ -1,4 +1,5 @@
 //! Runtime-commit deterministic request identity policy contracts.
+use crate::escape_json_string;
 
 /// Renders deterministic idempotency key for a runtime commit request.
 pub fn deterministic_runtime_commit_idempotency_key(
@@ -30,6 +31,22 @@ pub fn render_runtime_commit_wire_payload(
     format!(
         "operation_id={}\nstate_root={}\nactor_did={}\nnonce={}\npayload_hash={}\nidempotency_key={}\n",
         operation_id, state_root, actor_did, nonce, payload_hash, idempotency_key
+    )
+}
+
+/// Renders signed-envelope wire payload in canonical JSON field order.
+pub fn render_signed_envelope_wire_payload(
+    signer_key_id: &str,
+    message: &str,
+    signature: &str,
+    recovery_id: u8,
+) -> String {
+    format!(
+        "{{\"signer_key_id\":\"{}\",\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
+        escape_json_string(signer_key_id),
+        escape_json_string(message),
+        escape_json_string(signature),
+        recovery_id
     )
 }
 
@@ -126,6 +143,7 @@ mod tests {
         is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
         is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
         normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
+        render_signed_envelope_wire_payload,
     };
 
     #[test]
@@ -248,6 +266,20 @@ mod tests {
                 "state:epsilon".to_owned(),
                 "payload:epsilon".to_owned(),
             )
+        );
+    }
+
+    #[test]
+    fn unit_renders_signed_envelope_wire_payload_contract() {
+        let payload = render_signed_envelope_wire_payload(
+            "signer:key:7",
+            "message-value",
+            "signature-value",
+            7,
+        );
+        assert_eq!(
+            payload,
+            "{\"signer_key_id\":\"signer:key:7\",\"message\":\"message-value\",\"signature\":\"signature-value\",\"recovery_id\":7}"
         );
     }
 }

--- a/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs
@@ -5,6 +5,7 @@ use kamn_kolme::{
     is_valid_runtime_operation_id_input, is_valid_runtime_payload_hash_input,
     is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
     normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
+    render_signed_envelope_wire_payload,
 };
 
 #[test]
@@ -135,6 +136,16 @@ fn functional_runtime_request_identity_policy_normalizes_runtime_commit_request_
 }
 
 #[test]
+fn functional_runtime_request_identity_policy_renders_signed_envelope_wire_payload() {
+    let payload =
+        render_signed_envelope_wire_payload("signer:key:9", "message:delta", "signature:delta", 9);
+    assert_eq!(
+        payload,
+        "{\"signer_key_id\":\"signer:key:9\",\"message\":\"message:delta\",\"signature\":\"signature:delta\",\"recovery_id\":9}"
+    );
+}
+
+#[test]
 fn regression_issue_1894_runtime_request_identity_policy_rejects_multiline_request_fields() {
     // Regression: #1894
     assert!(!are_runtime_commit_request_fields_single_line(
@@ -215,5 +226,20 @@ fn regression_issue_1908_runtime_request_identity_policy_trims_outer_request_whi
             "state:zeta".to_owned(),
             "payload:zeta".to_owned(),
         )
+    );
+}
+
+#[test]
+fn regression_issue_1910_runtime_request_identity_policy_escapes_signed_envelope_fields() {
+    // Regression: #1910
+    let payload = render_signed_envelope_wire_payload(
+        "signer:key:\"x\"",
+        "message:\"x\"",
+        "signature:\"x\"",
+        1,
+    );
+    assert_eq!(
+        payload,
+        "{\"signer_key_id\":\"signer:key:\\\"x\\\"\",\"message\":\"message:\\\"x\\\"\",\"signature\":\"signature:\\\"x\\\"\",\"recovery_id\":1}"
     );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -72,6 +72,7 @@ Out of scope:
 - #1904: extracted signed-envelope field normalization contract to `kamn-kolme` (`normalize_runtime_commit_signed_envelope_fields`) and rewired `kamn-core` signed-envelope construction normalization delegation.
 - #1906: extracted runtime-commit canonical wire-payload renderer to `kamn-kolme` (`render_runtime_commit_wire_payload`) and rewired `kamn-core` runtime request payload serialization delegation.
 - #1908: extracted runtime request field normalization contract to `kamn-kolme` (`normalize_runtime_commit_request_fields`) and rewired `kamn-core` deterministic request construction normalization delegation.
+- #1910: extracted signed-envelope wire payload renderer to `kamn-kolme` (`render_signed_envelope_wire_payload`) and rewired `kamn-core` signed-envelope wire rendering delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract signed-envelope wire payload JSON rendering from `kamn-core` into `kamn-kolme` as an explicit runtime identity contract. This removes another deterministic rendering responsibility from `kolme_runtime_commit.rs` while preserving escaping and field-order semantics.

## Changes
- `crates/kamn-kolme/src/runtime_request_identity_policy.rs`: added `render_signed_envelope_wire_payload` contract and unit coverage.
- `crates/kamn-kolme/src/lib.rs`: exported signed-envelope wire renderer.
- `crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs`: added functional + regression coverage for signed-envelope wire rendering and escaping.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired `KolmeRuntimeCommitSignedBroadcastEnvelope::to_wire_payload` to delegate to `kamn-kolme` contract.
- `crates/kamn-core/tests/kolme_api_codec_contracts.rs`: added `#1910` regression for escaped signed-envelope wire payload stability.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added extraction-boundary assertions for delegated signed-envelope wire renderer and removed inline JSON format ownership.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1910` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged `#1910` under Phase 2 progress.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::render_signed_envelope_wire_payload`
 --> crates/kamn-kolme/tests/runtime_request_identity_policy_contracts.rs:8:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test runtime_request_identity_policy_contracts` (21 passed)
- `cargo test -p kamn-core --test kolme_api_codec_contracts` (15 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_renders_signed_envelope_wire_payload_contract` | |
| Functional   | ✅     | `functional_runtime_request_identity_policy_renders_signed_envelope_wire_payload` | |
| Integration  | ✅     | `regression_issue_1910_signed_envelope_wire_payload_escaping_remains_stable` validates core envelope -> delegated renderer contract path | |
| Regression   | ✅     | `regression_issue_1910_runtime_request_identity_policy_escapes_signed_envelope_fields` | |
| Performance  | N/A    | None | Extraction-only renderer delegation; no perf-path expansion |

## Risks & Rollback
- None.
- Rollback: revert commit `5404e10`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1910` progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1910
