### PR TITLE
refactor(kolme): extract transport idempotency normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -51,6 +51,7 @@ use kamn_kolme::{
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
     normalize_runtime_commit_request_fields as normalize_kolme_runtime_commit_request_fields_contract,
     normalize_runtime_commit_signed_envelope_fields as normalize_kolme_runtime_commit_signed_envelope_fields_contract,
+    normalize_transport_idempotency_key_input as normalize_kolme_transport_idempotency_key_input_contract,
     notification_event_to_provider_receipt as notification_event_to_kolme_provider_receipt_contract,
     parse_authorization_header_value as parse_kolme_authorization_header_value,
     parse_http_endpoint as parse_kolme_http_endpoint,
@@ -910,7 +911,8 @@ impl KolmeRuntimeCommitHttpTransport {
                 reason: "idempotency_key must not be empty".to_owned(),
             });
         }
-        let idempotency_key = idempotency_key.trim();
+        let idempotency_key =
+            normalize_kolme_transport_idempotency_key_input_contract(idempotency_key);
         let submit_path = normalize_kolme_broadcast_submit_path_input_contract(submit_path);
         let payload = request.to_json_payload();
         let response = self.execute_request(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -51,6 +51,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"{\\\"signer_key_id\\\":\\\"{}\\\",\\\"message\\\":\\\"{}\\\",\\\"signature\\\":\\\"{}\\\",\\\"recovery_id\\\":{}}\""
     ));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let idempotency_key = idempotency_key.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
@@ -74,6 +75,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_runtime_commit_wire_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_signed_envelope_wire_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_runtime_commit_request_fields_contract("));
+    assert!(
+        RUNTIME_COMMIT_SRC.contains("normalize_kolme_transport_idempotency_key_input_contract(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -55,6 +55,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1906"));
     assert!(DOC.contains("#1908"));
     assert!(DOC.contains("#1910"));
+    assert!(DOC.contains("#1912"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -411,6 +411,34 @@ fn integration_http_transport_submit_broadcast_request_put_and_parse_txhash() {
 }
 
 #[test]
+fn regression_issue_1912_http_transport_submit_broadcast_trims_idempotency_key() {
+    // Regression: #1912
+    let broadcast_request = KolmeApiBroadcastRequest::new("{\"nonce\":42}", "sig-42", 1)
+        .expect("broadcast request should build");
+    let base_url = spawn_single_request_server(
+        "{\"txhash\":\"tx-typed-1912\"}".to_owned(),
+        "HTTP/1.1 200 OK",
+        move |request| {
+            assert!(request.contains("PUT /broadcast HTTP/1.1"));
+            assert!(
+                request.contains("X-Idempotency-Key: kolme-runtime-commit:typed-broadcast-1912")
+            );
+        },
+    );
+
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let response = transport
+        .submit_broadcast_request(
+            base_url.as_str(),
+            "/broadcast",
+            &broadcast_request,
+            "  kolme-runtime-commit:typed-broadcast-1912  ",
+        )
+        .expect("broadcast helper should normalize idempotency key");
+    assert_eq!(response.txhash, "tx-typed-1912");
+}
+
+#[test]
 fn regression_issue_1888_http_transport_submit_broadcast_defaults_empty_submit_path() {
     // Regression: #1888
     let broadcast_request = KolmeApiBroadcastRequest::new("{\"nonce\":8}", "sig-8", 1)

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -118,7 +118,8 @@ pub use transport::{
 pub use transport_request_policy::{
     is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
     is_valid_transport_wire_payload_input, normalize_broadcast_submit_path_input,
-    parse_authorization_header_value, KolmeTransportRequestPolicyError,
+    normalize_transport_idempotency_key_input, parse_authorization_header_value,
+    KolmeTransportRequestPolicyError,
 };
 pub use websocket_policy::{
     find_http_header_boundary, is_valid_websocket_timeout_seconds, try_take_websocket_frame,

--- a/crates/kamn-kolme/src/transport_request_policy.rs
+++ b/crates/kamn-kolme/src/transport_request_policy.rs
@@ -32,6 +32,11 @@ pub fn is_valid_transport_idempotency_key_input(idempotency_key: &str) -> bool {
     !idempotency_key.trim().is_empty()
 }
 
+/// Normalizes transport idempotency-key input for deterministic header rendering.
+pub fn normalize_transport_idempotency_key_input(idempotency_key: &str) -> &str {
+    idempotency_key.trim()
+}
+
 /// Returns whether wire-payload input is non-empty after trimming.
 pub fn is_valid_transport_wire_payload_input(wire_payload: &str) -> bool {
     !wire_payload.trim().is_empty()

--- a/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/transport_request_policy_contracts.rs
@@ -1,7 +1,8 @@
 use kamn_kolme::{
     is_broadcast_submit_path, is_valid_transport_idempotency_key_input,
     is_valid_transport_wire_payload_input, normalize_broadcast_submit_path_input,
-    parse_authorization_header_value, KolmeTransportRequestPolicyError,
+    normalize_transport_idempotency_key_input, parse_authorization_header_value,
+    KolmeTransportRequestPolicyError,
 };
 
 #[test]
@@ -35,6 +36,14 @@ fn functional_transport_request_policy_normalizes_broadcast_submit_path_input() 
     assert_eq!(
         normalize_broadcast_submit_path_input(" /broadcast "),
         "/broadcast"
+    );
+}
+
+#[test]
+fn functional_transport_request_policy_normalizes_transport_idempotency_key_input() {
+    assert_eq!(
+        normalize_transport_idempotency_key_input("  kolme-runtime-commit:op-1  "),
+        "kolme-runtime-commit:op-1"
     );
 }
 
@@ -89,4 +98,13 @@ fn regression_issue_1886_transport_request_policy_rejects_empty_wire_payload_inp
 fn regression_issue_1888_transport_request_policy_defaults_empty_submit_path_to_broadcast() {
     // Regression: #1888
     assert_eq!(normalize_broadcast_submit_path_input(" "), "/broadcast");
+}
+
+#[test]
+fn regression_issue_1912_transport_request_policy_trims_outer_idempotency_whitespace() {
+    // Regression: #1912
+    assert_eq!(
+        normalize_transport_idempotency_key_input("\tkey:1912\t"),
+        "key:1912"
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -73,6 +73,7 @@ Out of scope:
 - #1906: extracted runtime-commit canonical wire-payload renderer to `kamn-kolme` (`render_runtime_commit_wire_payload`) and rewired `kamn-core` runtime request payload serialization delegation.
 - #1908: extracted runtime request field normalization contract to `kamn-kolme` (`normalize_runtime_commit_request_fields`) and rewired `kamn-core` deterministic request construction normalization delegation.
 - #1910: extracted signed-envelope wire payload renderer to `kamn-kolme` (`render_signed_envelope_wire_payload`) and rewired `kamn-core` signed-envelope wire rendering delegation.
+- #1912: extracted transport idempotency-key normalization contract to `kamn-kolme` (`normalize_transport_idempotency_key_input`) and rewired `kamn-core` HTTP broadcast submission normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract transport idempotency-key normalization from `kamn-core` into `kamn-kolme` transport request policy and delegate HTTP broadcast submission to the extracted contract. This removes another inline normalization rule from the runtime-commit monolith.

## Changes
- `crates/kamn-kolme/src/transport_request_policy.rs`: added `normalize_transport_idempotency_key_input` contract.
- `crates/kamn-kolme/src/lib.rs`: exported idempotency-key normalization contract.
- `crates/kamn-kolme/tests/transport_request_policy_contracts.rs`: added functional + regression coverage for idempotency normalization behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired `submit_broadcast_request` to delegate idempotency normalization to `kamn-kolme`.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`: added `#1912` regression validating whitespace-padded idempotency key is normalized in HTTP request headers.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary assertions removing inline idempotency trim ownership and requiring delegated helper usage.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1912` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added `#1912` Phase 2 progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test transport_request_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_transport_idempotency_key_input`
 --> crates/kamn-kolme/tests/transport_request_policy_contracts.rs:4:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test transport_request_policy_contracts` (13 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport` (27 passed, 1 ignored local opt-in live lane)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `functional_transport_request_policy_normalizes_transport_idempotency_key_input` (contract-level deterministic normalization) | |
| Functional   | ✅     | `functional_transport_request_policy_normalizes_transport_idempotency_key_input` | |
| Integration  | ✅     | `regression_issue_1912_http_transport_submit_broadcast_trims_idempotency_key` (`kamn-core` HTTP path with delegated helper) | |
| Regression   | ✅     | `regression_issue_1912_transport_request_policy_trims_outer_idempotency_whitespace` | |
| Performance  | N/A    | None | Extraction-only normalization move; no throughput/latency path changes |

## Risks & Rollback
- None.
- Rollback: revert commit `fc0760a`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1912` marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1912
