### PR TITLE
refactor(kolme): extract provider hint normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -49,6 +49,7 @@ use kamn_kolme::{
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
+    normalize_provider_hint_input as normalize_kolme_provider_hint_input_contract,
     normalize_runtime_commit_request_fields as normalize_kolme_runtime_commit_request_fields_contract,
     normalize_runtime_commit_signed_envelope_fields as normalize_kolme_runtime_commit_signed_envelope_fields_contract,
     normalize_transport_idempotency_key_input as normalize_kolme_transport_idempotency_key_input_contract,
@@ -1816,7 +1817,7 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
                 reason: "must not be empty",
             });
         }
-        let provider_hint = provider_hint.trim();
+        let provider_hint = normalize_kolme_provider_hint_input_contract(provider_hint);
         let mut provider = Self::new(base_url, "/broadcast", transport)?;
         provider.profile = KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast;
         provider.provider_hint = Some(provider_hint.to_owned());

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -52,6 +52,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
         "\"{\\\"signer_key_id\\\":\\\"{}\\\",\\\"message\\\":\\\"{}\\\",\\\"signature\\\":\\\"{}\\\",\\\"recovery_id\\\":{}}\""
     ));
     assert!(!RUNTIME_COMMIT_SRC.contains("let idempotency_key = idempotency_key.trim();"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let provider_hint = provider_hint.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
@@ -78,6 +79,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_COMMIT_SRC.contains("normalize_kolme_transport_idempotency_key_input_contract(")
     );
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -56,6 +56,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1908"));
     assert!(DOC.contains("#1910"));
     assert!(DOC.contains("#1912"));
+    assert!(DOC.contains("#1914"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -865,6 +865,41 @@ fn regression_kolme_fork_submit_profile_requires_non_empty_provider_hint() {
 }
 
 #[test]
+fn regression_issue_1914_kolme_fork_submit_profile_trims_provider_hint() {
+    // Regression: #1914
+    let wire_payload = "{\"message\":\"{\\\"pubkey\\\":\\\"pk1914\\\",\\\"nonce\\\":1,\\\"created\\\":\\\"2026-02-11T00:00:00Z\\\",\\\"messages\\\":[],\\\"max_height\\\":null}\",\"signature\":\"sig-1914\",\"recovery_id\":1}";
+    let idempotency_key = "kolme-runtime-commit:provider-hint-1914";
+
+    let base_url = spawn_single_request_server(
+        "{\"txhash\":\"ab12cd34\"}".to_owned(),
+        "HTTP/1.1 200 OK",
+        move |request| {
+            assert!(request.contains("PUT /broadcast HTTP/1.1"));
+        },
+    );
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+        base_url.as_str(),
+        "  kolme-fork-local  ",
+        transport,
+    )
+    .expect("provider should build");
+
+    let outcome = provider
+        .submit_runtime_commit(wire_payload, idempotency_key)
+        .expect("submit should succeed");
+    match outcome {
+        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => {
+            assert_eq!(receipt.provider, "kolme-fork-local");
+            assert_eq!(receipt.commit_id, "kolme-commit:ab12cd34");
+            assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Pending);
+        }
+        other => panic!("unexpected provider outcome: {other:?}"),
+    }
+}
+
+#[test]
 fn integration_kolme_fork_signed_envelope_submit_maps_txhash_response() {
     let request = KolmeRuntimeCommitRequest::deterministic(
         "op-1506-http-a",

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -80,10 +80,11 @@ pub use provider_outcome_policy::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
     is_valid_provider_hint_input, is_valid_receipt_commit_id_input,
     is_valid_receipt_provider_input, is_valid_runtime_provider_input,
-    parse_commit_id_from_response_fields, parse_live_provider_outcome,
-    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id, validate_provider_receipt_identity,
-    KolmeProviderOutcome, KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
+    normalize_provider_hint_input, parse_commit_id_from_response_fields,
+    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
+    require_commit_id_matches_expected_txhash, required_provider_response_field,
+    txhash_from_commit_id, validate_provider_receipt_identity, KolmeProviderOutcome,
+    KolmeProviderOutcomePolicyError, KolmeProviderReceiptIdentityError,
     KolmeRuntimeProviderOutcome,
 };
 pub use provider_response_policy::{

--- a/crates/kamn-kolme/src/provider_outcome_policy.rs
+++ b/crates/kamn-kolme/src/provider_outcome_policy.rs
@@ -330,6 +330,11 @@ pub fn is_valid_provider_hint_input(provider_hint: &str) -> bool {
     is_valid_runtime_provider_input(provider_hint)
 }
 
+/// Normalizes provider hint input for deterministic fork submit profile identity.
+pub fn normalize_provider_hint_input(provider_hint: &str) -> &str {
+    provider_hint.trim()
+}
+
 /// Validates receipt provider input for runtime lifecycle updates.
 pub fn is_valid_receipt_provider_input(receipt_provider: &str) -> bool {
     is_valid_runtime_provider_input(receipt_provider)

--- a/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs
@@ -2,9 +2,10 @@ use kamn_kolme::{
     deterministic_backend_commit_id, is_valid_expected_provider_input,
     is_valid_provider_hint_input, is_valid_receipt_commit_id_input,
     is_valid_receipt_provider_input, is_valid_runtime_provider_input,
-    parse_commit_id_from_response_fields, parse_live_provider_outcome,
-    parse_live_runtime_provider_outcome, require_commit_id_matches_expected_txhash,
-    required_provider_response_field, txhash_from_commit_id,
+    normalize_provider_hint_input, parse_commit_id_from_response_fields,
+    parse_live_provider_outcome, parse_live_runtime_provider_outcome,
+    require_commit_id_matches_expected_txhash, required_provider_response_field,
+    txhash_from_commit_id,
     validate_provider_receipt_identity as validate_provider_receipt_identity_contract,
     KolmeCommitReceiptFinality, KolmeProviderOutcome, KolmeProviderOutcomePolicyError,
     KolmeProviderReceiptIdentityError, KolmeRuntimeProviderOutcome, ReceiptFinality,
@@ -215,9 +216,26 @@ fn functional_provider_outcome_policy_accepts_non_empty_provider_hint_input() {
 }
 
 #[test]
+fn functional_provider_outcome_policy_normalizes_provider_hint_input() {
+    assert_eq!(
+        normalize_provider_hint_input("  kolme-fork  "),
+        "kolme-fork"
+    );
+}
+
+#[test]
 fn regression_issue_1882_provider_outcome_policy_rejects_empty_provider_hint_input() {
     // Regression: #1882
     assert!(!is_valid_provider_hint_input(" \t "));
+}
+
+#[test]
+fn regression_issue_1914_provider_outcome_policy_trims_outer_provider_hint_whitespace() {
+    // Regression: #1914
+    assert_eq!(
+        normalize_provider_hint_input("\nkolme-fork\n"),
+        "kolme-fork"
+    );
 }
 
 #[test]

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -74,6 +74,7 @@ Out of scope:
 - #1908: extracted runtime request field normalization contract to `kamn-kolme` (`normalize_runtime_commit_request_fields`) and rewired `kamn-core` deterministic request construction normalization delegation.
 - #1910: extracted signed-envelope wire payload renderer to `kamn-kolme` (`render_signed_envelope_wire_payload`) and rewired `kamn-core` signed-envelope wire rendering delegation.
 - #1912: extracted transport idempotency-key normalization contract to `kamn-kolme` (`normalize_transport_idempotency_key_input`) and rewired `kamn-core` HTTP broadcast submission normalization delegation.
+- #1914: extracted provider-hint normalization contract to `kamn-kolme` (`normalize_provider_hint_input`) and rewired `kamn-core` fork broadcast provider construction normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract provider-hint normalization from `kamn-core` into `kamn-kolme` provider outcome policy and delegate fork-broadcast provider construction to the extracted contract. This removes another inline normalization rule from the runtime-commit monolith.

## Changes
- `crates/kamn-kolme/src/provider_outcome_policy.rs`: added `normalize_provider_hint_input` contract.
- `crates/kamn-kolme/src/lib.rs`: exported provider-hint normalization contract.
- `crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs`: added functional + regression coverage for provider-hint normalization behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired fork-broadcast provider constructor to delegate provider-hint normalization to extracted contract.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`: added `#1914` regression confirming whitespace-padded provider hint resolves to normalized provider identity.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary assertions for removed inline provider-hint trim ownership and delegated helper presence.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1914` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added `#1914` Phase 2 progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test provider_outcome_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_provider_hint_input`
 --> crates/kamn-kolme/tests/provider_outcome_policy_contracts.rs:5:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test provider_outcome_policy_contracts` (23 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport` (28 passed, 1 ignored local opt-in live lane)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `functional_provider_outcome_policy_normalizes_provider_hint_input` (contract-level normalization behavior) | |
| Functional   | ✅     | `functional_provider_outcome_policy_normalizes_provider_hint_input` | |
| Integration  | ✅     | `regression_issue_1914_kolme_fork_submit_profile_trims_provider_hint` (`kamn-core` fork-broadcast path with delegated helper) | |
| Regression   | ✅     | `regression_issue_1914_provider_outcome_policy_trims_outer_provider_hint_whitespace` | |
| Performance  | N/A    | None | Extraction-only normalization move; no runtime perf-path changes |

## Risks & Rollback
- None.
- Rollback: revert commit `383d4e1`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1914` marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1914
