### PR TITLE
refactor(kolme): extract notifications provider normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -49,6 +49,7 @@ use kamn_kolme::{
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
+    normalize_notifications_provider_input as normalize_kolme_notifications_provider_input_contract,
     normalize_provider_hint_input as normalize_kolme_provider_hint_input_contract,
     normalize_runtime_commit_request_fields as normalize_kolme_runtime_commit_request_fields_contract,
     normalize_runtime_commit_signed_envelope_fields as normalize_kolme_runtime_commit_signed_envelope_fields_contract,
@@ -1642,7 +1643,7 @@ where
                 })?;
         Ok(Self {
             notifications_url,
-            provider: provider.trim().to_owned(),
+            provider: normalize_kolme_notifications_provider_input_contract(provider).to_owned(),
             max_reconnect_attempts,
             connector,
             connection: None,

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -53,6 +53,8 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     ));
     assert!(!RUNTIME_COMMIT_SRC.contains("let idempotency_key = idempotency_key.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let provider_hint = provider_hint.trim();"));
+    assert!(!RUNTIME_COMMIT_SRC
+        .contains("notifications_url,\n            provider: provider.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
@@ -80,6 +82,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         RUNTIME_COMMIT_SRC.contains("normalize_kolme_transport_idempotency_key_input_contract(")
     );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_notifications_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -57,6 +57,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1910"));
     assert!(DOC.contains("#1912"));
     assert!(DOC.contains("#1914"));
+    assert!(DOC.contains("#1916"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
@@ -195,6 +195,29 @@ fn functional_notifications_consumer_decodes_new_block_variant_to_final_receipt(
 }
 
 #[test]
+fn regression_issue_1916_notifications_consumer_trims_provider_input() {
+    // Regression: #1916
+    let connector = MockConnector::new(vec![Ok(MockConnection::new(vec![MockStep::Message(
+        "{\"NewBlock\":{\"block\":{\"txhash\":\"ab12cd34\"},\"height\":42}}".to_owned(),
+    )]))]);
+    let mut consumer = KolmeRuntimeCommitNotificationsConsumer::new(
+        "http://127.0.0.1:3030",
+        "/notifications",
+        "  kolme-fork-local  ",
+        1,
+        connector,
+    )
+    .expect("notifications consumer should build");
+
+    let receipt = consumer
+        .next_commit_receipt()
+        .expect("consumer should map one event");
+    assert_eq!(receipt.provider, "kolme-fork-local");
+    assert_eq!(receipt.commit_id, "kolme-commit:ab12cd34:h42");
+    assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Final);
+}
+
+#[test]
 fn integration_notifications_websocket_connector_receives_kolme_notification() {
     let port = spawn_mock_websocket_notification_server(
         "{\"NewBlock\":{\"block\":{\"txhash\":\"00c0ffee\"},\"height\":88}}",

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -71,9 +71,9 @@ pub use http_response_policy::{
 };
 pub use notification_policy::{
     is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
-    notification_event_to_provider_receipt, notification_event_to_receipt,
-    parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
-    KolmeNotificationReceipt, KolmeProviderNotificationReceipt,
+    normalize_notifications_provider_input, notification_event_to_provider_receipt,
+    notification_event_to_receipt, parse_notification_event, KolmeNotificationEvent,
+    KolmeNotificationPolicyError, KolmeNotificationReceipt, KolmeProviderNotificationReceipt,
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{

--- a/crates/kamn-kolme/src/notification_policy.rs
+++ b/crates/kamn-kolme/src/notification_policy.rs
@@ -164,6 +164,11 @@ pub fn is_valid_notifications_provider_input(provider: &str) -> bool {
     !provider.trim().is_empty()
 }
 
+/// Normalizes notifications consumer provider input for deterministic identity projection.
+pub fn normalize_notifications_provider_input(provider: &str) -> &str {
+    provider.trim()
+}
+
 /// Validates notifications consumer reconnect budget input.
 pub fn is_valid_notifications_reconnect_budget(max_reconnect_attempts: u32) -> bool {
     max_reconnect_attempts > 0

--- a/crates/kamn-kolme/tests/notification_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/notification_policy_contracts.rs
@@ -1,5 +1,6 @@
 use kamn_kolme::{
     is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
+    normalize_notifications_provider_input,
     notification_event_to_provider_receipt as notification_event_to_provider_receipt_contract,
     notification_event_to_receipt as notification_event_to_receipt_contract,
     parse_notification_event, KolmeCommitReceiptFinality, KolmeNotificationEvent,
@@ -106,8 +107,25 @@ fn functional_notification_policy_accepts_valid_notifications_consumer_inputs() 
 }
 
 #[test]
+fn functional_notification_policy_normalizes_notifications_provider_input() {
+    assert_eq!(
+        normalize_notifications_provider_input("  kolme-fork-local  "),
+        "kolme-fork-local"
+    );
+}
+
+#[test]
 fn regression_issue_1868_notification_policy_rejects_invalid_notifications_consumer_inputs() {
     // Regression: #1868
     assert!(!is_valid_notifications_provider_input(" "));
     assert!(!is_valid_notifications_reconnect_budget(0));
+}
+
+#[test]
+fn regression_issue_1916_notification_policy_trims_outer_provider_whitespace() {
+    // Regression: #1916
+    assert_eq!(
+        normalize_notifications_provider_input("\nkolme-fork-local\n"),
+        "kolme-fork-local"
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -75,6 +75,7 @@ Out of scope:
 - #1910: extracted signed-envelope wire payload renderer to `kamn-kolme` (`render_signed_envelope_wire_payload`) and rewired `kamn-core` signed-envelope wire rendering delegation.
 - #1912: extracted transport idempotency-key normalization contract to `kamn-kolme` (`normalize_transport_idempotency_key_input`) and rewired `kamn-core` HTTP broadcast submission normalization delegation.
 - #1914: extracted provider-hint normalization contract to `kamn-kolme` (`normalize_provider_hint_input`) and rewired `kamn-core` fork broadcast provider construction normalization delegation.
+- #1916: extracted notifications provider normalization contract to `kamn-kolme` (`normalize_notifications_provider_input`) and rewired `kamn-core` notifications consumer construction normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract notifications provider normalization from `kamn-core` into `kamn-kolme` notification policy and delegate notifications consumer construction to the extracted contract. This removes another inline normalization rule from the runtime commit monolith.

## Changes
- `crates/kamn-kolme/src/notification_policy.rs`: added `normalize_notifications_provider_input` contract.
- `crates/kamn-kolme/src/lib.rs`: exported notifications provider normalization contract.
- `crates/kamn-kolme/tests/notification_policy_contracts.rs`: added functional + regression tests for notifications provider normalization behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired notifications consumer constructor to delegate provider normalization to extracted contract.
- `crates/kamn-core/tests/kolme_runtime_commit_notifications.rs`: added `#1916` regression verifying whitespace-padded provider input yields normalized provider identity in commit receipts.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary assertions for removed inline notifications provider trim and delegated helper marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1916` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added `#1916` Phase 2 progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test notification_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_notifications_provider_input`
 --> crates/kamn-kolme/tests/notification_policy_contracts.rs:3:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test notification_policy_contracts` (10 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications` (5 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `functional_notification_policy_normalizes_notifications_provider_input` (contract normalization behavior) | |
| Functional   | ✅     | `functional_notification_policy_normalizes_notifications_provider_input` | |
| Integration  | ✅     | `regression_issue_1916_notifications_consumer_trims_provider_input` (`kamn-core` notifications path with delegated helper) | |
| Regression   | ✅     | `regression_issue_1916_notification_policy_trims_outer_provider_whitespace` | |
| Performance  | N/A    | None | Extraction-only normalization move; no performance-path expansion |

## Risks & Rollback
- None.
- Rollback: revert commit `56a2e03`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1916` marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1916
