### PR TITLE
refactor(kolme): extract finality endpoint normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -49,6 +49,7 @@ use kamn_kolme::{
     lifecycle_state_label as lifecycle_state_label_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
+    normalize_finality_endpoint_inputs as normalize_kolme_finality_endpoint_inputs_contract,
     normalize_notifications_provider_input as normalize_kolme_notifications_provider_input_contract,
     normalize_provider_hint_input as normalize_kolme_provider_hint_input_contract,
     normalize_runtime_commit_request_fields as normalize_kolme_runtime_commit_request_fields_contract,
@@ -1226,9 +1227,11 @@ impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T
                 reason: "must not be empty",
             });
         }
+        let (base_url, status_path) =
+            normalize_kolme_finality_endpoint_inputs_contract(base_url, status_path);
         Ok(Self {
-            base_url: base_url.trim().to_owned(),
-            status_path: status_path.trim().to_owned(),
+            base_url,
+            status_path,
             transport,
         })
     }

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -938,6 +938,30 @@ fn functional_finality_checker_maps_confirmed_alias_to_final_receipt() {
 }
 
 #[test]
+fn regression_issue_1918_finality_checker_trims_endpoint_inputs() {
+    // Regression: #1918
+    let response = r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"pending"}"#.to_owned();
+    let (transport, calls) = RecordingFinalityTransport::with_responses(vec![Ok(response)]);
+    let mut checker = KolmeRuntimeCommitFinalityChecker::new(
+        "  http://127.0.0.1:3030  ",
+        "  /commit/finality  ",
+        transport,
+    )
+    .expect("checker should build");
+
+    let receipt = checker
+        .check_commit_finality("kolme-commit:ab12cd34:h42")
+        .expect("checker should parse finality response");
+    assert_eq!(receipt.provider, "kolme-fork-local");
+    assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Pending);
+
+    let calls = calls.borrow();
+    assert_eq!(calls.len(), 1, "finality transport should be called once");
+    assert_eq!(calls[0].0, "http://127.0.0.1:3030");
+    assert_eq!(calls[0].1, "/commit/finality");
+}
+
+#[test]
 fn functional_finality_checker_polls_pending_then_final() {
     let pending =
         r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34:h42","finality":"pending"}"#.to_owned();

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -55,6 +55,8 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("let provider_hint = provider_hint.trim();"));
     assert!(!RUNTIME_COMMIT_SRC
         .contains("notifications_url,\n            provider: provider.trim().to_owned(),"));
+    assert!(!RUNTIME_COMMIT_SRC
+        .contains("base_url: base_url.trim().to_owned(),\n            status_path: status_path.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
@@ -83,6 +85,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_notifications_provider_input_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -58,6 +58,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1912"));
     assert!(DOC.contains("#1914"));
     assert!(DOC.contains("#1916"));
+    assert!(DOC.contains("#1918"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/endpoint_policy.rs
+++ b/crates/kamn-kolme/src/endpoint_policy.rs
@@ -126,6 +126,11 @@ pub fn is_valid_finality_status_path_input(status_path: &str) -> bool {
     !status_path.trim().is_empty()
 }
 
+/// Normalizes finality checker endpoint inputs for deterministic request composition.
+pub fn normalize_finality_endpoint_inputs(base_url: &str, status_path: &str) -> (String, String) {
+    (base_url.trim().to_owned(), status_path.trim().to_owned())
+}
+
 /// Validates live provider base URL input before broadcast submit requests.
 pub fn is_valid_live_provider_base_url_input(base_url: &str) -> bool {
     !base_url.trim().is_empty()

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -54,8 +54,9 @@ pub use endpoint_policy::{
     compose_finality_status_path, compose_notifications_websocket_url,
     is_valid_finality_base_url_input, is_valid_finality_status_path_input,
     is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
-    parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
-    KolmeParsedHttpEndpoint, KolmeParsedWebsocketEndpoint,
+    normalize_finality_endpoint_inputs, parse_http_endpoint, parse_websocket_endpoint,
+    KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
+    KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
 pub use finality_receipt_policy::{

--- a/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
@@ -2,7 +2,8 @@ use kamn_kolme::{
     compose_finality_status_path, compose_notifications_websocket_url,
     is_valid_finality_base_url_input, is_valid_finality_status_path_input,
     is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
-    parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
+    normalize_finality_endpoint_inputs, parse_http_endpoint, parse_websocket_endpoint,
+    KolmeEndpointPolicyError, KolmeHttpScheme,
 };
 
 #[test]
@@ -67,10 +68,35 @@ fn functional_endpoint_policy_accepts_non_empty_finality_checker_inputs() {
 }
 
 #[test]
+fn functional_endpoint_policy_normalizes_finality_endpoint_inputs() {
+    let normalized = normalize_finality_endpoint_inputs(
+        "  https://kolme.example  ",
+        "  /runtime-commit/status  ",
+    );
+    assert_eq!(
+        normalized,
+        (
+            "https://kolme.example".to_owned(),
+            "/runtime-commit/status".to_owned(),
+        )
+    );
+}
+
+#[test]
 fn regression_issue_1864_endpoint_policy_rejects_empty_finality_checker_inputs() {
     // Regression: #1864
     assert!(!is_valid_finality_base_url_input("   "));
     assert!(!is_valid_finality_status_path_input(""));
+}
+
+#[test]
+fn regression_issue_1918_endpoint_policy_trims_outer_finality_endpoint_whitespace() {
+    // Regression: #1918
+    let normalized = normalize_finality_endpoint_inputs("\nhttps://kolme.example\n", "\n/status\n");
+    assert_eq!(
+        normalized,
+        ("https://kolme.example".to_owned(), "/status".to_owned(),)
+    );
 }
 
 #[test]

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -76,6 +76,7 @@ Out of scope:
 - #1912: extracted transport idempotency-key normalization contract to `kamn-kolme` (`normalize_transport_idempotency_key_input`) and rewired `kamn-core` HTTP broadcast submission normalization delegation.
 - #1914: extracted provider-hint normalization contract to `kamn-kolme` (`normalize_provider_hint_input`) and rewired `kamn-core` fork broadcast provider construction normalization delegation.
 - #1916: extracted notifications provider normalization contract to `kamn-kolme` (`normalize_notifications_provider_input`) and rewired `kamn-core` notifications consumer construction normalization delegation.
+- #1918: extracted finality endpoint normalization contract to `kamn-kolme` (`normalize_finality_endpoint_inputs`) and rewired `kamn-core` finality checker constructor normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract finality endpoint normalization (`base_url`, `status_path`) from `kamn-core` into `kamn-kolme` endpoint policy and delegate finality checker constructor normalization to the extracted contract. This removes another inline normalization responsibility from `kolme_runtime_commit.rs`.

## Changes
- `crates/kamn-kolme/src/endpoint_policy.rs`: added `normalize_finality_endpoint_inputs` contract.
- `crates/kamn-kolme/src/lib.rs`: exported finality endpoint normalization contract.
- `crates/kamn-kolme/tests/endpoint_policy_contracts.rs`: added functional + regression tests for finality endpoint normalization behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired `KolmeRuntimeCommitFinalityChecker::new` to delegate endpoint normalization to `kamn-kolme` contract.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: added `#1918` regression verifying whitespace-padded finality endpoints are normalized before transport calls.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary assertions for removed inline finality endpoint trims and delegated helper marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1918` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added `#1918` Phase 2 progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test endpoint_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_finality_endpoint_inputs`
 --> crates/kamn-kolme/tests/endpoint_policy_contracts.rs:5:5
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test endpoint_policy_contracts` (10 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_client` (29 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `functional_endpoint_policy_normalizes_finality_endpoint_inputs` (contract-level normalization) | |
| Functional   | ✅     | `functional_endpoint_policy_normalizes_finality_endpoint_inputs` | |
| Integration  | ✅     | `regression_issue_1918_finality_checker_trims_endpoint_inputs` (`kamn-core` checker constructor -> transport call path) | |
| Regression   | ✅     | `regression_issue_1918_endpoint_policy_trims_outer_finality_endpoint_whitespace` | |
| Performance  | N/A    | None | Extraction-only normalization move; no perf-path expansion |

## Risks & Rollback
- None.
- Rollback: revert commit `1563614`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1918` marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1918
