### PR TITLE
refactor(kolme): extract live provider endpoint normalization contract

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -50,6 +50,7 @@ use kamn_kolme::{
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
     normalize_finality_endpoint_inputs as normalize_kolme_finality_endpoint_inputs_contract,
+    normalize_live_provider_endpoint_inputs as normalize_kolme_live_provider_endpoint_inputs_contract,
     normalize_notifications_provider_input as normalize_kolme_notifications_provider_input_contract,
     normalize_provider_hint_input as normalize_kolme_provider_hint_input_contract,
     normalize_runtime_commit_request_fields as normalize_kolme_runtime_commit_request_fields_contract,
@@ -1800,9 +1801,11 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
                 reason: "must not be empty",
             });
         }
+        let (base_url, submit_path) =
+            normalize_kolme_live_provider_endpoint_inputs_contract(base_url, submit_path);
         Ok(Self {
-            base_url: base_url.trim().to_owned(),
-            submit_path: submit_path.trim().to_owned(),
+            base_url,
+            submit_path,
             profile: KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit,
             provider_hint: None,
             transport,

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -714,6 +714,45 @@ fn functional_live_provider_maps_submitted_json_response_to_provider_outcome() {
 }
 
 #[test]
+fn regression_issue_1920_live_provider_trims_endpoint_inputs() {
+    // Regression: #1920
+    let response = r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:runtime:1920","finality":"pending"}"#.to_owned();
+    let (transport, calls) = RecordingTransport::with_result(Ok(response));
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        "  http://127.0.0.1:3030  ",
+        "  /broadcast/runtime-commit  ",
+        transport,
+    )
+    .expect("provider should build");
+
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-live-provider-1920",
+        "state:live",
+        "kamn:did:agent:live-provider-1920",
+        61,
+        "payload:live-provider-1920",
+    )
+    .expect("request should build");
+
+    let outcome = provider
+        .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
+        .expect("provider should return a parsed outcome");
+    assert_eq!(
+        outcome,
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-fork-local".to_owned(),
+            commit_id: "kolme-commit:runtime:1920".to_owned(),
+            finality: KolmeCommitReceiptFinality::Pending,
+        })
+    );
+
+    let calls = calls.borrow();
+    assert_eq!(calls.len(), 1, "provider transport should be called once");
+    assert_eq!(calls[0].0, "http://127.0.0.1:3030");
+    assert_eq!(calls[0].1, "/broadcast/runtime-commit");
+}
+
+#[test]
 fn unit_kolme_fork_live_provider_maps_txhash_only_response_using_provider_hint() {
     let response = r#"{"txhash":"ab12cd34"}"#.to_owned();
     let (transport, calls) = RecordingTransport::with_result(Ok(response));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -57,6 +57,8 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
         .contains("notifications_url,\n            provider: provider.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC
         .contains("base_url: base_url.trim().to_owned(),\n            status_path: status_path.trim().to_owned(),"));
+    assert!(!RUNTIME_COMMIT_SRC
+        .contains("base_url: base_url.trim().to_owned(),\n            submit_path: submit_path.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
@@ -86,6 +88,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_notifications_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -59,6 +59,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1914"));
     assert!(DOC.contains("#1916"));
     assert!(DOC.contains("#1918"));
+    assert!(DOC.contains("#1920"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/endpoint_policy.rs
+++ b/crates/kamn-kolme/src/endpoint_policy.rs
@@ -141,6 +141,14 @@ pub fn is_valid_live_provider_submit_path_input(submit_path: &str) -> bool {
     !submit_path.trim().is_empty()
 }
 
+/// Normalizes live provider endpoint inputs for deterministic broadcast submit composition.
+pub fn normalize_live_provider_endpoint_inputs(
+    base_url: &str,
+    submit_path: &str,
+) -> (String, String) {
+    (base_url.trim().to_owned(), submit_path.trim().to_owned())
+}
+
 /// Composes websocket notifications URL from HTTP base URL + notifications path.
 pub fn compose_notifications_websocket_url(
     base_url: &str,

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -54,9 +54,9 @@ pub use endpoint_policy::{
     compose_finality_status_path, compose_notifications_websocket_url,
     is_valid_finality_base_url_input, is_valid_finality_status_path_input,
     is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
-    normalize_finality_endpoint_inputs, parse_http_endpoint, parse_websocket_endpoint,
-    KolmeEndpointPolicyError, KolmeHttpScheme, KolmeParsedHttpEndpoint,
-    KolmeParsedWebsocketEndpoint,
+    normalize_finality_endpoint_inputs, normalize_live_provider_endpoint_inputs,
+    parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
+    KolmeParsedHttpEndpoint, KolmeParsedWebsocketEndpoint,
 };
 pub use finality::{resolve_finality, FinalityResolution, FinalityState};
 pub use finality_receipt_policy::{

--- a/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/endpoint_policy_contracts.rs
@@ -2,8 +2,8 @@ use kamn_kolme::{
     compose_finality_status_path, compose_notifications_websocket_url,
     is_valid_finality_base_url_input, is_valid_finality_status_path_input,
     is_valid_live_provider_base_url_input, is_valid_live_provider_submit_path_input,
-    normalize_finality_endpoint_inputs, parse_http_endpoint, parse_websocket_endpoint,
-    KolmeEndpointPolicyError, KolmeHttpScheme,
+    normalize_finality_endpoint_inputs, normalize_live_provider_endpoint_inputs,
+    parse_http_endpoint, parse_websocket_endpoint, KolmeEndpointPolicyError, KolmeHttpScheme,
 };
 
 #[test]
@@ -110,8 +110,34 @@ fn functional_endpoint_policy_accepts_non_empty_live_provider_inputs() {
 }
 
 #[test]
+fn functional_endpoint_policy_normalizes_live_provider_endpoint_inputs() {
+    let normalized = normalize_live_provider_endpoint_inputs(
+        "  https://kolme.example  ",
+        "  /broadcast/runtime-commit  ",
+    );
+    assert_eq!(
+        normalized,
+        (
+            "https://kolme.example".to_owned(),
+            "/broadcast/runtime-commit".to_owned(),
+        )
+    );
+}
+
+#[test]
 fn regression_issue_1872_endpoint_policy_rejects_empty_live_provider_inputs() {
     // Regression: #1872
     assert!(!is_valid_live_provider_base_url_input(""));
     assert!(!is_valid_live_provider_submit_path_input("   "));
+}
+
+#[test]
+fn regression_issue_1920_endpoint_policy_trims_outer_live_provider_endpoint_whitespace() {
+    // Regression: #1920
+    let normalized =
+        normalize_live_provider_endpoint_inputs("\nhttps://kolme.example\n", "\n/broadcast\n");
+    assert_eq!(
+        normalized,
+        ("https://kolme.example".to_owned(), "/broadcast".to_owned(),)
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -77,6 +77,7 @@ Out of scope:
 - #1914: extracted provider-hint normalization contract to `kamn-kolme` (`normalize_provider_hint_input`) and rewired `kamn-core` fork broadcast provider construction normalization delegation.
 - #1916: extracted notifications provider normalization contract to `kamn-kolme` (`normalize_notifications_provider_input`) and rewired `kamn-core` notifications consumer construction normalization delegation.
 - #1918: extracted finality endpoint normalization contract to `kamn-kolme` (`normalize_finality_endpoint_inputs`) and rewired `kamn-core` finality checker constructor normalization delegation.
+- #1920: extracted live provider endpoint normalization contract to `kamn-kolme` (`normalize_live_provider_endpoint_inputs`) and rewired `kamn-core` live provider constructor normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extract live provider endpoint normalization (`base_url`, `submit_path`) from `kamn-core` into `kamn-kolme` endpoint policy and delegate live provider constructor normalization to the extracted contract. This removes another inline endpoint normalization responsibility from `kolme_runtime_commit.rs`.

## Changes
- `crates/kamn-kolme/src/endpoint_policy.rs`: added `normalize_live_provider_endpoint_inputs` contract.
- `crates/kamn-kolme/src/lib.rs`: exported live provider endpoint normalization contract.
- `crates/kamn-kolme/tests/endpoint_policy_contracts.rs`: added functional + regression tests for live provider endpoint normalization behavior.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: rewired `KolmeRuntimeCommitLiveProvider::new` to delegate endpoint normalization to `kamn-kolme` contract.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: added `#1920` regression verifying whitespace-padded live provider endpoints are normalized before transport calls.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary assertions for removed inline live provider endpoint trims and delegated helper marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1920` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added `#1920` Phase 2 progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-kolme --test endpoint_policy_contracts`

Observed failure before implementation:
```
error[E0432]: unresolved import `kamn_kolme::normalize_live_provider_endpoint_inputs`
 --> crates/kamn-kolme/tests/endpoint_policy_contracts.rs:5:41
```

### 🟢 Green Phase
- `cargo test -p kamn-kolme --test endpoint_policy_contracts` (12 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_client` (30 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` (2 passed)
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs` (2 passed)

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `functional_endpoint_policy_normalizes_live_provider_endpoint_inputs` (contract-level normalization) | |
| Functional   | ✅     | `functional_endpoint_policy_normalizes_live_provider_endpoint_inputs` | |
| Integration  | ✅     | `regression_issue_1920_live_provider_trims_endpoint_inputs` (`kamn-core` live provider constructor -> transport call path) | |
| Regression   | ✅     | `regression_issue_1920_endpoint_policy_trims_outer_live_provider_endpoint_whitespace` | |
| Performance  | N/A    | None | Extraction-only normalization move; no performance-path expansion |

## Risks & Rollback
- None.
- Rollback: revert commit `78380db`.

## Documentation Updates
- Updated `docs/planning/kolme_runtime_commit_extraction_plan.md` with `#1920` marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (issue-scoped crate targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped matrix)
- [x] Docs updated (or justified why not)

Closes #1920
