### PR TITLE
refactor(kolme): extract block fallback constructor normalization contract (#1922)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -47,6 +47,7 @@ use kamn_kolme::{
     is_valid_websocket_timeout_seconds as is_kolme_valid_websocket_timeout_seconds_contract,
     lifecycle_state_for_finality as lifecycle_state_for_finality_contract,
     lifecycle_state_label as lifecycle_state_label_contract,
+    normalize_block_fallback_constructor_inputs as normalize_kolme_block_fallback_constructor_inputs_contract,
     normalize_broadcast_payload as normalize_kolme_broadcast_payload_contract,
     normalize_broadcast_submit_path_input as normalize_kolme_broadcast_submit_path_input_contract,
     normalize_finality_endpoint_inputs as normalize_kolme_finality_endpoint_inputs_contract,
@@ -1347,10 +1348,16 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                     }
                 }
             })?;
+        let (base_url, block_path_template, provider) =
+            normalize_kolme_block_fallback_constructor_inputs_contract(
+                base_url,
+                block_path_template,
+                provider,
+            );
         Ok(Self {
-            base_url: base_url.trim().to_owned(),
-            block_path_template: block_path_template.trim().to_owned(),
-            provider: provider.trim().to_owned(),
+            base_url,
+            block_path_template,
+            provider,
             max_block_lookups,
             transport,
         })

--- a/crates/kamn-core/tests/kolme_runtime_commit_block_fallback.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_block_fallback.rs
@@ -180,6 +180,41 @@ fn functional_block_fallback_reconciles_final_receipt_from_block_lookup() {
 }
 
 #[test]
+fn regression_issue_1922_block_fallback_constructor_normalization_delegates_to_contract() {
+    // Regression: #1922
+    let responses = vec![Ok(
+        "{\"provider\":\"kolme-fork-local\",\"block_height\":42,\"tx_hashes\":\"ab12cd34\"}"
+            .to_owned(),
+    )];
+    let (transport, calls) = RecordingBlockLookupTransport::with_responses(responses);
+    let mut reconciler = KolmeRuntimeCommitBlockFallbackReconciler::new(
+        "  http://127.0.0.1:3030  ",
+        "  /block/{height}  ",
+        "  kolme-fork-local  ",
+        2,
+        transport,
+    )
+    .expect("reconciler should build");
+
+    let receipt = reconciler
+        .reconcile_txhash("ab12cd34", 42, 42)
+        .expect("fallback should reconcile with normalized constructor inputs");
+    assert_eq!(receipt.provider, "kolme-fork-local");
+    assert_eq!(receipt.commit_id, "kolme-commit:ab12cd34:h42");
+    assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Final);
+
+    let observed_calls = calls.borrow();
+    assert_eq!(
+        observed_calls[0],
+        (
+            "http://127.0.0.1:3030".to_owned(),
+            "/block/{height}".to_owned(),
+            42
+        )
+    );
+}
+
+#[test]
 fn functional_block_fallback_reconciles_failed_receipt_from_block_lookup() {
     let responses = vec![Ok(
         "{\"provider\":\"kolme-fork-local\",\"block_height\":50,\"failed_tx_hashes\":\"ab12cd34\"}"

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -60,6 +60,9 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC
         .contains("base_url: base_url.trim().to_owned(),\n            submit_path: submit_path.trim().to_owned(),"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
+        "base_url: base_url.trim().to_owned(),\n            block_path_template: block_path_template.trim().to_owned(),\n            provider: provider.trim().to_owned(),"
+    ));
+    assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));
 }
@@ -87,6 +90,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_notifications_provider_input_contract("));
+    assert!(
+        RUNTIME_COMMIT_SRC.contains("normalize_kolme_block_fallback_constructor_inputs_contract(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -60,6 +60,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1916"));
     assert!(DOC.contains("#1918"));
     assert!(DOC.contains("#1920"));
+    assert!(DOC.contains("#1922"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-kolme/src/block_fallback_policy.rs
+++ b/crates/kamn-kolme/src/block_fallback_policy.rs
@@ -128,6 +128,19 @@ pub fn is_valid_block_fallback_provider_input(provider: &str) -> bool {
     !provider.trim().is_empty()
 }
 
+/// Normalizes block-fallback reconciler constructor inputs.
+pub fn normalize_block_fallback_constructor_inputs(
+    base_url: &str,
+    block_path_template: &str,
+    provider: &str,
+) -> (String, String, String) {
+    (
+        base_url.trim().to_owned(),
+        block_path_template.trim().to_owned(),
+        provider.trim().to_owned(),
+    )
+}
+
 /// Validates block-fallback reconciler lookup budget input.
 pub fn is_valid_block_fallback_lookup_budget(max_block_lookups: u64) -> bool {
     max_block_lookups > 0

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -33,9 +33,10 @@ pub use api_codec::{
 };
 pub use block_fallback_policy::{
     is_valid_block_fallback_base_url_input, is_valid_block_fallback_lookup_budget,
-    is_valid_block_fallback_provider_input, parse_block_fallback_response,
-    parse_fork_block_fallback_response, parse_provider_block_fallback_response,
-    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
+    is_valid_block_fallback_provider_input, normalize_block_fallback_constructor_inputs,
+    parse_block_fallback_response, parse_fork_block_fallback_response,
+    parse_provider_block_fallback_response, KolmeBlockFallbackPolicyError,
+    KolmeBlockFallbackResponse,
 };
 pub use block_scan_policy::{
     compose_block_fallback_unresolved_reason, is_valid_block_lookup_height,

--- a/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/block_fallback_policy_contracts.rs
@@ -1,8 +1,9 @@
 use kamn_kolme::{
     is_valid_block_fallback_base_url_input, is_valid_block_fallback_lookup_budget,
-    is_valid_block_fallback_provider_input, parse_block_fallback_response,
-    parse_fork_block_fallback_response, parse_provider_block_fallback_response,
-    KolmeBlockFallbackPolicyError, KolmeBlockFallbackResponse,
+    is_valid_block_fallback_provider_input, normalize_block_fallback_constructor_inputs,
+    parse_block_fallback_response, parse_fork_block_fallback_response,
+    parse_provider_block_fallback_response, KolmeBlockFallbackPolicyError,
+    KolmeBlockFallbackResponse,
 };
 
 #[test]
@@ -115,9 +116,44 @@ fn functional_block_fallback_policy_accepts_valid_constructor_guard_inputs() {
 }
 
 #[test]
+fn functional_block_fallback_policy_normalizes_constructor_inputs() {
+    let normalized = normalize_block_fallback_constructor_inputs(
+        "  https://kolme.example  ",
+        "  /block/{height}  ",
+        "  kolme-fork-local  ",
+    );
+    assert_eq!(
+        normalized,
+        (
+            "https://kolme.example".to_owned(),
+            "/block/{height}".to_owned(),
+            "kolme-fork-local".to_owned(),
+        )
+    );
+}
+
+#[test]
 fn regression_issue_1866_block_fallback_policy_rejects_invalid_constructor_guard_inputs() {
     // Regression: #1866
     assert!(!is_valid_block_fallback_base_url_input(" "));
     assert!(!is_valid_block_fallback_provider_input(""));
     assert!(!is_valid_block_fallback_lookup_budget(0));
+}
+
+#[test]
+fn regression_issue_1922_block_fallback_policy_trims_constructor_input_whitespace() {
+    // Regression: #1922
+    let normalized = normalize_block_fallback_constructor_inputs(
+        "\nhttps://kolme.example\n",
+        "\n/block/{height}\n",
+        "\nkolme-fork-local\n",
+    );
+    assert_eq!(
+        normalized,
+        (
+            "https://kolme.example".to_owned(),
+            "/block/{height}".to_owned(),
+            "kolme-fork-local".to_owned(),
+        )
+    );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -78,6 +78,7 @@ Out of scope:
 - #1916: extracted notifications provider normalization contract to `kamn-kolme` (`normalize_notifications_provider_input`) and rewired `kamn-core` notifications consumer construction normalization delegation.
 - #1918: extracted finality endpoint normalization contract to `kamn-kolme` (`normalize_finality_endpoint_inputs`) and rewired `kamn-core` finality checker constructor normalization delegation.
 - #1920: extracted live provider endpoint normalization contract to `kamn-kolme` (`normalize_live_provider_endpoint_inputs`) and rewired `kamn-core` live provider constructor normalization delegation.
+- #1922: extracted block-fallback constructor normalization contract to `kamn-kolme` (`normalize_block_fallback_constructor_inputs`) and rewired `kamn-core` block-fallback reconciler constructor normalization delegation.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1922

## Summary
Extract block-fallback reconciler constructor normalization into `kamn-kolme` and rewire `kamn-core` to delegate normalization through the extracted contract. This removes remaining inline trim ownership from the `kamn-core` constructor path while preserving behavior.

## Changes
- `crates/kamn-kolme/src/block_fallback_policy.rs`: added `normalize_block_fallback_constructor_inputs`.
- `crates/kamn-kolme/src/lib.rs`: exported block-fallback constructor normalization contract.
- `crates/kamn-kolme/tests/block_fallback_policy_contracts.rs`: added functional + regression coverage for constructor normalization.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegated block-fallback constructor normalization to `kamn-kolme`.
- `crates/kamn-core/tests/kolme_runtime_commit_block_fallback.rs`: added regression proving normalized constructor inputs flow through transport/reconciliation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary assertions for removed inline trim and delegated helper marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1922` marker check.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added Phase 2 progress marker for `#1922`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed block-fallback constructor uses delegated normalization and transport sees normalized inputs

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test block_fallback_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_block_fallback` |
| Integration | ✅     | `integration_http_transport_block_fallback_converges_with_mock_block_api` within block-fallback suite |
| Regression  | ✅     | `regression_issue_1922_block_fallback_policy_trims_constructor_input_whitespace`, `regression_issue_1922_block_fallback_constructor_normalization_delegates_to_contract`, extraction boundary/docs suites |
