### PR TITLE
refactor(kolme): extract notifications reconnect exhausted reason contract (#1924)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -9,6 +9,7 @@ use kamn_kolme::{
     commit_finality_label as commit_finality_label_contract,
     compose_block_fallback_unresolved_reason as compose_kolme_block_fallback_unresolved_reason_contract,
     compose_finality_status_path as compose_kolme_finality_status_path,
+    compose_notifications_reconnect_exhausted_reason as compose_kolme_notifications_reconnect_exhausted_reason_contract,
     compose_notifications_websocket_url as compose_kolme_notifications_websocket_url,
     deterministic_runtime_commit_id as deterministic_runtime_commit_id_contract,
     deterministic_runtime_commit_idempotency_key as deterministic_runtime_commit_idempotency_key_contract,
@@ -1674,7 +1675,12 @@ where
                     Err(_) => {
                         reconnect_attempts += 1;
                         if reconnect_attempts >= self.max_reconnect_attempts {
-                            return Err(reconnect_exhausted_error(self.max_reconnect_attempts));
+                            return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                                reason:
+                                    compose_kolme_notifications_reconnect_exhausted_reason_contract(
+                                        self.max_reconnect_attempts,
+                                    ),
+                            });
                         }
                         continue;
                     }
@@ -1692,7 +1698,11 @@ where
                     self.connection = None;
                     reconnect_attempts += 1;
                     if reconnect_attempts >= self.max_reconnect_attempts {
-                        return Err(reconnect_exhausted_error(self.max_reconnect_attempts));
+                        return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                            reason: compose_kolme_notifications_reconnect_exhausted_reason_contract(
+                                self.max_reconnect_attempts,
+                            ),
+                        });
                     }
                 }
             }
@@ -1960,14 +1970,6 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
                 Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
             }
         }
-    }
-}
-
-fn reconnect_exhausted_error(max_reconnect_attempts: u32) -> KolmeRuntimeCommitProviderError {
-    KolmeRuntimeCommitProviderError::Unavailable {
-        reason: format!(
-            "notification reconnect attempts exhausted after {max_reconnect_attempts} retries"
-        ),
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -42,6 +42,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_classification_to_provider_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome_policy_error_to_malformed("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn reconnect_exhausted_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
@@ -126,6 +127,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_status_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_notifications_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_notifications_reconnect_budget_contract("));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("compose_kolme_notifications_reconnect_exhausted_reason_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -61,6 +61,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1918"));
     assert!(DOC.contains("#1920"));
     assert!(DOC.contains("#1922"));
+    assert!(DOC.contains("#1924"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
@@ -287,3 +287,34 @@ fn regression_notifications_consumer_fails_closed_on_decode_and_retry_exhaustion
         })
     );
 }
+
+#[test]
+fn regression_issue_1924_notifications_consumer_reconnect_exhausted_reason_remains_stable() {
+    // Regression: #1924
+    let retry_connector = MockConnector::new(vec![
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial failed: refused".to_owned(),
+        }),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial failed: refused".to_owned(),
+        }),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial failed: refused".to_owned(),
+        }),
+    ]);
+    let mut retry_consumer = KolmeRuntimeCommitNotificationsConsumer::new(
+        "http://127.0.0.1:3030",
+        "/notifications",
+        "kolme-fork-local",
+        3,
+        retry_connector,
+    )
+    .expect("notifications consumer should build");
+
+    assert_eq!(
+        retry_consumer.next_notification_event(),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "notification reconnect attempts exhausted after 3 retries".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -72,10 +72,11 @@ pub use http_response_policy::{
     is_valid_http_response_bytes_input, parse_http_response_body, KolmeHttpResponsePolicyError,
 };
 pub use notification_policy::{
-    is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
-    normalize_notifications_provider_input, notification_event_to_provider_receipt,
-    notification_event_to_receipt, parse_notification_event, KolmeNotificationEvent,
-    KolmeNotificationPolicyError, KolmeNotificationReceipt, KolmeProviderNotificationReceipt,
+    compose_notifications_reconnect_exhausted_reason, is_valid_notifications_provider_input,
+    is_valid_notifications_reconnect_budget, normalize_notifications_provider_input,
+    notification_event_to_provider_receipt, notification_event_to_receipt,
+    parse_notification_event, KolmeNotificationEvent, KolmeNotificationPolicyError,
+    KolmeNotificationReceipt, KolmeProviderNotificationReceipt,
 };
 pub use pipeline::{PipelineError, RuntimeCommitPipeline};
 pub use provider_outcome_policy::{

--- a/crates/kamn-kolme/src/notification_policy.rs
+++ b/crates/kamn-kolme/src/notification_policy.rs
@@ -174,6 +174,11 @@ pub fn is_valid_notifications_reconnect_budget(max_reconnect_attempts: u32) -> b
     max_reconnect_attempts > 0
 }
 
+/// Composes deterministic notifications reconnect exhaustion reason text.
+pub fn compose_notifications_reconnect_exhausted_reason(max_reconnect_attempts: u32) -> String {
+    format!("notification reconnect attempts exhausted after {max_reconnect_attempts} retries")
+}
+
 fn find_notification_string_field(
     payload: &str,
     field: &str,

--- a/crates/kamn-kolme/tests/notification_policy_contracts.rs
+++ b/crates/kamn-kolme/tests/notification_policy_contracts.rs
@@ -1,6 +1,6 @@
 use kamn_kolme::{
-    is_valid_notifications_provider_input, is_valid_notifications_reconnect_budget,
-    normalize_notifications_provider_input,
+    compose_notifications_reconnect_exhausted_reason, is_valid_notifications_provider_input,
+    is_valid_notifications_reconnect_budget, normalize_notifications_provider_input,
     notification_event_to_provider_receipt as notification_event_to_provider_receipt_contract,
     notification_event_to_receipt as notification_event_to_receipt_contract,
     parse_notification_event, KolmeCommitReceiptFinality, KolmeNotificationEvent,
@@ -127,5 +127,23 @@ fn regression_issue_1916_notification_policy_trims_outer_provider_whitespace() {
     assert_eq!(
         normalize_notifications_provider_input("\nkolme-fork-local\n"),
         "kolme-fork-local"
+    );
+}
+
+#[test]
+fn functional_notification_policy_composes_reconnect_exhausted_reason() {
+    assert_eq!(
+        compose_notifications_reconnect_exhausted_reason(3),
+        "notification reconnect attempts exhausted after 3 retries"
+    );
+}
+
+#[test]
+fn regression_issue_1924_notification_policy_composes_reconnect_exhausted_reason_deterministically()
+{
+    // Regression: #1924
+    assert_eq!(
+        compose_notifications_reconnect_exhausted_reason(2),
+        "notification reconnect attempts exhausted after 2 retries"
     );
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -79,6 +79,7 @@ Out of scope:
 - #1918: extracted finality endpoint normalization contract to `kamn-kolme` (`normalize_finality_endpoint_inputs`) and rewired `kamn-core` finality checker constructor normalization delegation.
 - #1920: extracted live provider endpoint normalization contract to `kamn-kolme` (`normalize_live_provider_endpoint_inputs`) and rewired `kamn-core` live provider constructor normalization delegation.
 - #1922: extracted block-fallback constructor normalization contract to `kamn-kolme` (`normalize_block_fallback_constructor_inputs`) and rewired `kamn-core` block-fallback reconciler constructor normalization delegation.
+- #1924: extracted reconnect exhaustion reason composition contract to `kamn-kolme` (`compose_notifications_reconnect_exhausted_reason`) and rewired `kamn-core` notifications consumer reconnect exhaustion errors to delegate text composition.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1924

## Summary
Extract notifications reconnect-exhaustion reason composition into `kamn-kolme` and rewire `kamn-core` notifications consumer to delegate reason text composition through the extracted contract. This removes remaining local reconnect-reason helper ownership from `kolme_runtime_commit.rs` while preserving reconnect behavior.

## Changes
- `crates/kamn-kolme/src/notification_policy.rs`: added `compose_notifications_reconnect_exhausted_reason` contract.
- `crates/kamn-kolme/src/lib.rs`: exported reconnect-exhausted reason contract.
- `crates/kamn-kolme/tests/notification_policy_contracts.rs`: added functional and regression tests for deterministic reconnect-reason composition.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: delegated reconnect exhaustion error reason composition to `kamn-kolme` and removed local `reconnect_exhausted_error` helper.
- `crates/kamn-core/tests/kolme_runtime_commit_notifications.rs`: added regression for reconnect exhaustion reason stability.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary guards for removed local helper and delegated contract marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1924` marker requirement.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: recorded Phase 2 progress marker for `#1924`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed reconnect exhaustion error reasons are still deterministic and now delegated from `kamn-kolme`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-kolme --test notification_policy_contracts` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| Integration | ✅     | `integration_notifications_websocket_connector_receives_kolme_notification` in notifications suite |
| Regression  | ✅     | `regression_issue_1924_notification_policy_composes_reconnect_exhausted_reason_deterministically`, `regression_issue_1924_notifications_consumer_reconnect_exhausted_reason_remains_stable`, extraction boundary/docs suites |
