### PR TITLE
refactor(kolme): remove local notification parse wrapper glue (#1926)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -745,6 +745,28 @@ pub enum KolmeRuntimeCommitNotificationEvent {
     },
 }
 
+impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent {
+    fn from(value: KamnKolmeNotificationEvent) -> Self {
+        match value {
+            KamnKolmeNotificationEvent::NewBlock {
+                txhash,
+                block_height,
+            } => Self::NewBlock {
+                txhash,
+                block_height,
+            },
+            KamnKolmeNotificationEvent::FailedTransaction {
+                txhash,
+                proposed_height,
+            } => Self::FailedTransaction {
+                txhash,
+                proposed_height,
+            },
+            KamnKolmeNotificationEvent::LatestBlock { height } => Self::LatestBlock { height },
+        }
+    }
+}
+
 impl KolmeRuntimeCommitNotificationEvent {
     /// Converts notification event to a provider receipt when it carries tx finality information.
     pub fn to_provider_receipt(&self, provider: &str) -> Option<KolmeRuntimeCommitProviderReceipt> {
@@ -1693,7 +1715,14 @@ where
                 .expect("connection should exist before read")
                 .read_text_message();
             match result {
-                Ok(Some(payload)) => return parse_kolme_notification_event(payload.as_str()),
+                Ok(Some(payload)) => {
+                    let event = parse_kolme_notification_event_contract(payload.as_str()).map_err(
+                        |error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                            reason: error.to_string(),
+                        },
+                    )?;
+                    return Ok(event.into());
+                }
                 Ok(None) | Err(_) => {
                     self.connection = None;
                     reconnect_attempts += 1;
@@ -2000,35 +2029,6 @@ fn read_http_header_boundary(
             });
         }
         response_bytes.extend_from_slice(&chunk[..read]);
-    }
-}
-
-fn parse_kolme_notification_event(
-    payload: &str,
-) -> Result<KolmeRuntimeCommitNotificationEvent, KolmeRuntimeCommitProviderError> {
-    let event = parse_kolme_notification_event_contract(payload).map_err(|error| {
-        KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: error.to_string(),
-        }
-    })?;
-    match event {
-        KamnKolmeNotificationEvent::NewBlock {
-            txhash,
-            block_height,
-        } => Ok(KolmeRuntimeCommitNotificationEvent::NewBlock {
-            txhash,
-            block_height,
-        }),
-        KamnKolmeNotificationEvent::FailedTransaction {
-            txhash,
-            proposed_height,
-        } => Ok(KolmeRuntimeCommitNotificationEvent::FailedTransaction {
-            txhash,
-            proposed_height,
-        }),
-        KamnKolmeNotificationEvent::LatestBlock { height } => {
-            Ok(KolmeRuntimeCommitNotificationEvent::LatestBlock { height })
-        }
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -18,6 +18,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn render_block_path("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_block_fallback_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_fork_block_fallback_response("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_notification_event("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
@@ -130,6 +131,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC
         .contains("compose_kolme_notifications_reconnect_exhausted_reason_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent"));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -62,6 +62,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1920"));
     assert!(DOC.contains("#1922"));
     assert!(DOC.contains("#1924"));
+    assert!(DOC.contains("#1926"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
@@ -4,6 +4,7 @@ use kamn_core::{
     KolmeRuntimeCommitNotificationsConsumer, KolmeRuntimeCommitProviderError,
     KolmeRuntimeCommitWebsocketConnector,
 };
+use kamn_kolme::KolmeNotificationEvent as KamnKolmeNotificationEvent;
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -192,6 +193,22 @@ fn functional_notifications_consumer_decodes_new_block_variant_to_final_receipt(
     assert_eq!(receipt.provider, "kolme-fork-local");
     assert_eq!(receipt.commit_id, "kolme-commit:ab12cd34:h42");
     assert_eq!(receipt.finality, KolmeCommitReceiptFinality::Final);
+}
+
+#[test]
+fn regression_issue_1926_notification_event_conversion_preserves_variant_fields() {
+    // Regression: #1926
+    let event = KolmeRuntimeCommitNotificationEvent::from(KamnKolmeNotificationEvent::NewBlock {
+        txhash: "ab12cd34".to_owned(),
+        block_height: Some(42),
+    });
+    assert_eq!(
+        event,
+        KolmeRuntimeCommitNotificationEvent::NewBlock {
+            txhash: "ab12cd34".to_owned(),
+            block_height: Some(42),
+        }
+    );
 }
 
 #[test]

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -80,6 +80,7 @@ Out of scope:
 - #1920: extracted live provider endpoint normalization contract to `kamn-kolme` (`normalize_live_provider_endpoint_inputs`) and rewired `kamn-core` live provider constructor normalization delegation.
 - #1922: extracted block-fallback constructor normalization contract to `kamn-kolme` (`normalize_block_fallback_constructor_inputs`) and rewired `kamn-core` block-fallback reconciler constructor normalization delegation.
 - #1924: extracted reconnect exhaustion reason composition contract to `kamn-kolme` (`compose_notifications_reconnect_exhausted_reason`) and rewired `kamn-core` notifications consumer reconnect exhaustion errors to delegate text composition.
+- #1926: removed local notification parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeNotificationEvent` -> `KolmeRuntimeCommitNotificationEvent` conversion and inlining delegated parse contract mapping in notifications consumer flow.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1926

## Summary
Remove local notification parse wrapper glue from `kamn-core` runtime-commit flow by introducing direct conversion from `KamnKolmeNotificationEvent` to `KolmeRuntimeCommitNotificationEvent` and inlining delegated parse contract mapping in the notifications consumer.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent`, inlined delegated parse mapping in `next_notification_event`, and removed local `parse_kolme_notification_event` wrapper helper.
- `crates/kamn-core/tests/kolme_runtime_commit_notifications.rs`: added regression coverage for event conversion preserving variant fields.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added boundary guards for removed local wrapper + conversion marker.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1926` plan marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: recorded progress marker for `#1926`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: notifications consumer parse path remains fail-closed and produces unchanged event/receipt behavior

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `regression_issue_1926_notification_event_conversion_preserves_variant_fields` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| Integration | ✅     | `integration_notifications_websocket_connector_receives_kolme_notification` in notifications suite |
| Regression  | ✅     | extraction boundary/docs suites + `regression_issue_1926_notification_event_conversion_preserves_variant_fields` |
