### PR TITLE
refactor(kolme): remove local TLS CA env wrapper glue (#1928)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1054,7 +1054,14 @@ impl KolmeRuntimeCommitHttpTransport {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        if let Some(ca_file) = configured_tls_ca_file()? {
+        let configured_ca_file =
+            resolve_kolme_tls_ca_file_env_result_contract(std::env::var("KAMN_KOLME_TLS_CA_FILE"))
+                .map_err(|error| match error {
+                    KamnKolmeTlsPolicyError::Unavailable { reason } => {
+                        KolmeRuntimeCommitProviderError::Unavailable { reason }
+                    }
+                })?;
+        if let Some(ca_file) = configured_ca_file {
             command.arg("-CAfile").arg(ca_file);
         }
 
@@ -2030,16 +2037,6 @@ fn read_http_header_boundary(
         }
         response_bytes.extend_from_slice(&chunk[..read]);
     }
-}
-
-fn configured_tls_ca_file() -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
-    resolve_kolme_tls_ca_file_env_result_contract(std::env::var("KAMN_KOLME_TLS_CA_FILE")).map_err(
-        |error| match error {
-            KamnKolmeTlsPolicyError::Unavailable { reason } => {
-                KolmeRuntimeCommitProviderError::Unavailable { reason }
-            }
-        },
-    )
 }
 
 fn parse_live_provider_response(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -44,6 +44,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_transport_io_classification_to_provider_error("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn map_provider_outcome_policy_error_to_malformed("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn reconnect_exhausted_error("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn configured_tls_ca_file("));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
@@ -64,6 +65,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "base_url: base_url.trim().to_owned(),\n            block_path_template: block_path_template.trim().to_owned(),\n            provider: provider.trim().to_owned(),"
     ));
+    assert!(!RUNTIME_COMMIT_SRC.contains("if let Some(ca_file) = configured_tls_ca_file()?"));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -63,6 +63,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1922"));
     assert!(DOC.contains("#1924"));
     assert!(DOC.contains("#1926"));
+    assert!(DOC.contains("#1928"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -81,6 +81,7 @@ Out of scope:
 - #1922: extracted block-fallback constructor normalization contract to `kamn-kolme` (`normalize_block_fallback_constructor_inputs`) and rewired `kamn-core` block-fallback reconciler constructor normalization delegation.
 - #1924: extracted reconnect exhaustion reason composition contract to `kamn-kolme` (`compose_notifications_reconnect_exhausted_reason`) and rewired `kamn-core` notifications consumer reconnect exhaustion errors to delegate text composition.
 - #1926: removed local notification parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeNotificationEvent` -> `KolmeRuntimeCommitNotificationEvent` conversion and inlining delegated parse contract mapping in notifications consumer flow.
+- #1928: removed local TLS CA env wrapper glue from `kamn-core` by inlining delegated `resolve_tls_ca_file_env_result` contract mapping in HTTPS transport setup and deleting `configured_tls_ca_file` helper ownership.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1928

## Summary
Remove local TLS CA env wrapper glue from `kamn-core` runtime-commit HTTPS transport path by inlining delegated `kamn-kolme` TLS env result mapping at the callsite. This keeps behavior unchanged while reducing helper ownership in the monolithic module.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `configured_tls_ca_file` helper and inlined delegated `resolve_kolme_tls_ca_file_env_result_contract(std::env::var("KAMN_KOLME_TLS_CA_FILE"))` mapping in HTTPS request setup.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added guard asserting local TLS helper removal and callsite wrapper removal.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1928` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added progress marker for `#1928`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: HTTPS transport setup still applies optional TLS CA file via delegated env mapping

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | runtime client integration tests in `kolme_runtime_commit_client` remain green |
| Regression  | ✅     | extraction boundary/docs regression guards for `#1928` |
