### PR TITLE
refactor(kolme): remove local live-provider parse wrapper glue (#1930)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -812,6 +812,32 @@ pub enum KolmeRuntimeCommitProviderOutcome {
     },
 }
 
+impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome {
+    fn from(value: KamnKolmeRuntimeProviderOutcome) -> Self {
+        match value {
+            KamnKolmeRuntimeProviderOutcome::Submitted {
+                provider,
+                commit_id,
+                finality,
+            } => Self::Submitted(KolmeRuntimeCommitProviderReceipt {
+                provider,
+                commit_id,
+                finality,
+            }),
+            KamnKolmeRuntimeProviderOutcome::Duplicate {
+                provider,
+                commit_id,
+                finality,
+            } => Self::Duplicate(KolmeRuntimeCommitProviderReceipt {
+                provider,
+                commit_id,
+                finality,
+            }),
+            KamnKolmeRuntimeProviderOutcome::Rejected { reason } => Self::Rejected { reason },
+        }
+    }
+}
+
 /// Transport connection abstraction for consuming notifications text messages.
 pub trait KolmeRuntimeCommitNotificationsConnection {
     /// Reads the next notifications text message.
@@ -1903,7 +1929,12 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitProvider
             KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast => self.provider_hint.as_deref(),
             KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit => None,
         };
-        parse_live_provider_response(response.as_str(), provider_hint)
+        let outcome =
+            parse_kolme_live_runtime_provider_outcome_contract(response.as_str(), provider_hint)
+                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                })?;
+        Ok(outcome.into())
     }
 }
 
@@ -2036,43 +2067,6 @@ fn read_http_header_boundary(
             });
         }
         response_bytes.extend_from_slice(&chunk[..read]);
-    }
-}
-
-fn parse_live_provider_response(
-    response: &str,
-    provider_hint: Option<&str>,
-) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
-    match parse_kolme_live_runtime_provider_outcome_contract(response, provider_hint).map_err(
-        |error| KolmeRuntimeCommitProviderError::MalformedResponse {
-            reason: error.to_string(),
-        },
-    )? {
-        KamnKolmeRuntimeProviderOutcome::Submitted {
-            provider,
-            commit_id,
-            finality,
-        } => Ok(KolmeRuntimeCommitProviderOutcome::Submitted(
-            KolmeRuntimeCommitProviderReceipt {
-                provider,
-                commit_id,
-                finality,
-            },
-        )),
-        KamnKolmeRuntimeProviderOutcome::Duplicate {
-            provider,
-            commit_id,
-            finality,
-        } => Ok(KolmeRuntimeCommitProviderOutcome::Duplicate(
-            KolmeRuntimeCommitProviderReceipt {
-                provider,
-                commit_id,
-                finality,
-            },
-        )),
-        KamnKolmeRuntimeProviderOutcome::Rejected { reason } => {
-            Ok(KolmeRuntimeCommitProviderOutcome::Rejected { reason })
-        }
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_client.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client.rs
@@ -8,6 +8,7 @@ use kamn_core::{
     KolmeRuntimeCommitRequest, KolmeRuntimeCommitSignedBroadcastEnvelope,
     KolmeRuntimeCommitTransportErrorKind, RuntimeCommitLifecycleState, RuntimeCommitPipeline,
 };
+use kamn_kolme::KolmeRuntimeProviderOutcome as KamnKolmeRuntimeProviderOutcome;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -849,6 +850,36 @@ fn regression_live_provider_rejects_statusless_response_without_txhash() {
             Err(KolmeRuntimeCommitProviderError::MalformedResponse { .. })
         ),
         "provider must fail closed when neither status nor txhash is present"
+    );
+}
+
+#[test]
+fn regression_issue_1930_live_provider_outcome_conversion_preserves_semantics() {
+    // Regression: #1930
+    let submitted =
+        KolmeRuntimeCommitProviderOutcome::from(KamnKolmeRuntimeProviderOutcome::Submitted {
+            provider: "kolme-live".to_owned(),
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: kamn_kolme::KolmeCommitReceiptFinality::Final,
+        });
+    assert_eq!(
+        submitted,
+        KolmeRuntimeCommitProviderOutcome::Submitted(KolmeRuntimeCommitProviderReceipt {
+            provider: "kolme-live".to_owned(),
+            commit_id: "kolme-commit:ab12cd34".to_owned(),
+            finality: KolmeCommitReceiptFinality::Final,
+        })
+    );
+
+    let rejected =
+        KolmeRuntimeCommitProviderOutcome::from(KamnKolmeRuntimeProviderOutcome::Rejected {
+            reason: "duplicate idempotency".to_owned(),
+        });
+    assert_eq!(
+        rejected,
+        KolmeRuntimeCommitProviderOutcome::Rejected {
+            reason: "duplicate idempotency".to_owned(),
+        }
     );
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -19,6 +19,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_block_fallback_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_fork_block_fallback_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_notification_event("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_live_provider_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
@@ -137,6 +138,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent"));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
+    assert!(RUNTIME_COMMIT_SRC.contains(
+        "impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome"
+    ));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
     assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_websocket_timeout_seconds_contract("));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -64,6 +64,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1924"));
     assert!(DOC.contains("#1926"));
     assert!(DOC.contains("#1928"));
+    assert!(DOC.contains("#1930"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -82,6 +82,7 @@ Out of scope:
 - #1924: extracted reconnect exhaustion reason composition contract to `kamn-kolme` (`compose_notifications_reconnect_exhausted_reason`) and rewired `kamn-core` notifications consumer reconnect exhaustion errors to delegate text composition.
 - #1926: removed local notification parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeNotificationEvent` -> `KolmeRuntimeCommitNotificationEvent` conversion and inlining delegated parse contract mapping in notifications consumer flow.
 - #1928: removed local TLS CA env wrapper glue from `kamn-core` by inlining delegated `resolve_tls_ca_file_env_result` contract mapping in HTTPS transport setup and deleting `configured_tls_ca_file` helper ownership.
+- #1930: removed local live-provider parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeRuntimeProviderOutcome` -> `KolmeRuntimeCommitProviderOutcome` conversion and inlining delegated parse mapping in live-provider submission flow.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1930

## Summary
Remove local live-provider parse wrapper glue from `kamn-core` by introducing direct conversion from `KamnKolmeRuntimeProviderOutcome` and inlining delegated parse mapping in the live-provider submission path. This preserves fail-closed behavior while reducing helper ownership in `kolme_runtime_commit.rs`.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome`, inlined delegated parse mapping at live-provider submit callsite, removed `parse_live_provider_response` helper.
- `crates/kamn-core/tests/kolme_runtime_commit_client.rs`: added regression coverage for live-provider outcome conversion semantics.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added wrapper-removal + conversion-marker guards.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1930` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added progress marker for `#1930`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: live-provider submitted/duplicate/rejected outcomes map unchanged while wrapper helper is removed

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `regression_issue_1930_live_provider_outcome_conversion_preserves_semantics` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | runtime client integration lanes in `kolme_runtime_commit_client` remain green |
| Regression  | ✅     | extraction boundary/docs guards + `regression_issue_1930_live_provider_outcome_conversion_preserves_semantics` |
