### PR TITLE
refactor(kolme): remove local lifecycle-record helper glue (#1932)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -547,7 +547,30 @@ impl RuntimeCommitPipeline {
         request: KolmeRuntimeCommitRequest,
     ) -> Result<RuntimeCommitLifecycleRecord, KolmeRuntimeCommitError> {
         let outcome = client.submit_commit(&request)?;
-        let record = lifecycle_record_from_outcome(&request, &outcome);
+        let record = match &outcome {
+            KolmeRuntimeCommitOutcome::Submitted(receipt)
+            | KolmeRuntimeCommitOutcome::Duplicate(receipt) => {
+                let state = lifecycle_state_for_finality_contract(receipt.finality);
+                RuntimeCommitLifecycleRecord {
+                    operation_id: request.operation_id.clone(),
+                    idempotency_key: request.idempotency_key().to_owned(),
+                    state,
+                    needs_requeue: matches!(state, RuntimeCommitLifecycleState::Pending),
+                    receipt_provider: Some(receipt.provider.clone()),
+                    receipt_commit_id: Some(receipt.commit_id.clone()),
+                    last_error_reason: None,
+                }
+            }
+            KolmeRuntimeCommitOutcome::Rejected { reason } => RuntimeCommitLifecycleRecord {
+                operation_id: request.operation_id.clone(),
+                idempotency_key: request.idempotency_key().to_owned(),
+                state: RuntimeCommitLifecycleState::Failed,
+                needs_requeue: false,
+                receipt_provider: None,
+                receipt_commit_id: None,
+                last_error_reason: Some(reason.clone()),
+            },
+        };
         self.records_by_operation_id
             .insert(request.operation_id.clone(), record.clone());
         Ok(record)
@@ -2251,36 +2274,6 @@ impl fmt::Display for KolmeRuntimeCommitError {
 }
 
 impl std::error::Error for KolmeRuntimeCommitError {}
-
-fn lifecycle_record_from_outcome(
-    request: &KolmeRuntimeCommitRequest,
-    outcome: &KolmeRuntimeCommitOutcome,
-) -> RuntimeCommitLifecycleRecord {
-    match outcome {
-        KolmeRuntimeCommitOutcome::Submitted(receipt)
-        | KolmeRuntimeCommitOutcome::Duplicate(receipt) => {
-            let state = lifecycle_state_for_finality_contract(receipt.finality);
-            RuntimeCommitLifecycleRecord {
-                operation_id: request.operation_id.clone(),
-                idempotency_key: request.idempotency_key().to_owned(),
-                state,
-                needs_requeue: matches!(state, RuntimeCommitLifecycleState::Pending),
-                receipt_provider: Some(receipt.provider.clone()),
-                receipt_commit_id: Some(receipt.commit_id.clone()),
-                last_error_reason: None,
-            }
-        }
-        KolmeRuntimeCommitOutcome::Rejected { reason } => RuntimeCommitLifecycleRecord {
-            operation_id: request.operation_id.clone(),
-            idempotency_key: request.idempotency_key().to_owned(),
-            state: RuntimeCommitLifecycleState::Failed,
-            needs_requeue: false,
-            receipt_provider: None,
-            receipt_commit_id: None,
-            last_error_reason: Some(reason.clone()),
-        },
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -20,6 +20,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_fork_block_fallback_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_notification_event("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_live_provider_response("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn lifecycle_record_from_outcome("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
@@ -67,6 +68,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
         "base_url: base_url.trim().to_owned(),\n            block_path_template: block_path_template.trim().to_owned(),\n            provider: provider.trim().to_owned(),"
     ));
     assert!(!RUNTIME_COMMIT_SRC.contains("if let Some(ca_file) = configured_tls_ca_file()?"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let record = lifecycle_record_from_outcome("));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -65,6 +65,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1926"));
     assert!(DOC.contains("#1928"));
     assert!(DOC.contains("#1930"));
+    assert!(DOC.contains("#1932"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -83,6 +83,7 @@ Out of scope:
 - #1926: removed local notification parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeNotificationEvent` -> `KolmeRuntimeCommitNotificationEvent` conversion and inlining delegated parse contract mapping in notifications consumer flow.
 - #1928: removed local TLS CA env wrapper glue from `kamn-core` by inlining delegated `resolve_tls_ca_file_env_result` contract mapping in HTTPS transport setup and deleting `configured_tls_ca_file` helper ownership.
 - #1930: removed local live-provider parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeRuntimeProviderOutcome` -> `KolmeRuntimeCommitProviderOutcome` conversion and inlining delegated parse mapping in live-provider submission flow.
+- #1932: removed local lifecycle-record helper glue from `kamn-core` by inlining deterministic lifecycle-record construction in runtime pipeline submit path and deleting `lifecycle_record_from_outcome` helper ownership.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1932

## Summary
Remove local lifecycle-record helper glue from `kamn-core` runtime pipeline by inlining deterministic lifecycle-record construction at the submit callsite. This preserves behavior while reducing monolith helper ownership.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `lifecycle_record_from_outcome` and inlined equivalent deterministic record construction in `RuntimeCommitPipeline::submit_with_client`.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added guard assertions for removed helper and removed callsite wrapper usage.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1932` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added progress marker for `#1932`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: submitted/duplicate/rejected pipeline record fields remain deterministic and unchanged

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | adapter-backed pipeline integration lane in `kolme_runtime_commit_client` remains green |
| Regression  | ✅     | extraction boundary/docs guards for `#1932` |
