### PR TITLE
refactor(kolme): remove websocket header-boundary helper glue (#1934)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1653,7 +1653,30 @@ impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketCon
         })?;
 
         let mut response_bytes = Vec::new();
-        let header_end = read_http_header_boundary(&mut stream, &mut response_bytes)?;
+        let header_end = loop {
+            if let Some(position) =
+                find_kolme_http_header_boundary(&response_bytes).map_err(|error| match error {
+                    KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                        KolmeRuntimeCommitProviderError::Unavailable { reason }
+                    }
+                    KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                        KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                    }
+                })?
+            {
+                break position;
+            }
+            let mut chunk = [0_u8; 1024];
+            let read = stream.read(&mut chunk).map_err(|error| {
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+            })?;
+            if read == 0 {
+                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: "websocket handshake response is incomplete".to_owned(),
+                });
+            }
+            response_bytes.extend_from_slice(&chunk[..read]);
+        };
         let (header_bytes, trailing) = response_bytes.split_at(header_end + 4);
         validate_kolme_websocket_handshake_response(header_bytes).map_err(|error| match error {
             KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
@@ -2060,36 +2083,6 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
                 Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
             }
         }
-    }
-}
-
-fn read_http_header_boundary(
-    stream: &mut TcpStream,
-    response_bytes: &mut Vec<u8>,
-) -> Result<usize, KolmeRuntimeCommitProviderError> {
-    loop {
-        if let Some(position) =
-            find_kolme_http_header_boundary(response_bytes).map_err(|error| match error {
-                KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
-                    KolmeRuntimeCommitProviderError::Unavailable { reason }
-                }
-                KamnKolmeWebsocketPolicyError::Malformed { reason } => {
-                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-                }
-            })?
-        {
-            return Ok(position);
-        }
-        let mut chunk = [0_u8; 1024];
-        let read = stream.read(&mut chunk).map_err(|error| {
-            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-        })?;
-        if read == 0 {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "websocket handshake response is incomplete".to_owned(),
-            });
-        }
-        response_bytes.extend_from_slice(&chunk[..read]);
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -21,6 +21,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_kolme_notification_event("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn parse_live_provider_response("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn lifecycle_record_from_outcome("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("fn read_http_header_boundary("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn classify_tls_failure_reason("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn normalize_kolme_broadcast_payload("));
     assert!(!RUNTIME_COMMIT_SRC.contains("fn validate_websocket_handshake_response("));
@@ -69,6 +70,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     ));
     assert!(!RUNTIME_COMMIT_SRC.contains("if let Some(ca_file) = configured_tls_ca_file()?"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let record = lifecycle_record_from_outcome("));
+    assert!(!RUNTIME_COMMIT_SRC.contains("let header_end = read_http_header_boundary("));
     assert!(!RUNTIME_COMMIT_SRC.contains(
         "\"operation_id={}\\nstate_root={}\\nactor_did={}\\nnonce={}\\npayload_hash={}\\nidempotency_key={}\\n\""
     ));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -66,6 +66,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1928"));
     assert!(DOC.contains("#1930"));
     assert!(DOC.contains("#1932"));
+    assert!(DOC.contains("#1934"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -84,6 +84,7 @@ Out of scope:
 - #1928: removed local TLS CA env wrapper glue from `kamn-core` by inlining delegated `resolve_tls_ca_file_env_result` contract mapping in HTTPS transport setup and deleting `configured_tls_ca_file` helper ownership.
 - #1930: removed local live-provider parse wrapper glue from `kamn-core` by introducing direct `KamnKolmeRuntimeProviderOutcome` -> `KolmeRuntimeCommitProviderOutcome` conversion and inlining delegated parse mapping in live-provider submission flow.
 - #1932: removed local lifecycle-record helper glue from `kamn-core` by inlining deterministic lifecycle-record construction in runtime pipeline submit path and deleting `lifecycle_record_from_outcome` helper ownership.
+- #1934: removed websocket header-boundary helper glue from `kamn-core` by inlining deterministic handshake header-boundary read loop in connector `connect` flow and deleting `read_http_header_boundary` helper ownership.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1934

## Summary
Remove the final websocket header-boundary helper glue from `kamn-core` by inlining deterministic handshake header-boundary read logic in connector `connect` flow. This preserves fail-closed behavior and transport error mapping while eliminating the last local helper in `kolme_runtime_commit.rs`.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit.rs`: removed `read_http_header_boundary`; inlined equivalent deterministic read loop in websocket connector `connect` handshake path.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: added helper-removal and callsite-wrapper-removal assertions for websocket header-boundary logic.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1934` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added progress marker for `#1934`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: websocket handshake still fails closed on incomplete headers and continues to parse notification frames correctly

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary` |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| Integration | ✅     | `integration_notifications_websocket_connector_receives_kolme_notification` remains green |
| Regression  | ✅     | extraction boundary/docs guards for `#1934` |
