### PR TITLE
refactor(kolme): extract in-memory runtime client module file (#1938)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -103,7 +103,6 @@ use kamn_kolme::{
     RuntimeCommitLifecycleState as KamnKolmeRuntimeCommitLifecycleState,
     RuntimeLifecyclePolicyError as KamnKolmeRuntimeLifecyclePolicyError,
 };
-use std::collections::HashMap;
 use std::fmt;
 use std::io::{Read, Write};
 use std::net::TcpStream;
@@ -111,6 +110,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod in_memory_client;
 mod runtime_pipeline;
 
 /// Runtime commit submission request for the Kolme execution path.
@@ -500,6 +500,7 @@ pub enum KolmeRuntimeCommitOutcome {
 /// Runtime lifecycle state projected from commit receipt outcomes.
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
+pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
 pub use runtime_pipeline::{
     RuntimeCommitFinalityProjection, RuntimeCommitLifecycleRecord, RuntimeCommitPipeline,
 };
@@ -1916,93 +1917,6 @@ impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
                 Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
             }
         }
-    }
-}
-
-/// Deterministic in-memory commit client used for contract tests and local development.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct InMemoryKolmeRuntimeCommitClient {
-    provider: String,
-    receipts_by_idempotency_key: HashMap<String, KolmeRuntimeCommitReceipt>,
-    finality_by_idempotency_key: HashMap<String, KolmeCommitReceiptFinality>,
-    rejected_reasons_by_idempotency_key: HashMap<String, String>,
-}
-
-impl InMemoryKolmeRuntimeCommitClient {
-    /// Constructs an in-memory commit client.
-    pub fn new(provider: &str) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_runtime_provider_input_contract(provider) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider",
-                reason: "must not be empty",
-            });
-        }
-        Ok(Self {
-            provider: provider.to_owned(),
-            receipts_by_idempotency_key: HashMap::new(),
-            finality_by_idempotency_key: HashMap::new(),
-            rejected_reasons_by_idempotency_key: HashMap::new(),
-        })
-    }
-
-    /// Forces deterministic rejection for the provided idempotency key.
-    pub fn reject_idempotency_key(&mut self, idempotency_key: &str, reason: &str) {
-        self.rejected_reasons_by_idempotency_key
-            .insert(idempotency_key.to_owned(), reason.to_owned());
-    }
-
-    /// Overrides the receipt finality that will be emitted for a given idempotency key.
-    pub fn set_finality_for_idempotency_key(
-        &mut self,
-        idempotency_key: &str,
-        finality: KolmeCommitReceiptFinality,
-    ) {
-        self.finality_by_idempotency_key
-            .insert(idempotency_key.to_owned(), finality);
-    }
-}
-
-impl KolmeRuntimeCommitClient for InMemoryKolmeRuntimeCommitClient {
-    fn submit_commit(
-        &mut self,
-        request: &KolmeRuntimeCommitRequest,
-    ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
-        request.validate()?;
-
-        if let Some(reason) = self
-            .rejected_reasons_by_idempotency_key
-            .get(request.idempotency_key())
-        {
-            return Ok(KolmeRuntimeCommitOutcome::Rejected {
-                reason: reason.clone(),
-            });
-        }
-
-        if let Some(existing) = self
-            .receipts_by_idempotency_key
-            .get(request.idempotency_key())
-        {
-            return Ok(KolmeRuntimeCommitOutcome::Duplicate(existing.clone()));
-        }
-
-        let receipt = KolmeRuntimeCommitReceipt {
-            provider: self.provider.clone(),
-            commit_id: deterministic_runtime_commit_id_contract(
-                request.operation_id.as_str(),
-                request.actor_did.as_str(),
-                request.nonce,
-                request.payload_hash.as_str(),
-            ),
-            finality: self
-                .finality_by_idempotency_key
-                .get(request.idempotency_key())
-                .copied()
-                .unwrap_or(KolmeCommitReceiptFinality::Pending),
-        };
-
-        self.receipts_by_idempotency_key
-            .insert(request.idempotency_key().to_owned(), receipt.clone());
-        Ok(KolmeRuntimeCommitOutcome::Submitted(receipt))
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/in_memory_client.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/in_memory_client.rs
@@ -1,0 +1,95 @@
+//! Deterministic in-memory runtime commit client for tests and local development.
+
+use super::{
+    deterministic_runtime_commit_id_contract, is_kolme_valid_runtime_provider_input_contract,
+    KolmeCommitReceiptFinality, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitOutcome, KolmeRuntimeCommitReceipt, KolmeRuntimeCommitRequest,
+};
+use std::collections::HashMap;
+
+/// Deterministic in-memory commit client used for contract tests and local development.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct InMemoryKolmeRuntimeCommitClient {
+    provider: String,
+    receipts_by_idempotency_key: HashMap<String, KolmeRuntimeCommitReceipt>,
+    finality_by_idempotency_key: HashMap<String, KolmeCommitReceiptFinality>,
+    rejected_reasons_by_idempotency_key: HashMap<String, String>,
+}
+
+impl InMemoryKolmeRuntimeCommitClient {
+    /// Constructs an in-memory commit client.
+    pub fn new(provider: &str) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_runtime_provider_input_contract(provider) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            provider: provider.to_owned(),
+            receipts_by_idempotency_key: HashMap::new(),
+            finality_by_idempotency_key: HashMap::new(),
+            rejected_reasons_by_idempotency_key: HashMap::new(),
+        })
+    }
+
+    /// Forces deterministic rejection for the provided idempotency key.
+    pub fn reject_idempotency_key(&mut self, idempotency_key: &str, reason: &str) {
+        self.rejected_reasons_by_idempotency_key
+            .insert(idempotency_key.to_owned(), reason.to_owned());
+    }
+
+    /// Overrides the receipt finality that will be emitted for a given idempotency key.
+    pub fn set_finality_for_idempotency_key(
+        &mut self,
+        idempotency_key: &str,
+        finality: KolmeCommitReceiptFinality,
+    ) {
+        self.finality_by_idempotency_key
+            .insert(idempotency_key.to_owned(), finality);
+    }
+}
+
+impl KolmeRuntimeCommitClient for InMemoryKolmeRuntimeCommitClient {
+    fn submit_commit(
+        &mut self,
+        request: &KolmeRuntimeCommitRequest,
+    ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
+        request.validate()?;
+
+        if let Some(reason) = self
+            .rejected_reasons_by_idempotency_key
+            .get(request.idempotency_key())
+        {
+            return Ok(KolmeRuntimeCommitOutcome::Rejected {
+                reason: reason.clone(),
+            });
+        }
+
+        if let Some(existing) = self
+            .receipts_by_idempotency_key
+            .get(request.idempotency_key())
+        {
+            return Ok(KolmeRuntimeCommitOutcome::Duplicate(existing.clone()));
+        }
+
+        let receipt = KolmeRuntimeCommitReceipt {
+            provider: self.provider.clone(),
+            commit_id: deterministic_runtime_commit_id_contract(
+                request.operation_id.as_str(),
+                request.actor_did.as_str(),
+                request.nonce,
+                request.payload_hash.as_str(),
+            ),
+            finality: self
+                .finality_by_idempotency_key
+                .get(request.idempotency_key())
+                .copied()
+                .unwrap_or(KolmeCommitReceiptFinality::Pending),
+        };
+
+        self.receipts_by_idempotency_key
+            .insert(request.idempotency_key().to_owned(), receipt.clone());
+        Ok(KolmeRuntimeCommitOutcome::Submitted(receipt))
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,4 +1,5 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
+const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
 const RUNTIME_PIPELINE_SRC: &str = include_str!("../src/kolme_runtime_commit/runtime_pipeline.rs");
 
 #[test]
@@ -52,7 +53,9 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitLifecycleRecord"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitFinalityProjection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
@@ -95,7 +98,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_poll_attempt_budget_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_commit_id_request_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_id_contract("));
+    assert!(RUNTIME_IN_MEMORY_SRC.contains("deterministic_runtime_commit_id_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_runtime_commit_wire_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_signed_envelope_wire_payload_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_runtime_commit_request_fields_contract("));
@@ -162,7 +165,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_response_bytes_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
+    assert!(RUNTIME_IN_MEMORY_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_operation_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_state_root_input_contract("));
@@ -187,5 +190,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_submit_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use runtime_pipeline::{"));
+    assert!(
+        RUNTIME_COMMIT_SRC.contains("pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;")
+    );
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -68,6 +68,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1932"));
     assert!(DOC.contains("#1934"));
     assert!(DOC.contains("#1936"));
+    assert!(DOC.contains("#1938"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -86,6 +86,7 @@ Out of scope:
 - #1932: removed local lifecycle-record helper glue from `kamn-core` by inlining deterministic lifecycle-record construction in runtime pipeline submit path and deleting `lifecycle_record_from_outcome` helper ownership.
 - #1934: removed websocket header-boundary helper glue from `kamn-core` by inlining deterministic handshake header-boundary read loop in connector `connect` flow and deleting `read_http_header_boundary` helper ownership.
 - #1936: extracted runtime pipeline lifecycle record/projection ownership into `kolme_runtime_commit/runtime_pipeline.rs` and rewired `kolme_runtime_commit.rs` to re-export pipeline types from the dedicated submodule.
+- #1938: extracted in-memory runtime client ownership into `kolme_runtime_commit/in_memory_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `InMemoryKolmeRuntimeCommitClient` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1938

## Summary
Extract `InMemoryKolmeRuntimeCommitClient` ownership into a dedicated `kolme_runtime_commit/in_memory_client.rs` submodule and re-export the type from `kolme_runtime_commit.rs` to preserve public API compatibility.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/in_memory_client.rs`: added module owning `InMemoryKolmeRuntimeCommitClient` struct + impls.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod in_memory_client;` and `pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;`; removed inline in-memory client ownership.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated ownership boundary checks and moved marker assertions for in-memory-specific contract usage.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1938` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added progress marker for `#1938`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: in-memory submit/duplicate/reject behavior and pipeline integration remain unchanged

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | extraction-boundary ownership checks + in-memory client unit paths |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client` |
| Integration | ✅     | `integration_runtime_pipeline_accepts_adapter_backed_final_receipts` and finality suite remain green |
| Regression  | ✅     | extraction boundary/docs suites with `#1938` marker checks |
