### PR TITLE
refactor(kolme): extract notifications websocket transport module file (#1940)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -111,6 +111,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 mod in_memory_client;
+mod notifications_websocket;
 mod runtime_pipeline;
 
 /// Runtime commit submission request for the Kolme execution path.
@@ -501,6 +502,9 @@ pub enum KolmeRuntimeCommitOutcome {
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
+pub use notifications_websocket::{
+    KolmeRuntimeCommitWebsocketConnection, KolmeRuntimeCommitWebsocketConnector,
+};
 pub use runtime_pipeline::{
     RuntimeCommitFinalityProjection, RuntimeCommitLifecycleRecord, RuntimeCommitPipeline,
 };
@@ -1361,169 +1365,6 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 latest_height,
             ),
         })
-    }
-}
-
-/// Minimal websocket connector for Kolme `/notifications` consumption.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeRuntimeCommitWebsocketConnector {
-    timeout_seconds: u64,
-}
-
-impl KolmeRuntimeCommitWebsocketConnector {
-    /// Builds a websocket connector with deterministic timeout validation.
-    pub fn new(timeout_seconds: u64) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_websocket_timeout_seconds_contract(timeout_seconds) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "notifications_timeout_seconds",
-                reason: "must be positive",
-            });
-        }
-        Ok(Self { timeout_seconds })
-    }
-}
-
-/// Websocket connection implementation used by the default notifications connector.
-#[derive(Debug)]
-pub struct KolmeRuntimeCommitWebsocketConnection {
-    stream: TcpStream,
-    read_buffer: Vec<u8>,
-}
-
-impl KolmeRuntimeCommitWebsocketConnection {
-    fn new(stream: TcpStream, read_buffer: Vec<u8>) -> Self {
-        Self {
-            stream,
-            read_buffer,
-        }
-    }
-}
-
-impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketConnection {
-    fn read_text_message(&mut self) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
-        loop {
-            if let Some(frame) = try_take_kolme_websocket_frame(&mut self.read_buffer).map_err(
-                |error| match error {
-                    KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
-                        KolmeRuntimeCommitProviderError::Unavailable { reason }
-                    }
-                    KamnKolmeWebsocketPolicyError::Malformed { reason } => {
-                        KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-                    }
-                },
-            )? {
-                match frame {
-                    KamnKolmeWebsocketFrame::Text(payload_bytes) => {
-                        let payload = String::from_utf8(payload_bytes).map_err(|error| {
-                            KolmeRuntimeCommitProviderError::MalformedResponse {
-                                reason: format!(
-                                    "websocket text payload is not valid utf-8: {error}"
-                                ),
-                            }
-                        })?;
-                        return Ok(Some(payload));
-                    }
-                    KamnKolmeWebsocketFrame::Close => return Ok(None),
-                    KamnKolmeWebsocketFrame::Ping | KamnKolmeWebsocketFrame::Pong => continue,
-                }
-            }
-
-            let mut chunk = [0_u8; 1024];
-            let read = self.stream.read(&mut chunk).map_err(|error| {
-                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-            })?;
-            if read == 0 {
-                return Ok(None);
-            }
-            self.read_buffer.extend_from_slice(&chunk[..read]);
-        }
-    }
-}
-
-impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketConnector {
-    type Connection = KolmeRuntimeCommitWebsocketConnection;
-
-    fn connect(
-        &mut self,
-        notifications_url: &str,
-    ) -> Result<Self::Connection, KolmeRuntimeCommitProviderError> {
-        let endpoint = parse_kolme_websocket_endpoint(notifications_url).map_err(|error| {
-            KolmeRuntimeCommitProviderError::Unavailable {
-                reason: error.to_string(),
-            }
-        })?;
-        if endpoint.secure {
-            return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                reason: "wss:// notifications are not supported by this transport".to_owned(),
-            });
-        }
-
-        let mut stream =
-            TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
-                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-            })?;
-        let timeout = Duration::from_secs(self.timeout_seconds);
-        stream.set_read_timeout(Some(timeout)).map_err(|error| {
-            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-        })?;
-        stream.set_write_timeout(Some(timeout)).map_err(|error| {
-            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-        })?;
-
-        let handshake = format!(
-            concat!(
-                "GET {} HTTP/1.1\r\n",
-                "Host: {}\r\n",
-                "Upgrade: websocket\r\n",
-                "Connection: Upgrade\r\n",
-                "Sec-WebSocket-Key: {}\r\n",
-                "Sec-WebSocket-Version: 13\r\n",
-                "\r\n"
-            ),
-            endpoint.target_path, endpoint.host_header, "dGhlIHNhbXBsZSBub25jZQ=="
-        );
-        stream.write_all(handshake.as_bytes()).map_err(|error| {
-            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-        })?;
-
-        let mut response_bytes = Vec::new();
-        let header_end = loop {
-            if let Some(position) =
-                find_kolme_http_header_boundary(&response_bytes).map_err(|error| match error {
-                    KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
-                        KolmeRuntimeCommitProviderError::Unavailable { reason }
-                    }
-                    KamnKolmeWebsocketPolicyError::Malformed { reason } => {
-                        KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-                    }
-                })?
-            {
-                break position;
-            }
-            let mut chunk = [0_u8; 1024];
-            let read = stream.read(&mut chunk).map_err(|error| {
-                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-            })?;
-            if read == 0 {
-                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: "websocket handshake response is incomplete".to_owned(),
-                });
-            }
-            response_bytes.extend_from_slice(&chunk[..read]);
-        };
-        let (header_bytes, trailing) = response_bytes.split_at(header_end + 4);
-        validate_kolme_websocket_handshake_response(header_bytes).map_err(|error| match error {
-            KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
-                KolmeRuntimeCommitProviderError::Unavailable { reason }
-            }
-            KamnKolmeWebsocketPolicyError::Malformed { reason } => {
-                KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-            }
-        })?;
-        Ok(KolmeRuntimeCommitWebsocketConnection::new(
-            stream,
-            trailing.to_vec(),
-        ))
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/notifications_websocket.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/notifications_websocket.rs
@@ -1,0 +1,176 @@
+//! Websocket notifications transport connector/connection implementation.
+
+use super::{
+    classify_kolme_transport_io_error, find_kolme_http_header_boundary,
+    is_kolme_valid_websocket_timeout_seconds_contract, parse_kolme_websocket_endpoint,
+    try_take_kolme_websocket_frame, validate_kolme_websocket_handshake_response,
+    KamnKolmeWebsocketFrame, KamnKolmeWebsocketPolicyError, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitNotificationsConnection, KolmeRuntimeCommitNotificationsConnector,
+    KolmeRuntimeCommitProviderError,
+};
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+/// Minimal websocket connector for Kolme `/notifications` consumption.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitWebsocketConnector {
+    timeout_seconds: u64,
+}
+
+impl KolmeRuntimeCommitWebsocketConnector {
+    /// Builds a websocket connector with deterministic timeout validation.
+    pub fn new(timeout_seconds: u64) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_websocket_timeout_seconds_contract(timeout_seconds) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "notifications_timeout_seconds",
+                reason: "must be positive",
+            });
+        }
+        Ok(Self { timeout_seconds })
+    }
+}
+
+/// Websocket connection implementation used by the default notifications connector.
+#[derive(Debug)]
+pub struct KolmeRuntimeCommitWebsocketConnection {
+    stream: TcpStream,
+    read_buffer: Vec<u8>,
+}
+
+impl KolmeRuntimeCommitWebsocketConnection {
+    fn new(stream: TcpStream, read_buffer: Vec<u8>) -> Self {
+        Self {
+            stream,
+            read_buffer,
+        }
+    }
+}
+
+impl KolmeRuntimeCommitNotificationsConnection for KolmeRuntimeCommitWebsocketConnection {
+    fn read_text_message(&mut self) -> Result<Option<String>, KolmeRuntimeCommitProviderError> {
+        loop {
+            if let Some(frame) = try_take_kolme_websocket_frame(&mut self.read_buffer).map_err(
+                |error| match error {
+                    KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                        KolmeRuntimeCommitProviderError::Unavailable { reason }
+                    }
+                    KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                        KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                    }
+                },
+            )? {
+                match frame {
+                    KamnKolmeWebsocketFrame::Text(payload_bytes) => {
+                        let payload = String::from_utf8(payload_bytes).map_err(|error| {
+                            KolmeRuntimeCommitProviderError::MalformedResponse {
+                                reason: format!(
+                                    "websocket text payload is not valid utf-8: {error}"
+                                ),
+                            }
+                        })?;
+                        return Ok(Some(payload));
+                    }
+                    KamnKolmeWebsocketFrame::Close => return Ok(None),
+                    KamnKolmeWebsocketFrame::Ping | KamnKolmeWebsocketFrame::Pong => continue,
+                }
+            }
+
+            let mut chunk = [0_u8; 1024];
+            let read = self.stream.read(&mut chunk).map_err(|error| {
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+            })?;
+            if read == 0 {
+                return Ok(None);
+            }
+            self.read_buffer.extend_from_slice(&chunk[..read]);
+        }
+    }
+}
+
+impl KolmeRuntimeCommitNotificationsConnector for KolmeRuntimeCommitWebsocketConnector {
+    type Connection = KolmeRuntimeCommitWebsocketConnection;
+
+    fn connect(
+        &mut self,
+        notifications_url: &str,
+    ) -> Result<Self::Connection, KolmeRuntimeCommitProviderError> {
+        let endpoint = parse_kolme_websocket_endpoint(notifications_url).map_err(|error| {
+            KolmeRuntimeCommitProviderError::Unavailable {
+                reason: error.to_string(),
+            }
+        })?;
+        if endpoint.secure {
+            return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "wss:// notifications are not supported by this transport".to_owned(),
+            });
+        }
+
+        let mut stream =
+            TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+            })?;
+        let timeout = Duration::from_secs(self.timeout_seconds);
+        stream.set_read_timeout(Some(timeout)).map_err(|error| {
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+        })?;
+        stream.set_write_timeout(Some(timeout)).map_err(|error| {
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+        })?;
+
+        let handshake = format!(
+            concat!(
+                "GET {} HTTP/1.1\r\n",
+                "Host: {}\r\n",
+                "Upgrade: websocket\r\n",
+                "Connection: Upgrade\r\n",
+                "Sec-WebSocket-Key: {}\r\n",
+                "Sec-WebSocket-Version: 13\r\n",
+                "\r\n"
+            ),
+            endpoint.target_path, endpoint.host_header, "dGhlIHNhbXBsZSBub25jZQ=="
+        );
+        stream.write_all(handshake.as_bytes()).map_err(|error| {
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+        })?;
+
+        let mut response_bytes = Vec::new();
+        let header_end = loop {
+            if let Some(position) =
+                find_kolme_http_header_boundary(&response_bytes).map_err(|error| match error {
+                    KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                        KolmeRuntimeCommitProviderError::Unavailable { reason }
+                    }
+                    KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                        KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                    }
+                })?
+            {
+                break position;
+            }
+            let mut chunk = [0_u8; 1024];
+            let read = stream.read(&mut chunk).map_err(|error| {
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+            })?;
+            if read == 0 {
+                return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: "websocket handshake response is incomplete".to_owned(),
+                });
+            }
+            response_bytes.extend_from_slice(&chunk[..read]);
+        };
+        let (header_bytes, trailing) = response_bytes.split_at(header_end + 4);
+        validate_kolme_websocket_handshake_response(header_bytes).map_err(|error| match error {
+            KamnKolmeWebsocketPolicyError::Unavailable { reason } => {
+                KolmeRuntimeCommitProviderError::Unavailable { reason }
+            }
+            KamnKolmeWebsocketPolicyError::Malformed { reason } => {
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+            }
+        })?;
+        Ok(KolmeRuntimeCommitWebsocketConnection::new(
+            stream,
+            trailing.to_vec(),
+        ))
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,5 +1,7 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
+const RUNTIME_NOTIFICATIONS_WS_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/notifications_websocket.rs");
 const RUNTIME_PIPELINE_SRC: &str = include_str!("../src/kolme_runtime_commit/runtime_pipeline.rs");
 
 #[test]
@@ -54,6 +56,8 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitFinalityProjection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnector"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
@@ -114,7 +118,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_websocket_endpoint("));
+    assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("parse_kolme_websocket_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_submit_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_expected_provider_input_contract("));
@@ -128,7 +132,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_lookup_budget_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_websocket_handshake_response("));
+    assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("validate_kolme_websocket_handshake_response("));
     assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_tls_ca_file_env_result_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
@@ -154,8 +158,10 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         "impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome"
     ));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_response_body("));
-    assert!(RUNTIME_COMMIT_SRC.contains("find_kolme_http_header_boundary("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_websocket_timeout_seconds_contract("));
+    assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("find_kolme_http_header_boundary("));
+    assert!(
+        RUNTIME_NOTIFICATIONS_WS_SRC.contains("is_kolme_valid_websocket_timeout_seconds_contract(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_provider_receipt_identity_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("require_kolme_final_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
@@ -191,8 +197,10 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_websocket;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use runtime_pipeline::{"));
     assert!(
         RUNTIME_COMMIT_SRC.contains("pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;")
     );
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -69,6 +69,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1934"));
     assert!(DOC.contains("#1936"));
     assert!(DOC.contains("#1938"));
+    assert!(DOC.contains("#1940"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -87,6 +87,7 @@ Out of scope:
 - #1934: removed websocket header-boundary helper glue from `kamn-core` by inlining deterministic handshake header-boundary read loop in connector `connect` flow and deleting `read_http_header_boundary` helper ownership.
 - #1936: extracted runtime pipeline lifecycle record/projection ownership into `kolme_runtime_commit/runtime_pipeline.rs` and rewired `kolme_runtime_commit.rs` to re-export pipeline types from the dedicated submodule.
 - #1938: extracted in-memory runtime client ownership into `kolme_runtime_commit/in_memory_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `InMemoryKolmeRuntimeCommitClient` from the dedicated submodule.
+- #1940: extracted websocket notifications transport ownership into `kolme_runtime_commit/notifications_websocket.rs` and rewired `kolme_runtime_commit.rs` to re-export connector/connection types from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
Closes #1940

## Summary
Extract websocket notifications transport ownership (`KolmeRuntimeCommitWebsocketConnector` and `KolmeRuntimeCommitWebsocketConnection`) into a dedicated `kolme_runtime_commit/notifications_websocket.rs` submodule and re-export the moved types from `kolme_runtime_commit.rs` to preserve API compatibility.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/notifications_websocket.rs`: added module owning websocket connector/connection implementations.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod notifications_websocket;` and re-exports; removed inline websocket transport ownership.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated ownership guards and marker ownership to include websocket submodule source.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: added `#1940` marker assertion.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: added progress marker for `#1940`.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: websocket handshake, frame parsing, and notifications consumer behavior remain unchanged

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | extraction-boundary ownership checks for websocket transport split |
| Functional  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| Integration | ✅     | `integration_notifications_websocket_connector_receives_kolme_notification` remains green |
| Regression  | ✅     | extraction boundary/docs suites with `#1940` marker checks |
