### PR TITLE
refactor(kolme): extract notifications consumer module ownership (#1942)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -111,6 +111,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 mod in_memory_client;
+mod notifications_consumer;
 mod notifications_websocket;
 mod runtime_pipeline;
 
@@ -502,6 +503,7 @@ pub enum KolmeRuntimeCommitOutcome {
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
+pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;
 pub use notifications_websocket::{
     KolmeRuntimeCommitWebsocketConnection, KolmeRuntimeCommitWebsocketConnector,
 };
@@ -1368,143 +1370,6 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
     }
 }
 
-/// Deterministic notifications consumer for Kolme websocket events with bounded reconnect policy.
-pub struct KolmeRuntimeCommitNotificationsConsumer<C>
-where
-    C: KolmeRuntimeCommitNotificationsConnector,
-{
-    notifications_url: String,
-    provider: String,
-    max_reconnect_attempts: u32,
-    connector: C,
-    connection: Option<C::Connection>,
-}
-
-impl<C> KolmeRuntimeCommitNotificationsConsumer<C>
-where
-    C: KolmeRuntimeCommitNotificationsConnector,
-{
-    /// Builds notifications consumer from HTTP base URL and notifications path.
-    pub fn new(
-        base_url: &str,
-        notifications_path: &str,
-        provider: &str,
-        max_reconnect_attempts: u32,
-        connector: C,
-    ) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_notifications_provider_input_contract(provider) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "notifications_provider",
-                reason: "must not be empty",
-            });
-        }
-        if !is_kolme_valid_notifications_reconnect_budget_contract(max_reconnect_attempts) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "notifications_max_reconnect_attempts",
-                reason: "must be positive",
-            });
-        }
-        let notifications_url =
-            compose_kolme_notifications_websocket_url(base_url, notifications_path)
-                .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
-                    reason: error.to_string(),
-                })
-                .map_err(|error| match error {
-                    KolmeRuntimeCommitProviderError::Timeout => {
-                        KolmeRuntimeCommitError::ProviderTransport {
-                            kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
-                            detail: "provider request timed out".to_owned(),
-                        }
-                    }
-                    KolmeRuntimeCommitProviderError::Unavailable { reason } => {
-                        KolmeRuntimeCommitError::ProviderTransport {
-                            kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
-                            detail: reason,
-                        }
-                    }
-                    KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
-                        KolmeRuntimeCommitError::ProviderTransport {
-                            kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
-                            detail: reason,
-                        }
-                    }
-                })?;
-        Ok(Self {
-            notifications_url,
-            provider: normalize_kolme_notifications_provider_input_contract(provider).to_owned(),
-            max_reconnect_attempts,
-            connector,
-            connection: None,
-        })
-    }
-
-    /// Reads and parses one notifications event, reconnecting when the stream drops.
-    pub fn next_notification_event(
-        &mut self,
-    ) -> Result<KolmeRuntimeCommitNotificationEvent, KolmeRuntimeCommitProviderError> {
-        let mut reconnect_attempts = 0_u32;
-
-        loop {
-            if self.connection.is_none() {
-                match self.connector.connect(self.notifications_url.as_str()) {
-                    Ok(connection) => self.connection = Some(connection),
-                    Err(_) => {
-                        reconnect_attempts += 1;
-                        if reconnect_attempts >= self.max_reconnect_attempts {
-                            return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                                reason:
-                                    compose_kolme_notifications_reconnect_exhausted_reason_contract(
-                                        self.max_reconnect_attempts,
-                                    ),
-                            });
-                        }
-                        continue;
-                    }
-                }
-            }
-
-            let result = self
-                .connection
-                .as_mut()
-                .expect("connection should exist before read")
-                .read_text_message();
-            match result {
-                Ok(Some(payload)) => {
-                    let event = parse_kolme_notification_event_contract(payload.as_str()).map_err(
-                        |error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                            reason: error.to_string(),
-                        },
-                    )?;
-                    return Ok(event.into());
-                }
-                Ok(None) | Err(_) => {
-                    self.connection = None;
-                    reconnect_attempts += 1;
-                    if reconnect_attempts >= self.max_reconnect_attempts {
-                        return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                            reason: compose_kolme_notifications_reconnect_exhausted_reason_contract(
-                                self.max_reconnect_attempts,
-                            ),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    /// Reads notification events until one can be mapped to a commit receipt.
-    pub fn next_commit_receipt(
-        &mut self,
-    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        loop {
-            let event = self.next_notification_event()?;
-            if let Some(receipt) = event.to_provider_receipt(self.provider.as_str()) {
-                return Ok(receipt);
-            }
-        }
-    }
-}
-
 /// Fork-profile finality resolver that composes notifications and block fallback lookups.
 pub struct KolmeRuntimeCommitForkFinalityResolver<C, T>
 where
@@ -1557,7 +1422,7 @@ where
                 }
                 _ => {
                     let receipt = event
-                        .to_provider_receipt(self.notifications_consumer.provider.as_str())
+                        .to_provider_receipt(self.notifications_consumer.provider())
                         .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
                             reason: "notification event did not carry receipt data".to_owned(),
                         })?;

--- a/crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs
@@ -1,0 +1,154 @@
+//! Deterministic notifications consumer for Kolme websocket event streams.
+
+use super::{
+    compose_kolme_notifications_reconnect_exhausted_reason_contract,
+    compose_kolme_notifications_websocket_url,
+    is_kolme_valid_notifications_provider_input_contract,
+    is_kolme_valid_notifications_reconnect_budget_contract,
+    normalize_kolme_notifications_provider_input_contract, parse_kolme_notification_event_contract,
+    KolmeRuntimeCommitError, KolmeRuntimeCommitNotificationEvent,
+    KolmeRuntimeCommitNotificationsConnection, KolmeRuntimeCommitNotificationsConnector,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderReceipt,
+    KolmeRuntimeCommitTransportErrorKind,
+};
+
+/// Deterministic notifications consumer for Kolme websocket events with bounded reconnect policy.
+pub struct KolmeRuntimeCommitNotificationsConsumer<C>
+where
+    C: KolmeRuntimeCommitNotificationsConnector,
+{
+    notifications_url: String,
+    provider: String,
+    max_reconnect_attempts: u32,
+    connector: C,
+    connection: Option<C::Connection>,
+}
+
+impl<C> KolmeRuntimeCommitNotificationsConsumer<C>
+where
+    C: KolmeRuntimeCommitNotificationsConnector,
+{
+    /// Builds notifications consumer from HTTP base URL and notifications path.
+    pub fn new(
+        base_url: &str,
+        notifications_path: &str,
+        provider: &str,
+        max_reconnect_attempts: u32,
+        connector: C,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_notifications_provider_input_contract(provider) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "notifications_provider",
+                reason: "must not be empty",
+            });
+        }
+        if !is_kolme_valid_notifications_reconnect_budget_contract(max_reconnect_attempts) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "notifications_max_reconnect_attempts",
+                reason: "must be positive",
+            });
+        }
+        let notifications_url =
+            compose_kolme_notifications_websocket_url(base_url, notifications_path)
+                .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
+                    reason: error.to_string(),
+                })
+                .map_err(|error| match error {
+                    KolmeRuntimeCommitProviderError::Timeout => {
+                        KolmeRuntimeCommitError::ProviderTransport {
+                            kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+                            detail: "provider request timed out".to_owned(),
+                        }
+                    }
+                    KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+                        KolmeRuntimeCommitError::ProviderTransport {
+                            kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                            detail: reason,
+                        }
+                    }
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+                        KolmeRuntimeCommitError::ProviderTransport {
+                            kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                            detail: reason,
+                        }
+                    }
+                })?;
+        Ok(Self {
+            notifications_url,
+            provider: normalize_kolme_notifications_provider_input_contract(provider).to_owned(),
+            max_reconnect_attempts,
+            connector,
+            connection: None,
+        })
+    }
+
+    pub(crate) fn provider(&self) -> &str {
+        self.provider.as_str()
+    }
+
+    /// Reads and parses one notifications event, reconnecting when the stream drops.
+    pub fn next_notification_event(
+        &mut self,
+    ) -> Result<KolmeRuntimeCommitNotificationEvent, KolmeRuntimeCommitProviderError> {
+        let mut reconnect_attempts = 0_u32;
+
+        loop {
+            if self.connection.is_none() {
+                match self.connector.connect(self.notifications_url.as_str()) {
+                    Ok(connection) => self.connection = Some(connection),
+                    Err(_) => {
+                        reconnect_attempts += 1;
+                        if reconnect_attempts >= self.max_reconnect_attempts {
+                            return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                                reason:
+                                    compose_kolme_notifications_reconnect_exhausted_reason_contract(
+                                        self.max_reconnect_attempts,
+                                    ),
+                            });
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            let result = self
+                .connection
+                .as_mut()
+                .expect("connection should exist before read")
+                .read_text_message();
+            match result {
+                Ok(Some(payload)) => {
+                    let event = parse_kolme_notification_event_contract(payload.as_str()).map_err(
+                        |error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                            reason: error.to_string(),
+                        },
+                    )?;
+                    return Ok(event.into());
+                }
+                Ok(None) | Err(_) => {
+                    self.connection = None;
+                    reconnect_attempts += 1;
+                    if reconnect_attempts >= self.max_reconnect_attempts {
+                        return Err(KolmeRuntimeCommitProviderError::Unavailable {
+                            reason: compose_kolme_notifications_reconnect_exhausted_reason_contract(
+                                self.max_reconnect_attempts,
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reads notification events until one can be mapped to a commit receipt.
+    pub fn next_commit_receipt(
+        &mut self,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        loop {
+            let event = self.next_notification_event()?;
+            if let Some(receipt) = event.to_provider_receipt(self.provider.as_str()) {
+                return Ok(receipt);
+            }
+        }
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,5 +1,7 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
+const RUNTIME_NOTIFICATIONS_CONSUMER_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/notifications_consumer.rs");
 const RUNTIME_NOTIFICATIONS_WS_SRC: &str =
     include_str!("../src/kolme_runtime_commit/notifications_websocket.rs");
 const RUNTIME_PIPELINE_SRC: &str = include_str!("../src/kolme_runtime_commit/runtime_pipeline.rs");
@@ -56,10 +58,12 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitFinalityProjection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnector"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("impl<C> KolmeRuntimeCommitNotificationsConsumer<C>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signature = signature.trim();"));
@@ -110,7 +114,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         RUNTIME_COMMIT_SRC.contains("normalize_kolme_transport_idempotency_key_input_contract(")
     );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_notifications_provider_input_contract("));
+    assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
+        .contains("normalize_kolme_notifications_provider_input_contract("));
     assert!(
         RUNTIME_COMMIT_SRC.contains("normalize_kolme_block_fallback_constructor_inputs_contract(")
     );
@@ -122,7 +127,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_submit_path_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_expected_provider_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_notifications_websocket_url("));
+    assert!(
+        RUNTIME_NOTIFICATIONS_CONSUMER_SRC.contains("compose_kolme_notifications_websocket_url(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_lookup_height_contract("));
@@ -145,13 +152,17 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_status_path_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_notifications_provider_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_notifications_reconnect_budget_contract("));
-    assert!(RUNTIME_COMMIT_SRC
-        .contains("compose_kolme_notifications_reconnect_exhausted_reason_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_notification_event_contract("));
+    assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
+        .contains("is_kolme_valid_notifications_provider_input_contract("));
+    assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
+        .contains("is_kolme_valid_notifications_reconnect_budget_contract("));
+    assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC.contains("parse_kolme_notification_event_contract("));
     assert!(RUNTIME_COMMIT_SRC
         .contains("impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent"));
+    assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
+        .contains("compose_kolme_notifications_reconnect_exhausted_reason_contract("));
+    assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
+        .contains("normalize_kolme_notifications_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains(
@@ -197,10 +208,13 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_websocket;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use runtime_pipeline::{"));
     assert!(
         RUNTIME_COMMIT_SRC.contains("pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;")
     );
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -70,6 +70,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1936"));
     assert!(DOC.contains("#1938"));
     assert!(DOC.contains("#1940"));
+    assert!(DOC.contains("#1942"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -88,6 +88,7 @@ Out of scope:
 - #1936: extracted runtime pipeline lifecycle record/projection ownership into `kolme_runtime_commit/runtime_pipeline.rs` and rewired `kolme_runtime_commit.rs` to re-export pipeline types from the dedicated submodule.
 - #1938: extracted in-memory runtime client ownership into `kolme_runtime_commit/in_memory_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `InMemoryKolmeRuntimeCommitClient` from the dedicated submodule.
 - #1940: extracted websocket notifications transport ownership into `kolme_runtime_commit/notifications_websocket.rs` and rewired `kolme_runtime_commit.rs` to re-export connector/connection types from the dedicated submodule.
+- #1942: extracted notifications consumer ownership into `kolme_runtime_commit/notifications_consumer.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitNotificationsConsumer` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted `KolmeRuntimeCommitNotificationsConsumer` ownership from `kolme_runtime_commit.rs` into a dedicated `notifications_consumer.rs` submodule. This reduces monolith surface area while preserving public API behavior via re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs`: new owner module for consumer construction, reconnect loop, notification decoding, and receipt projection.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod notifications_consumer;`, re-exported `KolmeRuntimeCommitNotificationsConsumer`, removed inline consumer implementation, and switched fork resolver provider lookup to accessor.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for new ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1942` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1942 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/notifications_consumer.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Regression assertions updated to guard extracted ownership location (`// Regression: #1942` marker path in issue scope).
- Existing runtime commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_notifications` | |
| Integration  | ✅     | `integration_notifications_websocket_connector_receives_kolme_notification`, `integration_runtime_pipeline_accepts_adapter_backed_final_receipts`, `integration_commit_to_receipt_flow_is_deterministic` | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression tests in notifications/finality/client suites | |
| Performance  | N/A    | None added | Module ownership extraction only; no runtime-path semantics changed |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by existing suite parity.
- Rollback: revert this PR commit to restore inline consumer ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1942 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1942
