### PR TITLE
refactor(kolme): extract fork finality resolver module ownership (#1944)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -110,6 +110,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod fork_finality_resolver;
 mod in_memory_client;
 mod notifications_consumer;
 mod notifications_websocket;
@@ -502,6 +503,7 @@ pub enum KolmeRuntimeCommitOutcome {
 /// Runtime lifecycle state projected from commit receipt outcomes.
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
+pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
 pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;
 pub use notifications_websocket::{
@@ -1367,83 +1369,6 @@ impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbac
                 latest_height,
             ),
         })
-    }
-}
-
-/// Fork-profile finality resolver that composes notifications and block fallback lookups.
-pub struct KolmeRuntimeCommitForkFinalityResolver<C, T>
-where
-    C: KolmeRuntimeCommitNotificationsConnector,
-    T: KolmeRuntimeCommitBlockFallbackTransport,
-{
-    notifications_consumer: KolmeRuntimeCommitNotificationsConsumer<C>,
-    block_fallback_reconciler: KolmeRuntimeCommitBlockFallbackReconciler<T>,
-}
-
-impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>
-where
-    C: KolmeRuntimeCommitNotificationsConnector,
-    T: KolmeRuntimeCommitBlockFallbackTransport,
-{
-    /// Builds a fork finality resolver from notifications and block fallback components.
-    pub fn new(
-        notifications_consumer: KolmeRuntimeCommitNotificationsConsumer<C>,
-        block_fallback_reconciler: KolmeRuntimeCommitBlockFallbackReconciler<T>,
-    ) -> Self {
-        Self {
-            notifications_consumer,
-            block_fallback_reconciler,
-        }
-    }
-
-    /// Resolves finality for one commit id using notifications first, then bounded block fallback.
-    pub fn resolve_commit_finality(
-        &mut self,
-        commit_id: &str,
-        from_height: u64,
-        latest_height: u64,
-    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        let expected_txhash = txhash_from_kolme_commit_id(commit_id).map_err(|error| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: error.to_string(),
-            }
-        })?;
-
-        match self.notifications_consumer.next_notification_event() {
-            Ok(event) => match event {
-                KolmeRuntimeCommitNotificationEvent::LatestBlock { height } => {
-                    let upper_bound =
-                        resolve_kolme_lookup_upper_bound(from_height, latest_height, height);
-                    self.block_fallback_reconciler.reconcile_txhash(
-                        expected_txhash.as_str(),
-                        from_height,
-                        upper_bound,
-                    )
-                }
-                _ => {
-                    let receipt = event
-                        .to_provider_receipt(self.notifications_consumer.provider())
-                        .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
-                            reason: "notification event did not carry receipt data".to_owned(),
-                        })?;
-                    require_kolme_commit_id_matches_expected_txhash_contract(
-                        receipt.commit_id.as_str(),
-                        expected_txhash.as_str(),
-                    )
-                    .map_err(|error| {
-                        KolmeRuntimeCommitProviderError::MalformedResponse {
-                            reason: error.to_string(),
-                        }
-                    })?;
-                    Ok(receipt)
-                }
-            },
-            Err(KolmeRuntimeCommitProviderError::Unavailable { .. })
-            | Err(KolmeRuntimeCommitProviderError::Timeout) => self
-                .block_fallback_reconciler
-                .reconcile_txhash(expected_txhash.as_str(), from_height, latest_height),
-            Err(error @ KolmeRuntimeCommitProviderError::MalformedResponse { .. }) => Err(error),
-        }
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/fork_finality_resolver.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/fork_finality_resolver.rs
@@ -1,0 +1,86 @@
+//! Fork-profile finality resolver orchestration for notifications and block fallback.
+
+use super::{
+    require_kolme_commit_id_matches_expected_txhash_contract, resolve_kolme_lookup_upper_bound,
+    txhash_from_kolme_commit_id, KolmeRuntimeCommitBlockFallbackReconciler,
+    KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitNotificationEvent,
+    KolmeRuntimeCommitNotificationsConnector, KolmeRuntimeCommitNotificationsConsumer,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderReceipt,
+};
+
+/// Fork-profile finality resolver that composes notifications and block fallback lookups.
+pub struct KolmeRuntimeCommitForkFinalityResolver<C, T>
+where
+    C: KolmeRuntimeCommitNotificationsConnector,
+    T: KolmeRuntimeCommitBlockFallbackTransport,
+{
+    notifications_consumer: KolmeRuntimeCommitNotificationsConsumer<C>,
+    block_fallback_reconciler: KolmeRuntimeCommitBlockFallbackReconciler<T>,
+}
+
+impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>
+where
+    C: KolmeRuntimeCommitNotificationsConnector,
+    T: KolmeRuntimeCommitBlockFallbackTransport,
+{
+    /// Builds a fork finality resolver from notifications and block fallback components.
+    pub fn new(
+        notifications_consumer: KolmeRuntimeCommitNotificationsConsumer<C>,
+        block_fallback_reconciler: KolmeRuntimeCommitBlockFallbackReconciler<T>,
+    ) -> Self {
+        Self {
+            notifications_consumer,
+            block_fallback_reconciler,
+        }
+    }
+
+    /// Resolves finality for one commit id using notifications first, then bounded block fallback.
+    pub fn resolve_commit_finality(
+        &mut self,
+        commit_id: &str,
+        from_height: u64,
+        latest_height: u64,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        let expected_txhash = txhash_from_kolme_commit_id(commit_id).map_err(|error| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            }
+        })?;
+
+        match self.notifications_consumer.next_notification_event() {
+            Ok(event) => match event {
+                KolmeRuntimeCommitNotificationEvent::LatestBlock { height } => {
+                    let upper_bound =
+                        resolve_kolme_lookup_upper_bound(from_height, latest_height, height);
+                    self.block_fallback_reconciler.reconcile_txhash(
+                        expected_txhash.as_str(),
+                        from_height,
+                        upper_bound,
+                    )
+                }
+                _ => {
+                    let receipt = event
+                        .to_provider_receipt(self.notifications_consumer.provider())
+                        .ok_or_else(|| KolmeRuntimeCommitProviderError::MalformedResponse {
+                            reason: "notification event did not carry receipt data".to_owned(),
+                        })?;
+                    require_kolme_commit_id_matches_expected_txhash_contract(
+                        receipt.commit_id.as_str(),
+                        expected_txhash.as_str(),
+                    )
+                    .map_err(|error| {
+                        KolmeRuntimeCommitProviderError::MalformedResponse {
+                            reason: error.to_string(),
+                        }
+                    })?;
+                    Ok(receipt)
+                }
+            },
+            Err(KolmeRuntimeCommitProviderError::Unavailable { .. })
+            | Err(KolmeRuntimeCommitProviderError::Timeout) => self
+                .block_fallback_reconciler
+                .reconcile_txhash(expected_txhash.as_str(), from_height, latest_height),
+            Err(error @ KolmeRuntimeCommitProviderError::MalformedResponse { .. }) => Err(error),
+        }
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,5 +1,7 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
+const RUNTIME_FORK_FINALITY_RESOLVER_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/fork_finality_resolver.rs");
 const RUNTIME_NOTIFICATIONS_CONSUMER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/notifications_consumer.rs");
 const RUNTIME_NOTIFICATIONS_WS_SRC: &str =
@@ -58,11 +60,13 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitFinalityProjection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitForkFinalityResolver"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnector"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C> KolmeRuntimeCommitNotificationsConsumer<C>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let message = message.trim();"));
@@ -96,9 +100,8 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
     // Regression: #1824
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_finality_receipt("));
-    assert!(
-        RUNTIME_COMMIT_SRC.contains("require_kolme_commit_id_matches_expected_txhash_contract(")
-    );
+    assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC
+        .contains("require_kolme_commit_id_matches_expected_txhash_contract("));
     assert!(RUNTIME_PIPELINE_SRC.contains("lifecycle_state_for_finality_contract("));
     assert!(RUNTIME_PIPELINE_SRC.contains("lifecycle_state_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
@@ -121,7 +124,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("txhash_from_kolme_commit_id("));
+    assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("parse_kolme_websocket_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
@@ -143,12 +146,15 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_tls_ca_file_env_result_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
-    assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_lookup_upper_bound("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_txhash_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_block_fallback_unresolved_reason_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_finalized_block_txhash_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_failed_block_txhash_receipt_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
+    assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("txhash_from_kolme_commit_id("));
+    assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("resolve_kolme_lookup_upper_bound("));
+    assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC
+        .contains("require_kolme_commit_id_matches_expected_txhash_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_status_path_input_contract("));
@@ -208,6 +214,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod fork_finality_resolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_websocket;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use runtime_pipeline::{"));
@@ -216,5 +223,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;"));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -71,6 +71,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1938"));
     assert!(DOC.contains("#1940"));
     assert!(DOC.contains("#1942"));
+    assert!(DOC.contains("#1944"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -89,6 +89,7 @@ Out of scope:
 - #1938: extracted in-memory runtime client ownership into `kolme_runtime_commit/in_memory_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `InMemoryKolmeRuntimeCommitClient` from the dedicated submodule.
 - #1940: extracted websocket notifications transport ownership into `kolme_runtime_commit/notifications_websocket.rs` and rewired `kolme_runtime_commit.rs` to re-export connector/connection types from the dedicated submodule.
 - #1942: extracted notifications consumer ownership into `kolme_runtime_commit/notifications_consumer.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitNotificationsConsumer` from the dedicated submodule.
+- #1944: extracted fork finality resolver ownership into `kolme_runtime_commit/fork_finality_resolver.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitForkFinalityResolver` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted `KolmeRuntimeCommitForkFinalityResolver` ownership from `kolme_runtime_commit.rs` into a dedicated `fork_finality_resolver.rs` submodule. This continues Phase 3 decomposition while preserving public API behavior through re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/fork_finality_resolver.rs`: new owner module for notifications-first finality resolution and bounded block-fallback reconciliation flow.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod fork_finality_resolver;`, re-exported `KolmeRuntimeCommitForkFinalityResolver`, and removed inline resolver implementation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for resolver ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1944` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1944 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/fork_finality_resolver.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Extraction-boundary regression assertions updated to guard resolver ownership location.
- Existing runtime-commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_notifications` | |
| Integration  | ✅     | runtime commit integration tests in finality/client/notifications lanes | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression suites | |
| Performance  | N/A    | None added | Module ownership extraction only; runtime semantics unchanged |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by parity suites.
- Rollback: revert this PR commit to restore inline resolver ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1944 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1944
