### PR TITLE
refactor(kolme): extract finality checker module ownership (#1946)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -110,6 +110,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod finality_checker;
 mod fork_finality_resolver;
 mod in_memory_client;
 mod notifications_consumer;
@@ -503,6 +504,7 @@ pub enum KolmeRuntimeCommitOutcome {
 /// Runtime lifecycle state projected from commit receipt outcomes.
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
+pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
 pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;
@@ -1120,91 +1122,6 @@ impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTranspor
             }
         })?;
         self.execute_request(base_url, block_path.as_str(), "GET", None, &[])
-    }
-}
-
-/// Deterministic finality checker for live backend runtime commit receipts.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeRuntimeCommitFinalityChecker<T> {
-    base_url: String,
-    status_path: String,
-    transport: T,
-}
-
-impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T> {
-    /// Builds a finality checker with deterministic endpoint validation.
-    pub fn new(
-        base_url: &str,
-        status_path: &str,
-        transport: T,
-    ) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_finality_base_url_input_contract(base_url) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider_base_url",
-                reason: "must not be empty",
-            });
-        }
-        if !is_kolme_valid_finality_status_path_input_contract(status_path) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider_status_path",
-                reason: "must not be empty",
-            });
-        }
-        let (base_url, status_path) =
-            normalize_kolme_finality_endpoint_inputs_contract(base_url, status_path);
-        Ok(Self {
-            base_url,
-            status_path,
-            transport,
-        })
-    }
-
-    /// Fetches and parses one backend finality response for the provided commit.
-    pub fn check_commit_finality(
-        &mut self,
-        commit_id: &str,
-    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        if !is_kolme_valid_runtime_commit_id_request_contract(commit_id) {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "commit_id must not be empty".to_owned(),
-            });
-        }
-
-        let response = self.transport.fetch_runtime_commit_finality(
-            self.base_url.as_str(),
-            self.status_path.as_str(),
-            commit_id,
-        )?;
-        let receipt = parse_kolme_provider_finality_receipt(response.as_str(), commit_id).map_err(
-            |error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: error.to_string(),
-            },
-        )?;
-        Ok(KolmeRuntimeCommitProviderReceipt {
-            provider: receipt.provider,
-            commit_id: receipt.commit_id,
-            finality: receipt.finality,
-        })
-    }
-
-    /// Polls backend finality and returns the first non-pending receipt.
-    pub fn poll_finality(
-        &mut self,
-        commit_id: &str,
-        max_attempts: u32,
-    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        if !is_kolme_valid_poll_attempt_budget_contract(max_attempts) {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "max_attempts must be positive".to_owned(),
-            });
-        }
-        for _ in 0..max_attempts {
-            let receipt = self.check_commit_finality(commit_id)?;
-            if is_kolme_terminal_receipt_finality_contract(receipt.finality) {
-                return Ok(receipt);
-            }
-        }
-        Err(KolmeRuntimeCommitProviderError::Timeout)
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/finality_checker.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/finality_checker.rs
@@ -1,0 +1,95 @@
+//! Deterministic finality checker for live backend runtime commit receipts.
+
+use super::{
+    is_kolme_terminal_receipt_finality_contract, is_kolme_valid_finality_base_url_input_contract,
+    is_kolme_valid_finality_status_path_input_contract,
+    is_kolme_valid_poll_attempt_budget_contract, is_kolme_valid_runtime_commit_id_request_contract,
+    normalize_kolme_finality_endpoint_inputs_contract, parse_kolme_provider_finality_receipt,
+    KolmeRuntimeCommitError, KolmeRuntimeCommitFinalityTransport, KolmeRuntimeCommitProviderError,
+    KolmeRuntimeCommitProviderReceipt,
+};
+
+/// Deterministic finality checker for live backend runtime commit receipts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitFinalityChecker<T> {
+    base_url: String,
+    status_path: String,
+    transport: T,
+}
+
+impl<T: KolmeRuntimeCommitFinalityTransport> KolmeRuntimeCommitFinalityChecker<T> {
+    /// Builds a finality checker with deterministic endpoint validation.
+    pub fn new(
+        base_url: &str,
+        status_path: &str,
+        transport: T,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_finality_base_url_input_contract(base_url) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_base_url",
+                reason: "must not be empty",
+            });
+        }
+        if !is_kolme_valid_finality_status_path_input_contract(status_path) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_status_path",
+                reason: "must not be empty",
+            });
+        }
+        let (base_url, status_path) =
+            normalize_kolme_finality_endpoint_inputs_contract(base_url, status_path);
+        Ok(Self {
+            base_url,
+            status_path,
+            transport,
+        })
+    }
+
+    /// Fetches and parses one backend finality response for the provided commit.
+    pub fn check_commit_finality(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        if !is_kolme_valid_runtime_commit_id_request_contract(commit_id) {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "commit_id must not be empty".to_owned(),
+            });
+        }
+
+        let response = self.transport.fetch_runtime_commit_finality(
+            self.base_url.as_str(),
+            self.status_path.as_str(),
+            commit_id,
+        )?;
+        let receipt = parse_kolme_provider_finality_receipt(response.as_str(), commit_id).map_err(
+            |error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            },
+        )?;
+        Ok(KolmeRuntimeCommitProviderReceipt {
+            provider: receipt.provider,
+            commit_id: receipt.commit_id,
+            finality: receipt.finality,
+        })
+    }
+
+    /// Polls backend finality and returns the first non-pending receipt.
+    pub fn poll_finality(
+        &mut self,
+        commit_id: &str,
+        max_attempts: u32,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        if !is_kolme_valid_poll_attempt_budget_contract(max_attempts) {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "max_attempts must be positive".to_owned(),
+            });
+        }
+        for _ in 0..max_attempts {
+            let receipt = self.check_commit_finality(commit_id)?;
+            if is_kolme_terminal_receipt_finality_contract(receipt.finality) {
+                return Ok(receipt);
+            }
+        }
+        Err(KolmeRuntimeCommitProviderError::Timeout)
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,4 +1,6 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
+const RUNTIME_FINALITY_CHECKER_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/finality_checker.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
 const RUNTIME_FORK_FINALITY_RESOLVER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/fork_finality_resolver.rs");
@@ -60,12 +62,14 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitFinalityProjection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitFinalityChecker"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitForkFinalityResolver"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnector"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitFinalityTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C> KolmeRuntimeCommitNotificationsConsumer<C>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("let signer_key_id = signer_key_id.trim();"));
@@ -99,15 +103,17 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
 #[test]
 fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation() {
     // Regression: #1824
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_finality_receipt("));
+    assert!(RUNTIME_FINALITY_CHECKER_SRC.contains("parse_kolme_provider_finality_receipt("));
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC
         .contains("require_kolme_commit_id_matches_expected_txhash_contract("));
     assert!(RUNTIME_PIPELINE_SRC.contains("lifecycle_state_for_finality_contract("));
     assert!(RUNTIME_PIPELINE_SRC.contains("lifecycle_state_label_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_terminal_receipt_finality_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_poll_attempt_budget_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_commit_id_request_contract("));
+    assert!(RUNTIME_FINALITY_CHECKER_SRC.contains("is_kolme_terminal_receipt_finality_contract("));
+    assert!(RUNTIME_FINALITY_CHECKER_SRC.contains("is_kolme_valid_poll_attempt_budget_contract("));
+    assert!(
+        RUNTIME_FINALITY_CHECKER_SRC.contains("is_kolme_valid_runtime_commit_id_request_contract(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains("deterministic_runtime_commit_idempotency_key_contract("));
     assert!(RUNTIME_IN_MEMORY_SRC.contains("deterministic_runtime_commit_id_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_runtime_commit_wire_payload_contract("));
@@ -122,7 +128,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_COMMIT_SRC.contains("normalize_kolme_block_fallback_constructor_inputs_contract(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract("));
+    assert!(
+        RUNTIME_FINALITY_CHECKER_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
@@ -156,8 +164,11 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC
         .contains("require_kolme_commit_id_matches_expected_txhash_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_finality_status_path("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_base_url_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_finality_status_path_input_contract("));
+    assert!(
+        RUNTIME_FINALITY_CHECKER_SRC.contains("is_kolme_valid_finality_base_url_input_contract(")
+    );
+    assert!(RUNTIME_FINALITY_CHECKER_SRC
+        .contains("is_kolme_valid_finality_status_path_input_contract("));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("is_kolme_valid_notifications_provider_input_contract("));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
@@ -214,6 +225,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod finality_checker;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod fork_finality_resolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_websocket;"));
@@ -223,6 +235,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;"));
+    assert!(
+        RUNTIME_COMMIT_SRC.contains("pub use finality_checker::KolmeRuntimeCommitFinalityChecker;")
+    );
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -72,6 +72,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1940"));
     assert!(DOC.contains("#1942"));
     assert!(DOC.contains("#1944"));
+    assert!(DOC.contains("#1946"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -90,6 +90,7 @@ Out of scope:
 - #1940: extracted websocket notifications transport ownership into `kolme_runtime_commit/notifications_websocket.rs` and rewired `kolme_runtime_commit.rs` to re-export connector/connection types from the dedicated submodule.
 - #1942: extracted notifications consumer ownership into `kolme_runtime_commit/notifications_consumer.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitNotificationsConsumer` from the dedicated submodule.
 - #1944: extracted fork finality resolver ownership into `kolme_runtime_commit/fork_finality_resolver.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitForkFinalityResolver` from the dedicated submodule.
+- #1946: extracted finality checker ownership into `kolme_runtime_commit/finality_checker.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitFinalityChecker` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted `KolmeRuntimeCommitFinalityChecker` ownership from `kolme_runtime_commit.rs` into a dedicated `finality_checker.rs` submodule. This continues Phase 3 decomposition while preserving public API behavior through re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/finality_checker.rs`: new owner module for endpoint validation, receipt parsing, and bounded poll logic.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod finality_checker;`, re-exported `KolmeRuntimeCommitFinalityChecker`, and removed inline checker implementation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for finality checker ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1946` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1946 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/finality_checker.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Extraction-boundary regression assertions updated to guard finality checker ownership location.
- Existing runtime-commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_finality`, `kolme_runtime_commit_notifications` | |
| Integration  | ✅     | runtime commit integration tests in finality/client/notifications lanes | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression suites | |
| Performance  | N/A    | None added | Module ownership extraction only; runtime semantics unchanged |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by parity suites.
- Rollback: revert this PR commit to restore inline finality checker ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1946 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1946
