### PR TITLE
refactor(kolme): extract block fallback reconciler module ownership (#1948)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -110,6 +110,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod block_fallback_reconciler;
 mod finality_checker;
 mod fork_finality_resolver;
 mod in_memory_client;
@@ -504,6 +505,7 @@ pub enum KolmeRuntimeCommitOutcome {
 /// Runtime lifecycle state projected from commit receipt outcomes.
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
+pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
@@ -1122,170 +1124,6 @@ impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTranspor
             }
         })?;
         self.execute_request(base_url, block_path.as_str(), "GET", None, &[])
-    }
-}
-
-/// Deterministic `/block/{height}` fallback reconciler for missed notification windows.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeRuntimeCommitBlockFallbackReconciler<T> {
-    base_url: String,
-    block_path_template: String,
-    provider: String,
-    max_block_lookups: u64,
-    transport: T,
-}
-
-impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbackReconciler<T> {
-    /// Builds a block-fallback reconciler with deterministic validation.
-    pub fn new(
-        base_url: &str,
-        block_path_template: &str,
-        provider: &str,
-        max_block_lookups: u64,
-        transport: T,
-    ) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_block_fallback_base_url_input_contract(base_url) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider_base_url",
-                reason: "must not be empty",
-            });
-        }
-        if !is_kolme_valid_block_fallback_provider_input_contract(provider) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider",
-                reason: "must not be empty",
-            });
-        }
-        if !is_kolme_valid_block_fallback_lookup_budget_contract(max_block_lookups) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "max_block_lookups",
-                reason: "must be positive",
-            });
-        }
-        validate_kolme_block_path_template(block_path_template)
-            .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
-                reason: error.to_string(),
-            })
-            .map_err(|error| match error {
-                KolmeRuntimeCommitProviderError::Timeout => {
-                    KolmeRuntimeCommitError::ProviderTransport {
-                        kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
-                        detail: "provider request timed out".to_owned(),
-                    }
-                }
-                KolmeRuntimeCommitProviderError::Unavailable { reason } => {
-                    KolmeRuntimeCommitError::ProviderTransport {
-                        kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
-                        detail: reason,
-                    }
-                }
-                KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
-                    KolmeRuntimeCommitError::ProviderTransport {
-                        kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
-                        detail: reason,
-                    }
-                }
-            })?;
-        let (base_url, block_path_template, provider) =
-            normalize_kolme_block_fallback_constructor_inputs_contract(
-                base_url,
-                block_path_template,
-                provider,
-            );
-        Ok(Self {
-            base_url,
-            block_path_template,
-            provider,
-            max_block_lookups,
-            transport,
-        })
-    }
-
-    /// Reconciles one tx hash by scanning block responses in the provided height window.
-    pub fn reconcile_txhash(
-        &mut self,
-        txhash: &str,
-        from_height: u64,
-        latest_height: u64,
-    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
-        let txhash = validate_kolme_lookup_txhash_contract(txhash).map_err(|error| {
-            KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: error.to_string(),
-            }
-        })?;
-        validate_kolme_lookup_window(from_height, latest_height, self.max_block_lookups).map_err(
-            |error| match error {
-                BlockScanPolicyError::MaxLookupsExceeded { .. } => {
-                    KolmeRuntimeCommitProviderError::Unavailable {
-                        reason: error.to_string(),
-                    }
-                }
-                _ => KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: error.to_string(),
-                },
-            },
-        )?;
-
-        for height in from_height..=latest_height {
-            let response = self.transport.fetch_block_by_height(
-                self.base_url.as_str(),
-                self.block_path_template.as_str(),
-                height,
-            )?;
-            let block = parse_kolme_provider_block_fallback_response_contract(
-                response.as_str(),
-                self.provider.as_str(),
-                height,
-            )
-            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: error.to_string(),
-            })?;
-
-            validate_kolme_block_identity(
-                self.provider.as_str(),
-                block.provider.as_str(),
-                height,
-                block.block_height,
-            )
-            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: error.to_string(),
-            })?;
-
-            if block
-                .finalized_tx_hashes
-                .iter()
-                .any(|value| value == txhash.as_str())
-            {
-                let projection =
-                    project_kolme_finalized_block_txhash_receipt_contract(txhash.as_str(), height);
-                return Ok(KolmeRuntimeCommitProviderReceipt {
-                    provider: self.provider.clone(),
-                    commit_id: projection.commit_id,
-                    finality: commit_finality_from_receipt_finality_contract(projection.finality),
-                });
-            }
-            if block
-                .failed_tx_hashes
-                .iter()
-                .any(|value| value == txhash.as_str())
-            {
-                let projection =
-                    project_kolme_failed_block_txhash_receipt_contract(txhash.as_str());
-                return Ok(KolmeRuntimeCommitProviderReceipt {
-                    provider: self.provider.clone(),
-                    commit_id: projection.commit_id,
-                    finality: commit_finality_from_receipt_finality_contract(projection.finality),
-                });
-            }
-        }
-
-        Err(KolmeRuntimeCommitProviderError::Unavailable {
-            reason: compose_kolme_block_fallback_unresolved_reason_contract(
-                txhash.as_str(),
-                from_height,
-                latest_height,
-            ),
-        })
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/block_fallback_reconciler.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/block_fallback_reconciler.rs
@@ -1,0 +1,181 @@
+//! Deterministic `/block/{height}` fallback reconciler for missed notification windows.
+
+use super::{
+    commit_finality_from_receipt_finality_contract,
+    compose_kolme_block_fallback_unresolved_reason_contract,
+    is_kolme_valid_block_fallback_base_url_input_contract,
+    is_kolme_valid_block_fallback_lookup_budget_contract,
+    is_kolme_valid_block_fallback_provider_input_contract,
+    normalize_kolme_block_fallback_constructor_inputs_contract,
+    parse_kolme_provider_block_fallback_response_contract,
+    project_kolme_failed_block_txhash_receipt_contract,
+    project_kolme_finalized_block_txhash_receipt_contract, validate_kolme_block_identity,
+    validate_kolme_block_path_template, validate_kolme_lookup_txhash_contract,
+    validate_kolme_lookup_window, BlockScanPolicyError, KolmeRuntimeCommitBlockFallbackTransport,
+    KolmeRuntimeCommitError, KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderReceipt,
+    KolmeRuntimeCommitTransportErrorKind,
+};
+
+/// Deterministic `/block/{height}` fallback reconciler for missed notification windows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitBlockFallbackReconciler<T> {
+    base_url: String,
+    block_path_template: String,
+    provider: String,
+    max_block_lookups: u64,
+    transport: T,
+}
+
+impl<T: KolmeRuntimeCommitBlockFallbackTransport> KolmeRuntimeCommitBlockFallbackReconciler<T> {
+    /// Builds a block-fallback reconciler with deterministic validation.
+    pub fn new(
+        base_url: &str,
+        block_path_template: &str,
+        provider: &str,
+        max_block_lookups: u64,
+        transport: T,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_block_fallback_base_url_input_contract(base_url) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_base_url",
+                reason: "must not be empty",
+            });
+        }
+        if !is_kolme_valid_block_fallback_provider_input_contract(provider) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider",
+                reason: "must not be empty",
+            });
+        }
+        if !is_kolme_valid_block_fallback_lookup_budget_contract(max_block_lookups) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "max_block_lookups",
+                reason: "must be positive",
+            });
+        }
+        validate_kolme_block_path_template(block_path_template)
+            .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
+                reason: error.to_string(),
+            })
+            .map_err(|error| match error {
+                KolmeRuntimeCommitProviderError::Timeout => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+                        detail: "provider request timed out".to_owned(),
+                    }
+                }
+                KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                        detail: reason,
+                    }
+                }
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                        detail: reason,
+                    }
+                }
+            })?;
+        let (base_url, block_path_template, provider) =
+            normalize_kolme_block_fallback_constructor_inputs_contract(
+                base_url,
+                block_path_template,
+                provider,
+            );
+        Ok(Self {
+            base_url,
+            block_path_template,
+            provider,
+            max_block_lookups,
+            transport,
+        })
+    }
+
+    /// Reconciles one tx hash by scanning block responses in the provided height window.
+    pub fn reconcile_txhash(
+        &mut self,
+        txhash: &str,
+        from_height: u64,
+        latest_height: u64,
+    ) -> Result<KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitProviderError> {
+        let txhash = validate_kolme_lookup_txhash_contract(txhash).map_err(|error| {
+            KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            }
+        })?;
+        validate_kolme_lookup_window(from_height, latest_height, self.max_block_lookups).map_err(
+            |error| match error {
+                BlockScanPolicyError::MaxLookupsExceeded { .. } => {
+                    KolmeRuntimeCommitProviderError::Unavailable {
+                        reason: error.to_string(),
+                    }
+                }
+                _ => KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                },
+            },
+        )?;
+
+        for height in from_height..=latest_height {
+            let response = self.transport.fetch_block_by_height(
+                self.base_url.as_str(),
+                self.block_path_template.as_str(),
+                height,
+            )?;
+            let block = parse_kolme_provider_block_fallback_response_contract(
+                response.as_str(),
+                self.provider.as_str(),
+                height,
+            )
+            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            })?;
+
+            validate_kolme_block_identity(
+                self.provider.as_str(),
+                block.provider.as_str(),
+                height,
+                block.block_height,
+            )
+            .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: error.to_string(),
+            })?;
+
+            if block
+                .finalized_tx_hashes
+                .iter()
+                .any(|value| value == txhash.as_str())
+            {
+                let projection =
+                    project_kolme_finalized_block_txhash_receipt_contract(txhash.as_str(), height);
+                return Ok(KolmeRuntimeCommitProviderReceipt {
+                    provider: self.provider.clone(),
+                    commit_id: projection.commit_id,
+                    finality: commit_finality_from_receipt_finality_contract(projection.finality),
+                });
+            }
+            if block
+                .failed_tx_hashes
+                .iter()
+                .any(|value| value == txhash.as_str())
+            {
+                let projection =
+                    project_kolme_failed_block_txhash_receipt_contract(txhash.as_str());
+                return Ok(KolmeRuntimeCommitProviderReceipt {
+                    provider: self.provider.clone(),
+                    commit_id: projection.commit_id,
+                    finality: commit_finality_from_receipt_finality_contract(projection.finality),
+                });
+            }
+        }
+
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: compose_kolme_block_fallback_unresolved_reason_contract(
+                txhash.as_str(),
+                from_height,
+                latest_height,
+            ),
+        })
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,4 +1,6 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
+const RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/block_fallback_reconciler.rs");
 const RUNTIME_FINALITY_CHECKER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/finality_checker.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
@@ -62,6 +64,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitFinalityProjection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitBlockFallbackReconciler"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitFinalityChecker"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitForkFinalityResolver"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
@@ -69,6 +72,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitBlockFallbackTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitFinalityTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C> KolmeRuntimeCommitNotificationsConsumer<C>"));
@@ -125,9 +129,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("normalize_kolme_notifications_provider_input_contract("));
-    assert!(
-        RUNTIME_COMMIT_SRC.contains("normalize_kolme_block_fallback_constructor_inputs_contract(")
-    );
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("normalize_kolme_block_fallback_constructor_inputs_contract("));
     assert!(
         RUNTIME_FINALITY_CHECKER_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract(")
     );
@@ -141,24 +144,33 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_NOTIFICATIONS_CONSUMER_SRC.contains("compose_kolme_notifications_websocket_url(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_path_template("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC.contains("validate_kolme_block_path_template("));
     assert!(RUNTIME_COMMIT_SRC.contains("render_kolme_block_path("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_lookup_height_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_provider_block_fallback_response_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_base_url_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_provider_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_block_fallback_lookup_budget_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("parse_kolme_provider_block_fallback_response_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("is_kolme_valid_block_fallback_base_url_input_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("is_kolme_valid_block_fallback_provider_input_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("is_kolme_valid_block_fallback_lookup_budget_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_tls_failure_reason("));
     assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_broadcast_payload_contract("));
     assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("validate_kolme_websocket_handshake_response("));
     assert!(RUNTIME_COMMIT_SRC.contains("resolve_kolme_tls_ca_file_env_result_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_authorization_header_value("));
-    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_window("));
-    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_lookup_txhash_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("compose_kolme_block_fallback_unresolved_reason_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_finalized_block_txhash_receipt_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("project_kolme_failed_block_txhash_receipt_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_block_identity("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC.contains("validate_kolme_lookup_window("));
+    assert!(
+        RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC.contains("validate_kolme_lookup_txhash_contract(")
+    );
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("compose_kolme_block_fallback_unresolved_reason_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("project_kolme_finalized_block_txhash_receipt_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
+        .contains("project_kolme_failed_block_txhash_receipt_contract("));
+    assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC.contains("validate_kolme_block_identity("));
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("resolve_kolme_lookup_upper_bound("));
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC
@@ -225,6 +237,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod block_fallback_reconciler;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod finality_checker;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod fork_finality_resolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
@@ -235,6 +248,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;"));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;"));
     assert!(
         RUNTIME_COMMIT_SRC.contains("pub use finality_checker::KolmeRuntimeCommitFinalityChecker;")
     );

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -73,6 +73,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1942"));
     assert!(DOC.contains("#1944"));
     assert!(DOC.contains("#1946"));
+    assert!(DOC.contains("#1948"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -91,6 +91,7 @@ Out of scope:
 - #1942: extracted notifications consumer ownership into `kolme_runtime_commit/notifications_consumer.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitNotificationsConsumer` from the dedicated submodule.
 - #1944: extracted fork finality resolver ownership into `kolme_runtime_commit/fork_finality_resolver.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitForkFinalityResolver` from the dedicated submodule.
 - #1946: extracted finality checker ownership into `kolme_runtime_commit/finality_checker.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitFinalityChecker` from the dedicated submodule.
+- #1948: extracted block fallback reconciler ownership into `kolme_runtime_commit/block_fallback_reconciler.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitBlockFallbackReconciler` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted `KolmeRuntimeCommitBlockFallbackReconciler` ownership from `kolme_runtime_commit.rs` into a dedicated `block_fallback_reconciler.rs` submodule. This continues Phase 3 decomposition while preserving public API behavior through re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/block_fallback_reconciler.rs`: new owner module for constructor validation and txhash reconciliation over bounded block windows.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod block_fallback_reconciler;`, re-exported `KolmeRuntimeCommitBlockFallbackReconciler`, and removed inline reconciler implementation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for block fallback reconciler ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1948` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1948 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/block_fallback_reconciler.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Extraction-boundary regression assertions updated to guard block fallback reconciler ownership location.
- Existing runtime-commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_finality`, `kolme_runtime_commit_notifications` | |
| Integration  | ✅     | runtime commit integration tests in finality/client/notifications lanes | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression suites | |
| Performance  | N/A    | None added | Module ownership extraction only; runtime semantics unchanged |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by parity suites.
- Rollback: revert this PR commit to restore inline reconciler ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1948 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1948
