### PR TITLE
refactor(kolme): extract adapter-backed client module ownership (#1950)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -110,6 +110,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod adapter_backed_client;
 mod block_fallback_reconciler;
 mod finality_checker;
 mod fork_finality_resolver;
@@ -505,6 +506,7 @@ pub enum KolmeRuntimeCommitOutcome {
 /// Runtime lifecycle state projected from commit receipt outcomes.
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
+pub use adapter_backed_client::AdapterBackedKolmeRuntimeCommitClient;
 pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
@@ -1201,108 +1203,6 @@ impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitProvider
                     reason: error.to_string(),
                 })?;
         Ok(outcome.into())
-    }
-}
-
-/// Adapter-backed runtime commit client that enforces provider and finality policies.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AdapterBackedKolmeRuntimeCommitClient<P> {
-    expected_provider: String,
-    provider: P,
-}
-
-impl<P: KolmeRuntimeCommitProvider> AdapterBackedKolmeRuntimeCommitClient<P> {
-    /// Builds adapter-backed client with expected provider identifier.
-    pub fn new(expected_provider: &str, provider: P) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_expected_provider_input_contract(expected_provider) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "expected_provider",
-                reason: "must not be empty",
-            });
-        }
-        Ok(Self {
-            expected_provider: expected_provider.to_owned(),
-            provider,
-        })
-    }
-}
-
-impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
-    for AdapterBackedKolmeRuntimeCommitClient<P>
-{
-    fn submit_commit(
-        &mut self,
-        request: &KolmeRuntimeCommitRequest,
-    ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
-        request.validate()?;
-        let expected_provider = self.expected_provider.as_str();
-        let map_provider_receipt = |receipt: KolmeRuntimeCommitProviderReceipt| {
-            validate_kolme_provider_receipt_identity_contract(
-                expected_provider,
-                receipt.provider.as_str(),
-                receipt.commit_id.as_str(),
-            )
-            .map_err(|error| match error {
-                KamnKolmeProviderReceiptIdentityError::ProviderMismatch { expected, observed } => {
-                    KolmeRuntimeCommitError::ProviderMismatch { expected, observed }
-                }
-                KamnKolmeProviderReceiptIdentityError::EmptyCommitId => {
-                    KolmeRuntimeCommitError::InvalidRequest {
-                        field: "receipt_commit_id",
-                        reason: "must not be empty",
-                    }
-                }
-            })?;
-            require_kolme_final_receipt_finality_contract(receipt.finality).map_err(|error| {
-                match error {
-                    KamnKolmeRuntimeLifecyclePolicyError::NonFinalReceipt { finality } => {
-                        KolmeRuntimeCommitError::NonFinalReceipt {
-                            commit_id: receipt.commit_id.clone(),
-                            finality,
-                        }
-                    }
-                }
-            })?;
-            Ok(KolmeRuntimeCommitReceipt {
-                provider: receipt.provider,
-                commit_id: receipt.commit_id,
-                finality: receipt.finality,
-            })
-        };
-        let provider_outcome = self
-            .provider
-            .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
-            .map_err(|error| match error {
-                KolmeRuntimeCommitProviderError::Timeout => {
-                    KolmeRuntimeCommitError::ProviderTransport {
-                        kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
-                        detail: "provider request timed out".to_owned(),
-                    }
-                }
-                KolmeRuntimeCommitProviderError::Unavailable { reason } => {
-                    KolmeRuntimeCommitError::ProviderTransport {
-                        kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
-                        detail: reason,
-                    }
-                }
-                KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
-                    KolmeRuntimeCommitError::ProviderTransport {
-                        kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
-                        detail: reason,
-                    }
-                }
-            })?;
-        match provider_outcome {
-            KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => Ok(
-                KolmeRuntimeCommitOutcome::Submitted(map_provider_receipt(receipt)?),
-            ),
-            KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => Ok(
-                KolmeRuntimeCommitOutcome::Duplicate(map_provider_receipt(receipt)?),
-            ),
-            KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
-                Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
-            }
-        }
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/adapter_backed_client.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/adapter_backed_client.rs
@@ -1,0 +1,112 @@
+//! Adapter-backed runtime commit client ownership.
+
+use super::{
+    is_kolme_valid_expected_provider_input_contract, require_kolme_final_receipt_finality_contract,
+    validate_kolme_provider_receipt_identity_contract, KamnKolmeProviderReceiptIdentityError,
+    KamnKolmeRuntimeLifecyclePolicyError, KolmeRuntimeCommitClient, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitOutcome, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
+    KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderReceipt,
+    KolmeRuntimeCommitReceipt, KolmeRuntimeCommitRequest, KolmeRuntimeCommitTransportErrorKind,
+};
+
+/// Adapter-backed runtime commit client that enforces provider and finality policies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterBackedKolmeRuntimeCommitClient<P> {
+    expected_provider: String,
+    provider: P,
+}
+
+impl<P: KolmeRuntimeCommitProvider> AdapterBackedKolmeRuntimeCommitClient<P> {
+    /// Builds adapter-backed client with expected provider identifier.
+    pub fn new(expected_provider: &str, provider: P) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_expected_provider_input_contract(expected_provider) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "expected_provider",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            expected_provider: expected_provider.to_owned(),
+            provider,
+        })
+    }
+}
+
+impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient
+    for AdapterBackedKolmeRuntimeCommitClient<P>
+{
+    fn submit_commit(
+        &mut self,
+        request: &KolmeRuntimeCommitRequest,
+    ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError> {
+        request.validate()?;
+        let expected_provider = self.expected_provider.as_str();
+        let map_provider_receipt = |receipt: KolmeRuntimeCommitProviderReceipt| {
+            validate_kolme_provider_receipt_identity_contract(
+                expected_provider,
+                receipt.provider.as_str(),
+                receipt.commit_id.as_str(),
+            )
+            .map_err(|error| match error {
+                KamnKolmeProviderReceiptIdentityError::ProviderMismatch { expected, observed } => {
+                    KolmeRuntimeCommitError::ProviderMismatch { expected, observed }
+                }
+                KamnKolmeProviderReceiptIdentityError::EmptyCommitId => {
+                    KolmeRuntimeCommitError::InvalidRequest {
+                        field: "receipt_commit_id",
+                        reason: "must not be empty",
+                    }
+                }
+            })?;
+            require_kolme_final_receipt_finality_contract(receipt.finality).map_err(|error| {
+                match error {
+                    KamnKolmeRuntimeLifecyclePolicyError::NonFinalReceipt { finality } => {
+                        KolmeRuntimeCommitError::NonFinalReceipt {
+                            commit_id: receipt.commit_id.clone(),
+                            finality,
+                        }
+                    }
+                }
+            })?;
+            Ok(KolmeRuntimeCommitReceipt {
+                provider: receipt.provider,
+                commit_id: receipt.commit_id,
+                finality: receipt.finality,
+            })
+        };
+        let provider_outcome = self
+            .provider
+            .submit_runtime_commit(&request.to_wire_payload(), request.idempotency_key())
+            .map_err(|error| match error {
+                KolmeRuntimeCommitProviderError::Timeout => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Timeout,
+                        detail: "provider request timed out".to_owned(),
+                    }
+                }
+                KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::Unavailable,
+                        detail: reason,
+                    }
+                }
+                KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitError::ProviderTransport {
+                        kind: KolmeRuntimeCommitTransportErrorKind::MalformedResponse,
+                        detail: reason,
+                    }
+                }
+            })?;
+        match provider_outcome {
+            KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => Ok(
+                KolmeRuntimeCommitOutcome::Submitted(map_provider_receipt(receipt)?),
+            ),
+            KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => Ok(
+                KolmeRuntimeCommitOutcome::Duplicate(map_provider_receipt(receipt)?),
+            ),
+            KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
+                Ok(KolmeRuntimeCommitOutcome::Rejected { reason })
+            }
+        }
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -1,6 +1,8 @@
 const RUNTIME_COMMIT_SRC: &str = include_str!("../src/kolme_runtime_commit.rs");
 const RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/block_fallback_reconciler.rs");
+const RUNTIME_ADAPTER_BACKED_CLIENT_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/adapter_backed_client.rs");
 const RUNTIME_FINALITY_CHECKER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/finality_checker.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
@@ -65,6 +67,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitBlockFallbackReconciler"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct AdapterBackedKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitFinalityChecker"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitForkFinalityResolver"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
@@ -72,6 +75,10 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC
+        .contains("impl<P: KolmeRuntimeCommitProvider> AdapterBackedKolmeRuntimeCommitClient<P>"));
+    assert!(!RUNTIME_COMMIT_SRC
+        .contains("impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitBlockFallbackTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitFinalityTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>"));
@@ -140,7 +147,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("parse_kolme_websocket_endpoint("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_submit_path_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_expected_provider_input_contract("));
+    assert!(RUNTIME_ADAPTER_BACKED_CLIENT_SRC
+        .contains("is_kolme_valid_expected_provider_input_contract("));
     assert!(
         RUNTIME_NOTIFICATIONS_CONSUMER_SRC.contains("compose_kolme_notifications_websocket_url(")
     );
@@ -202,12 +210,17 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_NOTIFICATIONS_WS_SRC.contains("is_kolme_valid_websocket_timeout_seconds_contract(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains("validate_kolme_provider_receipt_identity_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("require_kolme_final_receipt_finality_contract("));
+    assert!(RUNTIME_ADAPTER_BACKED_CLIENT_SRC
+        .contains("validate_kolme_provider_receipt_identity_contract("));
+    assert!(RUNTIME_ADAPTER_BACKED_CLIENT_SRC
+        .contains("require_kolme_final_receipt_finality_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
     assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
-    assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout"));
-    assert!(RUNTIME_COMMIT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
+    assert!(
+        RUNTIME_ADAPTER_BACKED_CLIENT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout")
+    );
+    assert!(RUNTIME_ADAPTER_BACKED_CLIENT_SRC
+        .contains("KolmeRuntimeCommitTransportErrorKind::MalformedResponse"));
     assert!(RUNTIME_COMMIT_SRC.contains("classify_kolme_transport_io_error(&error)"));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_response_bytes_input_contract("));
@@ -237,6 +250,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod adapter_backed_client;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod block_fallback_reconciler;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod finality_checker;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod fork_finality_resolver;"));
@@ -248,6 +262,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;"));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("pub use adapter_backed_client::AdapterBackedKolmeRuntimeCommitClient;"));
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;"));
     assert!(

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -74,6 +74,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1944"));
     assert!(DOC.contains("#1946"));
     assert!(DOC.contains("#1948"));
+    assert!(DOC.contains("#1950"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -92,6 +92,7 @@ Out of scope:
 - #1944: extracted fork finality resolver ownership into `kolme_runtime_commit/fork_finality_resolver.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitForkFinalityResolver` from the dedicated submodule.
 - #1946: extracted finality checker ownership into `kolme_runtime_commit/finality_checker.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitFinalityChecker` from the dedicated submodule.
 - #1948: extracted block fallback reconciler ownership into `kolme_runtime_commit/block_fallback_reconciler.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitBlockFallbackReconciler` from the dedicated submodule.
+- #1950: extracted adapter-backed client ownership into `kolme_runtime_commit/adapter_backed_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `AdapterBackedKolmeRuntimeCommitClient` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted `AdapterBackedKolmeRuntimeCommitClient` ownership from `kolme_runtime_commit.rs` into a dedicated `adapter_backed_client.rs` submodule. This continues Phase 3 decomposition while preserving public API behavior through re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/adapter_backed_client.rs`: new owner module for adapter-backed provider/finality enforcement and outcome mapping.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod adapter_backed_client;`, re-exported `AdapterBackedKolmeRuntimeCommitClient`, and removed inline adapter-backed client implementation.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for adapter-backed client ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1950` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1950 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/adapter_backed_client.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Extraction-boundary regression assertions updated to guard adapter-backed client ownership location.
- Existing runtime-commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_client`, `kolme_runtime_commit_finality` | |
| Integration  | ✅     | runtime commit integration tests in client/finality/notifications lanes | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression suites | |
| Performance  | N/A    | None added | Module ownership extraction only; runtime semantics unchanged |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by parity suites.
- Rollback: revert this PR commit to restore inline adapter-backed client ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1950 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1950
