### PR TITLE
refactor(kolme): extract live provider module ownership (#1952)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -115,6 +115,7 @@ mod block_fallback_reconciler;
 mod finality_checker;
 mod fork_finality_resolver;
 mod in_memory_client;
+mod live_provider;
 mod notifications_consumer;
 mod notifications_websocket;
 mod runtime_pipeline;
@@ -511,6 +512,7 @@ pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
+pub use live_provider::KolmeRuntimeCommitLiveProvider;
 pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;
 pub use notifications_websocket::{
     KolmeRuntimeCommitWebsocketConnection, KolmeRuntimeCommitWebsocketConnector,
@@ -749,22 +751,6 @@ pub trait KolmeRuntimeCommitProviderTransport {
         wire_payload: &str,
         idempotency_key: &str,
     ) -> Result<String, KolmeRuntimeCommitProviderError>;
-}
-
-/// Provider implementation that bridges runtime commit requests through a live transport.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeRuntimeCommitLiveProvider<T> {
-    base_url: String,
-    submit_path: String,
-    profile: KolmeRuntimeCommitSubmitProfile,
-    provider_hint: Option<String>,
-    transport: T,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KolmeRuntimeCommitSubmitProfile {
-    LegacyRuntimeCommit,
-    KolmeForkBroadcast,
 }
 
 type ParsedHttpEndpoint = KamnKolmeParsedHttpEndpoint;
@@ -1126,83 +1112,6 @@ impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTranspor
             }
         })?;
         self.execute_request(base_url, block_path.as_str(), "GET", None, &[])
-    }
-}
-
-impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
-    /// Builds a live provider with deterministic endpoint validation.
-    pub fn new(
-        base_url: &str,
-        submit_path: &str,
-        transport: T,
-    ) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_live_provider_base_url_input_contract(base_url) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider_base_url",
-                reason: "must not be empty",
-            });
-        }
-        if !is_kolme_valid_live_provider_submit_path_input_contract(submit_path) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider_submit_path",
-                reason: "must not be empty",
-            });
-        }
-        let (base_url, submit_path) =
-            normalize_kolme_live_provider_endpoint_inputs_contract(base_url, submit_path);
-        Ok(Self {
-            base_url,
-            submit_path,
-            profile: KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit,
-            provider_hint: None,
-            transport,
-        })
-    }
-
-    /// Builds a live provider configured for `kolme_fork` broadcast semantics.
-    pub fn new_kolme_fork_broadcast_profile(
-        base_url: &str,
-        provider_hint: &str,
-        transport: T,
-    ) -> Result<Self, KolmeRuntimeCommitError> {
-        if !is_kolme_valid_provider_hint_input_contract(provider_hint) {
-            return Err(KolmeRuntimeCommitError::InvalidRequest {
-                field: "provider_hint",
-                reason: "must not be empty",
-            });
-        }
-        let provider_hint = normalize_kolme_provider_hint_input_contract(provider_hint);
-        let mut provider = Self::new(base_url, "/broadcast", transport)?;
-        provider.profile = KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast;
-        provider.provider_hint = Some(provider_hint.to_owned());
-        Ok(provider)
-    }
-}
-
-impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitProvider
-    for KolmeRuntimeCommitLiveProvider<T>
-{
-    fn submit_runtime_commit(
-        &mut self,
-        wire_payload: &str,
-        idempotency_key: &str,
-    ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
-        let response = self.transport.submit_runtime_commit(
-            self.base_url.as_str(),
-            self.submit_path.as_str(),
-            wire_payload,
-            idempotency_key,
-        )?;
-        let provider_hint = match self.profile {
-            KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast => self.provider_hint.as_deref(),
-            KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit => None,
-        };
-        let outcome =
-            parse_kolme_live_runtime_provider_outcome_contract(response.as_str(), provider_hint)
-                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
-                    reason: error.to_string(),
-                })?;
-        Ok(outcome.into())
     }
 }
 

--- a/crates/kamn-core/src/kolme_runtime_commit/live_provider.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/live_provider.rs
@@ -1,0 +1,105 @@
+//! Provider implementation that bridges runtime commit requests through a live transport.
+
+use super::{
+    is_kolme_valid_live_provider_base_url_input_contract,
+    is_kolme_valid_live_provider_submit_path_input_contract,
+    is_kolme_valid_provider_hint_input_contract,
+    normalize_kolme_live_provider_endpoint_inputs_contract,
+    normalize_kolme_provider_hint_input_contract,
+    parse_kolme_live_runtime_provider_outcome_contract, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
+    KolmeRuntimeCommitProviderTransport,
+};
+
+/// Provider implementation that bridges runtime commit requests through a live transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitLiveProvider<T> {
+    base_url: String,
+    submit_path: String,
+    profile: KolmeRuntimeCommitSubmitProfile,
+    provider_hint: Option<String>,
+    transport: T,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KolmeRuntimeCommitSubmitProfile {
+    LegacyRuntimeCommit,
+    KolmeForkBroadcast,
+}
+
+impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitLiveProvider<T> {
+    /// Builds a live provider with deterministic endpoint validation.
+    pub fn new(
+        base_url: &str,
+        submit_path: &str,
+        transport: T,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_live_provider_base_url_input_contract(base_url) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_base_url",
+                reason: "must not be empty",
+            });
+        }
+        if !is_kolme_valid_live_provider_submit_path_input_contract(submit_path) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_submit_path",
+                reason: "must not be empty",
+            });
+        }
+        let (base_url, submit_path) =
+            normalize_kolme_live_provider_endpoint_inputs_contract(base_url, submit_path);
+        Ok(Self {
+            base_url,
+            submit_path,
+            profile: KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit,
+            provider_hint: None,
+            transport,
+        })
+    }
+
+    /// Builds a live provider configured for `kolme_fork` broadcast semantics.
+    pub fn new_kolme_fork_broadcast_profile(
+        base_url: &str,
+        provider_hint: &str,
+        transport: T,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_provider_hint_input_contract(provider_hint) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "provider_hint",
+                reason: "must not be empty",
+            });
+        }
+        let provider_hint = normalize_kolme_provider_hint_input_contract(provider_hint);
+        let mut provider = Self::new(base_url, "/broadcast", transport)?;
+        provider.profile = KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast;
+        provider.provider_hint = Some(provider_hint.to_owned());
+        Ok(provider)
+    }
+}
+
+impl<T: KolmeRuntimeCommitProviderTransport> KolmeRuntimeCommitProvider
+    for KolmeRuntimeCommitLiveProvider<T>
+{
+    fn submit_runtime_commit(
+        &mut self,
+        wire_payload: &str,
+        idempotency_key: &str,
+    ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError> {
+        let response = self.transport.submit_runtime_commit(
+            self.base_url.as_str(),
+            self.submit_path.as_str(),
+            wire_payload,
+            idempotency_key,
+        )?;
+        let provider_hint = match self.profile {
+            KolmeRuntimeCommitSubmitProfile::KolmeForkBroadcast => self.provider_hint.as_deref(),
+            KolmeRuntimeCommitSubmitProfile::LegacyRuntimeCommit => None,
+        };
+        let outcome =
+            parse_kolme_live_runtime_provider_outcome_contract(response.as_str(), provider_hint)
+                .map_err(|error| KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: error.to_string(),
+                })?;
+        Ok(outcome.into())
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -3,6 +3,8 @@ const RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/block_fallback_reconciler.rs");
 const RUNTIME_ADAPTER_BACKED_CLIENT_SRC: &str =
     include_str!("../src/kolme_runtime_commit/adapter_backed_client.rs");
+const RUNTIME_LIVE_PROVIDER_SRC: &str =
+    include_str!("../src/kolme_runtime_commit/live_provider.rs");
 const RUNTIME_FINALITY_CHECKER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/finality_checker.rs");
 const RUNTIME_IN_MEMORY_SRC: &str = include_str!("../src/kolme_runtime_commit/in_memory_client.rs");
@@ -68,6 +70,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitBlockFallbackReconciler"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct AdapterBackedKolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitLiveProvider"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitFinalityChecker"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitForkFinalityResolver"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
@@ -79,6 +82,7 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
         .contains("impl<P: KolmeRuntimeCommitProvider> AdapterBackedKolmeRuntimeCommitClient<P>"));
     assert!(!RUNTIME_COMMIT_SRC
         .contains("impl<P: KolmeRuntimeCommitProvider> KolmeRuntimeCommitClient"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitProviderTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitBlockFallbackTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<T: KolmeRuntimeCommitFinalityTransport>"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl<C, T> KolmeRuntimeCommitForkFinalityResolver<C, T>"));
@@ -133,7 +137,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_COMMIT_SRC.contains("normalize_kolme_transport_idempotency_key_input_contract(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_provider_hint_input_contract("));
+    assert!(RUNTIME_LIVE_PROVIDER_SRC.contains("normalize_kolme_provider_hint_input_contract("));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("normalize_kolme_notifications_provider_input_contract("));
     assert!(RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC
@@ -141,12 +145,16 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(
         RUNTIME_FINALITY_CHECKER_SRC.contains("normalize_kolme_finality_endpoint_inputs_contract(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
+    assert!(RUNTIME_LIVE_PROVIDER_SRC
+        .contains("normalize_kolme_live_provider_endpoint_inputs_contract("));
     assert!(RUNTIME_FORK_FINALITY_RESOLVER_SRC.contains("txhash_from_kolme_commit_id("));
     assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_http_endpoint("));
     assert!(RUNTIME_NOTIFICATIONS_WS_SRC.contains("parse_kolme_websocket_endpoint("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_live_provider_submit_path_input_contract("));
+    assert!(
+        RUNTIME_LIVE_PROVIDER_SRC.contains("is_kolme_valid_live_provider_base_url_input_contract(")
+    );
+    assert!(RUNTIME_LIVE_PROVIDER_SRC
+        .contains("is_kolme_valid_live_provider_submit_path_input_contract("));
     assert!(RUNTIME_ADAPTER_BACKED_CLIENT_SRC
         .contains("is_kolme_valid_expected_provider_input_contract("));
     assert!(
@@ -201,7 +209,9 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("normalize_kolme_notifications_provider_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract("));
+    assert!(
+        RUNTIME_LIVE_PROVIDER_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract(")
+    );
     assert!(RUNTIME_COMMIT_SRC.contains(
         "impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome"
     ));
@@ -225,7 +235,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_transport_timeout_seconds_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_http_response_bytes_input_contract("));
     assert!(RUNTIME_IN_MEMORY_SRC.contains("is_kolme_valid_runtime_provider_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
+    assert!(RUNTIME_LIVE_PROVIDER_SRC.contains("is_kolme_valid_provider_hint_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_operation_id_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_state_root_input_contract("));
     assert!(RUNTIME_COMMIT_SRC.contains("is_kolme_valid_runtime_payload_hash_input_contract("));
@@ -252,6 +262,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod adapter_backed_client;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod block_fallback_reconciler;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod live_provider;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod finality_checker;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod fork_finality_resolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
@@ -266,6 +277,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("pub use adapter_backed_client::AdapterBackedKolmeRuntimeCommitClient;"));
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use live_provider::KolmeRuntimeCommitLiveProvider;"));
     assert!(
         RUNTIME_COMMIT_SRC.contains("pub use finality_checker::KolmeRuntimeCommitFinalityChecker;")
     );

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -75,6 +75,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1946"));
     assert!(DOC.contains("#1948"));
     assert!(DOC.contains("#1950"));
+    assert!(DOC.contains("#1952"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -93,6 +93,7 @@ Out of scope:
 - #1946: extracted finality checker ownership into `kolme_runtime_commit/finality_checker.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitFinalityChecker` from the dedicated submodule.
 - #1948: extracted block fallback reconciler ownership into `kolme_runtime_commit/block_fallback_reconciler.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitBlockFallbackReconciler` from the dedicated submodule.
 - #1950: extracted adapter-backed client ownership into `kolme_runtime_commit/adapter_backed_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `AdapterBackedKolmeRuntimeCommitClient` from the dedicated submodule.
+- #1952: extracted live provider ownership into `kolme_runtime_commit/live_provider.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitLiveProvider` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted `KolmeRuntimeCommitLiveProvider` ownership from `kolme_runtime_commit.rs` into a dedicated `live_provider.rs` submodule. This continues Phase 3 decomposition while preserving public API behavior through re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/live_provider.rs`: new owner module for live-provider constructors, profile handling, and provider transport outcome parsing.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod live_provider;`, re-exported `KolmeRuntimeCommitLiveProvider`, and removed inline live-provider ownership/impl blocks.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for live-provider ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1952` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1952 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/live_provider.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Extraction-boundary regression assertions updated to guard live-provider ownership location.
- Existing runtime-commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_client`, `kolme_runtime_commit_finality` | |
| Integration  | ✅     | runtime commit integration tests in client/finality/notifications lanes | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression suites | |
| Performance  | N/A    | None added | Module ownership extraction only; runtime semantics unchanged |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by parity suites.
- Rollback: revert this PR commit to restore inline live-provider ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1952 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1952
