### PR TITLE
refactor(kolme): extract api codec module ownership (#1956)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -106,6 +106,7 @@ use kamn_kolme::{
 use std::fmt;
 
 mod adapter_backed_client;
+mod api_codec;
 mod block_fallback_reconciler;
 mod finality_checker;
 mod fork_finality_resolver;
@@ -332,146 +333,6 @@ impl KolmeRuntimeCommitSignedBroadcastEnvelope {
     }
 }
 
-/// Typed nonce lookup request for Kolme `/get-next-nonce`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeApiNextNonceRequest {
-    /// Public key used to resolve next nonce and account identity.
-    pub pubkey: String,
-}
-
-impl KolmeApiNextNonceRequest {
-    /// Builds a deterministic nonce lookup request.
-    pub fn new(pubkey: &str) -> Result<Self, KolmeRuntimeCommitError> {
-        let extracted = KamnKolmeApiNextNonceRequest::new(pubkey).map_err(|error| match error {
-            KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
-                KolmeRuntimeCommitError::InvalidRequest { field, reason }
-            }
-            KamnKolmeApiCodecError::MalformedResponse { .. } => {
-                KolmeRuntimeCommitError::InvalidRequest {
-                    field: "codec_payload",
-                    reason: "must be valid json",
-                }
-            }
-        })?;
-        Ok(Self {
-            pubkey: extracted.pubkey,
-        })
-    }
-
-    /// Returns encoded request path for the configured nonce endpoint.
-    pub fn query_path(&self, nonce_path: &str) -> String {
-        KamnKolmeApiNextNonceRequest {
-            pubkey: self.pubkey.clone(),
-        }
-        .query_path(nonce_path)
-    }
-}
-
-/// Typed nonce lookup response for Kolme `/get-next-nonce`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeApiNextNonceResponse {
-    /// Monotonic next nonce for the provided public key.
-    pub next_nonce: u64,
-    /// Optional account identifier mapped to the provided public key.
-    pub account_id: Option<String>,
-}
-
-impl KolmeApiNextNonceResponse {
-    /// Parses one nonce lookup response JSON payload.
-    pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
-        let extracted =
-            KamnKolmeApiNextNonceResponse::parse_json(response).map_err(|error| match error {
-                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
-                    KolmeRuntimeCommitProviderError::MalformedResponse {
-                        reason: format!("invalid request {field}: {reason}"),
-                    }
-                }
-                KamnKolmeApiCodecError::MalformedResponse { reason } => {
-                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-                }
-            })?;
-        Ok(Self {
-            next_nonce: extracted.next_nonce,
-            account_id: extracted.account_id,
-        })
-    }
-}
-
-/// Typed broadcast request payload for Kolme `/broadcast`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeApiBroadcastRequest {
-    /// Tagged transaction message payload.
-    pub message: String,
-    /// Chain signature for the transaction message payload.
-    pub signature: String,
-    /// Signature recovery identifier.
-    pub recovery_id: u8,
-}
-
-impl KolmeApiBroadcastRequest {
-    /// Builds a deterministic broadcast request payload.
-    pub fn new(
-        message: &str,
-        signature: &str,
-        recovery_id: u8,
-    ) -> Result<Self, KolmeRuntimeCommitError> {
-        let extracted = KamnKolmeApiBroadcastRequest::new(message, signature, recovery_id)
-            .map_err(|error| match error {
-                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
-                    KolmeRuntimeCommitError::InvalidRequest { field, reason }
-                }
-                KamnKolmeApiCodecError::MalformedResponse { .. } => {
-                    KolmeRuntimeCommitError::InvalidRequest {
-                        field: "codec_payload",
-                        reason: "must be valid json",
-                    }
-                }
-            })?;
-        Ok(Self {
-            message: extracted.message,
-            signature: extracted.signature,
-            recovery_id: extracted.recovery_id,
-        })
-    }
-
-    /// Returns deterministic JSON payload in canonical field order.
-    pub fn to_json_payload(&self) -> String {
-        KamnKolmeApiBroadcastRequest {
-            message: self.message.clone(),
-            signature: self.signature.clone(),
-            recovery_id: self.recovery_id,
-        }
-        .to_json_payload()
-    }
-}
-
-/// Typed broadcast response payload for Kolme `/broadcast`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeApiBroadcastResponse {
-    /// Transaction hash identifier from broadcast response.
-    pub txhash: String,
-}
-
-impl KolmeApiBroadcastResponse {
-    /// Parses one broadcast response JSON payload.
-    pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
-        let extracted =
-            KamnKolmeApiBroadcastResponse::parse_json(response).map_err(|error| match error {
-                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
-                    KolmeRuntimeCommitProviderError::MalformedResponse {
-                        reason: format!("invalid request {field}: {reason}"),
-                    }
-                }
-                KamnKolmeApiCodecError::MalformedResponse { reason } => {
-                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
-                }
-            })?;
-        Ok(Self {
-            txhash: extracted.txhash,
-        })
-    }
-}
-
 /// Finality classification for a runtime commit receipt.
 pub type KolmeCommitReceiptFinality = KamnKolmeCommitReceiptFinality;
 
@@ -504,6 +365,10 @@ pub enum KolmeRuntimeCommitOutcome {
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
 
 pub use adapter_backed_client::AdapterBackedKolmeRuntimeCommitClient;
+pub use api_codec::{
+    KolmeApiBroadcastRequest, KolmeApiBroadcastResponse, KolmeApiNextNonceRequest,
+    KolmeApiNextNonceResponse,
+};
 pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;

--- a/crates/kamn-core/src/kolme_runtime_commit/api_codec.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/api_codec.rs
@@ -1,0 +1,147 @@
+//! Kolme API request/response codec ownership.
+
+use super::{
+    KamnKolmeApiBroadcastRequest, KamnKolmeApiBroadcastResponse, KamnKolmeApiCodecError,
+    KamnKolmeApiNextNonceRequest, KamnKolmeApiNextNonceResponse, KolmeRuntimeCommitError,
+    KolmeRuntimeCommitProviderError,
+};
+
+/// Typed nonce lookup request for Kolme `/get-next-nonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiNextNonceRequest {
+    /// Public key used to resolve next nonce and account identity.
+    pub pubkey: String,
+}
+
+impl KolmeApiNextNonceRequest {
+    /// Builds a deterministic nonce lookup request.
+    pub fn new(pubkey: &str) -> Result<Self, KolmeRuntimeCommitError> {
+        let extracted = KamnKolmeApiNextNonceRequest::new(pubkey).map_err(|error| match error {
+            KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                KolmeRuntimeCommitError::InvalidRequest { field, reason }
+            }
+            KamnKolmeApiCodecError::MalformedResponse { .. } => {
+                KolmeRuntimeCommitError::InvalidRequest {
+                    field: "codec_payload",
+                    reason: "must be valid json",
+                }
+            }
+        })?;
+        Ok(Self {
+            pubkey: extracted.pubkey,
+        })
+    }
+
+    /// Returns encoded request path for the configured nonce endpoint.
+    pub fn query_path(&self, nonce_path: &str) -> String {
+        KamnKolmeApiNextNonceRequest {
+            pubkey: self.pubkey.clone(),
+        }
+        .query_path(nonce_path)
+    }
+}
+
+/// Typed nonce lookup response for Kolme `/get-next-nonce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiNextNonceResponse {
+    /// Monotonic next nonce for the provided public key.
+    pub next_nonce: u64,
+    /// Optional account identifier mapped to the provided public key.
+    pub account_id: Option<String>,
+}
+
+impl KolmeApiNextNonceResponse {
+    /// Parses one nonce lookup response JSON payload.
+    pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
+        let extracted =
+            KamnKolmeApiNextNonceResponse::parse_json(response).map_err(|error| match error {
+                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse {
+                        reason: format!("invalid request {field}: {reason}"),
+                    }
+                }
+                KamnKolmeApiCodecError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                }
+            })?;
+        Ok(Self {
+            next_nonce: extracted.next_nonce,
+            account_id: extracted.account_id,
+        })
+    }
+}
+
+/// Typed broadcast request payload for Kolme `/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiBroadcastRequest {
+    /// Tagged transaction message payload.
+    pub message: String,
+    /// Chain signature for the transaction message payload.
+    pub signature: String,
+    /// Signature recovery identifier.
+    pub recovery_id: u8,
+}
+
+impl KolmeApiBroadcastRequest {
+    /// Builds a deterministic broadcast request payload.
+    pub fn new(
+        message: &str,
+        signature: &str,
+        recovery_id: u8,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        let extracted = KamnKolmeApiBroadcastRequest::new(message, signature, recovery_id)
+            .map_err(|error| match error {
+                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                    KolmeRuntimeCommitError::InvalidRequest { field, reason }
+                }
+                KamnKolmeApiCodecError::MalformedResponse { .. } => {
+                    KolmeRuntimeCommitError::InvalidRequest {
+                        field: "codec_payload",
+                        reason: "must be valid json",
+                    }
+                }
+            })?;
+        Ok(Self {
+            message: extracted.message,
+            signature: extracted.signature,
+            recovery_id: extracted.recovery_id,
+        })
+    }
+
+    /// Returns deterministic JSON payload in canonical field order.
+    pub fn to_json_payload(&self) -> String {
+        KamnKolmeApiBroadcastRequest {
+            message: self.message.clone(),
+            signature: self.signature.clone(),
+            recovery_id: self.recovery_id,
+        }
+        .to_json_payload()
+    }
+}
+
+/// Typed broadcast response payload for Kolme `/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeApiBroadcastResponse {
+    /// Transaction hash identifier from broadcast response.
+    pub txhash: String,
+}
+
+impl KolmeApiBroadcastResponse {
+    /// Parses one broadcast response JSON payload.
+    pub fn parse_json(response: &str) -> Result<Self, KolmeRuntimeCommitProviderError> {
+        let extracted =
+            KamnKolmeApiBroadcastResponse::parse_json(response).map_err(|error| match error {
+                KamnKolmeApiCodecError::InvalidRequest { field, reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse {
+                        reason: format!("invalid request {field}: {reason}"),
+                    }
+                }
+                KamnKolmeApiCodecError::MalformedResponse { reason } => {
+                    KolmeRuntimeCommitProviderError::MalformedResponse { reason }
+                }
+            })?;
+        Ok(Self {
+            txhash: extracted.txhash,
+        })
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -3,6 +3,7 @@ const RUNTIME_BLOCK_FALLBACK_RECONCILER_SRC: &str =
     include_str!("../src/kolme_runtime_commit/block_fallback_reconciler.rs");
 const RUNTIME_ADAPTER_BACKED_CLIENT_SRC: &str =
     include_str!("../src/kolme_runtime_commit/adapter_backed_client.rs");
+const RUNTIME_API_CODEC_SRC: &str = include_str!("../src/kolme_runtime_commit/api_codec.rs");
 const RUNTIME_HTTP_TRANSPORT_SRC: &str =
     include_str!("../src/kolme_runtime_commit/http_transport.rs");
 const RUNTIME_LIVE_PROVIDER_SRC: &str =
@@ -74,6 +75,10 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct AdapterBackedKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitLiveProvider"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitHttpTransport"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeApiNextNonceRequest"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeApiNextNonceResponse"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeApiBroadcastRequest"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeApiBroadcastResponse"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitFinalityChecker"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitForkFinalityResolver"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
@@ -233,8 +238,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("validate_kolme_provider_receipt_identity_contract("));
     assert!(RUNTIME_ADAPTER_BACKED_CLIENT_SRC
         .contains("require_kolme_final_receipt_finality_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
-    assert!(RUNTIME_COMMIT_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
+    assert!(RUNTIME_API_CODEC_SRC.contains("KamnKolmeApiNextNonceRequest::new("));
+    assert!(RUNTIME_API_CODEC_SRC.contains("KamnKolmeApiBroadcastResponse::parse_json("));
     assert!(
         RUNTIME_ADAPTER_BACKED_CLIENT_SRC.contains("KolmeRuntimeCommitTransportErrorKind::Timeout")
     );
@@ -275,6 +280,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod api_codec;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod adapter_backed_client;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod http_transport;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod block_fallback_reconciler;"));
@@ -289,6 +295,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     );
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use api_codec::{"));
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use adapter_backed_client::AdapterBackedKolmeRuntimeCommitClient;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use http_transport::KolmeRuntimeCommitHttpTransport;"));

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -77,6 +77,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1950"));
     assert!(DOC.contains("#1952"));
     assert!(DOC.contains("#1954"));
+    assert!(DOC.contains("#1956"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -95,6 +95,7 @@ Out of scope:
 - #1950: extracted adapter-backed client ownership into `kolme_runtime_commit/adapter_backed_client.rs` and rewired `kolme_runtime_commit.rs` to re-export `AdapterBackedKolmeRuntimeCommitClient` from the dedicated submodule.
 - #1952: extracted live provider ownership into `kolme_runtime_commit/live_provider.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitLiveProvider` from the dedicated submodule.
 - #1954: extracted HTTP transport ownership into `kolme_runtime_commit/http_transport.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitHttpTransport` from the dedicated submodule.
+- #1956: extracted API codec ownership into `kolme_runtime_commit/api_codec.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeApiNextNonce*`/`KolmeApiBroadcast*` types from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracted Kolme API request/response codec ownership from `kolme_runtime_commit.rs` into a dedicated `api_codec.rs` submodule. This continues Phase 3 decomposition while preserving public API behavior through re-export wiring.

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/api_codec.rs`: new owner module for `KolmeApiNextNonce*` and `KolmeApiBroadcast*` request/response parsing/rendering.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: added `mod api_codec;`, re-exported API codec types, and removed inline codec ownership/impl blocks.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated extraction boundary guards for API codec ownership location and module wiring.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1956` marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: logged #1956 extraction progress marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary -- --nocapture`

Failing output (before implementation):
`error: couldn't read crates/kamn-core/tests/../src/kolme_runtime_commit/api_codec.rs: No such file or directory`

### 🟢 Green Phase
Command chain:
`cargo fmt --check && cargo clippy -p kamn-core --tests -- -D warnings && cargo clippy -p kamn-kolme --tests -- -D warnings && cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary && cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs && cargo test -p kamn-core --test kolme_runtime_commit_notifications && cargo test -p kamn-core --test kolme_runtime_commit_finality && cargo test -p kamn-core --test kolme_runtime_commit_client`

Passing summary:
- extraction boundary: 2 passed
- extraction plan docs: 2 passed
- notifications: 7 passed
- finality: 10 passed
- runtime client: 31 passed

### 🔁 Regression
- Extraction-boundary regression assertions updated to guard API codec ownership location.
- Existing runtime-commit regression suites remain green in notifications/finality/client lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅     | `kolme_runtime_commit_client`, `kolme_runtime_commit_finality`, `kolme_runtime_commit_notifications` | |
| Integration  | ✅     | runtime commit integration tests in client/finality/notifications lanes | |
| Regression   | ✅     | extraction-boundary regression + existing runtime-commit regression suites | |
| Performance  | N/A    | None added | Module ownership extraction only; runtime semantics unchanged |

## Risks & Rollback
- None expected beyond module wiring mistakes; behavior preserved by parity suites.
- Rollback: revert this PR commit to restore inline API codec ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md` updated with #1956 progress marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed for `kamn-core` and `kamn-kolme` test targets)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant runtime-commit lanes)
- [x] Docs updated (or justified why not)

Closes #1956
