### PR TITLE
refactor(kolme-runtime): extract runtime error module file (#1960)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -103,11 +103,11 @@ use kamn_kolme::{
     RuntimeCommitLifecycleState as KamnKolmeRuntimeCommitLifecycleState,
     RuntimeLifecyclePolicyError as KamnKolmeRuntimeLifecyclePolicyError,
 };
-use std::fmt;
 
 mod adapter_backed_client;
 mod api_codec;
 mod block_fallback_reconciler;
+mod errors;
 mod finality_checker;
 mod fork_finality_resolver;
 mod http_transport;
@@ -155,6 +155,9 @@ pub use api_codec::{
     KolmeApiNextNonceResponse,
 };
 pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
+pub use errors::{
+    KolmeRuntimeCommitError, KolmeRuntimeCommitProviderError, KolmeRuntimeCommitTransportErrorKind,
+};
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
 pub use http_transport::KolmeRuntimeCommitHttpTransport;
@@ -176,59 +179,6 @@ pub trait KolmeRuntimeCommitClient {
         &mut self,
         request: &KolmeRuntimeCommitRequest,
     ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError>;
-}
-
-/// Typed transport error class emitted when adapter-backed provider calls fail.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitTransportErrorKind {
-    /// Provider call timed out.
-    Timeout,
-    /// Provider transport/channel is unavailable.
-    Unavailable,
-    /// Provider response payload is malformed.
-    MalformedResponse,
-}
-
-/// Provider-facing error for runtime commit adapter wiring.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitProviderError {
-    /// Provider call timed out before a response.
-    Timeout,
-    /// Provider transport/channel is unavailable.
-    Unavailable {
-        /// Provider-specific availability failure reason.
-        reason: String,
-    },
-    /// Provider emitted malformed payload/shape.
-    MalformedResponse {
-        /// Provider-specific malformed payload reason.
-        reason: String,
-    },
-}
-
-impl fmt::Display for KolmeRuntimeCommitProviderError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Timeout => write!(f, "provider request timed out"),
-            Self::Unavailable { reason } => write!(f, "provider unavailable: {reason}"),
-            Self::MalformedResponse { reason } => {
-                write!(f, "provider malformed response: {reason}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for KolmeRuntimeCommitProviderError {}
-
-impl From<KamnKolmeTransportIoClassification> for KolmeRuntimeCommitProviderError {
-    fn from(value: KamnKolmeTransportIoClassification) -> Self {
-        match value {
-            KamnKolmeTransportIoClassification::Timeout => Self::Timeout,
-            KamnKolmeTransportIoClassification::Unavailable { reason } => {
-                Self::Unavailable { reason }
-            }
-        }
-    }
 }
 
 /// Provider receipt payload returned by adapter-facing transport.
@@ -422,101 +372,6 @@ pub trait KolmeRuntimeCommitBlockFallbackTransport {
         height: u64,
     ) -> Result<String, KolmeRuntimeCommitProviderError>;
 }
-
-/// Error returned by runtime commit request validation or submission.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitError {
-    /// Request payload failed validation.
-    InvalidRequest {
-        /// Field failing validation.
-        field: &'static str,
-        /// Validation reason.
-        reason: &'static str,
-    },
-    /// Operation identifier was not found in runtime pipeline state.
-    UnknownOperationId {
-        /// Missing operation identifier.
-        operation_id: String,
-    },
-    /// Runtime attempted invalid lifecycle transition for receipt finality.
-    InvalidFinalityTransition {
-        /// Current lifecycle state label.
-        from: &'static str,
-        /// Target lifecycle state label.
-        to: &'static str,
-    },
-    /// Runtime receipt field differs from the operation's existing receipt marker.
-    ReceiptFieldMismatch {
-        /// Field name that mismatched.
-        field: &'static str,
-        /// Expected persisted value.
-        expected: String,
-        /// Observed incoming value.
-        observed: String,
-    },
-    /// Provider transport failed while submitting runtime commit payload.
-    ProviderTransport {
-        /// Typed transport error kind.
-        kind: KolmeRuntimeCommitTransportErrorKind,
-        /// Deterministic detail text for the transport error.
-        detail: String,
-    },
-    /// Provider identifier did not match configured expected provider.
-    ProviderMismatch {
-        /// Configured provider identifier.
-        expected: String,
-        /// Observed provider identifier from response.
-        observed: String,
-    },
-    /// Provider returned a non-final receipt which is rejected in adapter mode.
-    NonFinalReceipt {
-        /// Commit identifier returned by provider.
-        commit_id: String,
-        /// Observed non-final receipt state.
-        finality: KolmeCommitReceiptFinality,
-    },
-}
-
-impl fmt::Display for KolmeRuntimeCommitError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidRequest { field, reason } => {
-                write!(f, "invalid runtime commit request {field}: {reason}")
-            }
-            Self::UnknownOperationId { operation_id } => {
-                write!(f, "unknown runtime operation id: {operation_id}")
-            }
-            Self::InvalidFinalityTransition { from, to } => {
-                write!(f, "invalid finality transition from {from} to {to}")
-            }
-            Self::ReceiptFieldMismatch {
-                field,
-                expected,
-                observed,
-            } => write!(
-                f,
-                "receipt field mismatch for {field}: expected '{expected}', observed '{observed}'"
-            ),
-            Self::ProviderTransport { kind, detail } => {
-                write!(f, "provider transport failure ({kind:?}): {detail}")
-            }
-            Self::ProviderMismatch { expected, observed } => write!(
-                f,
-                "provider mismatch: expected '{expected}', observed '{observed}'"
-            ),
-            Self::NonFinalReceipt {
-                commit_id,
-                finality,
-            } => write!(
-                f,
-                "provider receipt must be final for commit '{commit_id}', observed {}",
-                commit_finality_label_contract(*finality)
-            ),
-        }
-    }
-}
-
-impl std::error::Error for KolmeRuntimeCommitError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/kamn-core/src/kolme_runtime_commit/errors.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/errors.rs
@@ -1,0 +1,154 @@
+//! Runtime-commit error ownership.
+
+use super::{
+    commit_finality_label_contract, KamnKolmeTransportIoClassification, KolmeCommitReceiptFinality,
+};
+use std::fmt;
+
+/// Typed transport error class emitted when adapter-backed provider calls fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitTransportErrorKind {
+    /// Provider call timed out.
+    Timeout,
+    /// Provider transport/channel is unavailable.
+    Unavailable,
+    /// Provider response payload is malformed.
+    MalformedResponse,
+}
+
+/// Provider-facing error for runtime commit adapter wiring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitProviderError {
+    /// Provider call timed out before a response.
+    Timeout,
+    /// Provider transport/channel is unavailable.
+    Unavailable {
+        /// Provider-specific availability failure reason.
+        reason: String,
+    },
+    /// Provider emitted malformed payload/shape.
+    MalformedResponse {
+        /// Provider-specific malformed payload reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeRuntimeCommitProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "provider request timed out"),
+            Self::Unavailable { reason } => write!(f, "provider unavailable: {reason}"),
+            Self::MalformedResponse { reason } => {
+                write!(f, "provider malformed response: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KolmeRuntimeCommitProviderError {}
+
+impl From<KamnKolmeTransportIoClassification> for KolmeRuntimeCommitProviderError {
+    fn from(value: KamnKolmeTransportIoClassification) -> Self {
+        match value {
+            KamnKolmeTransportIoClassification::Timeout => Self::Timeout,
+            KamnKolmeTransportIoClassification::Unavailable { reason } => {
+                Self::Unavailable { reason }
+            }
+        }
+    }
+}
+
+/// Error returned by runtime commit request validation or submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitError {
+    /// Request payload failed validation.
+    InvalidRequest {
+        /// Field failing validation.
+        field: &'static str,
+        /// Validation reason.
+        reason: &'static str,
+    },
+    /// Operation identifier was not found in runtime pipeline state.
+    UnknownOperationId {
+        /// Missing operation identifier.
+        operation_id: String,
+    },
+    /// Runtime attempted invalid lifecycle transition for receipt finality.
+    InvalidFinalityTransition {
+        /// Current lifecycle state label.
+        from: &'static str,
+        /// Target lifecycle state label.
+        to: &'static str,
+    },
+    /// Runtime receipt field differs from the operation's existing receipt marker.
+    ReceiptFieldMismatch {
+        /// Field name that mismatched.
+        field: &'static str,
+        /// Expected persisted value.
+        expected: String,
+        /// Observed incoming value.
+        observed: String,
+    },
+    /// Provider transport failed while submitting runtime commit payload.
+    ProviderTransport {
+        /// Typed transport error kind.
+        kind: KolmeRuntimeCommitTransportErrorKind,
+        /// Deterministic detail text for the transport error.
+        detail: String,
+    },
+    /// Provider identifier did not match configured expected provider.
+    ProviderMismatch {
+        /// Configured provider identifier.
+        expected: String,
+        /// Observed provider identifier from response.
+        observed: String,
+    },
+    /// Provider returned a non-final receipt which is rejected in adapter mode.
+    NonFinalReceipt {
+        /// Commit identifier returned by provider.
+        commit_id: String,
+        /// Observed non-final receipt state.
+        finality: KolmeCommitReceiptFinality,
+    },
+}
+
+impl fmt::Display for KolmeRuntimeCommitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest { field, reason } => {
+                write!(f, "invalid runtime commit request {field}: {reason}")
+            }
+            Self::UnknownOperationId { operation_id } => {
+                write!(f, "unknown runtime operation id: {operation_id}")
+            }
+            Self::InvalidFinalityTransition { from, to } => {
+                write!(f, "invalid finality transition from {from} to {to}")
+            }
+            Self::ReceiptFieldMismatch {
+                field,
+                expected,
+                observed,
+            } => write!(
+                f,
+                "receipt field mismatch for {field}: expected '{expected}', observed '{observed}'"
+            ),
+            Self::ProviderTransport { kind, detail } => {
+                write!(f, "provider transport failure ({kind:?}): {detail}")
+            }
+            Self::ProviderMismatch { expected, observed } => write!(
+                f,
+                "provider mismatch: expected '{expected}', observed '{observed}'"
+            ),
+            Self::NonFinalReceipt {
+                commit_id,
+                finality,
+            } => write!(
+                f,
+                "provider receipt must be final for commit '{commit_id}', observed {}",
+                commit_finality_label_contract(*finality)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for KolmeRuntimeCommitError {}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -20,6 +20,7 @@ const RUNTIME_NOTIFICATIONS_CONSUMER_SRC: &str =
 const RUNTIME_NOTIFICATIONS_WS_SRC: &str =
     include_str!("../src/kolme_runtime_commit/notifications_websocket.rs");
 const RUNTIME_PIPELINE_SRC: &str = include_str!("../src/kolme_runtime_commit/runtime_pipeline.rs");
+const RUNTIME_ERRORS_SRC: &str = include_str!("../src/kolme_runtime_commit/errors.rs");
 
 #[test]
 fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers() {
@@ -88,6 +89,10 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitNotificationsConsumer"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnector"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitWebsocketConnection"));
+    // Regression: #1960
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitError"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC
@@ -142,7 +147,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("require_kolme_commit_id_matches_expected_txhash_contract("));
     assert!(RUNTIME_PIPELINE_SRC.contains("lifecycle_state_for_finality_contract("));
     assert!(RUNTIME_PIPELINE_SRC.contains("lifecycle_state_label_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("commit_finality_label_contract("));
+    assert!(RUNTIME_ERRORS_SRC.contains("commit_finality_label_contract("));
     assert!(RUNTIME_FINALITY_CHECKER_SRC.contains("is_kolme_terminal_receipt_finality_contract("));
     assert!(RUNTIME_FINALITY_CHECKER_SRC.contains("is_kolme_valid_poll_attempt_budget_contract("));
     assert!(
@@ -290,7 +295,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("is_kolme_valid_transport_wire_payload_input_contract("));
     assert!(RUNTIME_HTTP_TRANSPORT_SRC
         .contains("normalize_kolme_broadcast_submit_path_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
+    assert!(RUNTIME_ERRORS_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod request_envelope;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
@@ -303,6 +308,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("mod fork_finality_resolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_websocket;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod errors;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use request_envelope::{"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use runtime_pipeline::{"));
     assert!(
@@ -323,4 +329,8 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use errors::{"));
+    assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
+    assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
+    assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitError"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -79,6 +79,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1954"));
     assert!(DOC.contains("#1956"));
     assert!(DOC.contains("#1958"));
+    assert!(DOC.contains("#1960"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -97,6 +97,7 @@ Out of scope:
 - #1954: extracted HTTP transport ownership into `kolme_runtime_commit/http_transport.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitHttpTransport` from the dedicated submodule.
 - #1956: extracted API codec ownership into `kolme_runtime_commit/api_codec.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeApiNextNonce*`/`KolmeApiBroadcast*` types from the dedicated submodule.
 - #1958: extracted runtime request/signed-envelope ownership into `kolme_runtime_commit/request_envelope.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitRequest` and `KolmeRuntimeCommitSignedBroadcastEnvelope` from the dedicated submodule.
+- #1960: extracted runtime error ownership into `kolme_runtime_commit/errors.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitTransportErrorKind`, `KolmeRuntimeCommitProviderError`, and `KolmeRuntimeCommitError` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts runtime-commit error ownership from `kolme_runtime_commit.rs` into a dedicated `errors.rs` submodule while preserving the public API via re-exports. This reduces root-module surface area and keeps fail-closed error semantics unchanged.

Closes #1960

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/errors.rs`: new owner module for `KolmeRuntimeCommitTransportErrorKind`, `KolmeRuntimeCommitProviderError`, and `KolmeRuntimeCommitError` + `Display`/`Error`/`From` impls.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: wires `mod errors;`, re-exports moved error types, removes in-file error ownership.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: adds boundary guards ensuring error ownership remains outside root module (`// Regression: #1960`).
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1960` extraction progress marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: adds `#1960` Phase 3 progress entry.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary --test kolme_runtime_commit_extraction_plan_docs`

Observed failure (expected):
`couldn't read ../src/kolme_runtime_commit/errors.rs: No such file or directory`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`

All passed.

### 🔁 Regression
Runtime-commit extraction and behavior suites remain green (boundary/docs/client/finality/notifications).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅ | `kolme_runtime_commit_client`, `kolme_runtime_commit_notifications`, `kolme_runtime_commit_finality` | |
| Integration  | ✅ | integration cases within runtime-commit test targets above | |
| Regression   | ✅ | extraction-boundary ownership guard + existing fail-closed regressions | |
| Performance  | N/A | | Module ownership split only; no runtime/perf-path behavior change |

## Risks & Rollback
- None expected; public API is preserved through re-exports and behavior stays unchanged.
- Rollback: revert this PR to restore in-file error ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
