### PR TITLE
refactor(kolme-runtime): extract runtime outcomes module file (#1962)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -115,36 +115,12 @@ mod in_memory_client;
 mod live_provider;
 mod notifications_consumer;
 mod notifications_websocket;
+mod outcomes;
 mod request_envelope;
 mod runtime_pipeline;
 
 /// Finality classification for a runtime commit receipt.
 pub type KolmeCommitReceiptFinality = KamnKolmeCommitReceiptFinality;
-
-/// Receipt emitted by the runtime commit client.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeRuntimeCommitReceipt {
-    /// Provider identifier.
-    pub provider: String,
-    /// Deterministic commit identifier.
-    pub commit_id: String,
-    /// Finality state for the receipt.
-    pub finality: KolmeCommitReceiptFinality,
-}
-
-/// Typed commit submission result.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitOutcome {
-    /// Request was accepted and submitted.
-    Submitted(KolmeRuntimeCommitReceipt),
-    /// Request matched an existing idempotency key.
-    Duplicate(KolmeRuntimeCommitReceipt),
-    /// Request was rejected with an explicit reason.
-    Rejected {
-        /// Deterministic rejection reason from provider/runtime policy.
-        reason: String,
-    },
-}
 
 /// Runtime lifecycle state projected from commit receipt outcomes.
 pub type RuntimeCommitLifecycleState = KamnKolmeRuntimeCommitLifecycleState;
@@ -167,6 +143,11 @@ pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;
 pub use notifications_websocket::{
     KolmeRuntimeCommitWebsocketConnection, KolmeRuntimeCommitWebsocketConnector,
 };
+pub use outcomes::{
+    KolmeRuntimeCommitNotificationEvent, KolmeRuntimeCommitOutcome,
+    KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderReceipt,
+    KolmeRuntimeCommitReceipt,
+};
 pub use request_envelope::{KolmeRuntimeCommitRequest, KolmeRuntimeCommitSignedBroadcastEnvelope};
 pub use runtime_pipeline::{
     RuntimeCommitFinalityProjection, RuntimeCommitLifecycleRecord, RuntimeCommitPipeline,
@@ -179,134 +160,6 @@ pub trait KolmeRuntimeCommitClient {
         &mut self,
         request: &KolmeRuntimeCommitRequest,
     ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError>;
-}
-
-/// Provider receipt payload returned by adapter-facing transport.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KolmeRuntimeCommitProviderReceipt {
-    /// Provider identifier returned by upstream.
-    pub provider: String,
-    /// Commit identifier returned by upstream.
-    pub commit_id: String,
-    /// Receipt finality classification returned by upstream.
-    pub finality: KolmeCommitReceiptFinality,
-}
-
-/// Typed notification event emitted by Kolme `/notifications` websocket.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitNotificationEvent {
-    /// Finalized transaction notification emitted from a new block event.
-    NewBlock {
-        /// Transaction hash observed in the block payload.
-        txhash: String,
-        /// Optional block height where the transaction finalized.
-        block_height: Option<u64>,
-    },
-    /// Failed transaction notification emitted by processor execution path.
-    FailedTransaction {
-        /// Transaction hash observed in failed-transaction payload.
-        txhash: String,
-        /// Optional proposed block height for the failed transaction.
-        proposed_height: Option<u64>,
-    },
-    /// Latest block watermark notification.
-    LatestBlock {
-        /// Latest observed block height.
-        height: u64,
-    },
-}
-
-impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent {
-    fn from(value: KamnKolmeNotificationEvent) -> Self {
-        match value {
-            KamnKolmeNotificationEvent::NewBlock {
-                txhash,
-                block_height,
-            } => Self::NewBlock {
-                txhash,
-                block_height,
-            },
-            KamnKolmeNotificationEvent::FailedTransaction {
-                txhash,
-                proposed_height,
-            } => Self::FailedTransaction {
-                txhash,
-                proposed_height,
-            },
-            KamnKolmeNotificationEvent::LatestBlock { height } => Self::LatestBlock { height },
-        }
-    }
-}
-
-impl KolmeRuntimeCommitNotificationEvent {
-    /// Converts notification event to a provider receipt when it carries tx finality information.
-    pub fn to_provider_receipt(&self, provider: &str) -> Option<KolmeRuntimeCommitProviderReceipt> {
-        let event = match self {
-            Self::NewBlock {
-                txhash,
-                block_height,
-            } => KamnKolmeNotificationEvent::NewBlock {
-                txhash: txhash.clone(),
-                block_height: *block_height,
-            },
-            Self::FailedTransaction {
-                txhash,
-                proposed_height,
-            } => KamnKolmeNotificationEvent::FailedTransaction {
-                txhash: txhash.clone(),
-                proposed_height: *proposed_height,
-            },
-            Self::LatestBlock { height } => {
-                KamnKolmeNotificationEvent::LatestBlock { height: *height }
-            }
-        };
-        let receipt = notification_event_to_kolme_provider_receipt_contract(provider, &event)?;
-        Some(KolmeRuntimeCommitProviderReceipt {
-            provider: receipt.provider,
-            commit_id: receipt.commit_id,
-            finality: receipt.finality,
-        })
-    }
-}
-
-/// Provider submission outcome used by adapter-backed runtime commit clients.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitProviderOutcome {
-    /// Provider accepted the submission.
-    Submitted(KolmeRuntimeCommitProviderReceipt),
-    /// Provider detected duplicate idempotency key.
-    Duplicate(KolmeRuntimeCommitProviderReceipt),
-    /// Provider rejected the submission with explicit reason.
-    Rejected {
-        /// Deterministic provider rejection reason.
-        reason: String,
-    },
-}
-
-impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome {
-    fn from(value: KamnKolmeRuntimeProviderOutcome) -> Self {
-        match value {
-            KamnKolmeRuntimeProviderOutcome::Submitted {
-                provider,
-                commit_id,
-                finality,
-            } => Self::Submitted(KolmeRuntimeCommitProviderReceipt {
-                provider,
-                commit_id,
-                finality,
-            }),
-            KamnKolmeRuntimeProviderOutcome::Duplicate {
-                provider,
-                commit_id,
-                finality,
-            } => Self::Duplicate(KolmeRuntimeCommitProviderReceipt {
-                provider,
-                commit_id,
-                finality,
-            }),
-            KamnKolmeRuntimeProviderOutcome::Rejected { reason } => Self::Rejected { reason },
-        }
-    }
 }
 
 /// Transport connection abstraction for consuming notifications text messages.

--- a/crates/kamn-core/src/kolme_runtime_commit/outcomes.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/outcomes.rs
@@ -1,0 +1,159 @@
+//! Runtime-commit receipt, outcome, and notification ownership.
+
+use super::{
+    notification_event_to_kolme_provider_receipt_contract, KamnKolmeNotificationEvent,
+    KamnKolmeRuntimeProviderOutcome, KolmeCommitReceiptFinality,
+};
+
+/// Receipt emitted by the runtime commit client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitReceipt {
+    /// Provider identifier.
+    pub provider: String,
+    /// Deterministic commit identifier.
+    pub commit_id: String,
+    /// Finality state for the receipt.
+    pub finality: KolmeCommitReceiptFinality,
+}
+
+/// Typed commit submission result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitOutcome {
+    /// Request was accepted and submitted.
+    Submitted(KolmeRuntimeCommitReceipt),
+    /// Request matched an existing idempotency key.
+    Duplicate(KolmeRuntimeCommitReceipt),
+    /// Request was rejected with an explicit reason.
+    Rejected {
+        /// Deterministic rejection reason from provider/runtime policy.
+        reason: String,
+    },
+}
+
+/// Provider receipt payload returned by adapter-facing transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitProviderReceipt {
+    /// Provider identifier returned by upstream.
+    pub provider: String,
+    /// Commit identifier returned by upstream.
+    pub commit_id: String,
+    /// Receipt finality classification returned by upstream.
+    pub finality: KolmeCommitReceiptFinality,
+}
+
+/// Typed notification event emitted by Kolme `/notifications` websocket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitNotificationEvent {
+    /// Finalized transaction notification emitted from a new block event.
+    NewBlock {
+        /// Transaction hash observed in the block payload.
+        txhash: String,
+        /// Optional block height where the transaction finalized.
+        block_height: Option<u64>,
+    },
+    /// Failed transaction notification emitted by processor execution path.
+    FailedTransaction {
+        /// Transaction hash observed in failed-transaction payload.
+        txhash: String,
+        /// Optional proposed block height for the failed transaction.
+        proposed_height: Option<u64>,
+    },
+    /// Latest block watermark notification.
+    LatestBlock {
+        /// Latest observed block height.
+        height: u64,
+    },
+}
+
+impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent {
+    fn from(value: KamnKolmeNotificationEvent) -> Self {
+        match value {
+            KamnKolmeNotificationEvent::NewBlock {
+                txhash,
+                block_height,
+            } => Self::NewBlock {
+                txhash,
+                block_height,
+            },
+            KamnKolmeNotificationEvent::FailedTransaction {
+                txhash,
+                proposed_height,
+            } => Self::FailedTransaction {
+                txhash,
+                proposed_height,
+            },
+            KamnKolmeNotificationEvent::LatestBlock { height } => Self::LatestBlock { height },
+        }
+    }
+}
+
+impl KolmeRuntimeCommitNotificationEvent {
+    /// Converts notification event to a provider receipt when it carries tx finality information.
+    pub fn to_provider_receipt(&self, provider: &str) -> Option<KolmeRuntimeCommitProviderReceipt> {
+        let event = match self {
+            Self::NewBlock {
+                txhash,
+                block_height,
+            } => KamnKolmeNotificationEvent::NewBlock {
+                txhash: txhash.clone(),
+                block_height: *block_height,
+            },
+            Self::FailedTransaction {
+                txhash,
+                proposed_height,
+            } => KamnKolmeNotificationEvent::FailedTransaction {
+                txhash: txhash.clone(),
+                proposed_height: *proposed_height,
+            },
+            Self::LatestBlock { height } => {
+                KamnKolmeNotificationEvent::LatestBlock { height: *height }
+            }
+        };
+        let receipt = notification_event_to_kolme_provider_receipt_contract(provider, &event)?;
+        Some(KolmeRuntimeCommitProviderReceipt {
+            provider: receipt.provider,
+            commit_id: receipt.commit_id,
+            finality: receipt.finality,
+        })
+    }
+}
+
+/// Provider submission outcome used by adapter-backed runtime commit clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitProviderOutcome {
+    /// Provider accepted the submission.
+    Submitted(KolmeRuntimeCommitProviderReceipt),
+    /// Provider detected duplicate idempotency key.
+    Duplicate(KolmeRuntimeCommitProviderReceipt),
+    /// Provider rejected the submission with explicit reason.
+    Rejected {
+        /// Deterministic provider rejection reason.
+        reason: String,
+    },
+}
+
+impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome {
+    fn from(value: KamnKolmeRuntimeProviderOutcome) -> Self {
+        match value {
+            KamnKolmeRuntimeProviderOutcome::Submitted {
+                provider,
+                commit_id,
+                finality,
+            } => Self::Submitted(KolmeRuntimeCommitProviderReceipt {
+                provider,
+                commit_id,
+                finality,
+            }),
+            KamnKolmeRuntimeProviderOutcome::Duplicate {
+                provider,
+                commit_id,
+                finality,
+            } => Self::Duplicate(KolmeRuntimeCommitProviderReceipt {
+                provider,
+                commit_id,
+                finality,
+            }),
+            KamnKolmeRuntimeProviderOutcome::Rejected { reason } => Self::Rejected { reason },
+        }
+    }
+}

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -21,6 +21,7 @@ const RUNTIME_NOTIFICATIONS_WS_SRC: &str =
     include_str!("../src/kolme_runtime_commit/notifications_websocket.rs");
 const RUNTIME_PIPELINE_SRC: &str = include_str!("../src/kolme_runtime_commit/runtime_pipeline.rs");
 const RUNTIME_ERRORS_SRC: &str = include_str!("../src/kolme_runtime_commit/errors.rs");
+const RUNTIME_OUTCOMES_SRC: &str = include_str!("../src/kolme_runtime_commit/outcomes.rs");
 
 #[test]
 fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers() {
@@ -93,6 +94,18 @@ fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers(
     assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
     assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitError"));
+    // Regression: #1962
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitReceipt"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitOutcome"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub struct KolmeRuntimeCommitProviderReceipt"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitProviderOutcome"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("pub enum KolmeRuntimeCommitNotificationEvent"));
+    assert!(!RUNTIME_COMMIT_SRC
+        .contains("impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent"));
+    assert!(!RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
+    assert!(!RUNTIME_COMMIT_SRC.contains(
+        "impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome"
+    ));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl RuntimeCommitPipeline"));
     assert!(!RUNTIME_COMMIT_SRC.contains("impl InMemoryKolmeRuntimeCommitClient"));
     assert!(!RUNTIME_COMMIT_SRC
@@ -230,17 +243,17 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("is_kolme_valid_notifications_reconnect_budget_contract("));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC.contains("parse_kolme_notification_event_contract("));
-    assert!(RUNTIME_COMMIT_SRC
+    assert!(RUNTIME_OUTCOMES_SRC
         .contains("impl From<KamnKolmeNotificationEvent> for KolmeRuntimeCommitNotificationEvent"));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("compose_kolme_notifications_reconnect_exhausted_reason_contract("));
     assert!(RUNTIME_NOTIFICATIONS_CONSUMER_SRC
         .contains("normalize_kolme_notifications_provider_input_contract("));
-    assert!(RUNTIME_COMMIT_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
+    assert!(RUNTIME_OUTCOMES_SRC.contains("notification_event_to_kolme_provider_receipt_contract("));
     assert!(
         RUNTIME_LIVE_PROVIDER_SRC.contains("parse_kolme_live_runtime_provider_outcome_contract(")
     );
-    assert!(RUNTIME_COMMIT_SRC.contains(
+    assert!(RUNTIME_OUTCOMES_SRC.contains(
         "impl From<KamnKolmeRuntimeProviderOutcome> for KolmeRuntimeCommitProviderOutcome"
     ));
     assert!(RUNTIME_HTTP_TRANSPORT_SRC.contains("parse_kolme_http_response_body("));
@@ -309,6 +322,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_consumer;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod notifications_websocket;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod errors;"));
+    assert!(RUNTIME_COMMIT_SRC.contains("mod outcomes;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use request_envelope::{"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use runtime_pipeline::{"));
     assert!(
@@ -330,7 +344,13 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use errors::{"));
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use outcomes::{"));
     assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
     assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
     assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitError"));
+    assert!(RUNTIME_OUTCOMES_SRC.contains("pub struct KolmeRuntimeCommitReceipt"));
+    assert!(RUNTIME_OUTCOMES_SRC.contains("pub enum KolmeRuntimeCommitOutcome"));
+    assert!(RUNTIME_OUTCOMES_SRC.contains("pub struct KolmeRuntimeCommitProviderReceipt"));
+    assert!(RUNTIME_OUTCOMES_SRC.contains("pub enum KolmeRuntimeCommitProviderOutcome"));
+    assert!(RUNTIME_OUTCOMES_SRC.contains("pub enum KolmeRuntimeCommitNotificationEvent"));
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs
@@ -80,6 +80,7 @@ fn regression_requires_phase_gates_and_validation_matrix_markers() {
     assert!(DOC.contains("#1956"));
     assert!(DOC.contains("#1958"));
     assert!(DOC.contains("#1960"));
+    assert!(DOC.contains("#1962"));
     assert!(DOC.contains("## Validation Matrix"));
     assert!(DOC.contains("Regression: #1814"));
 }

--- a/docs/planning/kolme_runtime_commit_extraction_plan.md
+++ b/docs/planning/kolme_runtime_commit_extraction_plan.md
@@ -98,6 +98,7 @@ Out of scope:
 - #1956: extracted API codec ownership into `kolme_runtime_commit/api_codec.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeApiNextNonce*`/`KolmeApiBroadcast*` types from the dedicated submodule.
 - #1958: extracted runtime request/signed-envelope ownership into `kolme_runtime_commit/request_envelope.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitRequest` and `KolmeRuntimeCommitSignedBroadcastEnvelope` from the dedicated submodule.
 - #1960: extracted runtime error ownership into `kolme_runtime_commit/errors.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitTransportErrorKind`, `KolmeRuntimeCommitProviderError`, and `KolmeRuntimeCommitError` from the dedicated submodule.
+- #1962: extracted runtime receipt/outcome/notification ownership into `kolme_runtime_commit/outcomes.rs` and rewired `kolme_runtime_commit.rs` to re-export `KolmeRuntimeCommitReceipt`, `KolmeRuntimeCommitOutcome`, `KolmeRuntimeCommitProviderReceipt`, `KolmeRuntimeCommitProviderOutcome`, and `KolmeRuntimeCommitNotificationEvent` from the dedicated submodule.
 
 ## Phase 3 - Adapter and lifecycle orchestration extraction
 - split remaining adapter/transport bridge glue into dedicated modules (or subcrate) with explicit ownership,


### PR DESCRIPTION
## Summary
Extracts runtime-commit receipt/outcome/notification ownership from `kolme_runtime_commit.rs` into a dedicated `outcomes.rs` submodule while preserving the public API via re-exports. This further narrows root-module ownership without behavior drift.

Closes #1962

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/outcomes.rs`: new owner module for receipt/outcome/provider-outcome/notification data types and conversion impls.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: wires `mod outcomes;`, re-exports moved types, removes in-file outcome/notification ownership.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: adds boundary guards ensuring runtime outcomes ownership remains outside root module (`// Regression: #1962`).
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_plan_docs.rs`: requires `#1962` extraction progress marker.
- `docs/planning/kolme_runtime_commit_extraction_plan.md`: adds `#1962` Phase 3 progress entry.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary --test kolme_runtime_commit_extraction_plan_docs`

Observed failure (expected):
`couldn't read ../src/kolme_runtime_commit/outcomes.rs: No such file or directory`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo clippy -p kamn-kolme --tests -- -D warnings`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_plan_docs`
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_finality`
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`

All passed.

### 🔁 Regression
Runtime-commit extraction and behavior suites remain green (boundary/docs/client/finality/notifications).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `kolme_runtime_commit_extraction_boundary` | |
| Functional   | ✅ | `kolme_runtime_commit_client`, `kolme_runtime_commit_notifications`, `kolme_runtime_commit_finality` | |
| Integration  | ✅ | integration cases within runtime-commit test targets above | |
| Regression   | ✅ | extraction-boundary ownership guard + existing fail-closed regressions | |
| Performance  | N/A | | Module ownership split only; no runtime/perf-path behavior change |

## Risks & Rollback
- None expected; public API is preserved through re-exports and behavior stays unchanged.
- Rollback: revert this PR to restore in-file outcome ownership in `kolme_runtime_commit.rs`.

## Documentation Updates
- `docs/planning/kolme_runtime_commit_extraction_plan.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-kolme --tests -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
