### PR TITLE
feat(kolme-lanes): add optional finality step to runtime live lane (#1969)

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -609,6 +609,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode dry-run --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
 - Explicit opt-in live execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
+- Optional post-submit finality follow-up execution:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --skip-preflight --live-command "printf 'status=submitted\\n'" --finality-command "printf 'finality=final\\n'" --finality-max-seconds 15 --max-seconds 90 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt --finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt`
 - Default live-provider smoke command executed by run mode:
   - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
 - Summary schema:
@@ -617,6 +619,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - bounded preflight probe against `<base-url>/healthz` before live submit execution (unless `--skip-preflight` is explicitly set)
   - explicit local-only opt-in marker (`KAMN_KOLME_LOCAL_HEAVY=1`)
   - bounded live command timeout via `--max-seconds`
+  - optional finality command timeout bound via `--finality-max-seconds`
   - machine-readable pass/fail reason codes for missing opt-in, preflight failure/timeout, command failure, and command timeout
 - Cost policy:
   - run mode fails closed without explicit local-only opt-in.

--- a/scripts/kolme/run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane.sh
@@ -8,12 +8,15 @@ MODE="dry-run"
 OUTPUT_JSON="/tmp/kolme-local-runtime-commit-live-summary.json"
 LIVE_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-output.txt"
 LIVE_COMMAND=""
+FINALITY_COMMAND=""
 MAX_SECONDS=90
 BASE_URL="http://127.0.0.1:3000"
 PROVIDER_HINT="kolme-fork-local"
 AUTHORIZATION_HEADER=""
 PREFLIGHT_MAX_SECONDS=10
+FINALITY_MAX_SECONDS=15
 SKIP_PREFLIGHT=0
+FINALITY_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-finality-output.txt"
 
 shell_escape() {
   printf "%q" "$1"
@@ -72,6 +75,30 @@ while [ "$#" -gt 0 ]; do
       MAX_SECONDS="$2"
       shift 2
       ;;
+    --finality-command)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --finality-command" >&2
+        exit 1
+      fi
+      FINALITY_COMMAND="$2"
+      shift 2
+      ;;
+    --finality-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --finality-max-seconds" >&2
+        exit 1
+      fi
+      FINALITY_MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --finality-output-file)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --finality-output-file" >&2
+        exit 1
+      fi
+      FINALITY_OUTPUT_FILE="$2"
+      shift 2
+      ;;
     --base-url)
       if [ "$#" -lt 2 ]; then
         echo "missing value for --base-url" >&2
@@ -117,6 +144,9 @@ Options:
   --output-json <path>          Deterministic summary report output path.
   --live-output-file <path>     Captured stdout/stderr for live command.
   --live-command <command>      Runtime-commit submit/finality command for run mode.
+  --finality-command <command>  Optional post-submit finality command for run mode.
+  --finality-output-file <path> Captured stdout/stderr for finality command.
+  --finality-max-seconds <n>    Max runtime budget in seconds for finality command.
   --max-seconds <n>             Max runtime budget in seconds for run mode.
   --base-url <url>              Live Kolme base URL used by default smoke command.
   --provider-hint <value>       Provider hint used by default live smoke command.
@@ -145,6 +175,11 @@ fi
 
 if ! [[ "$PREFLIGHT_MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$PREFLIGHT_MAX_SECONDS" -le 0 ]; then
   echo "preflight-max-seconds must be a positive integer" >&2
+  exit 1
+fi
+
+if ! [[ "$FINALITY_MAX_SECONDS" =~ ^[0-9]+$ ]] || [ "$FINALITY_MAX_SECONDS" -le 0 ]; then
+  echo "finality-max-seconds must be a positive integer" >&2
   exit 1
 fi
 
@@ -186,8 +221,13 @@ elapsed_seconds=0
 local_only_enforced="true"
 
 planned_command="$LIVE_COMMAND"
+planned_finality_command="$FINALITY_COMMAND"
+if [ -z "$planned_finality_command" ]; then
+  planned_finality_command="<not-configured>"
+fi
 record_check "runtime_commit_live_preflight" "$preflight_command" "planned"
 record_check "runtime_commit_live_command" "$planned_command" "planned"
+record_check "runtime_commit_live_finality_command" "$planned_finality_command" "planned"
 
 if [ "$MODE" = "run" ]; then
   : >"$CHECK_FILE"
@@ -195,6 +235,7 @@ if [ "$MODE" = "run" ]; then
 
   if ! "$LOCAL_HEAVY_GUARD"; then
     record_check "runtime_commit_live_command" "$planned_command" "fail"
+    record_check "runtime_commit_live_finality_command" "$planned_finality_command" "skipped"
     overall_status="fail"
     reason_code="local_opt_in_missing"
   elif [ "$SKIP_PREFLIGHT" -eq 1 ]; then
@@ -211,10 +252,12 @@ if [ "$MODE" = "run" ]; then
       record_check "runtime_commit_live_preflight" "$preflight_command" "fail"
       overall_status="fail"
       reason_code="live_preflight_timeout"
+      record_check "runtime_commit_live_finality_command" "$planned_finality_command" "skipped"
     else
       record_check "runtime_commit_live_preflight" "$preflight_command" "fail"
       overall_status="fail"
       reason_code="live_preflight_failed"
+      record_check "runtime_commit_live_finality_command" "$planned_finality_command" "skipped"
     fi
   fi
 
@@ -233,16 +276,44 @@ if [ "$MODE" = "run" ]; then
       record_check "runtime_commit_live_command" "$LIVE_COMMAND" "fail"
       overall_status="fail"
       reason_code="live_runtime_commit_command_timeout"
+      record_check "runtime_commit_live_finality_command" "$planned_finality_command" "skipped"
     else
       record_check "runtime_commit_live_command" "$LIVE_COMMAND" "fail"
       overall_status="fail"
       reason_code="live_runtime_commit_command_failed"
+      record_check "runtime_commit_live_finality_command" "$planned_finality_command" "skipped"
+    fi
+  fi
+
+  if [ "$overall_status" = "ok" ]; then
+    if [ -n "$FINALITY_COMMAND" ]; then
+      mkdir -p "$(dirname "$FINALITY_OUTPUT_FILE")"
+      finality_exit_code=0
+      set +e
+      timeout "${FINALITY_MAX_SECONDS}" bash -lc "$FINALITY_COMMAND" >"$FINALITY_OUTPUT_FILE" 2>&1
+      finality_exit_code=$?
+      set -e
+
+      if [ "$finality_exit_code" -eq 0 ]; then
+        record_check "runtime_commit_live_finality_command" "$FINALITY_COMMAND" "pass"
+        reason_code="live_runtime_commit_and_finality_commands_passed"
+      elif [ "$finality_exit_code" -eq 124 ]; then
+        record_check "runtime_commit_live_finality_command" "$FINALITY_COMMAND" "fail"
+        overall_status="fail"
+        reason_code="live_finality_command_timeout"
+      else
+        record_check "runtime_commit_live_finality_command" "$FINALITY_COMMAND" "fail"
+        overall_status="fail"
+        reason_code="live_finality_command_failed"
+      fi
+    else
+      record_check "runtime_commit_live_finality_command" "$planned_finality_command" "skipped"
     fi
   fi
 
   end_epoch="$(date +%s)"
   elapsed_seconds="$(( end_epoch - start_epoch ))"
-  if [ "$elapsed_seconds" -le "$MAX_SECONDS" ] && [ "$reason_code" != "live_runtime_commit_command_timeout" ]; then
+  if [ "$elapsed_seconds" -le "$MAX_SECONDS" ] && [ "$reason_code" != "live_runtime_commit_command_timeout" ] && [ "$reason_code" != "live_finality_command_timeout" ]; then
     budget_status="within_budget"
   else
     budget_status="exceeded_budget"
@@ -253,7 +324,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$FINALITY_COMMAND" "$FINALITY_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$FINALITY_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -270,11 +341,14 @@ max_seconds = int(sys.argv[7])
 budget_status = sys.argv[8]
 live_command = sys.argv[9]
 live_output_file = sys.argv[10]
-base_url = sys.argv[11]
-provider_hint = sys.argv[12]
-preflight_max_seconds = int(sys.argv[13])
-skip_preflight = sys.argv[14] == "1"
-checks_path = pathlib.Path(sys.argv[15])
+finality_command = sys.argv[11]
+finality_output_file = sys.argv[12]
+base_url = sys.argv[13]
+provider_hint = sys.argv[14]
+preflight_max_seconds = int(sys.argv[15])
+finality_max_seconds = int(sys.argv[16])
+skip_preflight = sys.argv[17] == "1"
+checks_path = pathlib.Path(sys.argv[18])
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -303,6 +377,10 @@ summary = {
     "budget_status": budget_status,
     "live_command": live_command,
     "live_output_file": live_output_file,
+    "finality_command": finality_command,
+    "finality_output_file": finality_output_file,
+    "finality_enabled": bool(finality_command.strip()),
+    "finality_max_seconds": finality_max_seconds,
     "base_url": base_url,
     "provider_hint": provider_hint,
     "preflight_enabled": not skip_preflight,
@@ -310,6 +388,7 @@ summary = {
     "checks": checks,
     "artifact_paths": [
         live_output_file,
+        finality_output_file,
     ],
 }
 

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -7,8 +7,9 @@ LOCAL_HEAVY_GUARD="$ROOT_DIR/scripts/framework/assert_local_heavy_opt_in.sh"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 TMP_REPORT="$(mktemp)"
 TMP_OUTPUT="$(mktemp)"
+TMP_FINALITY_OUTPUT="$(mktemp)"
 TMP_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_ERR"' EXIT
 
 extract_value() {
   local output="$1"
@@ -38,6 +39,17 @@ fi
 
 if ! grep -q "scripts/framework/assert_local_heavy_opt_in.sh" "$RUNNER"; then
   echo "expected runtime commit live runner to invoke shared local-heavy opt-in guard helper" >&2
+  exit 1
+fi
+
+# Regression: #1969
+if ! grep -q -- "--finality-command" "$RUNNER"; then
+  echo "expected runtime commit live runner to expose optional finality command argument" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_live_finality_command" "$RUNNER"; then
+  echo "expected runtime commit live runner to emit finality command check markers" >&2
   exit 1
 fi
 
@@ -80,6 +92,11 @@ if not any(
     for check in checks
 ):
     raise SystemExit("expected planned runtime commit live preflight check")
+if not any(
+    check.get("id") == "runtime_commit_live_finality_command" and check.get("status") == "planned"
+    for check in checks
+):
+    raise SystemExit("expected planned runtime commit live finality check")
 PY
 
 set +e
@@ -127,10 +144,10 @@ run_output="$(
     bash "$RUNNER" \
       --mode run \
       --skip-preflight \
-      --live-command "printf 'status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n'" \
-      --max-seconds 5 \
-      --output-json "$TMP_REPORT" \
-      --live-output-file "$TMP_OUTPUT"
+    --live-command "printf 'status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n'" \
+    --max-seconds 5 \
+    --output-json "$TMP_REPORT" \
+    --live-output-file "$TMP_OUTPUT"
 )"
 
 assert_eq "$(extract_value "$run_output" "status")" "ok" "expected run mode to pass"
@@ -157,6 +174,42 @@ if report.get("max_seconds") != 5:
     raise SystemExit("expected max_seconds=5")
 if "status=submitted" not in live_output:
     raise SystemExit("expected live command output marker")
+if report.get("finality_enabled") is not False:
+    raise SystemExit("expected finality_enabled=false when no finality command is configured")
+PY
+
+run_with_finality_output="$(
+  KAMN_KOLME_LOCAL_HEAVY=1 \
+    bash "$RUNNER" \
+      --mode run \
+      --skip-preflight \
+      --live-command "printf 'status=submitted\n'" \
+      --finality-command "printf 'finality=final\n'" \
+      --finality-max-seconds 3 \
+      --max-seconds 5 \
+      --output-json "$TMP_REPORT" \
+      --live-output-file "$TMP_OUTPUT" \
+      --finality-output-file "$TMP_FINALITY_OUTPUT"
+)"
+
+assert_eq "$(extract_value "$run_with_finality_output" "status")" "ok" "expected run mode with finality command to pass"
+assert_eq "$(extract_value "$run_with_finality_output" "reason_code")" "live_runtime_commit_and_finality_commands_passed" "expected combined pass reason code"
+
+python3 - "$TMP_REPORT" "$TMP_FINALITY_OUTPUT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+finality_output = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+if report.get("finality_enabled") is not True:
+    raise SystemExit("expected finality_enabled=true when finality command is configured")
+if report.get("reason_code") != "live_runtime_commit_and_finality_commands_passed":
+    raise SystemExit("expected combined pass reason code in summary")
+if "finality=final" not in finality_output:
+    raise SystemExit("expected finality command output marker")
 PY
 
 set +e
@@ -178,6 +231,31 @@ fi
 
 if ! grep -q "reason_code=live_runtime_commit_command_timeout" "$TMP_ERR"; then
   echo "expected timeout reason marker" >&2
+  exit 1
+fi
+
+set +e
+KAMN_KOLME_LOCAL_HEAVY=1 \
+  bash "$RUNNER" \
+    --mode run \
+    --skip-preflight \
+    --live-command "printf 'status=submitted\n'" \
+    --finality-command "sleep 2" \
+    --finality-max-seconds 1 \
+    --max-seconds 5 \
+    --output-json "$TMP_REPORT" \
+    --live-output-file "$TMP_OUTPUT" \
+    --finality-output-file "$TMP_FINALITY_OUTPUT" >"$TMP_ERR" 2>&1
+finality_timeout_code=$?
+set -e
+
+if [ "$finality_timeout_code" -eq 0 ]; then
+  echo "expected finality command timeout to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "reason_code=live_finality_command_timeout" "$TMP_ERR"; then
+  echo "expected finality timeout reason marker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Adds an optional post-submit finality command step to the local runtime-commit live lane runner. The lane now supports bounded finality follow-up execution with deterministic status/reason reporting while preserving local-only heavy guard behavior.

Closes #1969

## Changes
- `scripts/kolme/run_local_runtime_commit_live_lane.sh`
  - Adds `--finality-command`, `--finality-max-seconds`, and `--finality-output-file`.
  - Records deterministic `runtime_commit_live_finality_command` check status.
  - Adds summary/report fields: `finality_command`, `finality_output_file`, `finality_enabled`, `finality_max_seconds`.
  - Adds fail-closed reason codes for finality command failure/timeout.
- `scripts/kolme/test_run_local_runtime_commit_live_lane.sh`
  - Adds regression guard (`Regression: #1969`) for finality-command command surface.
  - Adds run-mode success test with finality command and timeout-failure test.
- `docs/planning/kolme-devnet-ops.md`
  - Documents optional finality follow-up command usage and bounded timeout behavior.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh`

Observed failure (expected):
`expected runtime commit live runner to expose optional finality command argument`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`

All passed.

### 🔁 Regression
Regression guard is explicit in lane contract test (`Regression: #1969`) and docs contract suite remains green.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `test_run_local_runtime_commit_live_lane.sh` argument/marker guards | |
| Functional   | ✅ | `test_run_local_runtime_commit_live_lane.sh` finality pass/timeout behavior | |
| Integration  | ✅ | `test_run_local_kamn_live_runtime_integration_contract_lane.sh`, `test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | |
| Regression   | ✅ | explicit `Regression: #1969` marker check | |
| Performance  | N/A | | Local-only bounded lane extension; no CI fast-gate expansion |

## Risks & Rollback
- Risk: low/medium; changes are confined to local lane orchestration.
- Rollback: revert this PR to restore previous live-lane behavior without optional finality step.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] TDD Red/Green evidence included above
- [x] Relevant local contract and docs tests are clean
