### PR TITLE
feat(kolme-lanes): add runtime finality pass-through in integration lane (#1971)

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,10 @@ bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-ru
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 210 --bootstrap-max-seconds 90 --localhost-signed-max-seconds 45 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
 
+# optional nested runtime finality follow-up pass-through
+KAMN_KOLME_LOCAL_HEAVY=1 \
+bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-commit-finality-command "printf 'finality=final\n'" --runtime-commit-finality-max-seconds 15 --runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
+
 # policy checker contract
 python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json
 

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -390,6 +390,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Explicit local-only live runtime integration execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 210 --bootstrap-max-seconds 90 --localhost-signed-max-seconds 45 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+- Optional runtime finality pass-through to nested live runner:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-commit-finality-command "printf 'finality=final\n'" --runtime-commit-finality-max-seconds 15 --runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Policy checker command:
   - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
 - Contract lane command:
@@ -401,6 +403,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `run_localhost_signed_integration_contract_lane.sh` run-mode validation of signed message admission/replay guards before Kolme runtime commit execution.
   - `run_local_kolme_live_api_conformance_harness.sh` run-mode validation for health/query/nonce/broadcast command contracts.
   - `run_local_runtime_commit_live_lane.sh` run-mode execution as the default runtime-commit endpoint step (no raw curl fallback by default).
+  - optional runtime finality pass-through (`--runtime-commit-finality-command`, `--runtime-commit-finality-max-seconds`, `--runtime-commit-finality-output-file`) is wired through to nested `run_local_runtime_commit_live_lane.sh`.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.
   - finality verification uses `/notifications` first with bounded `/block/{height}` fallback; no runtime commit status endpoint dependency.
@@ -777,6 +780,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local live API conformance harness fails closed for probe/native parity prerequisite failures, runtime budget overruns, and endpoint contract drift (`Regression: #1483`).
 - local fork bootstrap/readiness lane fails closed for sync/probe prerequisite failures, runtime budget overruns, and missing local opt-in (`Regression: #1488`).
 - local KAMN live runtime integration lane fails closed for bootstrap/localhost-signed/conformance/runtime-commit prerequisite drift, runtime budget overruns, and missing local opt-in (`Regression: #1489`).
+- local KAMN live runtime integration lane propagates runtime finality pass-through options and artifacts to nested runtime live lane command composition (`Regression: #1971`).
 - local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`).
 - unified local signed-to-Kolme demo lane fails closed for local opt-in, stage prerequisite drift, and runtime budget overruns (`Regression: #1640`).
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -168,14 +168,24 @@ def main() -> int:
     if "run_local_kamn_live_runtime_integration_contract_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference local KAMN live runtime integration contract lane", file=sys.stderr)
         return 1
+    # Regression: #1971
+    if "--runtime-commit-finality-command" not in doc_text:
+        print("expected Kolme devnet ops doc to document runtime finality pass-through command option", file=sys.stderr)
+        return 1
     if "run_localhost_signed_integration_contract_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference localhost signed integration prerequisite lane", file=sys.stderr)
         return 1
     if "Regression: #1489" not in doc_text:
         print("expected Kolme devnet ops doc to include local KAMN live runtime integration regression marker", file=sys.stderr)
         return 1
+    if "Regression: #1971" not in doc_text:
+        print("expected Kolme devnet ops doc to include runtime finality pass-through regression marker", file=sys.stderr)
+        return 1
     if "run_local_kamn_live_runtime_integration_contract_lane.sh" not in readme_text:
         print("expected README to reference local KAMN live runtime integration contract lane", file=sys.stderr)
+        return 1
+    if "--runtime-commit-finality-command" not in readme_text:
+        print("expected README to document runtime finality pass-through command option", file=sys.stderr)
         return 1
 
     elapsed_seconds = int(time.monotonic() - start_epoch)

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -15,6 +15,9 @@ CONFORMANCE_REPORT="/tmp/kolme-local-live-api-conformance-summary.json"
 LOCALHOST_SIGNED_REPORT="/tmp/localhost-signed-integration-contract-report.json"
 RUNTIME_COMMIT_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-endpoint-output.txt"
 RUNTIME_COMMIT_LIVE_SUMMARY="/tmp/kolme-local-runtime-commit-live-summary.json"
+RUNTIME_COMMIT_FINALITY_COMMAND=""
+RUNTIME_COMMIT_FINALITY_MAX_SECONDS=15
+RUNTIME_COMMIT_FINALITY_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-finality-output.txt"
 CHECKOUT_PATH="/tmp/kolme_fork"
 EXPECTED_REMOTE_URL="https://github.com/njfio/kolme_fork.git"
 EXPECTED_REF="refs/heads/main"
@@ -87,6 +90,30 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       RUNTIME_COMMIT_LIVE_SUMMARY="$2"
+      shift 2
+      ;;
+    --runtime-commit-finality-command)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --runtime-commit-finality-command" >&2
+        exit 1
+      fi
+      RUNTIME_COMMIT_FINALITY_COMMAND="$2"
+      shift 2
+      ;;
+    --runtime-commit-finality-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --runtime-commit-finality-max-seconds" >&2
+        exit 1
+      fi
+      RUNTIME_COMMIT_FINALITY_MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --runtime-commit-finality-output-file)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --runtime-commit-finality-output-file" >&2
+        exit 1
+      fi
+      RUNTIME_COMMIT_FINALITY_OUTPUT_FILE="$2"
       shift 2
       ;;
     --checkout-path)
@@ -189,6 +216,12 @@ Options:
   --localhost-signed-report <path>      Output path for localhost signed integration summary.
   --runtime-commit-output-file <path>   Captured stdout/stderr for runtime-commit endpoint command.
   --runtime-commit-live-summary <path>  Summary report output path for nested runtime-commit live lane runner.
+  --runtime-commit-finality-command <command>
+                                      Optional finality command passed through to nested runtime-commit live lane.
+  --runtime-commit-finality-max-seconds <n>
+                                      Max budget for runtime finality command passed through to nested live lane.
+  --runtime-commit-finality-output-file <path>
+                                      Captured stdout/stderr path for runtime finality command passed through to nested live lane.
   --checkout-path <path>                Local kolme_fork checkout path.
   --expected-remote-url <url>           Expected origin URL for checkout validation.
   --expected-ref <ref>                  Expected symbolic HEAD ref for checkout.
@@ -225,7 +258,7 @@ if [ -z "$BASE_URL" ] || [ -z "$FORK_CHAIN_VERSION" ]; then
   exit 1
 fi
 
-for numeric_value in "$MAX_SECONDS" "$BOOTSTRAP_MAX_SECONDS" "$CONFORMANCE_MAX_SECONDS" "$LOCALHOST_SIGNED_MAX_SECONDS" "$RUNTIME_COMMIT_MAX_SECONDS"; do
+for numeric_value in "$MAX_SECONDS" "$BOOTSTRAP_MAX_SECONDS" "$CONFORMANCE_MAX_SECONDS" "$LOCALHOST_SIGNED_MAX_SECONDS" "$RUNTIME_COMMIT_MAX_SECONDS" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS"; do
   if ! [[ "$numeric_value" =~ ^[0-9]+$ ]] || [ "$numeric_value" -le 0 ]; then
     echo "all max-second arguments must be positive integers" >&2
     exit 1
@@ -258,6 +291,9 @@ if [ ! -x "$LOCAL_HEAVY_GUARD" ]; then
 fi
 
 default_runtime_commit_command="KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url $(shell_escape "${BASE_URL}") --provider-hint kolme-fork-local --max-seconds ${RUNTIME_COMMIT_MAX_SECONDS} --preflight-max-seconds 10 --output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_SUMMARY}") --live-output-file $(shell_escape "${RUNTIME_COMMIT_OUTPUT_FILE}")"
+if [ -n "$RUNTIME_COMMIT_FINALITY_COMMAND" ]; then
+  default_runtime_commit_command="${default_runtime_commit_command} --finality-command $(shell_escape "${RUNTIME_COMMIT_FINALITY_COMMAND}") --finality-max-seconds ${RUNTIME_COMMIT_FINALITY_MAX_SECONDS} --finality-output-file $(shell_escape "${RUNTIME_COMMIT_FINALITY_OUTPUT_FILE}")"
+fi
 if [ -z "$RUNTIME_COMMIT_COMMAND" ]; then
   RUNTIME_COMMIT_COMMAND="$default_runtime_commit_command"
 fi
@@ -451,7 +487,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$CHECK_FILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$CHECK_FILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -473,14 +509,17 @@ budget_status = sys.argv[12]
 runtime_commit_command = sys.argv[13]
 runtime_commit_output_file = sys.argv[14]
 runtime_commit_live_summary = sys.argv[15]
-bootstrap_report = sys.argv[16]
-localhost_signed_report = sys.argv[17]
-conformance_report = sys.argv[18]
-bootstrap_reason_code = sys.argv[19]
-localhost_signed_reason_code = sys.argv[20]
-conformance_reason_code = sys.argv[21]
-runtime_commit_reason_code = sys.argv[22]
-checks_path = pathlib.Path(sys.argv[23])
+runtime_commit_finality_command = sys.argv[16]
+runtime_commit_finality_output_file = sys.argv[17]
+runtime_commit_finality_max_seconds = int(sys.argv[18])
+bootstrap_report = sys.argv[19]
+localhost_signed_report = sys.argv[20]
+conformance_report = sys.argv[21]
+bootstrap_reason_code = sys.argv[22]
+localhost_signed_reason_code = sys.argv[23]
+conformance_reason_code = sys.argv[24]
+runtime_commit_reason_code = sys.argv[25]
+checks_path = pathlib.Path(sys.argv[26])
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -514,6 +553,10 @@ summary = {
     "base_url": base_url,
     "fork_chain_version": fork_chain_version,
     "runtime_commit_command": runtime_commit_command,
+    "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
+    "runtime_commit_finality_output_file": runtime_commit_finality_output_file if runtime_commit_finality_command else "",
+    "runtime_commit_finality_enabled": bool(runtime_commit_finality_command),
+    "runtime_commit_finality_max_seconds": runtime_commit_finality_max_seconds,
     "bootstrap_reason_code": bootstrap_reason_code,
     "localhost_signed_reason_code": localhost_signed_reason_code,
     "conformance_reason_code": conformance_reason_code,
@@ -533,6 +576,9 @@ summary = {
         runtime_commit_live_summary,
     ],
 }
+
+if runtime_commit_finality_command:
+    summary["artifact_paths"].append(runtime_commit_finality_output_file)
 
 output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -33,6 +33,19 @@ if ! grep -q "run_local_runtime_commit_live_lane.sh" "$ROOT_DIR/scripts/kolme/ru
   exit 1
 fi
 
+# Regression: #1971
+required_runtime_finality_markers=(
+  "--runtime-commit-finality-command"
+  "--runtime-commit-finality-max-seconds"
+  "--runtime-commit-finality-output-file"
+)
+for marker in "${required_runtime_finality_markers[@]}"; do
+  if ! grep -q -- "$marker" "$ROOT_DIR/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh"; then
+    echo "expected local KAMN live runtime integration runner to expose finality pass-through marker: $marker" >&2
+    exit 1
+  fi
+done
+
 if [ ! -f "$MANIFEST" ]; then
   echo "expected local KAMN live runtime integration contract lane manifest to exist" >&2
   exit 1
@@ -63,6 +76,7 @@ required_coverage_markers=(
   "check_local_kamn_live_runtime_integration_policy.py"
   "run_localhost_signed_integration_contract_lane.sh"
   "Regression: #1489"
+  "Regression: #1971"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -81,6 +95,11 @@ if ! grep -q "run_local_kamn_live_runtime_integration_contract_lane.sh" "$DOC_FI
   exit 1
 fi
 
+if ! grep -q -- "--runtime-commit-finality-command" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to document runtime finality pass-through command option" >&2
+  exit 1
+fi
+
 if ! grep -q "check_local_kamn_live_runtime_integration_policy.py" "$README_FILE"; then
   echo "expected README to reference local KAMN live runtime integration policy checker" >&2
   exit 1
@@ -88,6 +107,11 @@ fi
 
 if ! grep -q "run_local_kamn_live_runtime_integration_contract_lane.sh" "$README_FILE"; then
   echo "expected README to reference local KAMN live runtime integration contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q -- "--runtime-commit-finality-command" "$README_FILE"; then
+  echo "expected README to document runtime finality pass-through command option" >&2
   exit 1
 fi
 
@@ -116,6 +140,40 @@ if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-integrati
     raise SystemExit("unexpected local KAMN live runtime integration contract-lane policy schema")
 if policy.get("final_decision") != "GO":
     raise SystemExit("expected local KAMN live runtime integration contract-lane policy final_decision GO")
+PY
+
+TMP_DIRECT_SUMMARY="$(mktemp)"
+TMP_DIRECT_RUNTIME_OUTPUT="$(mktemp)"
+TMP_DIRECT_RUNTIME_FINALITY_OUTPUT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_RUNTIME_OUTPUT" "$TMP_DIRECT_RUNTIME_FINALITY_OUTPUT"' EXIT
+
+bash "$ROOT_DIR/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh" \
+  --mode dry-run \
+  --runtime-commit-finality-command "printf 'finality=final\n'" \
+  --runtime-commit-finality-max-seconds 12 \
+  --runtime-commit-finality-output-file "$TMP_DIRECT_RUNTIME_FINALITY_OUTPUT" \
+  --runtime-commit-output-file "$TMP_DIRECT_RUNTIME_OUTPUT" \
+  --runtime-commit-live-summary "$TMP_DIRECT_SUMMARY.runtime.json" \
+  --output-json "$TMP_DIRECT_SUMMARY" >/dev/null
+
+python3 - "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_RUNTIME_FINALITY_OUTPUT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+runtime_command = summary.get("runtime_commit_command", "")
+if "--finality-command" not in runtime_command:
+    raise SystemExit("expected runtime commit command to include finality command pass-through")
+if "--finality-max-seconds 12" not in runtime_command:
+    raise SystemExit("expected runtime commit command to include finality max seconds pass-through")
+finality_output_path = pathlib.Path(sys.argv[2]).resolve()
+if f"--finality-output-file {finality_output_path}" not in runtime_command:
+    raise SystemExit("expected runtime commit command to include finality output pass-through")
+if str(finality_output_path) not in summary.get("artifact_paths", []):
+    raise SystemExit("expected integration summary artifact paths to include runtime finality output file")
 PY
 
 echo "local KAMN live runtime integration contract lane tests passed."


### PR DESCRIPTION
## Summary
Add runtime finality pass-through controls to the local KAMN live runtime integration lane so nested runtime-commit live execution can run optional submit+finality flows from one integration-lane entrypoint. This keeps local-only live validation orchestrated and auditable without adding CI-heavy defaults.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: add `--runtime-commit-finality-command`, `--runtime-commit-finality-max-seconds`, and `--runtime-commit-finality-output-file`; wire options into default nested `run_local_runtime_commit_live_lane.sh` command; include finality metadata/artifact path in summary output.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: add regression checks for pass-through option surface and dry-run command composition (`Regression: #1971`).
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: enforce docs/readme and regression marker coverage for new pass-through command option.
- `docs/planning/kolme-devnet-ops.md`: document optional runtime finality pass-through usage and add regression marker.
- `README.md`: document optional runtime finality pass-through invocation for local integration lane.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
```
Output:
```text
expected local KAMN live runtime integration runner to expose finality pass-through marker: --runtime-commit-finality-command
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Output summary:
```text
local KAMN live runtime integration contract lane tests passed.
local fork process lifecycle contract lane tests passed.
local runtime commit live lane tests passed.
75 passed; 0 failed (kolme_devnet_ops_docs)
```

### 🔁 Regression
Regression guard added and validated:
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` (`Regression: #1971`)
- `docs/planning/kolme-devnet-ops.md` (`Regression: #1971`)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` command-surface marker checks | |
| Functional   | ✅ | Same contract test includes dry-run command-composition assertions for finality pass-through flags | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`, `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | |
| Regression   | ✅ | `Regression: #1971` guard for option/doc/summary composition continuity | |
| Performance  | N/A | | Local-only bounded lane orchestration change only; no new throughput path introduced |

## Risks & Rollback
- None.
- Rollback plan: revert commit `fc215d3` if pass-through behavior or docs coupling regresses.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (covered in prior merged baseline for touched shell/docs scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to impacted lane/docs contracts)
- [x] Docs updated (or justified why not)

Closes #1971
Refs #1966
