### PR TITLE
feat(kolme-lanes): pass runtime finality through process lifecycle lane (#1973)

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,10 @@ bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode dry-run
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --max-seconds 300 --startup-max-seconds 45 --integration-max-seconds 240 --integration-bootstrap-max-seconds 90 --integration-conformance-max-seconds 180 --integration-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json
 
+# optional nested integration runtime finality pass-through
+KAMN_KOLME_LOCAL_HEAVY=1 \
+bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --integration-runtime-commit-finality-command "printf 'finality=final\n'" --integration-runtime-commit-finality-max-seconds 15 --integration-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json
+
 # policy checker contract
 python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py --report-file /tmp/kolme-local-fork-process-lifecycle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-process-lifecycle-policy.json
 

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -468,6 +468,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
 - Explicit local-only process lifecycle execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --max-seconds 300 --startup-max-seconds 45 --integration-max-seconds 240 --integration-bootstrap-max-seconds 90 --integration-conformance-max-seconds 180 --integration-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
+- Optional nested integration runtime finality pass-through:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --integration-runtime-commit-finality-command "printf 'finality=final\n'" --integration-runtime-commit-finality-max-seconds 15 --integration-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
 - Policy checker command:
   - `python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py --report-file /tmp/kolme-local-fork-process-lifecycle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-process-lifecycle-policy.json`
 - Contract lane command:
@@ -476,6 +478,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `kamn.kolme.local-fork-process-lifecycle-summary.v1`
 - Deterministic checkpoints include:
   - process command orchestration: start -> readiness probe -> nested `run_local_kamn_live_runtime_integration_lane.sh` -> teardown.
+  - optional integration runtime finality pass-through (`--integration-runtime-commit-finality-command`, `--integration-runtime-commit-finality-max-seconds`, `--integration-runtime-commit-finality-output-file`) is forwarded to nested integration lane runtime finality options.
   - readiness contract over `GET /healthz` and `GET /fork-info?chain_version=<version>`.
   - fail-closed reason codes for local opt-in, serve-command, bootstrap, readiness, integration, teardown, and budget drift.
 - Cost policy:
@@ -784,6 +787,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`).
 - unified local signed-to-Kolme demo lane fails closed for local opt-in, stage prerequisite drift, and runtime budget overruns (`Regression: #1640`).
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).
+- local fork process lifecycle integration lane propagates integration runtime finality pass-through options and artifacts to nested integration command composition (`Regression: #1973`).
 - local fork profile preflight lane fails closed for local opt-in, checkout/profile contract drift, probe command failures, and runtime budget overruns (`Regression: #1648`).
 - local fork profile preflight policy and contract-lane command/report drift remains fail-closed (`Regression: #1697`).
 - local fork self-test lane fails closed for local opt-in, nested matrix/policy checkpoint failures, and runtime budget overruns (`Regression: #1652`).

--- a/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py
@@ -169,14 +169,33 @@ def main() -> int:
     if "run_local_kolme_fork_process_lifecycle_contract_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference local Kolme fork process lifecycle contract lane", file=sys.stderr)
         return 1
+    # Regression: #1973
+    if "--integration-runtime-commit-finality-command" not in doc_text:
+        print(
+            "expected Kolme devnet ops doc to document process lifecycle integration finality pass-through option",
+            file=sys.stderr,
+        )
+        return 1
     if "run_local_kamn_live_runtime_integration_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference local KAMN live runtime integration prerequisite lane", file=sys.stderr)
         return 1
     if "Regression: #1494" not in doc_text:
         print("expected Kolme devnet ops doc to include local fork process lifecycle regression marker", file=sys.stderr)
         return 1
+    if "Regression: #1973" not in doc_text:
+        print(
+            "expected Kolme devnet ops doc to include process lifecycle integration finality pass-through regression marker",
+            file=sys.stderr,
+        )
+        return 1
     if "run_local_kolme_fork_process_lifecycle_contract_lane.sh" not in readme_text:
         print("expected README to reference local Kolme fork process lifecycle contract lane", file=sys.stderr)
+        return 1
+    if "--integration-runtime-commit-finality-command" not in readme_text:
+        print(
+            "expected README to document process lifecycle integration finality pass-through option",
+            file=sys.stderr,
+        )
         return 1
 
     elapsed_seconds = int(time.monotonic() - start_epoch)

--- a/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh
@@ -21,7 +21,14 @@ INTEGRATION_MAX_SECONDS=240
 INTEGRATION_BOOTSTRAP_MAX_SECONDS=90
 INTEGRATION_CONFORMANCE_MAX_SECONDS=180
 INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS=30
+INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND=""
+INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS=15
+INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-finality-output.txt"
 PROCESS_PID=""
+
+shell_escape() {
+  printf "%q" "$1"
+}
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -153,6 +160,30 @@ while [ "$#" -gt 0 ]; do
       INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS="$2"
       shift 2
       ;;
+    --integration-runtime-commit-finality-command)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --integration-runtime-commit-finality-command" >&2
+        exit 1
+      fi
+      INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND="$2"
+      shift 2
+      ;;
+    --integration-runtime-commit-finality-max-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --integration-runtime-commit-finality-max-seconds" >&2
+        exit 1
+      fi
+      INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS="$2"
+      shift 2
+      ;;
+    --integration-runtime-commit-finality-output-file)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --integration-runtime-commit-finality-output-file" >&2
+        exit 1
+      fi
+      INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE="$2"
+      shift 2
+      ;;
     --help|-h)
       cat <<'USAGE'
 Usage: run_local_kolme_fork_process_lifecycle_lane.sh [options]
@@ -174,6 +205,12 @@ Options:
   --integration-bootstrap-max-seconds <n>       Max bootstrap/readiness budget for nested integration lane.
   --integration-conformance-max-seconds <n>     Max live API conformance budget for nested integration lane.
   --integration-runtime-commit-max-seconds <n>  Max runtime-commit endpoint command budget for nested lane.
+  --integration-runtime-commit-finality-command <command>
+                                                 Optional runtime finality command passed through to nested integration lane.
+  --integration-runtime-commit-finality-max-seconds <n>
+                                                 Max runtime budget for runtime finality command passed through to nested integration lane.
+  --integration-runtime-commit-finality-output-file <path>
+                                                 Captured stdout/stderr path for runtime finality command passed through to nested integration lane.
 USAGE
       exit 0
       ;;
@@ -205,7 +242,8 @@ for numeric_value in \
   "$INTEGRATION_MAX_SECONDS" \
   "$INTEGRATION_BOOTSTRAP_MAX_SECONDS" \
   "$INTEGRATION_CONFORMANCE_MAX_SECONDS" \
-  "$INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS"; do
+  "$INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS" \
+  "$INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS"; do
   if ! [[ "$numeric_value" =~ ^[0-9]+$ ]] || [ "$numeric_value" -le 0 ]; then
     echo "all max-second arguments must be positive integers" >&2
     exit 1
@@ -315,6 +353,9 @@ graceful_teardown() {
 serve_command_planned="${SERVE_COMMAND:-<required-in-run-mode>}"
 readiness_command="curl --silent --show-error --fail ${BASE_URL%/}/healthz && curl --silent --show-error --fail ${BASE_URL%/}/fork-info?chain_version=${FORK_CHAIN_VERSION}"
 integration_command="bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --max-seconds ${INTEGRATION_MAX_SECONDS} --bootstrap-max-seconds ${INTEGRATION_BOOTSTRAP_MAX_SECONDS} --conformance-max-seconds ${INTEGRATION_CONFORMANCE_MAX_SECONDS} --runtime-commit-max-seconds ${INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS} --output-json ${INTEGRATION_REPORT}"
+if [ -n "$INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND" ]; then
+  integration_command="${integration_command} --runtime-commit-finality-command $(shell_escape "${INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND}") --runtime-commit-finality-max-seconds ${INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS} --runtime-commit-finality-output-file $(shell_escape "${INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE}")"
+fi
 teardown_command="kill <lifecycle-process-pid>"
 
 overall_status="ok"
@@ -395,22 +436,31 @@ if [ "$MODE" = "run" ]; then
 
       if [ "$overall_status" = "ok" ]; then
         integration_exit_code=0
+        integration_args=(
+          --mode run
+          --checkout-path "$CHECKOUT_PATH"
+          --expected-remote-url "$EXPECTED_REMOTE_URL"
+          --expected-ref "$EXPECTED_REF"
+          --base-url "$BASE_URL"
+          --fork-chain-version "$FORK_CHAIN_VERSION"
+          --max-seconds "$INTEGRATION_MAX_SECONDS"
+          --bootstrap-max-seconds "$INTEGRATION_BOOTSTRAP_MAX_SECONDS"
+          --conformance-max-seconds "$INTEGRATION_CONFORMANCE_MAX_SECONDS"
+          --runtime-commit-max-seconds "$INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS"
+          --output-json "$INTEGRATION_REPORT"
+        )
+        if [ -n "$INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND" ]; then
+          integration_args+=(
+            --runtime-commit-finality-command "$INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND"
+            --runtime-commit-finality-max-seconds "$INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS"
+            --runtime-commit-finality-output-file "$INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE"
+          )
+        fi
         set +e
         timeout "$INTEGRATION_MAX_SECONDS" \
           env KAMN_KOLME_LOCAL_HEAVY=1 \
           bash "$INTEGRATION_RUNNER" \
-            --mode run \
-            --checkout-path "$CHECKOUT_PATH" \
-            --expected-remote-url "$EXPECTED_REMOTE_URL" \
-            --expected-ref "$EXPECTED_REF" \
-            --base-url "$BASE_URL" \
-            --fork-chain-version "$FORK_CHAIN_VERSION" \
-            --max-seconds "$INTEGRATION_MAX_SECONDS" \
-            --bootstrap-max-seconds "$INTEGRATION_BOOTSTRAP_MAX_SECONDS" \
-            --conformance-max-seconds "$INTEGRATION_CONFORMANCE_MAX_SECONDS" \
-            --runtime-commit-max-seconds "$INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS" \
-            --output-json "$INTEGRATION_REPORT" \
-            >/dev/null
+            "${integration_args[@]}" >/dev/null
         integration_exit_code=$?
         set -e
 
@@ -457,7 +507,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$SERVE_COMMAND" "$PROCESS_OUTPUT_FILE" "$INTEGRATION_REPORT" "$start_reason_code" "$readiness_reason_code" "$integration_reason_code" "$teardown_reason_code" "$CHECK_FILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$SERVE_COMMAND" "$PROCESS_OUTPUT_FILE" "$INTEGRATION_REPORT" "$INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND" "$INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$start_reason_code" "$readiness_reason_code" "$integration_reason_code" "$teardown_reason_code" "$CHECK_FILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -479,11 +529,14 @@ budget_status = sys.argv[12]
 serve_command = sys.argv[13]
 process_output_file = sys.argv[14]
 integration_report = sys.argv[15]
-start_reason_code = sys.argv[16]
-readiness_reason_code = sys.argv[17]
-integration_reason_code = sys.argv[18]
-teardown_reason_code = sys.argv[19]
-checks_path = pathlib.Path(sys.argv[20])
+integration_runtime_commit_finality_command = sys.argv[16]
+integration_runtime_commit_finality_max_seconds = int(sys.argv[17])
+integration_runtime_commit_finality_output_file = sys.argv[18]
+start_reason_code = sys.argv[19]
+readiness_reason_code = sys.argv[20]
+integration_reason_code = sys.argv[21]
+teardown_reason_code = sys.argv[22]
+checks_path = pathlib.Path(sys.argv[23])
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -517,6 +570,14 @@ summary = {
     "base_url": base_url,
     "fork_chain_version": fork_chain_version,
     "serve_command": serve_command,
+    "integration_runtime_commit_finality_enabled": bool(integration_runtime_commit_finality_command),
+    "integration_runtime_commit_finality_command": (
+        integration_runtime_commit_finality_command if integration_runtime_commit_finality_command else ""
+    ),
+    "integration_runtime_commit_finality_max_seconds": integration_runtime_commit_finality_max_seconds,
+    "integration_runtime_commit_finality_output_file": (
+        integration_runtime_commit_finality_output_file if integration_runtime_commit_finality_command else ""
+    ),
     "start_reason_code": start_reason_code,
     "readiness_reason_code": readiness_reason_code,
     "integration_reason_code": integration_reason_code,
@@ -534,6 +595,9 @@ summary = {
         integration_report,
     ],
 }
+
+if integration_runtime_commit_finality_command:
+    summary["artifact_paths"].append(integration_runtime_commit_finality_output_file)
 
 output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")

--- a/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
@@ -27,6 +27,19 @@ if ! grep -q "scripts/framework/run_manifest_lane.sh" "$RUNNER"; then
   exit 1
 fi
 
+# Regression: #1973
+required_integration_finality_markers=(
+  "--integration-runtime-commit-finality-command"
+  "--integration-runtime-commit-finality-max-seconds"
+  "--integration-runtime-commit-finality-output-file"
+)
+for marker in "${required_integration_finality_markers[@]}"; do
+  if ! grep -q -- "$marker" "$ROOT_DIR/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh"; then
+    echo "expected local fork process lifecycle runner to expose integration finality pass-through marker: $marker" >&2
+    exit 1
+  fi
+done
+
 if [ ! -f "$MANIFEST" ]; then
   echo "expected local fork process lifecycle contract lane manifest to exist" >&2
   exit 1
@@ -57,6 +70,7 @@ required_coverage_markers=(
   "check_local_kolme_fork_process_lifecycle_policy.py"
   "run_local_kamn_live_runtime_integration_lane.sh"
   "Regression: #1494"
+  "Regression: #1973"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -75,6 +89,11 @@ if ! grep -q "run_local_kolme_fork_process_lifecycle_contract_lane.sh" "$DOC_FIL
   exit 1
 fi
 
+if ! grep -q -- "--integration-runtime-commit-finality-command" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to document process lifecycle integration finality pass-through command option" >&2
+  exit 1
+fi
+
 if ! grep -q "check_local_kolme_fork_process_lifecycle_policy.py" "$README_FILE"; then
   echo "expected README to reference local fork process lifecycle policy checker" >&2
   exit 1
@@ -82,6 +101,11 @@ fi
 
 if ! grep -q "run_local_kolme_fork_process_lifecycle_contract_lane.sh" "$README_FILE"; then
   echo "expected README to reference local fork process lifecycle contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q -- "--integration-runtime-commit-finality-command" "$README_FILE"; then
+  echo "expected README to document process lifecycle integration finality pass-through command option" >&2
   exit 1
 fi
 
@@ -110,6 +134,49 @@ if policy.get("schema_version") != "kamn.kolme.local-fork-process-lifecycle-poli
     raise SystemExit("unexpected local fork process lifecycle contract-lane policy schema")
 if policy.get("final_decision") != "GO":
     raise SystemExit("expected local fork process lifecycle contract-lane policy final_decision GO")
+PY
+
+TMP_DIRECT_SUMMARY="$(mktemp)"
+TMP_DIRECT_PROCESS_OUTPUT="$(mktemp)"
+TMP_DIRECT_INTEGRATION_REPORT="$(mktemp)"
+TMP_DIRECT_FINALITY_OUTPUT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_PROCESS_OUTPUT" "$TMP_DIRECT_INTEGRATION_REPORT" "$TMP_DIRECT_FINALITY_OUTPUT"' EXIT
+
+bash "$ROOT_DIR/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh" \
+  --mode dry-run \
+  --integration-runtime-commit-finality-command "printf 'finality=final\n'" \
+  --integration-runtime-commit-finality-max-seconds 11 \
+  --integration-runtime-commit-finality-output-file "$TMP_DIRECT_FINALITY_OUTPUT" \
+  --process-output-file "$TMP_DIRECT_PROCESS_OUTPUT" \
+  --integration-report "$TMP_DIRECT_INTEGRATION_REPORT" \
+  --output-json "$TMP_DIRECT_SUMMARY" >/dev/null
+
+python3 - "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_FINALITY_OUTPUT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+checks = summary.get("checks", [])
+integration_commands = [
+    check.get("command", "")
+    for check in checks
+    if isinstance(check, dict) and check.get("id") == "kamn_live_integration"
+]
+if len(integration_commands) != 1:
+    raise SystemExit("expected exactly one kamn_live_integration check command")
+integration_command = integration_commands[0]
+if "--runtime-commit-finality-command" not in integration_command:
+    raise SystemExit("expected nested integration command to include runtime finality command pass-through")
+if "--runtime-commit-finality-max-seconds 11" not in integration_command:
+    raise SystemExit("expected nested integration command to include runtime finality max seconds pass-through")
+finality_output_path = pathlib.Path(sys.argv[2]).resolve()
+if f"--runtime-commit-finality-output-file {finality_output_path}" not in integration_command:
+    raise SystemExit("expected nested integration command to include runtime finality output pass-through")
+if str(finality_output_path) not in summary.get("artifact_paths", []):
+    raise SystemExit("expected process lifecycle summary artifact paths to include integration finality output file")
 PY
 
 echo "local fork process lifecycle contract lane tests passed."


### PR DESCRIPTION
## Summary
Propagate runtime finality pass-through controls into the local Kolme fork process lifecycle lane so lifecycle orchestration can configure nested integration runtime submit+finality behavior from one top-level lane command. This keeps local-only live orchestration consistent with the integration-lane capability added in #1971.

## Changes
- `scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh`: add `--integration-runtime-commit-finality-command`, `--integration-runtime-commit-finality-max-seconds`, and `--integration-runtime-commit-finality-output-file`; forward them into nested `run_local_kamn_live_runtime_integration_lane.sh`; add finality metadata/artifact tracking in summary output.
- `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`: add regression checks for process lifecycle finality pass-through command surface and dry-run nested command composition (`Regression: #1973`).
- `scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py`: enforce docs/readme and regression marker coverage for new pass-through option.
- `docs/planning/kolme-devnet-ops.md`: document optional process lifecycle integration finality pass-through usage and add regression marker.
- `README.md`: add optional process lifecycle integration finality pass-through command example.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
```
Output:
```text
expected local fork process lifecycle runner to expose integration finality pass-through marker: --integration-runtime-commit-finality-command
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Output summary:
```text
local fork process lifecycle contract lane tests passed.
local KAMN live runtime integration contract lane tests passed.
75 passed; 0 failed (kolme_devnet_ops_docs)
```

### 🔁 Regression
Regression guard added and validated:
- `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` (`Regression: #1973`)
- `docs/planning/kolme-devnet-ops.md` (`Regression: #1973`)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` command-surface marker checks | |
| Functional   | ✅ | Same contract test validates dry-run nested integration command composition for finality pass-through options | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Regression   | ✅ | `Regression: #1973` guard for option/doc/summary composition continuity | |
| Performance  | N/A | | Local-only orchestration pass-through change; no new throughput path introduced |

## Risks & Rollback
- None.
- Rollback plan: revert commit `4ab9042` if lifecycle pass-through behavior regresses.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (covered in prior merged baseline for touched shell/docs scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to impacted lane/docs contracts)
- [x] Docs updated (or justified why not)

Closes #1973
Refs #1966
