### PR TITLE
feat(kolme-lanes): pass lifecycle finality through real-process wrapper (#1975)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,14 @@ KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_co
   --lifecycle-conformance-max-seconds 180 \
   --lifecycle-runtime-commit-max-seconds 30 \
   --output-json /tmp/kolme-local-fork-real-process-summary.json
+# optional lifecycle runtime finality pass-through into nested process lifecycle lane
+KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh \
+  --mode run \
+  --checkout-path /tmp/kolme_fork \
+  --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" \
+  --lifecycle-runtime-commit-finality-max-seconds 15 \
+  --lifecycle-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt \
+  --output-json /tmp/kolme-local-fork-real-process-summary.json
 python3 scripts/kolme/check_local_kolme_fork_real_process_policy.py \
   --report-file /tmp/kolme-local-fork-real-process-summary.json \
   --expected-final-decision GO \

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -582,6 +582,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Explicit local-only real-fork wrapper execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 360 --bootstrap-max-seconds 120 --preflight-max-seconds 45 --self-test-max-seconds 120 --self-test-matrix-max-seconds 60 --lifecycle-max-seconds 300 --lifecycle-startup-max-seconds 45 --lifecycle-integration-max-seconds 240 --lifecycle-bootstrap-max-seconds 90 --lifecycle-conformance-max-seconds 180 --lifecycle-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-real-process-summary.json`
+- Optional lifecycle runtime finality pass-through:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" --lifecycle-runtime-commit-finality-max-seconds 15 --lifecycle-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Default serve profile contract:
   - `cd <checkout-path> && cargo run --bin example-six-sigma -- serve api-server`
 - Checkout bootstrap prerequisite commands:
@@ -603,6 +605,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `run_local_kolme_fork_profile_preflight_lane.sh` and policy verification execute before self-test/lifecycle orchestration.
   - `run_local_kolme_fork_self_test_lane.sh` and policy verification execute before lifecycle orchestration.
   - `run_local_kolme_fork_process_lifecycle_lane.sh` run-mode composition with bounded budgets.
+  - optional lifecycle runtime finality pass-through (`--lifecycle-runtime-commit-finality-command`, `--lifecycle-runtime-commit-finality-max-seconds`, `--lifecycle-runtime-commit-finality-output-file`) is forwarded into nested process lifecycle integration finality options.
   - `check_local_kolme_fork_process_lifecycle_policy.py` GO decision verification.
 - Cost policy:
   - run mode fails closed without explicit local-only opt-in.
@@ -797,6 +800,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - real-fork local process wrapper bootstrap-first prerequisite ordering remains fail-closed for bootstrap lane/policy checkpoint drift (`Regression: #1667`).
 - local-only heavy E2E lane checkout-bootstrap contract checkpoint composition remains fail-closed for command/id ordering drift (`Regression: #1677`).
 - real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`).
+- real-fork local process wrapper lane propagates lifecycle runtime finality pass-through options into nested process lifecycle integration command composition (`Regression: #1975`).
 - real-fork local process wrapper policy checker lane remains fail-closed for schema/contracts/checkpoint drift (`Regression: #1671`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - local runtime-commit live proof lane preflight health probe and default live-provider ignored-test dispatch remain fail-closed (`Regression: #1829`).

--- a/scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py
@@ -142,6 +142,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Per-check budget for runtime-commit verification in lifecycle lane.",
     )
     parser.add_argument(
+        "--lifecycle-runtime-commit-finality-command",
+        default="",
+        help="Optional runtime finality command forwarded to lifecycle lane integration pass-through.",
+    )
+    parser.add_argument(
+        "--lifecycle-runtime-commit-finality-max-seconds",
+        default="15",
+        help="Per-check budget for runtime finality command in lifecycle lane integration pass-through.",
+    )
+    parser.add_argument(
+        "--lifecycle-runtime-commit-finality-output-file",
+        default="/tmp/kolme-local-runtime-commit-live-finality-output.txt",
+        help="Output file path for lifecycle lane integration finality command pass-through.",
+    )
+    parser.add_argument(
         "--self-test-matrix-command",
         action="append",
         default=[],
@@ -168,12 +183,16 @@ def ensure_docs() -> None:
         "run_local_kolme_fork_checkout_bootstrap_lane.sh",
         "check_local_kolme_fork_checkout_bootstrap_policy.py",
         "Regression: #1644",
+        "--lifecycle-runtime-commit-finality-command",
+        "Regression: #1975",
     )
     for marker in required_doc_markers:
         if marker not in doc_text:
             raise RuntimeError(f"expected Kolme devnet ops doc marker: {marker}")
     if "run_local_kolme_fork_real_process_contract_lane.sh" not in readme_text:
         raise RuntimeError("expected README to reference real-process wrapper contract lane")
+    if "--lifecycle-runtime-commit-finality-command" not in readme_text:
+        raise RuntimeError("expected README to document real-process lifecycle finality pass-through option")
 
 
 def build_contracts() -> dict[str, str]:
@@ -282,6 +301,18 @@ def run_mode_checks(
         self_test_policy = temp_root / "self-test-policy.json"
         lifecycle_report = temp_root / "lifecycle-summary.json"
         lifecycle_policy = temp_root / "lifecycle-policy.json"
+        artifact_paths = [
+            str(bootstrap_report),
+            str(bootstrap_policy),
+            str(preflight_report),
+            str(preflight_policy),
+            str(self_test_report),
+            str(self_test_policy),
+            str(lifecycle_report),
+            str(lifecycle_policy),
+        ]
+        if args.lifecycle_runtime_commit_finality_command:
+            artifact_paths.append(str(Path(args.lifecycle_runtime_commit_finality_output_file).resolve()))
 
         source_repo.mkdir(parents=True, exist_ok=True)
         subprocess.run(["git", "-C", str(source_repo), "init", "-q"], check=True)
@@ -300,7 +331,7 @@ def run_mode_checks(
             for check in checks:
                 check["status"] = "fail"
                 check["reason_code"] = "local_opt_in_missing"
-            return checks, "local_opt_in_missing"
+            return checks, "local_opt_in_missing", artifact_paths
 
         env["KAMN_KOLME_LOCAL_HEAVY"] = "1"
         checks.append(
@@ -315,6 +346,48 @@ def run_mode_checks(
         matrix_args: list[str] = []
         for command in args.self_test_matrix_command:
             matrix_args.extend(["--matrix-command", command])
+
+        process_lifecycle_command = [
+            "bash",
+            str(LIFECYCLE_RUNNER),
+            "--mode",
+            "dry-run",
+            "--checkout-path",
+            str(checkout_path),
+            "--expected-remote-url",
+            str(source_repo),
+            "--expected-ref",
+            "refs/heads/main",
+            "--base-url",
+            args.base_url,
+            "--fork-chain-version",
+            args.fork_chain_version,
+            "--max-seconds",
+            args.lifecycle_max_seconds,
+            "--startup-max-seconds",
+            args.lifecycle_startup_max_seconds,
+            "--integration-max-seconds",
+            args.lifecycle_integration_max_seconds,
+            "--integration-bootstrap-max-seconds",
+            args.lifecycle_bootstrap_max_seconds,
+            "--integration-conformance-max-seconds",
+            args.lifecycle_conformance_max_seconds,
+            "--integration-runtime-commit-max-seconds",
+            args.lifecycle_runtime_commit_max_seconds,
+            "--output-json",
+            str(lifecycle_report),
+        ]
+        if args.lifecycle_runtime_commit_finality_command:
+            process_lifecycle_command.extend(
+                [
+                    "--integration-runtime-commit-finality-command",
+                    args.lifecycle_runtime_commit_finality_command,
+                    "--integration-runtime-commit-finality-max-seconds",
+                    args.lifecycle_runtime_commit_finality_max_seconds,
+                    "--integration-runtime-commit-finality-output-file",
+                    args.lifecycle_runtime_commit_finality_output_file,
+                ]
+            )
 
         ordered_checks = [
             (
@@ -375,10 +448,6 @@ def run_mode_checks(
                     "dry-run",
                     "--checkout-path",
                     str(checkout_path),
-                    "--expected-remote-url",
-                    str(source_repo),
-                    "--expected-ref",
-                    "refs/heads/main",
                     "--output-json",
                     str(preflight_report),
                 ],
@@ -445,36 +514,7 @@ def run_mode_checks(
             ),
             (
                 "process_lifecycle_lane",
-                [
-                    "bash",
-                    str(LIFECYCLE_RUNNER),
-                    "--mode",
-                    "dry-run",
-                    "--checkout-path",
-                    str(checkout_path),
-                    "--expected-remote-url",
-                    str(source_repo),
-                    "--expected-ref",
-                    "refs/heads/main",
-                    "--base-url",
-                    args.base_url,
-                    "--fork-chain-version",
-                    args.fork_chain_version,
-                    "--max-seconds",
-                    args.lifecycle_max_seconds,
-                    "--startup-max-seconds",
-                    args.lifecycle_startup_max_seconds,
-                    "--integration-max-seconds",
-                    args.lifecycle_integration_max_seconds,
-                    "--bootstrap-max-seconds",
-                    args.lifecycle_bootstrap_max_seconds,
-                    "--conformance-max-seconds",
-                    args.lifecycle_conformance_max_seconds,
-                    "--runtime-commit-max-seconds",
-                    args.lifecycle_runtime_commit_max_seconds,
-                    "--output-json",
-                    str(lifecycle_report),
-                ],
+                process_lifecycle_command,
                 "checkpoint_failed_process_lifecycle_lane",
             ),
             (
@@ -543,17 +583,6 @@ def run_mode_checks(
                 }
             )
 
-        artifact_paths = [
-            str(bootstrap_report),
-            str(bootstrap_policy),
-            str(preflight_report),
-            str(preflight_policy),
-            str(self_test_report),
-            str(self_test_policy),
-            str(lifecycle_report),
-            str(lifecycle_policy),
-        ]
-
     return checks, observed_reason, artifact_paths
 
 
@@ -562,6 +591,11 @@ def main() -> int:
 
     if not args.max_seconds.isdigit() or int(args.max_seconds) <= 0:
         print("max-seconds must be a positive integer", file=sys.stderr)
+        return 1
+    if not args.lifecycle_runtime_commit_finality_max_seconds.isdigit() or int(
+        args.lifecycle_runtime_commit_finality_max_seconds
+    ) <= 0:
+        print("lifecycle-runtime-commit-finality-max-seconds must be a positive integer", file=sys.stderr)
         return 1
 
     for script, description in (
@@ -620,6 +654,14 @@ def main() -> int:
         "budget_status": budget_status,
         "selected_serve_command": selected_serve_command,
         "allow_non_fork_serve_command": bool(args.allow_non_fork_serve_command),
+        "lifecycle_runtime_commit_finality_enabled": bool(args.lifecycle_runtime_commit_finality_command),
+        "lifecycle_runtime_commit_finality_command": args.lifecycle_runtime_commit_finality_command,
+        "lifecycle_runtime_commit_finality_max_seconds": int(args.lifecycle_runtime_commit_finality_max_seconds),
+        "lifecycle_runtime_commit_finality_output_file": (
+            str(Path(args.lifecycle_runtime_commit_finality_output_file).resolve())
+            if args.lifecycle_runtime_commit_finality_command
+            else ""
+        ),
         "contracts": build_contracts(),
         "checks": checks,
         "artifact_paths": artifact_paths,

--- a/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
@@ -47,6 +47,22 @@ if [ ! -f "$CONTRACT_IMPL" ]; then
   exit 1
 fi
 
+# Regression: #1975
+required_lifecycle_finality_markers=(
+  "--lifecycle-runtime-commit-finality-command"
+  "--lifecycle-runtime-commit-finality-max-seconds"
+  "--lifecycle-runtime-commit-finality-output-file"
+  "--integration-bootstrap-max-seconds"
+  "--integration-conformance-max-seconds"
+  "--integration-runtime-commit-max-seconds"
+)
+for marker in "${required_lifecycle_finality_markers[@]}"; do
+  if ! grep -q -- "$marker" "$CONTRACT_IMPL"; then
+    echo "expected local fork real-process contract implementation to include lifecycle pass-through marker: $marker" >&2
+    exit 1
+  fi
+done
+
 if ! grep -q "run_local_kolme_fork_real_process_contract_lane.sh" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference local fork real-process contract lane" >&2
   exit 1
@@ -62,8 +78,18 @@ if ! grep -q "Regression: #1644" "$DOC_FILE"; then
   exit 1
 fi
 
+if ! grep -q -- "--lifecycle-runtime-commit-finality-command" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include lifecycle runtime finality pass-through command option" >&2
+  exit 1
+fi
+
 if ! grep -q "run_local_kolme_fork_real_process_contract_lane.sh" "$README_FILE"; then
   echo "expected README to reference local fork real-process contract lane" >&2
+  exit 1
+fi
+
+if ! grep -q -- "--lifecycle-runtime-commit-finality-command" "$README_FILE"; then
+  echo "expected README to include lifecycle runtime finality pass-through command option" >&2
   exit 1
 fi
 
@@ -76,5 +102,51 @@ if ! printf '%s\n' "$lane_output" | grep -q "local fork real-process wrapper con
   echo "expected local fork real-process contract lane success marker" >&2
   exit 1
 fi
+
+TMP_SUMMARY="$(mktemp)"
+TMP_POLICY="$(mktemp)"
+TMP_FINALITY_OUTPUT="$(mktemp)"
+trap 'rm -f "$TMP_SUMMARY" "$TMP_POLICY" "$TMP_FINALITY_OUTPUT"' EXIT
+
+KAMN_KOLME_LOCAL_HEAVY=1 python3 "$CONTRACT_IMPL" \
+  --mode run \
+  --max-seconds 180 \
+  --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" \
+  --lifecycle-runtime-commit-finality-max-seconds 13 \
+  --lifecycle-runtime-commit-finality-output-file "$TMP_FINALITY_OUTPUT" \
+  --output-json "$TMP_SUMMARY" \
+  --policy-output-json "$TMP_POLICY" >/dev/null
+
+python3 - "$TMP_SUMMARY" "$TMP_FINALITY_OUTPUT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+checks = summary.get("checks", [])
+lifecycle_commands = [
+    check.get("command", "")
+    for check in checks
+    if isinstance(check, dict) and check.get("id") == "process_lifecycle_lane"
+]
+if len(lifecycle_commands) != 1:
+    raise SystemExit("expected exactly one process_lifecycle_lane command entry")
+command = lifecycle_commands[0]
+if "--integration-bootstrap-max-seconds" not in command:
+    raise SystemExit("expected lifecycle command to use integration-bootstrap-max-seconds option name")
+if "--integration-conformance-max-seconds" not in command:
+    raise SystemExit("expected lifecycle command to use integration-conformance-max-seconds option name")
+if "--integration-runtime-commit-max-seconds" not in command:
+    raise SystemExit("expected lifecycle command to use integration-runtime-commit-max-seconds option name")
+if "--integration-runtime-commit-finality-command" not in command:
+    raise SystemExit("expected lifecycle command to include runtime finality command pass-through")
+if "--integration-runtime-commit-finality-max-seconds 13" not in command:
+    raise SystemExit("expected lifecycle command to include runtime finality max seconds pass-through")
+finality_output_path = pathlib.Path(sys.argv[2]).resolve()
+if f"--integration-runtime-commit-finality-output-file {finality_output_path}" not in command:
+    raise SystemExit("expected lifecycle command to include runtime finality output pass-through")
+PY
 
 echo "local fork real-process contract lane tests passed."


### PR DESCRIPTION
## Summary
Thread lifecycle runtime finality pass-through controls through the real-process wrapper contract lane and align nested process-lifecycle invocation option names with the current lifecycle lane contract. This completes wrapper-level forwarding for submit+finality orchestration across the local-only Kolme integration stack.

## Changes
- `scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py`: add parser args `--lifecycle-runtime-commit-finality-command`, `--lifecycle-runtime-commit-finality-max-seconds`, `--lifecycle-runtime-commit-finality-output-file`; forward them into nested process lifecycle command as `--integration-runtime-commit-finality-*`; align nested lifecycle arg names to `--integration-bootstrap-max-seconds`, `--integration-conformance-max-seconds`, and `--integration-runtime-commit-max-seconds`.
- `scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py`: fix run-mode profile-preflight invocation drift by removing unsupported `--expected-remote-url` / `--expected-ref` args.
- `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`: add regression checks for wrapper pass-through command surface and run-mode process-lifecycle command composition (`Regression: #1975`).
- `docs/planning/kolme-devnet-ops.md`: document optional real-process wrapper lifecycle finality pass-through and regression marker.
- `README.md`: add optional lifecycle finality pass-through usage example for real-process wrapper lane.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
```
Output:
```text
expected local fork real-process contract implementation to include lifecycle pass-through marker: --lifecycle-runtime-commit-finality-command
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Output summary:
```text
local fork real-process contract lane tests passed.
local fork process lifecycle contract lane tests passed.
local KAMN live runtime integration contract lane tests passed.
75 passed; 0 failed (kolme_devnet_ops_docs)
```

### 🔁 Regression
Regression guard added and validated:
- `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh` (`Regression: #1975`)
- `docs/planning/kolme-devnet-ops.md` (`Regression: #1975`)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh` marker checks | |
| Functional   | ✅ | Same test validates real-process run-mode `process_lifecycle_lane` command composition for lifecycle finality pass-through and integration option-name alignment | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`, `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Regression   | ✅ | `Regression: #1975` guard for wrapper pass-through/doc command contract continuity | |
| Performance  | N/A | | Local-only orchestration command-surface changes only; no throughput path changes |

## Risks & Rollback
- None.
- Rollback plan: revert commit `2cf7344` if wrapper command contract or pass-through behavior regresses.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (covered in prior merged baseline for touched shell/docs scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to impacted lane/docs contracts)
- [x] Docs updated (or justified why not)

Closes #1975
Refs #1966
