### PR TITLE
feat(kolme-lanes): add lifecycle mode control to real-process wrapper (#1977)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_co
 KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh \
   --mode run \
   --checkout-path /tmp/kolme_fork \
+  --lifecycle-mode run \
   --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" \
   --lifecycle-runtime-commit-finality-max-seconds 15 \
   --lifecycle-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt \

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -583,7 +583,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Explicit local-only real-fork wrapper execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 360 --bootstrap-max-seconds 120 --preflight-max-seconds 45 --self-test-max-seconds 120 --self-test-matrix-max-seconds 60 --lifecycle-max-seconds 300 --lifecycle-startup-max-seconds 45 --lifecycle-integration-max-seconds 240 --lifecycle-bootstrap-max-seconds 90 --lifecycle-conformance-max-seconds 180 --lifecycle-runtime-commit-max-seconds 30 --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Optional lifecycle runtime finality pass-through:
-  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" --lifecycle-runtime-commit-finality-max-seconds 15 --lifecycle-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-real-process-summary.json`
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_real_process_contract_lane.sh --mode run --checkout-path /tmp/kolme_fork --fork-remote-url https://github.com/njfio/kolme_fork.git --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --lifecycle-mode run --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" --lifecycle-runtime-commit-finality-max-seconds 15 --lifecycle-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-real-process-summary.json`
 - Default serve profile contract:
   - `cd <checkout-path> && cargo run --bin example-six-sigma -- serve api-server`
 - Checkout bootstrap prerequisite commands:
@@ -605,6 +605,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `run_local_kolme_fork_profile_preflight_lane.sh` and policy verification execute before self-test/lifecycle orchestration.
   - `run_local_kolme_fork_self_test_lane.sh` and policy verification execute before lifecycle orchestration.
   - `run_local_kolme_fork_process_lifecycle_lane.sh` run-mode composition with bounded budgets.
+  - lifecycle mode selector (`--lifecycle-mode dry-run|run`) controls whether nested process lifecycle lane executes planning-only flow or local run orchestration.
   - optional lifecycle runtime finality pass-through (`--lifecycle-runtime-commit-finality-command`, `--lifecycle-runtime-commit-finality-max-seconds`, `--lifecycle-runtime-commit-finality-output-file`) is forwarded into nested process lifecycle integration finality options.
   - `check_local_kolme_fork_process_lifecycle_policy.py` GO decision verification.
 - Cost policy:
@@ -801,6 +802,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local-only heavy E2E lane checkout-bootstrap contract checkpoint composition remains fail-closed for command/id ordering drift (`Regression: #1677`).
 - real-fork local process wrapper lane fails closed for local opt-in, serve-command profile drift, self-test/lifecycle/policy checkpoint failure, and runtime budget overruns (`Regression: #1644`).
 - real-fork local process wrapper lane propagates lifecycle runtime finality pass-through options into nested process lifecycle integration command composition (`Regression: #1975`).
+- real-fork local process wrapper lane lifecycle mode selector (`--lifecycle-mode`) remains fail-closed for nested process lifecycle command composition drift (`Regression: #1977`).
 - real-fork local process wrapper policy checker lane remains fail-closed for schema/contracts/checkpoint drift (`Regression: #1671`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - local runtime-commit live proof lane preflight health probe and default live-provider ignored-test dispatch remain fail-closed (`Regression: #1829`).

--- a/scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py
@@ -142,6 +142,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Per-check budget for runtime-commit verification in lifecycle lane.",
     )
     parser.add_argument(
+        "--lifecycle-mode",
+        default="dry-run",
+        choices=("dry-run", "run"),
+        help="Lifecycle lane execution mode forwarded to nested process lifecycle runner.",
+    )
+    parser.add_argument(
         "--lifecycle-runtime-commit-finality-command",
         default="",
         help="Optional runtime finality command forwarded to lifecycle lane integration pass-through.",
@@ -183,8 +189,10 @@ def ensure_docs() -> None:
         "run_local_kolme_fork_checkout_bootstrap_lane.sh",
         "check_local_kolme_fork_checkout_bootstrap_policy.py",
         "Regression: #1644",
+        "--lifecycle-mode",
         "--lifecycle-runtime-commit-finality-command",
         "Regression: #1975",
+        "Regression: #1977",
     )
     for marker in required_doc_markers:
         if marker not in doc_text:
@@ -351,7 +359,7 @@ def run_mode_checks(
             "bash",
             str(LIFECYCLE_RUNNER),
             "--mode",
-            "dry-run",
+            args.lifecycle_mode,
             "--checkout-path",
             str(checkout_path),
             "--expected-remote-url",
@@ -377,6 +385,13 @@ def run_mode_checks(
             "--output-json",
             str(lifecycle_report),
         ]
+        if args.lifecycle_mode == "run":
+            process_lifecycle_command.extend(
+                [
+                    "--serve-command",
+                    args.serve_command,
+                ]
+            )
         if args.lifecycle_runtime_commit_finality_command:
             process_lifecycle_command.extend(
                 [
@@ -654,6 +669,7 @@ def main() -> int:
         "budget_status": budget_status,
         "selected_serve_command": selected_serve_command,
         "allow_non_fork_serve_command": bool(args.allow_non_fork_serve_command),
+        "lifecycle_mode": args.lifecycle_mode,
         "lifecycle_runtime_commit_finality_enabled": bool(args.lifecycle_runtime_commit_finality_command),
         "lifecycle_runtime_commit_finality_command": args.lifecycle_runtime_commit_finality_command,
         "lifecycle_runtime_commit_finality_max_seconds": int(args.lifecycle_runtime_commit_finality_max_seconds),

--- a/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
@@ -49,6 +49,7 @@ fi
 
 # Regression: #1975
 required_lifecycle_finality_markers=(
+  "--lifecycle-mode"
   "--lifecycle-runtime-commit-finality-command"
   "--lifecycle-runtime-commit-finality-max-seconds"
   "--lifecycle-runtime-commit-finality-output-file"
@@ -83,6 +84,11 @@ if ! grep -q -- "--lifecycle-runtime-commit-finality-command" "$DOC_FILE"; then
   exit 1
 fi
 
+if ! grep -q -- "--lifecycle-mode" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include lifecycle mode option for real-process wrapper" >&2
+  exit 1
+fi
+
 if ! grep -q "run_local_kolme_fork_real_process_contract_lane.sh" "$README_FILE"; then
   echo "expected README to reference local fork real-process contract lane" >&2
   exit 1
@@ -90,6 +96,11 @@ fi
 
 if ! grep -q -- "--lifecycle-runtime-commit-finality-command" "$README_FILE"; then
   echo "expected README to include lifecycle runtime finality pass-through command option" >&2
+  exit 1
+fi
+
+if ! grep -q -- "--lifecycle-mode" "$README_FILE"; then
+  echo "expected README to include lifecycle mode option for real-process wrapper" >&2
   exit 1
 fi
 
@@ -111,6 +122,7 @@ trap 'rm -f "$TMP_SUMMARY" "$TMP_POLICY" "$TMP_FINALITY_OUTPUT"' EXIT
 KAMN_KOLME_LOCAL_HEAVY=1 python3 "$CONTRACT_IMPL" \
   --mode run \
   --max-seconds 180 \
+  --lifecycle-mode run \
   --lifecycle-runtime-commit-finality-command "printf 'finality=final\n'" \
   --lifecycle-runtime-commit-finality-max-seconds 13 \
   --lifecycle-runtime-commit-finality-output-file "$TMP_FINALITY_OUTPUT" \
@@ -134,6 +146,8 @@ lifecycle_commands = [
 if len(lifecycle_commands) != 1:
     raise SystemExit("expected exactly one process_lifecycle_lane command entry")
 command = lifecycle_commands[0]
+if "--mode run" not in command:
+    raise SystemExit("expected lifecycle command to run in lifecycle-mode run selection")
 if "--integration-bootstrap-max-seconds" not in command:
     raise SystemExit("expected lifecycle command to use integration-bootstrap-max-seconds option name")
 if "--integration-conformance-max-seconds" not in command:


### PR DESCRIPTION
## Summary
Add explicit lifecycle execution mode control (`--lifecycle-mode dry-run|run`) to the real-process wrapper contract lane and forward it into nested process lifecycle command composition. This enables top-level wrapper flows to request non-mock local lifecycle execution evidence while keeping local-only safeguards and bounded budgets.

## Changes
- `scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py`: add parser option `--lifecycle-mode` and include it in summary output.
- `scripts/kolme/contracts/local_kolme_fork_real_process_contract_lane.py`: forward selected lifecycle mode into nested process lifecycle runner command and pass `--serve-command` when lifecycle mode is `run`.
- `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`: add regression checks for lifecycle mode command-surface marker and run-mode lifecycle command composition (`Regression: #1977`).
- `docs/planning/kolme-devnet-ops.md`: document lifecycle mode selector and add regression marker.
- `README.md`: add lifecycle mode usage in real-process wrapper example.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
```
Output:
```text
expected local fork real-process contract implementation to include lifecycle pass-through marker: --lifecycle-mode
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Output summary:
```text
local fork real-process contract lane tests passed.
local fork process lifecycle contract lane tests passed.
local KAMN live runtime integration contract lane tests passed.
75 passed; 0 failed (kolme_devnet_ops_docs)
```

### 🔁 Regression
Regression guard added and validated:
- `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh` (`Regression: #1977`)
- `docs/planning/kolme-devnet-ops.md` (`Regression: #1977`)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh` lifecycle mode marker checks | |
| Functional   | ✅ | Same test validates nested `process_lifecycle_lane` command contains `--mode run` when lifecycle mode run is selected | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`, `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Regression   | ✅ | `Regression: #1977` guard for lifecycle mode command/docs continuity | |
| Performance  | N/A | | Local-only orchestration option/control change only; no throughput path change |

## Risks & Rollback
- None.
- Rollback plan: revert commit `e8545cf` if lifecycle mode command composition regresses.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (covered in prior merged baseline for touched shell/docs scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to impacted lane/docs contracts)
- [x] Docs updated (or justified why not)

Closes #1977
Refs #1966
