### PR TITLE
docs(kamn-core): graduate signature_profile docs allowlist (#1981)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -94,7 +94,7 @@ pub mod retention_engine;
 pub mod runtime;
 #[allow(missing_docs)]
 pub mod service_marketplace;
-#[allow(missing_docs)]
+/// Signature-profile compatibility fixtures and baseline verification helpers.
 pub mod signature_profile;
 #[allow(missing_docs)]
 pub mod signer_backend;

--- a/crates/kamn-core/src/signature_profile.rs
+++ b/crates/kamn-core/src/signature_profile.rs
@@ -1,22 +1,35 @@
+/// Canonical algorithm identifier for supported baseline signatures.
 pub const BASELINE_SIGNATURE_ALGORITHM: &str = "ed25519";
+/// Canonical profile identifier for supported baseline signatures.
 pub const BASELINE_SIGNATURE_PROFILE_ID: &str = "baseline-v1";
+/// Legacy unversioned profile identifier retained for compatibility fixtures.
 pub const LEGACY_SIGNATURE_PROFILE_ID: &str = "legacy-unversioned";
+/// Canonical unsupported algorithm identifier used in negative fixtures.
 pub const UNKNOWN_SIGNATURE_ALGORITHM_ID: &str = "secp256k1";
 
+/// Parsed metadata extracted from a `sig:<algorithm>:<profile_id>:...` signature.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignatureProfileMetadata {
+    /// Signature algorithm identifier segment.
     pub algorithm: String,
+    /// Signature profile identifier segment.
     pub profile_id: String,
 }
 
+/// Returns the canonical baseline signature algorithm identifier.
 pub fn baseline_signature_algorithm() -> &'static str {
     BASELINE_SIGNATURE_ALGORITHM
 }
 
+/// Returns the canonical baseline signature profile identifier.
 pub fn baseline_signature_profile_id() -> &'static str {
     BASELINE_SIGNATURE_PROFILE_ID
 }
 
+/// Parses signature profile metadata from a canonical `sig:` signature string.
+///
+/// Returns `None` when the signature does not match the expected segmented form
+/// or required segments are empty.
 pub fn parse_signature_profile_metadata(signature: &str) -> Option<SignatureProfileMetadata> {
     let suffix = signature.strip_prefix("sig:")?;
     let mut segments = suffix.splitn(3, ':');
@@ -34,6 +47,7 @@ pub fn parse_signature_profile_metadata(signature: &str) -> Option<SignatureProf
     })
 }
 
+/// Builds a deterministic baseline signature fixture for the provided fields.
 pub fn baseline_signature_for_fields(
     sender: &str,
     nonce: u64,
@@ -51,6 +65,7 @@ pub fn baseline_signature_for_fields(
     )
 }
 
+/// Builds a deterministic legacy signature fixture for compatibility tests.
 pub fn legacy_signature_for_fields(
     sender: &str,
     nonce: u64,
@@ -60,6 +75,7 @@ pub fn legacy_signature_for_fields(
     format!("sig:{}:{}:{}:{}", sender, nonce, state_hash, payload.len())
 }
 
+/// Builds a fixture with an unsupported profile identifier.
 pub fn unknown_signature_profile_for_fields(
     sender: &str,
     nonce: u64,
@@ -76,6 +92,7 @@ pub fn unknown_signature_profile_for_fields(
     )
 }
 
+/// Builds a fixture with an unsupported signature algorithm identifier.
 pub fn unknown_signature_algorithm_for_fields(
     sender: &str,
     nonce: u64,
@@ -93,13 +110,18 @@ pub fn unknown_signature_algorithm_for_fields(
     )
 }
 
+/// Compatibility fixture entry for signature profile verification behavior.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignatureProfileCompatibilityFixture {
+    /// Fixture identifier used in compatibility tables.
     pub fixture_id: &'static str,
+    /// Signature payload used for verification checks.
     pub signature: String,
+    /// Whether the fixture should pass supported-profile verification.
     pub should_verify: bool,
 }
 
+/// Returns compatibility fixtures for baseline, legacy, and unsupported variants.
 pub fn signature_profile_compatibility_fixtures_for_fields(
     sender: &str,
     nonce: u64,
@@ -130,6 +152,12 @@ pub fn signature_profile_compatibility_fixtures_for_fields(
     ]
 }
 
+/// Returns whether a signature matches the supported baseline profile.
+///
+/// This requires:
+/// - canonical algorithm id (`ed25519`),
+/// - canonical profile id (`baseline-v1`),
+/// - deterministic field rendering match.
 pub fn signature_matches_supported_profile_for_fields(
     signature: &str,
     sender: &str,

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -113,10 +113,11 @@ fn graduated_wave_three_task_lifecycle_module_must_not_return_to_missing_docs_al
 #[test]
 fn graduated_wave_four_runtime_safety_modules_must_not_return_to_allowlist() {
     // Regression: #1828
+    // Regression: #1981
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);
     let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
 
-    for module in ["key_recovery", "migrations", "smoke"] {
+    for module in ["key_recovery", "migrations", "signature_profile", "smoke"] {
         assert!(
             !actual.iter().any(|candidate| candidate == module),
             "{module} must stay graduated from #[allow(missing_docs)]"

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -163,10 +163,12 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `migrations`
   - `namespaces`
   - `smoke`
+  - `signature_profile`
   - `state`
   - `task_lifecycle`
 - Regression marker:
   - `Regression: #1828`
+  - `Regression: #1981`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -39,7 +39,6 @@ reputation_state
 retention_engine
 runtime
 service_marketplace
-signature_profile
 signer_backend
 task_artifacts
 task_operations

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -3,6 +3,7 @@ key_recovery
 kolme_runtime_commit
 migrations
 namespaces
+signature_profile
 smoke
 state
 task_lifecycle


### PR DESCRIPTION
## Summary
Graduate `signature_profile` from the `kamn-core` missing-docs allowlist by documenting its full public API and removing its `#[allow(missing_docs)]` exemption. This advances task #1717's adjacent-module graduation target while preserving strict docs-policy contracts.

## Changes
- `crates/kamn-core/src/lib.rs`: remove `#[allow(missing_docs)]` for `signature_profile`; add module-level export doc comment.
- `crates/kamn-core/src/signature_profile.rs`: add doc comments for all public constants, structs/fields, and functions.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: remove `signature_profile` from allowlist.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: add `signature_profile` to graduated modules fixture.
- `crates/kamn-core/tests/missing_docs_policy.rs`: include `signature_profile` in graduated module regression guard (`Regression: #1981`).
- `docs/architecture/kamn-core-module-map.md`: include `signature_profile` in graduated modules status and add marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Output (after removing allowlist first):
```text
error: missing documentation for a module
  --> crates/kamn-core/src/lib.rs:97:1
...
error: missing documentation for a constant
 --> crates/kamn-core/src/signature_profile.rs:1:1
...
error: could not compile `kamn-core` (lib) due to 21 previous errors
```

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core signature_profile -- --nocapture
cargo test -p kamn-core --test engineering_hardening_wave_docs
```
Output summary:
```text
RUSTFLAGS strict check: success
missing_docs_policy: 7 passed; 0 failed
signature_profile unit coverage: all signature_profile tests passed
engineering_hardening_wave_docs: 4 passed; 0 failed
```

### 🔁 Regression
Regression guard updated:
- `crates/kamn-core/tests/missing_docs_policy.rs` now enforces `signature_profile` remains graduated (`Regression: #1981`).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing `signature_profile` unit tests (`cargo test -p kamn-core signature_profile`) | |
| Functional   | ✅ | Strict docs lint gate (`RUSTFLAGS='-D warnings' cargo check -p kamn-core`) | |
| Integration  | ✅ | `cargo test -p kamn-core --test missing_docs_policy`, `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `Regression: #1981` in missing-docs policy test and module map | |
| Performance  | N/A | | Docs-only graduation changes |

## Risks & Rollback
- None.
- Rollback plan: revert commit `e20a8d4` if documentation/fixture drift is detected.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (no behavior changes; docs-focused graduation)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to impacted docs policy/tests)
- [x] Docs updated (or justified why not)

Closes #1981
Refs #1717
