### PR TITLE
docs(kamn-core): graduate agent_key_hierarchy docs allowlist (#1983)

### DIFF
--- a/crates/kamn-core/src/agent_key_hierarchy.rs
+++ b/crates/kamn-core/src/agent_key_hierarchy.rs
@@ -1,19 +1,27 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+/// Logical role binding for agent key material.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyRole {
+    /// Long-lived identity root key role.
     Identity,
+    /// Signing key role used for message and transaction signatures.
     Signing,
+    /// Agreement key role used for session/key-agreement flows.
     Agreement,
 }
 
+/// Ephemeral session key metadata tracked per session identifier.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EphemeralSessionKey {
+    /// Session-scoped key identifier.
     pub key_id: String,
+    /// Expiration timestamp in seconds.
     pub expires_at_secs: u64,
 }
 
+/// In-memory key hierarchy manager for role-bound and ephemeral keys.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentKeyHierarchy {
     identity_key_id: String,
@@ -23,6 +31,7 @@ pub struct AgentKeyHierarchy {
 }
 
 impl AgentKeyHierarchy {
+    /// Creates a new hierarchy with distinct non-empty role key identifiers.
     pub fn new(
         identity_key_id: &str,
         signing_key_id: &str,
@@ -41,6 +50,7 @@ impl AgentKeyHierarchy {
         })
     }
 
+    /// Returns the current key identifier for the requested role.
     pub fn current_key(&self, role: KeyRole) -> Result<&str, AgentKeyHierarchyError> {
         Ok(match role {
             KeyRole::Identity => &self.identity_key_id,
@@ -49,6 +59,7 @@ impl AgentKeyHierarchy {
         })
     }
 
+    /// Rotates the signing key while enforcing non-empty and cross-role uniqueness.
     pub fn rotate_signing_key(&mut self, key_id: &str) -> Result<(), AgentKeyHierarchyError> {
         ensure_non_empty("signing", key_id)?;
         if key_id == self.identity_key_id || key_id == self.agreement_key_id {
@@ -58,6 +69,7 @@ impl AgentKeyHierarchy {
         Ok(())
     }
 
+    /// Rotates the agreement key while enforcing non-empty and cross-role uniqueness.
     pub fn rotate_agreement_key(&mut self, key_id: &str) -> Result<(), AgentKeyHierarchyError> {
         ensure_non_empty("agreement", key_id)?;
         if key_id == self.identity_key_id || key_id == self.signing_key_id {
@@ -67,6 +79,10 @@ impl AgentKeyHierarchy {
         Ok(())
     }
 
+    /// Registers a new ephemeral key for a session.
+    ///
+    /// Fails when the session id is empty, the key id is empty, the expiry is
+    /// zero, or the session already exists.
     pub fn register_ephemeral(
         &mut self,
         session_id: &str,
@@ -96,6 +112,7 @@ impl AgentKeyHierarchy {
         Ok(())
     }
 
+    /// Returns the ephemeral key metadata for a session id.
     pub fn ephemeral_key(
         &self,
         session_id: &str,
@@ -105,6 +122,9 @@ impl AgentKeyHierarchy {
             .ok_or_else(|| AgentKeyHierarchyError::SessionNotFound(session_id.to_owned()))
     }
 
+    /// Removes an ephemeral session binding.
+    ///
+    /// Returns an error when the session id is not registered.
     pub fn retire_ephemeral(&mut self, session_id: &str) -> Result<(), AgentKeyHierarchyError> {
         if self.ephemeral_by_session.remove(session_id).is_none() {
             return Err(AgentKeyHierarchyError::SessionNotFound(
@@ -115,13 +135,20 @@ impl AgentKeyHierarchy {
     }
 }
 
+/// Errors produced by key hierarchy validation and mutation operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentKeyHierarchyError {
+    /// A role-bound or ephemeral key id was empty.
     EmptyKeyId(&'static str),
+    /// A key id was reused across role bindings.
     DuplicateRoleKey(String),
+    /// Session id for an ephemeral binding was empty.
     EmptySessionId,
+    /// Ephemeral session already exists.
     DuplicateSession(String),
+    /// Ephemeral session was not found.
     SessionNotFound(String),
+    /// Ephemeral expiry value was invalid.
     InvalidExpiry(u64),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! explicitly allow-listed while new public surfaces should carry docs by default.
 #![warn(missing_docs)]
 
-#[allow(missing_docs)]
+/// Agent key hierarchy roles, rotation, and ephemeral session key contracts.
 pub mod agent_key_hierarchy;
 #[allow(missing_docs)]
 pub mod agent_upgrade_workflow;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -130,6 +130,24 @@ fn graduated_wave_four_runtime_safety_modules_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_five_identity_module_must_not_return_to_allowlist() {
+    // Regression: #1983
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+
+    for module in ["agent_key_hierarchy"] {
+        assert!(
+            !actual.iter().any(|candidate| candidate == module),
+            "{module} must stay graduated from #[allow(missing_docs)]"
+        );
+        assert!(
+            !expected.iter().any(|candidate| candidate == module),
+            "allowlist fixture must keep {module} removed"
+        );
+    }
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -157,6 +157,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 ## Missing-Docs Graduation Status
 
 - Graduated modules currently enforced outside the allow-list:
+  - `agent_key_hierarchy`
   - `bootstrap`
   - `key_recovery`
   - `kolme_runtime_commit`
@@ -169,6 +170,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 - Regression marker:
   - `Regression: #1828`
   - `Regression: #1981`
+  - `Regression: #1983`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -1,4 +1,3 @@
-agent_key_hierarchy
 agent_upgrade_workflow
 anti_spam
 audit_exports

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -1,3 +1,4 @@
+agent_key_hierarchy
 bootstrap
 key_recovery
 kolme_runtime_commit


### PR DESCRIPTION
## Summary
Graduate `agent_key_hierarchy` from the `kamn-core` missing-docs allowlist by documenting all public API surfaces and removing its exemption from `lib.rs`. This continues #1717/#1712 allowlist reduction with strict docs policy enforcement.

## Changes
- `crates/kamn-core/src/lib.rs`: remove `#[allow(missing_docs)]` for `agent_key_hierarchy`; add module export doc comment.
- `crates/kamn-core/src/agent_key_hierarchy.rs`: add docs for public enum variants, structs/fields, methods, and error variants.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: remove `agent_key_hierarchy`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: add `agent_key_hierarchy`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: add regression guard test for `agent_key_hierarchy` graduation (`Regression: #1983`).
- `docs/architecture/kamn-core-module-map.md`: add `agent_key_hierarchy` to graduated modules and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Output (after removing allowlist first):
```text
error: missing documentation for a module
 --> crates/kamn-core/src/lib.rs:8:1
...
error: missing documentation for an enum
 --> crates/kamn-core/src/agent_key_hierarchy.rs:5:1
...
error: could not compile `kamn-core` (lib) due to 23 previous errors
```

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core agent_key_hierarchy -- --nocapture
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
```
Output summary:
```text
strict docs check: success
missing_docs_policy: 8 passed; 0 failed
agent_key_hierarchy tests: all passed
engineering_hardening_wave_docs: 4 passed; 0 failed
fmt/clippy: clean
```

### 🔁 Regression
Regression guard added and validated:
- `crates/kamn-core/tests/missing_docs_policy.rs` enforces `agent_key_hierarchy` remains graduated (`Regression: #1983`).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing `agent_key_hierarchy` tests | |
| Functional   | ✅ | strict docs-lint gate (`RUSTFLAGS='-D warnings' cargo check -p kamn-core`) | |
| Integration  | ✅ | `cargo test -p kamn-core --test missing_docs_policy`, `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `Regression: #1983` guard in missing-doc policy test/module map | |
| Performance  | N/A | | Docs-only graduation change |

## Risks & Rollback
- None.
- Rollback plan: revert commit `9112e37` if docs fixture alignment needs rollback.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to impacted docs policy/tests)
- [x] Docs updated (or justified why not)

Closes #1983
Refs #1717
