### PR TITLE
docs(kamn-core): graduate task_payment docs allowlist (#1987)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -106,7 +106,7 @@ pub mod task_artifacts;
 pub mod task_lifecycle;
 #[allow(missing_docs)]
 pub mod task_operations;
-#[allow(missing_docs)]
+/// Task payment offer/confirmation workflow backed by escrow release controls.
 pub mod task_payment;
 #[allow(missing_docs)]
 pub mod telegram_bridge;

--- a/crates/kamn-core/src/task_payment.rs
+++ b/crates/kamn-core/src/task_payment.rs
@@ -5,19 +5,29 @@ use crate::{
 use std::collections::BTreeMap;
 use std::fmt;
 
+/// Payment offer submitted for a completed task.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaymentOffer {
+    /// Task identifier that the offer settles.
     pub task_id: String,
+    /// Escrow identifier funding the payout.
     pub escrow_id: String,
+    /// Requester DID funding the payment.
     pub payer_did: String,
+    /// Assignee DID receiving the payment.
     pub payee_did: String,
+    /// Amount to release from escrow in atomic units.
     pub amount: u128,
 }
 
+/// Confirmation payload authorizing release for a payment offer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaymentConfirm {
+    /// Task identifier for the confirmed offer.
     pub task_id: String,
+    /// Escrow identifier tied to the offer.
     pub escrow_id: String,
+    /// Payer DID confirming release.
     pub confirmer_did: String,
 }
 
@@ -27,16 +37,19 @@ struct PendingOffer {
     confirmed: bool,
 }
 
+/// Task payment workflow that validates and tracks escrow-backed offers.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TaskPaymentWorkflow {
     offers_by_task: BTreeMap<String, PendingOffer>,
 }
 
 impl TaskPaymentWorkflow {
+    /// Creates an empty task-payment workflow.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Submits a payment offer after validating task, escrow, and participant constraints.
     pub fn submit_offer(
         &mut self,
         offer: PaymentOffer,
@@ -81,6 +94,7 @@ impl TaskPaymentWorkflow {
         Ok(())
     }
 
+    /// Confirms a submitted offer and releases escrow funds once.
     pub fn confirm_offer(
         &mut self,
         confirm: PaymentConfirm,
@@ -122,22 +136,68 @@ impl TaskPaymentWorkflow {
     }
 }
 
+/// Errors returned by task-payment offer and confirmation workflows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskPaymentError {
+    /// Confirmation already exists for the task.
     DuplicateConfirm(String),
+    /// Offer already exists for the task.
     DuplicateOffer(String),
+    /// Required field is missing.
     EmptyField(&'static str),
+    /// Escrow lifecycle call failed.
     Escrow(String),
-    EscrowMismatch { expected: String, found: String },
+    /// Escrow identifier does not match the submitted offer.
+    EscrowMismatch {
+        /// Expected escrow identifier.
+        expected: String,
+        /// Observed escrow identifier.
+        found: String,
+    },
+    /// DID failed validation.
     InvalidDid(String),
+    /// Offer amount is invalid.
     InvalidOfferAmount(u128),
-    PayerRequesterMismatch { expected: String, found: String },
-    PayeeAssigneeMismatch { expected: String, found: String },
-    OfferExceedsEscrow { offered: u128, remaining: u128 },
+    /// Payer DID does not match task requester.
+    PayerRequesterMismatch {
+        /// Expected requester DID.
+        expected: String,
+        /// Observed payer DID.
+        found: String,
+    },
+    /// Payee DID does not match task assignee.
+    PayeeAssigneeMismatch {
+        /// Expected assignee DID.
+        expected: String,
+        /// Observed payee DID.
+        found: String,
+    },
+    /// Offer amount exceeds remaining escrow balance.
+    OfferExceedsEscrow {
+        /// Amount offered for release.
+        offered: u128,
+        /// Remaining escrow balance.
+        remaining: u128,
+    },
+    /// Task lookup failed.
     TaskLookup(String),
+    /// Task is missing assignee required for payment routing.
     TaskMissingAssignee(String),
-    TaskNotCompleted { task_id: String, state: TaskState },
-    UnauthorizedConfirmer { expected: String, found: String },
+    /// Task is not completed and cannot be paid yet.
+    TaskNotCompleted {
+        /// Task identifier.
+        task_id: String,
+        /// Current task state.
+        state: TaskState,
+    },
+    /// Confirmer DID is not authorized to approve release.
+    UnauthorizedConfirmer {
+        /// Expected confirmer DID.
+        expected: String,
+        /// Observed confirmer DID.
+        found: String,
+    },
+    /// Offer for the given task does not exist.
     UnknownOffer(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -164,6 +164,23 @@ fn graduated_wave_six_marketplace_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_seven_task_payment_module_must_not_return_to_allowlist() {
+    // Regression: #1987
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "task_payment";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -167,12 +167,14 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `smoke`
   - `signature_profile`
   - `state`
+  - `task_payment`
   - `task_lifecycle`
 - Regression marker:
   - `Regression: #1828`
   - `Regression: #1981`
   - `Regression: #1983`
   - `Regression: #1985`
+  - `Regression: #1987`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -40,7 +40,6 @@ runtime
 signer_backend
 task_artifacts
 task_operations
-task_payment
 telegram_bridge
 token
 transaction

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -8,4 +8,5 @@ signature_profile
 smoke
 state
 service_marketplace
+task_payment
 task_lifecycle


### PR DESCRIPTION
## Summary
Graduates `task_payment` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting the full task-payment public API and aligning fixtures, policy tests, and architecture docs with the graduated state.

Closes #1987
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/task_payment.rs`: added rustdoc to all public structs, fields, methods, and error variants/fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `task_payment` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `task_payment`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `task_payment`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_seven_task_payment_module_must_not_return_to_allowlist` with `Regression: #1987`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules and regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing the allowlist exemption, with missing-doc errors on:
  - `pub mod task_payment` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/task_payment.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1987#issuecomment-3888695832

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (10 passed)
- `cargo test -p kamn-core --test task_payment_workflow` ✅ (7 passed)
- `cargo test -p kamn-core --test task_payment_workflow_docs` ✅ (7 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test task_payment_workflow` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1987`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate task_payment docs allowlist (#1987)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
