### PR TITLE
docs(kamn-core): graduate reputation_signals docs allowlist (#1989)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -84,7 +84,7 @@ pub mod operator_dashboard_ui;
 pub mod performance_targets;
 #[allow(missing_docs)]
 pub mod redaction_compliance;
-#[allow(missing_docs)]
+/// Reputation-signal weighting and candidate-ranking contracts for routing.
 pub mod reputation_signals;
 #[allow(missing_docs)]
 pub mod reputation_state;

--- a/crates/kamn-core/src/reputation_signals.rs
+++ b/crates/kamn-core/src/reputation_signals.rs
@@ -2,12 +2,18 @@ use crate::{AgentDid, ReputationStore, ServiceListing};
 use std::collections::BTreeSet;
 use std::fmt;
 
+/// Weight configuration used to convert reputation evidence into routing adjustments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RoutingSignalWeights {
+    /// Bonus per endorsement signal.
     pub endorsement_weight: i32,
+    /// Penalty per dispute signal.
     pub dispute_penalty_weight: i32,
+    /// Bonus applied when required capabilities are fully matched.
     pub capability_match_bonus: i32,
+    /// Penalty applied when required capabilities are not fully matched.
     pub capability_miss_penalty: i32,
+    /// Bonus per verified capability.
     pub verification_weight: i32,
 }
 
@@ -23,40 +29,65 @@ impl Default for RoutingSignalWeights {
     }
 }
 
+/// Aggregated reputation signal counts used in candidate ranking explanations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReputationSignalSummary {
+    /// Number of endorsements on record.
     pub endorsements: usize,
+    /// Number of disputes on record.
     pub disputes: usize,
+    /// Number of verified capabilities on record.
     pub verified_capabilities: usize,
+    /// Required capabilities matched by the candidate.
     pub matched_capabilities: Vec<String>,
 }
 
+/// Ranked agent candidate for routing decisions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RankedAgentCandidate {
+    /// Candidate agent DID.
     pub agent_did: String,
+    /// Baseline trust score.
     pub trust_score: u32,
+    /// Reputation signal adjustment applied to the baseline score.
     pub signal_adjustment: i32,
+    /// Final routing score after adjustment and clamping.
     pub routing_score: i32,
+    /// Signal breakdown used to compute adjustment.
     pub summary: ReputationSignalSummary,
 }
 
+/// Ranked service-listing candidate for marketplace discovery.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RankedListingCandidate {
+    /// Marketplace listing identifier.
     pub listing_id: String,
+    /// Provider DID for the listing.
     pub provider_did: String,
+    /// Baseline trust score.
     pub trust_score: u32,
+    /// Reputation signal adjustment applied to the baseline score.
     pub signal_adjustment: i32,
+    /// Final routing score after adjustment and clamping.
     pub routing_score: i32,
+    /// Required capabilities matched by the listing provider.
     pub matched_capabilities: Vec<String>,
 }
 
+/// Errors emitted while ranking candidates by reputation signals.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReputationSignalError {
+    /// No candidates were supplied.
     EmptyCandidates,
+    /// Candidate DID failed validation.
     InvalidCandidateDid(String),
+    /// Candidate DID appeared more than once.
     DuplicateCandidateDid(String),
+    /// Candidate has no reputation record.
     MissingReputation(String),
+    /// Required capabilities input contains invalid entries.
     InvalidRequiredCapability,
+    /// A weight value is negative.
     InvalidWeight(&'static str),
 }
 
@@ -83,6 +114,7 @@ impl fmt::Display for ReputationSignalError {
 
 impl std::error::Error for ReputationSignalError {}
 
+/// Ranks agent candidates using trust score plus weighted reputation signals.
 pub fn rank_agents_for_routing(
     store: &ReputationStore,
     candidate_dids: &[&str],
@@ -135,6 +167,7 @@ pub fn rank_agents_for_routing(
     Ok(ranked)
 }
 
+/// Ranks marketplace listings by provider reputation and capability fit.
 pub fn rank_listings_by_reputation(
     listings: &[ServiceListing],
     store: &ReputationStore,

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -181,6 +181,23 @@ fn graduated_wave_seven_task_payment_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_eight_reputation_signals_module_must_not_return_to_allowlist() {
+    // Regression: #1989
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "reputation_signals";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -163,6 +163,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `kolme_runtime_commit`
   - `migrations`
   - `namespaces`
+  - `reputation_signals`
   - `service_marketplace`
   - `smoke`
   - `signature_profile`
@@ -175,6 +176,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1983`
   - `Regression: #1985`
   - `Regression: #1987`
+  - `Regression: #1989`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -33,7 +33,6 @@ operator_dashboard_api
 operator_dashboard_ui
 performance_targets
 redaction_compliance
-reputation_signals
 reputation_state
 retention_engine
 runtime

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -4,6 +4,7 @@ key_recovery
 kolme_runtime_commit
 migrations
 namespaces
+reputation_signals
 signature_profile
 smoke
 state


### PR DESCRIPTION
## Summary
Graduates `reputation_signals` from the phased missing-docs allowlist in `kamn-core`. This extends #1717 docs-hardening cadence by documenting the public signal-ranking API and keeping fixtures, policy tests, and architecture docs synchronized with the graduated set.

Closes #1989
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/reputation_signals.rs`: added rustdoc for public structs, fields, enum variants, and ranking functions.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `reputation_signals` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `reputation_signals`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `reputation_signals`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_eight_reputation_signals_module_must_not_return_to_allowlist` with `Regression: #1989`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod reputation_signals` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/reputation_signals.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1989#issuecomment-3888706511

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (11 passed)
- `cargo test -p kamn-core --test reputation_signal_routing` ✅ (4 passed)
- `cargo test -p kamn-core --test reputation_signal_routing_docs` ✅ (8 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test reputation_signal_routing` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1989`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate reputation_signals docs allowlist (#1989)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
