### PR TITLE
docs(kamn-core): graduate telegram_bridge docs allowlist (#1991)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -108,7 +108,7 @@ pub mod task_lifecycle;
 pub mod task_operations;
 /// Task payment offer/confirmation workflow backed by escrow release controls.
 pub mod task_payment;
-#[allow(missing_docs)]
+/// Telegram inbound bridge validation, route checks, and envelope normalization.
 pub mod telegram_bridge;
 #[allow(missing_docs)]
 pub mod token;

--- a/crates/kamn-core/src/telegram_bridge.rs
+++ b/crates/kamn-core/src/telegram_bridge.rs
@@ -6,23 +6,35 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::sync::Mutex;
 
+/// Telegram bridge configuration for listener authorization and channel routing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelegramBridgeConfig {
+    /// DID used by the bridge agent identity.
     pub bridge_agent_did: String,
+    /// Listener DIDs allowed to submit inbound webhook payloads.
     pub authorized_listener_dids: BTreeSet<String>,
+    /// Shared webhook token expected on inbound requests.
     pub webhook_token: String,
+    /// Mapping from external Telegram channel id to target DID.
     pub channel_routes: BTreeMap<String, String>,
 }
 
+/// Normalized inbound webhook request metadata for Telegram bridge processing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelegramInboundRequest {
+    /// DID of the listener submitting the inbound payload.
     pub listener_did: String,
+    /// Webhook token presented by the listener.
     pub webhook_token: String,
+    /// Monotonic checkpoint value from external channel stream.
     pub checkpoint: u64,
+    /// Unix timestamp when listener observed the payload.
     pub observed_at_unix: u64,
+    /// Inbound envelope normalized for bridge adapter processing.
     pub inbound: BridgeInboundEnvelope,
 }
 
+/// Telegram bridge engine that validates inbound requests and normalizes payloads.
 #[derive(Debug)]
 pub struct TelegramBridgeEngine {
     config: TelegramBridgeConfig,
@@ -31,6 +43,7 @@ pub struct TelegramBridgeEngine {
 }
 
 impl TelegramBridgeEngine {
+    /// Creates a Telegram bridge engine after validating configuration shape and DIDs.
     pub fn new(config: TelegramBridgeConfig) -> Result<Self, TelegramBridgeError> {
         validate_did(&config.bridge_agent_did)?;
         if config.authorized_listener_dids.is_empty() {
@@ -60,6 +73,7 @@ impl TelegramBridgeEngine {
         })
     }
 
+    /// Validates and processes an inbound request into normalized bridge message form.
     pub fn process_inbound(
         &self,
         request: &TelegramInboundRequest,
@@ -74,6 +88,7 @@ impl TelegramBridgeEngine {
         Ok(normalized)
     }
 
+    /// Validates and processes an inbound request into canonical message-envelope form.
     pub fn process_inbound_to_envelope(
         &self,
         request: &TelegramInboundRequest,
@@ -158,24 +173,40 @@ impl TelegramBridgeEngine {
     }
 }
 
+/// Errors emitted by Telegram bridge configuration and inbound processing paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TelegramBridgeError {
+    /// Required field was empty.
     EmptyField(&'static str),
+    /// DID failed validation.
     InvalidDid(String),
+    /// Listener DID is not authorized.
     UnauthorizedListener(String),
+    /// Webhook token did not match configured value.
     InvalidWebhookToken,
+    /// Checkpoint is not strictly monotonic for a route channel.
     NonMonotonicCheckpoint {
+        /// External route channel identifier.
         external_channel_id: String,
+        /// Previously accepted checkpoint.
         last_checkpoint: u64,
+        /// Newly received checkpoint.
         received_checkpoint: u64,
     },
+    /// Checkpoint state lock could not be acquired.
     CheckpointStateUnavailable,
+    /// Route channel id does not exist in configured mapping.
     UnknownRouteChannel(String),
+    /// Inbound envelope target DID does not match configured route target DID.
     RouteTargetMismatch {
+        /// External route channel identifier.
         external_channel_id: String,
+        /// Expected route target DID from configuration.
         expected_target_did: String,
+        /// Target DID present in inbound payload.
         provided_target_did: String,
     },
+    /// Underlying bridge-adapter processing error.
     Bridge(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -198,6 +198,23 @@ fn graduated_wave_eight_reputation_signals_module_must_not_return_to_allowlist()
 }
 
 #[test]
+fn graduated_wave_nine_telegram_bridge_module_must_not_return_to_allowlist() {
+    // Regression: #1991
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "telegram_bridge";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -169,6 +169,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `signature_profile`
   - `state`
   - `task_payment`
+  - `telegram_bridge`
   - `task_lifecycle`
 - Regression marker:
   - `Regression: #1828`
@@ -177,6 +178,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1985`
   - `Regression: #1987`
   - `Regression: #1989`
+  - `Regression: #1991`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -39,7 +39,6 @@ runtime
 signer_backend
 task_artifacts
 task_operations
-telegram_bridge
 token
 transaction
 trust_score

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -10,4 +10,5 @@ smoke
 state
 service_marketplace
 task_payment
+telegram_bridge
 task_lifecycle


### PR DESCRIPTION
## Summary
Graduates `telegram_bridge` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting Telegram bridge public contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #1991
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/telegram_bridge.rs`: added rustdoc for public structs, fields, methods, enum variants, and variant fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `telegram_bridge` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `telegram_bridge`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `telegram_bridge`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_nine_telegram_bridge_module_must_not_return_to_allowlist` with `Regression: #1991`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod telegram_bridge` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/telegram_bridge.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1991#issuecomment-3888716532

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (12 passed)
- `cargo test -p kamn-core --test telegram_bridge` ✅ (7 passed)
- `cargo test -p kamn-core --test telegram_bridge_listener_docs` ✅ (4 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test telegram_bridge` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1991`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate telegram_bridge docs allowlist (#1991)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
