### PR TITLE
docs(kamn-core): graduate operator_actions docs allowlist (#1993)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -72,7 +72,7 @@ pub mod migrations;
 pub mod namespaces;
 #[allow(missing_docs)]
 pub mod observability;
-#[allow(missing_docs)]
+/// Permissioned operator configuration actions and audit-log service contracts.
 pub mod operator_actions;
 #[allow(missing_docs)]
 pub mod operator_binding;

--- a/crates/kamn-core/src/operator_actions.rs
+++ b/crates/kamn-core/src/operator_actions.rs
@@ -2,23 +2,35 @@ use crate::{OperatorBindingAction, OperatorBindingEngine, OperatorBindingError};
 use std::collections::BTreeMap;
 use std::fmt;
 
+/// Authorization outcome for a requested operator action.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OperatorActionOutcome {
+    /// Action passed authorization and was applied.
     Allowed,
+    /// Action failed authorization and was denied.
     Denied,
 }
 
+/// Immutable audit record for a permissioned operator action request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OperatorActionAuditRecord {
+    /// Agent DID owning the target configuration namespace.
     pub agent_did: String,
+    /// Operator DID requesting the action.
     pub operator_did: String,
+    /// Action type requested through operator binding policy.
     pub action: OperatorBindingAction,
+    /// Action target key/resource.
     pub target: String,
+    /// Optional action value payload.
     pub value: Option<String>,
+    /// Request timestamp in unix seconds.
     pub requested_at_unix: u64,
+    /// Final authorization outcome.
     pub outcome: OperatorActionOutcome,
 }
 
+/// Service that gates operator actions through binding authorization and audit logging.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PermissionedOperatorActionService {
     bindings: OperatorBindingEngine,
@@ -27,6 +39,7 @@ pub struct PermissionedOperatorActionService {
 }
 
 impl PermissionedOperatorActionService {
+    /// Creates a permissioned operator action service with the provided binding engine.
     pub fn new(bindings: OperatorBindingEngine) -> Self {
         Self {
             bindings,
@@ -35,6 +48,7 @@ impl PermissionedOperatorActionService {
         }
     }
 
+    /// Applies a configuration update when binding authorization allows the request.
     pub fn configure(
         &mut self,
         agent_did: &str,
@@ -85,6 +99,7 @@ impl PermissionedOperatorActionService {
         Ok(())
     }
 
+    /// Revokes an operator binding and records an audit decision.
     pub fn revoke_binding(
         &mut self,
         agent_did: &str,
@@ -122,6 +137,7 @@ impl PermissionedOperatorActionService {
         }
     }
 
+    /// Reads action audit history after authorization against read-history capability.
     pub fn read_history(
         &mut self,
         agent_did: &str,
@@ -160,12 +176,14 @@ impl PermissionedOperatorActionService {
         Ok(self.audit_log.clone())
     }
 
+    /// Returns the configured value for `(agent_did, config_key)` if present.
     pub fn setting(&self, agent_did: &str, config_key: &str) -> Option<String> {
         self.settings
             .get(&(agent_did.to_owned(), config_key.to_owned()))
             .cloned()
     }
 
+    /// Returns a snapshot copy of the full audit log.
     pub fn audit_log(&self) -> Vec<OperatorActionAuditRecord> {
         self.audit_log.clone()
     }
@@ -175,9 +193,12 @@ impl PermissionedOperatorActionService {
     }
 }
 
+/// Errors returned by permissioned operator action service operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OperatorActionServiceError {
+    /// Required input field was empty.
     EmptyField(&'static str),
+    /// Binding authorization or binding mutation failed.
     Binding(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -215,6 +215,23 @@ fn graduated_wave_nine_telegram_bridge_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_ten_operator_actions_module_must_not_return_to_allowlist() {
+    // Regression: #1993
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "operator_actions";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -163,6 +163,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `kolme_runtime_commit`
   - `migrations`
   - `namespaces`
+  - `operator_actions`
   - `reputation_signals`
   - `service_marketplace`
   - `smoke`
@@ -179,6 +180,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1987`
   - `Regression: #1989`
   - `Regression: #1991`
+  - `Regression: #1993`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -27,7 +27,6 @@ message_delivery_guards
 message_envelope
 message_lifecycle
 observability
-operator_actions
 operator_binding
 operator_dashboard_api
 operator_dashboard_ui

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -4,6 +4,7 @@ key_recovery
 kolme_runtime_commit
 migrations
 namespaces
+operator_actions
 reputation_signals
 signature_profile
 smoke


### PR DESCRIPTION
## Summary
Graduates `operator_actions` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting operator action service contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #1993
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/operator_actions.rs`: added rustdoc for public enums, structs, fields, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `operator_actions` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `operator_actions`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `operator_actions`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_ten_operator_actions_module_must_not_return_to_allowlist` with `Regression: #1993`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod operator_actions` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/operator_actions.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1993#issuecomment-3888729636

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (13 passed)
- `cargo test -p kamn-core --test operator_permissioned_actions` ✅ (5 passed)
- `cargo test -p kamn-core --test operator_permissioned_actions_docs` ✅ (4 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test operator_permissioned_actions` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1993`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate operator_actions docs allowlist (#1993)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
