### PR TITLE
docs(kamn-core): graduate transaction docs allowlist (#1995)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -112,7 +112,7 @@ pub mod task_payment;
 pub mod telegram_bridge;
 #[allow(missing_docs)]
 pub mod token;
-#[allow(missing_docs)]
+/// Baseline transaction validation and state-hash progression guard contracts.
 pub mod transaction;
 #[allow(missing_docs)]
 pub mod trust_score;

--- a/crates/kamn-core/src/transaction.rs
+++ b/crates/kamn-core/src/transaction.rs
@@ -4,19 +4,28 @@ use crate::signature_profile::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Initial expected state hash before any block commits.
 pub const GENESIS_STATE_HASH: &str = "state:genesis";
 
+/// Baseline transaction payload used by transaction guard validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BaselineTransaction {
+    /// Unique transaction identifier.
     pub id: String,
+    /// Sender identifier.
     pub sender: String,
+    /// Sender nonce expected to increase sequentially.
     pub nonce: u64,
+    /// Serialized payload content.
     pub payload: String,
+    /// State hash the transaction expects to build upon.
     pub state_hash: String,
+    /// Transaction signature for baseline profile validation.
     pub signature: String,
 }
 
 impl BaselineTransaction {
+    /// Creates a transaction and fills a baseline signature for its fields.
     pub fn signed(id: &str, sender: &str, nonce: u64, payload: &str, state_hash: &str) -> Self {
         let mut tx = Self {
             id: id.to_owned(),
@@ -30,6 +39,7 @@ impl BaselineTransaction {
         tx
     }
 
+    /// Computes the expected baseline signature for this transaction.
     pub fn expected_signature(&self) -> String {
         baseline_signature_for_fields(&self.sender, self.nonce, &self.state_hash, &self.payload)
     }
@@ -57,6 +67,7 @@ impl BaselineTransaction {
     }
 }
 
+/// Guard engine that validates transaction shape, signature, nonce, and state continuity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionGuards {
     expected_state_hash: String,
@@ -75,14 +86,17 @@ impl Default for TransactionGuards {
 }
 
 impl TransactionGuards {
+    /// Creates a new guard engine initialized at `GENESIS_STATE_HASH`.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Returns the state hash expected by the next transaction validation.
     pub fn expected_state_hash(&self) -> &str {
         &self.expected_state_hash
     }
 
+    /// Validates a transaction against guard rules and records nonce/id progression.
     pub fn validate_and_record(
         &mut self,
         tx: &BaselineTransaction,
@@ -134,6 +148,7 @@ impl TransactionGuards {
         Ok(())
     }
 
+    /// Commits a validated block and advances expected state hash.
     pub fn commit_block(
         &mut self,
         transactions: &[BaselineTransaction],
@@ -163,25 +178,41 @@ impl TransactionGuards {
     }
 }
 
+/// Errors emitted by transaction guard validation and commit flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransactionGuardError {
+    /// Transaction id has already been recorded.
     DuplicateTransactionId(String),
+    /// Required field was empty.
     EmptyField(&'static str),
+    /// Nonce value was invalid.
     InvalidNonce(u64),
+    /// Signature did not match baseline profile expectations.
     InvalidSignature {
+        /// Transaction identifier.
         tx_id: String,
+        /// Expected signature value.
         expected: String,
+        /// Observed signature value.
         found: String,
     },
+    /// Nonce did not match expected sender sequence.
     NonceOutOfSequence {
+        /// Sender identifier.
         sender: String,
+        /// Expected nonce value.
         expected: u64,
+        /// Observed nonce value.
         found: u64,
     },
+    /// Transaction state hash did not match current guard expectation.
     StateHashMismatch {
+        /// Expected state hash.
         expected: String,
+        /// Observed state hash.
         found: String,
     },
+    /// Block commit attempted for a transaction that was never validated.
     UnvalidatedCommittedTransaction(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -232,6 +232,23 @@ fn graduated_wave_ten_operator_actions_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_eleven_transaction_module_must_not_return_to_allowlist() {
+    // Regression: #1995
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "transaction";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -172,6 +172,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `task_payment`
   - `telegram_bridge`
   - `task_lifecycle`
+  - `transaction`
 - Regression marker:
   - `Regression: #1828`
   - `Regression: #1981`
@@ -181,6 +182,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1989`
   - `Regression: #1991`
   - `Regression: #1993`
+  - `Regression: #1995`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -39,7 +39,6 @@ signer_backend
 task_artifacts
 task_operations
 token
-transaction
 trust_score
 upgrade_orchestration
 validator_lifecycle

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -13,3 +13,4 @@ service_marketplace
 task_payment
 telegram_bridge
 task_lifecycle
+transaction


### PR DESCRIPTION
## Summary
Graduates `transaction` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting baseline transaction guard contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #1995
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/transaction.rs`: added rustdoc for public constant, structs, fields, methods, enum variants, and variant fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `transaction` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `transaction`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `transaction`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_eleven_transaction_module_must_not_return_to_allowlist` with `Regression: #1995`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod transaction` in `crates/kamn-core/src/lib.rs`
  - `GENESIS_STATE_HASH` and public API in `crates/kamn-core/src/transaction.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1995#issuecomment-3888740417

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (14 passed)
- `cargo test -p kamn-core --test transaction_guards` ✅ (7 passed)
- `cargo test -p kamn-core --test transaction_guards_docs` ✅ (4 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test transaction_guards` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1995`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate transaction docs allowlist (#1995)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
