### PR TITLE
docs(kamn-core): graduate task_artifacts docs allowlist (#1997)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -101,7 +101,7 @@ pub mod signer_backend;
 /// Deterministic triadic runtime smoke simulation contracts.
 pub mod smoke;
 pub mod state;
-#[allow(missing_docs)]
+/// Task artifact registration, integrity checks, and lookup contracts.
 pub mod task_artifacts;
 pub mod task_lifecycle;
 #[allow(missing_docs)]

--- a/crates/kamn-core/src/task_artifacts.rs
+++ b/crates/kamn-core/src/task_artifacts.rs
@@ -2,28 +2,45 @@ use crate::AgentDid;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Persisted task artifact metadata after successful registration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskArtifactRecord {
+    /// Stable artifact identifier.
     pub artifact_id: String,
+    /// Task identifier the artifact belongs to.
     pub task_id: String,
+    /// Creator DID for the artifact.
     pub creator: String,
+    /// Creation timestamp in unix seconds.
     pub created_at_unix: u64,
+    /// On-chain integrity hash for artifact verification.
     pub on_chain_hash: String,
+    /// Off-chain URI where artifact content is stored.
     pub off_chain_uri: String,
+    /// MIME-style content type for artifact payload.
     pub content_type: String,
 }
 
+/// Input payload used to register a new task artifact.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskArtifactSubmission {
+    /// Stable artifact identifier.
     pub artifact_id: String,
+    /// Task identifier the artifact belongs to.
     pub task_id: String,
+    /// Creator DID for the artifact.
     pub creator: String,
+    /// Creation timestamp in unix seconds.
     pub created_at_unix: u64,
+    /// On-chain integrity hash for artifact verification.
     pub on_chain_hash: String,
+    /// Off-chain URI where artifact content is stored.
     pub off_chain_uri: String,
+    /// MIME-style content type for artifact payload.
     pub content_type: String,
 }
 
+/// Registry for task-artifact storage keyed by artifact, task, and creator.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TaskArtifactRegistry {
     artifacts: BTreeMap<String, TaskArtifactRecord>,
@@ -32,15 +49,18 @@ pub struct TaskArtifactRegistry {
 }
 
 impl TaskArtifactRegistry {
+    /// Creates an empty task artifact registry.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Computes deterministic integrity fingerprint for `(task_id, creator, off_chain_uri)`.
     pub fn integrity_fingerprint(task_id: &str, creator: &str, off_chain_uri: &str) -> String {
         let canonical = format!("{task_id}|{creator}|{off_chain_uri}");
         fnv1a_hex(&canonical)
     }
 
+    /// Registers a new artifact after validating fields, DID, and integrity hash.
     pub fn register(
         &mut self,
         submission: TaskArtifactSubmission,
@@ -96,12 +116,14 @@ impl TaskArtifactRegistry {
         Ok(())
     }
 
+    /// Returns artifact record by identifier.
     pub fn artifact(&self, artifact_id: &str) -> Result<&TaskArtifactRecord, TaskArtifactError> {
         self.artifacts
             .get(artifact_id)
             .ok_or_else(|| TaskArtifactError::NotFound(artifact_id.to_owned()))
     }
 
+    /// Lists artifact ids associated with the provided task id.
     pub fn artifacts_for_task(&self, task_id: &str) -> Vec<String> {
         self.artifacts_by_task
             .get(task_id)
@@ -109,6 +131,7 @@ impl TaskArtifactRegistry {
             .unwrap_or_default()
     }
 
+    /// Lists artifact ids associated with the provided creator DID.
     pub fn artifacts_for_creator(&self, creator: &str) -> Vec<String> {
         self.artifacts_by_creator
             .get(creator)
@@ -117,12 +140,23 @@ impl TaskArtifactRegistry {
     }
 }
 
+/// Errors returned by task artifact registration and lookup flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskArtifactError {
+    /// Required field was empty.
     EmptyField(&'static str),
+    /// Creator DID failed validation.
     InvalidDid(String),
+    /// Artifact id already exists.
     DuplicateArtifactId(String),
-    IntegrityMismatch { expected: String, provided: String },
+    /// Integrity hash did not match expected fingerprint.
+    IntegrityMismatch {
+        /// Expected deterministic fingerprint.
+        expected: String,
+        /// Provided on-chain hash value.
+        provided: String,
+    },
+    /// Artifact id does not exist.
     NotFound(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -249,6 +249,23 @@ fn graduated_wave_eleven_transaction_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_twelve_task_artifacts_module_must_not_return_to_allowlist() {
+    // Regression: #1997
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "task_artifacts";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -169,6 +169,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `smoke`
   - `signature_profile`
   - `state`
+  - `task_artifacts`
   - `task_payment`
   - `telegram_bridge`
   - `task_lifecycle`
@@ -183,6 +184,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1991`
   - `Regression: #1993`
   - `Regression: #1995`
+  - `Regression: #1997`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -36,7 +36,6 @@ reputation_state
 retention_engine
 runtime
 signer_backend
-task_artifacts
 task_operations
 token
 trust_score

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -13,4 +13,5 @@ service_marketplace
 task_payment
 telegram_bridge
 task_lifecycle
+task_artifacts
 transaction


### PR DESCRIPTION
## Summary
Graduates `task_artifacts` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting artifact registry/integrity contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #1997
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/task_artifacts.rs`: added rustdoc for public structs, fields, methods, enum variants, and variant fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `task_artifacts` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `task_artifacts`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `task_artifacts`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_twelve_task_artifacts_module_must_not_return_to_allowlist` with `Regression: #1997`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod task_artifacts` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/task_artifacts.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1997#issuecomment-3888752073

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (15 passed)
- `cargo test -p kamn-core --test task_artifacts` ✅ (4 passed)
- `cargo test -p kamn-core --test task_operation_snapshot` ✅ (5 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test task_artifacts` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test task_operation_snapshot` and `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1997`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate task_artifacts docs allowlist (#1997)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
