### PR TITLE
docs(kamn-core): graduate direct_message_crypto docs allowlist (#1999)

### DIFF
--- a/crates/kamn-core/src/direct_message_crypto.rs
+++ b/crates/kamn-core/src/direct_message_crypto.rs
@@ -1,20 +1,31 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+/// Key agreement algorithm identifier used for direct-message shared-secret derivation.
 pub const DIRECT_MESSAGE_KEY_AGREEMENT_ALGORITHM: &str = "X25519";
+/// Cipher algorithm identifier used for direct-message payload encryption.
 pub const DIRECT_MESSAGE_CIPHER_ALGORITHM: &str = "XChaCha20-Poly1305";
 
+/// Encrypted direct-message payload and metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectMessageCiphertext {
+    /// Key agreement algorithm used to derive the shared secret.
     pub key_agreement_algorithm: String,
+    /// Cipher algorithm used to encrypt the payload.
     pub cipher_algorithm: String,
+    /// Sender key reference used in key agreement.
     pub sender_key_ref: String,
+    /// Recipient key reference used in key agreement.
     pub recipient_key_ref: String,
+    /// Nonce used for encryption.
     pub nonce: u64,
+    /// Hex-encoded ciphertext bytes.
     pub ciphertext: String,
+    /// Integrity/authentication tag for ciphertext verification.
     pub auth_tag: String,
 }
 
+/// Deterministic direct-message crypto engine with nonce reuse protection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectMessageCryptoEngine {
     sender_key_ref: String,
@@ -24,6 +35,7 @@ pub struct DirectMessageCryptoEngine {
 }
 
 impl DirectMessageCryptoEngine {
+    /// Creates a new engine for sender/recipient key references.
     pub fn new(
         sender_key_ref: &str,
         recipient_key_ref: &str,
@@ -42,6 +54,7 @@ impl DirectMessageCryptoEngine {
         })
     }
 
+    /// Encrypts plaintext with the provided nonce and returns ciphertext metadata.
     pub fn encrypt(
         &mut self,
         plaintext: &str,
@@ -82,6 +95,7 @@ impl DirectMessageCryptoEngine {
         })
     }
 
+    /// Decrypts ciphertext after algorithm and integrity validation.
     pub fn decrypt(
         &self,
         sealed: &DirectMessageCiphertext,
@@ -116,15 +130,24 @@ impl DirectMessageCryptoEngine {
     }
 }
 
+/// Errors emitted by direct-message crypto construction and processing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DirectMessageCryptoError {
+    /// Key reference for role was empty.
     EmptyKeyRef(&'static str),
+    /// Key reference for role did not match expected shape.
     InvalidKeyRef(&'static str),
+    /// Plaintext payload was empty.
     EmptyPayload,
+    /// Nonce value was invalid.
     InvalidNonce(u64),
+    /// Nonce was reused.
     NonceReuse(u64),
+    /// Ciphertext algorithm metadata did not match expected algorithms.
     AlgorithmMismatch,
+    /// Ciphertext integrity verification failed.
     IntegrityCheckFailed,
+    /// Ciphertext bytes were not valid hex or UTF-8 output.
     InvalidCiphertextEncoding,
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -40,7 +40,7 @@ pub mod data_classification;
 pub mod did;
 #[allow(missing_docs)]
 pub mod did_registry;
-#[allow(missing_docs)]
+/// Direct-message encryption/decryption contracts and error semantics.
 pub mod direct_message_crypto;
 #[allow(missing_docs)]
 pub mod discord_bridge;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -266,6 +266,23 @@ fn graduated_wave_twelve_task_artifacts_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_thirteen_direct_message_crypto_module_must_not_return_to_allowlist() {
+    // Regression: #1999
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "direct_message_crypto";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -159,6 +159,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 - Graduated modules currently enforced outside the allow-list:
   - `agent_key_hierarchy`
   - `bootstrap`
+  - `direct_message_crypto`
   - `key_recovery`
   - `kolme_runtime_commit`
   - `migrations`
@@ -185,6 +186,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1993`
   - `Regression: #1995`
   - `Regression: #1997`
+  - `Regression: #1999`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -14,7 +14,6 @@ cross_chain_receipt
 data_classification
 did
 did_registry
-direct_message_crypto
 discord_bridge
 durable_guard_store
 escrow

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -15,3 +15,4 @@ telegram_bridge
 task_lifecycle
 task_artifacts
 transaction
+direct_message_crypto


### PR DESCRIPTION
## Summary
Graduates `direct_message_crypto` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting direct-message crypto contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #1999
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/direct_message_crypto.rs`: added rustdoc for public constants, structs, fields, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `direct_message_crypto` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `direct_message_crypto`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `direct_message_crypto`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_thirteen_direct_message_crypto_module_must_not_return_to_allowlist` with `Regression: #1999`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod direct_message_crypto` in `crates/kamn-core/src/lib.rs`
  - public constants and public API in `crates/kamn-core/src/direct_message_crypto.rs`
- Red phase log: https://github.com/njfio/kamn/issues/1999#issuecomment-3888763264

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (16 passed)
- `cargo test -p kamn-core --test direct_message_encryption` ✅ (5 passed)
- `cargo test -p kamn-core --test key_management_and_encryption_docs` ✅ (2 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test direct_message_encryption` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #1999`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate direct_message_crypto docs allowlist (#1999)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
