### PR TITLE
docs(kamn-core): graduate operator_binding docs allowlist (#2001)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -74,7 +74,7 @@ pub mod namespaces;
 pub mod observability;
 /// Permissioned operator configuration actions and audit-log service contracts.
 pub mod operator_actions;
-#[allow(missing_docs)]
+/// Operator identity binding, proof validation, and authorization contracts.
 pub mod operator_binding;
 #[allow(missing_docs)]
 pub mod operator_dashboard_api;

--- a/crates/kamn-core/src/operator_binding.rs
+++ b/crates/kamn-core/src/operator_binding.rs
@@ -5,40 +5,58 @@ use std::fmt;
 const HUMAN_DID_PREFIX: &str = "kamn:did:human:";
 const CANONICAL_PROOF_TYPE: &str = "Ed25519Signature2020";
 
+/// Permissioned actions that an operator binding may authorize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum OperatorBindingAction {
+    /// Allow configuration mutations.
     Configure,
+    /// Allow binding revocation.
     Revoke,
+    /// Allow audit/history reads.
     ReadHistory,
 }
 
+/// Proof payload that attests operator authorization intent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OperatorBindingProof {
+    /// Proof type identifier.
     pub type_name: String,
+    /// Proof creation timestamp.
     pub created: String,
+    /// Verification method reference.
     pub verification_method: String,
+    /// Proof signature value.
     pub proof_value: String,
 }
 
+/// Persisted operator binding record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OperatorBindingRecord {
+    /// Agent DID owner of the binding scope.
     pub agent_did: String,
+    /// Operator DID granted permissions.
     pub operator_did: String,
+    /// Optional proof object for binding establishment.
     pub proof: Option<OperatorBindingProof>,
+    /// Authorized permission set.
     pub permissions: BTreeSet<OperatorBindingAction>,
+    /// Revocation flag.
     pub revoked: bool,
 }
 
+/// Engine that manages operator bindings and authorization checks.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OperatorBindingEngine {
     bindings: BTreeMap<(String, String), OperatorBindingRecord>,
 }
 
 impl OperatorBindingEngine {
+    /// Creates an empty operator binding engine.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Registers a new operator binding with required permissions and optional proof.
     pub fn register_binding(
         &mut self,
         agent_did: &str,
@@ -77,6 +95,7 @@ impl OperatorBindingEngine {
         Ok(())
     }
 
+    /// Authorizes operator action against a non-revoked binding record.
     pub fn authorize(
         &self,
         agent_did: &str,
@@ -102,6 +121,7 @@ impl OperatorBindingEngine {
         Ok(())
     }
 
+    /// Revokes an existing binding if caller has revoke permission.
     pub fn revoke_binding(
         &mut self,
         agent_did: &str,
@@ -137,6 +157,7 @@ impl OperatorBindingEngine {
         Ok(())
     }
 
+    /// Returns binding record for `(agent_did, operator_did)`.
     pub fn binding_for(
         &self,
         agent_did: &str,
@@ -161,31 +182,52 @@ impl OperatorBindingEngine {
     }
 }
 
+/// Errors emitted by operator binding registration and authorization.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OperatorBindingError {
+    /// Permission set was empty.
     EmptyPermissions,
+    /// Proof field was empty.
     EmptyProofField(&'static str),
+    /// Agent DID failed validation.
     InvalidAgentDid(String),
+    /// Operator DID failed validation.
     InvalidOperatorDid(String),
+    /// Proof type did not match required canonical type.
     InvalidProofType(String),
+    /// Proof verification method prefix did not match operator DID.
     ProofVerificationMethodMismatch {
+        /// Expected verification method prefix.
         expected_prefix: String,
+        /// Actual verification method value.
         actual: String,
     },
+    /// Binding already exists for `(agent_did, operator_did)`.
     DuplicateBinding {
+        /// Agent DID.
         agent_did: String,
+        /// Operator DID.
         operator_did: String,
     },
+    /// Binding not found for `(agent_did, operator_did)`.
     MissingBinding {
+        /// Agent DID.
         agent_did: String,
+        /// Operator DID.
         operator_did: String,
     },
+    /// Binding already revoked for `(agent_did, operator_did)`.
     RevokedBinding {
+        /// Agent DID.
         agent_did: String,
+        /// Operator DID.
         operator_did: String,
     },
+    /// Operator attempted an unauthorized action.
     UnauthorizedAction {
+        /// Operator DID.
         operator_did: String,
+        /// Unauthorized action.
         action: OperatorBindingAction,
     },
 }

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -283,6 +283,23 @@ fn graduated_wave_thirteen_direct_message_crypto_module_must_not_return_to_allow
 }
 
 #[test]
+fn graduated_wave_fourteen_operator_binding_module_must_not_return_to_allowlist() {
+    // Regression: #2001
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "operator_binding";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -165,6 +165,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `migrations`
   - `namespaces`
   - `operator_actions`
+  - `operator_binding`
   - `reputation_signals`
   - `service_marketplace`
   - `smoke`
@@ -187,6 +188,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1995`
   - `Regression: #1997`
   - `Regression: #1999`
+  - `Regression: #2001`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -26,7 +26,6 @@ message_delivery_guards
 message_envelope
 message_lifecycle
 observability
-operator_binding
 operator_dashboard_api
 operator_dashboard_ui
 performance_targets

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -5,6 +5,7 @@ kolme_runtime_commit
 migrations
 namespaces
 operator_actions
+operator_binding
 reputation_signals
 signature_profile
 smoke


### PR DESCRIPTION
## Summary
Graduates `operator_binding` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting operator binding proof/authorization contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #2001
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/operator_binding.rs`: added rustdoc for public enums, structs, fields, methods, and error variants/fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `operator_binding` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `operator_binding`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `operator_binding`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_fourteen_operator_binding_module_must_not_return_to_allowlist` with `Regression: #2001`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod operator_binding` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/operator_binding.rs`
- Red phase log: https://github.com/njfio/kamn/issues/2001#issuecomment-3888774995

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (17 passed)
- `cargo test -p kamn-core --test operator_binding_permissions` ✅ (4 passed)
- `cargo test -p kamn-core --test operator_permissioned_actions` ✅ (5 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test operator_binding_permissions` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test operator_permissioned_actions` and `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #2001`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate operator_binding docs allowlist (#2001)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
