### PR TITLE
docs(kamn-core): graduate anti_spam docs allowlist (#2003)

### DIFF
--- a/crates/kamn-core/src/anti_spam.rs
+++ b/crates/kamn-core/src/anti_spam.rs
@@ -1,12 +1,18 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 
+/// Anti-spam threshold configuration for deposit, rate, and suspension policies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AntiSpamConfig {
+    /// Maximum accepted messages per sender within a rolling window.
     pub max_messages_per_window: usize,
+    /// Rolling-window size in seconds for rate-limit evaluation.
     pub window_seconds: u64,
+    /// Minimum deposit required for sender admission.
     pub minimum_sybil_deposit: u64,
+    /// Consecutive rate-limit violations required to trigger suspension.
     pub suspension_violation_threshold: u32,
+    /// Suspension duration in seconds after threshold is exceeded.
     pub suspension_seconds: u64,
 }
 
@@ -22,42 +28,66 @@ impl Default for AntiSpamConfig {
     }
 }
 
+/// Admission decision returned by anti-spam evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AntiSpamDecision {
+    /// Message is accepted for downstream processing.
     Accepted,
+    /// Message is rejected with a typed reason.
     Rejected(AntiSpamRejection),
 }
 
+/// Typed rejection reasons emitted by anti-spam evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AntiSpamRejection {
+    /// Sender deposit is below required threshold.
     InsufficientDeposit {
+        /// Required minimum deposit.
         required: u64,
+        /// Provided sender deposit.
         provided: u64,
     },
+    /// Sender exceeded rolling-window rate limit.
     RateLimitExceeded {
+        /// Configured message limit.
         limit: usize,
+        /// Observed messages in window.
         observed: usize,
+        /// Window size in seconds.
         window_seconds: u64,
     },
+    /// Sender is currently suspended.
     SenderSuspended {
+        /// Unix timestamp when suspension expires.
         until_unix: u64,
     },
+    /// Message id has already been seen.
     DuplicateMessageId(String),
 }
 
+/// Aggregate anti-spam telemetry counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct AntiSpamTelemetry {
+    /// Total evaluated messages.
     pub total_processed: u64,
+    /// Count of accepted messages.
     pub accepted: u64,
+    /// Count of insufficient-deposit rejections.
     pub rejected_insufficient_deposit: u64,
+    /// Count of rate-limit rejections.
     pub rejected_rate_limit: u64,
+    /// Count of suspension rejections.
     pub rejected_suspended: u64,
+    /// Count of duplicate-message-id rejections.
     pub rejected_duplicate_message: u64,
 }
 
+/// Errors returned by anti-spam configuration and input validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AntiSpamError {
+    /// Anti-spam config is invalid.
     InvalidConfig(String),
+    /// Runtime input is invalid.
     InvalidInput(String),
 }
 
@@ -79,6 +109,7 @@ struct SenderState {
     suspended_until_unix: Option<u64>,
 }
 
+/// Stateful anti-spam engine tracking deposits, message ids, sender windows, and telemetry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AntiSpamEngine {
     config: AntiSpamConfig,
@@ -89,6 +120,7 @@ pub struct AntiSpamEngine {
 }
 
 impl AntiSpamEngine {
+    /// Creates a new anti-spam engine after validating configuration.
     pub fn new(config: AntiSpamConfig) -> Result<Self, AntiSpamError> {
         validate_config(config)?;
 
@@ -101,12 +133,14 @@ impl AntiSpamEngine {
         })
     }
 
+    /// Sets or updates sender deposit used for sybil-admission checks.
     pub fn set_deposit(&mut self, sender_did: &str, deposit: u64) -> Result<(), AntiSpamError> {
         validate_sender_did(sender_did)?;
         self.deposits.insert(sender_did.to_owned(), deposit);
         Ok(())
     }
 
+    /// Evaluates a sender/message at `now_unix` and returns admission decision.
     pub fn evaluate(
         &mut self,
         sender_did: &str,
@@ -178,6 +212,7 @@ impl AntiSpamEngine {
         Ok(AntiSpamDecision::Accepted)
     }
 
+    /// Returns a snapshot of anti-spam telemetry counters.
     pub fn telemetry(&self) -> AntiSpamTelemetry {
         self.telemetry
     }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -9,7 +9,7 @@
 pub mod agent_key_hierarchy;
 #[allow(missing_docs)]
 pub mod agent_upgrade_workflow;
-#[allow(missing_docs)]
+/// Anti-spam admission, rate-limit, and suspension policy contracts.
 pub mod anti_spam;
 #[allow(missing_docs)]
 pub mod audit_exports;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -300,6 +300,23 @@ fn graduated_wave_fourteen_operator_binding_module_must_not_return_to_allowlist(
 }
 
 #[test]
+fn graduated_wave_fifteen_anti_spam_module_must_not_return_to_allowlist() {
+    // Regression: #2003
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "anti_spam";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -158,6 +158,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 
 - Graduated modules currently enforced outside the allow-list:
   - `agent_key_hierarchy`
+  - `anti_spam`
   - `bootstrap`
   - `direct_message_crypto`
   - `key_recovery`
@@ -189,6 +190,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1997`
   - `Regression: #1999`
   - `Regression: #2001`
+  - `Regression: #2003`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -1,5 +1,4 @@
 agent_upgrade_workflow
-anti_spam
 audit_exports
 bridge_adapter
 channel_models

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -1,4 +1,5 @@
 agent_key_hierarchy
+anti_spam
 bootstrap
 key_recovery
 kolme_runtime_commit


### PR DESCRIPTION
## Summary
Graduates `anti_spam` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting anti-spam admission/rejection contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #2003
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/anti_spam.rs`: added rustdoc for public structs, fields, methods, enum variants, and variant fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `anti_spam` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `anti_spam`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `anti_spam`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_fifteen_anti_spam_module_must_not_return_to_allowlist` with `Regression: #2003`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod anti_spam` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/anti_spam.rs`
- Red phase log: https://github.com/njfio/kamn/issues/2003#issuecomment-3888788398

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (18 passed)
- `cargo test -p kamn-core --test anti_spam_controls` ✅ (6 passed)
- `cargo test -p kamn-core --test anti_spam_controls_docs` ✅ (3 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test anti_spam_controls` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #2003`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate anti_spam docs allowlist (#2003)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
