### PR TITLE
docs(kamn-core): graduate discord_bridge docs allowlist (#2005)

### DIFF
--- a/crates/kamn-core/src/discord_bridge.rs
+++ b/crates/kamn-core/src/discord_bridge.rs
@@ -6,35 +6,53 @@ use crate::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Discord bridge configuration for listeners, approvers, and channel routes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordBridgeConfig {
+    /// DID used by the bridge agent identity.
     pub bridge_agent_did: String,
+    /// Listener DIDs allowed to submit inbound events.
     pub authorized_listener_dids: BTreeSet<String>,
+    /// Approver DIDs allowed to approve outbound dispatches.
     pub authorized_approver_dids: BTreeSet<String>,
+    /// Number of unique approvals required per outbound request.
     pub required_approvals: usize,
+    /// Mapping from external channel id to target DID.
     pub channel_routes: BTreeMap<String, String>,
 }
 
+/// Inbound request metadata for Discord listener submissions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordInboundRequest {
+    /// Listener DID submitting the inbound request.
     pub listener_did: String,
+    /// Unix timestamp when event was observed.
     pub observed_at_unix: u64,
+    /// Normalized inbound bridge envelope.
     pub inbound: BridgeInboundEnvelope,
 }
 
+/// Approval evidence for an outbound Discord dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordOutboundApproval {
+    /// Outbound request identifier.
     pub request_id: String,
+    /// Required number of approvals.
     pub required_approvals: usize,
+    /// DID set that approved this request.
     pub approved_by: BTreeSet<String>,
 }
 
+/// Outbound dispatch payload coupled with approval evidence.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordOutboundDispatch {
+    /// Outbound envelope for platform dispatch.
     pub envelope: BridgeOutboundEnvelope,
+    /// Approval summary for dispatch authorization.
     pub approval: DiscordOutboundApproval,
 }
 
+/// Discord bridge engine for inbound normalization and outbound approval-gated dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordBridgeEngine {
     config: DiscordBridgeConfig,
@@ -42,6 +60,7 @@ pub struct DiscordBridgeEngine {
 }
 
 impl DiscordBridgeEngine {
+    /// Creates a Discord bridge engine after validating config and route policy.
     pub fn new(config: DiscordBridgeConfig) -> Result<Self, DiscordBridgeError> {
         validate_did(&config.bridge_agent_did)?;
         if config.authorized_listener_dids.is_empty() {
@@ -81,6 +100,7 @@ impl DiscordBridgeEngine {
         Ok(Self { config, bridge })
     }
 
+    /// Validates and processes inbound requests into normalized message form.
     pub fn process_inbound(
         &self,
         request: &DiscordInboundRequest,
@@ -92,6 +112,7 @@ impl DiscordBridgeEngine {
             .map_err(|error| DiscordBridgeError::Bridge(error.to_string()))
     }
 
+    /// Validates and processes inbound requests into canonical message-envelope form.
     pub fn process_inbound_to_envelope(
         &self,
         request: &DiscordInboundRequest,
@@ -143,6 +164,7 @@ impl DiscordBridgeEngine {
         Ok(())
     }
 
+    /// Processes outbound request after validating route and required approver set.
     pub fn process_outbound_with_approvals(
         &self,
         request: &BridgeOutboundRequest,
@@ -209,27 +231,45 @@ impl DiscordBridgeEngine {
     }
 }
 
+/// Errors emitted by Discord bridge validation and dispatch flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscordBridgeError {
+    /// Required field was empty.
     EmptyField(&'static str),
+    /// DID failed validation.
     InvalidDid(String),
+    /// Required approval count is invalid for configured approver set.
     InvalidRequiredApprovals {
+        /// Required approval count.
         required: usize,
+        /// Number of configured approvers.
         approver_count: usize,
     },
+    /// Listener DID is not authorized.
     UnauthorizedListener(String),
+    /// Approver DID is not authorized.
     UnauthorizedApprover(String),
+    /// Duplicate approval from same approver DID.
     DuplicateApproval(String),
+    /// Approval set did not meet required threshold.
     InsufficientApprovals {
+        /// Required approval count.
         required: usize,
+        /// Provided unique approvals.
         provided: usize,
     },
+    /// Route channel id is unknown.
     UnknownRouteChannel(String),
+    /// Target DID in payload does not match route mapping.
     RouteTargetMismatch {
+        /// External channel identifier.
         external_channel_id: String,
+        /// Expected target DID.
         expected_target_did: String,
+        /// Provided target DID.
         provided_target_did: String,
     },
+    /// Underlying bridge adapter error.
     Bridge(String),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -42,7 +42,7 @@ pub mod did;
 pub mod did_registry;
 /// Direct-message encryption/decryption contracts and error semantics.
 pub mod direct_message_crypto;
-#[allow(missing_docs)]
+/// Discord bridge ingress/egress routing and outbound approval contracts.
 pub mod discord_bridge;
 #[allow(missing_docs)]
 pub mod durable_guard_store;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -317,6 +317,23 @@ fn graduated_wave_fifteen_anti_spam_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_sixteen_discord_bridge_module_must_not_return_to_allowlist() {
+    // Regression: #2005
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "discord_bridge";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -161,6 +161,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `anti_spam`
   - `bootstrap`
   - `direct_message_crypto`
+  - `discord_bridge`
   - `key_recovery`
   - `kolme_runtime_commit`
   - `migrations`
@@ -191,6 +192,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #1999`
   - `Regression: #2001`
   - `Regression: #2003`
+  - `Regression: #2005`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -13,7 +13,6 @@ cross_chain_receipt
 data_classification
 did
 did_registry
-discord_bridge
 durable_guard_store
 escrow
 governance_workflow

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -18,3 +18,4 @@ task_lifecycle
 task_artifacts
 transaction
 direct_message_crypto
+discord_bridge


### PR DESCRIPTION
## Summary
Graduates `discord_bridge` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting Discord ingress/egress and quorum approval contracts while aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #2005
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/discord_bridge.rs`: added rustdoc for public structs, fields, methods, enum variants, and variant fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `discord_bridge` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `discord_bridge`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `discord_bridge`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_sixteen_discord_bridge_module_must_not_return_to_allowlist` with `Regression: #2005`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod discord_bridge` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/discord_bridge.rs`
- Red phase log: https://github.com/njfio/kamn/issues/2005#issuecomment-3888800385

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (19 passed)
- `cargo test -p kamn-core --test discord_bridge` ✅ (6 passed)
- `cargo test -p kamn-core --test discord_bridge_approver_docs` ✅ (3 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test discord_bridge` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #2005`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate discord_bridge docs allowlist (#2005)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
