### PR TITLE
docs(kamn-core): graduate key_lifecycle docs allowlist (#2007)

### DIFF
--- a/crates/kamn-core/src/key_lifecycle.rs
+++ b/crates/kamn-core/src/key_lifecycle.rs
@@ -1,42 +1,79 @@
+/// Key lifecycle state for an agent signing key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyLifecycleState {
+    /// Key is active and can sign traffic.
     Active,
+    /// Rotation has started and a pending key is staged.
     Rotating,
+    /// Key has been revoked and can no longer be used.
     Revoked,
 }
 
+/// Key lifecycle event emitted for audit and replay.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyLifecycleEvent {
+    /// Rotation started from one key id to a new key id.
     RotationInitiated {
+        /// Monotonic lifecycle sequence number.
         sequence: u64,
+        /// Previous active key id.
         from_key: String,
+        /// Staged next key id.
         to_key: String,
     },
+    /// Rotation was activated and pending key became active.
     RotationActivated {
+        /// Monotonic lifecycle sequence number.
         sequence: u64,
+        /// Newly active key id.
         active_key: String,
     },
+    /// Active key was revoked.
     KeyRevoked {
+        /// Monotonic lifecycle sequence number.
         sequence: u64,
+        /// Revoked key id.
         key_id: String,
     },
 }
 
+/// Canonical audit record for a single lifecycle event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyLifecycleAuditRecord {
+    /// Monotonic lifecycle sequence number.
     pub sequence: u64,
+    /// Canonical event kind.
     pub event_kind: String,
+    /// Canonical event payload.
     pub event_payload: String,
+    /// Previous record hash in audit chain.
     pub previous_hash: String,
+    /// Record hash computed from canonical fields.
     pub record_hash: String,
 }
 
+/// Errors returned while validating lifecycle audit trails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyLifecycleAuditError {
+    /// Audit trail was empty.
     EmptyAuditTrail,
-    SequenceGap { expected: u64, found: u64 },
-    BrokenHashChain { sequence: u64 },
-    HashMismatch { sequence: u64 },
+    /// Sequence numbers were not contiguous.
+    SequenceGap {
+        /// Expected sequence value.
+        expected: u64,
+        /// Observed sequence value.
+        found: u64,
+    },
+    /// Record previous-hash link did not match chain state.
+    BrokenHashChain {
+        /// Sequence where chain link failed.
+        sequence: u64,
+    },
+    /// Record hash did not match canonical recomputation.
+    HashMismatch {
+        /// Sequence where hash mismatch occurred.
+        sequence: u64,
+    },
 }
 
 impl std::fmt::Display for KeyLifecycleAuditError {
@@ -93,6 +130,7 @@ impl KeyLifecycleEvent {
     }
 }
 
+/// Key lifecycle state machine with deterministic audit-event emission.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyLifecycle {
     state: KeyLifecycleState,
@@ -103,6 +141,7 @@ pub struct KeyLifecycle {
 }
 
 impl KeyLifecycle {
+    /// Creates lifecycle with an initial active key id.
     pub fn new(active_key_id: &str) -> Result<Self, KeyLifecycleError> {
         if active_key_id.trim().is_empty() {
             return Err(KeyLifecycleError::EmptyKeyId);
@@ -116,22 +155,27 @@ impl KeyLifecycle {
         })
     }
 
+    /// Returns current lifecycle state.
     pub fn state(&self) -> KeyLifecycleState {
         self.state
     }
 
+    /// Returns current active key id.
     pub fn active_key_id(&self) -> &str {
         &self.active_key_id
     }
 
+    /// Returns pending key id when rotation is in progress.
     pub fn pending_key_id(&self) -> Option<&str> {
         self.pending_key_id.as_deref()
     }
 
+    /// Returns immutable lifecycle event history.
     pub fn events(&self) -> &[KeyLifecycleEvent] {
         &self.events
     }
 
+    /// Builds canonical audit records from lifecycle events.
     pub fn audit_records(&self) -> Vec<KeyLifecycleAuditRecord> {
         let mut records = Vec::with_capacity(self.events.len());
         let mut previous_hash = AUDIT_CHAIN_GENESIS.to_owned();
@@ -157,10 +201,12 @@ impl KeyLifecycle {
         records
     }
 
+    /// Verifies audit trail generated from in-memory lifecycle events.
     pub fn verify_audit_trail(&self) -> Result<(), KeyLifecycleAuditError> {
         Self::verify_audit_records(&self.audit_records())
     }
 
+    /// Verifies provided audit records for sequence continuity and hash-chain integrity.
     pub fn verify_audit_records(
         records: &[KeyLifecycleAuditRecord],
     ) -> Result<(), KeyLifecycleAuditError> {
@@ -204,6 +250,7 @@ impl KeyLifecycle {
         Ok(())
     }
 
+    /// Initiates rotation from active key to `next_key_id`.
     pub fn initiate_rotation(&mut self, next_key_id: &str) -> Result<(), KeyLifecycleError> {
         if next_key_id.trim().is_empty() {
             return Err(KeyLifecycleError::EmptyKeyId);
@@ -229,6 +276,7 @@ impl KeyLifecycle {
         Ok(())
     }
 
+    /// Activates currently pending key and returns lifecycle to active state.
     pub fn activate_rotation(&mut self) -> Result<(), KeyLifecycleError> {
         if self.state != KeyLifecycleState::Rotating {
             return Err(KeyLifecycleError::InvalidTransition {
@@ -256,6 +304,7 @@ impl KeyLifecycle {
         Ok(())
     }
 
+    /// Revokes the active key and transitions lifecycle to revoked state.
     pub fn revoke(&mut self) -> Result<(), KeyLifecycleError> {
         match self.state {
             KeyLifecycleState::Active | KeyLifecycleState::Rotating => {}
@@ -298,12 +347,18 @@ fn compute_audit_hash(
     format!("{hash:016x}")
 }
 
+/// Errors emitted by key lifecycle transitions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyLifecycleError {
+    /// Key id input was empty.
     EmptyKeyId,
+    /// Rotation target matched active key id.
     RotationKeyUnchanged,
+    /// Transition/action is invalid for current lifecycle state.
     InvalidTransition {
+        /// Current lifecycle state.
         from: KeyLifecycleState,
+        /// Requested transition action.
         action: &'static str,
     },
 }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -56,7 +56,7 @@ pub mod group_channel_crypto;
 pub mod instruction_verify;
 #[allow(missing_docs)]
 pub mod invariants;
-#[allow(missing_docs)]
+/// Key rotation/revocation state machine and audit-trail verification contracts.
 pub mod key_lifecycle;
 /// Key compromise and recovery lifecycle contracts.
 pub mod key_recovery;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -334,6 +334,23 @@ fn graduated_wave_sixteen_discord_bridge_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_seventeen_key_lifecycle_module_must_not_return_to_allowlist() {
+    // Regression: #2007
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "key_lifecycle";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -162,6 +162,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `bootstrap`
   - `direct_message_crypto`
   - `discord_bridge`
+  - `key_lifecycle`
   - `key_recovery`
   - `kolme_runtime_commit`
   - `migrations`
@@ -193,6 +194,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2001`
   - `Regression: #2003`
   - `Regression: #2005`
+  - `Regression: #2007`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -19,7 +19,6 @@ governance_workflow
 group_channel_crypto
 instruction_verify
 invariants
-key_lifecycle
 message_delivery_guards
 message_envelope
 message_lifecycle

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -2,6 +2,7 @@ agent_key_hierarchy
 anti_spam
 bootstrap
 key_recovery
+key_lifecycle
 kolme_runtime_commit
 migrations
 namespaces


### PR DESCRIPTION
## Summary
Graduates `key_lifecycle` from the phased missing-docs allowlist in `kamn-core`. This continues #1717 docs-hardening cadence by documenting key lifecycle transition/audit contracts and aligning fixtures, policy tests, and architecture docs with the graduated module set.

Closes #2007
Refs #1717
Refs #1712

## Changes
- `crates/kamn-core/src/key_lifecycle.rs`: added rustdoc for public enums, structs, fields, methods, and error variants/fields.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `key_lifecycle` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `key_lifecycle`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `key_lifecycle`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added `graduated_wave_seventeen_key_lifecycle_module_must_not_return_to_allowlist` with `Regression: #2007`.
- `docs/architecture/kamn-core-module-map.md`: updated graduated modules + regression markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Failed as expected after removing exemption, with missing-doc errors on:
  - `pub mod key_lifecycle` in `crates/kamn-core/src/lib.rs`
  - public API in `crates/kamn-core/src/key_lifecycle.rs`
- Red phase log: https://github.com/njfio/kamn/issues/2007#issuecomment-3888814934

### 🟢 Green Phase
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core` ✅
- `cargo test -p kamn-core --test missing_docs_policy` ✅ (20 passed)
- `cargo test -p kamn-core --test key_lifecycle` ✅ (7 passed)
- `cargo test -p kamn-core --test key_lifecycle_audit_trails_docs` ✅ (7 passed)

### 🔁 Regression
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅ (4 passed)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings` ✅
- `cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core --test key_lifecycle` | |
| Functional   | ✅ | strict docs lint via `RUSTFLAGS='-D warnings' cargo check -p kamn-core` | |
| Integration  | ✅ | `cargo test -p kamn-core --test key_lifecycle_audit_trails_docs` and `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` + new guard (`Regression: #2007`) | |
| Performance  | N/A | None | Docs/policy graduation only |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate key_lifecycle docs allowlist (#2007)`.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent commands above)
- [x] TDD Red/Green evidence included above
