### PR TITLE
docs(kamn-core): graduate validator_lifecycle missing-docs module

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -118,7 +118,7 @@ pub mod transaction;
 pub mod trust_score;
 #[allow(missing_docs)]
 pub mod upgrade_orchestration;
-#[allow(missing_docs)]
+/// Validator onboarding/offboarding, quorum-change, and rollback lifecycle contracts.
 pub mod validator_lifecycle;
 #[allow(missing_docs)]
 pub mod watchdog;

--- a/crates/kamn-core/src/validator_lifecycle.rs
+++ b/crates/kamn-core/src/validator_lifecycle.rs
@@ -1,39 +1,65 @@
+//! Validator lifecycle state machine and transition-proof policy contracts.
+//!
+//! This module models validator onboarding, offboarding, quorum reconfiguration,
+//! and rollback actions with auditable transition records.
+
 use crate::AgentDid;
 use std::collections::BTreeSet;
 use std::fmt;
 
+/// Evidence bundle authorizing a validator set transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorTransitionProof {
+    /// Governance or workflow proposal identifier for this transition.
     pub proposal_id: String,
+    /// Validator DIDs that approved the transition proposal.
     pub approver_dids: Vec<String>,
+    /// Deterministic digest for the transition authorization artifact.
     pub proof_hash: String,
 }
 
+/// Materialized validator-set state after a transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorSetSnapshot {
+    /// Active validator DIDs in deterministic order.
     pub validator_dids: Vec<String>,
+    /// Minimum approvals required for future transition proofs.
     pub quorum_threshold: usize,
+    /// Unix timestamp when this snapshot became active.
     pub updated_at_unix: u64,
 }
 
+/// Supported validator-set transition kinds.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidatorTransitionKind {
+    /// Adds a new validator DID to the active set.
     Onboard,
+    /// Removes an existing validator DID from the active set.
     Offboard,
+    /// Changes quorum threshold without changing validator membership.
     ReconfigureQuorum,
+    /// Reverts the previous transition and records rollback provenance.
     Rollback,
 }
 
+/// Immutable audit record describing one validator-set transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorTransitionRecord {
+    /// Transition variant executed.
     pub kind: ValidatorTransitionKind,
+    /// Subject validator DID for member add/remove transitions.
     pub subject_validator_did: Option<String>,
+    /// Snapshot before applying the transition.
     pub previous_snapshot: ValidatorSetSnapshot,
+    /// Snapshot after applying the transition.
     pub next_snapshot: ValidatorSetSnapshot,
+    /// Proof material used to authorize the transition.
     pub proof: ValidatorTransitionProof,
+    /// Unix timestamp when transition was requested.
     pub requested_at_unix: u64,
 }
 
+/// In-memory manager enforcing validator lifecycle transition policies.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorLifecycleManager {
     validator_dids: BTreeSet<String>,
@@ -44,6 +70,7 @@ pub struct ValidatorLifecycleManager {
 }
 
 impl ValidatorLifecycleManager {
+    /// Constructs a manager with an initial validator set and quorum threshold.
     pub fn new(
         validator_dids: Vec<String>,
         quorum_threshold: usize,
@@ -70,6 +97,7 @@ impl ValidatorLifecycleManager {
         })
     }
 
+    /// Adds a validator after DID/proof validation and self-approval checks.
     pub fn onboard_validator(
         &mut self,
         validator_did: &str,
@@ -103,6 +131,7 @@ impl ValidatorLifecycleManager {
         Ok(())
     }
 
+    /// Removes a validator while ensuring quorum remains satisfiable.
     pub fn offboard_validator(
         &mut self,
         validator_did: &str,
@@ -143,6 +172,7 @@ impl ValidatorLifecycleManager {
         Ok(())
     }
 
+    /// Updates quorum threshold using the current validator governance proof.
     pub fn reconfigure_quorum(
         &mut self,
         new_quorum_threshold: usize,
@@ -170,6 +200,7 @@ impl ValidatorLifecycleManager {
         Ok(())
     }
 
+    /// Rolls back the last transition and appends an explicit rollback record.
     pub fn rollback_last_transition(
         &mut self,
         rolled_back_by: &str,
@@ -209,6 +240,7 @@ impl ValidatorLifecycleManager {
         Ok(())
     }
 
+    /// Returns the current validator-set snapshot.
     pub fn snapshot(&self) -> ValidatorSetSnapshot {
         ValidatorSetSnapshot {
             validator_dids: self.validator_dids.iter().cloned().collect(),
@@ -217,6 +249,7 @@ impl ValidatorLifecycleManager {
         }
     }
 
+    /// Returns transition history in insertion order.
     pub fn transition_history(&self) -> Vec<ValidatorTransitionRecord> {
         self.transitions.clone()
     }
@@ -243,34 +276,57 @@ impl ValidatorLifecycleManager {
     }
 }
 
+/// Error surface for validator lifecycle state and transition-proof validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidatorLifecycleError {
+    /// A required string field was empty or whitespace.
     EmptyField(&'static str),
+    /// DID value failed `AgentDid` validation.
     InvalidDid(String),
+    /// Timestamp field was zero.
     InvalidTimestamp(&'static str),
+    /// Initial validator set was empty.
     EmptyValidatorSet,
+    /// Validator DID already exists in the active set.
     DuplicateValidator(String),
+    /// Validator DID does not exist in the active set.
     ValidatorNotFound(String),
+    /// Quorum threshold is outside `1..=validator_count`.
     InvalidQuorumThreshold {
+        /// Candidate quorum threshold value.
         quorum_threshold: usize,
+        /// Active validator count used for validation.
         validator_count: usize,
     },
+    /// Offboarding would violate quorum/validator-count invariants.
     QuorumWouldExceedValidatorCount {
+        /// Existing quorum threshold that would become invalid.
         quorum_threshold: usize,
+        /// Validator count after the attempted offboarding.
         validator_count: usize,
     },
+    /// Transition proof omitted required fields.
     InvalidTransitionProof(&'static str),
+    /// Transition proof did not include enough unique approvers.
     InsufficientTransitionApprovals {
+        /// Required unique approval count.
         required: usize,
+        /// Unique approval count provided by the proof.
         provided: usize,
     },
+    /// Transition proof fingerprint has already been consumed.
     TransitionProofReplay {
+        /// Proposal identifier from the replayed proof.
         proposal_id: String,
+        /// Proof hash from the replayed proof.
         proof_hash: String,
     },
+    /// Candidate validator approved its own onboarding proof.
     OnboardingSelfApproval {
+        /// Candidate validator DID that self-approved onboarding.
         validator_did: String,
     },
+    /// No prior transition exists to roll back.
     NoTransitionToRollback,
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -351,6 +351,23 @@ fn graduated_wave_seventeen_key_lifecycle_module_must_not_return_to_allowlist() 
 }
 
 #[test]
+fn graduated_wave_eighteen_validator_lifecycle_module_must_not_return_to_allowlist() {
+    // Regression: #2009
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "validator_lifecycle";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -179,6 +179,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `telegram_bridge`
   - `task_lifecycle`
   - `transaction`
+  - `validator_lifecycle`
 - Regression marker:
   - `Regression: #1828`
   - `Regression: #1981`
@@ -195,6 +196,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2003`
   - `Regression: #2005`
   - `Regression: #2007`
+  - `Regression: #2009`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -35,6 +35,5 @@ task_operations
 token
 trust_score
 upgrade_orchestration
-validator_lifecycle
 watchdog
 zk_message_proofs

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -20,3 +20,4 @@ task_artifacts
 transaction
 direct_message_crypto
 discord_bridge
+validator_lifecycle


### PR DESCRIPTION
## Summary
Graduates `validator_lifecycle` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This advances the docs-hardening wave while preserving behavior.

Closes #2009

## Changes
- `crates/kamn-core/src/validator_lifecycle.rs`: added module/type/field/method/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `validator_lifecycle` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `validator_lifecycle`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `validator_lifecycle`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2009`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod validator_lifecycle;`
- additional missing-doc errors across `validator_lifecycle.rs` public API (structs, fields, enum variants, methods, and error variants).

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core validator_lifecycle
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- `validator_lifecycle` targeted tests passed (unit + functional + integration + regression scenarios in existing suite).
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `21 passed; 0 failed`, including `graduated_wave_eighteen_validator_lifecycle_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `validator_lifecycle` unit tests executed via `cargo test -p kamn-core validator_lifecycle` | |
| Functional   | ✅     | Existing lifecycle functional scenarios executed in `tests/validator_lifecycle.rs` | |
| Integration  | ✅     | Existing integration assertions in `tests/validator_lifecycle.rs` executed | |
| Regression   | ✅     | Added `graduated_wave_eighteen_validator_lifecycle_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
