### PR TITLE
docs(kamn-core): graduate group_channel_crypto missing-docs module

### DIFF
--- a/crates/kamn-core/src/group_channel_crypto.rs
+++ b/crates/kamn-core/src/group_channel_crypto.rs
@@ -1,33 +1,58 @@
+//! Group channel sender-key lifecycle and message protection contracts.
+//!
+//! The implementation models sender-key distribution and epoch rotation for
+//! group channels plus deterministic encryption/decryption verification paths.
+
 use crate::AgentDid;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Key-derivation algorithm identifier stamped on group ciphertext envelopes.
 pub const GROUP_MESSAGE_KEY_DERIVATION_ALGORITHM: &str = "SenderKey-v1";
+/// Cipher algorithm identifier stamped on group ciphertext envelopes.
 pub const GROUP_MESSAGE_CIPHER_ALGORITHM: &str = "XChaCha20-Poly1305";
 
+/// Persisted sender-key distribution event for one sender generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SenderKeyDistributionRecord {
+    /// Channel identifier this sender-key distribution belongs to.
     pub channel_id: String,
+    /// Sender DID that owns the sender-key generation.
     pub sender_did: String,
+    /// Sender key reference used to derive message secrets.
     pub sender_key_ref: String,
+    /// Monotonic generation counter for sender-key rotations.
     pub key_generation: u64,
+    /// Recipients authorized to decrypt ciphertext from this generation.
     pub recipient_allowlist: BTreeSet<String>,
+    /// Whether this generation is currently active for encryption.
     pub active: bool,
 }
 
+/// Encrypted group message envelope carrying sender-key metadata and proofs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupMessageCiphertext {
+    /// Declared key-derivation algorithm for decryptor compatibility checks.
     pub key_derivation_algorithm: String,
+    /// Declared cipher algorithm for decryptor compatibility checks.
     pub cipher_algorithm: String,
+    /// Channel identifier this ciphertext targets.
     pub channel_id: String,
+    /// Sender DID that produced the ciphertext.
     pub sender_did: String,
+    /// Sender-key generation used to derive this ciphertext.
     pub key_generation: u64,
+    /// Nonce value used for this encryption operation.
     pub nonce: u64,
+    /// Hex-encoded encrypted payload bytes.
     pub ciphertext: String,
+    /// Integrity tag derived from shared secret, nonce, and ciphertext.
     pub auth_tag: String,
+    /// Deterministic signature token for sender-key provenance checks.
     pub signature: String,
 }
 
+/// In-memory engine for sender-key distribution, rotation, and message sealing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupChannelCryptoEngine {
     channel_id: String,
@@ -37,6 +62,7 @@ pub struct GroupChannelCryptoEngine {
 }
 
 impl GroupChannelCryptoEngine {
+    /// Constructs an engine for a specific channel identifier.
     pub fn new(channel_id: &str) -> Result<Self, GroupChannelCryptoError> {
         if channel_id.trim().is_empty() {
             return Err(GroupChannelCryptoError::EmptyChannelId);
@@ -50,6 +76,7 @@ impl GroupChannelCryptoEngine {
         })
     }
 
+    /// Distributes a new sender-key generation and marks the previous one inactive.
     pub fn distribute_sender_key(
         &mut self,
         sender_did: &str,
@@ -94,6 +121,7 @@ impl GroupChannelCryptoEngine {
         Ok(record)
     }
 
+    /// Rotates sender-key material by issuing a new distribution generation.
     pub fn rotate_sender_key(
         &mut self,
         sender_did: &str,
@@ -103,6 +131,7 @@ impl GroupChannelCryptoEngine {
         self.distribute_sender_key(sender_did, sender_key_ref, recipients)
     }
 
+    /// Returns the active sender-key generation for a sender DID.
     pub fn active_sender_key_generation(
         &self,
         sender_did: &str,
@@ -113,6 +142,7 @@ impl GroupChannelCryptoEngine {
             .ok_or_else(|| GroupChannelCryptoError::SenderKeyNotFound(sender_did.to_owned()))
     }
 
+    /// Returns a sender-key distribution record for a specific generation.
     pub fn sender_key_record(
         &self,
         sender_did: &str,
@@ -127,6 +157,7 @@ impl GroupChannelCryptoEngine {
             })
     }
 
+    /// Encrypts plaintext for a sender using the active sender-key generation.
     pub fn encrypt(
         &mut self,
         sender_did: &str,
@@ -187,6 +218,7 @@ impl GroupChannelCryptoEngine {
         })
     }
 
+    /// Decrypts a sealed group message for an authorized recipient DID.
     pub fn decrypt(
         &self,
         recipient_did: &str,
@@ -247,32 +279,55 @@ impl GroupChannelCryptoEngine {
     }
 }
 
+/// Error surface for group channel sender-key and ciphertext validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupChannelCryptoError {
+    /// Channel identifier was empty.
     EmptyChannelId,
+    /// Recipient allowlist was empty.
     EmptyRecipients,
+    /// Plaintext payload was empty.
     EmptyPayload,
+    /// Nonce value was invalid.
     InvalidNonce(u64),
+    /// Nonce was already used for the same sender/generation.
     NonceReuse(u64),
+    /// DID failed parser validation.
     InvalidDid(String),
+    /// Sender key reference format was invalid.
     InvalidSenderKeyRef,
+    /// Sender DID has no registered sender-key generation.
     SenderKeyNotFound(String),
+    /// Sender DID does not have the requested key generation.
     UnknownSenderKeyGeneration {
+        /// Sender DID requested.
         sender_did: String,
+        /// Sender-key generation requested.
         key_generation: u64,
     },
+    /// Recipient DID is not in the distribution allowlist.
     RecipientNotAuthorized {
+        /// Recipient DID that attempted decryption.
         recipient_did: String,
+        /// Sender DID that produced the ciphertext.
         sender_did: String,
+        /// Sender-key generation used by the ciphertext.
         key_generation: u64,
     },
+    /// Ciphertext declared unsupported algorithm identifiers.
     AlgorithmMismatch,
+    /// Ciphertext channel identifier does not match engine channel.
     ChannelMismatch {
+        /// Channel identifier expected by this engine.
         expected: String,
+        /// Channel identifier supplied by ciphertext.
         actual: String,
     },
+    /// Signature check failed for ciphertext provenance.
     SignatureMismatch,
+    /// Integrity tag verification failed.
     IntegrityCheckFailed,
+    /// Ciphertext encoding could not be decoded as valid hex.
     InvalidCiphertextEncoding,
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -50,7 +50,7 @@ pub mod durable_guard_store;
 pub mod escrow;
 #[allow(missing_docs)]
 pub mod governance_workflow;
-#[allow(missing_docs)]
+/// Group sender-key distribution, rotation, and encryption integrity contracts.
 pub mod group_channel_crypto;
 #[allow(missing_docs)]
 pub mod instruction_verify;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -368,6 +368,23 @@ fn graduated_wave_eighteen_validator_lifecycle_module_must_not_return_to_allowli
 }
 
 #[test]
+fn graduated_wave_nineteen_group_channel_crypto_module_must_not_return_to_allowlist() {
+    // Regression: #2011
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "group_channel_crypto";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -162,6 +162,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `bootstrap`
   - `direct_message_crypto`
   - `discord_bridge`
+  - `group_channel_crypto`
   - `key_lifecycle`
   - `key_recovery`
   - `kolme_runtime_commit`
@@ -197,6 +198,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2005`
   - `Regression: #2007`
   - `Regression: #2009`
+  - `Regression: #2011`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -16,7 +16,6 @@ did_registry
 durable_guard_store
 escrow
 governance_workflow
-group_channel_crypto
 instruction_verify
 invariants
 message_delivery_guards

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -21,3 +21,4 @@ transaction
 direct_message_crypto
 discord_bridge
 validator_lifecycle
+group_channel_crypto


### PR DESCRIPTION
## Summary
Graduates `group_channel_crypto` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This continues the phased docs-hardening rollout without changing runtime behavior.

Closes #2011

## Changes
- `crates/kamn-core/src/group_channel_crypto.rs`: added module/type/field/method/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `group_channel_crypto` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `group_channel_crypto`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `group_channel_crypto`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2011`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod group_channel_crypto;`
- additional missing-doc errors across `group_channel_crypto.rs` public constants, structs, fields, methods, and error variants.

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core group_channel_crypto
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- `group_channel_crypto` targeted tests passed.
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `22 passed; 0 failed`, including `graduated_wave_nineteen_group_channel_crypto_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `group_channel_crypto` unit tests executed via `cargo test -p kamn-core group_channel_crypto` | |
| Functional   | ✅     | Existing group sender-key lifecycle scenarios executed in module tests | |
| Integration  | ✅     | Existing integration behaviors exercised in filtered module suite | |
| Regression   | ✅     | Added `graduated_wave_nineteen_group_channel_crypto_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
