### PR TITLE
docs(kamn-core): graduate config missing-docs module

### DIFF
--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -1,14 +1,24 @@
+//! Node configuration contracts for role and sync-mode policy surfaces.
+//!
+//! This module defines strongly typed role and synchronization profiles used by
+//! runtime startup, recovery, and CLI/config validation paths.
+
 use std::fmt;
 use std::str::FromStr;
 
+/// Node execution role determining primary runtime responsibilities.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeRole {
+    /// Processes and executes protocol work units.
     Processor,
+    /// Primarily listens and relays events without approval authority.
     Listener,
+    /// Reviews and approves gated transitions or proposals.
     Approver,
 }
 
 impl NodeRole {
+    /// Returns the canonical lowercase string form used in config parsing.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Processor => "processor",
@@ -31,14 +41,19 @@ impl FromStr for NodeRole {
     }
 }
 
+/// Chain synchronization mode used for startup and recovery planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncMode {
+    /// Prioritize fast startup with minimal replay.
     Fast,
+    /// Replay more history with stricter version matching.
     Slow,
+    /// Maintain complete historical state and replay coverage.
     Archive,
 }
 
 impl SyncMode {
+    /// Returns the canonical lowercase string form used in config parsing.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Fast => "fast",
@@ -47,6 +62,7 @@ impl SyncMode {
         }
     }
 
+    /// Resolves the operational startup/recovery profile for this sync mode.
     pub fn profile(self) -> SyncOperationalProfile {
         match self {
             Self::Fast => SyncOperationalProfile {
@@ -87,40 +103,62 @@ impl FromStr for SyncMode {
     }
 }
 
+/// Startup strategy chosen by sync-mode policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncStartupStrategy {
+    /// Sync to latest state before serving traffic.
     StateSyncToLatest,
+    /// Replay blocks from genesis to construct local state.
     BlockReplayFromGenesis,
+    /// Perform archive-grade sync from genesis state.
     ArchiveStateSyncFromGenesis,
 }
 
+/// Recovery strategy chosen by sync-mode policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncRecoveryStrategy {
+    /// Resume from recent persisted state with minimal replay.
     ResumeRecentState,
+    /// Replay only missing block range after outage.
     ReplayMissingBlocks,
+    /// Replay archived history to preserve full lineage.
     ReplayArchivedHistory,
 }
 
+/// Derived operational profile for a selected synchronization mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SyncOperationalProfile {
+    /// Source sync mode that generated this profile.
     pub mode: SyncMode,
+    /// Startup strategy contract for initialization.
     pub startup_strategy: SyncStartupStrategy,
+    /// Recovery strategy contract after interruption.
     pub recovery_strategy: SyncRecoveryStrategy,
+    /// Whether chain-version parity is required before joining.
     pub requires_chain_version_match: bool,
+    /// Whether full historical state retention is required.
     pub maintain_full_history: bool,
 }
 
+/// Node runtime configuration envelope validated before startup.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeConfig {
+    /// Logical chain identifier the node should join.
     pub chain_id: String,
+    /// Expected chain runtime/schema version.
     pub chain_version: String,
+    /// Node runtime role.
     pub role: NodeRole,
+    /// Filesystem path used for durable node storage.
     pub storage_dir: String,
+    /// Whether gossip transport is enabled.
     pub enable_gossip: bool,
+    /// Synchronization mode used for startup/recovery.
     pub sync_mode: SyncMode,
 }
 
 impl NodeConfig {
+    /// Validates required configuration fields for non-empty values.
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.chain_id.trim().is_empty() {
             return Err(ConfigError::EmptyChainId);
@@ -134,33 +172,56 @@ impl NodeConfig {
         Ok(())
     }
 
+    /// Returns the derived operational sync profile for this configuration.
     pub fn operational_profile(&self) -> SyncOperationalProfile {
         self.sync_mode.profile()
     }
 }
 
+/// Error surface for config parsing and runtime option validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigError {
+    /// `chain_id` was empty.
     EmptyChainId,
+    /// `chain_version` was empty.
     EmptyChainVersion,
+    /// `storage_dir` was empty.
     EmptyStorageDir,
+    /// Migration planning argument validation failed.
     MigrationPlan(String),
+    /// Token model argument validation failed.
     TokenModel(String),
+    /// Unknown or invalid node role string.
     InvalidRole(String),
+    /// Unknown or invalid sync mode string.
     InvalidSyncMode(String),
+    /// Unknown or invalid output mode string.
     InvalidOutputMode(String),
+    /// Unknown or invalid node profile string.
     InvalidNodeProfile(String),
+    /// Unknown or invalid diagnostics mode string.
     InvalidDiagnosticsMode(String),
+    /// Unknown or invalid runtime mode string.
     InvalidRuntimeMode(String),
+    /// Invalid expected state version argument.
     InvalidExpectedStateVersion(String),
+    /// Invalid daemon control argument.
     InvalidDaemonControlArgument(String),
+    /// Invalid daemon lifecycle event argument.
     InvalidDaemonLifecycleEvent(String),
+    /// Invalid governance proposal argument.
     InvalidProposalArgument(String),
+    /// Invalid rejoin-attempt argument.
     InvalidRejoinAttemptArgument(String),
+    /// Runtime planner argument validation failure.
     RuntimePlanner(String),
+    /// Runtime recovery argument validation failure.
     RuntimeRecovery(String),
+    /// Runtime daemon lifecycle argument validation failure.
     RuntimeDaemonLifecycle(String),
+    /// Unknown command-line/config argument.
     UnknownArgument(String),
+    /// Argument flag required a value but none was provided.
     MissingArgumentValue(&'static str),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod bridge_adapter;
 pub mod channel_models;
 #[allow(missing_docs)]
 pub mod channel_policies;
-#[allow(missing_docs)]
+/// Node role, sync mode, and runtime configuration validation contracts.
 pub mod config;
 #[allow(missing_docs)]
 pub mod content_lifecycle;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -385,6 +385,23 @@ fn graduated_wave_nineteen_group_channel_crypto_module_must_not_return_to_allowl
 }
 
 #[test]
+fn graduated_wave_twenty_config_module_must_not_return_to_allowlist() {
+    // Regression: #2013
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "config";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -160,6 +160,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `agent_key_hierarchy`
   - `anti_spam`
   - `bootstrap`
+  - `config`
   - `direct_message_crypto`
   - `discord_bridge`
   - `group_channel_crypto`
@@ -199,6 +200,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2007`
   - `Regression: #2009`
   - `Regression: #2011`
+  - `Regression: #2013`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ audit_exports
 bridge_adapter
 channel_models
 channel_policies
-config
 content_lifecycle
 content_replication
 content_retrieval

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -22,3 +22,4 @@ direct_message_crypto
 discord_bridge
 validator_lifecycle
 group_channel_crypto
+config


### PR DESCRIPTION
## Summary
Graduates `config` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This advances docs hardening for runtime role/sync configuration contracts.

Closes #2013

## Changes
- `crates/kamn-core/src/config.rs`: added module/type/field/method/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `config` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `config`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `config`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2013`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod config;`
- additional missing-doc errors across `config.rs` public enums, variants, structs, fields, and methods.

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core config
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- config-targeted tests passed.
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `23 passed; 0 failed`, including `graduated_wave_twenty_config_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `config` unit tests executed via `cargo test -p kamn-core config` | |
| Functional   | ✅     | Existing config/sync-profile functional scenarios executed via filtered test run | |
| Integration  | ✅     | Existing integration paths in filtered suite executed (sync profile and runtime consumers) | |
| Regression   | ✅     | Added `graduated_wave_twenty_config_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
