### PR TITLE
docs(kamn-core): graduate content_storage missing-docs module

### DIFF
--- a/crates/kamn-core/src/content_storage.rs
+++ b/crates/kamn-core/src/content_storage.rs
@@ -1,3 +1,8 @@
+//! Content storage adapter contracts and CID/URI mapping helpers.
+//!
+//! This module defines in-memory reference behavior for storing content payloads,
+//! retrieving metadata, and verifying deterministic integrity tags.
+
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -5,40 +10,61 @@ const CID_PREFIX: &str = "kamn:cid:v1:";
 const CONTENT_URI_PREFIX: &str = "kamn:content:v1:";
 const CID_HASH_HEX_LEN: usize = 16;
 
+/// Stored content payload and metadata returned by `get`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentObject {
+    /// Deterministic content identifier.
     pub cid: String,
+    /// MIME media type associated with the payload.
     pub media_type: String,
+    /// Raw payload bytes.
     pub payload: Vec<u8>,
+    /// Deterministic integrity tag for payload verification.
     pub integrity_tag: String,
 }
 
+/// Content metadata returned by `head` and `put`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentHead {
+    /// Deterministic content identifier.
     pub cid: String,
+    /// MIME media type associated with the payload.
     pub media_type: String,
+    /// Payload length in bytes.
     pub size_bytes: u64,
+    /// Deterministic integrity tag for payload verification.
     pub integrity_tag: String,
 }
 
+/// Storage adapter interface for content put/get/head/verify operations.
 pub trait ContentStorageAdapter {
+    /// Stores payload bytes and returns metadata for the persisted object.
     fn put(&mut self, media_type: &str, payload: &[u8])
         -> Result<ContentHead, ContentStorageError>;
+    /// Loads a full content object by CID.
     fn get(&self, cid: &str) -> Result<ContentObject, ContentStorageError>;
+    /// Loads only metadata for a CID without payload bytes.
     fn head(&self, cid: &str) -> Result<ContentHead, ContentStorageError>;
+    /// Verifies CID and integrity tag against current stored payload.
     fn verify(&self, cid: &str) -> Result<(), ContentStorageError>;
 }
 
+/// In-memory reference implementation of `ContentStorageAdapter`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct InMemoryContentAdapter {
     objects: BTreeMap<String, StoredObject>,
 }
 
 impl InMemoryContentAdapter {
+    /// Constructs an empty in-memory content adapter.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Replaces payload bytes for a CID without updating integrity metadata.
+    ///
+    /// This helper is intentionally unsafe for integrity and is used in tests to
+    /// simulate storage corruption.
     pub fn replace_payload_unchecked(
         &mut self,
         cid: &str,
@@ -118,11 +144,13 @@ impl ContentStorageAdapter for InMemoryContentAdapter {
     }
 }
 
+/// Converts a CID into canonical content URI form.
 pub fn content_uri_for_cid(cid: &str) -> Result<String, ContentStorageError> {
     validate_cid(cid)?;
     Ok(format!("{CONTENT_URI_PREFIX}{cid}"))
 }
 
+/// Extracts and validates a CID from canonical content URI form.
 pub fn cid_from_content_uri(uri: &str) -> Result<String, ContentStorageError> {
     let cid = uri
         .strip_prefix(CONTENT_URI_PREFIX)
@@ -131,15 +159,24 @@ pub fn cid_from_content_uri(uri: &str) -> Result<String, ContentStorageError> {
     Ok(cid.to_owned())
 }
 
+/// Error surface for content storage parsing and integrity checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentStorageError {
+    /// Required string field was empty.
     EmptyField(&'static str),
+    /// CID string failed validation.
     InvalidCid(String),
+    /// Content URI string failed validation.
     InvalidContentUri(String),
+    /// Requested CID was not found in storage.
     NotFound(String),
+    /// Stored payload no longer matches expected integrity metadata.
     IntegrityMismatch {
+        /// CID that failed integrity verification.
         cid: String,
+        /// Expected integrity tag for current payload.
         expected: String,
+        /// Integrity tag found in stored metadata.
         found: String,
     },
 }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod content_lifecycle;
 pub mod content_replication;
 #[allow(missing_docs)]
 pub mod content_retrieval;
-#[allow(missing_docs)]
+/// Content storage adapter contracts, object metadata, and CID/URI helpers.
 pub mod content_storage;
 #[allow(missing_docs)]
 pub mod cross_chain_bridge;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -402,6 +402,23 @@ fn graduated_wave_twenty_config_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_twenty_one_content_storage_module_must_not_return_to_allowlist() {
+    // Regression: #2015
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "content_storage";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -161,6 +161,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `anti_spam`
   - `bootstrap`
   - `config`
+  - `content_storage`
   - `direct_message_crypto`
   - `discord_bridge`
   - `group_channel_crypto`
@@ -201,6 +202,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2009`
   - `Regression: #2011`
   - `Regression: #2013`
+  - `Regression: #2015`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -6,7 +6,6 @@ channel_policies
 content_lifecycle
 content_replication
 content_retrieval
-content_storage
 cross_chain_bridge
 cross_chain_receipt
 data_classification

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -23,3 +23,4 @@ discord_bridge
 validator_lifecycle
 group_channel_crypto
 config
+content_storage


### PR DESCRIPTION
## Summary
Graduates `content_storage` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This strengthens docs coverage for storage adapters and CID/URI helper contracts.

Closes #2015

## Changes
- `crates/kamn-core/src/content_storage.rs`: added module/type/field/trait/method/function/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `content_storage` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `content_storage`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `content_storage`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2015`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod content_storage;`
- additional missing-doc errors across `content_storage.rs` public structs, fields, trait methods, functions, and error variants.

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core content_storage
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- content-storage targeted tests passed.
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `24 passed; 0 failed`, including `graduated_wave_twenty_one_content_storage_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `content_storage` unit tests executed via `cargo test -p kamn-core content_storage` | |
| Functional   | ✅     | Existing adapter behavior tests executed in `tests/content_storage_adapter.rs` | |
| Integration  | ✅     | Existing integration path in `tests/content_storage_adapter.rs` (artifact URI reference) executed | |
| Regression   | ✅     | Added `graduated_wave_twenty_one_content_storage_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
