### PR TITLE
docs(kamn-core): graduate redaction_compliance missing-docs module

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -82,7 +82,7 @@ pub mod operator_dashboard_api;
 pub mod operator_dashboard_ui;
 #[allow(missing_docs)]
 pub mod performance_targets;
-#[allow(missing_docs)]
+/// Redaction request approval, audit-event, and visibility compliance contracts.
 pub mod redaction_compliance;
 /// Reputation-signal weighting and candidate-ranking contracts for routing.
 pub mod reputation_signals;

--- a/crates/kamn-core/src/redaction_compliance.rs
+++ b/crates/kamn-core/src/redaction_compliance.rs
@@ -1,44 +1,79 @@
+//! Redaction and tombstone compliance workflow contracts.
+//!
+//! The module models request submission, approval quorum, rejection handling, and
+//! audit trail emission for content visibility protection policies.
+
 use crate::{canonical_state_key, AgentDid};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Action requested by a compliance redaction workflow.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RedactionAction {
+    /// Redact the target while keeping placeholder visibility metadata.
     Redact,
+    /// Tombstone the target as removed content.
     Tombstone,
 }
 
+/// Current request lifecycle state for a redaction proposal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RedactionRequestStatus {
+    /// Request is waiting for additional approvals.
     PendingApproval {
+        /// Unique approvals currently collected.
         approvals_collected: usize,
+        /// Total approvals required to apply the request.
         approvals_required: usize,
     },
+    /// Request was explicitly rejected.
     Rejected,
+    /// Request reached approval quorum and was applied.
     Applied,
 }
 
+/// Visibility outcome for a protected target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RedactionVisibility {
+    /// Target remains available and unprotected.
     Available,
-    Redacted { request_id: String },
-    Tombstoned { request_id: String },
+    /// Target is redacted under the given request id.
+    Redacted {
+        /// Request identifier that triggered redaction.
+        request_id: String,
+    },
+    /// Target is tombstoned under the given request id.
+    Tombstoned {
+        /// Request identifier that triggered tombstoning.
+        request_id: String,
+    },
 }
 
+/// Audit-event category emitted by redaction workflows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RedactionAuditEventKind {
+    /// Request was submitted.
     Requested,
+    /// Request received an approval.
     Approved,
+    /// Request was rejected.
     Rejected,
+    /// Request was applied after quorum.
     Applied,
 }
 
+/// Audit trail entry attached to a redaction request id.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RedactionAuditEvent {
+    /// Request identifier associated with this audit event.
     pub request_id: String,
+    /// DID of the actor that produced this event.
     pub actor: String,
+    /// Event kind classification.
     pub kind: RedactionAuditEventKind,
+    /// Timestamp when the event occurred.
     pub at: String,
+    /// Human-readable reason or note payload.
     pub note: String,
 }
 
@@ -60,6 +95,7 @@ enum InternalStatus {
     Applied,
 }
 
+/// In-memory engine for redaction request lifecycle and visibility state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RedactionComplianceEngine {
     approvals_required: usize,
@@ -70,6 +106,7 @@ pub struct RedactionComplianceEngine {
 }
 
 impl RedactionComplianceEngine {
+    /// Constructs an engine with a fixed approval quorum requirement.
     pub fn new(approvals_required: usize) -> Result<Self, RedactionComplianceError> {
         if approvals_required == 0 {
             return Err(RedactionComplianceError::InvalidApprovalsRequired(
@@ -87,6 +124,7 @@ impl RedactionComplianceEngine {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Submits a redaction or tombstone request for a target record.
     pub fn submit_request(
         &mut self,
         request_id: &str,
@@ -142,6 +180,7 @@ impl RedactionComplianceEngine {
         Ok(())
     }
 
+    /// Approves a pending request and applies visibility protection at quorum.
     pub fn approve(
         &mut self,
         request_id: &str,
@@ -216,6 +255,7 @@ impl RedactionComplianceEngine {
         Ok(())
     }
 
+    /// Rejects a pending request and records an audit event.
     pub fn reject(
         &mut self,
         request_id: &str,
@@ -247,6 +287,7 @@ impl RedactionComplianceEngine {
         Ok(())
     }
 
+    /// Returns lifecycle status for the given request id.
     pub fn request_status(
         &self,
         request_id: &str,
@@ -266,6 +307,7 @@ impl RedactionComplianceEngine {
         })
     }
 
+    /// Returns current visibility state for a target namespace/entity pair.
     pub fn retrieve_visibility(
         &self,
         target_namespace: &str,
@@ -279,6 +321,7 @@ impl RedactionComplianceEngine {
             .unwrap_or(RedactionVisibility::Available))
     }
 
+    /// Builds the canonical storage key used to address a target record.
     pub fn target_storage_key(
         &self,
         target_namespace: &str,
@@ -288,6 +331,7 @@ impl RedactionComplianceEngine {
             .map_err(|error| RedactionComplianceError::InvalidTarget(error.to_string()))
     }
 
+    /// Returns audit events recorded for a request id.
     pub fn audit_events(
         &self,
         request_id: &str,
@@ -320,21 +364,35 @@ impl RedactionComplianceEngine {
     }
 }
 
+/// Error surface for redaction workflow validation and state transitions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RedactionComplianceError {
+    /// `approvals_required` was zero.
     InvalidApprovalsRequired(usize),
+    /// Required field was empty.
     EmptyField(&'static str),
+    /// DID value failed validation.
     InvalidDid(String),
+    /// Target namespace/entity key could not be canonicalized.
     InvalidTarget(String),
+    /// Request id already exists.
     DuplicateRequestId(String),
+    /// Target already has active protection from a prior request.
     TargetAlreadyProtected {
+        /// Target namespace.
         namespace: String,
+        /// Target entity identifier.
         entity_id: String,
     },
+    /// Request id was not found.
     NotFound(String),
+    /// Request is not in pending-approval state.
     RequestNotPendingApproval(String),
+    /// Approver duplicated an existing approval for the request.
     DuplicateApproval {
+        /// Request identifier.
         request_id: String,
+        /// Approver DID.
         approver: String,
     },
 }

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -419,6 +419,23 @@ fn graduated_wave_twenty_one_content_storage_module_must_not_return_to_allowlist
 }
 
 #[test]
+fn graduated_wave_twenty_two_redaction_compliance_module_must_not_return_to_allowlist() {
+    // Regression: #2017
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "redaction_compliance";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -172,6 +172,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `namespaces`
   - `operator_actions`
   - `operator_binding`
+  - `redaction_compliance`
   - `reputation_signals`
   - `service_marketplace`
   - `smoke`
@@ -203,6 +204,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2011`
   - `Regression: #2013`
   - `Regression: #2015`
+  - `Regression: #2017`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -23,7 +23,6 @@ observability
 operator_dashboard_api
 operator_dashboard_ui
 performance_targets
-redaction_compliance
 reputation_state
 retention_engine
 runtime

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -24,3 +24,4 @@ validator_lifecycle
 group_channel_crypto
 config
 content_storage
+redaction_compliance


### PR DESCRIPTION
## Summary
Graduates `redaction_compliance` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This strengthens docs coverage for redaction request lifecycle, approvals, and visibility/audit contracts.

Closes #2017

## Changes
- `crates/kamn-core/src/redaction_compliance.rs`: added module/type/field/method/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `redaction_compliance` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `redaction_compliance`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `redaction_compliance`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2017`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod redaction_compliance;`
- additional missing-doc errors across `redaction_compliance.rs` public enums, variant fields, structs, and methods.

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core redaction_compliance
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- redaction-compliance targeted tests passed.
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `25 passed; 0 failed`, including `graduated_wave_twenty_two_redaction_compliance_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `redaction_compliance` unit tests executed via `cargo test -p kamn-core redaction_compliance` | |
| Functional   | ✅     | Existing workflow behavior tests (`submit/approve/reject`) executed in module tests | |
| Integration  | ✅     | Existing redaction-related integration tests in suite remained green | |
| Regression   | ✅     | Added `graduated_wave_twenty_two_redaction_compliance_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
