### PR TITLE
docs(kamn-core): graduate cross_chain_bridge missing-docs module

### DIFF
--- a/crates/kamn-core/src/cross_chain_bridge.rs
+++ b/crates/kamn-core/src/cross_chain_bridge.rs
@@ -1,3 +1,8 @@
+//! Cross-chain ingress/egress bridge routing and approval contracts.
+//!
+//! This module validates listener and approver identities, enforces configured
+//! route maps, and normalizes bridge payloads for Ethereum and Solana lanes.
+
 use crate::{
     AgentDid, AllowAllBridgePolicy, BridgeAdapterEngine, BridgeInboundEnvelope,
     BridgeOutboundEnvelope, BridgeOutboundRequest, BridgePlatform, CanonicalMessageEnvelope,
@@ -6,9 +11,12 @@ use crate::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Supported external networks for cross-chain bridge routes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CrossChainNetwork {
+    /// Ethereum bridge lane.
     Ethereum,
+    /// Solana bridge lane.
     Solana,
 }
 
@@ -21,38 +29,59 @@ impl CrossChainNetwork {
     }
 }
 
+/// Static bridge configuration for listener/approver controls and routes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainBridgeConfig {
+    /// DID used as the bridge service identity.
     pub bridge_agent_did: String,
+    /// Listener DIDs authorized to submit inbound observations.
     pub authorized_listener_dids: BTreeSet<String>,
+    /// Approver DIDs authorized for outbound dispatch quorum.
     pub authorized_approver_dids: BTreeSet<String>,
+    /// Required unique approvals before dispatching outbound envelopes.
     pub required_approvals: usize,
+    /// Route map from external Ethereum channel id to target DID.
     pub ethereum_routes: BTreeMap<String, String>,
+    /// Route map from external Solana channel id to target DID.
     pub solana_routes: BTreeMap<String, String>,
 }
 
+/// Inbound bridge observation submitted by an authorized listener.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainInboundRequest {
+    /// Listener DID that observed the inbound event.
     pub listener_did: String,
+    /// Unix timestamp when the event was observed.
     pub observed_at_unix: u64,
+    /// External network lane used for routing.
     pub chain: CrossChainNetwork,
+    /// Raw inbound bridge envelope.
     pub inbound: BridgeInboundEnvelope,
 }
 
+/// Approval quorum material for an outbound dispatch request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainOutboundApproval {
+    /// External network lane being dispatched.
     pub chain: CrossChainNetwork,
+    /// Outbound request identifier.
     pub request_id: String,
+    /// Required approval threshold for dispatch.
     pub required_approvals: usize,
+    /// Unique approver DIDs that approved this dispatch.
     pub approved_by: BTreeSet<String>,
 }
 
+/// Outbound bridge envelope paired with approval quorum evidence.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainOutboundDispatch {
+    /// Final outbound envelope produced by bridge adapter processing.
     pub envelope: BridgeOutboundEnvelope,
+    /// Approval proof material used for dispatch authorization.
     pub approval: CrossChainOutboundApproval,
 }
 
+/// Engine coordinating inbound normalization and outbound gated dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainBridgeEngine {
     config: CrossChainBridgeConfig,
@@ -61,6 +90,7 @@ pub struct CrossChainBridgeEngine {
 }
 
 impl CrossChainBridgeEngine {
+    /// Constructs a bridge engine from validated configuration.
     pub fn new(config: CrossChainBridgeConfig) -> Result<Self, CrossChainBridgeError> {
         validate_did(&config.bridge_agent_did)?;
 
@@ -128,6 +158,7 @@ impl CrossChainBridgeEngine {
         })
     }
 
+    /// Validates and normalizes an inbound bridge request.
     pub fn process_inbound(
         &self,
         request: &CrossChainInboundRequest,
@@ -138,6 +169,7 @@ impl CrossChainBridgeEngine {
             .map_err(|error| CrossChainBridgeError::Bridge(error.to_string()))
     }
 
+    /// Converts a validated inbound request directly into canonical envelope form.
     pub fn process_inbound_to_envelope(
         &self,
         request: &CrossChainInboundRequest,
@@ -193,6 +225,7 @@ impl CrossChainBridgeEngine {
         Ok(())
     }
 
+    /// Validates approvals and dispatches an outbound bridge request.
     pub fn process_outbound_with_approvals(
         &self,
         chain: CrossChainNetwork,
@@ -276,31 +309,52 @@ impl CrossChainBridgeEngine {
     }
 }
 
+/// Error surface for cross-chain bridge configuration and processing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CrossChainBridgeError {
+    /// Required field was empty.
     EmptyField(&'static str),
+    /// DID value failed validation.
     InvalidDid(String),
+    /// Required approvals value was invalid for configured approver set.
     InvalidRequiredApprovals {
+        /// Required approval threshold requested.
         required: usize,
+        /// Number of configured approvers.
         approver_count: usize,
     },
+    /// Listener DID is not authorized.
     UnauthorizedListener(String),
+    /// Approver DID is not authorized.
     UnauthorizedApprover(String),
+    /// Duplicate approval from the same approver.
     DuplicateApproval(String),
+    /// Provided approvals are below quorum threshold.
     InsufficientApprovals {
+        /// Required approval threshold.
         required: usize,
+        /// Unique approvals provided.
         provided: usize,
     },
+    /// Route channel id was not found for the selected chain.
     UnknownRouteChannel {
+        /// Chain lane where route lookup failed.
         chain: CrossChainNetwork,
+        /// External channel identifier.
         channel_id: String,
     },
+    /// Route target DID did not match inbound envelope target DID.
     RouteTargetMismatch {
+        /// Chain lane where mismatch occurred.
         chain: CrossChainNetwork,
+        /// External channel identifier.
         external_channel_id: String,
+        /// Route table target DID.
         expected_target_did: String,
+        /// Target DID provided by inbound envelope.
         provided_target_did: String,
     },
+    /// Downstream bridge adapter error.
     Bridge(String),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod content_replication;
 pub mod content_retrieval;
 /// Content storage adapter contracts, object metadata, and CID/URI helpers.
 pub mod content_storage;
-#[allow(missing_docs)]
+/// Cross-chain route validation, inbound normalization, and outbound quorum dispatch contracts.
 pub mod cross_chain_bridge;
 #[allow(missing_docs)]
 pub mod cross_chain_receipt;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -436,6 +436,23 @@ fn graduated_wave_twenty_two_redaction_compliance_module_must_not_return_to_allo
 }
 
 #[test]
+fn graduated_wave_twenty_three_cross_chain_bridge_module_must_not_return_to_allowlist() {
+    // Regression: #2019
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "cross_chain_bridge";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -162,6 +162,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `bootstrap`
   - `config`
   - `content_storage`
+  - `cross_chain_bridge`
   - `direct_message_crypto`
   - `discord_bridge`
   - `group_channel_crypto`
@@ -205,6 +206,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2013`
   - `Regression: #2015`
   - `Regression: #2017`
+  - `Regression: #2019`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -6,7 +6,6 @@ channel_policies
 content_lifecycle
 content_replication
 content_retrieval
-cross_chain_bridge
 cross_chain_receipt
 data_classification
 did

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -25,3 +25,4 @@ group_channel_crypto
 config
 content_storage
 redaction_compliance
+cross_chain_bridge


### PR DESCRIPTION
## Summary
Graduates `cross_chain_bridge` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This improves docs coverage for cross-chain route validation and outbound approval quorum contracts.

Closes #2019

## Changes
- `crates/kamn-core/src/cross_chain_bridge.rs`: added module/type/field/method/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `cross_chain_bridge` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `cross_chain_bridge`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `cross_chain_bridge`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2019`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod cross_chain_bridge;`
- additional missing-doc errors across `cross_chain_bridge.rs` public enums, structs, fields, methods, and error variants.

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core cross_chain_bridge
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- cross-chain targeted tests passed.
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `26 passed; 0 failed`, including `graduated_wave_twenty_three_cross_chain_bridge_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `cross_chain_bridge` unit tests executed via `cargo test -p kamn-core cross_chain_bridge` | |
| Functional   | ✅     | Existing bridge behavior scenarios in `tests/cross_chain_bridge.rs` suite remained green | |
| Integration  | ✅     | Existing bridge-adapter integration checks in docs/adapter suites remained green | |
| Regression   | ✅     | Added `graduated_wave_twenty_three_cross_chain_bridge_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
