### PR TITLE
docs(kamn-core): graduate cross_chain_receipt missing-docs module

### DIFF
--- a/crates/kamn-core/src/cross_chain_receipt.rs
+++ b/crates/kamn-core/src/cross_chain_receipt.rs
@@ -1,10 +1,19 @@
+//! Cross-chain receipt normalization and finality policy contracts.
+//!
+//! This module maps network-specific receipt semantics into a normalized finality
+//! model used by bridge settlement and reconciliation workflows.
+
 use std::fmt;
 
+/// Ethereum confirmations required before a successful receipt is final.
 pub const ETHEREUM_FINAL_CONFIRMATION_THRESHOLD: u64 = 12;
 
+/// Supported receipt networks for normalization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CrossChainReceiptNetwork {
+    /// Ethereum receipts.
     Ethereum,
+    /// Near receipts.
     Near,
 }
 
@@ -17,43 +26,68 @@ impl CrossChainReceiptNetwork {
     }
 }
 
+/// Raw receipt execution status from external network sources.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CrossChainReceiptStatus {
+    /// Receipt execution completed successfully.
     Success,
+    /// Receipt execution is still pending.
     Pending,
+    /// Receipt execution failed.
     Failed,
 }
 
+/// Raw receipt proof payload before normalization.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrossChainReceiptProof {
+    /// Network where the receipt originated.
     pub network: CrossChainReceiptNetwork,
+    /// Receipt identifier.
     pub receipt_id: String,
+    /// Block reference containing the receipt.
     pub block_reference: String,
+    /// Network-specific finality label.
     pub finality_label: String,
+    /// Confirmation count observed for the receipt.
     pub confirmation_count: u64,
+    /// Raw execution status.
     pub status: CrossChainReceiptStatus,
 }
 
+/// Normalized settlement finality classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CrossChainReceiptFinality {
+    /// Receipt is final and safe for settlement.
     Final,
+    /// Receipt is not yet final.
     Pending,
+    /// Receipt failed and should not settle.
     Failed,
 }
 
+/// Network-agnostic receipt view used by settlement workflows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedCrossChainReceipt {
+    /// Source network.
     pub network: CrossChainReceiptNetwork,
+    /// Receipt identifier.
     pub receipt_id: String,
+    /// Block reference.
     pub block_reference: String,
+    /// Normalized finality classification.
     pub finality: CrossChainReceiptFinality,
 }
 
+/// Error surface for receipt normalization inputs and labels.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CrossChainReceiptNormalizationError {
+    /// Required string field was empty.
     EmptyField(&'static str),
+    /// Finality label is unsupported for the specified network.
     UnsupportedFinalityLabel {
+        /// Source network.
         network: CrossChainReceiptNetwork,
+        /// Unsupported finality label value.
         label: String,
     },
 }
@@ -71,6 +105,7 @@ impl fmt::Display for CrossChainReceiptNormalizationError {
 
 impl std::error::Error for CrossChainReceiptNormalizationError {}
 
+/// Converts a network-specific receipt proof into normalized finality form.
 pub fn normalize_cross_chain_receipt(
     proof: &CrossChainReceiptProof,
 ) -> Result<NormalizedCrossChainReceipt, CrossChainReceiptNormalizationError> {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -32,7 +32,7 @@ pub mod content_retrieval;
 pub mod content_storage;
 /// Cross-chain route validation, inbound normalization, and outbound quorum dispatch contracts.
 pub mod cross_chain_bridge;
-#[allow(missing_docs)]
+/// Cross-chain receipt proof normalization and finality mapping contracts.
 pub mod cross_chain_receipt;
 #[allow(missing_docs)]
 pub mod data_classification;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -453,6 +453,23 @@ fn graduated_wave_twenty_three_cross_chain_bridge_module_must_not_return_to_allo
 }
 
 #[test]
+fn graduated_wave_twenty_four_cross_chain_receipt_module_must_not_return_to_allowlist() {
+    // Regression: #2021
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "cross_chain_receipt";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -163,6 +163,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `config`
   - `content_storage`
   - `cross_chain_bridge`
+  - `cross_chain_receipt`
   - `direct_message_crypto`
   - `discord_bridge`
   - `group_channel_crypto`
@@ -207,6 +208,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2015`
   - `Regression: #2017`
   - `Regression: #2019`
+  - `Regression: #2021`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -6,7 +6,6 @@ channel_policies
 content_lifecycle
 content_replication
 content_retrieval
-cross_chain_receipt
 data_classification
 did
 did_registry

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -26,3 +26,4 @@ config
 content_storage
 redaction_compliance
 cross_chain_bridge
+cross_chain_receipt


### PR DESCRIPTION
## Summary
Graduates `cross_chain_receipt` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `lib.rs` exemption. This improves docs coverage for receipt normalization and finality mapping contracts.

Closes #2021

## Changes
- `crates/kamn-core/src/cross_chain_receipt.rs`: added module/type/field/function/enum rustdoc coverage across the public surface.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `cross_chain_receipt` and added module rustdoc.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `cross_chain_receipt`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `cross_chain_receipt`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression drift guard test (`Regression: #2021`).
- `docs/architecture/kamn-core-module-map.md`: updated graduated-module inventory and regression marker list.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Failing evidence:
- `error: missing documentation for a module` at `crates/kamn-core/src/lib.rs` for `pub mod cross_chain_receipt;`
- additional missing-doc errors across `cross_chain_receipt.rs` public constants, enums, structs, fields, and normalization function.

### 🟢 Green Phase
Commands:
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core cross_chain_receipt
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --all-targets --all-features --manifest-path Cargo.toml -- -D warnings
cargo clippy --all-targets --all-features --manifest-path crates/kamn-core/Cargo.toml -- -D warnings
```
Passing evidence:
- strict missing-doc check passed.
- cross-chain receipt targeted tests passed.
- policy/docs regression suites passed.
- fmt/clippy strict checks passed.

### 🔁 Regression
Command:
```bash
cargo test -p kamn-core --test missing_docs_policy
```
Result:
- `27 passed; 0 failed`, including `graduated_wave_twenty_four_cross_chain_receipt_module_must_not_return_to_allowlist`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing `cross_chain_receipt` unit tests executed via `cargo test -p kamn-core cross_chain_receipt` | |
| Functional   | ✅     | Existing finality normalization behavior tests executed in `tests/cross_chain_receipt_finality.rs` | |
| Integration  | ✅     | Existing bridge docs/integration checks referencing receipt finality remained green | |
| Regression   | ✅     | Added `graduated_wave_twenty_four_cross_chain_receipt_module_must_not_return_to_allowlist` in `tests/missing_docs_policy.rs` | |
| Performance  | N/A    | None | Docs/policy-only graduation; no runtime-path change |

## Risks & Rollback
- None (docs/policy hardening only; no behavior change intended).
- Rollback plan: revert this PR commit to restore prior allowlist and exemption state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` updated to reflect graduation + regression marker.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
