### PR TITLE
docs(kamn-core): graduate content_lifecycle from missing-docs allowlist (#2023)

### DIFF
--- a/crates/kamn-core/src/content_lifecycle.rs
+++ b/crates/kamn-core/src/content_lifecycle.rs
@@ -1,3 +1,5 @@
+//! Content retention, tombstone, and purge lifecycle contracts.
+
 use crate::{cid_from_content_uri, content_uri_for_cid, ContentStorageError};
 use std::collections::BTreeMap;
 use std::fmt;
@@ -10,59 +12,88 @@ const COMPLIANCE_RETAIN_SECS: u64 = 31_536_000;
 const COMPLIANCE_TOMBSTONE_SECS: u64 = 31_536_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Retention class used to derive expiry and tombstone windows.
 pub enum ContentRetentionClass {
+    /// Ephemeral content retained for a short period.
     ShortLived,
+    /// Default retention profile for standard content.
     Standard,
+    /// Long-retention profile for compliance-sensitive content.
     Compliance,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Derived retention profile used by lifecycle calculations.
 pub struct ContentRetentionProfile {
+    /// Seconds from creation until content becomes expired.
     pub retain_for_secs: u64,
+    /// Seconds from tombstone until purge is eligible.
     pub tombstone_for_secs: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Current lifecycle status for a content record at a point in time.
 pub enum ContentLifecycleStatus {
+    /// Content is within retention window and accessible.
     Active,
+    /// Content retention window elapsed and is due for tombstone.
     Expired,
+    /// Content has been tombstoned and is waiting for purge window.
     Tombstoned,
+    /// Content has been purged and cannot be accessed.
     Purged,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Cleanup action scheduler output for lifecycle maintenance.
 pub enum ContentCleanupActionKind {
+    /// Mark content as tombstoned.
     Tombstone,
+    /// Permanently purge content.
     Purge,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Scheduled cleanup action for a content identifier.
 pub struct ContentCleanupAction {
+    /// Content identifier the action applies to.
     pub cid: String,
+    /// Cleanup action to execute for the record.
     pub action: ContentCleanupActionKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Mutable lifecycle metadata tracked for a single content identifier.
 pub struct ContentLifecycleRecord {
+    /// Canonical content identifier.
     pub cid: String,
+    /// Retention class used to calculate lifecycle windows.
     pub retention_class: ContentRetentionClass,
+    /// Unix timestamp when the content was registered.
     pub created_at_unix: u64,
+    /// Unix timestamp when content first becomes expired.
     pub expires_at_unix: u64,
+    /// Unix timestamp when tombstone was applied, if any.
     pub tombstoned_at_unix: Option<u64>,
+    /// Unix timestamp after which purge is eligible, if tombstoned.
     pub purge_after_unix: Option<u64>,
+    /// Unix timestamp when purge was executed, if any.
     pub purged_at_unix: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// In-memory manager for content lifecycle registration and cleanup decisions.
 pub struct ContentLifecycleManager {
     records: BTreeMap<String, ContentLifecycleRecord>,
 }
 
 impl ContentLifecycleManager {
+    /// Creates an empty lifecycle manager.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Returns the retention profile associated with a retention class.
     pub fn retention_profile(class: ContentRetentionClass) -> ContentRetentionProfile {
         match class {
             ContentRetentionClass::ShortLived => ContentRetentionProfile {
@@ -80,6 +111,9 @@ impl ContentLifecycleManager {
         }
     }
 
+    /// Registers a new content lifecycle record and computes expiry from profile.
+    ///
+    /// Returns an error when CID is invalid, timestamp is zero, or CID already exists.
     pub fn register(
         &mut self,
         cid: &str,
@@ -108,6 +142,9 @@ impl ContentLifecycleManager {
         Ok(record)
     }
 
+    /// Applies tombstone state to an existing record and sets purge eligibility.
+    ///
+    /// This call is idempotent for already-tombstoned records.
     pub fn apply_tombstone(
         &mut self,
         cid: &str,
@@ -132,6 +169,7 @@ impl ContentLifecycleManager {
         Ok(record.clone())
     }
 
+    /// Resolves the lifecycle status for a content identifier at `now_unix`.
     pub fn lifecycle_status(
         &self,
         cid: &str,
@@ -153,6 +191,7 @@ impl ContentLifecycleManager {
         Ok(ContentLifecycleStatus::Active)
     }
 
+    /// Returns cleanup actions that are due at `now_unix`.
     pub fn cleanup_due(&self, now_unix: u64) -> Vec<ContentCleanupAction> {
         let mut actions = Vec::new();
         for (cid, record) in &self.records {
@@ -178,6 +217,9 @@ impl ContentLifecycleManager {
         actions
     }
 
+    /// Executes the cleanup action due for `cid` at `now_unix`.
+    ///
+    /// Returns the action performed (`Tombstone` or `Purge`) when due.
     pub fn execute_cleanup(
         &mut self,
         cid: &str,
@@ -206,6 +248,7 @@ impl ContentLifecycleManager {
         Err(ContentLifecycleError::NoCleanupDue(cid.to_owned()))
     }
 
+    /// Returns an error if content is not currently accessible at `now_unix`.
     pub fn assert_accessible(&self, cid: &str, now_unix: u64) -> Result<(), ContentLifecycleError> {
         match self.lifecycle_status(cid, now_unix)? {
             ContentLifecycleStatus::Active => Ok(()),
@@ -217,6 +260,9 @@ impl ContentLifecycleManager {
         }
     }
 
+    /// Validates a content URI and enforces accessibility at `now_unix`.
+    ///
+    /// Returns the extracted CID when access is permitted.
     pub fn assert_uri_accessible(
         &self,
         content_uri: &str,
@@ -230,15 +276,25 @@ impl ContentLifecycleManager {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Lifecycle manager error taxonomy.
 pub enum ContentLifecycleError {
+    /// A required input field was empty or zero.
     EmptyField(&'static str),
+    /// CID failed canonical validation.
     InvalidCid(String),
+    /// Content URI could not be parsed into a CID.
     InvalidContentUri(String),
+    /// Lifecycle record already exists for CID.
     DuplicateContent(String),
+    /// Lifecycle record does not exist for CID.
     NotFound(String),
+    /// No cleanup action is due at the provided timestamp.
     NoCleanupDue(String),
+    /// Content is expired and no longer accessible.
     Expired(String),
+    /// Content is tombstoned and not accessible.
     Tombstoned(String),
+    /// Content has been purged and is permanently inaccessible.
     Purged(String),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -22,7 +22,7 @@ pub mod channel_models;
 pub mod channel_policies;
 /// Node role, sync mode, and runtime configuration validation contracts.
 pub mod config;
-#[allow(missing_docs)]
+/// Content retention, tombstone scheduling, and purge eligibility contracts.
 pub mod content_lifecycle;
 #[allow(missing_docs)]
 pub mod content_replication;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -470,6 +470,23 @@ fn graduated_wave_twenty_four_cross_chain_receipt_module_must_not_return_to_allo
 }
 
 #[test]
+fn graduated_wave_twenty_five_content_lifecycle_module_must_not_return_to_allowlist() {
+    // Regression: #2023
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "content_lifecycle";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -161,6 +161,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `anti_spam`
   - `bootstrap`
   - `config`
+  - `content_lifecycle`
   - `content_storage`
   - `cross_chain_bridge`
   - `cross_chain_receipt`
@@ -209,6 +210,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2017`
   - `Regression: #2019`
   - `Regression: #2021`
+  - `Regression: #2023`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ audit_exports
 bridge_adapter
 channel_models
 channel_policies
-content_lifecycle
 content_replication
 content_retrieval
 data_classification

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -27,3 +27,4 @@ content_storage
 redaction_compliance
 cross_chain_bridge
 cross_chain_receipt
+content_lifecycle


### PR DESCRIPTION
## Summary
Graduate `content_lifecycle` from the phased missing-docs allowlist by removing the module-level allow, adding full public rustdoc coverage, and updating policy fixtures/regression guards so drift fails closed.

## Changes
- `crates/kamn-core/src/content_lifecycle.rs`: added rustdoc for all public enums, variants, structs, fields, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: documented `content_lifecycle` module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `content_lifecycle`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `content_lifecycle`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_twenty_five_content_lifecycle_module_must_not_return_to_allowlist` (`Regression: #2023`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`RUSTFLAGS='-D warnings' cargo check -p kamn-core`

Result (before docs graduation): failed with `missing documentation` errors for `pub mod content_lifecycle;` in `lib.rs` and public API items in `content_lifecycle.rs` (47 total errors).

### 🟢 Green Phase
Commands:
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- `cargo test -p kamn-core content_lifecycle`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`

Result: all pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`

Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `content_lifecycle` unit tests executed via `cargo test -p kamn-core content_lifecycle` | |
| Functional   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | Added `graduated_wave_twenty_five_content_lifecycle_module_must_not_return_to_allowlist` | |
| Performance  | N/A | | Docs/policy graduation; no runtime/perf path change |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore prior allowlist state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`
- Public API rustdocs in `crates/kamn-core/src/content_lifecycle.rs` and `crates/kamn-core/src/lib.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2023
Refs #1717
Refs #1712
