### PR TITLE
docs(kamn-core): graduate content_replication from missing-docs allowlist (#2025)

### DIFF
--- a/crates/kamn-core/src/content_replication.rs
+++ b/crates/kamn-core/src/content_replication.rs
@@ -1,15 +1,24 @@
+//! Content replication policy, availability health, and repair planning contracts.
+
 use crate::{ContentStorageAdapter, ContentStorageError};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Replication policy constraints used by the manager.
 pub struct ContentReplicationPolicy {
+    /// Minimum replicas required for healthy availability.
     pub minimum_replicas: u16,
+    /// Desired replicas used for repair planning.
     pub target_replicas: u16,
+    /// Maximum sequential repair failures before hard stop.
     pub max_repair_attempts: u8,
 }
 
 impl ContentReplicationPolicy {
+    /// Builds a validated replication policy.
+    ///
+    /// Returns an error if bounds are zero or inconsistent.
     pub fn new(
         minimum_replicas: u16,
         target_replicas: u16,
@@ -38,54 +47,83 @@ impl ContentReplicationPolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Availability health classification derived from replica counts.
 pub enum ContentAvailabilityHealth {
+    /// Replica count satisfies minimum threshold.
     Healthy,
+    /// Content exists but replicas are below minimum threshold.
     Degraded,
+    /// No replicas currently available.
     Unavailable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Availability snapshot for a tracked content object.
 pub struct ContentAvailabilitySnapshot {
+    /// Content identifier the snapshot describes.
     pub cid: String,
+    /// Derived health state for the current replica count.
     pub health: ContentAvailabilityHealth,
+    /// Number of currently known replicas.
     pub available_replicas: u16,
+    /// Minimum replicas required for healthy state.
     pub minimum_replicas: u16,
+    /// Target replicas expected after repair.
     pub target_replicas: u16,
+    /// Number of consecutive repair failures.
     pub repair_attempts: u8,
+    /// Unix timestamp for last replication check.
     pub last_checked_unix: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Alert payload emitted for non-healthy availability states.
 pub struct ContentAvailabilityAlert {
+    /// Content identifier in alert.
     pub cid: String,
+    /// Non-healthy availability status.
     pub health: ContentAvailabilityHealth,
+    /// Number of currently known replicas.
     pub available_replicas: u16,
+    /// Minimum replicas required for healthy state.
     pub minimum_replicas: u16,
+    /// Target replicas expected after repair.
     pub target_replicas: u16,
+    /// Number of consecutive repair failures.
     pub repair_attempts: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Reason why a repair action was generated.
 pub enum ContentRepairReason {
+    /// Replicas exist but target has not been reached.
     UnderReplicated,
+    /// No replicas exist for tracked content.
     MissingContent,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Planned repair action emitted by replication manager.
 pub struct ContentRepairAction {
+    /// Content identifier to repair.
     pub cid: String,
+    /// Number of replicas required to reach target.
     pub missing_replicas: u16,
+    /// Reason for this repair plan.
     pub reason: ContentRepairReason,
+    /// Repair attempt number that will be executed.
     pub attempt: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// In-memory replication health and repair orchestration manager.
 pub struct ContentReplicationManager {
     policy: ContentReplicationPolicy,
     records: BTreeMap<String, ContentReplicationRecord>,
 }
 
 impl ContentReplicationManager {
+    /// Creates a manager bound to a validated replication policy.
     pub fn new(policy: ContentReplicationPolicy) -> Self {
         Self {
             policy,
@@ -93,6 +131,7 @@ impl ContentReplicationManager {
         }
     }
 
+    /// Registers or refreshes tracked replicas for `cid` after storage validation.
     pub fn register_content<A: ContentStorageAdapter>(
         &mut self,
         adapter: &A,
@@ -122,6 +161,7 @@ impl ContentReplicationManager {
         self.availability(cid)
     }
 
+    /// Returns the current availability snapshot for `cid`.
     pub fn availability(
         &self,
         cid: &str,
@@ -133,6 +173,7 @@ impl ContentReplicationManager {
         Ok(build_snapshot(cid, record, &self.policy))
     }
 
+    /// Lists alerts for tracked content in degraded or unavailable health.
     pub fn availability_alerts(&self) -> Vec<ContentAvailabilityAlert> {
         self.records
             .iter()
@@ -154,6 +195,7 @@ impl ContentReplicationManager {
             .collect()
     }
 
+    /// Plans repair actions for tracked content below target replicas.
     pub fn plan_repairs(&mut self) -> Vec<ContentRepairAction> {
         let mut actions = Vec::new();
 
@@ -192,6 +234,7 @@ impl ContentReplicationManager {
         actions
     }
 
+    /// Applies a successful repair result for `cid` and returns updated snapshot.
     pub fn apply_repair_success(
         &mut self,
         cid: &str,
@@ -216,6 +259,9 @@ impl ContentReplicationManager {
         Ok(build_snapshot(cid, record, &self.policy))
     }
 
+    /// Records a failed repair attempt for `cid`.
+    ///
+    /// Returns `RepairAttemptsExceeded` when max retries are already consumed.
     pub fn apply_repair_failure(
         &mut self,
         cid: &str,
@@ -245,11 +291,22 @@ impl ContentReplicationManager {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Replication manager error taxonomy.
 pub enum ContentReplicationError {
+    /// Replication policy contains invalid bounds.
     InvalidPolicy(&'static str),
+    /// Required input field was empty or zero.
     EmptyField(&'static str),
+    /// Content identifier is not registered in manager state.
     UnknownContent(String),
-    RepairAttemptsExceeded { cid: String, max_attempts: u8 },
+    /// Repair retry budget has been exhausted for content.
+    RepairAttemptsExceeded {
+        /// Content identifier that exceeded retry budget.
+        cid: String,
+        /// Maximum repair attempts allowed by policy.
+        max_attempts: u8,
+    },
+    /// Underlying storage validation failed.
     Storage(ContentStorageError),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -24,7 +24,7 @@ pub mod channel_policies;
 pub mod config;
 /// Content retention, tombstone scheduling, and purge eligibility contracts.
 pub mod content_lifecycle;
-#[allow(missing_docs)]
+/// Replication policy, availability health, and repair action contracts.
 pub mod content_replication;
 #[allow(missing_docs)]
 pub mod content_retrieval;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -487,6 +487,23 @@ fn graduated_wave_twenty_five_content_lifecycle_module_must_not_return_to_allowl
 }
 
 #[test]
+fn graduated_wave_twenty_six_content_replication_module_must_not_return_to_allowlist() {
+    // Regression: #2025
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "content_replication";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -162,6 +162,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `bootstrap`
   - `config`
   - `content_lifecycle`
+  - `content_replication`
   - `content_storage`
   - `cross_chain_bridge`
   - `cross_chain_receipt`
@@ -211,6 +212,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2019`
   - `Regression: #2021`
   - `Regression: #2023`
+  - `Regression: #2025`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ audit_exports
 bridge_adapter
 channel_models
 channel_policies
-content_replication
 content_retrieval
 data_classification
 did

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -28,3 +28,4 @@ redaction_compliance
 cross_chain_bridge
 cross_chain_receipt
 content_lifecycle
+content_replication


### PR DESCRIPTION
## Summary
Graduate `content_replication` from the phased missing-docs allowlist by removing the module-level allow, adding full public rustdoc coverage, and updating policy fixtures/regression guards so drift fails closed.

## Changes
- `crates/kamn-core/src/content_replication.rs`: added rustdoc for all public enums, variants, structs, fields, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: documented `content_replication` module export and removed exemption.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `content_replication`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `content_replication`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_twenty_six_content_replication_module_must_not_return_to_allowlist` (`Regression: #2025`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`RUSTFLAGS='-D warnings' cargo check -p kamn-core`

Result (before docs graduation): failed with `missing documentation` errors across `content_replication.rs` public API (48 total errors).

### 🟢 Green Phase
Commands:
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- `cargo test -p kamn-core content_replication`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`

Result: all pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`

Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core content_replication` | |
| Functional   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | Added `graduated_wave_twenty_six_content_replication_module_must_not_return_to_allowlist` | |
| Performance  | N/A | | Docs/policy graduation; no runtime/perf path change |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore prior allowlist state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`
- Public API rustdocs in `crates/kamn-core/src/content_replication.rs` and `crates/kamn-core/src/lib.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2025
Refs #1717
Refs #1712
