### PR TITLE
docs(kamn-core): graduate content_retrieval from missing-docs allowlist (#2027)

### DIFF
--- a/crates/kamn-core/src/content_retrieval.rs
+++ b/crates/kamn-core/src/content_retrieval.rs
@@ -1,3 +1,5 @@
+//! Content retrieval authorization, caching, and audit-event contracts.
+
 use crate::{
     AgentDid, ChannelAction, ChannelPermissionEngine, ChannelPolicyError, ContentStorageAdapter,
     ContentStorageError,
@@ -6,11 +8,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Retrieval engine cache configuration.
 pub struct ContentRetrievalConfig {
+    /// Maximum seconds cached retrieval entries remain valid.
     pub cache_ttl_secs: u64,
 }
 
 impl ContentRetrievalConfig {
+    /// Builds a validated retrieval config.
     pub fn new(cache_ttl_secs: u64) -> Result<Self, ContentRetrievalError> {
         if cache_ttl_secs == 0 {
             return Err(ContentRetrievalError::InvalidConfig("cache_ttl_secs"));
@@ -20,8 +25,11 @@ impl ContentRetrievalConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Resource scope requested for content retrieval.
 pub enum ContentRetrievalScope {
+    /// Channel-scoped retrieval keyed by channel identifier.
     Channel(String),
+    /// Task-scoped retrieval keyed by task identifier.
     Task(String),
 }
 
@@ -35,14 +43,20 @@ impl ContentRetrievalScope {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Authenticated retrieval request envelope.
 pub struct ContentRetrievalRequest {
+    /// Content identifier requested by caller.
     pub cid: String,
+    /// Requester DID initiating the read.
     pub requester: String,
+    /// Retrieval scope controlling authorization path.
     pub scope: ContentRetrievalScope,
+    /// Unix timestamp when the request was created.
     pub requested_at_unix: u64,
 }
 
 impl ContentRetrievalRequest {
+    /// Constructs a validated retrieval request.
     pub fn new(
         cid: &str,
         requester: &str,
@@ -68,30 +82,46 @@ impl ContentRetrievalRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Authorization outcome recorded for retrieval attempts.
 pub enum ContentRetrievalOutcome {
+    /// Request was authorized and retrieval completed.
     Allowed,
+    /// Request failed authorization.
     Denied,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Audit event emitted for each retrieval decision.
 pub struct ContentRetrievalAuditEvent {
+    /// Content identifier targeted by the request.
     pub cid: String,
+    /// Requester DID that initiated retrieval.
     pub requester: String,
+    /// Scope used during authorization.
     pub scope: ContentRetrievalScope,
+    /// Unix timestamp when retrieval was requested.
     pub requested_at_unix: u64,
+    /// Authorization decision outcome.
     pub outcome: ContentRetrievalOutcome,
+    /// Whether payload came from cache.
     pub cache_hit: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Retrieval result payload returned to authorized callers.
 pub struct ContentRetrievalResult {
+    /// Content identifier returned by storage.
     pub cid: String,
+    /// MIME media type associated with payload.
     pub media_type: String,
+    /// Raw content payload bytes.
     pub payload: Vec<u8>,
+    /// True when result came from cache.
     pub from_cache: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Retrieval engine implementing scope-based authorization and cache behavior.
 pub struct ContentRetrievalEngine {
     config: ContentRetrievalConfig,
     task_read_allowlist: BTreeMap<String, BTreeSet<String>>,
@@ -100,6 +130,7 @@ pub struct ContentRetrievalEngine {
 }
 
 impl ContentRetrievalEngine {
+    /// Creates a retrieval engine from validated config.
     pub fn new(config: ContentRetrievalConfig) -> Self {
         Self {
             config,
@@ -109,6 +140,7 @@ impl ContentRetrievalEngine {
         }
     }
 
+    /// Grants task-scoped read permission to a requester DID.
     pub fn grant_task_read(
         &mut self,
         task_id: &str,
@@ -125,14 +157,17 @@ impl ContentRetrievalEngine {
         Ok(())
     }
 
+    /// Invalidates cached retrieval entries for a CID.
     pub fn invalidate_cache_for_cid(&mut self, cid: &str) {
         self.cache.retain(|_, entry| entry.cid != cid);
     }
 
+    /// Returns retrieval audit events accumulated by this engine.
     pub fn audit_events(&self) -> Vec<ContentRetrievalAuditEvent> {
         self.audit_events.clone()
     }
 
+    /// Retrieves content for an authorized request, applying cache policy.
     pub fn retrieve<A: ContentStorageAdapter>(
         &mut self,
         adapter: &A,
@@ -245,16 +280,26 @@ impl ContentRetrievalEngine {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Retrieval engine error taxonomy.
 pub enum ContentRetrievalError {
+    /// Retrieval config contained invalid values.
     InvalidConfig(&'static str),
+    /// A required field was empty or zero.
     EmptyField(&'static str),
+    /// Requester DID failed parsing/validation.
     InvalidDid(String),
+    /// Requester is not authorized for target scope.
     Unauthorized {
+        /// Requester DID rejected by authorization.
         requester: String,
+        /// Scope where authorization failed.
         scope: ContentRetrievalScope,
     },
+    /// Channel permission engine was required but not provided.
     MissingChannelPermissions(String),
+    /// Channel authorization call returned a policy error.
     ChannelPolicy(ChannelPolicyError),
+    /// Storage adapter returned retrieval/validation failure.
     Storage(ContentStorageError),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -26,7 +26,7 @@ pub mod config;
 pub mod content_lifecycle;
 /// Replication policy, availability health, and repair action contracts.
 pub mod content_replication;
-#[allow(missing_docs)]
+/// Retrieval access policy, caching controls, and audit event contracts.
 pub mod content_retrieval;
 /// Content storage adapter contracts, object metadata, and CID/URI helpers.
 pub mod content_storage;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -504,6 +504,23 @@ fn graduated_wave_twenty_six_content_replication_module_must_not_return_to_allow
 }
 
 #[test]
+fn graduated_wave_twenty_seven_content_retrieval_module_must_not_return_to_allowlist() {
+    // Regression: #2027
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "content_retrieval";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -163,6 +163,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `config`
   - `content_lifecycle`
   - `content_replication`
+  - `content_retrieval`
   - `content_storage`
   - `cross_chain_bridge`
   - `cross_chain_receipt`
@@ -213,6 +214,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2021`
   - `Regression: #2023`
   - `Regression: #2025`
+  - `Regression: #2027`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ audit_exports
 bridge_adapter
 channel_models
 channel_policies
-content_retrieval
 data_classification
 did
 did_registry

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -29,3 +29,4 @@ cross_chain_bridge
 cross_chain_receipt
 content_lifecycle
 content_replication
+content_retrieval


### PR DESCRIPTION
## Summary
Graduate `content_retrieval` from the phased missing-docs allowlist by removing the module-level allow, adding full public rustdoc coverage, and updating policy fixtures/regression guards so drift fails closed.

## Changes
- `crates/kamn-core/src/content_retrieval.rs`: added rustdoc for public enums, variants, structs, fields, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: documented `content_retrieval` module export and removed exemption.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `content_retrieval`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `content_retrieval`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_twenty_seven_content_retrieval_module_must_not_return_to_allowlist` (`Regression: #2027`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`RUSTFLAGS='-D warnings' cargo check -p kamn-core`

Result (before docs graduation): failed with `missing documentation` errors across `content_retrieval.rs` public API (43 total errors).

### 🟢 Green Phase
Commands:
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- `cargo test -p kamn-core content_retrieval`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`

Result: all pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`

Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core content_retrieval` | |
| Functional   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | Added `graduated_wave_twenty_seven_content_retrieval_module_must_not_return_to_allowlist` | |
| Performance  | N/A | | Docs/policy graduation; no runtime/perf path change |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore prior allowlist state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`
- Public API rustdocs in `crates/kamn-core/src/content_retrieval.rs` and `crates/kamn-core/src/lib.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2027
Refs #1717
Refs #1712
