### PR TITLE
docs(kamn-core): graduate data_classification from missing-docs allowlist (#2029)

### DIFF
--- a/crates/kamn-core/src/data_classification.rs
+++ b/crates/kamn-core/src/data_classification.rs
@@ -1,59 +1,91 @@
+//! Data classification policy contracts for write authorization and status reporting.
+
 use crate::{canonical_state_key, AgentDid};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Ordered classification level applied to domain writes.
 pub enum DataClassificationLevel {
+    /// Lowest-sensitivity data suitable for broad visibility.
     Public,
+    /// Internal-only data that should stay within trusted operators.
     Internal,
+    /// Sensitive data requiring explicit tags and tighter controls.
     Sensitive,
+    /// Highest-sensitivity data requiring strict controls.
     Restricted,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Write domain used for minimum classification policy lookup.
 pub enum WriteDomain {
+    /// Message and channel payload domain.
     Messages,
+    /// Task and workflow record domain.
     Tasks,
+    /// Escrow and settlement state domain.
     Escrows,
+    /// Reputation and trust signal domain.
     Reputation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Classification policy defining minimum levels and required tags.
 pub struct ClassificationPolicy {
+    /// Minimum classification level required per write domain.
     pub minimum_by_domain: BTreeMap<WriteDomain, DataClassificationLevel>,
+    /// Required tags keyed by classification level.
     pub required_tags_by_level: BTreeMap<DataClassificationLevel, BTreeSet<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Classification label and tags attached to a write request.
 pub struct WriteTag {
+    /// Provided classification level for the write.
     pub level: DataClassificationLevel,
+    /// Free-form governance/compliance tags attached by caller.
     pub tags: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Context describing a pending write authorization request.
 pub struct WriteRequestContext {
+    /// Domain receiving the write.
     pub domain: WriteDomain,
+    /// Domain-local record identifier.
     pub record_id: String,
+    /// Actor DID requesting the write.
     pub actor: String,
+    /// Classification metadata for the write.
     pub tag: WriteTag,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Derived classification status for a given record/tag pairing.
 pub struct ClassificationStatus {
+    /// Domain evaluated for status.
     pub domain: WriteDomain,
+    /// Domain-local record identifier.
     pub record_id: String,
+    /// Policy minimum classification for the domain.
     pub minimum_level: DataClassificationLevel,
+    /// Caller-provided classification level.
     pub provided_level: DataClassificationLevel,
+    /// Missing required tags for the provided level.
     pub missing_tags: Vec<String>,
+    /// True when policy checks authorize the write.
     pub authorized: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Engine that validates data classification constraints for writes.
 pub struct DataClassificationEngine {
     policy: ClassificationPolicy,
 }
 
 impl DataClassificationEngine {
+    /// Constructs a classification engine from validated policy.
     pub fn new(policy: ClassificationPolicy) -> Result<Self, DataClassificationError> {
         for domain in [
             WriteDomain::Messages,
@@ -77,6 +109,7 @@ impl DataClassificationEngine {
         Ok(Self { policy })
     }
 
+    /// Authorizes a write request and returns canonical state key on success.
     pub fn authorize_write(
         &mut self,
         context: &WriteRequestContext,
@@ -110,6 +143,7 @@ impl DataClassificationEngine {
         .map_err(|error| DataClassificationError::InvalidPolicy(error.to_string()))
     }
 
+    /// Computes authorization status for a domain/record and provided tag.
     pub fn status_for(
         &self,
         domain: WriteDomain,
@@ -169,20 +203,33 @@ impl DataClassificationEngine {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Data classification engine error taxonomy.
 pub enum DataClassificationError {
+    /// Policy configuration failed validation.
     InvalidPolicy(String),
+    /// Required field value was empty.
     EmptyField(&'static str),
+    /// Tag value failed validation.
     InvalidTag(String),
+    /// Actor DID failed parse/validation.
     InvalidDid(String),
+    /// Caller omitted one or more required tags for classification level.
     MissingRequiredTags {
+        /// Classification level with required tag policy.
         level: DataClassificationLevel,
+        /// Tags missing from caller payload.
         missing: BTreeSet<String>,
     },
+    /// Caller provided classification level below domain minimum.
     ClassificationBelowDomainMinimum {
+        /// Domain enforcing the minimum.
         domain: WriteDomain,
+        /// Required minimum level from policy.
         required: DataClassificationLevel,
+        /// Caller-provided level.
         provided: DataClassificationLevel,
     },
+    /// Sensitive/restricted write was submitted without tags.
     UntaggedSensitiveWrite(String),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod content_storage;
 pub mod cross_chain_bridge;
 /// Cross-chain receipt proof normalization and finality mapping contracts.
 pub mod cross_chain_receipt;
-#[allow(missing_docs)]
+/// Data-domain classification policy and write-tag validation contracts.
 pub mod data_classification;
 #[allow(missing_docs)]
 pub mod did;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -521,6 +521,23 @@ fn graduated_wave_twenty_seven_content_retrieval_module_must_not_return_to_allow
 }
 
 #[test]
+fn graduated_wave_twenty_eight_data_classification_module_must_not_return_to_allowlist() {
+    // Regression: #2029
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "data_classification";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -164,6 +164,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `content_lifecycle`
   - `content_replication`
   - `content_retrieval`
+  - `data_classification`
   - `content_storage`
   - `cross_chain_bridge`
   - `cross_chain_receipt`
@@ -215,6 +216,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2023`
   - `Regression: #2025`
   - `Regression: #2027`
+  - `Regression: #2029`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ audit_exports
 bridge_adapter
 channel_models
 channel_policies
-data_classification
 did
 did_registry
 durable_guard_store

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -30,3 +30,4 @@ cross_chain_receipt
 content_lifecycle
 content_replication
 content_retrieval
+data_classification


### PR DESCRIPTION
## Summary
Graduate `data_classification` from the phased missing-docs allowlist by removing the module-level allow, adding full public rustdoc coverage, and updating policy fixtures/regression guards so drift fails closed.

## Changes
- `crates/kamn-core/src/data_classification.rs`: added rustdoc for public enums, variants, structs, fields, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: documented `data_classification` module export and removed exemption.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `data_classification`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `data_classification`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_twenty_eight_data_classification_module_must_not_return_to_allowlist` (`Regression: #2029`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation and regression marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`RUSTFLAGS='-D warnings' cargo check -p kamn-core`

Result (before docs graduation): failed with `missing documentation` errors across `data_classification.rs` public API (45 total errors).

### 🟢 Green Phase
Commands:
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- `cargo test -p kamn-core data_classification`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`

Result: all pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`

Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `cargo test -p kamn-core data_classification` | |
| Functional   | ✅ | `cargo test -p kamn-core --test missing_docs_policy` | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | Added `graduated_wave_twenty_eight_data_classification_module_must_not_return_to_allowlist` | |
| Performance  | N/A | | Docs/policy graduation; no runtime/perf path change |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore prior allowlist state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`
- Public API rustdocs in `crates/kamn-core/src/data_classification.rs` and `crates/kamn-core/src/lib.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2029
Refs #1717
Refs #1712
