### PR TITLE
docs(kamn-core): graduate durable_guard_store missing docs (#2035)

### DIFF
--- a/crates/kamn-core/src/durable_guard_store.rs
+++ b/crates/kamn-core/src/durable_guard_store.rs
@@ -1,3 +1,5 @@
+//! Durable snapshot store contracts for delivery guard and channel policy state.
+
 use crate::{
     ChannelPermissionEngine, ChannelPermissions, ChannelPolicySnapshot,
     ChannelPolicySnapshotChannel, ChannelPolicySnapshotError, DeliveryGuardSnapshot,
@@ -10,16 +12,22 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
 
+/// Schema version for serialized durable guard bundles.
 pub const DURABLE_GUARD_BUNDLE_SCHEMA_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Combined snapshot bundle for delivery guards and channel policy state.
 pub struct DurableGuardSnapshotBundle {
+    /// Bundle schema version.
     pub schema_version: u16,
+    /// Delivery guard snapshot payload.
     pub delivery_guard: DeliveryGuardSnapshot,
+    /// Channel policy snapshot payload.
     pub channel_policy: ChannelPolicySnapshot,
 }
 
 impl DurableGuardSnapshotBundle {
+    /// Captures a snapshot bundle from live guard engines.
     pub fn capture(
         delivery_guards: &MessageDeliveryGuards,
         channel_permissions: &ChannelPermissionEngine,
@@ -31,6 +39,7 @@ impl DurableGuardSnapshotBundle {
         }
     }
 
+    /// Restores snapshot bundle into live guard engines.
     pub fn restore_into(
         self,
         delivery_guards: &mut MessageDeliveryGuards,
@@ -55,11 +64,22 @@ impl DurableGuardSnapshotBundle {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Durable snapshot store error taxonomy.
 pub enum DurableGuardSnapshotStoreError {
-    BundleSchemaVersionMismatch { expected: u16, found: u16 },
+    /// Bundle schema version does not match current runtime schema.
+    BundleSchemaVersionMismatch {
+        /// Expected schema version.
+        expected: u16,
+        /// Found schema version in payload.
+        found: u16,
+    },
+    /// I/O failure while reading or writing snapshot payload.
     Io(String),
+    /// Payload failed structural or semantic validation.
     InvalidPayload(String),
+    /// Delivery snapshot payload could not be restored.
     DeliverySnapshot(DeliveryGuardSnapshotError),
+    /// Channel-policy snapshot payload could not be restored.
     ChannelPolicySnapshot(ChannelPolicySnapshotError),
 }
 
@@ -94,40 +114,50 @@ impl From<ChannelPolicySnapshotError> for DurableGuardSnapshotStoreError {
     }
 }
 
+/// Store interface for whole durable guard bundles.
 pub trait DurableGuardBundleSnapshotStore {
+    /// Saves a durable guard bundle.
     fn save_bundle(
         &mut self,
         bundle: DurableGuardSnapshotBundle,
     ) -> Result<(), DurableGuardSnapshotStoreError>;
 
+    /// Loads a durable guard bundle, if present.
     fn load_bundle(
         &self,
     ) -> Result<Option<DurableGuardSnapshotBundle>, DurableGuardSnapshotStoreError>;
 }
 
+/// Store interface for delivery-guard snapshot lane.
 pub trait DeliveryGuardSnapshotStore {
+    /// Saves only delivery-guard snapshot payload.
     fn save_delivery_guard(
         &mut self,
         snapshot: DeliveryGuardSnapshot,
     ) -> Result<(), DurableGuardSnapshotStoreError>;
 
+    /// Loads only delivery-guard snapshot payload, if present.
     fn load_delivery_guard(
         &self,
     ) -> Result<Option<DeliveryGuardSnapshot>, DurableGuardSnapshotStoreError>;
 }
 
+/// Store interface for channel-policy snapshot lane.
 pub trait ChannelPolicySnapshotStore {
+    /// Saves only channel-policy snapshot payload.
     fn save_channel_policy(
         &mut self,
         snapshot: ChannelPolicySnapshot,
     ) -> Result<(), DurableGuardSnapshotStoreError>;
 
+    /// Loads only channel-policy snapshot payload, if present.
     fn load_channel_policy(
         &self,
     ) -> Result<Option<ChannelPolicySnapshot>, DurableGuardSnapshotStoreError>;
 }
 
 #[derive(Debug, Clone, Default)]
+/// In-memory durable snapshot store implementation for tests and local runtime.
 pub struct InMemoryDurableGuardSnapshotStore {
     bundle: Option<DurableGuardSnapshotBundle>,
 }
@@ -187,11 +217,13 @@ impl ChannelPolicySnapshotStore for InMemoryDurableGuardSnapshotStore {
 }
 
 #[derive(Debug, Clone)]
+/// File-backed durable snapshot store implementation.
 pub struct FileDurableGuardSnapshotStore {
     path: PathBuf,
 }
 
 impl FileDurableGuardSnapshotStore {
+    /// Creates a file-backed snapshot store rooted at `path`.
     pub fn new(path: PathBuf) -> Result<Self, DurableGuardSnapshotStoreError> {
         if path.is_dir() {
             return Err(DurableGuardSnapshotStoreError::InvalidPayload(

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -44,7 +44,7 @@ pub mod did_registry;
 pub mod direct_message_crypto;
 /// Discord bridge ingress/egress routing and outbound approval contracts.
 pub mod discord_bridge;
-#[allow(missing_docs)]
+/// Durable snapshot contracts for guard-state and policy persistence.
 pub mod durable_guard_store;
 #[allow(missing_docs)]
 pub mod escrow;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -572,6 +572,23 @@ fn graduated_wave_thirty_did_registry_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_thirty_one_durable_guard_store_module_must_not_return_to_allowlist() {
+    // Regression: #2035
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "durable_guard_store";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -172,6 +172,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `cross_chain_receipt`
   - `direct_message_crypto`
   - `discord_bridge`
+  - `durable_guard_store`
   - `group_channel_crypto`
   - `key_lifecycle`
   - `key_recovery`
@@ -221,6 +222,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2029`
   - `Regression: #2031`
   - `Regression: #2033`
+  - `Regression: #2035`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ audit_exports
 bridge_adapter
 channel_models
 channel_policies
-durable_guard_store
 escrow
 governance_workflow
 instruction_verify

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -33,3 +33,4 @@ content_retrieval
 data_classification
 did
 did_registry
+durable_guard_store


### PR DESCRIPTION
Closes #2035

## Summary
Graduate `durable_guard_store` from the `kamn-core` missing-docs allowlist by adding rustdoc coverage to its public API and updating policy fixtures/regression markers. This advances the docs-hardening wave while keeping strict missing-doc contracts fail-closed.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `durable_guard_store` and added module-level docs.
- `crates/kamn-core/src/durable_guard_store.rs`: added rustdoc for public constants, structs/fields, enum variants, traits, and public methods.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `durable_guard_store`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `durable_guard_store`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard test for wave 31 (`Regression: #2035`).
- `docs/architecture/kamn-core-module-map.md`: added module to graduated list and added `Regression: #2035` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Expected failure observed after removing `#[allow(missing_docs)]` for `durable_guard_store`:
- missing-doc diagnostics emitted for `durable_guard_store` public API
- total failures: `27` missing-doc errors
- compile failed as expected

### 🟢 Green Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core durable_guard_store
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings
```
All commands passed.

### 🔁 Regression
```bash
cargo test
```
Passed across workspace (`kamn-core`, `kamn-kolme`, `kamn-node`, `kamn-sdk`) with no new failures.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `cargo test -p kamn-core durable_guard_store` | |
| Functional   | N/A    | | Docs-hardening only; no feature behavior changes. |
| Integration  | ✅     | `cargo test` workspace regression includes integration coverage | |
| Regression   | ✅     | `crates/kamn-core/tests/missing_docs_policy.rs` (`Regression: #2035`) | |
| Performance  | N/A    | | Docs-hardening only; no runtime/perf-path modifications. |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate durable_guard_store missing docs (#2035)` if any docs-policy drift appears.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
