### PR TITLE
docs(kamn-core): graduate audit_exports missing docs (#2037)

### DIFF
--- a/crates/kamn-core/src/audit_exports.rs
+++ b/crates/kamn-core/src/audit_exports.rs
@@ -1,71 +1,111 @@
+//! Audit export contracts for compliance and operator evidence workflows.
+
 use crate::AgentDid;
 use std::collections::BTreeSet;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Domain namespace for an auditable event record.
 pub enum AuditDomain {
+    /// Message lifecycle and delivery events.
     Messages,
+    /// Task lifecycle and assignment events.
     Tasks,
+    /// Escrow state and settlement events.
     Escrows,
+    /// Reputation signal and score mutation events.
     Reputation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Canonical audit event record captured for export bundles.
 pub struct AuditEventRecord {
+    /// Logical domain this event belongs to.
     pub domain: AuditDomain,
+    /// Stable event identifier in the source domain.
     pub event_id: String,
+    /// Event timestamp in canonical UTC string form.
     pub occurred_at: String,
+    /// DID of the actor that caused the event.
     pub actor: String,
+    /// Action label describing the event mutation.
     pub action: String,
+    /// Digest of the payload associated with this event.
     pub payload_digest: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Export wire format for rendered audit bundles.
 pub enum AuditExportFormat {
+    /// Single JSON object bundle.
     Json,
+    /// JSON Lines stream format.
     JsonLines,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Filter constraints applied during audit export selection.
 pub struct AuditExportFilter {
+    /// Optional domain allowlist. Empty means all domains.
     pub domains: BTreeSet<AuditDomain>,
+    /// Optional actor DID allowlist. Empty means all actors.
     pub actor_allowlist: BTreeSet<String>,
+    /// Optional lower-bound timestamp (inclusive).
     pub from_inclusive: Option<String>,
+    /// Optional upper-bound timestamp (inclusive).
     pub to_inclusive: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request payload used to materialize an audit export bundle.
 pub struct AuditExportRequest {
+    /// Stable identifier for the export request.
     pub request_id: String,
+    /// DID requesting the export.
     pub requested_by: String,
+    /// Request timestamp in canonical UTC string form.
     pub requested_at: String,
+    /// Desired export output format.
     pub format: AuditExportFormat,
+    /// Selection filter for records included in the bundle.
     pub filter: AuditExportFilter,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Manifest metadata emitted with every audit export bundle.
 pub struct AuditExportManifest {
+    /// Identifier of the originating request.
     pub request_id: String,
+    /// DID that requested the export.
     pub requested_by: String,
+    /// Timestamp when the export was produced.
     pub exported_at: String,
+    /// Format used to render this bundle.
     pub format: AuditExportFormat,
+    /// Number of records included in the bundle.
     pub record_count: usize,
+    /// Deterministic integrity digest across exported records.
     pub integrity_hash: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Full audit export payload including records and manifest metadata.
 pub struct AuditExportBundle {
+    /// Exported audit records after filter application.
     pub records: Vec<AuditEventRecord>,
+    /// Bundle manifest metadata and integrity digest.
     pub manifest: AuditExportManifest,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// In-memory audit export engine with exporter authorization controls.
 pub struct AuditExportEngine {
     authorized_exporters: BTreeSet<String>,
     events: Vec<AuditEventRecord>,
 }
 
 impl AuditExportEngine {
+    /// Builds an export engine from an authorized exporter DID set.
     pub fn new(authorized_exporters: Vec<String>) -> Result<Self, AuditExportError> {
         if authorized_exporters.is_empty() {
             return Err(AuditExportError::EmptyAuthorizedExporters);
@@ -83,6 +123,7 @@ impl AuditExportEngine {
         })
     }
 
+    /// Ingests and validates a new audit record into the export store.
     pub fn ingest_event(&mut self, event: AuditEventRecord) -> Result<(), AuditExportError> {
         validate_non_empty("event_id", &event.event_id)?;
         validate_non_empty("occurred_at", &event.occurred_at)?;
@@ -93,6 +134,7 @@ impl AuditExportEngine {
         Ok(())
     }
 
+    /// Exports a filtered bundle for an authorized requestor DID.
     pub fn export(
         &self,
         request: &AuditExportRequest,
@@ -153,11 +195,22 @@ impl AuditExportEngine {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error taxonomy for audit export validation and authorization failures.
 pub enum AuditExportError {
+    /// Engine constructor received an empty exporter allowlist.
     EmptyAuthorizedExporters,
+    /// A required field was empty after trimming.
     EmptyField(&'static str),
+    /// A DID field failed syntactic validation.
     InvalidDid(String),
-    InvalidTimeWindow { from: String, to: String },
+    /// Time window lower-bound is later than the upper-bound.
+    InvalidTimeWindow {
+        /// Inclusive lower-bound supplied by the request.
+        from: String,
+        /// Inclusive upper-bound supplied by the request.
+        to: String,
+    },
+    /// Request DID is not authorized to export audit data.
     UnauthorizedExporter(String),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -11,7 +11,7 @@ pub mod agent_key_hierarchy;
 pub mod agent_upgrade_workflow;
 /// Anti-spam admission, rate-limit, and suspension policy contracts.
 pub mod anti_spam;
-#[allow(missing_docs)]
+/// Audit export filters, bundles, and governance evidence contracts.
 pub mod audit_exports;
 pub mod bootstrap;
 #[allow(missing_docs)]

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -589,6 +589,23 @@ fn graduated_wave_thirty_one_durable_guard_store_module_must_not_return_to_allow
 }
 
 #[test]
+fn graduated_wave_thirty_two_audit_exports_module_must_not_return_to_allowlist() {
+    // Regression: #2037
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "audit_exports";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -159,6 +159,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 - Graduated modules currently enforced outside the allow-list:
   - `agent_key_hierarchy`
   - `anti_spam`
+  - `audit_exports`
   - `bootstrap`
   - `config`
   - `content_lifecycle`
@@ -223,6 +224,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2031`
   - `Regression: #2033`
   - `Regression: #2035`
+  - `Regression: #2037`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -1,5 +1,4 @@
 agent_upgrade_workflow
-audit_exports
 bridge_adapter
 channel_models
 channel_policies

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -34,3 +34,4 @@ data_classification
 did
 did_registry
 durable_guard_store
+audit_exports


### PR DESCRIPTION
Closes #2037

## Summary
Graduate `audit_exports` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the exemption from `lib.rs`. This advances the docs-hardening wave while keeping allowlist/graduated fixtures and regression policy enforcement aligned.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `audit_exports` and added module-level docs.
- `crates/kamn-core/src/audit_exports.rs`: added rustdoc for public enums/variants, structs/fields, errors, and public methods.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `audit_exports`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `audit_exports`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard test for wave 32 (`Regression: #2037`).
- `docs/architecture/kamn-core-module-map.md`: added module to graduated list and added `Regression: #2037` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Expected failure observed after removing `#[allow(missing_docs)]` for `audit_exports`:
- missing-doc diagnostics emitted for `audit_exports` public API
- total failures: `48` missing-doc errors
- compile failed as expected

### 🟢 Green Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core audit_exports
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings
```
All commands passed.

### 🔁 Regression
```bash
cargo test
```
Passed across workspace (`kamn-core`, `kamn-kolme`, `kamn-node`, `kamn-sdk`) with no new failures.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `cargo test -p kamn-core audit_exports` | |
| Functional   | N/A    | | Docs-hardening only; no feature behavior changes. |
| Integration  | ✅     | `cargo test` workspace regression includes integration coverage | |
| Regression   | ✅     | `crates/kamn-core/tests/missing_docs_policy.rs` (`Regression: #2037`) | |
| Performance  | N/A    | | Docs-hardening only; no runtime/perf-path modifications. |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate audit_exports missing docs (#2037)` if any docs-policy drift appears.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
