### PR TITLE
docs(kamn-core): graduate performance_targets missing docs (#2039)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -80,7 +80,7 @@ pub mod operator_binding;
 pub mod operator_dashboard_api;
 #[allow(missing_docs)]
 pub mod operator_dashboard_ui;
-#[allow(missing_docs)]
+/// Performance target thresholds and benchmark outcome classification contracts.
 pub mod performance_targets;
 /// Redaction request approval, audit-event, and visibility compliance contracts.
 pub mod redaction_compliance;

--- a/crates/kamn-core/src/performance_targets.rs
+++ b/crates/kamn-core/src/performance_targets.rs
@@ -1,11 +1,18 @@
+//! Performance target contracts and benchmark-go/no-go evaluation helpers.
+
 use crate::observability::ObservabilitySample;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Runtime performance dimensions evaluated against PRD thresholds.
 pub enum PerformanceMetric {
+    /// Median end-to-end latency (milliseconds).
     LatencyP50,
+    /// Tail latency (p99, milliseconds).
     LatencyP99,
+    /// Sustained throughput (transactions/messages per second).
     Throughput,
+    /// Service availability percentage.
     Availability,
 }
 
@@ -38,14 +45,20 @@ impl PerformanceMetric {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Performance thresholds derived from the product requirement baseline.
 pub struct PrdPerformanceTargets {
+    /// Maximum allowed p50 latency.
     pub max_latency_p50_ms: u64,
+    /// Maximum allowed p99 latency.
     pub max_latency_p99_ms: u64,
+    /// Minimum required throughput.
     pub min_throughput_tps: u64,
+    /// Minimum required availability percentage.
     pub min_availability_pct: f64,
 }
 
 impl PrdPerformanceTargets {
+    /// Returns the default PRD v13.2 performance threshold set.
     pub fn v13_2() -> Self {
         Self {
             max_latency_p50_ms: 100,
@@ -57,46 +70,72 @@ impl PrdPerformanceTargets {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Single benchmark sample used in aggregate performance evaluation.
 pub struct PerformanceSample {
+    /// Observed p50 latency in milliseconds.
     pub latency_p50_ms: u64,
+    /// Observed p99 latency in milliseconds.
     pub latency_p99_ms: u64,
+    /// Observed throughput in transactions/messages per second.
     pub throughput_tps: u64,
+    /// Observed availability percentage.
     pub availability_pct: f64,
+    /// Sample timestamp (epoch seconds).
     pub timestamp_epoch_s: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Aggregated benchmark values used for target comparison.
 pub struct PerformanceAggregate {
+    /// Aggregated p50 latency in milliseconds.
     pub latency_p50_ms: u64,
+    /// Aggregated p99 latency in milliseconds.
     pub latency_p99_ms: u64,
+    /// Aggregated throughput in transactions/messages per second.
     pub throughput_tps: u64,
+    /// Aggregated availability percentage.
     pub availability_pct: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Result for a single metric compared against its threshold.
 pub struct PerformanceMetricResult {
+    /// Metric that was evaluated.
     pub metric: PerformanceMetric,
+    /// Observed metric value.
     pub observed: f64,
+    /// Threshold applied during evaluation.
     pub threshold: f64,
+    /// Whether the observed value meets the threshold.
     pub met: bool,
+    /// Percent deviation from threshold (0 when met).
     pub deviation_pct: f64,
+    /// Suggested remediation when metric is not met.
     pub remediation: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Full run-level performance evaluation report.
 pub struct PerformanceRunReport {
+    /// Identifier for the benchmark run.
     pub run_id: String,
+    /// Number of samples included in this run.
     pub sample_count: usize,
+    /// Aggregate values computed from all samples.
     pub aggregate: PerformanceAggregate,
+    /// Per-metric evaluation results.
     pub results: Vec<PerformanceMetricResult>,
+    /// True when all metrics meet configured thresholds.
     pub meets_targets: bool,
 }
 
 impl PerformanceRunReport {
+    /// Returns the evaluation result for a specific metric, if present.
     pub fn metric_result(&self, metric: PerformanceMetric) -> Option<&PerformanceMetricResult> {
         self.results.iter().find(|result| result.metric == metric)
     }
 
+    /// Returns failed metrics ordered by remediation priority.
     pub fn bottlenecks(&self) -> Vec<PerformanceMetric> {
         let mut failed: Vec<&PerformanceMetricResult> =
             self.results.iter().filter(|result| !result.met).collect();
@@ -112,10 +151,23 @@ impl PerformanceRunReport {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Error taxonomy for performance sample and run validation.
 pub enum PerformanceRunError {
+    /// Run does not contain any samples.
     EmptySamples,
-    InvalidAvailability { value: f64 },
-    InvalidLatencyOrder { p50: u64, p99: u64 },
+    /// Availability sample is outside 0..=100.
+    InvalidAvailability {
+        /// Invalid availability value.
+        value: f64,
+    },
+    /// p99 latency is lower than p50 latency.
+    InvalidLatencyOrder {
+        /// Observed p50 latency.
+        p50: u64,
+        /// Observed p99 latency.
+        p99: u64,
+    },
+    /// Throughput sample is zero.
     ZeroThroughput,
 }
 
@@ -142,6 +194,7 @@ impl fmt::Display for PerformanceRunError {
 
 impl std::error::Error for PerformanceRunError {}
 
+/// Evaluates a benchmark run against PRD target thresholds.
 pub fn evaluate_performance_run(
     run_id: impl Into<String>,
     samples: &[PerformanceSample],
@@ -190,6 +243,7 @@ pub fn evaluate_performance_run(
     })
 }
 
+/// Converts observability samples and evaluates them against PRD targets.
 pub fn evaluate_performance_from_observability(
     run_id: impl Into<String>,
     samples: &[ObservabilitySample],

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -606,6 +606,23 @@ fn graduated_wave_thirty_two_audit_exports_module_must_not_return_to_allowlist()
 }
 
 #[test]
+fn graduated_wave_thirty_three_performance_targets_module_must_not_return_to_allowlist() {
+    // Regression: #2039
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "performance_targets";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -182,6 +182,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `namespaces`
   - `operator_actions`
   - `operator_binding`
+  - `performance_targets`
   - `redaction_compliance`
   - `reputation_signals`
   - `service_marketplace`
@@ -225,6 +226,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2033`
   - `Regression: #2035`
   - `Regression: #2037`
+  - `Regression: #2039`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -12,7 +12,6 @@ message_lifecycle
 observability
 operator_dashboard_api
 operator_dashboard_ui
-performance_targets
 reputation_state
 retention_engine
 runtime

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -35,3 +35,4 @@ did
 did_registry
 durable_guard_store
 audit_exports
+performance_targets


### PR DESCRIPTION
Closes #2039

## Summary
Graduate `performance_targets` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the exemption from `lib.rs`. This advances docs hardening for benchmark-go/no-go contracts while preserving fixture/test/doc policy alignment.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `performance_targets` and added module-level docs.
- `crates/kamn-core/src/performance_targets.rs`: added rustdoc for public enums/variants, structs/fields, errors, and public functions/methods.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `performance_targets`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `performance_targets`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard test for wave 33 (`Regression: #2039`).
- `docs/architecture/kamn-core-module-map.md`: added module to graduated list and added `Regression: #2039` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Expected failure observed after removing `#[allow(missing_docs)]` for `performance_targets`:
- missing-doc diagnostics emitted for `performance_targets` public API
- total failures: `47` missing-doc errors
- compile failed as expected

### 🟢 Green Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core performance_targets
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings
```
All commands passed.

### 🔁 Regression
```bash
cargo test
```
Passed across workspace (`kamn-core`, `kamn-kolme`, `kamn-node`, `kamn-sdk`) with no new failures.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `cargo test -p kamn-core performance_targets` | |
| Functional   | N/A    | | Docs-hardening only; no feature behavior changes. |
| Integration  | ✅     | `cargo test` workspace regression includes integration coverage | |
| Regression   | ✅     | `crates/kamn-core/tests/missing_docs_policy.rs` (`Regression: #2039`) | |
| Performance  | N/A    | | Docs-hardening only; no runtime/perf-path modifications. |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate performance_targets missing docs (#2039)` if any docs-policy drift appears.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
