### PR TITLE
docs(kamn-core): graduate retention_engine missing docs (#2041)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -88,7 +88,7 @@ pub mod redaction_compliance;
 pub mod reputation_signals;
 #[allow(missing_docs)]
 pub mod reputation_state;
-#[allow(missing_docs)]
+/// Retention policy evaluation, tombstone lifecycle, and purge guard contracts.
 pub mod retention_engine;
 #[allow(missing_docs)]
 pub mod runtime;

--- a/crates/kamn-core/src/retention_engine.rs
+++ b/crates/kamn-core/src/retention_engine.rs
@@ -1,52 +1,77 @@
+//! Retention policy contracts and expiration evaluation helpers.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Logical domain used to select retention rules for a record.
 pub enum RetentionDomain {
+    /// Message domain records.
     Messages,
+    /// Task domain records.
     Tasks,
+    /// Escrow domain records.
     Escrows,
+    /// Reputation domain records.
     Reputation,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Retention rule class applied to a record.
 pub enum RetentionClass {
+    /// Maximum record age in seconds.
     MaxAgeSeconds(u64),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Retention policy with default and per-domain class overrides.
 pub struct RetentionEnginePolicy {
+    /// Default class used when no domain override exists.
     pub default_class: RetentionClass,
+    /// Domain-specific retention class overrides.
     pub overrides: BTreeMap<RetentionDomain, RetentionClass>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Canonical retention record input evaluated by the policy engine.
 pub struct RetentionRecord {
+    /// Domain the record belongs to.
     pub domain: RetentionDomain,
+    /// Stable identifier of the retained record.
     pub record_id: String,
+    /// Record creation timestamp (epoch seconds).
     pub created_at_secs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Retention status projection for a specific record.
 pub struct RetentionStatus {
+    /// Domain of the evaluated record.
     pub domain: RetentionDomain,
+    /// Identifier of the evaluated record.
     pub record_id: String,
+    /// Effective retention class used for evaluation.
     pub class: RetentionClass,
+    /// Expiration timestamp (epoch seconds).
     pub expires_at_secs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Batch evaluation output containing expired record identifiers.
 pub struct RetentionEvaluation {
+    /// Record IDs that expired during this evaluation cycle.
     pub expired_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// In-memory retention policy engine with resurfaced-record protection.
 pub struct RetentionPolicyEngine {
     policy: RetentionEnginePolicy,
     blocked_ids: BTreeSet<String>,
 }
 
 impl RetentionPolicyEngine {
+    /// Builds a retention policy engine after validating all classes.
     pub fn new(policy: RetentionEnginePolicy) -> Result<Self, RetentionPolicyError> {
         validate_class(policy.default_class)?;
         for class in policy.overrides.values() {
@@ -59,6 +84,7 @@ impl RetentionPolicyEngine {
         })
     }
 
+    /// Evaluates records at `now_secs` and returns records that expired.
     pub fn evaluate(
         &mut self,
         now_secs: u64,
@@ -90,6 +116,7 @@ impl RetentionPolicyEngine {
         Ok(RetentionEvaluation { expired_ids })
     }
 
+    /// Computes retention status for a single record.
     pub fn status_for(
         &self,
         record: &RetentionRecord,
@@ -114,9 +141,13 @@ impl RetentionPolicyEngine {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error taxonomy for retention policy validation and evaluation failures.
 pub enum RetentionPolicyError {
+    /// Retention class has an invalid maximum age.
     InvalidRetentionClass(u64),
+    /// Required field was empty after trimming.
     EmptyField(&'static str),
+    /// Previously expired record resurfaced in a later evaluation.
     ResurfacedExpiredRecord(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -623,6 +623,23 @@ fn graduated_wave_thirty_three_performance_targets_module_must_not_return_to_all
 }
 
 #[test]
+fn graduated_wave_thirty_four_retention_engine_module_must_not_return_to_allowlist() {
+    // Regression: #2041
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "retention_engine";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -184,6 +184,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `operator_binding`
   - `performance_targets`
   - `redaction_compliance`
+  - `retention_engine`
   - `reputation_signals`
   - `service_marketplace`
   - `smoke`
@@ -227,6 +228,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2035`
   - `Regression: #2037`
   - `Regression: #2039`
+  - `Regression: #2041`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -13,7 +13,6 @@ observability
 operator_dashboard_api
 operator_dashboard_ui
 reputation_state
-retention_engine
 runtime
 signer_backend
 task_operations

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -36,3 +36,4 @@ did_registry
 durable_guard_store
 audit_exports
 performance_targets
+retention_engine


### PR DESCRIPTION
Closes #2041

## Summary
Graduate `retention_engine` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the exemption from `lib.rs`. This continues docs hardening for retention/compliance contracts while keeping fixtures, regression checks, and architecture markers aligned.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `retention_engine` and added module-level docs.
- `crates/kamn-core/src/retention_engine.rs`: added rustdoc for public enums/variants, structs/fields, errors, and public methods.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `retention_engine`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `retention_engine`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard test for wave 34 (`Regression: #2041`).
- `docs/architecture/kamn-core-module-map.md`: added module to graduated list and added `Regression: #2041` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Expected failure observed after removing `#[allow(missing_docs)]` for `retention_engine`:
- missing-doc diagnostics emitted for `retention_engine` public API
- total failures: `29` missing-doc errors
- compile failed as expected

### 🟢 Green Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core retention_engine
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings
```
All commands passed.

### 🔁 Regression
```bash
cargo test
```
Passed across workspace (`kamn-core`, `kamn-kolme`, `kamn-node`, `kamn-sdk`) with no new failures.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `cargo test -p kamn-core retention_engine` | |
| Functional   | N/A    | | Docs-hardening only; no feature behavior changes. |
| Integration  | ✅     | `cargo test` workspace regression includes integration coverage | |
| Regression   | ✅     | `crates/kamn-core/tests/missing_docs_policy.rs` (`Regression: #2041`) | |
| Performance  | N/A    | | Docs-hardening only; no runtime/perf-path modifications. |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate retention_engine missing docs (#2041)` if any docs-policy drift appears.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
