### PR TITLE
docs(kamn-core): graduate token missing docs (#2043)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -110,7 +110,7 @@ pub mod task_operations;
 pub mod task_payment;
 /// Telegram inbound bridge validation, route checks, and envelope normalization.
 pub mod telegram_bridge;
-#[allow(missing_docs)]
+/// Token configuration, supply allocation, and transfer guard contracts.
 pub mod token;
 /// Baseline transaction validation and state-hash progression guard contracts.
 pub mod transaction;

--- a/crates/kamn-core/src/token.rs
+++ b/crates/kamn-core/src/token.rs
@@ -1,21 +1,34 @@
+//! Token configuration and genesis allocation validation contracts.
+
 use std::collections::HashSet;
 use std::fmt;
 
+/// Default token symbol.
 pub const DEFAULT_TOKEN_SYMBOL: &str = "KAMN";
+/// Default total token supply.
 pub const DEFAULT_TOTAL_SUPPLY: u128 = 1_000_000_000;
+/// Default token decimal precision.
 pub const DEFAULT_DECIMALS: u8 = 18;
+/// Basis-point total expected across all genesis allocation buckets.
 pub const TOTAL_ALLOCATION_BPS: u16 = 10_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Logical bucket for genesis token allocation.
 pub enum AllocationBucket {
+    /// Ecosystem and growth incentives allocation.
     EcosystemIncentives,
+    /// Protocol development and maintenance allocation.
     ProtocolDevelopment,
+    /// Validator and network participation rewards allocation.
     ValidatorRewards,
+    /// Initial liquidity provisioning allocation.
     InitialLiquidity,
+    /// Community grants and public goods allocation.
     CommunityGrants,
 }
 
 impl AllocationBucket {
+    /// Returns a stable snake_case identifier for the bucket.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::EcosystemIncentives => "ecosystem_incentives",
@@ -28,25 +41,36 @@ impl AllocationBucket {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Genesis allocation entry for one allocation bucket.
 pub struct GenesisAllocation {
+    /// Allocation bucket identifier.
     pub bucket: AllocationBucket,
+    /// Share in basis points.
     pub share_bps: u16,
+    /// Absolute token amount assigned to the bucket.
     pub amount: u128,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Token configuration including supply, precision, and allocations.
 pub struct TokenConfig {
+    /// Token symbol.
     pub symbol: String,
+    /// Total token supply.
     pub total_supply: u128,
+    /// Token decimal precision.
     pub decimals: u8,
+    /// Genesis allocation table.
     pub allocations: Vec<GenesisAllocation>,
 }
 
 impl TokenConfig {
+    /// Returns the allocation entry for `bucket`, if present.
     pub fn allocation_for(&self, bucket: AllocationBucket) -> Option<&GenesisAllocation> {
         self.allocations.iter().find(|item| item.bucket == bucket)
     }
 
+    /// Validates symbol, supply, decimals, and allocation invariants.
     pub fn validate(&self) -> Result<(), TokenConfigError> {
         if self.symbol.trim().is_empty() {
             return Err(TokenConfigError::EmptySymbol);
@@ -104,6 +128,7 @@ impl TokenConfig {
     }
 }
 
+/// Returns the default token configuration.
 pub fn default_token_config() -> TokenConfig {
     TokenConfig {
         symbol: DEFAULT_TOKEN_SYMBOL.to_owned(),
@@ -140,17 +165,39 @@ pub fn default_token_config() -> TokenConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error taxonomy for token configuration validation failures.
 pub enum TokenConfigError {
+    /// Token symbol is empty after trimming.
     EmptySymbol,
+    /// Token symbol contains invalid characters or casing.
     InvalidSymbol(String),
+    /// Total supply is zero.
     ZeroSupply,
+    /// Decimals exceed the supported precision.
     InvalidDecimals(u8),
+    /// Allocation table is empty.
     EmptyAllocations,
+    /// Allocation bucket appears multiple times.
     DuplicateBucket(AllocationBucket),
+    /// Allocation share is zero.
     ZeroShare(AllocationBucket),
+    /// Allocation amount is zero.
     ZeroAmount(AllocationBucket),
-    AllocationShareSum { expected: u16, actual: u16 },
-    AllocationAmountSum { expected: u128, actual: u128 },
+    /// Allocation share sum does not match total basis points.
+    AllocationShareSum {
+        /// Expected basis-point sum.
+        expected: u16,
+        /// Observed basis-point sum.
+        actual: u16,
+    },
+    /// Allocation amount sum does not match total supply.
+    AllocationAmountSum {
+        /// Expected allocation amount sum.
+        expected: u128,
+        /// Observed allocation amount sum.
+        actual: u128,
+    },
+    /// Allocation amount accumulation overflowed.
     AmountOverflow,
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -640,6 +640,23 @@ fn graduated_wave_thirty_four_retention_engine_module_must_not_return_to_allowli
 }
 
 #[test]
+fn graduated_wave_thirty_five_token_module_must_not_return_to_allowlist() {
+    // Regression: #2043
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "token";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -190,6 +190,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `smoke`
   - `signature_profile`
   - `state`
+  - `token`
   - `task_artifacts`
   - `task_payment`
   - `telegram_bridge`
@@ -229,6 +230,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2037`
   - `Regression: #2039`
   - `Regression: #2041`
+  - `Regression: #2043`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -16,7 +16,6 @@ reputation_state
 runtime
 signer_backend
 task_operations
-token
 trust_score
 upgrade_orchestration
 watchdog

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -37,3 +37,4 @@ durable_guard_store
 audit_exports
 performance_targets
 retention_engine
+token


### PR DESCRIPTION
Closes #2043

## Summary
Graduate `token` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the exemption from `lib.rs`. This advances docs hardening for token/supply/allocations contracts while keeping fixture, regression, and architecture policy artifacts aligned.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `token` and added module-level docs.
- `crates/kamn-core/src/token.rs`: added rustdoc for public constants, enums/variants, structs/fields, errors, and public functions/methods.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `token`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `token`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard test for wave 35 (`Regression: #2043`).
- `docs/architecture/kamn-core-module-map.md`: added module to graduated list and added `Regression: #2043` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
```
Expected failure observed after removing `#[allow(missing_docs)]` for `token`:
- missing-doc diagnostics emitted for `token` public API
- total failures: `39` missing-doc errors
- compile failed as expected

### 🟢 Green Phase
```bash
RUSTFLAGS='-D warnings' cargo check -p kamn-core
cargo test -p kamn-core token
cargo test -p kamn-core --test missing_docs_policy
cargo test -p kamn-core --test engineering_hardening_wave_docs
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings
```
All commands passed.

### 🔁 Regression
```bash
cargo test
```
Passed across workspace (`kamn-core`, `kamn-kolme`, `kamn-node`, `kamn-sdk`) with no new failures.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `cargo test -p kamn-core token` | |
| Functional   | N/A    | | Docs-hardening only; no feature behavior changes. |
| Integration  | ✅     | `cargo test` workspace regression includes integration coverage | |
| Regression   | ✅     | `crates/kamn-core/tests/missing_docs_policy.rs` (`Regression: #2043`) | |
| Performance  | N/A    | | Docs-hardening only; no runtime/perf-path modifications. |

## Risks & Rollback
- None.
- Rollback plan: revert commit `docs(kamn-core): graduate token missing docs (#2043)` if any docs-policy drift appears.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
