### PR TITLE
docs(kamn-core): graduate invariants missing-docs allowlist

### DIFF
--- a/crates/kamn-core/src/invariants.rs
+++ b/crates/kamn-core/src/invariants.rs
@@ -1,15 +1,21 @@
+//! Invariant catalog and taxonomy contracts for deterministic guardrail mapping.
+
 use std::fmt;
 
 use crate::smoke::SmokeError;
 use crate::transaction::TransactionGuardError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Invariant domain partition used in the canonical catalog.
 pub enum InvariantDomain {
+    /// Invariants tied to transaction envelope and sequencing rules.
     Transactions,
+    /// Invariants tied to state-commit transition rules.
     StateTransitions,
 }
 
 impl InvariantDomain {
+    /// Returns a stable machine-readable domain label.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Transactions => "transactions",
@@ -19,17 +25,26 @@ impl InvariantDomain {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Stable failure-code taxonomy for invariant violations.
 pub enum InvariantFailureCode {
+    /// Required field was empty.
     EmptyField,
+    /// Nonce value was invalid.
     InvalidNonce,
+    /// Nonce value was not sequential for sender.
     NonceOutOfSequence,
+    /// Signature verification failed.
     InvalidSignature,
+    /// State hash did not match expected value.
     StateHashMismatch,
+    /// Transaction identifier was duplicated.
     DuplicateTransactionId,
+    /// Unvalidated transaction attempted state commit.
     UnvalidatedCommittedTransaction,
 }
 
 impl InvariantFailureCode {
+    /// Returns the stable external failure code label.
     pub fn as_code(&self) -> &'static str {
         match self {
             Self::EmptyField => "INV-TX-001-EMPTY-FIELD",
@@ -44,12 +59,19 @@ impl InvariantFailureCode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Canonical invariant specification entry.
 pub struct InvariantSpec {
+    /// Stable invariant identifier.
     pub id: &'static str,
+    /// Invariant domain.
     pub domain: InvariantDomain,
+    /// Human-readable invariant description.
     pub description: &'static str,
+    /// PRD section references backing the invariant.
     pub prd_refs: &'static [&'static str],
+    /// Owning issue identifier.
     pub owner_issue: &'static str,
+    /// Failure codes associated with this invariant.
     pub failure_codes: &'static [InvariantFailureCode],
 }
 
@@ -64,6 +86,7 @@ const FAILURES_TX_005: &[InvariantFailureCode] = &[InvariantFailureCode::Duplica
 const FAILURES_TX_006: &[InvariantFailureCode] =
     &[InvariantFailureCode::UnvalidatedCommittedTransaction];
 
+/// Canonical sorted invariant catalog used across runtime guardrails.
 pub const INVARIANT_CATALOG: &[InvariantSpec] = &[
     InvariantSpec {
         id: "INV-TX-001",
@@ -115,14 +138,17 @@ pub const INVARIANT_CATALOG: &[InvariantSpec] = &[
     },
 ];
 
+/// Returns the canonical invariant catalog.
 pub fn catalog() -> &'static [InvariantSpec] {
     INVARIANT_CATALOG
 }
 
+/// Looks up an invariant by stable identifier.
 pub fn invariant_by_id(id: &str) -> Option<&'static InvariantSpec> {
     catalog().iter().find(|entry| entry.id == id)
 }
 
+/// Validates catalog shape constraints and identifier ordering.
 pub fn validate_catalog(entries: &[InvariantSpec]) -> Result<(), InvariantCatalogError> {
     if entries.is_empty() {
         return Err(InvariantCatalogError::EmptyCatalog);
@@ -156,12 +182,17 @@ pub fn validate_catalog(entries: &[InvariantSpec]) -> Result<(), InvariantCatalo
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Invariant violation instance produced by taxonomy classification.
 pub struct InvariantViolation {
+    /// Stable invariant identifier.
     pub invariant_id: &'static str,
+    /// Failure code for this violation.
     pub failure_code: InvariantFailureCode,
+    /// Human-readable violation message.
     pub message: String,
 }
 
+/// Maps a transaction guard error to a deterministic invariant violation.
 pub fn classify_transaction_guard_error(error: &TransactionGuardError) -> InvariantViolation {
     match error {
         TransactionGuardError::EmptyField(_) => InvariantViolation {
@@ -202,6 +233,7 @@ pub fn classify_transaction_guard_error(error: &TransactionGuardError) -> Invari
     }
 }
 
+/// Maps a smoke-test error to an optional invariant violation.
 pub fn classify_smoke_error(error: &SmokeError) -> Option<InvariantViolation> {
     match error {
         SmokeError::Guard(guard_error) => Some(classify_transaction_guard_error(guard_error)),
@@ -210,12 +242,23 @@ pub fn classify_smoke_error(error: &SmokeError) -> Option<InvariantViolation> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error taxonomy for invariant catalog validation failures.
 pub enum InvariantCatalogError {
+    /// Duplicate invariant identifier encountered.
     DuplicateId(String),
+    /// Catalog is empty.
     EmptyCatalog,
+    /// Invariant identifier is empty.
     EmptyInvariantId,
+    /// Invariant has no failure-code mappings.
     MissingFailureCodes(String),
-    Unsorted { previous: String, current: String },
+    /// Catalog ordering is not lexicographically sorted by identifier.
+    Unsorted {
+        /// Previous identifier in sequence.
+        previous: String,
+        /// Current identifier that violated ordering.
+        current: String,
+    },
 }
 
 impl fmt::Display for InvariantCatalogError {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -54,7 +54,7 @@ pub mod governance_workflow;
 pub mod group_channel_crypto;
 #[allow(missing_docs)]
 pub mod instruction_verify;
-#[allow(missing_docs)]
+/// Invariant catalog, taxonomy, and guardrail policy contracts.
 pub mod invariants;
 /// Key rotation/revocation state machine and audit-trail verification contracts.
 pub mod key_lifecycle;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -708,6 +708,23 @@ fn graduated_wave_thirty_eight_operator_dashboard_ui_module_must_not_return_to_a
 }
 
 #[test]
+fn graduated_wave_thirty_nine_invariants_module_must_not_return_to_allowlist() {
+    // Regression: #2051
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "invariants";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -175,6 +175,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `discord_bridge`
   - `durable_guard_store`
   - `group_channel_crypto`
+  - `invariants`
   - `key_lifecycle`
   - `key_recovery`
   - `kolme_runtime_commit`
@@ -237,6 +238,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2045`
   - `Regression: #2047`
   - `Regression: #2049`
+  - `Regression: #2051`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -5,7 +5,6 @@ channel_policies
 escrow
 governance_workflow
 instruction_verify
-invariants
 message_delivery_guards
 message_envelope
 message_lifecycle

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -41,3 +41,4 @@ token
 observability
 operator_dashboard_api
 operator_dashboard_ui
+invariants


### PR DESCRIPTION
Closes #2051

## Summary
Graduates `invariants` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `#[allow(missing_docs)]` exemption from the crate export surface. This continues the issue-driven docs-hardening sequence for core verification modules.

## Changes
- `crates/kamn-core/src/lib.rs`: removed allowlist exemption for `invariants` and added module rustdoc summary.
- `crates/kamn-core/src/invariants.rs`: added rustdoc coverage for module, public enums/structs/fields, functions, constants, and errors.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `invariants`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `invariants`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_thirty_nine_invariants_module_must_not_return_to_allowlist` (marker `Regression: #2051`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation + regression marker.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict missing-docs lint passes after exemption removal and fixtures/docs/policy tests remain aligned.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core invariants` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | `graduated_wave_thirty_nine_invariants_module_must_not_return_to_allowlist` |

## Execution Log (Red -> Green)
- Red: removed exemption and verified strict docs lint failed with missing-doc errors in `invariants`.
- Green: added rustdoc coverage and synchronization edits; reran strict validation to green.
- Regression: full workspace validation remained green (`cargo test`, strict clippy/fmt).
