### PR TITLE
docs(kamn-core): graduate message_delivery_guards missing-docs allowlist

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod key_lifecycle;
 /// Key compromise and recovery lifecycle contracts.
 pub mod key_recovery;
 pub mod kolme_runtime_commit;
-#[allow(missing_docs)]
+/// Message delivery replay, nonce, and acceptance window guardrail contracts.
 pub mod message_delivery_guards;
 #[allow(missing_docs)]
 pub mod message_envelope;

--- a/crates/kamn-core/src/message_delivery_guards.rs
+++ b/crates/kamn-core/src/message_delivery_guards.rs
@@ -1,24 +1,45 @@
+//! Message delivery replay, nonce, and snapshot guardrail contracts.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Schema version for serialized delivery guard snapshots.
 pub const DELIVERY_GUARD_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Input contract for delivery guard validation.
 pub struct DeliveryGuardInput {
+    /// Stable message identifier.
     pub message_id: String,
+    /// Sender DID.
     pub sender: String,
+    /// Recipient DID.
     pub recipient: String,
+    /// Monotonic sender nonce.
     pub nonce: u64,
+    /// Message creation timestamp.
     pub created: String,
+    /// Message expiration timestamp.
     pub expires: String,
+    /// Delivery receive timestamp.
     pub received_at: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Failure taxonomy for delivery validation rejections.
 pub enum DeliveryFailureCode {
-    NonceOutOfSequence { expected: u64, found: u64 },
+    /// Nonce does not match the expected sender sequence.
+    NonceOutOfSequence {
+        /// Expected nonce value.
+        expected: u64,
+        /// Observed nonce value.
+        found: u64,
+    },
+    /// Message identifier has already been accepted.
     Replay,
+    /// Message was received after expiration.
     Expired,
+    /// Created/expires window is invalid.
     InvalidWindow,
 }
 
@@ -34,52 +55,86 @@ impl DeliveryFailureCode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Signed notice emitted for rejected deliveries.
 pub struct FailedDeliveryNotice {
+    /// Message identifier.
     pub message_id: String,
+    /// Sender DID.
     pub sender: String,
+    /// Recipient DID.
     pub recipient: String,
+    /// Failure classification.
     pub code: DeliveryFailureCode,
+    /// Human-readable rejection details.
     pub detail: String,
+    /// Notice timestamp.
     pub timestamp: String,
+    /// Deterministic notice signature payload.
     pub signature: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Delivery validation output.
 pub enum DeliveryValidationResult {
+    /// Delivery was accepted and nonce state updated.
     Accepted,
+    /// Delivery was rejected with failure notice.
     Rejected(FailedDeliveryNotice),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// In-memory delivery guard engine.
 pub struct MessageDeliveryGuards {
     next_nonce_by_sender: BTreeMap<String, u64>,
     seen_message_ids: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Snapshot payload for persisting delivery guard state.
 pub struct DeliveryGuardSnapshot {
+    /// Snapshot schema version.
     pub schema_version: u16,
+    /// Expected next nonce per sender.
     pub next_nonce_by_sender: BTreeMap<String, u64>,
+    /// Set of already accepted message ids.
     pub seen_message_ids: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error taxonomy for delivery guard snapshot restoration.
 pub enum DeliveryGuardSnapshotError {
-    SchemaVersionMismatch { expected: u16, found: u16 },
+    /// Snapshot schema version does not match runtime expectation.
+    SchemaVersionMismatch {
+        /// Expected schema version.
+        expected: u16,
+        /// Found schema version.
+        found: u16,
+    },
+    /// Sender id in snapshot is invalid.
     InvalidSender(String),
-    InvalidNonce { sender: String, nonce: u64 },
+    /// Nonce in snapshot is invalid.
+    InvalidNonce {
+        /// Sender id associated with the invalid nonce.
+        sender: String,
+        /// Invalid nonce value.
+        nonce: u64,
+    },
+    /// Message id in snapshot is invalid.
     InvalidMessageId(String),
 }
 
 impl MessageDeliveryGuards {
+    /// Creates an empty delivery guard state.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Returns the expected nonce for `sender`.
     pub fn expected_nonce(&self, sender: &str) -> u64 {
         self.next_nonce_by_sender.get(sender).copied().unwrap_or(1)
     }
 
+    /// Validates a delivery input and updates guard state on success.
     pub fn validate(&mut self, input: DeliveryGuardInput) -> DeliveryValidationResult {
         if input.expires <= input.created {
             return DeliveryValidationResult::Rejected(self.failed_notice(
@@ -124,6 +179,7 @@ impl MessageDeliveryGuards {
         DeliveryValidationResult::Accepted
     }
 
+    /// Exports current state as a snapshot payload.
     pub fn export_snapshot(&self) -> DeliveryGuardSnapshot {
         DeliveryGuardSnapshot {
             schema_version: DELIVERY_GUARD_SNAPSHOT_SCHEMA_VERSION,
@@ -132,6 +188,7 @@ impl MessageDeliveryGuards {
         }
     }
 
+    /// Restores state from a validated snapshot payload.
     pub fn restore_snapshot(
         &mut self,
         snapshot: DeliveryGuardSnapshot,
@@ -168,6 +225,7 @@ impl MessageDeliveryGuards {
         Ok(())
     }
 
+    /// Constructs a guard engine from a snapshot payload.
     pub fn from_snapshot(
         snapshot: DeliveryGuardSnapshot,
     ) -> Result<Self, DeliveryGuardSnapshotError> {

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -725,6 +725,23 @@ fn graduated_wave_thirty_nine_invariants_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_forty_message_delivery_guards_module_must_not_return_to_allowlist() {
+    // Regression: #2053
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "message_delivery_guards";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -179,6 +179,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `key_lifecycle`
   - `key_recovery`
   - `kolme_runtime_commit`
+  - `message_delivery_guards`
   - `migrations`
   - `namespaces`
   - `observability`
@@ -239,6 +240,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2047`
   - `Regression: #2049`
   - `Regression: #2051`
+  - `Regression: #2053`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -5,7 +5,6 @@ channel_policies
 escrow
 governance_workflow
 instruction_verify
-message_delivery_guards
 message_envelope
 message_lifecycle
 reputation_state

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -42,3 +42,4 @@ observability
 operator_dashboard_api
 operator_dashboard_ui
 invariants
+message_delivery_guards


### PR DESCRIPTION
Closes #2053

## Summary
Graduates `message_delivery_guards` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `#[allow(missing_docs)]` exemption from the crate export surface. This continues the issue-driven docs-hardening sequence for delivery integrity modules.

## Changes
- `crates/kamn-core/src/lib.rs`: removed allowlist exemption for `message_delivery_guards` and added module rustdoc summary.
- `crates/kamn-core/src/message_delivery_guards.rs`: added rustdoc coverage for module, public structs/fields, enums/variants, constants, methods, and snapshot errors.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `message_delivery_guards`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `message_delivery_guards`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_forty_message_delivery_guards_module_must_not_return_to_allowlist` (marker `Regression: #2053`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation + regression marker.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict missing-docs lint passes after exemption removal and fixtures/docs/policy tests remain aligned.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core message_delivery_guards` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | `graduated_wave_forty_message_delivery_guards_module_must_not_return_to_allowlist` |

## Execution Log (Red -> Green)
- Red: removed exemption and verified strict docs lint failed with missing-doc errors in `message_delivery_guards`.
- Green: added rustdoc coverage and synchronization edits; reran strict validation to green.
- Regression: full workspace validation remained green (`cargo test`, strict clippy/fmt).
