### PR TITLE
docs(kamn-core): graduate trust_score missing-docs allowlist

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -114,7 +114,7 @@ pub mod telegram_bridge;
 pub mod token;
 /// Baseline transaction validation and state-hash progression guard contracts.
 pub mod transaction;
-#[allow(missing_docs)]
+/// Trust score policy model, abuse penalties, and persistence calculation helpers.
 pub mod trust_score;
 #[allow(missing_docs)]
 pub mod upgrade_orchestration;

--- a/crates/kamn-core/src/trust_score.rs
+++ b/crates/kamn-core/src/trust_score.rs
@@ -1,8 +1,13 @@
+//! Trust score policy contracts with anti-gaming penalties and decay weighting.
+
 use crate::{AgentReputation, ReputationError, ReputationStore};
 use std::fmt;
 
+/// Stable engine version identifier for trust score policy contracts.
 pub const TRUST_SCORE_ENGINE_VERSION: &str = "v2-prd-8-2-anti-gaming";
+/// Minimum bounded trust score.
 pub const TRUST_SCORE_MIN: i32 = 0;
+/// Maximum bounded trust score.
 pub const TRUST_SCORE_MAX: i32 = 1_000;
 const DECAY_WINDOW_RECENT_BLOCKS: u64 = 128;
 const DECAY_WINDOW_MID_BLOCKS: u64 = 512;
@@ -14,35 +19,59 @@ const ABUSE_PENALTY_CHURN_SPIKE: i32 = 60;
 const ABUSE_PENALTY_COMPOUND: i32 = 140;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Abuse penalty categories applied by trust score classification.
 pub enum AbusePenaltyKind {
+    /// No abuse signals triggered.
     None,
+    /// Delegation reciprocity-ring pattern detected.
     ReciprocityRing,
+    /// Burst-spam failure pattern detected.
     BurstSpam,
+    /// Dispute churn spike pattern detected.
     ChurnSpike,
+    /// Multiple abuse signals triggered simultaneously.
     Compound,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Detailed trust score component breakdown.
 pub struct TrustScoreBreakdown {
+    /// Base score anchor.
     pub base_score: i32,
+    /// Delivery-rate contribution.
     pub delivery_component: i32,
+    /// Response-time contribution.
     pub response_component: i32,
+    /// Dispute-rate penalty.
     pub dispute_penalty: i32,
+    /// Pre-decay volume bonus.
     pub volume_bonus: i32,
+    /// Pre-decay endorsement bonus.
     pub endorsement_bonus: i32,
+    /// Decay multiplier in basis points.
     pub decay_multiplier_bps: u16,
+    /// Post-decay volume bonus.
     pub decayed_volume_bonus: i32,
+    /// Post-decay endorsement bonus.
     pub decayed_endorsement_bonus: i32,
+    /// Abuse penalty kind applied.
     pub abuse_penalty_kind: AbusePenaltyKind,
+    /// Abuse penalty points subtracted.
     pub abuse_penalty_points: i32,
+    /// Unbounded raw score prior to clamp.
     pub raw_score: i32,
+    /// Final bounded score persisted to state.
     pub final_score: u32,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Error taxonomy for trust score calculation and persistence.
 pub enum TrustScoreError {
+    /// Delivery rate is outside `0.0..=1.0`.
     InvalidDeliveryRate(f64),
+    /// Dispute rate is outside `0.0..=1.0`.
     InvalidDisputeRate(f64),
+    /// Underlying reputation store operation failed.
     Reputation(ReputationError),
 }
 
@@ -68,6 +97,7 @@ impl From<ReputationError> for TrustScoreError {
     }
 }
 
+/// Computes a trust score breakdown for an agent reputation record.
 pub fn calculate_trust_score(
     agent: &AgentReputation,
 ) -> Result<TrustScoreBreakdown, TrustScoreError> {
@@ -187,6 +217,7 @@ fn classify_abuse_penalty(agent: &AgentReputation) -> (AbusePenaltyKind, i32) {
     }
 }
 
+/// Recomputes and persists trust score for `agent_did` at `block_height`.
 pub fn recalculate_and_persist_trust_score(
     store: &mut ReputationStore,
     agent_did: &str,

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -742,6 +742,23 @@ fn graduated_wave_forty_message_delivery_guards_module_must_not_return_to_allowl
 }
 
 #[test]
+fn graduated_wave_forty_one_trust_score_module_must_not_return_to_allowlist() {
+    // Regression: #2055
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "trust_score";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -200,6 +200,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `task_payment`
   - `telegram_bridge`
   - `task_lifecycle`
+  - `trust_score`
   - `transaction`
   - `validator_lifecycle`
 - Regression marker:
@@ -241,6 +242,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2049`
   - `Regression: #2051`
   - `Regression: #2053`
+  - `Regression: #2055`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -11,7 +11,6 @@ reputation_state
 runtime
 signer_backend
 task_operations
-trust_score
 upgrade_orchestration
 watchdog
 zk_message_proofs

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -43,3 +43,4 @@ operator_dashboard_api
 operator_dashboard_ui
 invariants
 message_delivery_guards
+trust_score


### PR DESCRIPTION
Closes #2055

## Summary
Graduates `trust_score` from the `kamn-core` missing-docs allowlist by documenting its public API and removing the `#[allow(missing_docs)]` exemption from the crate export surface. This continues the issue-driven docs-hardening sequence for reputation and anti-abuse modules.

## Changes
- `crates/kamn-core/src/lib.rs`: removed allowlist exemption for `trust_score` and added module rustdoc summary.
- `crates/kamn-core/src/trust_score.rs`: added rustdoc coverage for module, public constants, enums/variants, structs/fields, errors, and exported functions.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `trust_score`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `trust_score`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_forty_one_trust_score_module_must_not_return_to_allowlist` (marker `Regression: #2055`).
- `docs/architecture/kamn-core-module-map.md`: recorded graduation + regression marker.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict missing-docs lint passes after exemption removal and fixtures/docs/policy tests remain aligned.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core trust_score` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | `graduated_wave_forty_one_trust_score_module_must_not_return_to_allowlist` |

## Execution Log (Red -> Green)
- Red: removed exemption and verified strict docs lint failed with missing-doc errors in `trust_score`.
- Green: added rustdoc coverage and synchronization edits; reran strict validation to green.
- Regression: full workspace validation remained green (`cargo test`, strict clippy/fmt).
