### PR TITLE
docs(kamn-core): graduate watchdog missing-docs module

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -120,7 +120,7 @@ pub mod trust_score;
 pub mod upgrade_orchestration;
 /// Validator onboarding/offboarding, quorum-change, and rollback lifecycle contracts.
 pub mod validator_lifecycle;
-#[allow(missing_docs)]
+/// Runtime watchdog anomaly taxonomy and report contracts.
 pub mod watchdog;
 #[allow(missing_docs)]
 pub mod zk_message_proofs;

--- a/crates/kamn-core/src/watchdog.rs
+++ b/crates/kamn-core/src/watchdog.rs
@@ -1,40 +1,65 @@
+//! Runtime watchdog anomaly classification and alerting contracts.
+
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Alert severity level emitted by watchdog analysis.
 pub enum WatchdogSeverity {
+    /// Warning-level anomaly.
     Warning,
+    /// Critical anomaly.
     Critical,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Anomaly taxonomy produced by watchdog observations.
 pub enum WatchdogAlertKind {
+    /// Block parent hash mismatch anomaly.
     InvalidBlockParent {
+        /// Block identifier.
         block_id: String,
+        /// Expected parent hash.
         expected_parent: String,
+        /// Observed parent hash.
         observed_parent: String,
     },
+    /// Potential censorship signal from delivery ratio degradation.
     CensorshipSignal {
+        /// Message identifier.
         message_id: String,
+        /// Number of delivered recipients.
         delivered_recipients: usize,
+        /// Number of expected recipients.
         expected_recipients: usize,
+        /// Observed delivery ratio percentage.
         observed_ratio_pct: u8,
     },
+    /// Quorum-signature anomaly for a block.
     QuorumAnomaly {
+        /// Block identifier.
         block_id: String,
+        /// Observed signature count.
         observed_signatures: u16,
+        /// Minimum required signature count.
         min_required_signatures: u16,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Alert record emitted by watchdog analysis.
 pub struct WatchdogAlert {
+    /// Alert severity.
     pub severity: WatchdogSeverity,
+    /// Alert kind payload.
     pub kind: WatchdogAlertKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Runtime watchdog policy configuration.
 pub struct WatchdogConfig {
+    /// Minimum signatures required for block quorum.
     pub min_quorum_signatures: u16,
+    /// Minimum healthy delivery ratio percentage.
     pub min_delivery_ratio_pct: u8,
 }
 
@@ -48,23 +73,36 @@ impl Default for WatchdogConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Observation payload ingested by watchdog analysis.
 pub enum WatchdogObservation {
+    /// Block-level observation.
     Block {
+        /// Block identifier.
         block_id: String,
+        /// Current block state hash.
         state_hash: String,
+        /// Parent block state hash.
         parent_state_hash: String,
+        /// Observed quorum signatures.
         quorum_signatures: u16,
+        /// Expected validator count for this block.
         expected_validator_count: u16,
     },
+    /// Gossip delivery observation.
     GossipDelivery {
+        /// Message identifier.
         message_id: String,
+        /// Target recipients count.
         target_recipients: usize,
+        /// Delivered recipients count.
         delivered_recipients: usize,
+        /// Expected recipients count.
         expected_recipients: usize,
     },
 }
 
 impl WatchdogObservation {
+    /// Constructs a block observation payload.
     pub fn block(
         block_id: &str,
         state_hash: &str,
@@ -81,6 +119,7 @@ impl WatchdogObservation {
         }
     }
 
+    /// Constructs a gossip delivery observation payload.
     pub fn gossip_delivery(
         message_id: &str,
         target_recipients: usize,
@@ -97,14 +136,20 @@ impl WatchdogObservation {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Aggregate watchdog counters snapshot.
 pub struct WatchdogSnapshot {
+    /// Total observations processed.
     pub total_observations: usize,
+    /// Total emitted alerts.
     pub total_alerts: usize,
+    /// Total warning alerts.
     pub warning_alerts: usize,
+    /// Total critical alerts.
     pub critical_alerts: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Stateful watchdog engine for runtime anomaly classification.
 pub struct WatchdogNode {
     config: WatchdogConfig,
     last_state_hash: Option<String>,
@@ -114,6 +159,7 @@ pub struct WatchdogNode {
 }
 
 impl WatchdogNode {
+    /// Creates a watchdog node from validated config.
     pub fn new(config: WatchdogConfig) -> Result<Self, WatchdogError> {
         validate_config(config)?;
 
@@ -126,6 +172,7 @@ impl WatchdogNode {
         })
     }
 
+    /// Processes an observation and returns emitted alerts.
     pub fn observe(
         &mut self,
         observation: WatchdogObservation,
@@ -168,6 +215,7 @@ impl WatchdogNode {
         Ok(alerts)
     }
 
+    /// Returns aggregate counters for processed observations and alerts.
     pub fn snapshot(&self) -> WatchdogSnapshot {
         WatchdogSnapshot {
             total_observations: self.total_observations,
@@ -272,8 +320,11 @@ impl WatchdogNode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error taxonomy for watchdog configuration and observation validation.
 pub enum WatchdogError {
+    /// Configuration is invalid.
     InvalidConfig(String),
+    /// Observation payload is invalid.
     InvalidObservation(String),
 }
 

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -759,6 +759,23 @@ fn graduated_wave_forty_one_trust_score_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_forty_two_watchdog_module_must_not_return_to_allowlist() {
+    // Regression: #2057
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "watchdog";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -203,6 +203,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `trust_score`
   - `transaction`
   - `validator_lifecycle`
+  - `watchdog`
 - Regression marker:
   - `Regression: #1828`
   - `Regression: #1981`
@@ -243,6 +244,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2051`
   - `Regression: #2053`
   - `Regression: #2055`
+  - `Regression: #2057`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -12,5 +12,4 @@ runtime
 signer_backend
 task_operations
 upgrade_orchestration
-watchdog
 zk_message_proofs

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -44,3 +44,4 @@ operator_dashboard_ui
 invariants
 message_delivery_guards
 trust_score
+watchdog


### PR DESCRIPTION
## Summary
Graduates `watchdog` from the missing-docs allowlist by documenting its public API and removing the exemption in `kamn-core`.
This keeps the docs-hardening wave moving on runtime reliability modules and locks the graduation with policy and architecture regression guards.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `watchdog` export and added module-level doc context.
- `crates/kamn-core/src/watchdog.rs`: added rustdoc coverage for public enums, structs, fields, and constructor/observer APIs.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `watchdog`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `watchdog`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added graduation drift guard `graduated_wave_forty_two_watchdog_module_must_not_return_to_allowlist` with marker `Regression: #2057`.
- `docs/architecture/kamn-core-module-map.md`: marked `watchdog` graduated and added `Regression: #2057` marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict docs lint + policy/docs suites + full workspace tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core watchdog` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | Added `graduated_wave_forty_two_watchdog_module_must_not_return_to_allowlist` (`Regression: #2057`) |

Closes #2057
