### PR TITLE
docs(kamn-core): graduate message envelope missing-docs module

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -63,7 +63,7 @@ pub mod key_recovery;
 pub mod kolme_runtime_commit;
 /// Message delivery replay, nonce, and acceptance window guardrail contracts.
 pub mod message_delivery_guards;
-#[allow(missing_docs)]
+/// Canonical message envelope schema validation and normalization contracts.
 pub mod message_envelope;
 #[allow(missing_docs)]
 pub mod message_lifecycle;

--- a/crates/kamn-core/src/message_envelope.rs
+++ b/crates/kamn-core/src/message_envelope.rs
@@ -1,9 +1,14 @@
+//! Canonical message envelope schema, validation rules, and payload normalization.
+
 use crate::AgentDid;
 use std::collections::BTreeMap;
 use std::fmt;
 
+/// Required envelope type identifier for canonical KAMN messages.
 pub const CANONICAL_MESSAGE_ENVELOPE_TYPE: &str = "kamn:message:v1";
+/// Required encryption algorithm for canonical envelope headers.
 pub const CANONICAL_ENCRYPTION_ALGORITHM: &str = "X25519-XChaCha20-Poly1305";
+/// Required proof purpose for canonical envelope signatures.
 pub const CANONICAL_PROOF_PURPOSE: &str = "authentication";
 
 const ALLOWED_MESSAGE_TYPES: [&str; 11] = [
@@ -20,59 +25,94 @@ const ALLOWED_MESSAGE_TYPES: [&str; 11] = [
     "Revocation",
 ];
 
+/// Envelope metadata fields used for routing, replay protection, and threading.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvelopeMetadata {
+    /// Stable message identifier.
     pub id: String,
+    /// Envelope schema type discriminator.
     pub type_name: String,
+    /// Sender DID.
     pub from: String,
+    /// Recipient DID list.
     pub to: Vec<String>,
+    /// Creation timestamp string.
     pub created: String,
+    /// Expiration timestamp string.
     pub expires: String,
+    /// Optional thread identifier.
     pub thread_id: Option<String>,
+    /// Optional parent message identifier.
     pub parent_id: Option<String>,
+    /// Monotonic sender nonce.
     pub nonce: u64,
 }
 
+/// Envelope encryption descriptor for recipient key distribution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvelopeEncryption {
+    /// Encryption algorithm name.
     pub algorithm: String,
+    /// Recipient public key references.
     pub recipient_keys: Vec<String>,
 }
 
+/// Header metadata describing message semantics and encryption policy.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvelopeHeader {
+    /// Domain-specific message type.
     pub message_type: String,
+    /// Delivery priority label.
     pub priority: String,
+    /// Payload content type.
     pub content_type: String,
+    /// Encryption parameters.
     pub encryption: EnvelopeEncryption,
 }
 
+/// Attachment pointer included in the envelope body.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachmentRef {
+    /// Attachment identifier.
     pub id: String,
+    /// Attachment media type.
     pub media_type: String,
+    /// Attachment retrieval URI.
     pub uri: String,
 }
 
+/// Signature proof block for envelope authenticity checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvelopeProof {
+    /// Proof type name.
     pub type_name: String,
+    /// Proof creation timestamp string.
     pub created: String,
+    /// Verification method DID URL.
     pub verification_method: String,
+    /// Proof purpose value.
     pub proof_purpose: String,
+    /// Signature payload value.
     pub proof_value: String,
 }
 
+/// Canonical message envelope contract with metadata, payload, and proof sections.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CanonicalMessageEnvelope {
+    /// Envelope metadata section.
     pub envelope: EnvelopeMetadata,
+    /// Envelope header section.
     pub header: EnvelopeHeader,
+    /// Canonical body key/value payload.
     pub body: BTreeMap<String, String>,
+    /// Attachment references for out-of-band content.
     pub attachments: Vec<AttachmentRef>,
+    /// Signature proof section.
     pub proof: EnvelopeProof,
 }
 
 impl CanonicalMessageEnvelope {
+    /// Validates all envelope contract rules.
     pub fn validate(&self) -> Result<(), MessageEnvelopeError> {
         require_non_empty("envelope.id", &self.envelope.id)?;
         if self.envelope.type_name != CANONICAL_MESSAGE_ENVELOPE_TYPE {
@@ -189,6 +229,7 @@ impl CanonicalMessageEnvelope {
         Ok(())
     }
 
+    /// Renders a deterministic canonical payload string for signing and verification.
     pub fn canonical_payload(&self) -> String {
         let mut recipients = self.envelope.to.clone();
         recipients.sort();
@@ -262,30 +303,52 @@ impl CanonicalMessageEnvelope {
     }
 }
 
+/// Validation and normalization error taxonomy for canonical message envelopes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MessageEnvelopeError {
+    /// A required field is empty.
     EmptyField(&'static str),
+    /// Envelope type does not match the canonical type.
     InvalidEnvelopeType(String),
+    /// Sender DID is invalid.
     InvalidSenderDid(String),
+    /// Recipient list is empty.
     EmptyRecipients,
+    /// A recipient DID is invalid.
     InvalidRecipientDid(String),
+    /// Envelope expiry is not strictly after creation time.
     InvalidExpiryWindow {
+        /// Creation timestamp string.
         created: String,
+        /// Expiration timestamp string.
         expires: String,
     },
+    /// Envelope nonce is invalid.
     InvalidNonce(u64),
+    /// Header message type is not supported.
     InvalidMessageType(String),
+    /// Header encryption algorithm does not match the canonical algorithm.
     InvalidEncryptionAlgorithm(String),
+    /// Header recipient key list is empty.
     EmptyRecipientKeys,
+    /// Body map is empty.
     EmptyBody,
+    /// Body entry contains invalid key/value data.
     InvalidBodyEntry(String),
+    /// Attachment has an invalid required field.
     InvalidAttachmentField {
+        /// Attachment identifier.
         attachment_id: String,
+        /// Field name that failed validation.
         field: &'static str,
     },
+    /// Proof purpose does not match the canonical purpose.
     InvalidProofPurpose(String),
+    /// Proof verification method does not match sender DID prefix.
     ProofVerificationMethodMismatch {
+        /// Expected verification method DID URL prefix.
         expected_prefix: String,
+        /// Observed verification method DID URL.
         actual: String,
     },
 }

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -776,6 +776,23 @@ fn graduated_wave_forty_two_watchdog_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_forty_three_message_envelope_module_must_not_return_to_allowlist() {
+    // Regression: #2059
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "message_envelope";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -180,6 +180,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `key_recovery`
   - `kolme_runtime_commit`
   - `message_delivery_guards`
+  - `message_envelope`
   - `migrations`
   - `namespaces`
   - `observability`
@@ -245,6 +246,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2053`
   - `Regression: #2055`
   - `Regression: #2057`
+  - `Regression: #2059`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -5,7 +5,6 @@ channel_policies
 escrow
 governance_workflow
 instruction_verify
-message_envelope
 message_lifecycle
 reputation_state
 runtime

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -45,3 +45,4 @@ invariants
 message_delivery_guards
 trust_score
 watchdog
+message_envelope


### PR DESCRIPTION
## Summary
Graduates `message_envelope` from the missing-docs allowlist by documenting its public API and removing the exemption in `kamn-core`.
This hardens docs coverage on canonical message wire contracts and locks the graduation with policy and architecture regression guards.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `message_envelope` export and added module-level doc context.
- `crates/kamn-core/src/message_envelope.rs`: added rustdoc coverage for public constants, structs, fields, methods, and error taxonomy.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `message_envelope`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `message_envelope`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added graduation drift guard `graduated_wave_forty_three_message_envelope_module_must_not_return_to_allowlist` with marker `Regression: #2059`.
- `docs/architecture/kamn-core-module-map.md`: marked `message_envelope` graduated and added `Regression: #2059` marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict docs lint + policy/docs suites + full workspace tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core message_envelope` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | Added `graduated_wave_forty_three_message_envelope_module_must_not_return_to_allowlist` (`Regression: #2059`) |

Closes #2059
