### PR TITLE
docs(kamn-core): graduate escrow missing-docs module

### DIFF
--- a/crates/kamn-core/src/escrow.rs
+++ b/crates/kamn-core/src/escrow.rs
@@ -1,29 +1,47 @@
+//! Escrow lifecycle contracts for release, refund, dispute, and receipt-finality reconciliation.
+
 use std::fmt;
 
+/// Escrow lifecycle status projection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowStatus {
+    /// Funds are locked and no settlement has happened yet.
     Funded,
+    /// Partial release has occurred and a remainder is still locked.
     PartiallyReleased {
+        /// Total amount released to the payee.
         released: u128,
+        /// Remaining amount still held in escrow.
         remaining: u128,
     },
+    /// Full amount has been released to the payee.
     Released,
+    /// Remaining amount has been fully refunded to the payer.
     Refunded,
+    /// Escrow is under dispute.
     Disputed,
+    /// Dispute resolution split has been finalized.
     Resolved {
+        /// Total amount released to the payee after resolution.
         released_total: u128,
+        /// Total amount refunded to the payer after resolution.
         refunded_total: u128,
     },
 }
 
+/// Receipt finality classification used to decide settlement outcomes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EscrowReceiptFinality {
+    /// Receipt finality is confirmed.
     Final,
+    /// Receipt is observed but not yet final.
     Pending,
+    /// Receipt finality indicates failure.
     Failed,
 }
 
 impl EscrowReceiptFinality {
+    /// Parses receipt finality from a case-insensitive string.
     pub fn parse(value: &str) -> Result<Self, EscrowLifecycleError> {
         let normalized = value.trim().to_ascii_uppercase();
         match normalized.as_str() {
@@ -37,47 +55,81 @@ impl EscrowReceiptFinality {
     }
 }
 
+/// Settlement actions gated by receipt finality.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowSettlementAction {
+    /// Release a specific amount to the payee.
     Release {
+        /// Amount to release.
         amount: u128,
     },
+    /// Refund all remaining escrow balance.
     RefundRemaining,
+    /// Refund after timeout threshold is reached.
     TimeoutRefund {
+        /// Current Unix timestamp.
         current_unix: u64,
+        /// Timeout Unix timestamp.
         timeout_unix: u64,
     },
 }
 
+/// State transition actions for evidence-driven escrow mutation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowTransitionAction {
+    /// Release a specific amount to the payee.
     Release {
+        /// Amount to release.
         amount: u128,
     },
+    /// Refund all remaining escrow balance.
     RefundRemaining,
+    /// Move escrow into disputed state.
     Dispute,
+    /// Resolve a dispute by splitting the remaining balance.
     Resolve {
+        /// Amount released to the payee.
         release_to_payee: u128,
+        /// Amount refunded to the payer.
         refund_to_payer: u128,
     },
 }
 
+/// Transition evidence record emitted for successful state mutations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EscrowTransitionEvidence {
+    /// Previous status.
     pub from: EscrowStatus,
+    /// Action that was applied.
     pub action: EscrowTransitionAction,
+    /// Resulting status.
     pub to: EscrowStatus,
+    /// Stable reason code for policy/audit matching.
     pub reason_code: &'static str,
 }
 
+/// Settlement outcome projection after receipt-finality reconciliation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowSettlementOutcome {
-    Settled { status: EscrowStatus },
-    Pending { reason: &'static str },
-    Rejected { reason: &'static str },
+    /// Settlement succeeded and status is finalized.
+    Settled {
+        /// Finalized escrow status after successful settlement.
+        status: EscrowStatus,
+    },
+    /// Settlement is deferred while receipt finality remains pending.
+    Pending {
+        /// Reason the settlement remains pending.
+        reason: &'static str,
+    },
+    /// Settlement was rejected due to failed finality.
+    Rejected {
+        /// Reason settlement was rejected.
+        reason: &'static str,
+    },
 }
 
 impl EscrowSettlementOutcome {
+    /// Returns a stable reason code for the projected settlement outcome.
     pub fn reason_code(&self) -> &'static str {
         match self {
             Self::Settled { .. } => "escrow_settlement_finalized",
@@ -87,6 +139,7 @@ impl EscrowSettlementOutcome {
     }
 }
 
+/// Mutable escrow lifecycle state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EscrowLifecycle {
     total_amount: u128,
@@ -96,6 +149,7 @@ pub struct EscrowLifecycle {
 }
 
 impl EscrowLifecycle {
+    /// Creates a new escrow lifecycle with a non-zero total amount.
     pub fn new(total_amount: u128) -> Result<Self, EscrowLifecycleError> {
         if total_amount == 0 {
             return Err(EscrowLifecycleError::ZeroAmount);
@@ -108,24 +162,29 @@ impl EscrowLifecycle {
         })
     }
 
+    /// Returns the current escrow status.
     pub fn status(&self) -> EscrowStatus {
         self.status.clone()
     }
 
+    /// Returns the currently unreleased and unrefunded amount.
     pub fn remaining_amount(&self) -> u128 {
         self.total_amount
             .saturating_sub(self.released_total)
             .saturating_sub(self.refunded_total)
     }
 
+    /// Returns the total amount released to the payee.
     pub fn released_amount(&self) -> u128 {
         self.released_total
     }
 
+    /// Returns the total amount refunded to the payer.
     pub fn refunded_amount(&self) -> u128 {
         self.refunded_total
     }
 
+    /// Releases an amount from escrow to the payee.
     pub fn release(&mut self, amount: u128) -> Result<(), EscrowLifecycleError> {
         if amount == 0 {
             return Err(EscrowLifecycleError::ZeroAmount);
@@ -161,6 +220,7 @@ impl EscrowLifecycle {
         Ok(())
     }
 
+    /// Refunds the remaining escrow balance to the payer.
     pub fn refund_remaining(&mut self) -> Result<(), EscrowLifecycleError> {
         match self.status {
             EscrowStatus::Funded
@@ -178,6 +238,7 @@ impl EscrowLifecycle {
         Ok(())
     }
 
+    /// Refunds remaining balance only if timeout has elapsed.
     pub fn refund_after_timeout(
         &mut self,
         current_unix: u64,
@@ -192,6 +253,7 @@ impl EscrowLifecycle {
         self.refund_remaining()
     }
 
+    /// Moves escrow into disputed state.
     pub fn dispute(&mut self) -> Result<(), EscrowLifecycleError> {
         match self.status {
             EscrowStatus::Funded | EscrowStatus::PartiallyReleased { .. } => {
@@ -202,6 +264,7 @@ impl EscrowLifecycle {
         }
     }
 
+    /// Resolves a disputed escrow by applying an exact split of remaining balance.
     pub fn resolve(
         &mut self,
         release_to_payee: u128,
@@ -237,6 +300,7 @@ impl EscrowLifecycle {
         Ok(())
     }
 
+    /// Applies a transition action and returns evidence for the successful mutation.
     pub fn apply_transition_with_evidence(
         &mut self,
         action: EscrowTransitionAction,
@@ -260,6 +324,7 @@ impl EscrowLifecycle {
         })
     }
 
+    /// Reconciles settlement action against receipt finality and returns outcome.
     pub fn reconcile_receipt_finality(
         &mut self,
         receipt_id: &str,
@@ -302,34 +367,54 @@ impl EscrowLifecycle {
     }
 }
 
+/// Error taxonomy for escrow lifecycle validation and transition failures.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EscrowLifecycleError {
+    /// Amount is zero where positive value is required.
     ZeroAmount,
+    /// Required receipt evidence is missing.
     MissingReceiptEvidence,
+    /// Receipt finality string is invalid.
     InvalidReceiptFinality {
+        /// Observed finality string.
         found: String,
     },
+    /// Requested amount is invalid for current remaining balance.
     InvalidAmount {
+        /// Action name that failed validation.
         action: &'static str,
+        /// Requested amount.
         amount: u128,
+        /// Remaining amount available for action.
         remaining: u128,
     },
+    /// Requested transition is not allowed from current status.
     InvalidTransition {
+        /// Current status.
         from: EscrowStatus,
+        /// Action name.
         action: &'static str,
     },
+    /// Dispute resolution split does not match remaining balance.
     ResolutionMismatch {
+        /// Remaining amount expected to be split.
         expected_remaining: u128,
+        /// Actual split amount provided.
         actual_split: u128,
     },
+    /// Timeout refund attempted before timeout elapsed.
     TimeoutNotElapsed {
+        /// Current Unix timestamp.
         current_unix: u64,
+        /// Required timeout Unix timestamp.
         timeout_unix: u64,
     },
+    /// Arithmetic overflow occurred while accumulating totals.
     AmountOverflow,
 }
 
 impl EscrowLifecycleError {
+    /// Returns a stable reason code for telemetry and policy contracts.
     pub fn reason_code(&self) -> &'static str {
         match self {
             Self::ZeroAmount => "escrow_amount_zero",

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -46,7 +46,7 @@ pub mod direct_message_crypto;
 pub mod discord_bridge;
 /// Durable snapshot contracts for guard-state and policy persistence.
 pub mod durable_guard_store;
-#[allow(missing_docs)]
+/// Escrow hold, release, refund, and dispute lifecycle contracts.
 pub mod escrow;
 #[allow(missing_docs)]
 pub mod governance_workflow;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -810,6 +810,23 @@ fn graduated_wave_forty_four_upgrade_orchestration_module_must_not_return_to_all
 }
 
 #[test]
+fn graduated_wave_forty_five_escrow_module_must_not_return_to_allowlist() {
+    // Regression: #2063
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "escrow";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -174,6 +174,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `direct_message_crypto`
   - `discord_bridge`
   - `durable_guard_store`
+  - `escrow`
   - `group_channel_crypto`
   - `invariants`
   - `key_lifecycle`
@@ -249,6 +250,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2057`
   - `Regression: #2059`
   - `Regression: #2061`
+  - `Regression: #2063`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -2,7 +2,6 @@ agent_upgrade_workflow
 bridge_adapter
 channel_models
 channel_policies
-escrow
 governance_workflow
 instruction_verify
 message_lifecycle

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -47,3 +47,4 @@ trust_score
 watchdog
 message_envelope
 upgrade_orchestration
+escrow


### PR DESCRIPTION
## Summary
Graduates `escrow` from the missing-docs allowlist by documenting its public API and removing the exemption in `kamn-core`.
This hardens docs coverage on escrow settlement/dispute lifecycle contracts while locking the graduation with policy and architecture regression guards.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `escrow` export and added module-level doc context.
- `crates/kamn-core/src/escrow.rs`: added rustdoc coverage for public enums, structs, variant fields, methods, and error taxonomy.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `escrow`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `escrow`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added graduation drift guard `graduated_wave_forty_five_escrow_module_must_not_return_to_allowlist` with marker `Regression: #2063`.
- `docs/architecture/kamn-core-module-map.md`: marked `escrow` graduated and added `Regression: #2063` marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict docs lint + policy/docs suites + full workspace tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core escrow` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | Added `graduated_wave_forty_five_escrow_module_must_not_return_to_allowlist` (`Regression: #2063`) |

Closes #2063
