### PR TITLE
docs(kamn-core): graduate instruction verify missing-docs module

### DIFF
--- a/crates/kamn-core/src/instruction_verify.rs
+++ b/crates/kamn-core/src/instruction_verify.rs
@@ -1,37 +1,60 @@
+//! Instruction claim verification contracts and replay-safe consumption flow.
+
 use crate::AgentDid;
 use std::collections::{HashMap, HashSet};
 
+/// Default maximum claim validity window in seconds (24h).
 pub const DEFAULT_MAX_CLAIM_VALIDITY_WINDOW_SECS: u64 = 24 * 60 * 60;
 
+/// Canonical instruction record persisted for verification.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstructionRecord {
+    /// Instruction identifier.
     pub id: String,
+    /// Sender DID associated with the instruction.
     pub from_did: String,
+    /// Canonical payload hash.
     pub payload_hash: String,
+    /// Signature over the instruction payload.
     pub signature: String,
+    /// Inclusion proof reference for chain anchoring.
     pub inclusion_proof_ref: String,
 }
 
+/// Verification claim supplied by a caller for a specific instruction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstructionClaim {
+    /// Referenced instruction identifier.
     pub instruction_id: String,
+    /// Claimed sender DID.
     pub from_did: String,
+    /// Claimed payload hash.
     pub payload_hash: String,
+    /// Claimed signature.
     pub signature: String,
+    /// Claimed inclusion proof reference.
     pub inclusion_proof_ref: String,
+    /// Claim expiry timestamp in Unix seconds.
     pub expires_at_unix: u64,
 }
 
+/// Verification context containing instruction records and policy controls.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerificationContext {
+    /// Current evaluation timestamp in Unix seconds.
     pub now_unix: u64,
+    /// Instruction records keyed by instruction id.
     pub instructions: HashMap<String, InstructionRecord>,
+    /// Sender DID allowlist for accepted claims.
     pub authorized_senders: HashSet<String>,
+    /// Maximum allowed claim validity window in seconds.
     pub max_claim_validity_window_secs: u64,
+    /// Instruction ids already consumed by successful verification.
     pub consumed_instruction_ids: HashSet<String>,
 }
 
 impl VerificationContext {
+    /// Creates a context with default bounded validity-window policy.
     pub fn new(now_unix: u64) -> Self {
         Self {
             now_unix,
@@ -42,21 +65,25 @@ impl VerificationContext {
         }
     }
 
+    /// Inserts an instruction record into the context.
     pub fn with_instruction(mut self, record: InstructionRecord) -> Self {
         self.instructions.insert(record.id.clone(), record);
         self
     }
 
+    /// Adds an authorized sender DID to the allowlist.
     pub fn with_authorized_sender(mut self, did: &str) -> Self {
         self.authorized_senders.insert(did.to_owned());
         self
     }
 
+    /// Overrides the maximum claim validity window in seconds.
     pub fn with_max_claim_validity_window_secs(mut self, max_window_secs: u64) -> Self {
         self.max_claim_validity_window_secs = max_window_secs;
         self
     }
 
+    /// Marks an instruction id as already consumed.
     pub fn with_consumed_instruction_id(mut self, instruction_id: &str) -> Self {
         self.consumed_instruction_ids
             .insert(instruction_id.to_owned());
@@ -64,47 +91,76 @@ impl VerificationContext {
     }
 }
 
+/// Verification failure taxonomy.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerificationFailure {
+    /// Referenced instruction id is not present in context.
     MissingInstruction(String),
+    /// Claim or record inclusion proof reference is missing.
     MissingInclusionProofReference,
+    /// Claim sender DID is invalid.
     InvalidClaimSenderDid(String),
+    /// Record sender DID is invalid.
     InvalidRecordSenderDid(String),
+    /// Claim sender does not match record sender.
     SenderMismatch {
+        /// Expected sender DID from record.
         expected: String,
+        /// Sender DID provided by claim.
         actual: String,
     },
+    /// Claim payload hash does not match record payload hash.
     PayloadMismatch,
+    /// Claim signature is missing.
     MissingClaimSignature,
+    /// Record signature is missing.
     MissingRecordSignature,
+    /// Claim signature does not match record signature.
     SignatureMismatch,
+    /// Inclusion proof reference does not match record.
     InclusionProofMismatch {
+        /// Expected inclusion proof reference from record.
         expected: String,
+        /// Inclusion proof reference provided by claim.
         actual: String,
     },
+    /// Claim sender is not in authorized sender allowlist.
     UnauthorizedSender(String),
+    /// Claim is expired at evaluation time.
     Expired {
+        /// Claim expiry timestamp.
         expires_at: u64,
+        /// Evaluation timestamp.
         now: u64,
     },
+    /// Claim validity window exceeds configured maximum.
     OverlongValidityWindow {
+        /// Maximum allowed window in seconds.
         max_window_secs: u64,
+        /// Requested window in seconds.
         requested_window_secs: u64,
     },
+    /// Instruction id was already consumed by a previous valid claim.
     ReplayClaim {
+        /// Replayed instruction identifier.
         instruction_id: String,
     },
 }
 
+/// Verification result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerificationOutcome {
+    /// Verification succeeded.
     Valid,
+    /// Verification failed with specific reason.
     Rejected(VerificationFailure),
 }
 
+/// Stateless instruction verifier.
 pub struct InstructionVerifier;
 
 impl InstructionVerifier {
+    /// Verifies a claim against instruction record data and policy context.
     pub fn verify(claim: &InstructionClaim, context: &VerificationContext) -> VerificationOutcome {
         let record = match context.instructions.get(&claim.instruction_id) {
             Some(value) => value,
@@ -177,6 +233,7 @@ impl InstructionVerifier {
         VerificationOutcome::Valid
     }
 
+    /// Verifies a claim and records consumption on success.
     pub fn verify_and_record(
         claim: &InstructionClaim,
         context: &mut VerificationContext,

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -52,7 +52,7 @@ pub mod escrow;
 pub mod governance_workflow;
 /// Group sender-key distribution, rotation, and encryption integrity contracts.
 pub mod group_channel_crypto;
-#[allow(missing_docs)]
+/// Instruction claim verification, inclusion-proof checks, and record contracts.
 pub mod instruction_verify;
 /// Invariant catalog, taxonomy, and guardrail policy contracts.
 pub mod invariants;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -827,6 +827,23 @@ fn graduated_wave_forty_five_escrow_module_must_not_return_to_allowlist() {
 }
 
 #[test]
+fn graduated_wave_forty_six_instruction_verify_module_must_not_return_to_allowlist() {
+    // Regression: #2065
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "instruction_verify";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -177,6 +177,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `escrow`
   - `group_channel_crypto`
   - `invariants`
+  - `instruction_verify`
   - `key_lifecycle`
   - `key_recovery`
   - `kolme_runtime_commit`
@@ -251,6 +252,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2059`
   - `Regression: #2061`
   - `Regression: #2063`
+  - `Regression: #2065`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -3,7 +3,6 @@ bridge_adapter
 channel_models
 channel_policies
 governance_workflow
-instruction_verify
 message_lifecycle
 reputation_state
 runtime

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -48,3 +48,4 @@ watchdog
 message_envelope
 upgrade_orchestration
 escrow
+instruction_verify


### PR DESCRIPTION
## Summary
Graduates `instruction_verify` from the missing-docs allowlist by documenting its public API and removing the exemption in `kamn-core`.
This hardens docs coverage on instruction-claim verification integrity contracts while locking the graduation with policy and architecture regression guards.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `instruction_verify` export and added module-level doc context.
- `crates/kamn-core/src/instruction_verify.rs`: added rustdoc coverage for public constants, structs, fields, builder methods, verifier methods, and verification failure taxonomy.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `instruction_verify`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `instruction_verify`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added graduation drift guard `graduated_wave_forty_six_instruction_verify_module_must_not_return_to_allowlist` with marker `Regression: #2065`.
- `docs/architecture/kamn-core-module-map.md`: marked `instruction_verify` graduated and added `Regression: #2065` marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict docs lint + policy/docs suites + full workspace tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core instruction_verify` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | Added `graduated_wave_forty_six_instruction_verify_module_must_not_return_to_allowlist` (`Regression: #2065`) |

Closes #2065
