### PR TITLE
docs(kamn-core): graduate reputation state missing-docs module

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -86,7 +86,7 @@ pub mod performance_targets;
 pub mod redaction_compliance;
 /// Reputation-signal weighting and candidate-ranking contracts for routing.
 pub mod reputation_signals;
-#[allow(missing_docs)]
+/// Reputation state persistence, restore, and export contracts.
 pub mod reputation_state;
 /// Retention policy evaluation, tombstone lifecycle, and purge guard contracts.
 pub mod retention_engine;

--- a/crates/kamn-core/src/reputation_state.rs
+++ b/crates/kamn-core/src/reputation_state.rs
@@ -1,73 +1,120 @@
+//! Reputation state persistence, mutation, and restore contracts.
+
 use crate::{canonical_state_key, AgentDid, StateKeyError, StateVersion, APP_STATE_VERSION};
 use std::collections::HashMap;
 use std::fmt;
 
+/// Default trust score assigned to newly registered agents.
 pub const DEFAULT_TRUST_SCORE: u32 = 500;
+/// Maximum allowed trust score.
 pub const MAX_TRUST_SCORE: u32 = 1_000;
 
+/// Task outcome categories used for reputation accounting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReputationTaskOutcome {
+    /// Task completed successfully.
     Completed,
+    /// Task failed.
     Failed,
+    /// Task delegated to another agent.
     Delegated,
 }
 
+/// Endorsement evidence attached to an agent reputation profile.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Endorsement {
+    /// Endorsement identifier.
     pub endorsement_id: String,
+    /// DID of endorsing agent.
     pub from_agent_did: String,
+    /// Human-readable endorsement note.
     pub note: String,
+    /// Block height where endorsement was anchored.
     pub block_height: u64,
 }
 
+/// Dispute record attached to an agent reputation profile.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DisputeRecord {
+    /// Dispute identifier.
     pub dispute_id: String,
+    /// DID of dispute opener.
     pub opened_by: String,
+    /// Dispute reason text.
     pub reason: String,
+    /// Block height where dispute was opened.
     pub block_height: u64,
 }
 
+/// Capability verification evidence entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CapabilityVerification {
+    /// Capability identifier.
     pub capability: String,
+    /// DID of verifier.
     pub verifier_did: String,
+    /// Proof reference for verification evidence.
     pub proof_ref: String,
+    /// Block height where verification was recorded.
     pub block_height: u64,
 }
 
+/// Trust-score snapshot at a specific block height.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScoreSnapshot {
+    /// Trust score value.
     pub trust_score: u32,
+    /// Block height of snapshot.
     pub block_height: u64,
 }
 
+/// Canonical in-memory reputation profile for an agent.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AgentReputation {
+    /// Agent DID.
     pub agent_did: String,
+    /// Current trust score.
     pub trust_score: u32,
+    /// Delivery success rate for completed/failed tasks.
     pub delivery_rate: f64,
+    /// Average response time across sampled outcomes.
     pub response_time_avg_ms: u64,
+    /// Ratio of disputes to completed/failed tasks.
     pub dispute_rate: f64,
+    /// Total completed tasks.
     pub tasks_completed: u64,
+    /// Total failed tasks.
     pub tasks_failed: u64,
+    /// Total delegated tasks.
     pub tasks_delegated: u64,
+    /// Total earned value.
     pub total_earned: u64,
+    /// Total spent value.
     pub total_spent: u64,
+    /// Endorsement history.
     pub endorsements: Vec<Endorsement>,
+    /// Dispute history.
     pub disputes: Vec<DisputeRecord>,
+    /// Verified capability entries.
     pub verified_capabilities: Vec<CapabilityVerification>,
+    /// Last block height that mutated this profile.
     pub last_updated_block: u64,
+    /// Trust-score history snapshots.
     pub score_history: Vec<ScoreSnapshot>,
 }
 
+/// Persisted reputation record with canonical state-key metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReputationPersistedRecord {
+    /// Canonical state key.
     pub state_key: String,
+    /// State schema version.
     pub state_version: StateVersion,
+    /// Agent reputation payload.
     pub reputation: AgentReputation,
 }
 
+/// In-memory store for agent reputation profiles.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReputationStore {
     state_version: StateVersion,
@@ -83,31 +130,53 @@ impl Default for ReputationStore {
     }
 }
 
+/// Error taxonomy for reputation-store validation and persistence flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReputationError {
+    /// Agent DID is invalid.
     InvalidAgentDid(String),
+    /// Agent already exists in store.
     AgentAlreadyExists(String),
+    /// Agent was not found in store.
     AgentNotFound(String),
+    /// Required field is empty.
     EmptyField(&'static str),
+    /// Block height is invalid.
     InvalidBlockHeight,
+    /// Response-time sample is required for this outcome.
     MissingResponseTime {
+        /// Outcome requiring response-time sample.
         outcome: ReputationTaskOutcome,
     },
+    /// Endorsement id already exists for this agent.
     DuplicateEndorsementId(String),
+    /// Dispute id already exists for this agent.
     DuplicateDisputeId(String),
+    /// Capability verification duplicate detected.
     DuplicateCapabilityVerification {
+        /// Capability value.
         capability: String,
+        /// Verifier DID.
         verifier_did: String,
     },
+    /// Trust score is out of allowed bounds.
     ScoreOutOfRange(u32),
+    /// Canonical state-key generation/validation error.
     StateKey(StateKeyError),
+    /// Persisted state key does not match canonical key.
     StateKeyMismatch {
+        /// Expected canonical state key.
         expected: String,
+        /// Observed persisted state key.
         actual: String,
     },
+    /// Duplicate persisted state key encountered during restore.
     DuplicateStateKey(String),
+    /// Persisted schema version mismatch.
     VersionMismatch {
+        /// Expected state version.
         expected: StateVersion,
+        /// Found state version.
         found: StateVersion,
     },
 }
@@ -161,14 +230,17 @@ impl fmt::Display for ReputationError {
 impl std::error::Error for ReputationError {}
 
 impl ReputationStore {
+    /// Returns the store schema version.
     pub fn state_version(&self) -> StateVersion {
         self.state_version
     }
 
+    /// Returns an immutable view of an agent profile.
     pub fn get_agent(&self, agent_did: &str) -> Option<&AgentReputation> {
         self.agents.get(agent_did)
     }
 
+    /// Registers a new agent with default reputation values.
     pub fn register_agent(
         &mut self,
         agent_did: &str,
@@ -207,6 +279,7 @@ impl ReputationStore {
         Ok(())
     }
 
+    /// Records a task outcome and updates derived reputation metrics.
     pub fn record_task_outcome(
         &mut self,
         agent_did: &str,
@@ -260,6 +333,7 @@ impl ReputationStore {
         Ok(())
     }
 
+    /// Records endorsement evidence for an agent.
     pub fn record_endorsement(
         &mut self,
         agent_did: &str,
@@ -285,6 +359,7 @@ impl ReputationStore {
         Ok(())
     }
 
+    /// Records a dispute for an agent and refreshes dispute rate.
     pub fn record_dispute(
         &mut self,
         agent_did: &str,
@@ -316,6 +391,7 @@ impl ReputationStore {
         Ok(())
     }
 
+    /// Records capability verification evidence for an agent.
     pub fn record_capability_verification(
         &mut self,
         agent_did: &str,
@@ -341,6 +417,7 @@ impl ReputationStore {
         Ok(())
     }
 
+    /// Sets trust score and appends a score-history snapshot.
     pub fn set_trust_score(
         &mut self,
         agent_did: &str,
@@ -362,6 +439,7 @@ impl ReputationStore {
         Ok(())
     }
 
+    /// Exports canonical persisted records sorted by state key.
     pub fn export_records(&self) -> Vec<ReputationPersistedRecord> {
         let mut records = self
             .agents
@@ -380,6 +458,7 @@ impl ReputationStore {
         records
     }
 
+    /// Restores a store from persisted records with strict validation.
     pub fn restore_from_records(
         records: &[ReputationPersistedRecord],
     ) -> Result<Self, ReputationError> {
@@ -430,6 +509,7 @@ impl ReputationStore {
     }
 }
 
+/// Builds the canonical reputation state key for an agent DID.
 pub fn agent_state_key(agent_did: &str) -> Result<String, ReputationError> {
     let did = AgentDid::parse(agent_did)
         .map_err(|error| ReputationError::InvalidAgentDid(error.to_string()))?;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -844,6 +844,23 @@ fn graduated_wave_forty_six_instruction_verify_module_must_not_return_to_allowli
 }
 
 #[test]
+fn graduated_wave_forty_seven_reputation_state_module_must_not_return_to_allowlist() {
+    // Regression: #2067
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "reputation_state";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -194,6 +194,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `redaction_compliance`
   - `retention_engine`
   - `reputation_signals`
+  - `reputation_state`
   - `service_marketplace`
   - `smoke`
   - `signature_profile`
@@ -253,6 +254,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2061`
   - `Regression: #2063`
   - `Regression: #2065`
+  - `Regression: #2067`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -4,7 +4,6 @@ channel_models
 channel_policies
 governance_workflow
 message_lifecycle
-reputation_state
 runtime
 signer_backend
 task_operations

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -49,3 +49,4 @@ message_envelope
 upgrade_orchestration
 escrow
 instruction_verify
+reputation_state


### PR DESCRIPTION
## Summary
Graduates `reputation_state` from the missing-docs allowlist by documenting its public API and removing the exemption in `kamn-core`.
This hardens docs coverage on reputation state persistence and restore contracts while locking the graduation with policy and architecture regression guards.

## Changes
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `reputation_state` export and added module-level doc context.
- `crates/kamn-core/src/reputation_state.rs`: added rustdoc coverage for public constants, structs, fields, store methods, state-key helper, and error taxonomy.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `reputation_state`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `reputation_state`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added graduation drift guard `graduated_wave_forty_seven_reputation_state_module_must_not_return_to_allowlist` with marker `Regression: #2067`.
- `docs/architecture/kamn-core-module-map.md`: marked `reputation_state` graduated and added `Regression: #2067` marker.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: strict docs lint + policy/docs suites + full workspace tests

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core reputation_state` |
| Functional  | ✅     | `RUSTFLAGS='-D warnings' cargo check -p kamn-core` |
| Integration | ✅     | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --test engineering_hardening_wave_docs` |
| Regression  | ✅     | Added `graduated_wave_forty_seven_reputation_state_module_must_not_return_to_allowlist` (`Regression: #2067`) |

Closes #2067
