### PR TITLE
docs(kamn-core): graduate agent_upgrade_workflow from allowlist

### DIFF
--- a/crates/kamn-core/src/agent_upgrade_workflow.rs
+++ b/crates/kamn-core/src/agent_upgrade_workflow.rs
@@ -1,3 +1,5 @@
+//! Agent-driven runtime upgrade proposal, review, governance, and activation workflow contracts.
+
 use crate::{
     AgentDid, GovernanceProposalDraft, GovernanceProposalRecord, GovernanceProposalStatus,
     GovernanceVoteChoice, GovernanceVoteRecord, GovernanceWorkflow, GovernanceWorkflowError,
@@ -6,69 +8,115 @@ use crate::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+/// Configuration parameters used to initialize an agent-driven upgrade workflow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentUpgradeWorkflowConfig {
+    /// Runtime version currently active at workflow initialization.
     pub current_version: String,
+    /// DID allowlist for agents permitted to submit upgrade proposals.
     pub allowed_agent_proposers: Vec<String>,
+    /// DID allowlist for validators permitted to review and vote.
     pub allowed_validator_voters: Vec<String>,
+    /// Minimum number of distinct human reviews required before governance submission.
     pub required_human_reviews: usize,
+    /// Governance quorum required to approve the proposal.
     pub required_validator_quorum: usize,
+    /// Minimum delay, in seconds, between governance approval and activation.
     pub min_activation_delay_secs: u64,
 }
 
+/// Draft payload submitted by an authorized agent proposer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentUpgradeProposalDraft {
+    /// Unique upgrade proposal identifier.
     pub proposal_id: String,
+    /// Candidate runtime version to activate if the workflow succeeds.
     pub target_version: String,
+    /// DID of the proposing agent.
     pub agent_did: String,
+    /// Human-readable rationale for the upgrade.
     pub rationale: String,
+    /// Proposal creation timestamp in Unix seconds.
     pub created_at_unix: u64,
+    /// Governance voting deadline timestamp in Unix seconds.
     pub voting_deadline_unix: u64,
 }
 
+/// Lifecycle state machine for agent-driven upgrade proposals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentUpgradeProposalState {
+    /// Proposal exists and is collecting required human reviews.
     PendingHumanReview,
+    /// Proposal has been promoted and is currently in governance voting.
     GovernanceVoting,
+    /// Governance has approved the proposal and activation delay may apply.
     GovernanceApproved,
+    /// Upgrade has been executed and marked active.
     Activated,
 }
 
+/// Canonical state snapshot for a proposal tracked by this workflow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentUpgradeProposalRecord {
+    /// Unique proposal identifier.
     pub proposal_id: String,
+    /// Candidate runtime version requested by the proposal.
     pub target_version: String,
+    /// DID of the original proposing agent.
     pub agent_did: String,
+    /// Human-readable upgrade rationale.
     pub rationale: String,
+    /// Proposal creation timestamp in Unix seconds.
     pub created_at_unix: u64,
+    /// Governance voting deadline timestamp in Unix seconds.
     pub voting_deadline_unix: u64,
+    /// Set of reviewers that approved this proposal for governance submission.
     pub human_reviewers: BTreeSet<String>,
+    /// Current proposal lifecycle state.
     pub state: AgentUpgradeProposalState,
+    /// Current governance status mirrored from the governance workflow.
     pub governance_status: GovernanceProposalStatus,
+    /// Timestamp when governance first reached approved status.
     pub governance_approved_at_unix: Option<u64>,
+    /// Timestamp when upgrade activation completed.
     pub activated_at_unix: Option<u64>,
+    /// Governance operation hash used during final execution.
     pub operation_hash: Option<String>,
 }
 
+/// Audit event kinds emitted by the agent-driven upgrade workflow.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentUpgradeAuditEventKind {
+    /// An agent submitted a proposal draft.
     AgentProposed,
+    /// A human reviewer approved the proposal for governance promotion.
     HumanReviewApproved,
+    /// The proposal was submitted into governance voting.
     GovernanceSubmitted,
+    /// Governance reached quorum approval for the proposal.
     GovernanceApproved,
+    /// Governance execution completed for the proposal.
     GovernanceExecuted,
+    /// The runtime upgrade was activated.
     UpgradeActivated,
 }
 
+/// Immutable audit event record emitted by the workflow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentUpgradeAuditEvent {
+    /// Proposal identifier associated with this event.
     pub proposal_id: String,
+    /// DID or system actor responsible for the event.
     pub actor_did: String,
+    /// Event timestamp in Unix seconds.
     pub event_at_unix: u64,
+    /// Event classification.
     pub kind: AgentUpgradeAuditEventKind,
+    /// Optional operator-facing annotation for this event.
     pub note: Option<String>,
 }
 
+/// In-memory workflow coordinating proposal review, governance, and activation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentDrivenUpgradeWorkflow {
     allowed_agent_proposers: BTreeSet<String>,
@@ -83,6 +131,7 @@ pub struct AgentDrivenUpgradeWorkflow {
 }
 
 impl AgentDrivenUpgradeWorkflow {
+    /// Construct a workflow instance after validating config invariants and DID allowlists.
     pub fn new(config: AgentUpgradeWorkflowConfig) -> Result<Self, AgentUpgradeWorkflowError> {
         if config.required_human_reviews == 0 {
             return Err(AgentUpgradeWorkflowError::InvalidRequiredHumanReviews(0));
@@ -127,6 +176,7 @@ impl AgentDrivenUpgradeWorkflow {
         })
     }
 
+    /// Register a new proposal from an authorized agent and seed upgrade orchestration state.
     pub fn submit_agent_proposal(
         &mut self,
         draft: AgentUpgradeProposalDraft,
@@ -189,6 +239,7 @@ impl AgentDrivenUpgradeWorkflow {
         Ok(())
     }
 
+    /// Record a distinct human-review approval for a pending proposal.
     pub fn approve_human_review(
         &mut self,
         proposal_id: &str,
@@ -223,6 +274,7 @@ impl AgentDrivenUpgradeWorkflow {
         Ok(())
     }
 
+    /// Promote a reviewed proposal into governance voting.
     pub fn submit_to_governance(
         &mut self,
         proposal_id: &str,
@@ -281,6 +333,7 @@ impl AgentDrivenUpgradeWorkflow {
         Ok(())
     }
 
+    /// Cast a governance vote from an allowlisted validator and update mirrored proposal state.
     pub fn cast_validator_vote(
         &mut self,
         proposal_id: &str,
@@ -320,6 +373,7 @@ impl AgentDrivenUpgradeWorkflow {
         Ok(())
     }
 
+    /// Execute governance-approved proposal and activate the runtime upgrade once delay passes.
     pub fn finalize_upgrade(
         &mut self,
         proposal_id: &str,
@@ -404,18 +458,22 @@ impl AgentDrivenUpgradeWorkflow {
         Ok(())
     }
 
+    /// Return proposal snapshot by identifier if present.
     pub fn proposal(&self, proposal_id: &str) -> Option<AgentUpgradeProposalRecord> {
         self.proposals.get(proposal_id).cloned()
     }
 
+    /// Return mirrored governance proposal record by identifier if present.
     pub fn governance_record(&self, proposal_id: &str) -> Option<GovernanceProposalRecord> {
         self.governance.proposal(proposal_id)
     }
 
+    /// Return upgrade-orchestrator audit view for all tracked operations.
     pub fn upgrade_audit_view(&self) -> VersionUpgradeAuditView {
         self.orchestrator.audit_view()
     }
 
+    /// Return emitted agent workflow audit events in insertion order.
     pub fn agent_audit_log(&self) -> Vec<AgentUpgradeAuditEvent> {
         self.events.clone()
     }
@@ -442,48 +500,84 @@ fn apply_yes_votes_as_upgrade_approvals(
     Ok(())
 }
 
+/// Errors emitted by the agent-driven upgrade workflow lifecycle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentUpgradeWorkflowError {
+    /// Required string field was empty or whitespace.
     EmptyField(&'static str),
+    /// DID failed canonical parse/validation.
     InvalidDid(String),
+    /// Timestamp field was zero or otherwise invalid.
     InvalidTimestamp(&'static str),
+    /// Voting deadline does not occur after the reference creation/submission timestamp.
     InvalidDeadline {
+        /// Reference creation/submission timestamp in Unix seconds.
         created_at_unix: u64,
+        /// Voting deadline timestamp in Unix seconds.
         voting_deadline_unix: u64,
     },
+    /// Required human-review threshold must be positive.
     InvalidRequiredHumanReviews(usize),
+    /// Required validator quorum must be positive.
     InvalidRequiredValidatorQuorum(usize),
+    /// Activation delay must be positive.
     InvalidMinActivationDelaySecs(u64),
+    /// Agent proposer allowlist is empty.
     MissingAllowedAgentProposers,
+    /// Validator voter allowlist is empty.
     MissingAllowedValidatorVoters,
+    /// Agent DID is not authorized to submit proposals.
     UnauthorizedAgentProposer(String),
+    /// Reviewer DID is not authorized for human review approval.
     UnauthorizedHumanReviewer(String),
+    /// Validator DID is not authorized to vote.
     UnauthorizedValidatorVoter(String),
+    /// Proposal identifier already exists.
     ProposalAlreadyExists(String),
+    /// Proposal identifier does not exist.
     ProposalNotFound(String),
+    /// Reviewer submitted a duplicate human approval for the same proposal.
     DuplicateHumanReview {
+        /// Proposal identifier.
         proposal_id: String,
+        /// Reviewer DID that attempted duplicate approval.
         reviewer_did: String,
     },
+    /// Proposal does not yet meet required human-review threshold.
     InsufficientHumanReviews {
+        /// Required number of distinct human reviews.
         required: usize,
+        /// Number of reviews currently recorded.
         provided: usize,
     },
+    /// Proposal state does not permit submission into governance.
     GovernanceSubmissionNotAllowed {
+        /// Proposal identifier.
         proposal_id: String,
+        /// Current proposal state that blocks transition.
         state: AgentUpgradeProposalState,
     },
+    /// Governance status is not approved at execution time.
     GovernanceStatusNotApproved {
+        /// Proposal identifier.
         proposal_id: String,
+        /// Governance status observed when execution was attempted.
         status: GovernanceProposalStatus,
     },
+    /// Governance approval timestamp was never recorded for the proposal.
     MissingGovernanceApprovalTimestamp(String),
+    /// Activation attempted before minimum post-approval delay elapsed.
     ActivationDelayNotElapsed {
+        /// Proposal identifier.
         proposal_id: String,
+        /// Earliest valid activation timestamp in Unix seconds.
         earliest_activation_unix: u64,
+        /// Attempted activation timestamp in Unix seconds.
         attempted_activation_unix: u64,
     },
+    /// Wrapped error propagated from governance workflow operations.
     GovernanceWorkflow(GovernanceWorkflowError),
+    /// Wrapped error propagated from upgrade orchestrator operations.
     UpgradeOrchestration(UpgradeOrchestrationError),
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -7,7 +7,7 @@
 
 /// Agent key hierarchy roles, rotation, and ephemeral session key contracts.
 pub mod agent_key_hierarchy;
-#[allow(missing_docs)]
+/// Agent-driven upgrade proposal, review, and execution workflow contracts.
 pub mod agent_upgrade_workflow;
 /// Anti-spam admission, rate-limit, and suspension policy contracts.
 pub mod anti_spam;

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -929,6 +929,23 @@ fn graduated_wave_fifty_one_governance_workflow_module_must_not_return_to_allowl
 }
 
 #[test]
+fn graduated_wave_fifty_two_agent_upgrade_workflow_module_must_not_return_to_allowlist() {
+    // Regression: #2077
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "agent_upgrade_workflow";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -158,6 +158,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 
 - Graduated modules currently enforced outside the allow-list:
   - `agent_key_hierarchy`
+  - `agent_upgrade_workflow`
   - `anti_spam`
   - `audit_exports`
   - `bootstrap`
@@ -263,6 +264,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2071`
   - `Regression: #2073`
   - `Regression: #2075`
+  - `Regression: #2077`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -1,4 +1,3 @@
-agent_upgrade_workflow
 message_lifecycle
 runtime
 signer_backend

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -54,3 +54,4 @@ channel_policies
 bridge_adapter
 channel_models
 governance_workflow
+agent_upgrade_workflow


### PR DESCRIPTION
## Summary
Graduated `agent_upgrade_workflow` from the `kamn-core` missing-docs allowlist by documenting its public API and enforcing drift guards. This advances the docs-hardening wave for governance/control-plane modules without changing runtime behavior.

## Changes
- `crates/kamn-core/src/agent_upgrade_workflow.rs`: added rustdoc for public structs, fields, enums, methods, and error variants.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `agent_upgrade_workflow` and kept explicit module doc coverage.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `agent_upgrade_workflow`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `agent_upgrade_workflow`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_fifty_two_agent_upgrade_workflow_module_must_not_return_to_allowlist` (`Regression: #2077`).
- `docs/architecture/kamn-core-module-map.md`: added `agent_upgrade_workflow` to graduated modules and appended `Regression: #2077` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`RUSTFLAGS='-D warnings' cargo check -p kamn-core`

Output (failure excerpt):
`error: could not compile 'kamn-core' (lib) due to 92 previous errors`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- `cargo test -p kamn-core agent_upgrade_workflow`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`
- `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`

Result:
All commands passed.

### 🔁 Regression
Command:
`cargo test`

Result:
Full workspace test suite passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing `agent_upgrade_workflow` unit tests remain green via `cargo test -p kamn-core agent_upgrade_workflow` | |
| Functional   | ✅ | Strict missing-docs lint for `kamn-core` (`RUSTFLAGS='-D warnings' cargo check -p kamn-core`) | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | Added `graduated_wave_fifty_two_agent_upgrade_workflow_module_must_not_return_to_allowlist` in `missing_docs_policy.rs` | |
| Performance  | N/A | None | Docs/policy graduation only; no runtime path changes |

## Risks & Rollback
- None.
- Rollback plan: revert this PR to restore previous allowlist+fixture/doc state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` graduation list and regression markers updated.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2077
