### PR TITLE
docs(kamn-core): graduate task_operations from allowlist

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -104,7 +104,7 @@ pub mod state;
 /// Task artifact registration, integrity checks, and lookup contracts.
 pub mod task_artifacts;
 pub mod task_lifecycle;
-#[allow(missing_docs)]
+/// Task mutation APIs, dependency graph orchestration, and snapshot persistence contracts.
 pub mod task_operations;
 /// Task payment offer/confirmation workflow backed by escrow release controls.
 pub mod task_payment;

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -1,3 +1,5 @@
+//! Task operation workflow contracts, dependency orchestration, and snapshot persistence.
+
 use crate::{AgentDid, TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -6,55 +8,89 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
 
+/// Notice kinds emitted for task operation lifecycle activity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TaskOperationNoticeKind {
+    /// Task was submitted by requester.
     Submitted,
+    /// Task was accepted by assignee.
     Accepted,
+    /// Task assignment was delegated.
     Delegated,
+    /// Assignee started task work.
     Started,
+    /// Assignee requested additional input.
     InputRequired,
+    /// Task was blocked due to external/internal issue.
     Blocked,
+    /// Task was completed successfully.
     Completed,
+    /// Task was marked failed.
     Failed,
+    /// Task was cancelled by requester or assignee.
     Cancelled,
 }
 
+/// Canonical mutable task operation record tracked by engine state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskOperationRecord {
+    /// Unique task identifier.
     pub task_id: String,
+    /// DID of requester that submitted the task.
     pub requester: String,
+    /// DID of assigned worker, when assigned.
     pub assignee: Option<String>,
+    /// Human-readable task description.
     pub description: String,
+    /// Task lifecycle state machine and transition history.
     pub lifecycle: TaskLifecycle,
 }
 
+/// Draft payload for submitting a task batch with dependency edges.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SwarmTaskDraft {
+    /// Unique task identifier.
     pub task_id: String,
+    /// DID of requester that submitted the task.
     pub requester: String,
+    /// Human-readable task description.
     pub description: String,
+    /// Dependency task identifiers that must complete before work can start.
     pub dependencies: Vec<String>,
 }
 
+/// Schema version for serialized task operation snapshots.
 pub const TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
 
+/// Snapshot projection for a single task operation record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskOperationRecordSnapshot {
+    /// Unique task identifier.
     pub task_id: String,
+    /// DID of requester that submitted the task.
     pub requester: String,
+    /// DID of assigned worker, when assigned.
     pub assignee: Option<String>,
+    /// Human-readable task description.
     pub description: String,
+    /// Serialized lifecycle history in transition order.
     pub lifecycle_history: Vec<TaskState>,
+    /// Serialized dependency identifiers.
     pub dependencies: Vec<String>,
+    /// Serialized task operation notices.
     pub notices: Vec<TaskOperationNoticeKind>,
 }
 
+/// Serialized snapshot for all task operation engine records.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskOperationSnapshot {
+    /// Snapshot schema version.
     pub schema_version: u16,
+    /// Serialized task records contained in snapshot.
     pub tasks: Vec<TaskOperationRecordSnapshot>,
 }
 
+/// In-memory engine for task operations, dependency gating, and lifecycle transitions.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TaskOperationEngine {
     tasks: BTreeMap<String, TaskOperationRecord>,
@@ -63,10 +99,12 @@ pub struct TaskOperationEngine {
 }
 
 impl TaskOperationEngine {
+    /// Construct an empty task operation engine.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Submit a single task with requester and description metadata.
     pub fn submit(
         &mut self,
         task_id: &str,
@@ -100,6 +138,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Submit a batch of tasks and validate dependency graph integrity.
     pub fn submit_swarm_tasks(
         &mut self,
         drafts: Vec<SwarmTaskDraft>,
@@ -166,6 +205,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Accept a task as assignee and transition lifecycle to accepted state.
     pub fn accept(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
         validate_did(actor)?;
         let record = self.task_mut(task_id)?;
@@ -188,6 +228,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Delegate a task from current assignee to a new assignee.
     pub fn delegate(
         &mut self,
         task_id: &str,
@@ -208,6 +249,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Start task work after dependency-satisfaction checks pass.
     pub fn start_work(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
         validate_did(actor)?;
         if let Some(dependency_id) = self.unsatisfied_dependency(task_id)? {
@@ -226,6 +268,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Mark task as blocked with a non-empty reason.
     pub fn block(
         &mut self,
         task_id: &str,
@@ -246,6 +289,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Move task into input-required state with a non-empty reason.
     pub fn request_input(
         &mut self,
         task_id: &str,
@@ -266,6 +310,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Complete task as assignee.
     pub fn complete(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
         validate_did(actor)?;
         let record = self.task_mut(task_id)?;
@@ -278,6 +323,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Mark task as failed with a non-empty reason.
     pub fn fail(
         &mut self,
         task_id: &str,
@@ -298,6 +344,7 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Cancel a task as requester or current assignee.
     pub fn cancel(&mut self, task_id: &str, actor: &str) -> Result<(), TaskOperationError> {
         validate_did(actor)?;
         let record = self.task_mut(task_id)?;
@@ -318,12 +365,14 @@ impl TaskOperationEngine {
         Ok(())
     }
 
+    /// Return immutable task record by identifier.
     pub fn task(&self, task_id: &str) -> Result<&TaskOperationRecord, TaskOperationError> {
         self.tasks
             .get(task_id)
             .ok_or_else(|| TaskOperationError::NotFound(task_id.to_owned()))
     }
 
+    /// Return task notice history in insertion order for the given task.
     pub fn notices(&self, task_id: &str) -> Vec<TaskOperationNoticeKind> {
         self.notices_by_task
             .get(task_id)
@@ -331,6 +380,7 @@ impl TaskOperationEngine {
             .unwrap_or_default()
     }
 
+    /// Return task identifiers that are accepted/delegated and dependency-ready.
     pub fn ready_tasks(&self) -> Vec<String> {
         self.tasks
             .iter()
@@ -352,6 +402,7 @@ impl TaskOperationEngine {
             .collect()
     }
 
+    /// Export full engine state into serializable snapshot form.
     pub fn export_snapshot(&self) -> TaskOperationSnapshot {
         let tasks = self
             .tasks
@@ -376,6 +427,7 @@ impl TaskOperationEngine {
         }
     }
 
+    /// Restore engine state from snapshot after schema, graph, and lifecycle validation.
     pub fn restore_snapshot(
         &mut self,
         snapshot: TaskOperationSnapshot,
@@ -533,43 +585,73 @@ impl TaskOperationEngine {
     }
 }
 
+/// Errors emitted by task operation lifecycle, dependency graph, and snapshot restore flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskOperationError {
+    /// Task identifier was not found.
     NotFound(String),
+    /// Task identifier already exists.
     DuplicateTaskId(String),
+    /// Swarm submission provided no tasks.
     EmptySwarmTaskSet,
+    /// Duplicate dependency edge was declared for a task.
     DuplicateDependency {
+        /// Task identifier containing duplicate dependency.
         task_id: String,
+        /// Duplicate dependency identifier.
         dependency_id: String,
     },
+    /// Dependency references an unknown task identifier.
     UnknownDependency {
+        /// Task identifier referencing unknown dependency.
         task_id: String,
+        /// Unknown dependency identifier.
         dependency_id: String,
     },
+    /// Dependency graph contains a cycle.
     CyclicDependency {
+        /// Task identifier where cycle detection terminated.
         task_id: String,
     },
+    /// Task cannot proceed because dependency is not completed.
     DependencyNotSatisfied {
+        /// Task identifier blocked by dependency.
         task_id: String,
+        /// Unsatisfied dependency identifier.
         dependency_id: String,
     },
+    /// Snapshot schema version does not match expected contract.
     SnapshotVersionMismatch {
+        /// Expected snapshot schema version.
         expected: u16,
+        /// Snapshot schema version found in payload.
         found: u16,
     },
+    /// Snapshot restore detected dependency that is not completed for an in-progress terminal task.
     SnapshotDependencyNotCompleted {
+        /// Task identifier blocked by dependency state.
         task_id: String,
+        /// Dependency identifier in invalid state for restore.
         dependency_id: String,
+        /// Dependency state observed in snapshot payload.
         dependency_state: TaskState,
     },
+    /// Snapshot payload failed semantic validation.
     InvalidSnapshot(String),
+    /// DID parse/validation failed.
     InvalidDid(String),
+    /// Task description is empty.
     EmptyDescription,
+    /// Required reason field is empty for a transition action.
     EmptyReason(&'static str),
+    /// Actor is not authorized for requested operation.
     UnauthorizedActor {
+        /// Actor DID attempting operation.
         actor: String,
+        /// Required actor policy for operation.
         required: &'static str,
     },
+    /// Wrapped lifecycle transition error.
     Lifecycle(String),
 }
 
@@ -623,10 +705,14 @@ impl fmt::Display for TaskOperationError {
 
 impl std::error::Error for TaskOperationError {}
 
+/// Errors emitted by task operation snapshot-store serialization/persistence operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskOperationSnapshotStoreError {
+    /// Underlying filesystem I/O operation failed.
     Io(String),
+    /// Serialized payload is malformed or violates delimiter contract.
     InvalidPayload(String),
+    /// Wrapped snapshot validation error from task operation engine.
     Snapshot(TaskOperationError),
 }
 
@@ -644,15 +730,19 @@ impl fmt::Display for TaskOperationSnapshotStoreError {
 
 impl std::error::Error for TaskOperationSnapshotStoreError {}
 
+/// Snapshot persistence abstraction for task operation state.
 pub trait TaskOperationSnapshotStore {
+    /// Persist latest snapshot payload.
     fn write(
         &mut self,
         snapshot: TaskOperationSnapshot,
     ) -> Result<(), TaskOperationSnapshotStoreError>;
+    /// Read latest snapshot payload if present.
     fn read_latest(&self)
         -> Result<Option<TaskOperationSnapshot>, TaskOperationSnapshotStoreError>;
 }
 
+/// In-memory snapshot store implementation for tests and ephemeral runtime paths.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct InMemoryTaskOperationSnapshotStore {
     latest: Option<TaskOperationSnapshot>,
@@ -674,18 +764,23 @@ impl TaskOperationSnapshotStore for InMemoryTaskOperationSnapshotStore {
     }
 }
 
+/// Filesystem-backed snapshot store implementation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileTaskOperationSnapshotStore {
     path: PathBuf,
 }
 
+/// Recovery outcome for filesystem snapshot repair flow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskOperationRecoveryResult {
+    /// Latest valid snapshot after recovery path.
     pub latest: Option<TaskOperationSnapshot>,
+    /// Whether recovery rewrote corrupted payload to repaired baseline.
     pub repaired: bool,
 }
 
 impl FileTaskOperationSnapshotStore {
+    /// Construct filesystem snapshot store with target path.
     pub fn new(path: PathBuf) -> Result<Self, TaskOperationSnapshotStoreError> {
         if path.as_os_str().is_empty() {
             return Err(TaskOperationSnapshotStoreError::InvalidPayload(
@@ -695,6 +790,7 @@ impl FileTaskOperationSnapshotStore {
         Ok(Self { path })
     }
 
+    /// Attempt to read latest snapshot; if corrupt, repair file and return empty state.
     pub fn recover_latest_and_repair(
         &mut self,
     ) -> Result<TaskOperationRecoveryResult, TaskOperationSnapshotStoreError> {

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -963,6 +963,23 @@ fn graduated_wave_fifty_three_signer_backend_module_must_not_return_to_allowlist
 }
 
 #[test]
+fn graduated_wave_fifty_four_task_operations_module_must_not_return_to_allowlist() {
+    // Regression: #2081
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "task_operations";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -207,6 +207,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `state`
   - `token`
   - `task_artifacts`
+  - `task_operations`
   - `task_payment`
   - `telegram_bridge`
   - `task_lifecycle`
@@ -267,6 +268,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2075`
   - `Regression: #2077`
   - `Regression: #2079`
+  - `Regression: #2081`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -1,4 +1,3 @@
 message_lifecycle
 runtime
-task_operations
 zk_message_proofs

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -56,3 +56,4 @@ channel_models
 governance_workflow
 agent_upgrade_workflow
 signer_backend
+task_operations


### PR DESCRIPTION
## Summary
Graduated `task_operations` from the `kamn-core` missing-docs allowlist by documenting its full public API and enforcing drift guards. This advances docs-hardening for the task-domain control surface without changing runtime behavior.

## Changes
- `crates/kamn-core/src/task_operations.rs`: added rustdoc for public enums/variants, structs/fields, constants, engine methods, error variants, snapshot-store trait APIs, and recovery structures.
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` from `task_operations` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `task_operations`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `task_operations`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_fifty_four_task_operations_module_must_not_return_to_allowlist` (`Regression: #2081`).
- `docs/architecture/kamn-core-module-map.md`: added `task_operations` to graduated modules and appended `Regression: #2081` marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`RUSTFLAGS='-D warnings' cargo check -p kamn-core`

Output (failure excerpt):
`error: could not compile 'kamn-core' (lib) due to 95 previous errors`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- `cargo test -p kamn-core task_operations`
- `cargo test -p kamn-core --test missing_docs_policy`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`
- `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`

Result:
All commands passed.

### 🔁 Regression
Command:
`cargo test`

Result:
Full workspace test suite passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing `task_operations` tests remain green via `cargo test -p kamn-core task_operations` | |
| Functional   | ✅ | Strict missing-docs lint for `kamn-core` (`RUSTFLAGS='-D warnings' cargo check -p kamn-core`) | |
| Integration  | ✅ | `cargo test -p kamn-core --test engineering_hardening_wave_docs` | |
| Regression   | ✅ | Added `graduated_wave_fifty_four_task_operations_module_must_not_return_to_allowlist` in `missing_docs_policy.rs` | |
| Performance  | N/A | None | Docs/policy graduation only; no runtime path changes |

## Risks & Rollback
- None.
- Rollback plan: revert this PR to restore previous allowlist+fixture/doc state.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md` graduation list and regression markers updated.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2081
