### PR TITLE
docs(kamn-core): graduate message_lifecycle from allowlist (#2085)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -65,7 +65,7 @@ pub mod kolme_runtime_commit;
 pub mod message_delivery_guards;
 /// Canonical message envelope schema validation and normalization contracts.
 pub mod message_envelope;
-#[allow(missing_docs)]
+/// Message lifecycle models, snapshot contracts, and proof-admission flow.
 pub mod message_lifecycle;
 /// State schema migration planning and validation contracts.
 pub mod migrations;

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -10,14 +10,23 @@ use std::io::Write;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Canonical lifecycle state for a message tracked by [`MessageLifecycleStore`].
 pub enum MessageStatus {
+    /// Message metadata is registered but not signed.
     Created,
+    /// Message is signed and ready for broadcast.
     Signed,
+    /// Message has been broadcast to the transport layer.
     Broadcast,
+    /// Message is included by the target chain/runtime.
     Included,
+    /// Message is delivered to recipients.
     Delivered,
+    /// Message is validated with processor proof evidence.
     Validated,
+    /// Message is rejected after validation or policy checks.
     Rejected,
+    /// Message is expired and no longer active.
     Expired,
 }
 
@@ -31,26 +40,39 @@ struct MessageRecord {
     history: Vec<MessageStatus>,
 }
 
+/// Schema version for serialized lifecycle snapshots.
 pub const MESSAGE_LIFECYCLE_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Serializable snapshot record for one message lifecycle entry.
 pub struct MessageRecordSnapshot {
+    /// Stable message identifier.
     pub message_id: String,
+    /// Sender DID.
     pub sender: String,
+    /// Recipient DID set.
     pub recipients: Vec<String>,
+    /// Envelope creation timestamp.
     pub created: String,
+    /// Envelope expiry timestamp.
     pub expires: String,
+    /// Current lifecycle status.
     pub status: MessageStatus,
+    /// Ordered status transition history.
     pub history: Vec<MessageStatus>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Serializable snapshot of all lifecycle records.
 pub struct MessageLifecycleSnapshot {
+    /// Snapshot schema version.
     pub schema_version: u16,
+    /// Snapshot records keyed by message id inside the payload.
     pub records: Vec<MessageRecordSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// In-memory lifecycle index for message status and participant lookups.
 pub struct MessageLifecycleStore {
     records: BTreeMap<String, MessageRecord>,
     ids_by_status: BTreeMap<MessageStatus, BTreeSet<String>>,
@@ -59,10 +81,12 @@ pub struct MessageLifecycleStore {
 }
 
 impl MessageLifecycleStore {
+    /// Creates an empty lifecycle store.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Registers a new message with sender/recipient metadata and lifecycle timestamps.
     pub fn register(
         &mut self,
         message_id: &str,
@@ -135,6 +159,7 @@ impl MessageLifecycleStore {
         Ok(())
     }
 
+    /// Returns the current status for a message id.
     pub fn status(&self, message_id: &str) -> Result<MessageStatus, MessageLifecycleError> {
         self.records
             .get(message_id)
@@ -142,6 +167,7 @@ impl MessageLifecycleStore {
             .ok_or_else(|| MessageLifecycleError::NotFound(message_id.to_owned()))
     }
 
+    /// Applies a lifecycle transition when the edge is valid under policy.
     pub fn transition(
         &mut self,
         message_id: &str,
@@ -160,6 +186,7 @@ impl MessageLifecycleStore {
         Ok(())
     }
 
+    /// Expires one message when `observed_at` is after the stored expiry timestamp.
     pub fn expire_message_if_overdue(
         &mut self,
         message_id: &str,
@@ -180,6 +207,7 @@ impl MessageLifecycleStore {
         Ok(true)
     }
 
+    /// Expires all active messages that are overdue at `observed_at`.
     pub fn expire_overdue_messages(
         &mut self,
         observed_at: &str,
@@ -204,6 +232,7 @@ impl MessageLifecycleStore {
         Ok(overdue_ids)
     }
 
+    /// Returns message ids in the provided lifecycle status.
     pub fn ids_by_status(&self, status: MessageStatus) -> Vec<String> {
         self.ids_by_status
             .get(&status)
@@ -211,6 +240,7 @@ impl MessageLifecycleStore {
             .unwrap_or_default()
     }
 
+    /// Returns message ids registered by the sender DID.
     pub fn ids_by_sender(&self, sender: &str) -> Vec<String> {
         self.ids_by_sender
             .get(sender)
@@ -218,6 +248,7 @@ impl MessageLifecycleStore {
             .unwrap_or_default()
     }
 
+    /// Returns message ids that include the provided recipient DID.
     pub fn ids_by_recipient(&self, recipient: &str) -> Vec<String> {
         self.ids_by_recipient
             .get(recipient)
@@ -225,6 +256,7 @@ impl MessageLifecycleStore {
             .unwrap_or_default()
     }
 
+    /// Returns `(created, expires)` timestamps for a message envelope.
     pub fn envelope_timestamps(
         &self,
         message_id: &str,
@@ -236,6 +268,7 @@ impl MessageLifecycleStore {
         Ok((&record.created, &record.expires))
     }
 
+    /// Returns the transition history for a message.
     pub fn history(&self, message_id: &str) -> Result<&[MessageStatus], MessageLifecycleError> {
         let record = self
             .records
@@ -244,6 +277,7 @@ impl MessageLifecycleStore {
         Ok(&record.history)
     }
 
+    /// Returns `(sender, recipients)` for a message.
     pub fn participants(
         &self,
         message_id: &str,
@@ -255,6 +289,7 @@ impl MessageLifecycleStore {
         Ok((&record.sender, &record.recipients))
     }
 
+    /// Exports all records into a deterministic snapshot payload model.
     pub fn export_snapshot(&self) -> MessageLifecycleSnapshot {
         let records = self
             .records
@@ -276,6 +311,7 @@ impl MessageLifecycleStore {
         }
     }
 
+    /// Restores all records from a previously exported lifecycle snapshot.
     pub fn restore_snapshot(
         &mut self,
         snapshot: MessageLifecycleSnapshot,
@@ -400,6 +436,7 @@ impl MessageLifecycleStore {
         Ok(())
     }
 
+    /// Validates processor proof evidence for a delivered message and transitions it to validated.
     pub fn validate_with_processor_proof(
         &mut self,
         message_id: &str,
@@ -428,20 +465,34 @@ impl MessageLifecycleStore {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Lifecycle domain validation errors.
 pub enum MessageLifecycleError {
+    /// Message id is empty.
     EmptyMessageId,
+    /// Message id already exists in the store.
     DuplicateMessageId(String),
+    /// Sender DID is invalid.
     InvalidSenderDid(String),
+    /// Recipient list is empty.
     EmptyRecipients,
+    /// One of the recipient DIDs is invalid.
     InvalidRecipientDid(String),
+    /// Timestamp field is empty.
     EmptyTimestamp(&'static str),
+    /// Expiry is not strictly after creation time.
     InvalidExpiryWindow {
+        /// Creation timestamp that failed validation.
         created: String,
+        /// Expiry timestamp that failed validation.
         expires: String,
     },
+    /// Requested message id does not exist.
     NotFound(String),
+    /// Lifecycle transition edge is not permitted.
     InvalidTransition {
+        /// Current status.
         from: MessageStatus,
+        /// Requested next status.
         to: MessageStatus,
     },
 }
@@ -473,9 +524,16 @@ impl fmt::Display for MessageLifecycleError {
 impl std::error::Error for MessageLifecycleError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Proof admission errors while validating delivered messages.
 pub enum MessageProofAdmissionError {
+    /// Underlying lifecycle error.
     Lifecycle(MessageLifecycleError),
-    InvalidValidationState { found: MessageStatus },
+    /// Message is not in `Delivered` state.
+    InvalidValidationState {
+        /// Lifecycle status observed during proof admission.
+        found: MessageStatus,
+    },
+    /// Underlying proof evaluator error.
     Proof(ZkDesignError),
 }
 
@@ -495,10 +553,20 @@ impl fmt::Display for MessageProofAdmissionError {
 impl std::error::Error for MessageProofAdmissionError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Snapshot parsing/restoration errors for lifecycle state.
 pub enum MessageLifecycleSnapshotError {
-    SnapshotVersionMismatch { expected: u16, found: u16 },
+    /// Snapshot schema version differs from the active version.
+    SnapshotVersionMismatch {
+        /// Required schema version.
+        expected: u16,
+        /// Observed schema version in payload.
+        found: u16,
+    },
+    /// Duplicate message id appears in one snapshot payload.
     DuplicateMessageId(String),
+    /// Snapshot payload is malformed or internally inconsistent.
     InvalidSnapshot(String),
+    /// Underlying lifecycle validation error while restoring.
     Lifecycle(MessageLifecycleError),
 }
 
@@ -523,9 +591,13 @@ impl fmt::Display for MessageLifecycleSnapshotError {
 impl std::error::Error for MessageLifecycleSnapshotError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Storage-layer errors for lifecycle snapshot persistence.
 pub enum MessageLifecycleSnapshotStoreError {
+    /// File I/O error detail.
     Io(String),
+    /// Raw snapshot payload is invalid.
     InvalidPayload(String),
+    /// Parsed snapshot is invalid under lifecycle constraints.
     Snapshot(MessageLifecycleSnapshotError),
 }
 
@@ -546,17 +618,21 @@ impl fmt::Display for MessageLifecycleSnapshotStoreError {
 
 impl std::error::Error for MessageLifecycleSnapshotStoreError {}
 
+/// Snapshot persistence contract for lifecycle state.
 pub trait MessageLifecycleSnapshotStore {
+    /// Writes the latest lifecycle snapshot.
     fn write(
         &mut self,
         snapshot: MessageLifecycleSnapshot,
     ) -> Result<(), MessageLifecycleSnapshotStoreError>;
+    /// Reads the latest lifecycle snapshot, if present.
     fn read_latest(
         &self,
     ) -> Result<Option<MessageLifecycleSnapshot>, MessageLifecycleSnapshotStoreError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// In-memory snapshot store used by tests and lightweight workflows.
 pub struct InMemoryMessageLifecycleSnapshotStore {
     latest: Option<MessageLifecycleSnapshot>,
 }
@@ -578,17 +654,22 @@ impl MessageLifecycleSnapshotStore for InMemoryMessageLifecycleSnapshotStore {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// File-backed snapshot store for lifecycle state recovery.
 pub struct FileMessageLifecycleSnapshotStore {
     path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Recovery result returned when loading/repairing file-backed snapshots.
 pub struct MessageLifecycleRecoveryResult {
+    /// Latest valid snapshot if one exists.
     pub latest: Option<MessageLifecycleSnapshot>,
+    /// Whether recovery repaired a malformed on-disk payload.
     pub repaired: bool,
 }
 
 impl FileMessageLifecycleSnapshotStore {
+    /// Creates a file-backed snapshot store at `path`.
     pub fn new(path: PathBuf) -> Result<Self, MessageLifecycleSnapshotStoreError> {
         if path.as_os_str().is_empty() {
             return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
@@ -598,6 +679,7 @@ impl FileMessageLifecycleSnapshotStore {
         Ok(Self { path })
     }
 
+    /// Loads the latest snapshot and repairs malformed payloads by truncating the file.
     pub fn recover_latest_and_repair(
         &mut self,
     ) -> Result<MessageLifecycleRecoveryResult, MessageLifecycleSnapshotStoreError> {

--- a/crates/kamn-core/tests/missing_docs_policy.rs
+++ b/crates/kamn-core/tests/missing_docs_policy.rs
@@ -997,6 +997,23 @@ fn graduated_wave_fifty_five_zk_message_proofs_module_must_not_return_to_allowli
 }
 
 #[test]
+fn graduated_wave_fifty_six_message_lifecycle_module_must_not_return_to_allowlist() {
+    // Regression: #2085
+    let actual = allowlisted_modules_from_core_lib(CORE_LIB);
+    let expected = allowlisted_modules_from_fixture(ALLOWLIST_FIXTURE);
+    let module = "message_lifecycle";
+
+    assert!(
+        !actual.iter().any(|candidate| candidate == module),
+        "{module} must stay graduated from #[allow(missing_docs)]"
+    );
+    assert!(
+        !expected.iter().any(|candidate| candidate == module),
+        "allowlist fixture must keep {module} removed"
+    );
+}
+
+#[test]
 fn graduated_modules_fixture_must_not_overlap_missing_docs_allowlist() {
     // Regression: #1723
     let actual = allowlisted_modules_from_core_lib(CORE_LIB);

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -188,6 +188,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `kolme_runtime_commit`
   - `message_delivery_guards`
   - `message_envelope`
+  - `message_lifecycle`
   - `migrations`
   - `namespaces`
   - `observability`
@@ -271,6 +272,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `Regression: #2079`
   - `Regression: #2081`
   - `Regression: #2083`
+  - `Regression: #2085`
 
 ## Contributor Entrypoint Matrix
 

--- a/fixtures/ci/kamn_core_missing_docs_allowlist.txt
+++ b/fixtures/ci/kamn_core_missing_docs_allowlist.txt
@@ -1,2 +1,1 @@
-message_lifecycle
 runtime

--- a/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
+++ b/fixtures/ci/kamn_core_missing_docs_graduated_modules.txt
@@ -58,3 +58,4 @@ agent_upgrade_workflow
 signer_backend
 task_operations
 zk_message_proofs
+message_lifecycle


### PR DESCRIPTION
## Summary
Graduates `message_lifecycle` from the `kamn-core` missing-docs allowlist and locks the graduation with regression fixtures/tests. This leaves only `runtime` in the allowlist.

## Changes
- `crates/kamn-core/src/message_lifecycle.rs`: added rustdoc across public API (status model, snapshots, store methods, errors, and snapshot-store contracts).
- `crates/kamn-core/src/lib.rs`: removed `#[allow(missing_docs)]` for `message_lifecycle` and documented module export.
- `fixtures/ci/kamn_core_missing_docs_allowlist.txt`: removed `message_lifecycle`.
- `fixtures/ci/kamn_core_missing_docs_graduated_modules.txt`: added `message_lifecycle`.
- `crates/kamn-core/tests/missing_docs_policy.rs`: added regression guard `graduated_wave_fifty_six_message_lifecycle_module_must_not_return_to_allowlist` (`Regression: #2085`).
- `docs/architecture/kamn-core-module-map.md`: recorded module graduation and regression marker for `#2085`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
- Evidence captured on issue comment: https://github.com/njfio/kamn/issues/2085#issuecomment-3889656170
- Result: expected failure with `78` missing-doc errors after removing the `message_lifecycle` allow.

### 🟢 Green Phase
- Commands:
  - `cargo fmt --check`
  - `RUSTFLAGS='-D warnings' cargo check -p kamn-core`
  - `cargo test -p kamn-core message_lifecycle`
  - `cargo test -p kamn-core --test missing_docs_policy`
  - `cargo test -p kamn-core --test engineering_hardening_wave_docs`
  - `cargo clippy --manifest-path crates/kamn-core/Cargo.toml --all-targets -- -D warnings`
  - `cargo clippy --workspace --all-targets -- -D warnings`
- Result: all pass.

### 🔁 Regression
- Command: `cargo test`
- Result: full workspace regression pass (including `kamn-core`, `kamn-kolme`, `kamn-node`, and `kamn-sdk` lanes).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing `message_lifecycle` unit tests and targeted run under Green | |
| Functional   | ✅ | Existing `message_lifecycle` functional tests and targeted run under Green | |
| Integration  | ✅ | Existing `message_lifecycle` integration tests and full `cargo test` regression run | |
| Regression   | ✅ | Added `graduated_wave_fifty_six_message_lifecycle_module_must_not_return_to_allowlist` | |
| Performance  | N/A | | Docs/allowlist graduation change; no runtime-path behavior changed |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to re-add allowlist status for `message_lifecycle` and remove the new regression marker.

## Documentation Updates
- `docs/architecture/kamn-core-module-map.md`
- Rustdoc updates in `crates/kamn-core/src/message_lifecycle.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2085
