### PR TITLE
fix(ci): clear duplicate-content pending for symlink wrappers (#2090)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -31,7 +31,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
 - `script_count`
 - `shell_line_total`
 - `duplicate_basename`
-- `duplicate_content`
+- `duplicate_content` (regular files only; symlink wrappers are excluded)
 
 The checker also computes per-PR deltas against `.ci/script-surface-baseline.env` and emits:
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -321,6 +321,7 @@ Regression policy:
 - nonce/broadcast parity matrix selector/docs/runtime-budget drift remains fail-closed (`Regression: #1462`).
 - fast-gate native Kolme API parity lane schema/routing/runtime-budget drift remains fail-closed (`Regression: #1466`).
 - script-surface budget temporary `script_count` waiver scope/expiry drift remains fail-closed (`Regression: #1497`).
+- script-surface duplicate-content policy excludes symlink dispatch wrappers and remains fail-closed for duplicated regular files (`Regression: #2090`).
 - Kolme command-surface missing-both coverage drift remains fail-closed (`Regression: #1561`).
 - Kolme command-surface asymmetry split drift remains fail-closed (`Regression: #1565`).
 - Kolme command-surface asymmetry policy-file schema drift remains fail-closed (`Regression: #1569`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -39,6 +39,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `scripts/kolme/run_contract_lane_dispatch.sh`
 - Compatibility wrapper shape:
   - all manifest-only `scripts/kolme/run_*contract_lane.sh` wrappers are symlinks to the shared dispatcher.
+- Script-surface duplicate-content policy alignment:
+  - symlinked dispatcher wrappers are excluded from `duplicate_content` budget checks; duplicate-content enforcement remains fail-closed for regular files.
 - Dispatcher matrix guard:
   - `bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`
 - CI contract surface:
@@ -47,6 +49,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `scripts/ci/test_ci_tools.sh`
 - Regression marker:
   - `Regression: #1827`
+  - `Regression: #2090`
 
 ## Shared Manifest-Migration CI Dispatcher (Issue #1833)
 

--- a/scripts/ci/check_script_duplication_budget.py
+++ b/scripts/ci/check_script_duplication_budget.py
@@ -117,8 +117,12 @@ def compute_metrics(scripts_root: Path) -> ScriptMetrics:
         count for count in basename_counts.values() if count > 1
     )
 
+    # Treat symlink wrappers as intentional command-surface entries and only
+    # enforce duplicate-content policy across regular files.
     content_counts = Counter(
-        hashlib.sha256(path.read_bytes()).hexdigest() for path in scripts
+        hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in scripts
+        if not path.is_symlink()
     )
     duplicate_content = sum(
         count for count in content_counts.values() if count > 1

--- a/scripts/ci/test_check_script_duplication_budget.sh
+++ b/scripts/ci/test_check_script_duplication_budget.sh
@@ -12,7 +12,7 @@ if [ ! -x "$SCRIPT" ]; then
 fi
 
 SCRIPTS_ROOT="$TMP_DIR/scripts"
-mkdir -p "$SCRIPTS_ROOT/a" "$SCRIPTS_ROOT/b"
+mkdir -p "$SCRIPTS_ROOT/a" "$SCRIPTS_ROOT/b" "$SCRIPTS_ROOT/c" "$SCRIPTS_ROOT/d"
 cat >"$SCRIPTS_ROOT/a/run_alpha.sh" <<'EOF_SCRIPT'
 #!/usr/bin/env bash
 echo "alpha"
@@ -21,6 +21,7 @@ cat >"$SCRIPTS_ROOT/b/run_beta.sh" <<'EOF_SCRIPT'
 #!/usr/bin/env bash
 echo "beta"
 EOF_SCRIPT
+ln -s ../a/run_alpha.sh "$SCRIPTS_ROOT/c/run_alpha_dispatch.sh"
 
 PASS_BUDGET="$TMP_DIR/pass-budget.env"
 cat >"$PASS_BUDGET" <<'EOF_BUDGET'
@@ -53,8 +54,12 @@ if ! printf '%s\n' "$pass_output" | grep -q '^violations=none$'; then
   echo "expected no violations on pass path" >&2
   exit 1
 fi
-if ! printf '%s\n' "$pass_output" | grep -q '^delta_script_count=1$'; then
+if ! printf '%s\n' "$pass_output" | grep -q '^delta_script_count=2$'; then
   echo "expected deterministic script_count delta output on pass path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$pass_output" | grep -q '^duplicate_content=0$'; then
+  echo "expected symlink wrappers to be excluded from duplicate_content metric" >&2
   exit 1
 fi
 if ! printf '%s\n' "$pass_output" | grep -q '^remediation=none$'; then
@@ -169,6 +174,39 @@ if [ "$expired_waiver_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$expired_waiver_output" | grep -q 'waiver_error=waiver has expired'; then
   echo "expected explicit expired waiver error output" >&2
+  exit 1
+fi
+
+cat >"$SCRIPTS_ROOT/d/run_alpha_copy.sh" <<'EOF_SCRIPT'
+#!/usr/bin/env bash
+echo "alpha"
+EOF_SCRIPT
+
+DUPLICATE_CONTENT_BUDGET="$TMP_DIR/duplicate-content-budget.env"
+cat >"$DUPLICATE_CONTENT_BUDGET" <<'EOF_BUDGET'
+SCRIPT_COUNT_MAX=20
+SHELL_LINE_TOTAL_MAX=200
+DUPLICATE_BASENAME_MAX=0
+DUPLICATE_CONTENT_MAX=0
+EOF_BUDGET
+
+set +e
+duplicate_content_output="$(
+  bash "$SCRIPT" \
+    --scripts-root "$SCRIPTS_ROOT" \
+    --budget-file "$DUPLICATE_CONTENT_BUDGET" \
+    --baseline-file "$BASELINE_FILE" \
+    --waiver-file "$TMP_DIR/missing-waiver.json" 2>&1
+)"
+duplicate_content_code=$?
+set -e
+
+if [ "$duplicate_content_code" -eq 0 ]; then
+  echo "expected checker to fail when regular files duplicate content" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$duplicate_content_output" | grep -q 'violations=duplicate_content'; then
+  echo "expected duplicate_content violation marker for regular-file duplicate" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Clears `pending=duplicate_content` in script-surface budget policy by excluding symlink dispatch wrappers from duplicate-content hashing while keeping fail-closed behavior for duplicated regular shell files. This unblocks the next waiver-retirement task without weakening command-surface safeguards.

## Changes
- `scripts/ci/check_script_duplication_budget.py`: `duplicate_content` metric now hashes regular files only (`*.sh` symlinks still counted for `script_count`/`shell_line_total`).
- `scripts/ci/test_check_script_duplication_budget.sh`: added regression coverage for symlink-wrapper exclusion and explicit regular-file duplicate-content failure path.
- `docs/ci/ci-cost-and-lane-framework.md`: documented duplicate-content metric scope.
- `docs/ci/strategy.md`: added regression marker for symlink-wrapper duplicate-content policy.
- `docs/planning/kolme-devnet-ops.md`: documented policy alignment for symlinked contract-lane wrappers (`Regression: #2090`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `python3 scripts/ci/check_script_duplication_budget.py --scripts-root scripts --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file .ci/script-surface-budget-waiver.json --output-json /tmp/script-surface-report-2090-red.json`
- Evidence captured on issue comment: https://github.com/njfio/kamn/issues/2090#issuecomment-3889736982
- Result: `status=fail`, `duplicate_content=26`, `pending=duplicate_content`.

### 🟢 Green Phase
- Commands:
  - `python3 scripts/ci/check_script_duplication_budget.py --scripts-root scripts --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file .ci/script-surface-budget-waiver.json --output-json /tmp/script-surface-report-2090-green.json`
  - `bash scripts/ci/test_check_script_duplication_budget.sh`
  - `bash scripts/ci/test_ci_tools.sh`
  - `cargo test -p kamn-core --test ci_strategy_docs`
  - `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- Result: all pass; budget checker now reports `duplicate_content=0`, `pending=none`, `status=pass` (with existing script-count/shell-line waiver still active).

### 🔁 Regression
- Command: `bash scripts/ci/test_ci_tools.sh`
- Result: full CI tool regression suite passes, including Kolme manifest migration and docs policy contract lanes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Added checker assertions in `test_check_script_duplication_budget.sh` for symlink exclusion + regular-file duplicate failure | |
| Functional   | ✅ | Verified budget checker pass path with real repo metrics (`pending=none`) | |
| Integration  | ✅ | `test_ci_tools.sh` and targeted docs contract tests (`ci_strategy_docs`, `kolme_devnet_ops_docs`) | |
| Regression   | ✅ | Added policy/docs regression markers and checker contract coverage (`Regression: #2090`) | |
| Performance  | ✅ | Validation kept local; no PR fast-gate expansion or heavy lane enablement | |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore previous duplicate-content hashing behavior and docs/test updates.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A; no Rust formatting changes required)
- [x] `cargo clippy -- -D warnings` — clean (N/A; no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2090
