### PR TITLE
fix(kolme): enforce live-provider runtime evidence policy contracts (#2095)

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -151,4 +151,5 @@ fn regression_requires_make_and_selector_demo_contract_marker() {
     assert!(DOC.contains("Regression: #1466"));
     assert!(DOC.contains("Regression: #1497"));
     assert!(DOC.contains("Regression: #2093"));
+    assert!(DOC.contains("Regression: #2095"));
 }

--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -583,6 +583,9 @@ fn regression_requires_local_runtime_commit_live_guard_marker() {
     assert!(PLAN.contains(
         "local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`)."
     ));
+    assert!(PLAN.contains(
+        "local runtime-commit live proof lane evidence policy remains fail-closed for missing live-provider command marker contracts (`Regression: #2095`)."
+    ));
 }
 
 #[test]

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -39,6 +39,7 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains(
         "cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact"
     ));
+    assert!(DOC.contains("check_local_runtime_commit_live_evidence_policy.py"));
     assert!(DOC.contains("scripts/kolme/run_runtime_commit_contract_lane.sh"));
     assert!(DOC.contains("run_local_kamn_live_runtime_integration_lane.sh --mode run"));
     assert!(DOC.contains("--runtime-commit-finality-command"));
@@ -58,6 +59,7 @@ fn regression_requires_adapter_provider_mismatch_and_non_final_fail_closed_marke
     assert!(DOC.contains("`Regression: #1503`"));
     assert!(DOC.contains("`Regression: #1506`"));
     assert!(DOC.contains("`Regression: #1533`"));
+    assert!(DOC.contains("`Regression: #2095`"));
     assert!(DOC.contains("`Regression: #1775`"));
     assert!(DOC.contains("`Regression: #1777`"));
     assert!(DOC.contains("`Regression: #1779`"));

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -315,6 +315,7 @@ Regression policy:
 - local fork process lifecycle integration run-mode exclusion parity remains fail-closed (`Regression: #1494`).
 - local runtime-commit live run-mode exclusion parity remains fail-closed (`Regression: #1451`).
 - local runtime-commit live preflight health-probe and default live-provider ignored-test dispatch parity remains fail-closed (`Regression: #1829`).
+- local runtime-commit live evidence policy marker parity remains fail-closed for missing `KolmeRuntimeCommitLiveProvider` command markers (`Regression: #2095`).
 - local native API parity live-proof run-mode exclusion parity remains fail-closed (`Regression: #1467`).
 - native parity fast/local command matrix docs parity remains fail-closed (`Regression: #1468`).
 - local probe fork-info chain_version query and native parity broadcast method drift remains fail-closed (`Regression: #1482`).

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -187,6 +187,7 @@ cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_ht
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact
 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode dry-run --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt
+python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/kolme-local-runtime-commit-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-runtime-commit-live-policy.json
 KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt
 bash scripts/kolme/run_runtime_commit_contract_lane.sh
 ```
@@ -223,6 +224,7 @@ cargo test -p kamn-core
 - direct signed transaction payload normalization drift remains fail-closed (`Regression: #1516`).
 - direct signed transaction required-field validation drift remains fail-closed (`Regression: #1519`).
 - local live-node provider smoke preflight and ignored-test dispatch remain fail-closed (`Regression: #1829`).
+- local runtime-commit live evidence policy markers for `KolmeRuntimeCommitLiveProvider` path remain fail-closed (`Regression: #2095`).
 - typed nonce/broadcast HTTP helper mapping drift remains fail-closed (`Regression: #1533`).
 - provider response field parser extraction parity drift remains fail-closed (`Regression: #1745`).
 - flat JSON parser extraction parity drift remains fail-closed (`Regression: #1747`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -627,6 +627,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt`
 - Optional post-submit finality follow-up execution:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --skip-preflight --live-command "printf 'status=submitted\\n'" --finality-command "printf 'finality=final\\n'" --finality-max-seconds 15 --max-seconds 90 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt --finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt`
+- Evidence policy checker command:
+  - `python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/kolme-local-runtime-commit-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-runtime-commit-live-policy.json`
 - Default live-provider smoke command executed by run mode:
   - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
 - Summary schema:
@@ -812,6 +814,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - real-fork local process wrapper policy checker lane remains fail-closed for schema/contracts/checkpoint drift (`Regression: #1671`).
 - local runtime-commit live proof lane fails closed without local opt-in and for command timeout/failure paths (`Regression: #1450`).
 - local runtime-commit live proof lane preflight health probe and default live-provider ignored-test dispatch remain fail-closed (`Regression: #1829`).
+- local runtime-commit live proof lane evidence policy remains fail-closed for missing live-provider command marker contracts (`Regression: #2095`).
 - local native API parity live proof lane fails closed without local opt-in and on nonce/broadcast/finality timeout or command failures (`Regression: #1465`).
 - native parity fast/local command matrix docs drift remains fail-closed (`Regression: #1468`).
 - local probe fork-info query semantics and native parity broadcast method drift remain fail-closed (`Regression: #1482`).

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -194,6 +194,7 @@ required_snippets=(
   "Regression: #1466"
   "Regression: #1497"
   "Regression: #2093"
+  "Regression: #2095"
   "Regression: #1561"
   "Regression: #1565"
   "Regression: #1569"

--- a/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
+++ b/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate local runtime-commit live lane evidence policy."
+    )
+    parser.add_argument("--report-file", required=True)
+    parser.add_argument("--expected-final-decision", required=True, choices=["GO", "NO-GO"])
+    parser.add_argument("--ci-fast-gate", required=True, choices=["PASS", "FAIL"])
+    parser.add_argument("--require-reason-code", action="append", default=[])
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, list[str]]:
+    reason_codes: list[str] = []
+
+    if report.get("schema_version") != "kamn.kolme.local-runtime-commit-live-summary.v1":
+        reason_codes.append("schema_version_mismatch")
+
+    mode = report.get("mode")
+    if mode not in ("dry-run", "run"):
+        reason_codes.append("mode_invalid")
+
+    status = report.get("status")
+    if status not in ("ok", "fail"):
+        reason_codes.append("status_invalid")
+
+    reason_code = report.get("reason_code")
+    if not isinstance(reason_code, str) or not reason_code.strip():
+        reason_codes.append("reason_code_missing")
+
+    if report.get("local_only_enforced") is not True:
+        reason_codes.append("local_only_enforced_missing")
+
+    if report.get("provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+        reason_codes.append("provider_client_contract_mismatch")
+
+    if report.get("provider_submit_profile_contract") != "kolme_fork_broadcast_profile":
+        reason_codes.append("provider_submit_profile_contract_mismatch")
+
+    if (
+        report.get("provider_command_marker")
+        != "integration_kolme_fork_live_node_submit_reaches_endpoint"
+    ):
+        reason_codes.append("provider_command_marker_mismatch")
+
+    provider_command_marker_present = report.get("provider_command_marker_present")
+    if not isinstance(provider_command_marker_present, bool):
+        reason_codes.append("provider_command_marker_present_invalid")
+    elif provider_command_marker_present is False:
+        reason_codes.append("provider_command_marker_missing")
+
+    checks = report.get("checks")
+    if not isinstance(checks, list) or not checks:
+        reason_codes.append("checks_missing")
+
+    budget_status = report.get("budget_status")
+    if budget_status not in ("not_run", "within_budget", "exceeded_budget"):
+        reason_codes.append("budget_status_invalid")
+
+    allowed_ok_reason_codes = {
+        "dry_run_no_commands_executed",
+        "live_runtime_commit_command_passed",
+        "live_runtime_commit_and_finality_commands_passed",
+    }
+
+    if status == "ok":
+        if reason_code not in allowed_ok_reason_codes:
+            reason_codes.append("ok_status_reason_code_invalid")
+        if mode == "dry-run" and reason_code != "dry_run_no_commands_executed":
+            reason_codes.append("dry_run_reason_code_mismatch")
+        if mode == "run" and reason_code == "dry_run_no_commands_executed":
+            reason_codes.append("run_reason_code_mismatch")
+        if budget_status == "exceeded_budget":
+            reason_codes.append("ok_status_budget_exceeded")
+    elif status == "fail" and reason_code in allowed_ok_reason_codes:
+        reason_codes.append("fail_status_reason_code_mismatch")
+
+    if args.ci_fast_gate != "PASS":
+        reason_codes.append("ci_fast_gate_failed")
+
+    for required_reason_code in args.require_reason_code:
+        if reason_code != required_reason_code:
+            reason_codes.append(f"required_reason_code_missing:{required_reason_code}")
+
+    observed_final_decision = ""
+    if status == "ok":
+        observed_final_decision = "GO"
+    elif status == "fail":
+        observed_final_decision = "NO-GO"
+
+    if observed_final_decision and observed_final_decision != args.expected_final_decision:
+        reason_codes.append("observed_final_decision_mismatch")
+
+    final_decision = "GO" if not reason_codes else "NO-GO"
+    return final_decision, reason_codes
+
+
+def main() -> int:
+    args = parse_args()
+    report_path = Path(args.report_file).resolve()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    observed_status = report.get("status")
+    observed_final_decision = ""
+    if observed_status == "ok":
+        observed_final_decision = "GO"
+    elif observed_status == "fail":
+        observed_final_decision = "NO-GO"
+
+    final_decision, reason_codes = evaluate(report, args)
+    output = {
+        "schema_version": "kamn.kolme.local-runtime-commit-live-policy-report.v1",
+        "report_file": str(report_path),
+        "expected_final_decision": args.expected_final_decision,
+        "ci_fast_gate": args.ci_fast_gate,
+        "required_reason_codes": args.require_reason_code,
+        "observed_status": observed_status,
+        "observed_final_decision": observed_final_decision,
+        "observed_reason_code": report.get("reason_code"),
+        "reason_codes": reason_codes,
+        "final_decision": final_decision,
+    }
+
+    if args.output_json:
+        output_path = Path(args.output_json).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(output, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    status = "ok" if final_decision == "GO" else "fail"
+    failed_checks = ",".join(reason_codes) if reason_codes else "none"
+    print(f"status={status}")
+    print(f"final_decision={final_decision}")
+    print(f"failed_checks={failed_checks}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+
+    return 0 if final_decision == "GO" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane.sh
@@ -202,6 +202,14 @@ if [ -z "$LIVE_COMMAND" ]; then
   LIVE_COMMAND="$(default_live_command)"
 fi
 
+PROVIDER_CLIENT_CONTRACT="KolmeRuntimeCommitLiveProvider"
+PROVIDER_SUBMIT_PROFILE_CONTRACT="kolme_fork_broadcast_profile"
+PROVIDER_COMMAND_MARKER="integration_kolme_fork_live_node_submit_reaches_endpoint"
+PROVIDER_COMMAND_MARKER_PRESENT="false"
+if [[ "$LIVE_COMMAND" == *"$PROVIDER_COMMAND_MARKER"* ]]; then
+  PROVIDER_COMMAND_MARKER_PRESENT="true"
+fi
+
 preflight_command="curl --silent --show-error --fail --max-time ${PREFLIGHT_MAX_SECONDS} ${BASE_URL%/}/healthz"
 
 CHECK_FILE="$(mktemp)"
@@ -324,7 +332,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$FINALITY_COMMAND" "$FINALITY_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$FINALITY_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$FINALITY_COMMAND" "$FINALITY_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$FINALITY_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" "$PROVIDER_CLIENT_CONTRACT" "$PROVIDER_SUBMIT_PROFILE_CONTRACT" "$PROVIDER_COMMAND_MARKER" "$PROVIDER_COMMAND_MARKER_PRESENT" <<'PY'
 from __future__ import annotations
 
 import json
@@ -349,6 +357,10 @@ preflight_max_seconds = int(sys.argv[15])
 finality_max_seconds = int(sys.argv[16])
 skip_preflight = sys.argv[17] == "1"
 checks_path = pathlib.Path(sys.argv[18])
+provider_client_contract = sys.argv[19]
+provider_submit_profile_contract = sys.argv[20]
+provider_command_marker = sys.argv[21]
+provider_command_marker_present = sys.argv[22] == "true"
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -383,6 +395,10 @@ summary = {
     "finality_max_seconds": finality_max_seconds,
     "base_url": base_url,
     "provider_hint": provider_hint,
+    "provider_client_contract": provider_client_contract,
+    "provider_submit_profile_contract": provider_submit_profile_contract,
+    "provider_command_marker": provider_command_marker,
+    "provider_command_marker_present": provider_command_marker_present,
     "preflight_enabled": not skip_preflight,
     "preflight_max_seconds": preflight_max_seconds,
     "checks": checks,

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -3,13 +3,16 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUNNER="$ROOT_DIR/scripts/kolme/run_local_runtime_commit_live_lane.sh"
+CHECKER="$ROOT_DIR/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py"
 LOCAL_HEAVY_GUARD="$ROOT_DIR/scripts/framework/assert_local_heavy_opt_in.sh"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 TMP_REPORT="$(mktemp)"
 TMP_OUTPUT="$(mktemp)"
 TMP_FINALITY_OUTPUT="$(mktemp)"
+TMP_POLICY_REPORT="$(mktemp)"
+TMP_POLICY_ERR="$(mktemp)"
 TMP_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_ERR"' EXIT
 
 extract_value() {
   local output="$1"
@@ -34,6 +37,11 @@ fi
 
 if [ ! -x "$LOCAL_HEAVY_GUARD" ]; then
   echo "expected shared local-heavy opt-in guard helper to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected local runtime commit live evidence policy checker to be executable" >&2
   exit 1
 fi
 
@@ -84,6 +92,14 @@ if report.get("mode") != "dry-run":
     raise SystemExit("expected dry-run mode")
 if report.get("local_only_enforced") is not True:
     raise SystemExit("expected local_only_enforced=true")
+if report.get("provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+    raise SystemExit("expected provider client contract marker")
+if report.get("provider_submit_profile_contract") != "kolme_fork_broadcast_profile":
+    raise SystemExit("expected provider submit profile contract marker")
+if report.get("provider_command_marker") != "integration_kolme_fork_live_node_submit_reaches_endpoint":
+    raise SystemExit("expected live provider command marker")
+if report.get("provider_command_marker_present") is not True:
+    raise SystemExit("expected default dry-run command to include live provider marker")
 checks = report.get("checks")
 if not isinstance(checks, list) or not checks:
     raise SystemExit("expected deterministic checks in summary")
@@ -98,6 +114,15 @@ if not any(
 ):
     raise SystemExit("expected planned runtime commit live finality check")
 PY
+
+checker_output="$(
+  python3 "$CHECKER" \
+    --report-file "$TMP_REPORT" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY_REPORT"
+)"
+assert_eq "$(extract_value "$checker_output" "status")" "ok" "expected live evidence policy checker to pass dry-run report"
 
 set +e
 KAMN_KOLME_LOCAL_HEAVY=1 \
@@ -231,6 +256,23 @@ fi
 
 if ! grep -q "reason_code=live_runtime_commit_command_timeout" "$TMP_ERR"; then
   echo "expected timeout reason marker" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS >"$TMP_POLICY_ERR" 2>&1
+policy_failure_code=$?
+set -e
+
+if [ "$policy_failure_code" -eq 0 ]; then
+  echo "expected evidence policy checker to fail when live provider command marker is absent" >&2
+  exit 1
+fi
+if ! grep -q "provider_command_marker_missing" "$TMP_POLICY_ERR"; then
+  echo "expected provider marker failure reason from evidence policy checker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Added deterministic live-provider evidence markers to the local runtime-commit live lane and enforced them through a new fail-closed evidence policy checker.
This closes a key proof gap for #2089 by making `KolmeRuntimeCommitLiveProvider` path evidence machine-verifiable in local integration artifacts without adding PR fast-gate live-node cost.

Closes #2095
Refs #2089

## Changes
- `scripts/kolme/run_local_runtime_commit_live_lane.sh`: emit provider evidence fields in summary (`provider_client_contract`, submit-profile marker, command marker + presence).
- `scripts/kolme/check_local_runtime_commit_live_evidence_policy.py`: new fail-closed policy checker for runtime live evidence artifacts.
- `scripts/kolme/test_run_local_runtime_commit_live_lane.sh`: Red/Green coverage for checker pass/fail and marker enforcement.
- `docs/foundation/kolme-runtime-commit-client.md`, `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`: documented policy command and regression marker `Regression: #2095`.
- `scripts/ci/test_ci_strategy_contract.sh`, `crates/kamn-core/tests/ci_strategy_docs.rs`, `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`, `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`: updated contract/doc tests for new marker coverage.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
```
Output:
```text
expected local runtime commit live evidence policy checker to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo test -p kamn-core --test kolme_devnet_ops_docs
bash scripts/ci/test_ci_strategy_contract.sh
cargo test -p kamn-core --test ci_strategy_docs
```
All passed locally.

### 🔁 Regression
Commands:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
All passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/kolme/check_local_runtime_commit_live_evidence_policy.py` fail-closed validations exercised by `test_run_local_runtime_commit_live_lane.sh` | |
| Functional   | ✅     | `scripts/kolme/test_run_local_runtime_commit_live_lane.sh` dry-run GO + marker-missing NO-GO policy paths | |
| Integration  | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`, `cargo test -p kamn-core --test kolme_devnet_ops_docs`, `bash scripts/ci/test_ci_strategy_contract.sh`, `cargo test -p kamn-core --test ci_strategy_docs` | |
| Regression   | ✅     | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` with new `Regression: #2095` coverage | |
| Performance  | N/A    | No live-node workload added to PR fast-gate; local live execution remains opt-in | CI fast-mode cost posture unchanged |

## Risks & Rollback
- None expected; this is a fail-closed evidence-policy hardening change.
- Rollback: revert this PR to restore previous evidence-summary schema and policy behavior.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (run as `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
