### PR TITLE
feat(kolme): add fail-closed local-only fast-gate markers for live validation (#2113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --repo
 # bounded contract lane (spawns local mock API server + pinned checkout fixture)
 bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json
 # schema: kamn.kolme.local-kamn-live-runtime-integration-summary.v1
+# local-only CI boundary marker: ci_fast_gate_eligible=false (contracts.ci_fast_gate_scope=local-only)
 ```
 
 ### Run Local Kolme Fork Process Lifecycle Integration Lane

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -198,6 +198,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   - local KAMN live runtime integration run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds 210 --bootstrap-max-seconds 90 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
     - nested runtime step composes through `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` and captures runtime policy artifacts.
+    - integration summary must emit `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
     - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
   - local fork process lifecycle integration run-mode commands remain excluded from ci-fast-gate.
@@ -320,6 +321,7 @@ Regression policy:
 - local KAMN live runtime integration run-mode exclusion parity remains fail-closed (`Regression: #1489`).
 - local KAMN live runtime integration runtime-step contract-lane composition and runtime policy artifact parity remain fail-closed (`Regression: #2101`).
 - local KAMN live runtime integration runtime provider contract pass-through and nested runtime policy parity remain fail-closed (`Regression: #2112`).
+- local KAMN live runtime integration local-only fast-gate exclusion summary markers remain fail-closed (`Regression: #2113`).
 - local fork process lifecycle integration run-mode exclusion parity remains fail-closed (`Regression: #1494`).
 - local fork process lifecycle integration runtime policy report linkage to nested integration command composition and artifact lineage remains fail-closed (`Regression: #2104`).
 - local fork process lifecycle rollback/recovery evidence linkage markers remain fail-closed in summary/policy/docs contracts (`Regression: #2107`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -409,8 +409,9 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `run_localhost_signed_integration_contract_lane.sh` run-mode validation of signed message admission/replay guards before Kolme runtime commit execution.
   - `run_local_kolme_live_api_conformance_harness.sh` run-mode validation for health/query/nonce/broadcast command contracts.
   - `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` is composed as the default runtime-commit endpoint step (no raw curl fallback by default).
-- optional runtime finality pass-through (`--runtime-commit-finality-command`, `--runtime-commit-finality-max-seconds`, `--runtime-commit-finality-output-file`) and `--runtime-commit-live-policy-report` are wired through to nested runtime finality evidence contract composition.
-- runtime provider contract marker (`--runtime-provider-client-contract`) remains explicit and fail-closed for `KolmeRuntimeCommitLiveProvider`.
+  - optional runtime finality pass-through (`--runtime-commit-finality-command`, `--runtime-commit-finality-max-seconds`, `--runtime-commit-finality-output-file`) and `--runtime-commit-live-policy-report` are wired through to nested runtime finality evidence contract composition.
+  - runtime provider contract marker (`--runtime-provider-client-contract`) remains explicit and fail-closed for `KolmeRuntimeCommitLiveProvider`.
+  - integration summary emits `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` for explicit PR-fast-gate exclusion enforcement.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.
   - finality verification uses `/notifications` first with bounded `/block/{height}` fallback; no runtime commit status endpoint dependency.
@@ -806,6 +807,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local KAMN live runtime integration lane propagates runtime finality pass-through options and artifacts to nested runtime live lane command composition (`Regression: #1971`).
 - local KAMN live runtime integration lane composes runtime finality evidence contract-lane policy artifacts and remains fail-closed for missing runtime policy evidence (`Regression: #2101`).
 - local KAMN live runtime integration lane forwards explicit runtime provider contract markers into nested runtime policy checks and remains fail-closed on provider-contract drift (`Regression: #2112`).
+- local KAMN live runtime integration lane emits fail-closed local-only fast-gate exclusion markers (`ci_fast_gate_eligible=false`, `contracts.ci_fast_gate_scope=local-only`) in summary/policy/docs contracts (`Regression: #2113`).
 - local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`).
 - unified local signed-to-Kolme demo lane fails closed for local opt-in, stage prerequisite drift, and runtime budget overruns (`Regression: #1640`).
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -39,6 +39,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if report.get("local_only_enforced") is not True:
         reason_codes.append("local_only_enforced_missing")
 
+    ci_fast_gate_eligible = report.get("ci_fast_gate_eligible")
+    if not isinstance(ci_fast_gate_eligible, bool):
+        reason_codes.append("ci_fast_gate_eligible_invalid")
+    elif ci_fast_gate_eligible is True:
+        reason_codes.append("ci_fast_gate_eligibility_violation")
+
     elapsed_seconds = report.get("elapsed_seconds")
     if not isinstance(elapsed_seconds, int) or elapsed_seconds < 0:
         reason_codes.append("elapsed_seconds_invalid")
@@ -77,6 +83,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(contracts, dict):
         reason_codes.append("contracts_missing")
     else:
+        if contracts.get("ci_fast_gate_scope") != "local-only":
+            reason_codes.append("ci_fast_gate_scope_mismatch")
         if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
             reason_codes.append("runtime_provider_client_contract_contract_mismatch")
         if contracts.get("runtime_commit_endpoint") != "/broadcast/runtime-commit":

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -193,6 +193,13 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+    # Regression: #2113
+    if "ci_fast_gate_eligible" not in doc_text:
+        print(
+            "expected Kolme devnet ops doc to document local-only fast-gate eligibility marker",
+            file=sys.stderr,
+        )
+        return 1
     if "run_localhost_signed_integration_contract_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference localhost signed integration prerequisite lane", file=sys.stderr)
         return 1
@@ -227,6 +234,12 @@ def main() -> int:
     if "--runtime-provider-client-contract" not in readme_text:
         print(
             "expected README to document runtime provider contract option",
+            file=sys.stderr,
+        )
+        return 1
+    if "ci_fast_gate_eligible" not in readme_text:
+        print(
+            "expected README to document local-only fast-gate eligibility marker",
             file=sys.stderr,
         )
         return 1

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -645,6 +645,7 @@ summary = {
     "status": status,
     "reason_code": reason_code,
     "local_only_enforced": True,
+    "ci_fast_gate_eligible": False,
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
     "budget_status": budget_status,
@@ -666,6 +667,7 @@ summary = {
     "runtime_commit_reason_code": runtime_commit_reason_code,
     "runtime_commit_policy_reason_code": runtime_commit_policy_reason_code,
     "contracts": {
+        "ci_fast_gate_scope": "local-only",
         "runtime_provider_client_contract": runtime_provider_client_contract,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -88,6 +88,7 @@ required_coverage_markers=(
   "Regression: #1971"
   "Regression: #2101"
   "Regression: #2112"
+  "Regression: #2113"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -116,6 +117,11 @@ if ! grep -q -- "--runtime-provider-client-contract" "$DOC_FILE"; then
   exit 1
 fi
 
+if ! grep -q "ci_fast_gate_eligible" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to document local-only fast-gate eligibility marker" >&2
+  exit 1
+fi
+
 if ! grep -q "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference runtime finality evidence contract lane composition in local KAMN integration lane" >&2
   exit 1
@@ -138,6 +144,11 @@ fi
 
 if ! grep -q -- "--runtime-provider-client-contract" "$README_FILE"; then
   echo "expected README to document runtime provider contract option" >&2
+  exit 1
+fi
+
+if ! grep -q "ci_fast_gate_eligible" "$README_FILE"; then
+  echo "expected README to document local-only fast-gate eligibility marker" >&2
   exit 1
 fi
 
@@ -180,6 +191,11 @@ if not isinstance(checks, list) or not any(
     raise SystemExit("expected runtime commit policy planned check marker in contract-lane summary")
 if summary.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
     raise SystemExit("expected runtime provider client contract marker in contract-lane summary")
+if summary.get("ci_fast_gate_eligible") is not False:
+    raise SystemExit("expected local-only fast-gate exclusion marker in contract-lane summary")
+contracts = summary.get("contracts", {})
+if contracts.get("ci_fast_gate_scope") != "local-only":
+    raise SystemExit("expected local-only fast-gate scope contract marker in contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("unexpected local KAMN live runtime integration contract-lane policy schema")
 if policy.get("final_decision") != "GO":


### PR DESCRIPTION
## Summary
This change hardens local live-node validation boundaries by emitting explicit fast-gate exclusion markers in the local KAMN runtime integration summary and enforcing them in policy/contracts/docs. It keeps live-node validation local-only and fail-closed without adding PR CI cost.

Closes #2113

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
  - emits `ci_fast_gate_eligible=false`
  - emits `contracts.ci_fast_gate_scope=local-only`
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`
  - fail-closed checks for local-only fast-gate markers
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`
  - contract coverage and docs-marker checks for `Regression: #2113`
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
  - asserts local-only fast-gate summary/contracts/docs markers
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`
  - document local-only fast-gate marker semantics and regression policy

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`

Failing output:
- `expected local KAMN live runtime integration contract implementation to include coverage marker: Regression: #2113`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `bash scripts/ci/test_readme_contract.sh`

Passing output markers:
- `local KAMN live runtime integration contract lane tests passed.`
- `CI strategy contract tests passed.`
- `README contract tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh`
- `bash scripts/ci/test_kolme_command_surface_coverage_contract.sh`
- `bash scripts/ci/test_kolme_command_surface_asymmetry_contract.sh`
- `bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`
- `bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `cargo test -p kamn-core --test ci_strategy_docs`

Pass summary:
- all commands above passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `check_local_kamn_live_runtime_integration_policy.py` local-only fast-gate marker checks | |
| Functional   | ✅ | `test_run_local_kamn_live_runtime_integration_contract_lane.sh` summary/contracts/docs marker validation | |
| Integration  | ✅ | process lifecycle + real-process wrapper contract lanes remain green with nested integration marker changes | |
| Regression   | ✅ | CI/readme/docs contract suites and Kolme command-surface parity suites | |
| Performance  | ✅ | no new heavy lane added to PR fast-gate; local-only boundary remains explicit | |

## Risks & Rollback
- None (marker/policy/docs hardening only).
- Rollback plan: revert this PR commit to restore prior summary/policy marker behavior.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
