### PR TITLE
docs(kolme): harden live-provider operator runbook coverage (#2114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --ou
 # local-only CI boundary marker: ci_fast_gate_eligible=false (contracts.ci_fast_gate_scope=local-only)
 ```
 
+Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`
+
 ### Run Local Kolme Fork Process Lifecycle Integration Lane
 
 ```bash

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -199,6 +199,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds 210 --bootstrap-max-seconds 90 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
     - nested runtime step composes through `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` and captures runtime policy artifacts.
     - integration summary must emit `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
+    - operator workflow reference: `Live Provider Operator Runbook (Issue #2114)` in `docs/planning/kolme-devnet-ops.md`.
     - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
   - local fork process lifecycle integration run-mode commands remain excluded from ci-fast-gate.
@@ -322,6 +323,7 @@ Regression policy:
 - local KAMN live runtime integration runtime-step contract-lane composition and runtime policy artifact parity remain fail-closed (`Regression: #2101`).
 - local KAMN live runtime integration runtime provider contract pass-through and nested runtime policy parity remain fail-closed (`Regression: #2112`).
 - local KAMN live runtime integration local-only fast-gate exclusion summary markers remain fail-closed (`Regression: #2113`).
+- live provider operator runbook command/checkpoint/troubleshooting marker parity remains fail-closed across docs and README references (`Regression: #2114`).
 - local fork process lifecycle integration run-mode exclusion parity remains fail-closed (`Regression: #1494`).
 - local fork process lifecycle integration runtime policy report linkage to nested integration command composition and artifact lineage remains fail-closed (`Regression: #2104`).
 - local fork process lifecycle rollback/recovery evidence linkage markers remain fail-closed in summary/policy/docs contracts (`Regression: #2107`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -420,6 +420,55 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - lane default budget is bounded to 210 seconds with per-stage budget caps.
   - local KAMN live runtime integration run-mode execution remains excluded from PR fast-gate workflow routing.
 
+## Live Provider Operator Runbook (Issue #2114)
+
+### Prerequisites (Local)
+
+- Local fork checkout exists at `/tmp/kolme_fork` (or a chosen path) with:
+  - `origin` remote set to `https://github.com/njfio/kolme_fork.git`
+  - symbolic `HEAD` resolving to `refs/heads/main`
+- Local API endpoint for fork node is reachable at `http://127.0.0.1:3000` and responds to:
+  - `GET /healthz`
+  - `GET /fork-info?chain_version=v0.15.2`
+- Local heavy opt-in is explicit for run mode:
+  - `export KAMN_KOLME_LOCAL_HEAVY=1`
+
+### Execution Flow
+
+1. Dry-run integration plan:
+   - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+2. Run integration lane (local-only):
+   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds 210 --bootstrap-max-seconds 90 --localhost-signed-max-seconds 45 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+3. Validate policy decision:
+   - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
+
+Operator checkpoints:
+- summary must include `ci_fast_gate_eligible=false`
+- summary contracts must include `ci_fast_gate_scope=local-only`
+- summary must include `runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider`
+
+### Rollback and Recovery Evidence
+
+- If integration run fails, execute process lifecycle lane with explicit rollback/recovery evidence paths:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
+- Confirm process lifecycle policy decision:
+  - `python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py --report-file /tmp/kolme-local-fork-process-lifecycle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-process-lifecycle-policy.json`
+- Archive artifacts for release audit:
+  - integration summary + policy
+  - process lifecycle summary + policy
+  - rollback/recovery evidence JSON files
+
+### Troubleshooting
+
+- `reason_code=local_opt_in_missing`:
+  - set `KAMN_KOLME_LOCAL_HEAVY=1` and rerun.
+- `reason_code=bootstrap_readiness_failed`:
+  - re-run bootstrap lane directly and inspect checkout/probe markers.
+- `reason_code=runtime_commit_policy_failed`:
+  - inspect `/tmp/kolme-local-runtime-commit-live-policy.json` for provider marker or evidence mismatch.
+- `ci_fast_gate_eligibility_violation` or `ci_fast_gate_scope_mismatch` from policy checker:
+  - verify summary still emits `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
+
 ## Localhost Two-Process Signed-Message Demo Contract (Issue #1612)
 
 - Makefile demo command:
@@ -808,6 +857,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - local KAMN live runtime integration lane composes runtime finality evidence contract-lane policy artifacts and remains fail-closed for missing runtime policy evidence (`Regression: #2101`).
 - local KAMN live runtime integration lane forwards explicit runtime provider contract markers into nested runtime policy checks and remains fail-closed on provider-contract drift (`Regression: #2112`).
 - local KAMN live runtime integration lane emits fail-closed local-only fast-gate exclusion markers (`ci_fast_gate_eligible=false`, `contracts.ci_fast_gate_scope=local-only`) in summary/policy/docs contracts (`Regression: #2113`).
+- live provider operator runbook command/checkpoint/troubleshooting markers remain fail-closed across devnet ops docs and README cross-reference (`Regression: #2114`).
 - local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`).
 - unified local signed-to-Kolme demo lane fails closed for local opt-in, stage prerequisite drift, and runtime budget overruns (`Regression: #1640`).
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -200,6 +200,13 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+    # Regression: #2114
+    if "Live Provider Operator Runbook (Issue #2114)" not in doc_text:
+        print(
+            "expected Kolme devnet ops doc to include live provider operator runbook section marker",
+            file=sys.stderr,
+        )
+        return 1
     if "run_localhost_signed_integration_contract_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference localhost signed integration prerequisite lane", file=sys.stderr)
         return 1
@@ -240,6 +247,12 @@ def main() -> int:
     if "ci_fast_gate_eligible" not in readme_text:
         print(
             "expected README to document local-only fast-gate eligibility marker",
+            file=sys.stderr,
+        )
+        return 1
+    if "Live Provider Operator Runbook (Issue #2114)" not in readme_text:
+        print(
+            "expected README to reference live provider operator runbook section marker",
             file=sys.stderr,
         )
         return 1

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -89,6 +89,7 @@ required_coverage_markers=(
   "Regression: #2101"
   "Regression: #2112"
   "Regression: #2113"
+  "Regression: #2114"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -122,6 +123,20 @@ if ! grep -q "ci_fast_gate_eligible" "$DOC_FILE"; then
   exit 1
 fi
 
+required_runbook_doc_markers=(
+  "Live Provider Operator Runbook (Issue #2114)"
+  "Prerequisites (Local)"
+  "Execution Flow"
+  "Rollback and Recovery Evidence"
+  "Troubleshooting"
+)
+for marker in "${required_runbook_doc_markers[@]}"; do
+  if ! grep -q "$marker" "$DOC_FILE"; then
+    echo "expected Kolme devnet ops doc to include runbook marker: $marker" >&2
+    exit 1
+  fi
+done
+
 if ! grep -q "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to reference runtime finality evidence contract lane composition in local KAMN integration lane" >&2
   exit 1
@@ -149,6 +164,11 @@ fi
 
 if ! grep -q "ci_fast_gate_eligible" "$README_FILE"; then
   echo "expected README to document local-only fast-gate eligibility marker" >&2
+  exit 1
+fi
+
+if ! grep -q "Live Provider Operator Runbook (Issue #2114)" "$README_FILE"; then
+  echo "expected README to reference live provider operator runbook section" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This PR publishes a structured live-provider operator runbook and adds fail-closed contract coverage for runbook marker drift across devnet ops docs and README references. It improves operator usability while keeping CI cost boundaries unchanged.

Closes #2114

## Changes
- `docs/planning/kolme-devnet-ops.md`
  - adds `Live Provider Operator Runbook (Issue #2114)` section
  - adds `Prerequisites (Local)`, `Execution Flow`, `Rollback and Recovery Evidence`, and `Troubleshooting` subsections
  - adds regression marker `Regression: #2114`
- `README.md`
  - adds cross-reference to the new runbook section
- `docs/ci/strategy.md`
  - references runbook in local-only KAMN live runtime integration policy guidance
  - adds regression marker `Regression: #2114`
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`
  - enforces runbook marker presence in docs and README (`Regression: #2114`)
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
  - adds contract assertions for required runbook markers and README cross-reference

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`

Failing output:
- `expected Kolme devnet ops doc to include runbook marker: Live Provider Operator Runbook (Issue #2114)`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `bash scripts/ci/test_readme_contract.sh`

Passing output markers:
- `local KAMN live runtime integration contract lane tests passed.`
- `CI strategy contract tests passed.`
- `README contract tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh`
- `bash scripts/ci/test_kolme_command_surface_coverage_contract.sh`
- `bash scripts/ci/test_kolme_command_surface_asymmetry_contract.sh`
- `bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`
- `bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `cargo test -p kamn-core --test ci_strategy_docs`

Pass summary:
- all commands above passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Contract implementation checks for runbook markers in docs/README | |
| Functional   | ✅ | `test_run_local_kamn_live_runtime_integration_contract_lane.sh` runbook marker assertions | |
| Integration  | ✅ | integration/process/real-process lanes remain green with runbook marker enforcement | |
| Regression   | ✅ | CI/readme/docs contracts + Kolme command-surface contracts + docs Rust tests | |
| Performance  | ✅ | docs/contract-only hardening; no added PR-fast-gate heavy execution | |

## Risks & Rollback
- None (documentation and contract-marker enforcement only).
- Rollback plan: revert this PR commit to remove new runbook marker requirements.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
