### PR TITLE
feat(kolme): add live-node bundle contract lane parity guard (#2134)

### DIFF
--- a/.ci/kolme-command-surface-asymmetry-policy.json
+++ b/.ci/kolme-command-surface-asymmetry-policy.json
@@ -33,6 +33,7 @@
     "scripts/kolme/test_run_local_kolme_fork_self_test_contract_lane.sh",
     "scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh",
     "scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh",
+    "scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh",
     "scripts/kolme/test_run_local_signed_to_kolme_demo_contract_lane.sh",
     "scripts/kolme/test_run_runtime_commit_contract_lane.sh",
     "scripts/kolme/test_run_runtime_commit_replay_contract_lane.sh",

--- a/README.md
+++ b/README.md
@@ -556,7 +556,15 @@ bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode dry-run 
 # explicit local-only bundle execution
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json
+
+# policy checker contract
+python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json
+
+# bounded contract lane (dry-run + policy composition + docs parity checks)
+bash scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json --policy-output-json /tmp/kolme-local-live-node-validation-bundle-policy.json
 # schema: kamn.kolme.local-live-node-validation-bundle-summary.v1
+# policy schema: kamn.kolme.local-live-node-validation-bundle-policy-report.v1
+# Regression: #2134
 ```
 
 ### Run Local Kolme Fork Process Lifecycle Integration Lane

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -211,6 +211,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   - local live-node validation bundle run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
     - `python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
+    - `bash scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json --policy-output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
     - bundle policy GO decisions require `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` and complete nested evidence lineage.
   - local fork profile preflight run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh --mode run --checkout-path /tmp/kolme_fork --max-seconds 45 --output-json /tmp/kolme-local-fork-profile-preflight-summary.json`
@@ -328,6 +329,7 @@ Regression policy:
 - local KAMN live runtime integration runtime provider contract pass-through and nested runtime policy parity remain fail-closed (`Regression: #2112`).
 - local KAMN live runtime integration local-only fast-gate exclusion summary markers remain fail-closed (`Regression: #2113`).
 - live provider operator runbook command/checkpoint/troubleshooting marker parity remains fail-closed across docs and README references (`Regression: #2114`).
+- local live-node validation bundle contract lane and docs parity command surfaces remain fail-closed across devnet ops, CI strategy, and README (`Regression: #2134`).
 - local fork process lifecycle integration run-mode exclusion parity remains fail-closed (`Regression: #1494`).
 - local fork process lifecycle integration runtime policy report linkage to nested integration command composition and artifact lineage remains fail-closed (`Regression: #2104`).
 - local fork process lifecycle rollback/recovery evidence linkage markers remain fail-closed in summary/policy/docs contracts (`Regression: #2107`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -477,6 +477,8 @@ Operator checkpoints:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
 - Policy checker command:
   - `python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
+- Contract lane command:
+  - `bash scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json --policy-output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
 - Summary schema:
   - `kamn.kolme.local-live-node-validation-bundle-summary.v1`
 - Policy schema:
@@ -493,6 +495,7 @@ Operator checkpoints:
   - bundle lane run mode remains local-only and requires explicit opt-in.
   - summary must emit `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
   - run-mode execution remains excluded from PR fast-gate workflow routing.
+  - contract lane remains dry-run-only and bounded for low-cost docs/command parity enforcement (`Regression: #2134`).
 
 ## Localhost Two-Process Signed-Message Demo Contract (Issue #1612)
 
@@ -883,6 +886,7 @@ Operator checkpoints:
 - local KAMN live runtime integration lane forwards explicit runtime provider contract markers into nested runtime policy checks and remains fail-closed on provider-contract drift (`Regression: #2112`).
 - local KAMN live runtime integration lane emits fail-closed local-only fast-gate exclusion markers (`ci_fast_gate_eligible=false`, `contracts.ci_fast_gate_scope=local-only`) in summary/policy/docs contracts (`Regression: #2113`).
 - live provider operator runbook command/checkpoint/troubleshooting markers remain fail-closed across devnet ops docs and README cross-reference (`Regression: #2114`).
+- local live-node validation bundle contract lane and docs parity markers remain fail-closed across devnet ops, CI strategy, and README command surfaces (`Regression: #2134`).
 - local KAMN live runtime integration lane requires bounded localhost signed integration prerequisite execution before runtime commit submission (`Regression: #1636`).
 - unified local signed-to-Kolme demo lane fails closed for local opt-in, stage prerequisite drift, and runtime budget overruns (`Regression: #1640`).
 - local fork process lifecycle integration lane fails closed for process start/readiness/integration/teardown/budget drift and missing local opt-in (`Regression: #1494`).

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -109,6 +109,7 @@ bash "$ROOT_DIR/scripts/kolme/test_run_local_kolme_fork_bootstrap_readiness_cont
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh"
+bash "$ROOT_DIR/scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_signed_to_kolme_demo_contract_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kolme_fork_profile_preflight_lane.sh"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -39,6 +39,7 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/kolme/test_run_local_bootstrap_health_checks_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_check_local_e2e_integration_policy.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh"'
+  'bash "$ROOT_DIR/scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_run_local_e2e_integration_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_check_local_heavy_validation_matrix_policy.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_run_local_heavy_validation_matrix_contract_lane.sh"'

--- a/scripts/framework/manifests/kolme_local_live_node_validation_bundle_contract_lane.json
+++ b/scripts/framework/manifests/kolme_local_live_node_validation_bundle_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "kolme.local_live_node_validation_bundle.contract",
+  "evidence_key": "kolme_local_live_node_validation_bundle_contract_lane:v1",
+  "reason_key": "kolme_local_live_node_validation_bundle_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py"
+    ]
+  }
+}

--- a/scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py
+++ b/scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Contract lane runner for local live-node validation bundle checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+RUNNER = ROOT_DIR / "scripts/kolme/run_local_live_node_validation_bundle_lane.sh"
+CHECKER = ROOT_DIR / "scripts/kolme/check_local_live_node_validation_bundle_policy.py"
+DOC_FILE = ROOT_DIR / "docs/planning/kolme-devnet-ops.md"
+CI_DOC_FILE = ROOT_DIR / "docs/ci/strategy.md"
+README_FILE = ROOT_DIR / "README.md"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run local live-node validation bundle contract lane checks."
+    )
+    parser.add_argument(
+        "--output-json",
+        default="/tmp/kolme-local-live-node-validation-bundle-summary.json",
+        help="Bundle summary output.",
+    )
+    parser.add_argument(
+        "--policy-output-json",
+        default="/tmp/kolme-local-live-node-validation-bundle-policy.json",
+        help="Bundle policy checker report output.",
+    )
+    parser.add_argument(
+        "--max-seconds",
+        default="180",
+        help="Total runtime budget in seconds.",
+    )
+    parser.add_argument(
+        "--fork-chain-version",
+        default="v0.15.2",
+        help="Required fork-info chain_version query value.",
+    )
+    return parser
+
+
+def ensure_markers_present(text: str, markers: list[str], source_name: str) -> list[str]:
+    missing: list[str] = []
+    for marker in markers:
+        if marker not in text:
+            missing.append(f"{source_name}_missing_marker:{marker}")
+    return missing
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    if not args.max_seconds.isdigit() or int(args.max_seconds) <= 0:
+        print("max-seconds must be a positive integer", file=sys.stderr)
+        return 1
+    max_seconds = int(args.max_seconds)
+
+    if not RUNNER.is_file() or not RUNNER.stat().st_mode & 0o111:
+        print("expected local live-node validation bundle runner to be executable", file=sys.stderr)
+        return 1
+    if not CHECKER.is_file() or not CHECKER.stat().st_mode & 0o111:
+        print("expected local live-node validation bundle policy checker to be executable", file=sys.stderr)
+        return 1
+    if not DOC_FILE.is_file():
+        print("expected Kolme devnet ops documentation to exist", file=sys.stderr)
+        return 1
+    if not CI_DOC_FILE.is_file():
+        print("expected CI strategy documentation to exist", file=sys.stderr)
+        return 1
+    if not README_FILE.is_file():
+        print("expected README to exist", file=sys.stderr)
+        return 1
+
+    start_epoch = time.monotonic()
+
+    with tempfile.TemporaryDirectory(prefix="kolme-live-node-bundle-contract-") as temp_dir:
+        temp_path = Path(temp_dir)
+        checkout_path = temp_path / "kolme_fork"
+        checkout_path.mkdir(parents=True, exist_ok=True)
+
+        subprocess.run(["git", "-C", str(checkout_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(checkout_path), "checkout", "-q", "-b", "main"], check=True)
+        subprocess.run(["git", "-C", str(checkout_path), "config", "user.email", "ci@example.com"], check=True)
+        subprocess.run(["git", "-C", str(checkout_path), "config", "user.name", "CI Runner"], check=True)
+        (checkout_path / "README.md").write_text(
+            "local live-node validation bundle fixture\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "-C", str(checkout_path), "add", "README.md"], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(checkout_path),
+                "commit",
+                "-q",
+                "-m",
+                "init live-node bundle fixture",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(checkout_path),
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/njfio/kolme_fork.git",
+            ],
+            check=True,
+        )
+
+        subprocess.run(
+            [
+                "bash",
+                str(RUNNER),
+                "--mode",
+                "dry-run",
+                "--checkout-path",
+                str(checkout_path),
+                "--expected-remote-url",
+                "https://github.com/njfio/kolme_fork.git",
+                "--expected-ref",
+                "refs/heads/main",
+                "--base-url",
+                "http://127.0.0.1:3000",
+                "--fork-chain-version",
+                args.fork_chain_version,
+                "--max-seconds",
+                str(max_seconds),
+                "--output-json",
+                args.output_json,
+            ],
+            cwd=ROOT_DIR,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+        subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                args.output_json,
+                "--expected-final-decision",
+                "GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "dry_run_no_commands_executed",
+                "--output-json",
+                args.policy_output_json,
+            ],
+            cwd=ROOT_DIR,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+    summary = json.loads(Path(args.output_json).read_text(encoding="utf-8"))
+    policy = json.loads(Path(args.policy_output_json).read_text(encoding="utf-8"))
+    if summary.get("schema_version") != "kamn.kolme.local-live-node-validation-bundle-summary.v1":
+        print("unexpected local live-node validation bundle summary schema", file=sys.stderr)
+        return 1
+    if summary.get("status") != "ok":
+        print("expected local live-node validation bundle summary status ok", file=sys.stderr)
+        return 1
+    if summary.get("reason_code") != "dry_run_no_commands_executed":
+        print("expected dry-run reason code in local live-node validation bundle summary", file=sys.stderr)
+        return 1
+    if summary.get("ci_fast_gate_eligible") is not False:
+        print("expected local-only fast-gate exclusion marker in bundle summary", file=sys.stderr)
+        return 1
+    contracts = summary.get("contracts", {})
+    if not isinstance(contracts, dict):
+        print("expected bundle summary contracts object", file=sys.stderr)
+        return 1
+    if contracts.get("ci_fast_gate_scope") != "local-only":
+        print("expected local-only fast-gate scope contract marker in bundle summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+        print("expected runtime provider contract marker in bundle summary", file=sys.stderr)
+        return 1
+    if policy.get("schema_version") != "kamn.kolme.local-live-node-validation-bundle-policy-report.v1":
+        print("unexpected local live-node validation bundle policy report schema", file=sys.stderr)
+        return 1
+    if policy.get("final_decision") != "GO":
+        print("expected bundle policy final_decision GO", file=sys.stderr)
+        return 1
+
+    doc_markers = [
+        "run_local_live_node_validation_bundle_lane.sh",
+        "check_local_live_node_validation_bundle_policy.py",
+        "run_local_live_node_validation_bundle_contract_lane.sh",
+        "Regression: #2134",
+    ]
+    ci_doc_markers = [
+        "run_local_live_node_validation_bundle_lane.sh",
+        "check_local_live_node_validation_bundle_policy.py",
+        "run_local_live_node_validation_bundle_contract_lane.sh",
+        "Regression: #2134",
+    ]
+    readme_markers = [
+        "run_local_live_node_validation_bundle_lane.sh",
+        "check_local_live_node_validation_bundle_policy.py",
+        "run_local_live_node_validation_bundle_contract_lane.sh",
+        "Regression: #2134",
+    ]
+
+    missing_markers: list[str] = []
+    missing_markers.extend(
+        ensure_markers_present(
+            DOC_FILE.read_text(encoding="utf-8"), doc_markers, "docs/planning/kolme-devnet-ops.md"
+        )
+    )
+    missing_markers.extend(
+        ensure_markers_present(
+            CI_DOC_FILE.read_text(encoding="utf-8"), ci_doc_markers, "docs/ci/strategy.md"
+        )
+    )
+    missing_markers.extend(
+        ensure_markers_present(
+            README_FILE.read_text(encoding="utf-8"), readme_markers, "README.md"
+        )
+    )
+    if missing_markers:
+        print(",".join(missing_markers), file=sys.stderr)
+        return 1
+
+    elapsed_seconds = int(time.monotonic() - start_epoch)
+    if elapsed_seconds > max_seconds:
+        print(
+            f"local live-node validation bundle contract lane exceeded runtime budget: {elapsed_seconds}s",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("local live-node validation bundle contract lane tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_contract_lane_dispatch.sh
+++ b/scripts/kolme/run_contract_lane_dispatch.sh
@@ -59,6 +59,7 @@ resolve_manifest_name() {
     run_local_e2e_integration_contract_lane.sh) echo "kolme_local_e2e_integration_contract_lane.json" ;;
     run_local_heavy_validation_matrix_contract_lane.sh) echo "kolme_local_heavy_validation_matrix_contract_lane.json" ;;
     run_local_kamn_live_runtime_integration_contract_lane.sh) echo "kolme_local_kamn_live_runtime_integration_contract_lane.json" ;;
+    run_local_live_node_validation_bundle_contract_lane.sh) echo "kolme_local_live_node_validation_bundle_contract_lane.json" ;;
     run_local_kolme_fork_bootstrap_readiness_contract_lane.sh) echo "kolme_local_kolme_fork_bootstrap_readiness_contract_lane.json" ;;
     run_local_kolme_fork_checkout_bootstrap_contract_lane.sh) echo "kolme_local_kolme_fork_checkout_bootstrap_contract_lane.json" ;;
     run_local_kolme_fork_portability_preflight_contract_lane.sh) echo "kolme_local_fork_portability_preflight_contract_lane.json" ;;

--- a/scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh
+++ b/scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh
@@ -1,0 +1,1 @@
+run_contract_lane_dispatch.sh

--- a/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
+++ b/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
@@ -16,6 +16,7 @@ lane_wrappers=(
   "run_local_e2e_integration_contract_lane.sh"
   "run_local_heavy_validation_matrix_contract_lane.sh"
   "run_local_kamn_live_runtime_integration_contract_lane.sh"
+  "run_local_live_node_validation_bundle_contract_lane.sh"
   "run_local_kolme_fork_bootstrap_readiness_contract_lane.sh"
   "run_local_kolme_fork_checkout_bootstrap_contract_lane.sh"
   "run_local_kolme_fork_portability_preflight_contract_lane.sh"

--- a/scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
+++ b/scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh"
+CHECKER="$ROOT_DIR/scripts/kolme/check_local_live_node_validation_bundle_policy.py"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/kolme_local_live_node_validation_bundle_contract_lane.json"
+CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+TMP_POLICY_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local live-node validation bundle contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected local live-node validation bundle policy checker to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q "scripts/framework/run_manifest_lane.sh" "$RUNNER"; then
+  echo "expected local live-node validation bundle contract lane to dispatch through manifest wrapper" >&2
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected local live-node validation bundle contract lane manifest to exist" >&2
+  exit 1
+fi
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest_path = pathlib.Path(sys.argv[1])
+payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+contract_command = payload.get("phases", {}).get("contract")
+if contract_command != [
+    "python3",
+    "scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py",
+]:
+    raise SystemExit("expected local live-node validation bundle manifest contract command")
+PY
+
+if [ ! -f "$CONTRACT_IMPL" ]; then
+  echo "expected local live-node validation bundle contract implementation to exist" >&2
+  exit 1
+fi
+
+required_coverage_markers=(
+  "run_local_live_node_validation_bundle_lane.sh"
+  "check_local_live_node_validation_bundle_policy.py"
+  "run_local_live_node_validation_bundle_contract_lane.sh"
+  "docs/planning/kolme-devnet-ops.md"
+  "docs/ci/strategy.md"
+  "README.md"
+  "Regression: #2134"
+)
+for marker in "${required_coverage_markers[@]}"; do
+  if ! grep -q "$marker" "$CONTRACT_IMPL"; then
+    echo "expected local live-node validation bundle contract implementation to include coverage marker: $marker" >&2
+    exit 1
+  fi
+done
+
+for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
+  if ! grep -q "run_local_live_node_validation_bundle_lane.sh" "$docs_file"; then
+    echo "expected docs parity to include bundle runner marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "check_local_live_node_validation_bundle_policy.py" "$docs_file"; then
+    echo "expected docs parity to include bundle policy checker marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "run_local_live_node_validation_bundle_contract_lane.sh" "$docs_file"; then
+    echo "expected docs parity to include bundle contract lane marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2134" "$docs_file"; then
+    echo "expected docs parity to include bundle workflow regression marker in $docs_file" >&2
+    exit 1
+  fi
+done
+
+bash "$RUNNER" --output-json "$TMP_REPORT" --policy-output-json "$TMP_POLICY_REPORT" >/dev/null
+
+python3 - "$TMP_REPORT" "$TMP_POLICY_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if summary.get("schema_version") != "kamn.kolme.local-live-node-validation-bundle-summary.v1":
+    raise SystemExit("unexpected local live-node validation bundle contract-lane summary schema")
+if summary.get("status") != "ok":
+    raise SystemExit("expected local live-node validation bundle contract-lane summary status ok")
+if summary.get("reason_code") != "dry_run_no_commands_executed":
+    raise SystemExit("expected dry_run_no_commands_executed reason code in bundle contract-lane summary")
+if summary.get("ci_fast_gate_eligible") is not False:
+    raise SystemExit("expected local-only fast-gate exclusion marker in bundle contract-lane summary")
+contracts = summary.get("contracts", {})
+if contracts.get("ci_fast_gate_scope") != "local-only":
+    raise SystemExit("expected local-only fast-gate scope contract marker in bundle contract-lane summary")
+if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+    raise SystemExit("expected runtime provider contract marker in bundle contract-lane summary")
+if policy.get("schema_version") != "kamn.kolme.local-live-node-validation-bundle-policy-report.v1":
+    raise SystemExit("unexpected local live-node validation bundle contract-lane policy schema")
+if policy.get("final_decision") != "GO":
+    raise SystemExit("expected local live-node validation bundle contract-lane policy final_decision GO")
+if policy.get("reason_codes") != []:
+    raise SystemExit("expected no policy reason codes for bundle contract-lane dry-run composition")
+PY
+
+echo "local live-node validation bundle contract lane tests passed."


### PR DESCRIPTION
## Summary
Adds a manifest-dispatched contract lane for the local live-node validation bundle and enforces fail-closed docs parity across planning, CI strategy, and README command surfaces. This closes the remaining story slice for deterministic bundle workflow guardrails.

Closes #2134
Refs #2131

## Changes
- `scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh`: new dispatcher wrapper entrypoint for bundle contract lane.
- `scripts/framework/manifests/kolme_local_live_node_validation_bundle_contract_lane.json`: new manifest mapping contract phase to implementation.
- `scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py`: new contract implementation for dry-run bundle+policy composition and docs parity checks.
- `scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh`: new contract lane test harness with marker/parity assertions.
- `scripts/kolme/run_contract_lane_dispatch.sh`: adds manifest resolution mapping for new bundle contract wrapper.
- `scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`: includes new wrapper in dispatcher matrix guard.
- `scripts/ci/test_ci_tools.sh`: adds new bundle contract lane test to aggregate CI tools lane.
- `.ci/kolme-command-surface-asymmetry-policy.json`: extends approved `ci_tools_only` set with new test.
- `scripts/ci/test_ci_tools_command_surface_contract.sh`: pins new command-surface entry.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: add bundle contract lane command references and `Regression: #2134` parity markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
```
Observed failure:
```text
expected local live-node validation bundle contract lane runner to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
bash scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh
bash scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh
bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
```
Observed pass markers:
```text
local live-node validation bundle contract lane tests passed.
local live-node validation bundle lane tests passed.
local live-node validation bundle policy checker tests passed.
Kolme contract lane dispatcher wrapper matrix tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_kolme_command_surface_coverage_contract.sh
bash scripts/ci/test_kolme_command_surface_asymmetry_contract.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_readme_contract.sh
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Results:
- all commands pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Added marker-presence helper coverage through `ensure_markers_present` contract assertions and test harness marker checks | |
| Functional   | ✅     | Added bundle contract lane dry-run summary+policy GO verification in `scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh` | |
| Integration  | ✅     | Added manifest-dispatch wrapper mapping + contract lane execution composition checks | |
| Regression   | ✅     | Added docs parity + regression marker checks across devnet ops/CI strategy/README and CI command-surface guard updates | |
| Performance  | ✅     | Contract lane remains dry-run-only with bounded runtime budget and no PR fast-gate expansion | |

## Risks & Rollback
- None.
- Rollback plan: revert this PR to remove the bundle contract lane wrapper/manifest/tests and restore prior docs/command-surface state.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
