### PR TITLE
fix(ci): correct symlink accounting in Kolme wrapper baseline (#2146)

### DIFF
--- a/fixtures/kolme_compatibility/wrapper_inventory_baseline.json
+++ b/fixtures/kolme_compatibility/wrapper_inventory_baseline.json
@@ -4,97 +4,97 @@
       "lane_id": "kolme.block.fallback.reconciliation",
       "manifest_file": "scripts/framework/manifests/kolme_block_fallback_reconciliation_contract_lane.json",
       "priority": "P0",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_block_fallback_reconciliation_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.local.fork.rust_matrix",
       "manifest_file": "scripts/framework/manifests/kolme_local_fork_rust_test_matrix_contract_lane.json",
       "priority": "P1",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.local.heavy.validation_matrix",
       "manifest_file": "scripts/framework/manifests/kolme_local_heavy_validation_matrix_contract_lane.json",
       "priority": "P2",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_local_heavy_validation_matrix_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.local.kamn.live_runtime_integration",
       "manifest_file": "scripts/framework/manifests/kolme_local_kamn_live_runtime_integration_contract_lane.json",
       "priority": "P1",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.nonce.broadcast.parity",
       "manifest_file": "scripts/framework/manifests/kolme_nonce_broadcast_parity_contract_lane.json",
       "priority": "P1",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_nonce_broadcast_parity_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.notifications.consumer",
       "manifest_file": "scripts/framework/manifests/kolme_notifications_consumer_contract_lane.json",
       "priority": "P0",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_notifications_consumer_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.runtime.commit.adapter",
       "manifest_file": "scripts/framework/manifests/kolme_runtime_commit_adapter_contract_lane.json",
       "priority": "P0",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_runtime_commit_adapter_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.runtime.commit.replay",
       "manifest_file": "scripts/framework/manifests/kolme_runtime_commit_replay_contract_lane.json",
       "priority": "P0",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_runtime_commit_replay_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     },
     {
       "lane_id": "kolme.version.compatibility",
       "manifest_file": "scripts/framework/manifests/kolme_version_compatibility_contract_lane.json",
       "priority": "P1",
-      "shell_loc": 111,
+      "shell_loc": 1,
       "source_entry": "scripts/kolme/run_version_compatibility_contract_lane.sh",
       "status": "planned",
       "target_runner": "framework_manifest_lane",
-      "wrapper_kind": "regular_file"
+      "wrapper_kind": "symlink"
     }
   ],
-  "regular_file_wrapper_count": 9,
+  "regular_file_wrapper_count": 0,
   "schema_version": "kamn.kolme.wrapper-inventory-baseline.v1",
   "source_matrix_file": "fixtures/kolme_compatibility/lane_migration_matrix.json",
-  "symlink_wrapper_count": 0,
-  "total_shell_loc": 999,
+  "symlink_wrapper_count": 9,
+  "total_shell_loc": 9,
   "wrapper_count": 9
 }

--- a/scripts/ci/kolme_wrapper_inventory_baseline.py
+++ b/scripts/ci/kolme_wrapper_inventory_baseline.py
@@ -140,7 +140,7 @@ def build_inventory(*, matrix_file: Path, repo_root: Path) -> dict[str, Any]:
             label=f"lane[{index}]",
         )
 
-        wrapper_path = (repo_root / source_entry).resolve()
+        wrapper_path = repo_root / source_entry
         if not wrapper_path.exists():
             fail(f"lane wrapper path does not exist for {lane_id}: {source_entry}")
         if not wrapper_path.is_file():

--- a/scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
+++ b/scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
@@ -43,7 +43,21 @@ bash "$GENERATE_SCRIPT" \
 
 grep -q '^status=generated$' "$TMP_DIR/generate.out"
 grep -q '^wrapper_count=9$' "$TMP_DIR/generate.out"
-grep -q '^total_shell_loc=999$' "$TMP_DIR/generate.out"
+grep -q '^total_shell_loc=9$' "$TMP_DIR/generate.out"
+
+python3 - "$GENERATED_BASELINE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload["symlink_wrapper_count"] != 9:
+    raise SystemExit("expected symlink_wrapper_count to be 9")
+if payload["regular_file_wrapper_count"] != 0:
+    raise SystemExit("expected regular_file_wrapper_count to be 0")
+if payload["total_shell_loc"] != 9:
+    raise SystemExit("expected total_shell_loc to be 9")
+PY
 
 python3 - "$BASELINE_FIXTURE" "$GENERATED_BASELINE" <<'PY'
 import json


### PR DESCRIPTION
## Summary
Fixes a correctness bug in Kolme wrapper inventory accounting where symlink wrappers were resolved before classification, causing them to be counted as regular files with inflated shell LOC totals. The baseline fixture and contract expectations now reflect actual wrapper semantics.

Closes #2146

## Changes
- `scripts/ci/kolme_wrapper_inventory_baseline.py`: preserve wrapper path for `is_symlink()` and LOC accounting instead of resolving to dispatcher target first.
- `fixtures/kolme_compatibility/wrapper_inventory_baseline.json`: regenerated with corrected totals (`symlink_wrapper_count=9`, `regular_file_wrapper_count=0`, `total_shell_loc=9`).
- `scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh`: tightened assertions for symlink/regular wrapper counts and corrected shell LOC expectation.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Legacy behavior snapshot (pre-fix implementation):
```bash
python3 scripts/ci/.tmp_kolme_wrapper_inventory_baseline_old.py generate --matrix-file fixtures/kolme_compatibility/lane_migration_matrix.json --output-json /tmp/kolme-old-baseline.json
```
Output:
```text
status=generated
wrapper_count=9
total_shell_loc=999
```
This violates expected symlink accounting for the current matrix.

### 🟢 Green Phase
```bash
python3 scripts/ci/kolme_wrapper_inventory_baseline.py generate --matrix-file fixtures/kolme_compatibility/lane_migration_matrix.json --output-json /tmp/kolme-new-baseline.json
```
Output:
```text
status=generated
wrapper_count=9
total_shell_loc=9
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh` symlink/regular classification assertions | |
| Functional   | ✅ | Baseline generation contract path now checks corrected totals | |
| Integration  | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` includes baseline contract lane | |
| Regression   | ✅ | Existing command-surface + fast CI tools regression suites green | |
| Performance  | ✅ | No added commands in fast gate; same contract lane runtime envelope | |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to restore previous accounting behavior (not recommended due incorrect baseline semantics).

## Documentation Updates
- None required: command surface and documented workflow are unchanged; only accounting semantics are corrected.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
