### PR TITLE
feat(ci): add tranche-1 dispatcher execution parity contract (#2118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ python3 scripts/kolme/check_local_native_api_parity_live_proof_policy.py --repor
 
 Local-only heavy Kolme run-mode commands stay excluded from ci-fast-gate.
 
+### Kolme Tranche-1 Wrapper/Dispatcher Execution Parity
+
+```bash
+# Runs in aggregate CI-tools lane (not fast-gate) to keep PR cost bounded.
+bash scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
+```
+
+This validates that tranche-1 wrapper entrypoints and direct manifest dispatch
+produce equivalent normalized execution output.
+
 ### Fast Make Lanes
 
 ```bash

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -75,6 +75,12 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 
 - Migration guard contract:
   - `bash scripts/ci/test_kolme_tranche1_manifest_migration_contract.sh`
+- Execution parity contract (wrapper entrypoint vs direct manifest dispatch):
+  - `bash scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh`
+  - compares normalized execution output for each tranche lane between:
+    - `scripts/kolme/run_*_contract_lane.sh`
+    - `scripts/framework/run_manifest_lane.sh --manifest ... --phase contract`
+  - stays in aggregate `scripts/ci/test_ci_tools.sh` (not PR fast gate) to preserve bounded fast-gate runtime cost.
 - Migrated manifest-backed wrappers:
   - `scripts/kolme/run_snapshot_drift_contract_lane.sh`
   - `scripts/kolme/run_notifications_consumer_contract_lane.sh`
@@ -873,6 +879,7 @@ Operator checkpoints:
 - local bootstrap health summary policy and contract-lane command/report drift remain fail-closed (`Regression: #1692`).
 - lane migration matrix schema/order/required-lane drift remains fail-closed (`Regression: #1721`).
 - tranche-1 manifest migration wrapper routing and shell-LOC budget drift remains fail-closed (`Regression: #1722`).
+- tranche-1 wrapper/direct manifest execution parity drift remains fail-closed (`Regression: #2118`).
 - runtime+nonce manifest migration wrapper routing and shell-LOC budget drift remains fail-closed (`Regression: #1763`).
 - version+matrix manifest migration wrapper routing and shell-LOC budget drift remains fail-closed (`Regression: #1765`).
 - profile+self-test+portability manifest migration wrapper routing and shell-LOC budget drift remains fail-closed (`Regression: #1767`).

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -70,6 +70,7 @@ bash "$ROOT_DIR/scripts/ci/test_kolme_bootstrap_conformance_runtime_process_mani
 bash "$ROOT_DIR/scripts/ci/test_kolme_parity_demo_real_process_manifest_migration_contract.sh"
 bash "$ROOT_DIR/scripts/ci/test_kolme_manifest_migration_contract_dispatch_wrapper_matrix.sh"
 bash "$ROOT_DIR/scripts/ci/test_run_kolme_manifest_migration_contract_dispatch.sh"
+bash "$ROOT_DIR/scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh"
 bash "$ROOT_DIR/scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_flaky_registry.sh"
 bash "$ROOT_DIR/scripts/ci/test_summarize_budget_artifacts.sh"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -16,6 +16,7 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/ci/test_kolme_parity_demo_real_process_manifest_migration_contract.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_kolme_manifest_migration_contract_dispatch_wrapper_matrix.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_run_kolme_manifest_migration_contract_dispatch.sh"'
+  'bash "$ROOT_DIR/scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_check_lane_migration_matrix_policy.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh"'

--- a/scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
+++ b/scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG_FILE="$ROOT_DIR/fixtures/ci/kolme_manifest_migration_contract_groups.json"
+MANIFEST_RUNNER="$ROOT_DIR/scripts/framework/run_manifest_lane.sh"
+GROUP_KEY="tranche1"
+MAX_SECONDS_ENV="KAMN_KOLME_TRANCHE1_DISPATCH_PARITY_MAX_SECONDS"
+DEFAULT_MAX_SECONDS=240
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "expected migration group config file to exist: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST_RUNNER" ]; then
+  echo "expected manifest runner script to exist: $MANIFEST_RUNNER" >&2
+  exit 1
+fi
+
+max_seconds="${!MAX_SECONDS_ENV:-$DEFAULT_MAX_SECONDS}"
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]] || [ "$max_seconds" -le 0 ]; then
+  echo "$MAX_SECONDS_ENV must be a positive integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mapfile -t lane_specs < <(python3 - "$CONFIG_FILE" "$GROUP_KEY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+config_path = Path(sys.argv[1])
+group_key = sys.argv[2]
+payload = json.loads(config_path.read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.kolme-manifest-migration-contract-groups.v1":
+    raise SystemExit("unexpected migration group schema")
+group = payload.get("groups", {}).get(group_key)
+if not isinstance(group, dict):
+    raise SystemExit(f"missing migration group: {group_key}")
+lanes = group.get("lanes")
+if not isinstance(lanes, list) or not lanes:
+    raise SystemExit(f"migration group {group_key} lanes must be non-empty")
+for lane in lanes:
+    lane_script = lane.get("lane_script")
+    manifest_file = lane.get("manifest_file")
+    lane_id = lane.get("lane_id")
+    if not all(isinstance(field, str) and field for field in (lane_script, manifest_file, lane_id)):
+        raise SystemExit(f"invalid lane entry in group {group_key}")
+    print(f"{lane_script}|{manifest_file}|{lane_id}")
+PY
+)
+
+if [ "${#lane_specs[@]}" -eq 0 ]; then
+  echo "expected non-empty lane specs for group $GROUP_KEY" >&2
+  exit 1
+fi
+
+normalize_output() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+patterns = (
+    re.compile(r"^\s*Finished `.* target\(s\) in .*s$"),
+    re.compile(r"^\s*Running tests/.+\(target/.+\)$"),
+)
+for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    line = raw.rstrip()
+    if not line:
+        continue
+    if any(pattern.match(line) for pattern in patterns):
+        continue
+    print(line)
+PY
+}
+
+start_epoch="$(date +%s)"
+
+for spec in "${lane_specs[@]}"; do
+  IFS='|' read -r lane_script manifest_file lane_id <<<"$spec"
+
+  lane_script_path="$ROOT_DIR/$lane_script"
+  manifest_path="$ROOT_DIR/$manifest_file"
+
+  if [ ! -f "$lane_script_path" ]; then
+    echo "expected lane script file for parity check: $lane_script_path" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$manifest_path" ]; then
+    echo "expected manifest file for parity check: $manifest_path" >&2
+    exit 1
+  fi
+
+  wrapper_output="$TMP_DIR/${lane_id//./_}.wrapper.out"
+  direct_output="$TMP_DIR/${lane_id//./_}.direct.out"
+  wrapper_normalized="$TMP_DIR/${lane_id//./_}.wrapper.normalized.out"
+  direct_normalized="$TMP_DIR/${lane_id//./_}.direct.normalized.out"
+
+  if ! bash "$lane_script_path" >"$wrapper_output" 2>&1; then
+    echo "expected wrapper lane command to pass for parity check: $lane_script" >&2
+    cat "$wrapper_output" >&2 || true
+    exit 1
+  fi
+
+  if ! bash "$MANIFEST_RUNNER" --manifest "$manifest_path" --phase contract >"$direct_output" 2>&1; then
+    echo "expected direct manifest lane command to pass for parity check: $manifest_file" >&2
+    cat "$direct_output" >&2 || true
+    exit 1
+  fi
+
+  normalize_output "$wrapper_output" >"$wrapper_normalized"
+  normalize_output "$direct_output" >"$direct_normalized"
+
+  if ! grep -Fxq "lane_id=$lane_id" "$wrapper_normalized"; then
+    echo "expected wrapper output to include lane_id marker: $lane_id" >&2
+    cat "$wrapper_normalized" >&2 || true
+    exit 1
+  fi
+
+  if ! grep -Fxq "lane_id=$lane_id" "$direct_normalized"; then
+    echo "expected direct output to include lane_id marker: $lane_id" >&2
+    cat "$direct_normalized" >&2 || true
+    exit 1
+  fi
+
+  if ! grep -Fxq "status=ok" "$wrapper_normalized"; then
+    echo "expected wrapper output to include status=ok for lane: $lane_id" >&2
+    cat "$wrapper_normalized" >&2 || true
+    exit 1
+  fi
+
+  if ! grep -Fxq "status=ok" "$direct_normalized"; then
+    echo "expected direct output to include status=ok for lane: $lane_id" >&2
+    cat "$direct_normalized" >&2 || true
+    exit 1
+  fi
+
+  if ! diff -u "$wrapper_normalized" "$direct_normalized" >/dev/null; then
+    echo "expected wrapper/direct normalized outputs to match for lane: $lane_id" >&2
+    diff -u "$wrapper_normalized" "$direct_normalized" >&2 || true
+    exit 1
+  fi
+
+  elapsed_seconds=$(( $(date +%s) - start_epoch ))
+  if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+    echo "tranche-1 dispatch execution parity contract exceeded runtime budget: ${elapsed_seconds}s" >&2
+    exit 1
+  fi
+
+done
+
+echo "Kolme tranche-1 dispatch execution parity contract tests passed."


### PR DESCRIPTION
## Summary
Adds an explicit first-cohort dispatcher parity contract for Kolme tranche-1 lanes by comparing wrapper entrypoint execution output with direct manifest-dispatch execution output. The lane runs in aggregate CI-tools mode (not fast-gate) to keep PR cost bounded while adding stronger parity evidence.

Closes #2118

## Changes
- `scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh`: new tranche-1 parity contract lane.
- `scripts/ci/test_ci_tools.sh`: includes the new parity lane in aggregate (non-fast) CI-tools regression.
- `scripts/ci/test_ci_tools_command_surface_contract.sh`: requires parity lane command presence in CI-tools command surface.
- `docs/planning/kolme-devnet-ops.md`: documents tranche-1 execution parity guard + regression marker.
- `README.md`: adds migration-safe invocation guidance for tranche-1 wrapper/direct parity contract.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Initial parity lane run (before helper fixes) failed:
```bash
bash scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
```
Output:
```text
expected manifest runner to be executable: /home/n/Code/kamn/scripts/framework/run_manifest_lane.sh
```

### 🟢 Green Phase
```bash
bash scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
```
Output:
```text
Kolme tranche-1 dispatch execution parity contract tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
bash scripts/ci/test_readme_contract.sh
cargo test -p kamn-core --test kolme_devnet_ops_docs
cargo test -p kamn-core --test ci_strategy_docs
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Parity lane normalization and marker assertions in `test_kolme_tranche1_dispatch_execution_parity_contract.sh` | |
| Functional   | ✅ | Wrapper vs direct manifest execution parity for tranche-1 lanes | |
| Integration  | ✅ | Aggregate CI-tools lane includes new parity contract (non-fast mode) | |
| Regression   | ✅ | Command-surface/docs contracts + fast CI-tools regression remain green | |
| Performance  | ✅ | Parity lane intentionally excluded from fast-gate; no PR fast-gate runtime increase | |

## Risks & Rollback
- Low risk; adds validation and docs only.
- Rollback: revert this PR commit to remove parity lane wiring/docs.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
