### PR TITLE
feat(kolme): deterministic real-node runtime evidence profiles

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -224,6 +224,15 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
 - Local KAMN runtime integration lane:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-commit-finality-command "printf 'finality=final\n'" --runtime-commit-finality-max-seconds 15 --runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
   - runtime step composes through `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` and captures nested runtime evidence policy artifacts.
+  - integration summary emits deterministic runtime evidence profile markers:
+    - `runtime_commit_command_profile`
+    - `runtime_commit_policy_command_profile`
+    - `runtime_commit_command_profile_version`
+  - real-node summary/profile checker contract requires:
+    - `runtime_commit_command_profile=real-node-non-synthetic-v1`
+    - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
+    - `runtime_commit_command_profile_version=v1`
+  - marker/profile drift is fail-closed in `check_local_kamn_live_runtime_real_node_profile_policy.py`.
 - Local fork process lifecycle lane:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --integration-runtime-commit-finality-command "printf 'finality=final\n'" --integration-runtime-commit-finality-max-seconds 15 --integration-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
 - Real-process wrapper lane with lifecycle run intent:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -424,6 +424,11 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - optional runtime finality pass-through (`--runtime-commit-finality-command`, `--runtime-commit-finality-max-seconds`, `--runtime-commit-finality-output-file`) and `--runtime-commit-live-policy-report` are wired through to nested runtime finality evidence contract composition.
   - runtime provider contract marker (`--runtime-provider-client-contract`) remains explicit and fail-closed for `KolmeRuntimeCommitLiveProvider`.
   - runtime integration profile marker (`--runtime-profile standard|real-node`) remains explicit and is emitted into summary + contracts fields for release-decision audits.
+  - deterministic runtime evidence profile markers are emitted in summary fields:
+    - `runtime_commit_command_profile`
+    - `runtime_commit_policy_command_profile`
+    - `runtime_commit_command_profile_version`
+  - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
   - integration summary emits `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` for explicit PR-fast-gate exclusion enforcement.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -74,6 +74,24 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif runtime_provider_client_contract != "KolmeRuntimeCommitLiveProvider":
         reason_codes.append("runtime_provider_client_contract_mismatch")
 
+    runtime_commit_command_profile = report.get("runtime_commit_command_profile")
+    if not isinstance(runtime_commit_command_profile, str) or not runtime_commit_command_profile.strip():
+        reason_codes.append("runtime_commit_command_profile_missing")
+    elif runtime_commit_command_profile != "real-node-non-synthetic-v1":
+        reason_codes.append("runtime_commit_command_profile_mismatch")
+
+    runtime_commit_policy_command_profile = report.get("runtime_commit_policy_command_profile")
+    if not isinstance(runtime_commit_policy_command_profile, str) or not runtime_commit_policy_command_profile.strip():
+        reason_codes.append("runtime_commit_policy_command_profile_missing")
+    elif runtime_commit_policy_command_profile != "real-node-non-synthetic-v1":
+        reason_codes.append("runtime_commit_policy_command_profile_mismatch")
+
+    runtime_commit_command_profile_version = report.get("runtime_commit_command_profile_version")
+    if not isinstance(runtime_commit_command_profile_version, str) or not runtime_commit_command_profile_version.strip():
+        reason_codes.append("runtime_commit_command_profile_version_missing")
+    elif runtime_commit_command_profile_version != "v1":
+        reason_codes.append("runtime_commit_command_profile_version_mismatch")
+
     runtime_commit_command = report.get("runtime_commit_command")
     if not isinstance(runtime_commit_command, str) or not runtime_commit_command.strip():
         reason_codes.append("runtime_commit_command_missing")

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -195,6 +195,15 @@ def main() -> int:
     if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
         print("expected strict non-synthetic runtime marker in contract-lane summary command", file=sys.stderr)
         return 1
+    if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
+        print("expected deterministic runtime commit command profile marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":
+        print("expected deterministic runtime commit policy command profile marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_commit_command_profile_version") != "v1":
+        print("expected runtime commit command profile marker version in contract-lane summary", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in real-node profile contract-lane summary", file=sys.stderr)

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -351,8 +351,13 @@ if [ -z "$effective_runtime_commit_finality_command" ]; then
 fi
 
 runtime_commit_non_synthetic_flag=""
+runtime_commit_command_profile="standard-default-v1"
+runtime_commit_policy_command_profile="standard-default-v1"
+runtime_commit_command_profile_version="v1"
 if [ "$RUNTIME_PROFILE" = "real-node" ]; then
   runtime_commit_non_synthetic_flag=" --require-non-synthetic-run-evidence"
+  runtime_commit_command_profile="real-node-non-synthetic-v1"
+  runtime_commit_policy_command_profile="real-node-non-synthetic-v1"
 fi
 
 default_runtime_commit_command="KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_SUMMARY}") --policy-output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_POLICY_REPORT}") --live-output-file $(shell_escape "${RUNTIME_COMMIT_OUTPUT_FILE}") --finality-output-file $(shell_escape "${RUNTIME_COMMIT_FINALITY_OUTPUT_FILE}") --max-seconds ${RUNTIME_COMMIT_MAX_SECONDS} --expected-provider-client-contract $(shell_escape "${RUNTIME_PROVIDER_CLIENT_CONTRACT}")${runtime_commit_non_synthetic_flag} --live-command $(shell_escape "${default_runtime_commit_live_submit_command}") --finality-command $(shell_escape "${effective_runtime_commit_finality_command}") --finality-max-seconds ${RUNTIME_COMMIT_FINALITY_MAX_SECONDS}"
@@ -609,7 +614,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" <<'PY'
 from __future__ import annotations
 
 import json
@@ -646,6 +651,9 @@ runtime_commit_policy_reason_code = sys.argv[27]
 runtime_profile = sys.argv[28]
 checks_path = pathlib.Path(sys.argv[29])
 runtime_provider_client_contract = sys.argv[30]
+runtime_commit_command_profile = sys.argv[31]
+runtime_commit_policy_command_profile = sys.argv[32]
+runtime_commit_command_profile_version = sys.argv[33]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -682,6 +690,9 @@ summary = {
     "runtime_commit_command": runtime_commit_command,
     "runtime_provider_client_contract": runtime_provider_client_contract,
     "runtime_profile": runtime_profile,
+    "runtime_commit_command_profile": runtime_commit_command_profile,
+    "runtime_commit_policy_command_profile": runtime_commit_policy_command_profile,
+    "runtime_commit_command_profile_version": runtime_commit_command_profile_version,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
     "runtime_commit_finality_output_file": runtime_commit_finality_output_file if runtime_commit_finality_command else "",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -56,6 +56,9 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "fork_chain_version": "v0.15.2",
   "runtime_profile": "real-node",
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+  "runtime_commit_command_profile": "real-node-non-synthetic-v1",
+  "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
+  "runtime_commit_command_profile_version": "v1",
   "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "runtime_commit_finality_command": "",
@@ -161,6 +164,9 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "budget_status": "not_run",
   "runtime_profile": "standard",
   "runtime_provider_client_contract": "InMemoryKolmeRuntimeCommitClient",
+  "runtime_commit_command_profile": "standard-default-v1",
+  "runtime_commit_policy_command_profile": "standard-default-v1",
+  "runtime_commit_command_profile_version": "v0",
   "runtime_commit_command": "echo runtime",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "contracts": {
@@ -208,6 +214,21 @@ if ! grep -q "runtime_provider_client_contract_mismatch" "$TMP_ERR"; then
   exit 1
 fi
 
+if ! grep -q "runtime_commit_command_profile_mismatch" "$TMP_ERR"; then
+  echo "expected runtime commit command profile mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_policy_command_profile_mismatch" "$TMP_ERR"; then
+  echo "expected runtime commit policy command profile mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_command_profile_version_mismatch" "$TMP_ERR"; then
+  echo "expected runtime commit profile marker version mismatch reason for policy failure" >&2
+  exit 1
+fi
+
 if ! grep -q "runtime_commit_non_synthetic_policy_marker_missing" "$TMP_ERR"; then
   echo "expected strict non-synthetic marker requirement reason for policy failure" >&2
   exit 1
@@ -245,6 +266,12 @@ if not isinstance(runtime_commit_command, str):
     raise SystemExit("expected runtime_commit_command string in runner-generated summary")
 if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in real-node profile runtime commit command")
+if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected deterministic runtime commit command profile marker in runner-generated summary")
+if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected deterministic runtime commit policy command profile marker in runner-generated summary")
+if summary.get("runtime_commit_command_profile_version") != "v1":
+    raise SystemExit("expected runtime commit command profile marker version in runner-generated summary")
 PY
 
 python3 - "$TMP_INTEGRATION_POLICY_OUT" <<'PY'

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -87,6 +87,12 @@ if not isinstance(runtime_commit_command, str):
     raise SystemExit("expected runtime_commit_command to be present in integration summary")
 if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in integration runtime_commit_command")
+if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected deterministic runtime commit command profile marker for real-node profile")
+if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected deterministic runtime commit policy command profile marker for real-node profile")
+if summary.get("runtime_commit_command_profile_version") != "v1":
+    raise SystemExit("expected runtime commit command profile marker version for real-node profile")
 contracts = summary.get("contracts", {})
 if not isinstance(contracts, dict):
     raise SystemExit("expected contracts object in integration summary")


### PR DESCRIPTION
## Summary
Adds deterministic runtime evidence command-profile markers for local KAMN real-node runtime integration summaries and enforces fail-closed marker validation in the real-node profile policy checker. This closes marker-drift gaps while preserving local-only, cost-bounded validation behavior.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: emits deterministic profile markers in integration summaries (`runtime_commit_command_profile`, `runtime_commit_policy_command_profile`, `runtime_commit_command_profile_version`) with explicit real-node defaults.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: adds fail-closed checks for marker presence/version/profile drift.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: validates emitted marker fields in contract-lane summary checks.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: adds real-node marker assertions.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: adds fixture marker coverage + drift mismatch assertions.
- `docs/foundation/kolme-runtime-commit-client.md`: documents deterministic profile marker semantics.
- `docs/planning/kolme-devnet-ops.md`: documents real-node marker requirements and fail-closed drift behavior.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
# expected deterministic runtime commit command profile marker for real-node profile

bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# expected runtime commit command profile mismatch reason for policy failure

python3 scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py --max-seconds 180
# expected deterministic runtime commit command profile marker in contract-lane summary
```

### 🟢 Green Phase
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
# local KAMN live runtime integration real-node profile tests passed.

bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# local KAMN live runtime real-node profile policy checker tests passed.

python3 scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py --max-seconds 180
# local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_readme_contract.sh
python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` fixture checks for marker/version invariants | |
| Functional   | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` marker emission checks | |
| Integration  | ✅ | `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`; `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | |
| Regression   | ✅ | Drift fail-closed assertions + integration/runtime contract lane reruns listed above | |
| Performance  | N/A | No new CI heavy lanes; local-only runtime boundaries unchanged | Current issue scope is marker determinism/policy drift only |

## Risks & Rollback
- No breaking API surface; summary schema fields are additive and checker behavior is stricter for real-node profile reports.
- Rollback: revert this PR to remove marker enforcement and restore previous checker leniency.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant local/runtime integration scope)
- [x] Docs updated (or justified why not)

Closes #2161
Refs #2160
Refs #2097
