### PR TITLE
feat(kolme): prove strict-marker go/no-go contract behavior

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -410,6 +410,13 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
 - Real-node profile policy checker command:
   - `python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --require-non-synthetic-run-evidence --output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
+- Strict-marker GO/NO-GO proofs:
+  - GO proof uses the command above and requires deterministic markers:
+    - `runtime_commit_command_profile=real-node-non-synthetic-v1`
+    - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
+    - `runtime_commit_command_profile_version=v1`
+  - NO-GO marker-drift proof must surface `runtime_commit_command_profile_mismatch` when profile marker contracts drift from `real-node-non-synthetic-v1`.
+  - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
 - Real-node profile contract lane command:
   - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
 - Contract lane command:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -5,6 +5,8 @@ import argparse
 import json
 from pathlib import Path
 
+NON_SYNTHETIC_SUBMIT_PROBE_MARKER = "integration_kolme_fork_live_node_submit_reaches_endpoint"
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -102,6 +104,11 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_provider_contract_marker_missing")
         if args.require_non_synthetic_run_evidence and "--require-non-synthetic-run-evidence" not in runtime_commit_command:
             reason_codes.append("runtime_commit_non_synthetic_policy_marker_missing")
+        if (
+            runtime_commit_command_profile == "real-node-non-synthetic-v1"
+            and NON_SYNTHETIC_SUBMIT_PROBE_MARKER not in runtime_commit_command
+        ):
+            reason_codes.append("runtime_commit_non_synthetic_submit_probe_missing")
 
     runtime_commit_live_policy_report = report.get("runtime_commit_live_policy_report")
     if not isinstance(runtime_commit_live_policy_report, str) or not runtime_commit_live_policy_report.strip():

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -54,6 +54,30 @@ def ensure_markers_present(text: str, markers: list[str], source_name: str) -> l
     return missing
 
 
+def run_real_node_policy_check(
+    report_file: Path, output_json: Path, expected_final_decision: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "python3",
+            str(CHECKER),
+            "--report-file",
+            str(report_file),
+            "--expected-final-decision",
+            expected_final_decision,
+            "--ci-fast-gate",
+            "PASS",
+            "--require-non-synthetic-run-evidence",
+            "--output-json",
+            str(output_json),
+        ],
+        cwd=ROOT_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def main() -> int:
     args = build_parser().parse_args()
 
@@ -153,26 +177,17 @@ def main() -> int:
             stdout=subprocess.DEVNULL,
         )
 
-        subprocess.run(
-            [
-                "python3",
-                str(CHECKER),
-                "--report-file",
-                args.output_json,
-                "--expected-final-decision",
-                "GO",
-                "--ci-fast-gate",
-                "PASS",
-                "--require-reason-code",
-                "dry_run_no_commands_executed",
-                "--require-non-synthetic-run-evidence",
-                "--output-json",
-                args.policy_output_json,
-            ],
-            cwd=ROOT_DIR,
-            check=True,
-            stdout=subprocess.DEVNULL,
+        policy_result = run_real_node_policy_check(
+            report_file=Path(args.output_json),
+            output_json=Path(args.policy_output_json),
+            expected_final_decision="GO",
         )
+        if policy_result.returncode != 0:
+            print("expected real-node policy checker GO path to pass", file=sys.stderr)
+            stderr = policy_result.stderr.strip()
+            if stderr:
+                print(stderr, file=sys.stderr)
+            return 1
 
     summary = json.loads(Path(args.output_json).read_text(encoding="utf-8"))
     policy = json.loads(Path(args.policy_output_json).read_text(encoding="utf-8"))
@@ -217,6 +232,81 @@ def main() -> int:
     if policy.get("final_decision") != "GO":
         print("expected real-node profile policy final_decision GO", file=sys.stderr)
         return 1
+    if policy.get("observed_reason_code") != "dry_run_no_commands_executed":
+        print("expected dry-run observed reason code in real-node profile policy output", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="kolme-runtime-real-node-negative-") as temp_dir:
+        negative_path = Path(temp_dir)
+
+        marker_drift_summary_file = negative_path / "marker_drift_summary.json"
+        marker_drift_policy_file = negative_path / "marker_drift_policy.json"
+        marker_drift_summary = dict(summary)
+        marker_drift_summary["runtime_commit_command_profile"] = "standard-default-v1"
+        marker_drift_summary_file.write_text(
+            json.dumps(marker_drift_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        marker_drift_result = run_real_node_policy_check(
+            report_file=marker_drift_summary_file,
+            output_json=marker_drift_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if marker_drift_result.returncode == 0:
+            print("expected marker drift negative proof to fail closed", file=sys.stderr)
+            return 1
+        marker_drift_policy = json.loads(marker_drift_policy_file.read_text(encoding="utf-8"))
+        marker_drift_reason_codes = marker_drift_policy.get("reason_codes")
+        if not isinstance(marker_drift_reason_codes, list):
+            print("expected reason_codes list in marker drift policy output", file=sys.stderr)
+            return 1
+        if "runtime_commit_command_profile_mismatch" not in marker_drift_reason_codes:
+            print("expected runtime_commit_command_profile_mismatch in marker drift policy output", file=sys.stderr)
+            return 1
+        if marker_drift_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for marker drift policy output", file=sys.stderr)
+            return 1
+
+        synthetic_regression_summary_file = negative_path / "synthetic_regression_summary.json"
+        synthetic_regression_policy_file = negative_path / "synthetic_regression_policy.json"
+        synthetic_regression_summary = dict(summary)
+        synthetic_regression_summary["runtime_commit_command"] = (
+            "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh "
+            "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
+            "--require-non-synthetic-run-evidence "
+            "--live-command \"printf 'runtime=synthetic\\\\n'\" "
+            "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
+        )
+        synthetic_regression_summary_file.write_text(
+            json.dumps(synthetic_regression_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        synthetic_regression_result = run_real_node_policy_check(
+            report_file=synthetic_regression_summary_file,
+            output_json=synthetic_regression_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if synthetic_regression_result.returncode == 0:
+            print("expected synthetic command regression negative proof to fail closed", file=sys.stderr)
+            return 1
+        synthetic_regression_policy = json.loads(
+            synthetic_regression_policy_file.read_text(encoding="utf-8")
+        )
+        synthetic_regression_reason_codes = synthetic_regression_policy.get("reason_codes")
+        if not isinstance(synthetic_regression_reason_codes, list):
+            print("expected reason_codes list in synthetic regression policy output", file=sys.stderr)
+            return 1
+        if "runtime_commit_non_synthetic_submit_probe_missing" not in synthetic_regression_reason_codes:
+            print(
+                "expected runtime_commit_non_synthetic_submit_probe_missing in synthetic regression policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if synthetic_regression_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for synthetic regression policy output", file=sys.stderr)
+            return 1
 
     doc_markers = [
         "--runtime-profile real-node",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -10,6 +10,7 @@ README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
+TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
 TMP_INTEGRATION_POLICY_OUT="$TMP_DIR/integration-policy-report.json"
 TMP_SUMMARY="$TMP_DIR/integration-summary.json"
@@ -59,7 +60,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
-  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "runtime_commit_finality_command": "",
   "runtime_commit_finality_output_file": "",
@@ -239,6 +240,105 @@ if ! grep -q "check_missing:runtime_commit_endpoint" "$TMP_ERR"; then
   exit 1
 fi
 
+cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
+{
+  "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
+  "mode": "dry-run",
+  "status": "ok",
+  "reason_code": "dry_run_no_commands_executed",
+  "local_only_enforced": true,
+  "ci_fast_gate_eligible": false,
+  "elapsed_seconds": 0,
+  "max_seconds": 210,
+  "budget_status": "not_run",
+  "runtime_profile": "real-node",
+  "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+  "runtime_commit_command_profile": "real-node-non-synthetic-v1",
+  "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
+  "runtime_commit_command_profile_version": "v1",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"printf 'runtime=synthetic\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
+  "runtime_commit_finality_command": "",
+  "runtime_commit_finality_output_file": "",
+  "runtime_commit_finality_enabled": false,
+  "runtime_commit_finality_max_seconds": 15,
+  "bootstrap_reason_code": "not_run",
+  "localhost_signed_reason_code": "not_run",
+  "conformance_reason_code": "not_run",
+  "runtime_commit_reason_code": "not_run",
+  "runtime_commit_policy_reason_code": "not_run",
+  "contracts": {
+    "ci_fast_gate_scope": "local-only",
+    "runtime_profile": "real-node",
+    "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+    "runtime_commit_endpoint": "/broadcast/runtime-commit",
+    "runtime_commit_method": "POST",
+    "runtime_commit_finality_primary_endpoint": "/notifications",
+    "runtime_commit_finality_fallback_endpoint": "/block/{height}"
+  },
+  "checks": [
+    {
+      "id": "bootstrap_readiness",
+      "command": "bash scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "localhost_signed_integration",
+      "command": "bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed.json",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "live_api_conformance",
+      "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_commit_endpoint",
+      "command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"printf 'runtime=synthetic\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_commit_policy",
+      "command": "python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/runtime-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-non-synthetic-run-evidence --output-json /tmp/runtime-policy.json",
+      "status": "planned",
+      "reason_code": "not_run"
+    }
+  ],
+  "artifact_paths": [
+    "/tmp/bootstrap-summary.json",
+    "/tmp/localhost-signed.json",
+    "/tmp/conformance-summary.json",
+    "/tmp/runtime-output.log",
+    "/tmp/runtime-summary.json",
+    "/tmp/runtime-policy.json"
+  ]
+}
+JSON
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_SYNTHETIC" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+synthetic_exit_code=$?
+set -e
+
+if [ "$synthetic_exit_code" -eq 0 ]; then
+  echo "expected real-node profile policy checker to fail for synthetic command regression" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_non_synthetic_submit_probe_missing" "$TMP_ERR"; then
+  echo "expected non-synthetic submit probe marker requirement reason for synthetic policy failure" >&2
+  exit 1
+fi
+
 bash "$RUNNER" \
   --mode dry-run \
   --runtime-profile real-node \
@@ -266,6 +366,8 @@ if not isinstance(runtime_commit_command, str):
     raise SystemExit("expected runtime_commit_command string in runner-generated summary")
 if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in real-node profile runtime commit command")
+if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_commit_command:
+    raise SystemExit("expected non-synthetic runtime submit probe marker in real-node profile runtime commit command")
 if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit command profile marker in runner-generated summary")
 if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -87,6 +87,8 @@ if not isinstance(runtime_commit_command, str):
     raise SystemExit("expected runtime_commit_command to be present in integration summary")
 if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in integration runtime_commit_command")
+if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_commit_command:
+    raise SystemExit("expected non-synthetic runtime submit probe marker in integration runtime_commit_command")
 if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit command profile marker for real-node profile")
 if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -11,7 +11,11 @@ CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
 README_FILE="$ROOT_DIR/README.md"
 TMP_REPORT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT"' EXIT
+TMP_DRIFT_REPORT="$(mktemp)"
+TMP_SYNTHETIC_REPORT="$(mktemp)"
+TMP_NEGATIVE_POLICY="$(mktemp)"
+TMP_NEGATIVE_ERR="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime real-node profile contract lane runner to be executable" >&2
@@ -61,6 +65,8 @@ required_coverage_markers=(
   "docs/planning/kolme-devnet-ops.md"
   "docs/ci/strategy.md"
   "README.md"
+  "runtime_commit_command_profile_mismatch"
+  "runtime_commit_non_synthetic_submit_probe_missing"
   "Regression: #2139"
 )
 for marker in "${required_coverage_markers[@]}"; do
@@ -111,6 +117,8 @@ if not isinstance(runtime_commit_command, str):
     raise SystemExit("expected runtime_commit_command in real-node profile contract-lane summary")
 if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in real-node profile contract-lane summary")
+if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_commit_command:
+    raise SystemExit("expected non-synthetic runtime submit probe marker in real-node profile contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_profile") != "real-node":
     raise SystemExit("expected contracts.runtime_profile=real-node in real-node profile contract-lane summary")
@@ -121,5 +129,73 @@ if policy.get("final_decision") != "GO":
 if policy.get("reason_codes") != []:
     raise SystemExit("expected no policy reason codes for real-node profile contract-lane dry-run composition")
 PY
+
+python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+base_summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+drift_summary = dict(base_summary)
+drift_summary["runtime_commit_command_profile"] = "standard-default-v1"
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(drift_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+synthetic_summary = dict(base_summary)
+synthetic_summary["runtime_commit_command"] = (
+    "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh "
+    "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
+    "--require-non-synthetic-run-evidence "
+    "--live-command \"printf 'runtime=synthetic\\\\n'\" "
+    "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
+)
+pathlib.Path(sys.argv[3]).write_text(
+    json.dumps(synthetic_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_DRIFT_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+drift_exit_code=$?
+set -e
+
+if [ "$drift_exit_code" -eq 0 ]; then
+  echo "expected marker-drift negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_command_profile_mismatch" "$TMP_NEGATIVE_ERR"; then
+  echo "expected runtime command profile drift reason in negative proof output" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_SYNTHETIC_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+synthetic_exit_code=$?
+set -e
+
+if [ "$synthetic_exit_code" -eq 0 ]; then
+  echo "expected synthetic-command negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_non_synthetic_submit_probe_missing" "$TMP_NEGATIVE_ERR"; then
+  echo "expected non-synthetic submit probe marker reason in synthetic-command negative proof output" >&2
+  exit 1
+fi
 
 echo "local KAMN live runtime real-node profile contract lane tests passed."


### PR DESCRIPTION
## Summary
Extends the local real-node contract lane and policy checker to prove strict-marker GO and explicit NO-GO paths for marker drift and synthetic-command regressions. This makes strict non-synthetic profile behavior auditable and fail-closed under deterministic reason codes.

## Changes
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: adds non-synthetic submit probe marker enforcement for `real-node-non-synthetic-v1` (`runtime_commit_non_synthetic_submit_probe_missing`).
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: adds explicit negative proofs that require NO-GO on:
  - profile marker drift (`runtime_commit_command_profile_mismatch`)
  - synthetic-command regression (`runtime_commit_non_synthetic_submit_probe_missing`)
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: adds dedicated synthetic regression fixture + reason-code assertions.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: adds contract-lane negative-proof checks for marker drift and synthetic command regressions.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: asserts non-synthetic submit probe marker presence in composed runtime command.
- `docs/planning/kolme-devnet-ops.md`: adds strict-marker GO/NO-GO proof guidance and expected reason codes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# expected non-synthetic submit probe marker requirement reason for policy failure

bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
# expected local KAMN live runtime real-node profile contract implementation to include coverage marker: runtime_commit_command_profile_mismatch
```

### 🟢 Green Phase
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# local KAMN live runtime real-node profile policy checker tests passed.

bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
# local KAMN live runtime real-node profile contract lane tests passed.

python3 scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py --max-seconds 180
# local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_readme_contract.sh
python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `test_check_local_kamn_live_runtime_real_node_profile_policy.sh` fixture-level reason-code assertions | |
| Functional   | ✅ | `test_run_local_kamn_live_runtime_integration_real_node_profile.sh` strict marker + submit probe assertions | |
| Integration  | ✅ | `local_kamn_live_runtime_real_node_profile_contract_lane.py`; `test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | |
| Regression   | ✅ | Explicit NO-GO proofs for marker drift + synthetic regression; broader lane regressions listed above | |
| Performance  | N/A | No new CI heavy run-mode paths added | Task keeps local-only bounded behavior |

## Risks & Rollback
- Behavior is stricter for real-node profile checker/contracts and may fail previously lenient summaries missing non-synthetic submit probe markers.
- Rollback: revert this PR to remove stricter NO-GO enforcement paths.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2162
Refs #2160
Refs #2097
