### PR TITLE
feat(kolme): enforce live-provider-only real-node cutover

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -233,6 +233,11 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
     - `runtime_commit_command_profile_version=v1`
   - marker/profile drift is fail-closed in `check_local_kamn_live_runtime_real_node_profile_policy.py`.
+  - real-node runner composition rejects in-memory fallback references:
+    - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
+  - real-node checker fails closed when in-memory provider references appear in strict command/policy surfaces:
+    - `runtime_commit_in_memory_provider_reference_detected`
+    - `runtime_commit_policy_check_in_memory_provider_reference_detected`
 - Local fork process lifecycle lane:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --integration-runtime-commit-finality-command "printf 'finality=final\n'" --integration-runtime-commit-finality-max-seconds 15 --integration-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
 - Real-process wrapper lane with lifecycle run intent:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -436,6 +436,11 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_policy_command_profile`
     - `runtime_commit_command_profile_version`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
+  - real-node profile command composition rejects in-memory fallback references at runner boundary:
+    - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
+  - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:
+    - `runtime_commit_in_memory_provider_reference_detected`
+    - `runtime_commit_policy_check_in_memory_provider_reference_detected`
   - integration summary emits `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` for explicit PR-fast-gate exclusion enforcement.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 NON_SYNTHETIC_SUBMIT_PROBE_MARKER = "integration_kolme_fork_live_node_submit_reaches_endpoint"
+IN_MEMORY_PROVIDER_MARKER = "InMemoryKolmeRuntimeCommitClient"
 
 
 def parse_args() -> argparse.Namespace:
@@ -109,6 +110,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and NON_SYNTHETIC_SUBMIT_PROBE_MARKER not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_non_synthetic_submit_probe_missing")
+        if IN_MEMORY_PROVIDER_MARKER in runtime_commit_command:
+            reason_codes.append("runtime_commit_in_memory_provider_reference_detected")
 
     runtime_commit_live_policy_report = report.get("runtime_commit_live_policy_report")
     if not isinstance(runtime_commit_live_policy_report, str) or not runtime_commit_live_policy_report.strip():
@@ -175,6 +178,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and "--require-non-synthetic-run-evidence" not in runtime_commit_policy_check_command
         ):
             reason_codes.append("runtime_commit_policy_check_non_synthetic_marker_missing")
+        if runtime_commit_policy_check_command is not None and IN_MEMORY_PROVIDER_MARKER in runtime_commit_policy_check_command:
+            reason_codes.append("runtime_commit_policy_check_in_memory_provider_reference_detected")
 
     artifact_paths = report.get("artifact_paths")
     if not isinstance(artifact_paths, list) or not artifact_paths:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -210,6 +210,9 @@ def main() -> int:
     if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
         print("expected strict non-synthetic runtime marker in contract-lane summary command", file=sys.stderr)
         return 1
+    if "InMemoryKolmeRuntimeCommitClient" in runtime_commit_command:
+        print("expected live-provider-only runtime command composition in real-node contract-lane summary", file=sys.stderr)
+        return 1
     if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
         print("expected deterministic runtime commit command profile marker in contract-lane summary", file=sys.stderr)
         return 1
@@ -306,6 +309,47 @@ def main() -> int:
             return 1
         if synthetic_regression_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for synthetic regression policy output", file=sys.stderr)
+            return 1
+
+        in_memory_provider_summary_file = negative_path / "in_memory_provider_summary.json"
+        in_memory_provider_policy_file = negative_path / "in_memory_provider_policy.json"
+        in_memory_provider_summary = dict(summary)
+        in_memory_provider_summary["runtime_commit_command"] = (
+            "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh "
+            "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
+            "--require-non-synthetic-run-evidence "
+            "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
+            "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+            "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
+            "--provider-hint InMemoryKolmeRuntimeCommitClient "
+            "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
+        )
+        in_memory_provider_summary_file.write_text(
+            json.dumps(in_memory_provider_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        in_memory_provider_result = run_real_node_policy_check(
+            report_file=in_memory_provider_summary_file,
+            output_json=in_memory_provider_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if in_memory_provider_result.returncode == 0:
+            print("expected in-memory provider regression negative proof to fail closed", file=sys.stderr)
+            return 1
+        in_memory_provider_policy = json.loads(in_memory_provider_policy_file.read_text(encoding="utf-8"))
+        in_memory_provider_reason_codes = in_memory_provider_policy.get("reason_codes")
+        if not isinstance(in_memory_provider_reason_codes, list):
+            print("expected reason_codes list in in-memory provider regression policy output", file=sys.stderr)
+            return 1
+        if "runtime_commit_in_memory_provider_reference_detected" not in in_memory_provider_reason_codes:
+            print(
+                "expected runtime_commit_in_memory_provider_reference_detected in in-memory provider regression policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if in_memory_provider_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for in-memory provider regression policy output", file=sys.stderr)
             return 1
 
     doc_markers = [

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -366,6 +366,11 @@ if [ -z "$RUNTIME_COMMIT_COMMAND" ]; then
   RUNTIME_COMMIT_FINALITY_COMMAND="$effective_runtime_commit_finality_command"
 fi
 
+if [ "$RUNTIME_PROFILE" = "real-node" ] && [[ "$RUNTIME_COMMIT_COMMAND" == *"InMemoryKolmeRuntimeCommitClient"* ]]; then
+  echo "runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node" >&2
+  exit 1
+fi
+
 CHECK_FILE="$(mktemp)"
 trap 'rm -f "$CHECK_FILE"' EXIT
 

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -11,6 +11,7 @@ TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
+TMP_REPORT_INMEMORY="$TMP_DIR/inmemory-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
 TMP_INTEGRATION_POLICY_OUT="$TMP_DIR/integration-policy-report.json"
 TMP_SUMMARY="$TMP_DIR/integration-summary.json"
@@ -336,6 +337,105 @@ fi
 
 if ! grep -q "runtime_commit_non_synthetic_submit_probe_missing" "$TMP_ERR"; then
   echo "expected non-synthetic submit probe marker requirement reason for synthetic policy failure" >&2
+  exit 1
+fi
+
+cat >"$TMP_REPORT_INMEMORY" <<'JSON'
+{
+  "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
+  "mode": "dry-run",
+  "status": "ok",
+  "reason_code": "dry_run_no_commands_executed",
+  "local_only_enforced": true,
+  "ci_fast_gate_eligible": false,
+  "elapsed_seconds": 0,
+  "max_seconds": 210,
+  "budget_status": "not_run",
+  "runtime_profile": "real-node",
+  "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+  "runtime_commit_command_profile": "real-node-non-synthetic-v1",
+  "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
+  "runtime_commit_command_profile_version": "v1",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
+  "runtime_commit_finality_command": "",
+  "runtime_commit_finality_output_file": "",
+  "runtime_commit_finality_enabled": false,
+  "runtime_commit_finality_max_seconds": 15,
+  "bootstrap_reason_code": "not_run",
+  "localhost_signed_reason_code": "not_run",
+  "conformance_reason_code": "not_run",
+  "runtime_commit_reason_code": "not_run",
+  "runtime_commit_policy_reason_code": "not_run",
+  "contracts": {
+    "ci_fast_gate_scope": "local-only",
+    "runtime_profile": "real-node",
+    "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+    "runtime_commit_endpoint": "/broadcast/runtime-commit",
+    "runtime_commit_method": "POST",
+    "runtime_commit_finality_primary_endpoint": "/notifications",
+    "runtime_commit_finality_fallback_endpoint": "/block/{height}"
+  },
+  "checks": [
+    {
+      "id": "bootstrap_readiness",
+      "command": "bash scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "localhost_signed_integration",
+      "command": "bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed.json",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "live_api_conformance",
+      "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_commit_endpoint",
+      "command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_commit_policy",
+      "command": "python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/runtime-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-non-synthetic-run-evidence --output-json /tmp/runtime-policy.json",
+      "status": "planned",
+      "reason_code": "not_run"
+    }
+  ],
+  "artifact_paths": [
+    "/tmp/bootstrap-summary.json",
+    "/tmp/localhost-signed.json",
+    "/tmp/conformance-summary.json",
+    "/tmp/runtime-output.log",
+    "/tmp/runtime-summary.json",
+    "/tmp/runtime-policy.json"
+  ]
+}
+JSON
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_INMEMORY" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+inmemory_exit_code=$?
+set -e
+
+if [ "$inmemory_exit_code" -eq 0 ]; then
+  echo "expected real-node profile policy checker to fail for in-memory provider reference drift" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_in_memory_provider_reference_detected" "$TMP_ERR"; then
+  echo "expected in-memory provider reference reason for policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -106,6 +106,28 @@ PY
 
 set +e
 bash "$RUNNER" \
+  --mode dry-run \
+  --runtime-profile real-node \
+  --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \
+  --runtime-commit-command "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --live-command \"printf 'runtime=in-memory\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json $TMP_RUNTIME_SUMMARY --policy-output-json $TMP_RUNTIME_POLICY" \
+  --runtime-commit-live-summary "$TMP_RUNTIME_SUMMARY" \
+  --runtime-commit-live-policy-report "$TMP_RUNTIME_POLICY" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+dry_run_inmemory_exit_code=$?
+set -e
+
+if [ "$dry_run_inmemory_exit_code" -eq 0 ]; then
+  echo "expected real-node profile dry-run to fail closed when runtime commit command references InMemory provider" >&2
+  exit 1
+fi
+
+if ! grep -q "must not reference InMemoryKolmeRuntimeCommitClient" "$TMP_ERR"; then
+  echo "expected deterministic in-memory provider rejection message for real-node profile dry-run" >&2
+  exit 1
+fi
+
+set +e
+bash "$RUNNER" \
   --mode run \
   --runtime-profile real-node \
   --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -13,9 +13,10 @@ TMP_REPORT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
 TMP_DRIFT_REPORT="$(mktemp)"
 TMP_SYNTHETIC_REPORT="$(mktemp)"
+TMP_INMEMORY_REPORT="$(mktemp)"
 TMP_NEGATIVE_POLICY="$(mktemp)"
 TMP_NEGATIVE_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime real-node profile contract lane runner to be executable" >&2
@@ -67,6 +68,7 @@ required_coverage_markers=(
   "README.md"
   "runtime_commit_command_profile_mismatch"
   "runtime_commit_non_synthetic_submit_probe_missing"
+  "runtime_commit_in_memory_provider_reference_detected"
   "Regression: #2139"
 )
 for marker in "${required_coverage_markers[@]}"; do
@@ -130,7 +132,7 @@ if policy.get("reason_codes") != []:
     raise SystemExit("expected no policy reason codes for real-node profile contract-lane dry-run composition")
 PY
 
-python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" <<'PY'
+python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" <<'PY'
 import json
 import pathlib
 import sys
@@ -154,6 +156,22 @@ synthetic_summary["runtime_commit_command"] = (
 )
 pathlib.Path(sys.argv[3]).write_text(
     json.dumps(synthetic_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+inmemory_summary = dict(base_summary)
+inmemory_summary["runtime_commit_command"] = (
+    "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh "
+    "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
+    "--require-non-synthetic-run-evidence "
+    "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
+    "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+    "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
+    "--provider-hint InMemoryKolmeRuntimeCommitClient "
+    "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
+)
+pathlib.Path(sys.argv[4]).write_text(
+    json.dumps(inmemory_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
 PY
@@ -195,6 +213,26 @@ fi
 
 if ! grep -q "runtime_commit_non_synthetic_submit_probe_missing" "$TMP_NEGATIVE_ERR"; then
   echo "expected non-synthetic submit probe marker reason in synthetic-command negative proof output" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_INMEMORY_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+inmemory_exit_code=$?
+set -e
+
+if [ "$inmemory_exit_code" -eq 0 ]; then
+  echo "expected in-memory provider reference negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_in_memory_provider_reference_detected" "$TMP_NEGATIVE_ERR"; then
+  echo "expected in-memory provider reference reason in negative proof output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Enforces live-provider-only behavior for strict real-node runtime integration by rejecting in-memory provider references at runner and policy levels. Adds deterministic NO-GO proofs for in-memory drift and updates operator docs for the new fail-closed behavior.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: real-node profile now fail-closes if `--runtime-commit-command` contains `InMemoryKolmeRuntimeCommitClient`.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: adds in-memory reference detection reason codes:
  - `runtime_commit_in_memory_provider_reference_detected`
  - `runtime_commit_policy_check_in_memory_provider_reference_detected`
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: adds NO-GO negative proof for in-memory provider drift.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: adds runner-level in-memory rejection assertion.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: adds policy fixture proving NO-GO on in-memory provider references.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: adds in-memory negative proof assertion.
- `docs/foundation/kolme-runtime-commit-client.md`: documents in-memory fallback rejection in strict real-node profile.
- `docs/planning/kolme-devnet-ops.md`: documents fail-closed in-memory drift reason codes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# expected in-memory provider reference reason for policy failure

bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
# expected local KAMN live runtime real-node profile contract implementation to include coverage marker: runtime_commit_in_memory_provider_reference_detected
```

### 🟢 Green Phase
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
# local KAMN live runtime integration real-node profile tests passed.

bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# local KAMN live runtime real-node profile policy checker tests passed.

bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
# local KAMN live runtime real-node profile contract lane tests passed.

python3 scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py --max-seconds 180
# local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh
python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_readme_contract.sh
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `test_check_local_kamn_live_runtime_real_node_profile_policy.sh` reason-code fixture coverage | |
| Functional   | ✅ | `test_run_local_kamn_live_runtime_integration_real_node_profile.sh` runner-level in-memory rejection assertion | |
| Integration  | ✅ | `local_kamn_live_runtime_real_node_profile_contract_lane.py` + `test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | |
| Regression   | ✅ | negative proofs for in-memory drift + integration/runtime contract reruns | |
| Performance  | ✅ | no new heavy CI path; local-only fast-gate exclusions unchanged | |

## Risks & Rollback
- Strict real-node profile now rejects custom runtime command strings containing in-memory markers; this may fail previously permissive local overrides.
- Rollback: revert this PR to restore prior lenient behavior.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: None.
Expected runtime delta: ~0s; existing script lanes only.
Expected runner-minute delta: ~0 runner-minutes.
Rollback plan if CI cost/runtime regresses: revert this PR.

Closes #2168
Refs #2167
Refs #2097
