### PR TITLE
fix(kolme): enforce real secp256k1 runtime signing profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,195 @@
 version = 4
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
 name = "kamn-core"
 version = "0.1.0"
 dependencies = [
+ "k256",
  "kamn-kolme",
 ]
 
@@ -23,3 +209,119 @@ dependencies = [
 [[package]]
 name = "kamn-sdk"
 version = "0.1.0"
+
+[[package]]
+name = "libc"
+version = "0.2.181"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/README.md
+++ b/README.md
@@ -577,9 +577,13 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # strict profile NO-GO drift/synthetic reason markers
 # runtime_commit_command_profile_mismatch
 # runtime_commit_non_synthetic_submit_probe_missing
+# runtime_commit_real_signing_profile_marker_missing
 
 # strict profile non-synthetic submit probe marker
 # integration_kolme_fork_live_node_submit_reaches_endpoint
+
+# strict profile real-signing marker
+# KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1
 
 # real-node profile contract lane (dry-run summary + policy + docs parity)
 bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -10,5 +10,8 @@ path = "src/lib.rs"
 [dependencies]
 kamn-kolme = { path = "../kamn-kolme" }
 
+[dev-dependencies]
+k256 = { version = "0.13.4", features = ["ecdsa"] }
+
 [lints]
 workspace = true

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -1,3 +1,4 @@
+use k256::ecdsa::{RecoveryId, Signature, SigningKey, VerifyingKey};
 use kamn_core::{
     KolmeApiBroadcastRequest, KolmeApiNextNonceRequest, KolmeCommitReceiptFinality,
     KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitFinalityChecker,
@@ -14,6 +15,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{env, fs};
 
 const TLS_CA_FILE_ENV: &str = "KAMN_KOLME_TLS_CA_FILE";
+const KOLME_LIVE_SIGNING_PROFILE_ENV: &str = "KAMN_KOLME_LIVE_SIGNING_PROFILE";
+const KOLME_FORK_SECP256K1_PROFILE: &str = "kolme-fork-secp256k1-v1";
+const KOLME_FORK_LIVE_SMOKE_SECRET_KEY_HEX: &str =
+    "658c3528422eb527b4c108b8f6d1e5f629543c304ea49cf608c67794424291c4";
 
 fn tls_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -89,6 +94,72 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     let path = env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
     fs::create_dir_all(&path).expect("temporary directory should be created");
     path
+}
+
+fn decode_hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(10 + (byte - b'a')),
+        b'A'..=b'F' => Some(10 + (byte - b'A')),
+        _ => None,
+    }
+}
+
+fn decode_hex_bytes(input: &str) -> Result<Vec<u8>, String> {
+    let trimmed = input.trim();
+    if !trimmed.len().is_multiple_of(2) {
+        return Err("hex string must contain an even number of characters".to_owned());
+    }
+
+    let mut bytes = Vec::with_capacity(trimmed.len() / 2);
+    for pair in trimmed.as_bytes().chunks_exact(2) {
+        let high = decode_hex_nibble(pair[0])
+            .ok_or_else(|| format!("invalid hex character: {}", pair[0] as char))?;
+        let low = decode_hex_nibble(pair[1])
+            .ok_or_else(|| format!("invalid hex character: {}", pair[1] as char))?;
+        bytes.push((high << 4) | low);
+    }
+
+    Ok(bytes)
+}
+
+fn encode_hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn kolme_fork_live_smoke_signing_key() -> SigningKey {
+    let private_key = decode_hex_bytes(KOLME_FORK_LIVE_SMOKE_SECRET_KEY_HEX)
+        .expect("kolme fork live smoke private key hex must decode");
+    SigningKey::from_slice(private_key.as_slice())
+        .expect("kolme fork live smoke private key bytes must be valid secp256k1 key")
+}
+
+fn kolme_fork_live_smoke_pubkey_hex() -> String {
+    let signing_key = kolme_fork_live_smoke_signing_key();
+    encode_hex_lower(
+        signing_key
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    )
+}
+
+fn kolme_fork_sign_message(message: &str) -> (String, u8) {
+    let signing_key = kolme_fork_live_smoke_signing_key();
+    let (signature, recovery_id) = signing_key
+        .sign_recoverable(message.as_bytes())
+        .expect("kolme fork live smoke signature generation must succeed");
+    let signature_bytes = signature.to_bytes();
+    (
+        encode_hex_lower(signature_bytes.as_ref()),
+        recovery_id.to_byte(),
+    )
 }
 
 fn generate_self_signed_certificate(temp_dir: &Path) -> (PathBuf, PathBuf) {
@@ -1093,7 +1164,13 @@ fn integration_kolme_fork_live_node_submit_reaches_endpoint() {
         .expect("KAMN_KOLME_LIVE_BASE_URL must be set for live node smoke");
     let provider_hint =
         env::var("KAMN_KOLME_LIVE_PROVIDER_HINT").unwrap_or_else(|_| "kolme-fork-local".to_owned());
+    let signing_profile = env::var(KOLME_LIVE_SIGNING_PROFILE_ENV)
+        .unwrap_or_else(|_| KOLME_FORK_SECP256K1_PROFILE.to_owned());
     let authorization_header = env::var("KAMN_KOLME_LIVE_AUTHORIZATION").ok();
+    assert_eq!(
+        signing_profile, KOLME_FORK_SECP256K1_PROFILE,
+        "live node smoke must use fork-compatible secp256k1 signing profile"
+    );
 
     let transport = if let Some(value) = authorization_header {
         KolmeRuntimeCommitHttpTransport::new_with_authorization(10, value.as_str())
@@ -1113,12 +1190,17 @@ fn integration_kolme_fork_live_node_submit_reaches_endpoint() {
         .duration_since(UNIX_EPOCH)
         .expect("system clock should be after unix epoch")
         .as_nanos();
+    let signer_pubkey = kolme_fork_live_smoke_pubkey_hex();
+    let nonce = ((unique_suffix % 1_000_000_000_u128) as u64) + 1;
     let message_json = format!(
-        "{{\"pubkey\":\"pk-live-smoke-{unique_suffix}\",\"nonce\":1,\"created\":\"2026-02-11T00:00:00Z\",\"messages\":[],\"max_height\":null}}"
+        "{{\"pubkey\":\"{signer_pubkey}\",\"nonce\":{nonce},\"created\":\"2026-02-11T00:00:00Z\",\"messages\":[],\"max_height\":null}}"
     );
+    let (signature, recovery_id) = kolme_fork_sign_message(message_json.as_str());
     let wire_payload = format!(
-        "{{\"message\":\"{}\",\"signature\":\"sig-live-smoke-{unique_suffix}\",\"recovery_id\":1}}",
-        message_json.replace('\\', "\\\\").replace('\"', "\\\"")
+        "{{\"message\":\"{}\",\"signature\":\"{}\",\"recovery_id\":{}}}",
+        message_json.replace('\\', "\\\\").replace('\"', "\\\""),
+        signature,
+        recovery_id
     );
     let idempotency_key = format!("kolme-runtime-commit:live-smoke:{unique_suffix}");
 
@@ -1144,4 +1226,42 @@ fn integration_kolme_fork_live_node_submit_reaches_endpoint() {
             panic!("live node smoke expected endpoint reachability outcome, got error: {other:?}");
         }
     }
+}
+
+#[test]
+fn unit_kolme_fork_live_smoke_signer_emits_recoverable_secp256k1_signature() {
+    let pubkey = kolme_fork_live_smoke_pubkey_hex();
+    let message_json = format!(
+        "{{\"pubkey\":\"{pubkey}\",\"nonce\":7,\"created\":\"2026-02-11T00:00:00Z\",\"messages\":[],\"max_height\":null}}"
+    );
+    let (signature_hex, recovery_id) = kolme_fork_sign_message(message_json.as_str());
+
+    assert_eq!(signature_hex.len(), 128);
+    assert!(
+        signature_hex
+            .chars()
+            .all(|character| character.is_ascii_hexdigit()),
+        "signature must be lowercase/uppercase hex bytes"
+    );
+    assert!(recovery_id <= 3, "recovery id must be in secp256k1 range");
+
+    let signature_bytes =
+        decode_hex_bytes(signature_hex.as_str()).expect("signature hex must decode for recovery");
+    let signature = Signature::from_slice(signature_bytes.as_slice())
+        .expect("signature bytes must decode into a secp256k1 signature");
+    let recovery = RecoveryId::from_byte(recovery_id).expect("recovery id must decode");
+    let recovered_key =
+        VerifyingKey::recover_from_msg(message_json.as_bytes(), &signature, recovery)
+            .expect("signature must recover a verifying key");
+    let recovered_pubkey = encode_hex_lower(recovered_key.to_encoded_point(true).as_bytes());
+    assert_eq!(recovered_pubkey, pubkey);
+}
+
+#[test]
+fn regression_live_node_smoke_signature_payload_must_not_use_synthetic_literal() {
+    const SOURCE: &str = include_str!("kolme_runtime_commit_http_transport.rs");
+    assert!(
+        !SOURCE.contains("\\\"signature\\\":\\\"sig-live-smoke-"),
+        "live-node smoke payload must use real secp256k1 signature generation"
+    );
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -252,8 +252,11 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - strict profile NO-GO drift/synthetic reasons:
       - `runtime_commit_command_profile_mismatch`
       - `runtime_commit_non_synthetic_submit_probe_missing`
+      - `runtime_commit_real_signing_profile_marker_missing`
     - strict profile non-synthetic submit probe marker:
       - `integration_kolme_fork_live_node_submit_reaches_endpoint`
+    - strict profile real-signing marker:
+      - `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`
     - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
     - strict real-node runtime evidence marker path remains local-only and excluded from ci-fast-gate.
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -219,6 +219,7 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --finality-command "printf 'finality=final\n'" --finality-max-seconds 15 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt --finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt`
   - `bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json /tmp/kolme-local-runtime-commit-live-summary.json --policy-output-json /tmp/kolme-local-runtime-commit-live-policy.json`
   - evidence markers `submit_evidence_marker_present` and `finality_evidence_marker_present` must both pass for GO decisions in run mode.
+  - default live command composition emits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1` and policy fails closed when the signing-profile marker is absent.
   - summary emits synthetic-command classification markers: `live_command_synthetic`, `finality_command_synthetic`, and `synthetic_evidence_classification_version=v1`.
   - use `--require-non-synthetic-run-evidence` in `check_local_runtime_commit_live_evidence_policy.py` when validating real-node run evidence to fail closed on marker-only command paths.
 - Local KAMN runtime integration lane:
@@ -233,6 +234,8 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
     - `runtime_commit_command_profile_version=v1`
   - marker/profile drift is fail-closed in `check_local_kamn_live_runtime_real_node_profile_policy.py`.
+  - strict real-node checker additionally fails closed when runtime command surfaces omit fork-aligned signing profile marker:
+    - `runtime_commit_real_signing_profile_marker_missing`
   - real-node runner composition rejects in-memory fallback references:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
   - real-node checker fails closed when in-memory provider references appear in strict command/policy surfaces:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -417,6 +417,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_command_profile_version=v1`
   - NO-GO marker-drift proof must surface `runtime_commit_command_profile_mismatch` when profile marker contracts drift from `real-node-non-synthetic-v1`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
+  - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
 - Real-node profile contract lane command:
   - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
 - Contract lane command:
@@ -436,6 +437,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_policy_command_profile`
     - `runtime_commit_command_profile_version`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
+  - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`; checker fails closed with `runtime_commit_real_signing_profile_marker_missing` when omitted.
   - real-node profile command composition rejects in-memory fallback references at runner boundary:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:
@@ -746,7 +748,7 @@ Operator checkpoints:
 - Finality evidence contract lane command:
   - `bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json /tmp/kolme-local-runtime-commit-live-summary.json --policy-output-json /tmp/kolme-local-runtime-commit-live-policy.json`
 - Default live-provider smoke command executed by run mode:
-  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
+  - `KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
 - Summary schema:
   - `kamn.kolme.local-runtime-commit-live-summary.v1`
   - policy schema: `kamn.kolme.local-runtime-commit-live-policy-report.v1`

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 NON_SYNTHETIC_SUBMIT_PROBE_MARKER = "integration_kolme_fork_live_node_submit_reaches_endpoint"
 IN_MEMORY_PROVIDER_MARKER = "InMemoryKolmeRuntimeCommitClient"
+REAL_SIGNING_PROFILE_MARKER = "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
 
 
 def parse_args() -> argparse.Namespace:
@@ -110,6 +111,11 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and NON_SYNTHETIC_SUBMIT_PROBE_MARKER not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_non_synthetic_submit_probe_missing")
+        if (
+            runtime_commit_command_profile == "real-node-non-synthetic-v1"
+            and REAL_SIGNING_PROFILE_MARKER not in runtime_commit_command
+        ):
+            reason_codes.append("runtime_commit_real_signing_profile_marker_missing")
         if IN_MEMORY_PROVIDER_MARKER in runtime_commit_command:
             reason_codes.append("runtime_commit_in_memory_provider_reference_detected")
 

--- a/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
+++ b/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
@@ -66,6 +66,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif provider_command_marker_present is False:
         reason_codes.append("provider_command_marker_missing")
 
+    if (
+        report.get("provider_signing_profile_marker")
+        != "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
+    ):
+        reason_codes.append("provider_signing_profile_marker_mismatch")
+
+    provider_signing_profile_marker_present = report.get("provider_signing_profile_marker_present")
+    if not isinstance(provider_signing_profile_marker_present, bool):
+        reason_codes.append("provider_signing_profile_marker_present_invalid")
+    elif provider_signing_profile_marker_present is False:
+        reason_codes.append("provider_signing_profile_marker_missing")
+
     if report.get("submit_evidence_marker") != "status=submitted":
         reason_codes.append("submit_evidence_marker_mismatch")
 

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -210,6 +210,9 @@ def main() -> int:
     if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
         print("expected strict non-synthetic runtime marker in contract-lane summary command", file=sys.stderr)
         return 1
+    if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
+        print("expected real signing profile marker in contract-lane summary command", file=sys.stderr)
+        return 1
     if "InMemoryKolmeRuntimeCommitClient" in runtime_commit_command:
         print("expected live-provider-only runtime command composition in real-node contract-lane summary", file=sys.stderr)
         return 1
@@ -307,6 +310,12 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+        if "runtime_commit_real_signing_profile_marker_missing" not in synthetic_regression_reason_codes:
+            print(
+                "expected runtime_commit_real_signing_profile_marker_missing in synthetic regression policy output",
+                file=sys.stderr,
+            )
+            return 1
         if synthetic_regression_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for synthetic regression policy output", file=sys.stderr)
             return 1
@@ -319,7 +328,7 @@ def main() -> int:
             "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
             "--require-non-synthetic-run-evidence "
             "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
-            "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+            "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
             "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
             "--provider-hint InMemoryKolmeRuntimeCommitClient "
             "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -344,7 +344,7 @@ if [ ! -x "$LOCAL_HEAVY_GUARD" ]; then
   exit 1
 fi
 
-default_runtime_commit_live_submit_command="KAMN_KOLME_LIVE_BASE_URL=$(shell_escape "${BASE_URL}") KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\n'"
+default_runtime_commit_live_submit_command="KAMN_KOLME_LIVE_BASE_URL=$(shell_escape "${BASE_URL}") KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\n'"
 effective_runtime_commit_finality_command="$RUNTIME_COMMIT_FINALITY_COMMAND"
 if [ -z "$effective_runtime_commit_finality_command" ]; then
   effective_runtime_commit_finality_command="printf 'finality=final\\n'"

--- a/scripts/kolme/run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane.sh
@@ -26,6 +26,7 @@ default_live_command() {
   local command
   command="KAMN_KOLME_LIVE_BASE_URL=$(shell_escape "$BASE_URL")"
   command="${command} KAMN_KOLME_LIVE_PROVIDER_HINT=$(shell_escape "$PROVIDER_HINT")"
+  command="${command} KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
   if [ -n "$AUTHORIZATION_HEADER" ]; then
     command="${command} KAMN_KOLME_LIVE_AUTHORIZATION=$(shell_escape "$AUTHORIZATION_HEADER")"
   fi
@@ -209,6 +210,11 @@ PROVIDER_COMMAND_MARKER_PRESENT="false"
 if [[ "$LIVE_COMMAND" == *"$PROVIDER_COMMAND_MARKER"* ]]; then
   PROVIDER_COMMAND_MARKER_PRESENT="true"
 fi
+PROVIDER_SIGNING_PROFILE_MARKER="KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
+PROVIDER_SIGNING_PROFILE_MARKER_PRESENT="false"
+if [[ "$LIVE_COMMAND" == *"$PROVIDER_SIGNING_PROFILE_MARKER"* ]]; then
+  PROVIDER_SIGNING_PROFILE_MARKER_PRESENT="true"
+fi
 
 SUBMIT_EVIDENCE_MARKER="status=submitted"
 SUBMIT_EVIDENCE_MARKER_PRESENT="false"
@@ -358,7 +364,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$FINALITY_COMMAND" "$FINALITY_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$FINALITY_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" "$PROVIDER_CLIENT_CONTRACT" "$PROVIDER_SUBMIT_PROFILE_CONTRACT" "$PROVIDER_COMMAND_MARKER" "$PROVIDER_COMMAND_MARKER_PRESENT" "$SUBMIT_EVIDENCE_MARKER" "$SUBMIT_EVIDENCE_MARKER_PRESENT" "$FINALITY_EVIDENCE_MARKER" "$FINALITY_EVIDENCE_MARKER_PRESENT" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$LIVE_COMMAND" "$LIVE_OUTPUT_FILE" "$FINALITY_COMMAND" "$FINALITY_OUTPUT_FILE" "$BASE_URL" "$PROVIDER_HINT" "$PREFLIGHT_MAX_SECONDS" "$FINALITY_MAX_SECONDS" "$SKIP_PREFLIGHT" "$CHECK_FILE" "$PROVIDER_CLIENT_CONTRACT" "$PROVIDER_SUBMIT_PROFILE_CONTRACT" "$PROVIDER_COMMAND_MARKER" "$PROVIDER_COMMAND_MARKER_PRESENT" "$PROVIDER_SIGNING_PROFILE_MARKER" "$PROVIDER_SIGNING_PROFILE_MARKER_PRESENT" "$SUBMIT_EVIDENCE_MARKER" "$SUBMIT_EVIDENCE_MARKER_PRESENT" "$FINALITY_EVIDENCE_MARKER" "$FINALITY_EVIDENCE_MARKER_PRESENT" <<'PY'
 from __future__ import annotations
 
 import json
@@ -387,10 +393,12 @@ provider_client_contract = sys.argv[19]
 provider_submit_profile_contract = sys.argv[20]
 provider_command_marker = sys.argv[21]
 provider_command_marker_present = sys.argv[22] == "true"
-submit_evidence_marker = sys.argv[23]
-submit_evidence_marker_present = sys.argv[24] == "true"
-finality_evidence_marker = sys.argv[25]
-finality_evidence_marker_present = sys.argv[26] == "true"
+provider_signing_profile_marker = sys.argv[23]
+provider_signing_profile_marker_present = sys.argv[24] == "true"
+submit_evidence_marker = sys.argv[25]
+submit_evidence_marker_present = sys.argv[26] == "true"
+finality_evidence_marker = sys.argv[27]
+finality_evidence_marker_present = sys.argv[28] == "true"
 
 def classify_synthetic_command(command: str) -> bool:
     normalized = " ".join(command.strip().split())
@@ -464,6 +472,8 @@ summary = {
     "provider_submit_profile_contract": provider_submit_profile_contract,
     "provider_command_marker": provider_command_marker,
     "provider_command_marker_present": provider_command_marker_present,
+    "provider_signing_profile_marker": provider_signing_profile_marker,
+    "provider_signing_profile_marker_present": provider_signing_profile_marker_present,
     "submit_evidence_marker": submit_evidence_marker,
     "submit_evidence_marker_present": submit_evidence_marker_present,
     "finality_evidence_marker": finality_evidence_marker,

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -61,7 +61,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
-  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "runtime_commit_finality_command": "",
   "runtime_commit_finality_output_file": "",
@@ -340,6 +340,11 @@ if ! grep -q "runtime_commit_non_synthetic_submit_probe_missing" "$TMP_ERR"; the
   exit 1
 fi
 
+if ! grep -q "runtime_commit_real_signing_profile_marker_missing" "$TMP_ERR"; then
+  echo "expected real signing profile marker requirement reason for synthetic policy failure" >&2
+  exit 1
+fi
+
 cat >"$TMP_REPORT_INMEMORY" <<'JSON'
 {
   "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
@@ -356,7 +361,7 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
-  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "runtime_commit_finality_command": "",
   "runtime_commit_finality_output_file": "",
@@ -397,7 +402,7 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     },
     {
       "id": "runtime_commit_endpoint",
-      "command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+      "command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
       "status": "planned",
       "reason_code": "not_run"
     },
@@ -468,6 +473,8 @@ if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in real-node profile runtime commit command")
 if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_commit_command:
     raise SystemExit("expected non-synthetic runtime submit probe marker in real-node profile runtime commit command")
+if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
+    raise SystemExit("expected real signing profile marker in real-node profile runtime commit command")
 if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit command profile marker in runner-generated summary")
 if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -261,6 +261,8 @@ if f"--policy-output-json {policy_output_path}" not in runtime_command:
     raise SystemExit("expected runtime commit command to include runtime policy report pass-through")
 if "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider" not in runtime_command:
     raise SystemExit("expected runtime commit command to include live provider contract pass-through")
+if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_command:
+    raise SystemExit("expected runtime commit command to include real signing profile marker")
 if str(finality_output_path) not in summary.get("artifact_paths", []):
     raise SystemExit("expected integration summary artifact paths to include runtime finality output file")
 if str(policy_output_path) not in summary.get("artifact_paths", []):

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -89,6 +89,8 @@ if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in integration runtime_commit_command")
 if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_commit_command:
     raise SystemExit("expected non-synthetic runtime submit probe marker in integration runtime_commit_command")
+if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
+    raise SystemExit("expected real signing profile marker in integration runtime_commit_command")
 if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit command profile marker for real-node profile")
 if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -121,6 +121,8 @@ if "--require-non-synthetic-run-evidence" not in runtime_commit_command:
     raise SystemExit("expected strict non-synthetic runtime marker in real-node profile contract-lane summary")
 if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_commit_command:
     raise SystemExit("expected non-synthetic runtime submit probe marker in real-node profile contract-lane summary")
+if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
+    raise SystemExit("expected real signing profile marker in real-node profile contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_profile") != "real-node":
     raise SystemExit("expected contracts.runtime_profile=real-node in real-node profile contract-lane summary")
@@ -165,7 +167,7 @@ inmemory_summary["runtime_commit_command"] = (
     "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
     "--require-non-synthetic-run-evidence "
     "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
-    "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+    "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
     "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
     "--provider-hint InMemoryKolmeRuntimeCommitClient "
     "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
@@ -213,6 +215,11 @@ fi
 
 if ! grep -q "runtime_commit_non_synthetic_submit_probe_missing" "$TMP_NEGATIVE_ERR"; then
   echo "expected non-synthetic submit probe marker reason in synthetic-command negative proof output" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_real_signing_profile_marker_missing" "$TMP_NEGATIVE_ERR"; then
+  echo "expected real signing profile marker reason in synthetic-command negative proof output" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -100,6 +100,10 @@ if report.get("provider_command_marker") != "integration_kolme_fork_live_node_su
     raise SystemExit("expected live provider command marker")
 if report.get("provider_command_marker_present") is not True:
     raise SystemExit("expected default dry-run command to include live provider marker")
+if report.get("provider_signing_profile_marker") != "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1":
+    raise SystemExit("expected deterministic live signing profile marker")
+if report.get("provider_signing_profile_marker_present") is not True:
+    raise SystemExit("expected default dry-run command to include live signing profile marker")
 if report.get("submit_evidence_marker") != "status=submitted":
     raise SystemExit("expected deterministic submit evidence marker")
 if report.get("submit_evidence_marker_present") is not False:


### PR DESCRIPTION
Closes #2169

## Summary
This replaces synthetic `sig-*` live-node smoke payload signatures with fork-aligned recoverable secp256k1 signing semantics and hardens runtime-lane policy to require explicit real-signing profile markers. It closes a false-positive gap where strict real-node profiles could pass without proving the real signing path.

## Changes
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`: added deterministic secp256k1 signing helper (k256), replaced live smoke payload literal signature path, and added recoverability unit coverage.
- `crates/kamn-core/Cargo.toml`, `Cargo.lock`: added `k256` dev-dependency for test-only real signing semantics.
- `scripts/kolme/run_local_runtime_commit_live_lane.sh`: added default signing marker (`KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`) and summary fields `provider_signing_profile_marker*`.
- `scripts/kolme/check_local_runtime_commit_live_evidence_policy.py`: fail-closed checks for signing marker mismatch/missing.
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: propagated signing marker into default nested runtime command composition.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: fail-closed reason `runtime_commit_real_signing_profile_marker_missing` for strict real-node profile drift.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py` and related shell tests: added marker assertions and negative-proof expectations.
- `README.md`, `docs/foundation/kolme-runtime-commit-client.md`, `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`: documented strict real-signing marker and new fail-closed reason code.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Failing checks before implementation:
```bash
bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
# expected deterministic live signing profile marker

bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
# expected real signing profile marker requirement reason for synthetic policy failure

cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_live_node_smoke_signature_payload_must_not_use_synthetic_literal
# FAILED: live-node smoke payload must use real secp256k1 signature generation
```

### 🟢 Green Phase
Passing checks after implementation:
```bash
bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
cargo test -p kamn-core --test kolme_runtime_commit_http_transport
```

### 🔁 Regression
Validation + quality gates:
```bash
bash scripts/ci/test_readme_contract.sh
bash scripts/ci/test_ci_strategy_contract.sh
python3 -m py_compile scripts/kolme/check_local_runtime_commit_live_evidence_policy.py scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_kolme_fork_live_smoke_signer_emits_recoverable_secp256k1_signature` | |
| Functional   | ✅     | Updated runtime lane + policy shell tests for signing marker contracts | |
| Integration  | ✅     | Updated real-node profile contract lanes and integration lane tests | |
| Regression   | ✅     | Synthetic literal guard + marker drift NO-GO proofs | |
| Performance  | ✅     | Local-only bounded lane budgets unchanged; CI fast-gate remains dry-run/contract focused | |

## Risks & Rollback
- No production runtime path changes; scope is test/lane-policy hardening and docs.
- Risk: stricter marker contracts can fail older local scripts that omit `KAMN_KOLME_LIVE_SIGNING_PROFILE`.
- Rollback: revert commit `198cb36` to restore previous non-strict signing-marker behavior.

## Documentation Updates
- `README.md`
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (targeted lane + contract suites)
- [x] Docs updated (or justified why not)
