### PR TITLE
feat(node): add kolme-live runtime profile wiring

### DIFF
--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -209,6 +209,10 @@ pub enum ConfigError {
     InvalidDaemonControlArgument(String),
     /// Invalid daemon lifecycle event argument.
     InvalidDaemonLifecycleEvent(String),
+    /// Invalid live Kolme provider hint argument.
+    InvalidKolmeLiveProviderHint(String),
+    /// Invalid live Kolme signing profile argument.
+    InvalidKolmeLiveSigningProfile(String),
     /// Invalid governance proposal argument.
     InvalidProposalArgument(String),
     /// Invalid rejoin-attempt argument.
@@ -219,6 +223,8 @@ pub enum ConfigError {
     RuntimeRecovery(String),
     /// Runtime daemon lifecycle argument validation failure.
     RuntimeDaemonLifecycle(String),
+    /// Runtime Kolme live-provider wiring validation failure.
+    RuntimeKolmeLive(String),
     /// Unknown command-line/config argument.
     UnknownArgument(String),
     /// Argument flag required a value but none was provided.
@@ -250,6 +256,12 @@ impl fmt::Display for ConfigError {
             Self::InvalidDaemonLifecycleEvent(value) => {
                 write!(f, "invalid daemon lifecycle event: {value}")
             }
+            Self::InvalidKolmeLiveProviderHint(value) => {
+                write!(f, "invalid kolme live provider hint: {value}")
+            }
+            Self::InvalidKolmeLiveSigningProfile(value) => {
+                write!(f, "invalid kolme live signing profile: {value}")
+            }
             Self::InvalidProposalArgument(value) => {
                 write!(f, "invalid proposal argument: {value}")
             }
@@ -264,6 +276,9 @@ impl fmt::Display for ConfigError {
             }
             Self::RuntimeDaemonLifecycle(message) => {
                 write!(f, "runtime daemon lifecycle validation failed: {message}")
+            }
+            Self::RuntimeKolmeLive(message) => {
+                write!(f, "runtime kolme live validation failed: {message}")
             }
             Self::UnknownArgument(value) => write!(f, "unknown argument: {value}"),
             Self::MissingArgumentValue(flag) => {

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -2,10 +2,16 @@ use std::env;
 use std::process::ExitCode;
 
 use kamn_core::{
-    bootstrap, BootstrapPlan, ConfigError, DeterministicProposalPlanner, NodeConfig, NodeRole,
+    bootstrap, BootstrapPlan, ConfigError, DeterministicProposalPlanner,
+    KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitLiveProvider, NodeConfig, NodeRole,
     PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, RecoveryRejoinGuard,
     RecoveryStatus, RejoinAttempt, SyncMode,
 };
+
+const KOLME_LIVE_PROVIDER_CONTRACT: &str = "KolmeRuntimeCommitLiveProvider";
+const KOLME_LIVE_SIGNING_PROFILE: &str = "kolme-fork-secp256k1-v1";
+const KOLME_IN_MEMORY_PROVIDER_MARKER: &str = "InMemoryKolmeRuntimeCommitClient";
+const KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS: u64 = 30;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct OutputMode {
@@ -51,6 +57,7 @@ enum RuntimeModeKind {
     Planning,
     RecoveryCheck,
     Daemon,
+    KolmeLive,
 }
 
 impl RuntimeMode {
@@ -78,12 +85,19 @@ impl RuntimeMode {
         }
     }
 
+    fn kolme_live() -> Self {
+        Self {
+            kind: RuntimeModeKind::KolmeLive,
+        }
+    }
+
     fn parse(value: &str) -> Result<Self, ConfigError> {
         match value {
             "bootstrap" => Ok(Self::bootstrap()),
             "planning" => Ok(Self::planning()),
             "recovery-check" => Ok(Self::recovery_check()),
             "daemon" => Ok(Self::daemon()),
+            "kolme-live" => Ok(Self::kolme_live()),
             other => Err(ConfigError::InvalidRuntimeMode(other.to_owned())),
         }
     }
@@ -94,6 +108,7 @@ impl RuntimeMode {
             RuntimeModeKind::Planning => "planning",
             RuntimeModeKind::RecoveryCheck => "recovery-check",
             RuntimeModeKind::Daemon => "daemon",
+            RuntimeModeKind::KolmeLive => "kolme-live",
         }
     }
 }
@@ -189,6 +204,9 @@ struct NodeCli {
     daemon_tick_interval_ms: Option<u64>,
     daemon_peer_id: Option<String>,
     daemon_lifecycle_events: Vec<PeerLifecycleEvent>,
+    kolme_live_base_url: Option<String>,
+    kolme_live_provider_hint: Option<String>,
+    kolme_live_signing_profile: Option<String>,
     output_mode: OutputMode,
     diagnostics_mode: DiagnosticsMode,
 }
@@ -220,6 +238,23 @@ struct DaemonExecution {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct KolmeLiveExecution {
+    provider_client_contract: String,
+    base_url: String,
+    provider_hint: String,
+    signing_profile: String,
+    execution_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct RuntimeExecutionBundle {
+    planning: Option<PlanningExecution>,
+    recovery: Option<RecoveryExecution>,
+    daemon: Option<DaemonExecution>,
+    kolme_live: Option<KolmeLiveExecution>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct NodeBootstrapReport {
     runtime_mode: String,
     diagnostics_mode: String,
@@ -238,6 +273,11 @@ struct NodeBootstrapReport {
     daemon_peer_id: Option<String>,
     daemon_peer_lifecycle_final_state: Option<String>,
     daemon_peer_lifecycle_applied_events: Option<Vec<String>>,
+    kolme_live_provider_client_contract: Option<String>,
+    kolme_live_base_url: Option<String>,
+    kolme_live_provider_hint: Option<String>,
+    kolme_live_signing_profile: Option<String>,
+    kolme_live_execution_status: Option<String>,
     profile: Option<String>,
     role: String,
     chain_id: String,
@@ -272,6 +312,9 @@ where
     let mut daemon_tick_interval_ms: Option<u64> = None;
     let mut daemon_peer_id: Option<String> = None;
     let mut daemon_lifecycle_events: Vec<PeerLifecycleEvent> = Vec::new();
+    let mut kolme_live_base_url: Option<String> = None;
+    let mut kolme_live_provider_hint: Option<String> = None;
+    let mut kolme_live_signing_profile: Option<String> = None;
     let mut output_mode = OutputMode::text();
     let mut diagnostics_mode = DiagnosticsMode::basic();
     let mut role_overridden = false;
@@ -382,6 +425,22 @@ where
                 ))?;
                 daemon_lifecycle_events.push(parse_daemon_lifecycle_event(&value)?);
             }
+            "--kolme-live-base-url" => {
+                kolme_live_base_url = Some(
+                    iter.next()
+                        .ok_or(ConfigError::MissingArgumentValue("--kolme-live-base-url"))?,
+                );
+            }
+            "--kolme-live-provider-hint" => {
+                kolme_live_provider_hint = Some(iter.next().ok_or(
+                    ConfigError::MissingArgumentValue("--kolme-live-provider-hint"),
+                )?);
+            }
+            "--kolme-live-signing-profile" => {
+                kolme_live_signing_profile = Some(iter.next().ok_or(
+                    ConfigError::MissingArgumentValue("--kolme-live-signing-profile"),
+                )?);
+            }
             "--output" => {
                 let value = iter
                     .next()
@@ -457,6 +516,37 @@ where
             return Err(ConfigError::MissingArgumentValue("--daemon-peer-id"));
         }
     }
+    if runtime_mode.kind == RuntimeModeKind::KolmeLive {
+        if kolme_live_base_url.is_none() {
+            return Err(ConfigError::MissingArgumentValue("--kolme-live-base-url"));
+        }
+        if kolme_live_provider_hint.is_none() {
+            return Err(ConfigError::MissingArgumentValue(
+                "--kolme-live-provider-hint",
+            ));
+        }
+        if kolme_live_signing_profile.is_none() {
+            return Err(ConfigError::MissingArgumentValue(
+                "--kolme-live-signing-profile",
+            ));
+        }
+        let provider_hint = kolme_live_provider_hint
+            .as_ref()
+            .expect("provider hint is required for kolme-live mode");
+        if provider_hint.contains(KOLME_IN_MEMORY_PROVIDER_MARKER) {
+            return Err(ConfigError::InvalidKolmeLiveProviderHint(
+                provider_hint.to_owned(),
+            ));
+        }
+        let signing_profile = kolme_live_signing_profile
+            .as_ref()
+            .expect("signing profile is required for kolme-live mode");
+        if signing_profile != KOLME_LIVE_SIGNING_PROFILE {
+            return Err(ConfigError::InvalidKolmeLiveSigningProfile(
+                signing_profile.to_owned(),
+            ));
+        }
+    }
 
     Ok(NodeCli {
         profile,
@@ -475,6 +565,9 @@ where
         daemon_tick_interval_ms,
         daemon_peer_id,
         daemon_lifecycle_events,
+        kolme_live_base_url,
+        kolme_live_provider_hint,
+        kolme_live_signing_profile,
         output_mode,
         diagnostics_mode,
     })
@@ -583,6 +676,9 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         daemon_tick_interval_ms,
         daemon_peer_id,
         daemon_lifecycle_events,
+        kolme_live_base_url,
+        kolme_live_provider_hint,
+        kolme_live_signing_profile,
         output_mode: _,
         diagnostics_mode,
     } = cli;
@@ -596,8 +692,8 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
     };
 
     let plan = bootstrap(config)?;
-    let (planning, recovery, daemon) = match runtime_mode.kind {
-        RuntimeModeKind::Bootstrap => (None, None, None),
+    let runtime_execution = match runtime_mode.kind {
+        RuntimeModeKind::Bootstrap => RuntimeExecutionBundle::default(),
         RuntimeModeKind::Planning => {
             let expected_state_hash = expected_state_hash
                 .ok_or(ConfigError::MissingArgumentValue("--expected-state-hash"))?;
@@ -605,15 +701,14 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             let proposal_plan = planner
                 .plan(proposals)
                 .map_err(|error| ConfigError::RuntimePlanner(error.to_string()))?;
-            (
-                Some(PlanningExecution {
+            RuntimeExecutionBundle {
+                planning: Some(PlanningExecution {
                     expected_state_hash,
                     candidate_count: proposal_plan.ordered_candidates().len(),
                     scheduled_candidate_ids: proposal_plan.ordered_candidate_ids(),
                 }),
-                None,
-                None,
-            )
+                ..RuntimeExecutionBundle::default()
+            }
         }
         RuntimeModeKind::RecoveryCheck => {
             let expected_state_version = expected_state_version.ok_or(
@@ -639,16 +734,15 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 };
                 decisions.push(decision);
             }
-            (
-                None,
-                Some(RecoveryExecution {
+            RuntimeExecutionBundle {
+                recovery: Some(RecoveryExecution {
                     expected_state_version,
                     expected_state_hash,
                     attempt_count: decisions.len(),
                     decisions,
                 }),
-                None,
-            )
+                ..RuntimeExecutionBundle::default()
+            }
         }
         RuntimeModeKind::Daemon => {
             let max_ticks =
@@ -677,10 +771,8 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                     }
                     None => (None, None, None),
                 };
-            (
-                None,
-                None,
-                Some(DaemonExecution {
+            RuntimeExecutionBundle {
+                daemon: Some(DaemonExecution {
                     max_ticks,
                     tick_interval_ms,
                     executed_ticks: max_ticks,
@@ -689,7 +781,43 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                     peer_lifecycle_final_state,
                     peer_lifecycle_applied_events,
                 }),
+                ..RuntimeExecutionBundle::default()
+            }
+        }
+        RuntimeModeKind::KolmeLive => {
+            let base_url = kolme_live_base_url
+                .ok_or(ConfigError::MissingArgumentValue("--kolme-live-base-url"))?;
+            let provider_hint = kolme_live_provider_hint.ok_or(
+                ConfigError::MissingArgumentValue("--kolme-live-provider-hint"),
+            )?;
+            let signing_profile = kolme_live_signing_profile.ok_or(
+                ConfigError::MissingArgumentValue("--kolme-live-signing-profile"),
+            )?;
+            if provider_hint.contains(KOLME_IN_MEMORY_PROVIDER_MARKER) {
+                return Err(ConfigError::InvalidKolmeLiveProviderHint(provider_hint));
+            }
+            if signing_profile != KOLME_LIVE_SIGNING_PROFILE {
+                return Err(ConfigError::InvalidKolmeLiveSigningProfile(signing_profile));
+            }
+            let transport =
+                KolmeRuntimeCommitHttpTransport::new(KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS)
+                    .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+            let _provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+                base_url.as_str(),
+                provider_hint.as_str(),
+                transport,
             )
+            .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+            RuntimeExecutionBundle {
+                kolme_live: Some(KolmeLiveExecution {
+                    provider_client_contract: KOLME_LIVE_PROVIDER_CONTRACT.to_owned(),
+                    base_url,
+                    provider_hint,
+                    signing_profile,
+                    execution_status: "provider-configured".to_owned(),
+                }),
+                ..RuntimeExecutionBundle::default()
+            }
         }
     };
     let report = build_bootstrap_report(
@@ -697,9 +825,7 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         profile,
         diagnostics_mode,
         runtime_mode,
-        planning,
-        recovery,
-        daemon,
+        runtime_execution,
     );
 
     Ok(report)
@@ -710,10 +836,14 @@ fn build_bootstrap_report(
     profile: Option<LocalProfile>,
     diagnostics_mode: DiagnosticsMode,
     runtime_mode: RuntimeMode,
-    planning: Option<PlanningExecution>,
-    recovery: Option<RecoveryExecution>,
-    daemon: Option<DaemonExecution>,
+    runtime_execution: RuntimeExecutionBundle,
 ) -> NodeBootstrapReport {
+    let RuntimeExecutionBundle {
+        planning,
+        recovery,
+        daemon,
+        kolme_live,
+    } = runtime_execution;
     let operational_profile = plan.config.operational_profile();
     let components = plan
         .wiring
@@ -749,6 +879,21 @@ fn build_bootstrap_report(
     let daemon_peer_lifecycle_applied_events = daemon
         .as_ref()
         .and_then(|daemon| daemon.peer_lifecycle_applied_events.clone());
+    let kolme_live_provider_client_contract = kolme_live
+        .as_ref()
+        .map(|execution| execution.provider_client_contract.clone());
+    let kolme_live_base_url = kolme_live
+        .as_ref()
+        .map(|execution| execution.base_url.clone());
+    let kolme_live_provider_hint = kolme_live
+        .as_ref()
+        .map(|execution| execution.provider_hint.clone());
+    let kolme_live_signing_profile = kolme_live
+        .as_ref()
+        .map(|execution| execution.signing_profile.clone());
+    let kolme_live_execution_status = kolme_live
+        .as_ref()
+        .map(|execution| execution.execution_status.clone());
     NodeBootstrapReport {
         runtime_mode: runtime_mode.as_str().to_owned(),
         diagnostics_mode: diagnostics_mode.as_str().to_owned(),
@@ -767,6 +912,11 @@ fn build_bootstrap_report(
         daemon_peer_id,
         daemon_peer_lifecycle_final_state,
         daemon_peer_lifecycle_applied_events,
+        kolme_live_provider_client_contract,
+        kolme_live_base_url,
+        kolme_live_provider_hint,
+        kolme_live_signing_profile,
+        kolme_live_execution_status,
         profile: profile.map(LocalProfile::as_str).map(str::to_owned),
         role: plan.config.role.as_str().to_owned(),
         chain_id: plan.config.chain_id.clone(),
@@ -844,8 +994,22 @@ fn render_text_report(report: &NodeBootstrapReport) -> String {
         .as_ref()
         .map(|value| value.join(", "))
         .unwrap_or_else(|| "none".to_owned());
+    let kolme_live_provider_client_contract = report
+        .kolme_live_provider_client_contract
+        .as_deref()
+        .unwrap_or("none");
+    let kolme_live_base_url = report.kolme_live_base_url.as_deref().unwrap_or("none");
+    let kolme_live_provider_hint = report.kolme_live_provider_hint.as_deref().unwrap_or("none");
+    let kolme_live_signing_profile = report
+        .kolme_live_signing_profile
+        .as_deref()
+        .unwrap_or("none");
+    let kolme_live_execution_status = report
+        .kolme_live_execution_status
+        .as_deref()
+        .unwrap_or("none");
     format!(
-        "KAMN node bootstrap\n  runtime_mode: {}\n  diagnostics_mode: {}\n  profile: {}\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  sync_mode: {}\n  sync_startup: {}\n  sync_recovery: {}\n  state_version: {}\n  pending_migrations: {}\n  component_count: {}\n  planning_expected_state_hash: {}\n  planning_candidate_count: {}\n  planning_scheduled_candidate_ids: {}\n  recovery_expected_state_version: {}\n  recovery_expected_state_hash: {}\n  recovery_attempt_count: {}\n  recovery_decisions: {}\n  daemon_max_ticks: {}\n  daemon_tick_interval_ms: {}\n  daemon_executed_ticks: {}\n  daemon_completion_reason: {}\n  daemon_peer_id: {}\n  daemon_peer_lifecycle_final_state: {}\n  daemon_peer_lifecycle_applied_events: {}\n  components: {}",
+        "KAMN node bootstrap\n  runtime_mode: {}\n  diagnostics_mode: {}\n  profile: {}\n  role: {}\n  chain: {} ({})\n  storage: {}\n  gossip: {}\n  sync_mode: {}\n  sync_startup: {}\n  sync_recovery: {}\n  state_version: {}\n  pending_migrations: {}\n  component_count: {}\n  planning_expected_state_hash: {}\n  planning_candidate_count: {}\n  planning_scheduled_candidate_ids: {}\n  recovery_expected_state_version: {}\n  recovery_expected_state_hash: {}\n  recovery_attempt_count: {}\n  recovery_decisions: {}\n  daemon_max_ticks: {}\n  daemon_tick_interval_ms: {}\n  daemon_executed_ticks: {}\n  daemon_completion_reason: {}\n  daemon_peer_id: {}\n  daemon_peer_lifecycle_final_state: {}\n  daemon_peer_lifecycle_applied_events: {}\n  kolme_live_provider_client_contract: {}\n  kolme_live_base_url: {}\n  kolme_live_provider_hint: {}\n  kolme_live_signing_profile: {}\n  kolme_live_execution_status: {}\n  components: {}",
         report.runtime_mode,
         report.diagnostics_mode,
         profile,
@@ -878,6 +1042,11 @@ fn render_text_report(report: &NodeBootstrapReport) -> String {
         daemon_peer_id,
         daemon_peer_lifecycle_final_state,
         daemon_peer_lifecycle_applied_events,
+        kolme_live_provider_client_contract,
+        kolme_live_base_url,
+        kolme_live_provider_hint,
+        kolme_live_signing_profile,
+        kolme_live_execution_status,
         report.components.join(", "),
     )
 }
@@ -964,6 +1133,26 @@ fn render_json_report(report: &NodeBootstrapReport) -> String {
         ),
         None => "null".to_owned(),
     };
+    let kolme_live_provider_client_contract = match &report.kolme_live_provider_client_contract {
+        Some(value) => format!("\"{}\"", json_escape(value)),
+        None => "null".to_owned(),
+    };
+    let kolme_live_base_url = match &report.kolme_live_base_url {
+        Some(value) => format!("\"{}\"", json_escape(value)),
+        None => "null".to_owned(),
+    };
+    let kolme_live_provider_hint = match &report.kolme_live_provider_hint {
+        Some(value) => format!("\"{}\"", json_escape(value)),
+        None => "null".to_owned(),
+    };
+    let kolme_live_signing_profile = match &report.kolme_live_signing_profile {
+        Some(value) => format!("\"{}\"", json_escape(value)),
+        None => "null".to_owned(),
+    };
+    let kolme_live_execution_status = match &report.kolme_live_execution_status {
+        Some(value) => format!("\"{}\"", json_escape(value)),
+        None => "null".to_owned(),
+    };
     let components = report
         .components
         .iter()
@@ -971,7 +1160,7 @@ fn render_json_report(report: &NodeBootstrapReport) -> String {
         .collect::<Vec<String>>()
         .join(",");
     format!(
-        "{{\"runtime_mode\":\"{}\",\"diagnostics_mode\":\"{}\",\"profile\":{},\"role\":\"{}\",\"chain_id\":\"{}\",\"chain_version\":\"{}\",\"storage_dir\":\"{}\",\"gossip_enabled\":{},\"sync_mode\":\"{}\",\"sync_startup\":\"{}\",\"sync_recovery\":\"{}\",\"state_version\":{},\"pending_migrations\":{},\"component_count\":{},\"planning_expected_state_hash\":{},\"planning_candidate_count\":{},\"planning_scheduled_candidate_ids\":{},\"recovery_expected_state_version\":{},\"recovery_expected_state_hash\":{},\"recovery_attempt_count\":{},\"recovery_decisions\":{},\"daemon_max_ticks\":{},\"daemon_tick_interval_ms\":{},\"daemon_executed_ticks\":{},\"daemon_completion_reason\":{},\"daemon_peer_id\":{},\"daemon_peer_lifecycle_final_state\":{},\"daemon_peer_lifecycle_applied_events\":{},\"components\":[{}]}}",
+        "{{\"runtime_mode\":\"{}\",\"diagnostics_mode\":\"{}\",\"profile\":{},\"role\":\"{}\",\"chain_id\":\"{}\",\"chain_version\":\"{}\",\"storage_dir\":\"{}\",\"gossip_enabled\":{},\"sync_mode\":\"{}\",\"sync_startup\":\"{}\",\"sync_recovery\":\"{}\",\"state_version\":{},\"pending_migrations\":{},\"component_count\":{},\"planning_expected_state_hash\":{},\"planning_candidate_count\":{},\"planning_scheduled_candidate_ids\":{},\"recovery_expected_state_version\":{},\"recovery_expected_state_hash\":{},\"recovery_attempt_count\":{},\"recovery_decisions\":{},\"daemon_max_ticks\":{},\"daemon_tick_interval_ms\":{},\"daemon_executed_ticks\":{},\"daemon_completion_reason\":{},\"daemon_peer_id\":{},\"daemon_peer_lifecycle_final_state\":{},\"daemon_peer_lifecycle_applied_events\":{},\"kolme_live_provider_client_contract\":{},\"kolme_live_base_url\":{},\"kolme_live_provider_hint\":{},\"kolme_live_signing_profile\":{},\"kolme_live_execution_status\":{},\"components\":[{}]}}",
         json_escape(&report.runtime_mode),
         json_escape(&report.diagnostics_mode),
         profile,
@@ -1000,6 +1189,11 @@ fn render_json_report(report: &NodeBootstrapReport) -> String {
         daemon_peer_id,
         daemon_peer_lifecycle_final_state,
         daemon_peer_lifecycle_applied_events,
+        kolme_live_provider_client_contract,
+        kolme_live_base_url,
+        kolme_live_provider_hint,
+        kolme_live_signing_profile,
+        kolme_live_execution_status,
         components,
     )
 }
@@ -1025,7 +1219,7 @@ fn main() -> ExitCode {
 mod tests {
     use super::{
         build_bootstrap_report, execute, parse_args, render_bootstrap_report, DiagnosticsMode,
-        LocalProfile, NodeBootstrapReport, OutputMode, RuntimeMode,
+        LocalProfile, NodeBootstrapReport, OutputMode, RuntimeExecutionBundle, RuntimeMode,
     };
     use kamn_core::{bootstrap, ConfigError, NodeConfig, NodeRole, SyncMode};
 
@@ -1054,6 +1248,9 @@ mod tests {
         assert_eq!(parsed.daemon_tick_interval_ms, None);
         assert_eq!(parsed.daemon_peer_id, None);
         assert!(parsed.daemon_lifecycle_events.is_empty());
+        assert_eq!(parsed.kolme_live_base_url, None);
+        assert_eq!(parsed.kolme_live_provider_hint, None);
+        assert_eq!(parsed.kolme_live_signing_profile, None);
         assert_eq!(parsed.output_mode, OutputMode::text());
         assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::basic());
     }
@@ -1189,6 +1386,38 @@ mod tests {
     }
 
     #[test]
+    fn parses_runtime_mode_kolme_live_with_required_flags() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+        ];
+
+        let parsed = parse_args(args).expect("kolme-live args should parse");
+        assert_eq!(parsed.runtime_mode.as_str(), "kolme-live");
+        assert_eq!(
+            parsed.kolme_live_base_url,
+            Some("http://127.0.0.1:3000".to_owned())
+        );
+        assert_eq!(
+            parsed.kolme_live_provider_hint,
+            Some("kolme-fork-local".to_owned())
+        );
+        assert_eq!(
+            parsed.kolme_live_signing_profile,
+            Some("kolme-fork-secp256k1-v1".to_owned())
+        );
+    }
+
+    #[test]
     fn parses_local_listener_profile_defaults() {
         let args = vec![
             "kamn-node".to_owned(),
@@ -1249,6 +1478,11 @@ mod tests {
             daemon_peer_id: None,
             daemon_peer_lifecycle_final_state: None,
             daemon_peer_lifecycle_applied_events: None,
+            kolme_live_provider_client_contract: None,
+            kolme_live_base_url: None,
+            kolme_live_provider_hint: None,
+            kolme_live_signing_profile: None,
+            kolme_live_execution_status: None,
             profile: None,
             role: "processor".to_owned(),
             chain_id: "kamn-devnet".to_owned(),
@@ -1294,9 +1528,7 @@ mod tests {
             parsed.profile,
             parsed.diagnostics_mode,
             RuntimeMode::bootstrap(),
-            None,
-            None,
-            None,
+            RuntimeExecutionBundle::default(),
         );
         let rendered = render_bootstrap_report(&report, parsed.output_mode);
 
@@ -1332,9 +1564,7 @@ mod tests {
             parsed.profile,
             parsed.diagnostics_mode,
             RuntimeMode::bootstrap(),
-            None,
-            None,
-            None,
+            RuntimeExecutionBundle::default(),
         );
         let rendered = render_bootstrap_report(&report, parsed.output_mode);
 
@@ -1371,9 +1601,7 @@ mod tests {
             parsed.profile,
             parsed.diagnostics_mode,
             RuntimeMode::bootstrap(),
-            None,
-            None,
-            None,
+            RuntimeExecutionBundle::default(),
         );
         let rendered = render_bootstrap_report(&report, parsed.output_mode);
 
@@ -1476,6 +1704,34 @@ mod tests {
                 "\"daemon_peer_lifecycle_applied_events\":[\"start-connect\",\"handshake-succeeded\",\"heartbeat-missed\",\"heartbeat-restored\"]"
             )
         );
+    }
+
+    #[test]
+    fn integration_runtime_kolme_live_renders_provider_contract_markers() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+            "--output".to_owned(),
+            "json".to_owned(),
+        ];
+
+        let parsed = parse_args(args).expect("kolme-live args should parse");
+        let report = execute(parsed).expect("kolme-live execution should succeed");
+        let rendered = render_bootstrap_report(&report, OutputMode::json());
+        assert!(rendered.contains("\"runtime_mode\":\"kolme-live\""));
+        assert!(rendered.contains(
+            "\"kolme_live_provider_client_contract\":\"KolmeRuntimeCommitLiveProvider\""
+        ));
+        assert!(rendered.contains("\"kolme_live_signing_profile\":\"kolme-fork-secp256k1-v1\""));
     }
 
     #[test]
@@ -1612,6 +1868,113 @@ mod tests {
             parse_args(args),
             Err(ConfigError::MissingArgumentValue(
                 "--daemon-tick-interval-ms"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_kolme_live_without_base_url() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+        ];
+        assert_eq!(
+            parse_args(args),
+            Err(ConfigError::MissingArgumentValue("--kolme-live-base-url"))
+        );
+    }
+
+    #[test]
+    fn rejects_kolme_live_without_provider_hint() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+        ];
+        assert_eq!(
+            parse_args(args),
+            Err(ConfigError::MissingArgumentValue(
+                "--kolme-live-provider-hint"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_kolme_live_without_signing_profile() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+        ];
+        assert_eq!(
+            parse_args(args),
+            Err(ConfigError::MissingArgumentValue(
+                "--kolme-live-signing-profile"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_kolme_live_with_invalid_signing_profile() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "synthetic-signing-profile".to_owned(),
+        ];
+        assert_eq!(
+            parse_args(args),
+            Err(ConfigError::InvalidKolmeLiveSigningProfile(
+                "synthetic-signing-profile".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_kolme_live_with_in_memory_provider_hint_marker() {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "InMemoryKolmeRuntimeCommitClient".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+        ];
+        assert_eq!(
+            parse_args(args),
+            Err(ConfigError::InvalidKolmeLiveProviderHint(
+                "InMemoryKolmeRuntimeCommitClient".to_owned()
             ))
         );
     }

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -13,10 +13,17 @@ fn doc_contains_output_mode_scope_and_rules() {
     assert!(DOC.contains("--runtime-mode planning"));
     assert!(DOC.contains("--runtime-mode recovery-check"));
     assert!(DOC.contains("--runtime-mode daemon"));
+    assert!(DOC.contains("--runtime-mode kolme-live"));
+    assert!(DOC.contains("--kolme-live-base-url"));
+    assert!(DOC.contains("--kolme-live-provider-hint"));
+    assert!(DOC.contains("--kolme-live-signing-profile"));
     assert!(DOC.contains("ConfigError::InvalidRuntimeMode"));
     assert!(DOC.contains("ConfigError::InvalidDaemonControlArgument"));
     assert!(DOC.contains("ConfigError::InvalidDaemonLifecycleEvent"));
     assert!(DOC.contains("ConfigError::RuntimeDaemonLifecycle"));
+    assert!(DOC.contains("ConfigError::InvalidKolmeLiveProviderHint"));
+    assert!(DOC.contains("ConfigError::InvalidKolmeLiveSigningProfile"));
+    assert!(DOC.contains("ConfigError::RuntimeKolmeLive"));
 }
 
 #[test]
@@ -36,6 +43,11 @@ fn doc_contains_deterministic_json_fields() {
     assert!(DOC.contains("daemon_completion_reason"));
     assert!(DOC.contains("daemon_peer_lifecycle_final_state"));
     assert!(DOC.contains("daemon_peer_lifecycle_applied_events"));
+    assert!(DOC.contains("kolme_live_provider_client_contract"));
+    assert!(DOC.contains("kolme_live_base_url"));
+    assert!(DOC.contains("kolme_live_provider_hint"));
+    assert!(DOC.contains("kolme_live_signing_profile"));
+    assert!(DOC.contains("kolme_live_execution_status"));
     assert!(DOC.contains("sync_mode"));
     assert!(DOC.contains("components"));
 }
@@ -91,6 +103,17 @@ fn doc_contains_runtime_daemon_rules() {
     assert!(DOC.contains("execute_processor_daemon_tick"));
     assert!(DOC.contains("typed construct-lock errors"));
     assert!(DOC.contains("tick-budget-exhausted"));
+}
+
+#[test]
+fn doc_contains_runtime_kolme_live_rules() {
+    assert!(DOC.contains("## Kolme Live Runtime Rules"));
+    assert!(DOC.contains("`kolme-live`"));
+    assert!(DOC.contains("--kolme-live-base-url"));
+    assert!(DOC.contains("--kolme-live-provider-hint"));
+    assert!(DOC.contains("--kolme-live-signing-profile"));
+    assert!(DOC.contains("KolmeRuntimeCommitLiveProvider"));
+    assert!(DOC.contains("kolme-fork-secp256k1-v1"));
 }
 
 #[test]
@@ -182,4 +205,12 @@ fn regression_requires_runtime_daemon_lease_guard_rules() {
     assert!(
         DOC.contains("daemon lease guard no-lease/invalid-owner rejection (`Regression: #388`)")
     );
+}
+
+#[test]
+fn regression_requires_runtime_kolme_live_guard_rules() {
+    // Regression: #2175
+    assert!(DOC.contains(
+        "in-memory fallback and invalid signing profile rejection (`Regression: #2175`)"
+    ));
 }

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -215,6 +215,13 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
 - Local-only heavy execution remains opt-in and bounded:
   - all non-dry-run orchestration lanes require `KAMN_KOLME_LOCAL_HEAVY=1`.
   - CI fast-gate remains dry-run/contract focused; local run-mode is intentionally opt-in to control cost.
+- `kamn-node` live-provider runtime profile (CI-safe configuration validation):
+  - `cargo run -p kamn-node -- --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1 --output json`
+  - expected deterministic report markers:
+    - `kolme_live_provider_client_contract=KolmeRuntimeCommitLiveProvider`
+    - `kolme_live_signing_profile=kolme-fork-secp256k1-v1`
+    - `kolme_live_execution_status=provider-configured`
+  - in-memory fallback markers and non-fork signing profiles are rejected fail-closed by typed node config errors.
 - Runtime live lane (submit + optional finality):
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --finality-command "printf 'finality=final\n'" --finality-max-seconds 15 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt --finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt`
   - `bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json /tmp/kolme-local-runtime-commit-live-summary.json --policy-output-json /tmp/kolme-local-runtime-commit-live-policy.json`
@@ -265,6 +272,7 @@ cargo test -p kamn-core
 - direct signed transaction required-field validation drift remains fail-closed (`Regression: #1519`).
 - local live-node provider smoke preflight and ignored-test dispatch remain fail-closed (`Regression: #1829`).
 - local runtime-commit live evidence policy markers for `KolmeRuntimeCommitLiveProvider` path remain fail-closed (`Regression: #2095`).
+- `kamn-node` kolme-live runtime profile guardrails reject in-memory provider-hint fallback and invalid signing-profile drift (`Regression: #2175`).
 - local runtime-commit submit/finality evidence marker policy and contract lane parity remain fail-closed (`Regression: #2099`).
 - local KAMN live runtime integration runtime-step contract composition remains fail-closed for missing runtime policy evidence artifacts (`Regression: #2101`).
 - typed nonce/broadcast HTTP helper mapping drift remains fail-closed (`Regression: #1533`).

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -1,4 +1,4 @@
-# Node Runtime CLI Contracts (Issues #306 / #307 / #309 / #310 / #335 / #336 / #348 / #349)
+# Node Runtime CLI Contracts (Issues #306 / #307 / #309 / #310 / #335 / #336 / #348 / #349 / #2175)
 
 This document captures node-runtime productionization slices for machine-readable output, local role profile projection, diagnostics snapshots, deterministic runtime planning execution, and deterministic recovery-check evaluation.
 
@@ -24,6 +24,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--runtime-mode planning`
   - `--runtime-mode recovery-check`
   - `--runtime-mode daemon`
+  - `--runtime-mode kolme-live`
 - Added runtime planning inputs:
   - `--expected-state-hash <state-hash>`
   - `--proposal <id|sender-did|nonce|state-hash>` (repeatable)
@@ -36,16 +37,23 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--daemon-tick-interval-ms <positive-integer>`
   - `--daemon-peer-id <peer-id>` (optional)
   - `--daemon-lifecycle-event <start-connect|handshake-succeeded|heartbeat-missed|heartbeat-restored|disconnect|rejoin>` (repeatable)
+- Added Kolme live runtime controls:
+  - `--kolme-live-base-url <http(s)-endpoint>`
+  - `--kolme-live-provider-hint <provider-hint>`
+  - `--kolme-live-signing-profile <signing-profile>`
 - Added explicit runtime mode and proposal validation handling through:
   - `ConfigError::InvalidRuntimeMode`
   - `ConfigError::InvalidExpectedStateVersion`
   - `ConfigError::InvalidDaemonControlArgument`
   - `ConfigError::InvalidDaemonLifecycleEvent`
+  - `ConfigError::InvalidKolmeLiveProviderHint`
+  - `ConfigError::InvalidKolmeLiveSigningProfile`
   - `ConfigError::InvalidProposalArgument`
   - `ConfigError::InvalidRejoinAttemptArgument`
   - `ConfigError::RuntimePlanner`
   - `ConfigError::RuntimeRecovery`
   - `ConfigError::RuntimeDaemonLifecycle`
+  - `ConfigError::RuntimeKolmeLive`
 
 ## Output Mode Rules
 - Default behavior remains text output when `--output` is omitted.
@@ -78,6 +86,11 @@ This document captures node-runtime productionization slices for machine-readabl
   - `daemon_peer_id`
   - `daemon_peer_lifecycle_final_state`
   - `daemon_peer_lifecycle_applied_events`
+  - `kolme_live_provider_client_contract`
+  - `kolme_live_base_url`
+  - `kolme_live_provider_hint`
+  - `kolme_live_signing_profile`
+  - `kolme_live_execution_status`
   - `components`
 - Invalid modes are rejected with explicit typed error.
 
@@ -155,6 +168,9 @@ This document captures node-runtime productionization slices for machine-readabl
 - Daemon mode:
   - `kamn-node --role processor --runtime-mode daemon`
   - `kamn-node --role processor --runtime-mode daemon --daemon-max-ticks 3 --daemon-tick-interval-ms 25`
+- Kolme-live mode:
+  - `kamn-node --role processor --runtime-mode kolme-live`
+  - `kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1`
 
 ## Daemon Runtime Rules
 - Supported runtime modes:
@@ -177,6 +193,21 @@ This document captures node-runtime productionization slices for machine-readabl
   - `daemon_executed_ticks` equals configured `daemon_max_ticks`
   - `daemon_completion_reason` emits `tick-budget-exhausted`
 
+## Kolme Live Runtime Rules
+- Supported runtime modes:
+  - `bootstrap` (default)
+  - `kolme-live`
+- Kolme-live mode requires:
+  - `--kolme-live-base-url`
+  - `--kolme-live-provider-hint`
+  - `--kolme-live-signing-profile`
+- Provider wiring is fail-closed:
+  - runtime config must reject in-memory provider-hint markers such as `InMemoryKolmeRuntimeCommitClient`
+  - signing profile must match `kolme-fork-secp256k1-v1`
+- Runtime path constructs `KolmeRuntimeCommitLiveProvider` with deterministic transport timeout and reports:
+  - `kolme_live_provider_client_contract=KolmeRuntimeCommitLiveProvider`
+  - `kolme_live_execution_status=provider-configured`
+
 ## Test Coverage Mapping
 - Unit:
   - default mode behavior and mode parsing checks
@@ -193,6 +224,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - zero/invalid daemon bounded-loop control rejection (`Regression: #348`)
   - invalid daemon lifecycle transition rejection (`Regression: #349`)
   - daemon lease guard no-lease/invalid-owner rejection (`Regression: #388`)
+  - in-memory fallback and invalid signing profile rejection (`Regression: #2175`)
 
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
@@ -217,6 +249,7 @@ cargo test -p kamn-core
 ```bash
 cargo test -p kamn-node integration_runtime_daemon_renders_bounded_completion_output
 cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
+cargo test -p kamn-node integration_runtime_kolme_live_renders_provider_contract_markers
 ```
 
 ## Processor HA Runtime References


### PR DESCRIPTION
## Summary
This adds a new `kamn-node` runtime execution mode, `kolme-live`, that wires node runtime configuration through `KolmeRuntimeCommitLiveProvider` with fail-closed guardrails for provider-hint and signing-profile drift. It also extends deterministic node runtime reporting and documentation contracts so node-level Kolme live profile behavior is explicitly verifiable.

## Linked Issues
- Closes #2175
- Refs #2174
- Refs #2097

## Changes
- `crates/kamn-node/src/main.rs`: added `kolme-live` runtime mode, CLI flags, validation, provider construction path, deterministic report fields, and new unit/integration/regression tests.
- `crates/kamn-core/src/config.rs`: added typed config/runtime errors for Kolme live profile validation.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added docs-contract assertions for `kolme-live` command surface and regression markers.
- `docs/foundation/node-runtime-cli.md`: documented `kolme-live` mode, required flags, deterministic JSON fields, and regression guard semantics.
- `docs/foundation/kolme-runtime-commit-client.md`: documented node CLI `kolme-live` usage and marker expectations.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-node parses_runtime_mode_kolme_live_with_required_flags -- --exact
```
Expected failure before implementation:
- `error[E0609]: no field 'kolme_live_base_url' on type 'NodeCli'`
- `error[E0609]: no field 'kolme_live_provider_hint' on type 'NodeCli'`
- `error[E0609]: no field 'kolme_live_signing_profile' on type 'NodeCli'`

### 🟢 Green Phase
```bash
cargo test -p kamn-node
cargo test -p kamn-node --test node_runtime_cli_docs
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo test -p kamn-core config::tests:: -- --nocapture
cargo fmt --check
cargo clippy -p kamn-node -p kamn-core --tests -- -D warnings
```

### 🔁 Regression
```bash
cargo test -p kamn-node integration_runtime_kolme_live_renders_provider_contract_markers -- --exact
cargo test -p kamn-node rejects_kolme_live_with_invalid_signing_profile -- --exact
cargo test -p kamn-node rejects_kolme_live_with_in_memory_provider_hint_marker -- --exact
cargo test -p kamn-node --test node_runtime_cli_docs
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | new parse/validation tests for `kolme-live` flags and fail-closed error paths in `crates/kamn-node/src/main.rs` | |
| Functional   | ✅ | deterministic runtime report rendering assertions for new `kolme_live_*` fields | |
| Integration  | ✅ | `integration_runtime_kolme_live_renders_provider_contract_markers` validates live-provider runtime wiring path | |
| Regression   | ✅ | in-memory fallback/signing profile drift rejection tests + docs regression marker (`Regression: #2175`) | |
| Performance  | ✅ | no new heavy CI lane; checks remain local compile/test and docs-contract level | |

## Risks & Rollback
- Risk: node CLI/runtime surface grows; misuse of `kolme-live` flags could surface new config errors for existing scripts.
- Risk: downstream tooling consuming node JSON may need to tolerate added `kolme_live_*` fields.
- Rollback plan: revert commit `92edffb`.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/foundation/kolme-runtime-commit-client.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-node -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: N/A
- Expected runtime delta: N/A
- Expected runner-minute delta: N/A
- Rollback plan if CI cost/runtime regresses: N/A
