### PR TITLE
test(ci): deterministic reason codes for Kolme wrapper trend policy

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -205,6 +205,11 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - trend-policy command:
       - `bash scripts/ci/check_kolme_wrapper_budget_trend.sh --matrix-file fixtures/kolme_compatibility/lane_migration_matrix.json --baseline-file fixtures/kolme_compatibility/wrapper_inventory_baseline.json --output-json /tmp/kolme-wrapper-budget-trend-report.json`
     - trend mode allows shell-surface reductions and fails only on growth beyond configured thresholds.
+    - deterministic reason-code surface is emitted for automation:
+      - `reason_codes=none` (pass)
+      - `reason_codes=wrapper_count_delta_threshold_exceeded`
+      - `reason_codes=total_shell_loc_delta_threshold_exceeded`
+      - `reason_codes=lane_shell_loc_increase_violation`
     - Regression: #2119
   - shared dispatcher wrapper-matrix guard stays on PR fast gate:
     - `bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`

--- a/scripts/ci/kolme_wrapper_inventory_baseline.py
+++ b/scripts/ci/kolme_wrapper_inventory_baseline.py
@@ -329,13 +329,16 @@ def command_check(args: argparse.Namespace) -> int:
     current_lane_ids = set(current_lanes)
 
     violations: list[str] = []
+    reason_codes: set[str] = set()
 
     missing_lanes = sorted(baseline_lane_ids - current_lane_ids)
     extra_lanes = sorted(current_lane_ids - baseline_lane_ids)
     if missing_lanes:
         violations.append(f"missing lanes in current inventory: {', '.join(missing_lanes)}")
+        reason_codes.add("missing_lanes_in_current_inventory")
     if extra_lanes:
         violations.append(f"unexpected new lanes in current inventory: {', '.join(extra_lanes)}")
+        reason_codes.add("unexpected_new_lanes_in_current_inventory")
 
     lane_deltas: list[dict[str, Any]] = []
     for lane_id in sorted(baseline_lane_ids & current_lane_ids):
@@ -360,6 +363,12 @@ def command_check(args: argparse.Namespace) -> int:
                 violations.append(
                     f"lane {lane_id} changed {key}: baseline={baseline_lane[key]} current={current_lane[key]}"
                 )
+                if key == "source_entry":
+                    reason_codes.add("lane_source_entry_drift")
+                elif key == "manifest_file":
+                    reason_codes.add("lane_manifest_file_drift")
+                elif key == "wrapper_kind":
+                    reason_codes.add("lane_wrapper_kind_drift")
         if trend_mode:
             if enforce_lane_shell_loc_nonincreasing and shell_loc_delta > 0:
                 violations.append(
@@ -367,10 +376,12 @@ def command_check(args: argparse.Namespace) -> int:
                     f"{lane_id} shell_loc increased beyond nonincreasing policy: "
                     f"baseline={baseline_lane['shell_loc']} current={current_lane['shell_loc']}"
                 )
+                reason_codes.add("lane_shell_loc_increase_violation")
         elif shell_loc_delta != 0:
             violations.append(
                 f"lane {lane_id} shell_loc drifted: baseline={baseline_lane['shell_loc']} current={current_lane['shell_loc']}"
             )
+            reason_codes.add("lane_shell_loc_drift")
 
     totals_delta = {
         "wrapper_count_delta": current["wrapper_count"] - baseline["wrapper_count"],
@@ -386,12 +397,16 @@ def command_check(args: argparse.Namespace) -> int:
                 f"delta={totals_delta['wrapper_count_delta']} "
                 f"threshold={max_wrapper_count_increase}"
             )
+            reason_codes.add("wrapper_count_delta_threshold_exceeded")
         if totals_delta["total_shell_loc_delta"] > max_total_shell_loc_increase:
             violations.append(
                 "total_shell_loc_delta exceeded trend threshold: "
                 f"delta={totals_delta['total_shell_loc_delta']} "
                 f"threshold={max_total_shell_loc_increase}"
             )
+            reason_codes.add("total_shell_loc_delta_threshold_exceeded")
+
+    sorted_reason_codes = sorted(reason_codes)
 
     report_payload = {
         "schema_version": DELTA_REPORT_SCHEMA_VERSION,
@@ -417,6 +432,7 @@ def command_check(args: argparse.Namespace) -> int:
             "enforce_lane_shell_loc_nonincreasing": enforce_lane_shell_loc_nonincreasing,
         },
         "lane_deltas": lane_deltas,
+        "reason_codes": sorted_reason_codes,
         "violations": violations,
         "status": "fail" if violations else "pass",
     }
@@ -429,6 +445,7 @@ def command_check(args: argparse.Namespace) -> int:
     print(f"wrapper_count_delta={totals_delta['wrapper_count_delta']}")
     print(f"total_shell_loc_delta={totals_delta['total_shell_loc_delta']}")
     print(f"violation_count={len(violations)}")
+    print(f"reason_codes={'none' if not sorted_reason_codes else ','.join(sorted_reason_codes)}")
 
     if violations:
         for violation in violations:

--- a/scripts/ci/test_check_kolme_wrapper_budget_trend.sh
+++ b/scripts/ci/test_check_kolme_wrapper_budget_trend.sh
@@ -47,6 +47,7 @@ grep -q '^mode=trend$' "$TMP_DIR/pass.out"
 grep -q '^wrapper_count_delta=0$' "$TMP_DIR/pass.out"
 grep -q '^total_shell_loc_delta=0$' "$TMP_DIR/pass.out"
 grep -q '^violation_count=0$' "$TMP_DIR/pass.out"
+grep -q '^reason_codes=none$' "$TMP_DIR/pass.out"
 
 MUTATED_BASELINE="$TMP_DIR/mutated-baseline.json"
 cp "$BASELINE_FIXTURE" "$MUTATED_BASELINE"
@@ -71,6 +72,7 @@ fi
 
 grep -q '^status=fail$' "$TMP_DIR/fail.out"
 grep -q '^mode=trend$' "$TMP_DIR/fail.out"
+grep -q '^reason_codes=total_shell_loc_delta_threshold_exceeded$' "$TMP_DIR/fail.out"
 grep -q 'total_shell_loc_delta exceeded trend threshold' "$TMP_DIR/fail.out"
 
 RELAXED_THRESHOLD="$TMP_DIR/relaxed-threshold.json"
@@ -91,5 +93,6 @@ python3 "$PYTHON_CHECKER" check \
 
 grep -q '^status=pass$' "$TMP_DIR/relaxed.out"
 grep -q '^mode=trend$' "$TMP_DIR/relaxed.out"
+grep -q '^reason_codes=none$' "$TMP_DIR/relaxed.out"
 
 echo "Kolme wrapper budget trend checker tests passed."

--- a/scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
+++ b/scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
@@ -80,6 +80,7 @@ grep -q '^status=pass$' "$TMP_DIR/check-pass.out"
 grep -q '^wrapper_count_delta=0$' "$TMP_DIR/check-pass.out"
 grep -q '^total_shell_loc_delta=0$' "$TMP_DIR/check-pass.out"
 grep -q '^violation_count=0$' "$TMP_DIR/check-pass.out"
+grep -q '^reason_codes=none$' "$TMP_DIR/check-pass.out"
 
 MUTATED_BASELINE="$TMP_DIR/mutated-baseline.json"
 cp "$BASELINE_FIXTURE" "$MUTATED_BASELINE"
@@ -102,6 +103,7 @@ if bash "$CHECK_SCRIPT" \
   exit 1
 fi
 grep -q '^status=fail$' "$TMP_DIR/check-mutated-baseline.out"
+grep -q '^reason_codes=lane_shell_loc_drift$' "$TMP_DIR/check-mutated-baseline.out"
 grep -q 'shell_loc drifted' "$TMP_DIR/check-mutated-baseline.out"
 
 MUTATED_MATRIX="$TMP_DIR/mutated-matrix.json"


### PR DESCRIPTION
## Summary
Add deterministic `reason_codes` output to Kolme wrapper inventory/trend policy checks so CI automation can consume stable failure semantics instead of free-text-only violations.

Closes #2187

## Changes
- `scripts/ci/kolme_wrapper_inventory_baseline.py`: emit sorted `reason_codes` in JSON and stdout for strict/trend checks.
- `scripts/ci/test_check_kolme_wrapper_budget_trend.sh`: enforce reason-code markers on pass/fail paths.
- `scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh`: enforce strict-check reason-code markers.
- `docs/ci/strategy.md`: document deterministic wrapper trend reason-code surface.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Added failing assertions for `reason_codes` markers in `scripts/ci/test_check_kolme_wrapper_budget_trend.sh`.
- Failure observed before implementation because checker output omitted `reason_codes` (only status/mode/deltas/violation_count were emitted).

### 🟢 Green Phase
- `bash scripts/ci/test_check_kolme_wrapper_budget_trend.sh` ✅
- `bash scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh` ✅

### 🔁 Regression
- `bash scripts/ci/test_ci_strategy_contract.sh` ✅
- `bash scripts/ci/test_ci_tools_command_surface_contract.sh` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Shell/Python contract layer change; behavior validated via contract tests. |
| Functional   | ✅     | `scripts/ci/test_check_kolme_wrapper_budget_trend.sh` | Validates policy outputs for pass/fail trend flows. |
| Integration  | ✅     | `scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh` | Validates baseline generation+check integration and drift detection. |
| Regression   | ✅     | `scripts/ci/test_check_kolme_wrapper_budget_trend.sh`, `scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh` | Locks deterministic reason-code surface. |
| Performance  | N/A    | None                 | No runtime-path or throughput change. |

## Risks & Rollback
- Risk: low; output surface is additive and deterministic.
- Rollback: revert this PR to return to previous text-only violation output.

## Documentation Updates
- Updated `docs/ci/strategy.md` wrapper-budget trend section with reason-code markers.

## Validation Checklist
- [ ] `cargo fmt --check` — clean (N/A: no Rust changes)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: no Rust changes)
- [x] TDD Red/Green evidence included above
