### PR TITLE
fix(kolme): enforce signing marker in live finality evidence lane

### DIFF
--- a/scripts/kolme/contracts/local_runtime_commit_live_finality_evidence_contract_lane.py
+++ b/scripts/kolme/contracts/local_runtime_commit_live_finality_evidence_contract_lane.py
@@ -170,7 +170,7 @@ def main() -> int:
             "run",
             "--skip-preflight",
             "--live-command",
-            "printf 'status=submitted\\nintegration_kolme_fork_live_node_submit_reaches_endpoint\\n'",
+            "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 printf 'status=submitted\\nintegration_kolme_fork_live_node_submit_reaches_endpoint\\n'",
             "--finality-command",
             "printf 'finality=final\\n'",
             "--max-seconds",


### PR DESCRIPTION
## Summary
Patch the runtime live-finality evidence contract lane fixture command to include the required signing-profile marker so provider policy checks stay GO for provider-only live paths.

Closes #2195

## Changes
- `scripts/kolme/contracts/local_runtime_commit_live_finality_evidence_contract_lane.py`:
  - run-mode fixture `--live-command` now includes `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh` failed.
- Failure reason from policy output: `provider_signing_profile_marker_missing`.

### 🟢 Green Phase
- `bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh` ✅
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` ✅
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` ✅

### 🔁 Regression
- `cargo test -p kamn-node runtime_kolme_live -- --nocapture` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Command composition contract fix validated via lane/policy tests. |
| Functional   | ✅     | `test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh` | Validates expected GO decision path. |
| Integration  | ✅     | `test_run_local_kamn_live_runtime_integration_real_node_profile.sh` | Validates nested runtime lane composition in real-node profile. |
| Regression   | ✅     | `test_check_local_kamn_live_runtime_real_node_profile_policy.sh`, `cargo test -p kamn-node runtime_kolme_live` | Prevents provider/signing marker drift regressions. |
| Performance  | N/A    | None                 | No runtime budget/path expansion. |

## Risks & Rollback
- Risk: low; fixture command-surface marker alignment only.
- Rollback: revert this PR to restore previous fixture command string.

## Documentation Updates
- None required (existing docs already require this marker).

## Validation Checklist
- [ ] `cargo fmt --check` — clean (N/A: no Rust changes)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: no Rust changes)
- [x] TDD Red/Green evidence included above
