### PR TITLE
feat(kolme): enforce signer profile evidence contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,17 +578,26 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_commit_command_profile=real-node-non-synthetic-v1
 # runtime_commit_policy_command_profile=real-node-non-synthetic-v1
 # runtime_commit_command_profile_version=v1
+# runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE
+# runtime_signer_profile=ops-primary
+# runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
 
 # strict profile NO-GO drift/synthetic reason markers
 # runtime_commit_command_profile_mismatch
+# runtime_signer_profile_mismatch
+# runtime_signer_private_key_env_mismatch
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing
+# runtime_commit_signer_profile_marker_missing
 
 # strict profile non-synthetic submit probe marker
 # integration_kolme_fork_live_node_submit_reaches_endpoint
 
 # strict profile real-signing marker
 # KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1
+
+# strict profile signer marker
+# KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary
 
 # real-node profile contract lane (dry-run summary + policy + docs parity)
 bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -265,14 +265,22 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_commit_command_profile=real-node-non-synthetic-v1`
       - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
       - `runtime_commit_command_profile_version=v1`
+      - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
+      - `runtime_signer_profile=ops-primary`
+      - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - strict profile NO-GO drift/synthetic reasons:
       - `runtime_commit_command_profile_mismatch`
+      - `runtime_signer_profile_mismatch`
+      - `runtime_signer_private_key_env_mismatch`
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`
+      - `runtime_commit_signer_profile_marker_missing`
     - strict profile non-synthetic submit probe marker:
       - `integration_kolme_fork_live_node_submit_reaches_endpoint`
     - strict profile real-signing marker:
       - `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`
+    - strict profile signer marker:
+      - `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`
     - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
     - strict real-node runtime evidence marker path remains local-only and excluded from ci-fast-gate.
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -415,9 +415,15 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_command_profile=real-node-non-synthetic-v1`
     - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
     - `runtime_commit_command_profile_version=v1`
+    - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
+    - `runtime_signer_profile=ops-primary`
+    - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
   - NO-GO marker-drift proof must surface `runtime_commit_command_profile_mismatch` when profile marker contracts drift from `real-node-non-synthetic-v1`.
+  - NO-GO signer-profile drift proof must surface `runtime_signer_profile_mismatch` when summary signer profile markers drift from `ops-primary`.
+  - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
+  - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`.
 - Real-node profile contract lane command:
   - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
 - Contract lane command:
@@ -436,8 +442,16 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_command_profile`
     - `runtime_commit_policy_command_profile`
     - `runtime_commit_command_profile_version`
+    - `runtime_signer_profile_selector_env`
+    - `runtime_signer_profile`
+    - `runtime_signer_private_key_env`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
+  - real-node profile requires signer profile summary/contracts markers:
+    - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
+    - `runtime_signer_profile=ops-primary`
+    - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`; checker fails closed with `runtime_commit_real_signing_profile_marker_missing` when omitted.
+  - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile command composition rejects in-memory fallback references at runner boundary:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -8,6 +8,10 @@ from pathlib import Path
 NON_SYNTHETIC_SUBMIT_PROBE_MARKER = "integration_kolme_fork_live_node_submit_reaches_endpoint"
 IN_MEMORY_PROVIDER_MARKER = "InMemoryKolmeRuntimeCommitClient"
 REAL_SIGNING_PROFILE_MARKER = "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
+REAL_SIGNER_PROFILE_SELECTOR_ENV = "KAMN_KOLME_LIVE_SIGNER_PROFILE"
+REAL_SIGNER_PROFILE = "ops-primary"
+REAL_SIGNER_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+REAL_SIGNER_PROFILE_COMMAND_MARKER = "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary"
 
 
 def parse_args() -> argparse.Namespace:
@@ -78,6 +82,24 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif runtime_provider_client_contract != "KolmeRuntimeCommitLiveProvider":
         reason_codes.append("runtime_provider_client_contract_mismatch")
 
+    runtime_signer_profile_selector_env = report.get("runtime_signer_profile_selector_env")
+    if not isinstance(runtime_signer_profile_selector_env, str) or not runtime_signer_profile_selector_env.strip():
+        reason_codes.append("runtime_signer_profile_selector_env_missing")
+    elif runtime_signer_profile_selector_env != REAL_SIGNER_PROFILE_SELECTOR_ENV:
+        reason_codes.append("runtime_signer_profile_selector_env_mismatch")
+
+    runtime_signer_profile = report.get("runtime_signer_profile")
+    if not isinstance(runtime_signer_profile, str) or not runtime_signer_profile.strip():
+        reason_codes.append("runtime_signer_profile_missing")
+    elif runtime_signer_profile != REAL_SIGNER_PROFILE:
+        reason_codes.append("runtime_signer_profile_mismatch")
+
+    runtime_signer_private_key_env = report.get("runtime_signer_private_key_env")
+    if not isinstance(runtime_signer_private_key_env, str) or not runtime_signer_private_key_env.strip():
+        reason_codes.append("runtime_signer_private_key_env_missing")
+    elif runtime_signer_private_key_env != REAL_SIGNER_PRIVATE_KEY_ENV:
+        reason_codes.append("runtime_signer_private_key_env_mismatch")
+
     runtime_commit_command_profile = report.get("runtime_commit_command_profile")
     if not isinstance(runtime_commit_command_profile, str) or not runtime_commit_command_profile.strip():
         reason_codes.append("runtime_commit_command_profile_missing")
@@ -116,6 +138,11 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and REAL_SIGNING_PROFILE_MARKER not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_real_signing_profile_marker_missing")
+        if (
+            runtime_commit_command_profile == "real-node-non-synthetic-v1"
+            and REAL_SIGNER_PROFILE_COMMAND_MARKER not in runtime_commit_command
+        ):
+            reason_codes.append("runtime_commit_signer_profile_marker_missing")
         if IN_MEMORY_PROVIDER_MARKER in runtime_commit_command:
             reason_codes.append("runtime_commit_in_memory_provider_reference_detected")
 
@@ -133,6 +160,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_profile_contract_mismatch")
         if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
             reason_codes.append("runtime_provider_client_contract_contract_mismatch")
+        if contracts.get("runtime_signer_profile_selector_env") != REAL_SIGNER_PROFILE_SELECTOR_ENV:
+            reason_codes.append("runtime_signer_profile_selector_env_contract_mismatch")
+        if contracts.get("runtime_signer_profile") != REAL_SIGNER_PROFILE:
+            reason_codes.append("runtime_signer_profile_contract_mismatch")
+        if contracts.get("runtime_signer_private_key_env") != REAL_SIGNER_PRIVATE_KEY_ENV:
+            reason_codes.append("runtime_signer_private_key_env_contract_mismatch")
         if contracts.get("runtime_commit_endpoint") != "/broadcast/runtime-commit":
             reason_codes.append("runtime_commit_endpoint_mismatch")
         if contracts.get("runtime_commit_method") != "POST":

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -213,6 +213,9 @@ def main() -> int:
     if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
         print("expected real signing profile marker in contract-lane summary command", file=sys.stderr)
         return 1
+    if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary" not in runtime_commit_command:
+        print("expected signer profile marker in contract-lane summary command", file=sys.stderr)
+        return 1
     if "InMemoryKolmeRuntimeCommitClient" in runtime_commit_command:
         print("expected live-provider-only runtime command composition in real-node contract-lane summary", file=sys.stderr)
         return 1
@@ -225,12 +228,30 @@ def main() -> int:
     if summary.get("runtime_commit_command_profile_version") != "v1":
         print("expected runtime commit command profile marker version in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+        print("expected signer profile selector env marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_profile") != "ops-primary":
+        print("expected signer profile marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+        print("expected signer private key env marker in contract-lane summary", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in real-node profile contract-lane summary", file=sys.stderr)
         return 1
     if contracts.get("runtime_profile") != "real-node":
         print("expected contracts.runtime_profile=real-node in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+        print("expected contracts signer profile selector env marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_profile") != "ops-primary":
+        print("expected contracts signer profile marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+        print("expected contracts signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
     if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
         print("unexpected real-node profile policy schema in contract-lane output", file=sys.stderr)
@@ -272,6 +293,38 @@ def main() -> int:
             return 1
         if marker_drift_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for marker drift policy output", file=sys.stderr)
+            return 1
+
+        signer_profile_drift_summary_file = negative_path / "signer_profile_drift_summary.json"
+        signer_profile_drift_policy_file = negative_path / "signer_profile_drift_policy.json"
+        signer_profile_drift_summary = dict(summary)
+        signer_profile_drift_summary["runtime_signer_profile"] = "ops-secondary"
+        signer_profile_drift_summary["runtime_signer_private_key_env"] = (
+            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+        )
+        signer_profile_drift_summary_file.write_text(
+            json.dumps(signer_profile_drift_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        signer_profile_drift_result = run_real_node_policy_check(
+            report_file=signer_profile_drift_summary_file,
+            output_json=signer_profile_drift_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if signer_profile_drift_result.returncode == 0:
+            print("expected signer profile drift negative proof to fail closed", file=sys.stderr)
+            return 1
+        signer_profile_drift_policy = json.loads(signer_profile_drift_policy_file.read_text(encoding="utf-8"))
+        signer_profile_drift_reason_codes = signer_profile_drift_policy.get("reason_codes")
+        if not isinstance(signer_profile_drift_reason_codes, list):
+            print("expected reason_codes list in signer profile drift policy output", file=sys.stderr)
+            return 1
+        if "runtime_signer_profile_mismatch" not in signer_profile_drift_reason_codes:
+            print("expected runtime_signer_profile_mismatch in signer profile drift policy output", file=sys.stderr)
+            return 1
+        if signer_profile_drift_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for signer profile drift policy output", file=sys.stderr)
             return 1
 
         synthetic_regression_summary_file = negative_path / "synthetic_regression_summary.json"
@@ -316,6 +369,12 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+        if "runtime_commit_signer_profile_marker_missing" not in synthetic_regression_reason_codes:
+            print(
+                "expected runtime_commit_signer_profile_marker_missing in synthetic regression policy output",
+                file=sys.stderr,
+            )
+            return 1
         if synthetic_regression_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for synthetic regression policy output", file=sys.stderr)
             return 1
@@ -328,7 +387,7 @@ def main() -> int:
             "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
             "--require-non-synthetic-run-evidence "
             "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
-            "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+            "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
             "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
             "--provider-hint InMemoryKolmeRuntimeCommitClient "
             "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
@@ -366,6 +425,7 @@ def main() -> int:
         "check_local_kamn_live_runtime_real_node_profile_policy.py",
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
+        "runtime_signer_profile=ops-primary",
         "Regression: #2139",
     ]
     ci_doc_markers = [
@@ -373,6 +433,7 @@ def main() -> int:
         "check_local_kamn_live_runtime_real_node_profile_policy.py",
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
+        "runtime_signer_profile=ops-primary",
         "Regression: #2139",
     ]
     readme_markers = [
@@ -380,6 +441,7 @@ def main() -> int:
         "check_local_kamn_live_runtime_real_node_profile_policy.py",
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
+        "runtime_signer_profile=ops-primary",
         "Regression: #2139",
     ]
 

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -33,6 +33,9 @@ BOOTSTRAP_MAX_SECONDS=90
 CONFORMANCE_MAX_SECONDS=180
 LOCALHOST_SIGNED_MAX_SECONDS=45
 RUNTIME_COMMIT_MAX_SECONDS=30
+RUNTIME_SIGNER_PROFILE_SELECTOR_ENV=""
+RUNTIME_SIGNER_PROFILE=""
+RUNTIME_SIGNER_PRIVATE_KEY_ENV=""
 
 shell_escape() {
   printf "%q" "$1"
@@ -344,7 +347,7 @@ if [ ! -x "$LOCAL_HEAVY_GUARD" ]; then
   exit 1
 fi
 
-default_runtime_commit_live_submit_command="KAMN_KOLME_LIVE_BASE_URL=$(shell_escape "${BASE_URL}") KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\n'"
+default_runtime_commit_live_submit_command_prefix="KAMN_KOLME_LIVE_BASE_URL=$(shell_escape "${BASE_URL}") KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local"
 effective_runtime_commit_finality_command="$RUNTIME_COMMIT_FINALITY_COMMAND"
 if [ -z "$effective_runtime_commit_finality_command" ]; then
   effective_runtime_commit_finality_command="printf 'finality=final\\n'"
@@ -358,7 +361,15 @@ if [ "$RUNTIME_PROFILE" = "real-node" ]; then
   runtime_commit_non_synthetic_flag=" --require-non-synthetic-run-evidence"
   runtime_commit_command_profile="real-node-non-synthetic-v1"
   runtime_commit_policy_command_profile="real-node-non-synthetic-v1"
+  RUNTIME_SIGNER_PROFILE_SELECTOR_ENV="KAMN_KOLME_LIVE_SIGNER_PROFILE"
+  RUNTIME_SIGNER_PROFILE="ops-primary"
+  RUNTIME_SIGNER_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 fi
+
+if [ -n "$RUNTIME_SIGNER_PROFILE" ]; then
+  default_runtime_commit_live_submit_command_prefix="${default_runtime_commit_live_submit_command_prefix} KAMN_KOLME_LIVE_SIGNER_PROFILE=${RUNTIME_SIGNER_PROFILE}"
+fi
+default_runtime_commit_live_submit_command="${default_runtime_commit_live_submit_command_prefix} KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\n'"
 
 default_runtime_commit_command="KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_SUMMARY}") --policy-output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_POLICY_REPORT}") --live-output-file $(shell_escape "${RUNTIME_COMMIT_OUTPUT_FILE}") --finality-output-file $(shell_escape "${RUNTIME_COMMIT_FINALITY_OUTPUT_FILE}") --max-seconds ${RUNTIME_COMMIT_MAX_SECONDS} --expected-provider-client-contract $(shell_escape "${RUNTIME_PROVIDER_CLIENT_CONTRACT}")${runtime_commit_non_synthetic_flag} --live-command $(shell_escape "${default_runtime_commit_live_submit_command}") --finality-command $(shell_escape "${effective_runtime_commit_finality_command}") --finality-max-seconds ${RUNTIME_COMMIT_FINALITY_MAX_SECONDS}"
 if [ -z "$RUNTIME_COMMIT_COMMAND" ]; then
@@ -619,7 +630,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" <<'PY'
 from __future__ import annotations
 
 import json
@@ -659,6 +670,9 @@ runtime_provider_client_contract = sys.argv[30]
 runtime_commit_command_profile = sys.argv[31]
 runtime_commit_policy_command_profile = sys.argv[32]
 runtime_commit_command_profile_version = sys.argv[33]
+runtime_signer_profile_selector_env = sys.argv[34]
+runtime_signer_profile = sys.argv[35]
+runtime_signer_private_key_env = sys.argv[36]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -698,6 +712,9 @@ summary = {
     "runtime_commit_command_profile": runtime_commit_command_profile,
     "runtime_commit_policy_command_profile": runtime_commit_policy_command_profile,
     "runtime_commit_command_profile_version": runtime_commit_command_profile_version,
+    "runtime_signer_profile_selector_env": runtime_signer_profile_selector_env,
+    "runtime_signer_profile": runtime_signer_profile,
+    "runtime_signer_private_key_env": runtime_signer_private_key_env,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
     "runtime_commit_finality_output_file": runtime_commit_finality_output_file if runtime_commit_finality_command else "",
@@ -712,6 +729,9 @@ summary = {
         "ci_fast_gate_scope": "local-only",
         "runtime_provider_client_contract": runtime_provider_client_contract,
         "runtime_profile": runtime_profile,
+        "runtime_signer_profile_selector_env": runtime_signer_profile_selector_env,
+        "runtime_signer_profile": runtime_signer_profile,
+        "runtime_signer_private_key_env": runtime_signer_private_key_env,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",
         "runtime_commit_finality_primary_endpoint": "/notifications",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -58,10 +58,13 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "fork_chain_version": "v0.15.2",
   "runtime_profile": "real-node",
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+  "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+  "runtime_signer_profile": "ops-primary",
+  "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
-  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "runtime_commit_finality_command": "",
   "runtime_commit_finality_output_file": "",
@@ -76,6 +79,9 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "ci_fast_gate_scope": "local-only",
     "runtime_profile": "real-node",
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+    "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+    "runtime_signer_profile": "ops-primary",
+    "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -166,6 +172,9 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "budget_status": "not_run",
   "runtime_profile": "standard",
   "runtime_provider_client_contract": "InMemoryKolmeRuntimeCommitClient",
+  "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+  "runtime_signer_profile": "ops-secondary",
+  "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
   "runtime_commit_command_profile": "standard-default-v1",
   "runtime_commit_policy_command_profile": "standard-default-v1",
   "runtime_commit_command_profile_version": "v0",
@@ -174,7 +183,10 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "contracts": {
     "ci_fast_gate_scope": "ci-fast-gate",
     "runtime_profile": "standard",
-    "runtime_provider_client_contract": "InMemoryKolmeRuntimeCommitClient"
+    "runtime_provider_client_contract": "InMemoryKolmeRuntimeCommitClient",
+    "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+    "runtime_signer_profile": "ops-secondary",
+    "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
   },
   "checks": [
     {
@@ -226,6 +238,16 @@ if ! grep -q "runtime_commit_policy_command_profile_mismatch" "$TMP_ERR"; then
   exit 1
 fi
 
+if ! grep -q "runtime_signer_profile_mismatch" "$TMP_ERR"; then
+  echo "expected signer profile mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_private_key_env_mismatch" "$TMP_ERR"; then
+  echo "expected signer private key env mismatch reason for policy failure" >&2
+  exit 1
+fi
+
 if ! grep -q "runtime_commit_command_profile_version_mismatch" "$TMP_ERR"; then
   echo "expected runtime commit profile marker version mismatch reason for policy failure" >&2
   exit 1
@@ -254,6 +276,9 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
   "budget_status": "not_run",
   "runtime_profile": "real-node",
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+  "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+  "runtime_signer_profile": "ops-primary",
+  "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
@@ -272,6 +297,9 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
     "ci_fast_gate_scope": "local-only",
     "runtime_profile": "real-node",
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+    "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+    "runtime_signer_profile": "ops-primary",
+    "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -345,6 +373,11 @@ if ! grep -q "runtime_commit_real_signing_profile_marker_missing" "$TMP_ERR"; th
   exit 1
 fi
 
+if ! grep -q "runtime_commit_signer_profile_marker_missing" "$TMP_ERR"; then
+  echo "expected signer profile marker requirement reason for synthetic policy failure" >&2
+  exit 1
+fi
+
 cat >"$TMP_REPORT_INMEMORY" <<'JSON'
 {
   "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
@@ -358,10 +391,13 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
   "budget_status": "not_run",
   "runtime_profile": "real-node",
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+  "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+  "runtime_signer_profile": "ops-primary",
+  "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
-  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
+  "runtime_commit_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --require-non-synthetic-run-evidence --live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" --provider-hint InMemoryKolmeRuntimeCommitClient --output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json",
   "runtime_commit_live_policy_report": "/tmp/runtime-policy.json",
   "runtime_commit_finality_command": "",
   "runtime_commit_finality_output_file": "",
@@ -376,6 +412,9 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     "ci_fast_gate_scope": "local-only",
     "runtime_profile": "real-node",
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
+    "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
+    "runtime_signer_profile": "ops-primary",
+    "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -475,12 +514,20 @@ if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_com
     raise SystemExit("expected non-synthetic runtime submit probe marker in real-node profile runtime commit command")
 if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
     raise SystemExit("expected real signing profile marker in real-node profile runtime commit command")
+if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary" not in runtime_commit_command:
+    raise SystemExit("expected signer profile marker in real-node profile runtime commit command")
 if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit command profile marker in runner-generated summary")
 if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit policy command profile marker in runner-generated summary")
 if summary.get("runtime_commit_command_profile_version") != "v1":
     raise SystemExit("expected runtime commit command profile marker version in runner-generated summary")
+if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+    raise SystemExit("expected signer profile selector env marker in runner-generated summary")
+if summary.get("runtime_signer_profile") != "ops-primary":
+    raise SystemExit("expected signer profile marker in runner-generated summary")
+if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    raise SystemExit("expected signer private key env marker in runner-generated summary")
 PY
 
 python3 - "$TMP_INTEGRATION_POLICY_OUT" <<'PY'

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -91,12 +91,20 @@ if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_com
     raise SystemExit("expected non-synthetic runtime submit probe marker in integration runtime_commit_command")
 if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
     raise SystemExit("expected real signing profile marker in integration runtime_commit_command")
+if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary" not in runtime_commit_command:
+    raise SystemExit("expected signer profile marker in integration runtime_commit_command")
 if summary.get("runtime_commit_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit command profile marker for real-node profile")
 if summary.get("runtime_commit_policy_command_profile") != "real-node-non-synthetic-v1":
     raise SystemExit("expected deterministic runtime commit policy command profile marker for real-node profile")
 if summary.get("runtime_commit_command_profile_version") != "v1":
     raise SystemExit("expected runtime commit command profile marker version for real-node profile")
+if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+    raise SystemExit("expected signer profile selector env marker for real-node profile")
+if summary.get("runtime_signer_profile") != "ops-primary":
+    raise SystemExit("expected signer profile marker for real-node profile")
+if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    raise SystemExit("expected signer private key env marker for real-node profile")
 contracts = summary.get("contracts", {})
 if not isinstance(contracts, dict):
     raise SystemExit("expected contracts object in integration summary")
@@ -104,6 +112,12 @@ if contracts.get("runtime_profile") != "real-node":
     raise SystemExit("expected contracts.runtime_profile=real-node in integration summary")
 if contracts.get("ci_fast_gate_scope") != "local-only":
     raise SystemExit("expected local-only fast-gate scope marker in integration summary")
+if contracts.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+    raise SystemExit("expected contracts signer profile selector env marker in integration summary")
+if contracts.get("runtime_signer_profile") != "ops-primary":
+    raise SystemExit("expected contracts signer profile marker in integration summary")
+if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    raise SystemExit("expected contracts signer private key env marker in integration summary")
 PY
 
 set +e

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -12,11 +12,12 @@ README_FILE="$ROOT_DIR/README.md"
 TMP_REPORT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
 TMP_DRIFT_REPORT="$(mktemp)"
+TMP_SIGNER_DRIFT_REPORT="$(mktemp)"
 TMP_SYNTHETIC_REPORT="$(mktemp)"
 TMP_INMEMORY_REPORT="$(mktemp)"
 TMP_NEGATIVE_POLICY="$(mktemp)"
 TMP_NEGATIVE_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime real-node profile contract lane runner to be executable" >&2
@@ -67,6 +68,8 @@ required_coverage_markers=(
   "docs/ci/strategy.md"
   "README.md"
   "runtime_commit_command_profile_mismatch"
+  "runtime_signer_profile_mismatch"
+  "runtime_commit_signer_profile_marker_missing"
   "runtime_commit_non_synthetic_submit_probe_missing"
   "runtime_commit_in_memory_provider_reference_detected"
   "Regression: #2139"
@@ -123,9 +126,23 @@ if "integration_kolme_fork_live_node_submit_reaches_endpoint" not in runtime_com
     raise SystemExit("expected non-synthetic runtime submit probe marker in real-node profile contract-lane summary")
 if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
     raise SystemExit("expected real signing profile marker in real-node profile contract-lane summary")
+if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary" not in runtime_commit_command:
+    raise SystemExit("expected signer profile marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+    raise SystemExit("expected signer profile selector env marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_profile") != "ops-primary":
+    raise SystemExit("expected signer profile marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    raise SystemExit("expected signer private key env marker in real-node profile contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_profile") != "real-node":
     raise SystemExit("expected contracts.runtime_profile=real-node in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
+    raise SystemExit("expected contracts signer profile selector env marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_profile") != "ops-primary":
+    raise SystemExit("expected contracts signer profile marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    raise SystemExit("expected contracts signer private key env marker in real-node profile contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
     raise SystemExit("unexpected real-node profile contract-lane policy schema")
 if policy.get("final_decision") != "GO":
@@ -134,7 +151,7 @@ if policy.get("reason_codes") != []:
     raise SystemExit("expected no policy reason codes for real-node profile contract-lane dry-run composition")
 PY
 
-python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" <<'PY'
+python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" <<'PY'
 import json
 import pathlib
 import sys
@@ -148,6 +165,14 @@ pathlib.Path(sys.argv[2]).write_text(
     encoding="utf-8",
 )
 
+signer_drift_summary = dict(base_summary)
+signer_drift_summary["runtime_signer_profile"] = "ops-secondary"
+signer_drift_summary["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+pathlib.Path(sys.argv[3]).write_text(
+    json.dumps(signer_drift_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
 synthetic_summary = dict(base_summary)
 synthetic_summary["runtime_commit_command"] = (
     "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh "
@@ -156,7 +181,7 @@ synthetic_summary["runtime_commit_command"] = (
     "--live-command \"printf 'runtime=synthetic\\\\n'\" "
     "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
 )
-pathlib.Path(sys.argv[3]).write_text(
+pathlib.Path(sys.argv[4]).write_text(
     json.dumps(synthetic_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
@@ -167,12 +192,12 @@ inmemory_summary["runtime_commit_command"] = (
     "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
     "--require-non-synthetic-run-evidence "
     "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
-    "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+    "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
     "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
     "--provider-hint InMemoryKolmeRuntimeCommitClient "
     "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
 )
-pathlib.Path(sys.argv[4]).write_text(
+pathlib.Path(sys.argv[5]).write_text(
     json.dumps(inmemory_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
@@ -200,6 +225,26 @@ fi
 
 set +e
 python3 "$CHECKER" \
+  --report-file "$TMP_SIGNER_DRIFT_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+signer_drift_exit_code=$?
+set -e
+
+if [ "$signer_drift_exit_code" -eq 0 ]; then
+  echo "expected signer profile drift negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_profile_mismatch" "$TMP_NEGATIVE_ERR"; then
+  echo "expected signer profile drift reason in negative proof output" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
   --report-file "$TMP_SYNTHETIC_REPORT" \
   --expected-final-decision NO-GO \
   --ci-fast-gate PASS \
@@ -220,6 +265,11 @@ fi
 
 if ! grep -q "runtime_commit_real_signing_profile_marker_missing" "$TMP_NEGATIVE_ERR"; then
   echo "expected real signing profile marker reason in synthetic-command negative proof output" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_signer_profile_marker_missing" "$TMP_NEGATIVE_ERR"; then
+  echo "expected signer profile marker reason in synthetic-command negative proof output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Enforces deterministic multi-signer profile evidence contracts for the local real-node Kolme lane so profile drift fails closed at policy time.
Adds explicit signer-profile summary/contract markers and verifies command-surface profile markers in GO/NO-GO scenarios.

Closes #2223

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: emits signer-profile selector/profile/key-env markers in summary + contracts and composes real-node command marker `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: validates signer-profile evidence fields and command marker; adds fail-closed reason codes for missing/mismatched signer-profile evidence.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: extends contract proofs to cover signer-profile drift and marker omission scenarios.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: adds GO/NO-GO fixtures for signer-profile evidence and regression reasons.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: asserts signer-profile markers in generated summary/contracts and command composition.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: adds negative signer-profile drift proof and required coverage markers.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: updates real-node marker/reason-code contracts for docs parity.

## Risks & Compatibility
- Low risk; changes are additive and scoped to local real-node profile evidence contracts and tests.
- No CI fast-gate expansion; heavy lane execution remains local-only.

## Validation
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: updated docs contract markers and reason-code parity

Test runs:
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`
- `bash -n scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | policy fixture checks and reason-code assertions in `test_check_local_kamn_live_runtime_real_node_profile_policy.sh` |
| Functional  | ✅     | summary schema/marker assertions in `test_run_local_kamn_live_runtime_integration_real_node_profile.sh` |
| Integration | ✅     | contract lane execution in `test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` |
| Regression  | ✅     | signer-profile drift and synthetic marker omission fail-closed proofs |
