### PR TITLE
fix(kolme): remove fallback signer private-key semantics from preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,12 +629,15 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 
 # deterministic preflight marker contracts
 # signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE
+# fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
 # contracts.ci_fast_gate_scope=ci-fast-gate
 # contracts.required_runtime_mode=kolme-live
+# contracts.fallback_private_key_path_allowed=false
 
 # strict preflight NO-GO drift reasons
 # runtime_mode_mismatch
 # signer_profile_mismatch
+# fallback_signer_secret_present_violation
 # checkpoint_failed_signer_secret_contract
 
 # schema: kamn.kolme.local-live-deployment-preflight-summary.v1

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -299,11 +299,14 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - deterministic marker contracts:
       - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
+      - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
       - `contracts.required_runtime_mode=kolme-live`
+      - `contracts.fallback_private_key_path_allowed=false`
     - fail-closed drift reasons:
       - `runtime_mode_mismatch`
       - `signer_profile_mismatch`
+      - `fallback_signer_secret_present_violation`
       - `checkpoint_failed_signer_secret_contract`
     - deployment preflight contract lane parity remains fail-closed (`Regression: #2226`).
   - local fork process lifecycle integration run-mode commands remain excluded from ci-fast-gate.

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -226,6 +226,7 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - nonce source contract: `GET /get-next-nonce?pubkey=...` through `KolmeRuntimeCommitHttpTransport`.
     - signer profile selector contract: `KAMN_KOLME_LIVE_SIGNER_PROFILE` with supported values `ops-primary` (default) and `ops-secondary`; unsupported values fail closed.
     - private key source contracts: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX` for `ops-primary`, `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY` for `ops-secondary` (required for selected profile; no fallback private key path).
+    - fallback private key marker contract: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` must remain unset; policy fails closed with `fallback_signer_secret_present_violation` when present.
     - synthetic fallback signature material (`signature=<idempotency_key>`) is rejected by runtime tests/policies.
   - in-memory fallback markers and non-fork signing profiles are rejected fail-closed by typed node config errors.
 - Runtime live lane (submit + optional finality):

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -10,6 +10,19 @@ For semantic versioning policy and compatibility rules, see `docs/foundation/ver
 - CI fast gate and deferred deep lane both green.
 - Rollback runbook version pinned.
 - Release candidate artifact digest verified.
+- Kolme live signer custody preflight passes with no fallback private-key marker evidence (`fallback_signer_secret_present_violation` is absent).
+
+## Kolme Signer Custody Gate (Issue #2240)
+- Deployment preflight lane command:
+  - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+- Policy checker command:
+  - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+- Required signer-custody markers:
+  - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `fallback_signer_secret_present=false`
+  - `contracts.fallback_private_key_path_allowed=false`
+- Fail-closed policy reason:
+  - `fallback_signer_secret_present_violation`
 
 ## Deterministic Dry-Run Workflow
 1. Create release candidate tag.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -484,18 +484,23 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `runtime_mode_contract`: runtime mode must match `kolme-live`.
   - `signer_profile_contract`: profile must be `ops-primary` or `ops-secondary`.
   - `signer_secret_contract`: selected signer secret env must be present and 64-char hex.
+  - `fallback_private_key_contract`: fallback signer secret env must remain unset.
   - summary fields include deterministic signer custody markers:
     - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
     - `signer_profile`
     - `signer_private_key_env`
+    - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `fallback_signer_secret_present=false`
   - contracts include:
     - `contracts.ci_fast_gate_scope=ci-fast-gate`
     - `contracts.required_runtime_mode=kolme-live`
     - `contracts.required_secret_hex_length=64`
+    - `contracts.fallback_private_key_path_allowed=false`
 - Fail-closed reasons include:
   - `runtime_mode_mismatch`
   - `signer_profile_mismatch`
   - `signer_private_key_env_mismatch`
+  - `fallback_signer_secret_present_violation`
   - `checkpoint_failed_signer_secret_contract`
 - Cost policy:
   - lane is lightweight and `ci_fast_gate_eligible=true`.
@@ -518,6 +523,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Runtime signer custody contract envs are set for deployment preflight before integration execution:
   - `export KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`
   - `export KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=<64-hex-private-key>`
+  - `unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
 
 ### Execution Flow
 

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -11,6 +11,7 @@ PRIMARY_SIGNER_PROFILE = "ops-primary"
 SECONDARY_SIGNER_PROFILE = "ops-secondary"
 PRIMARY_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 SECONDARY_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+FALLBACK_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH = 64
 
 
@@ -95,9 +96,21 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif expected_signer_env and signer_private_key_env != expected_signer_env:
         reason_codes.append("signer_private_key_env_mismatch")
 
+    fallback_signer_private_key_env = report.get("fallback_signer_private_key_env")
+    if not isinstance(fallback_signer_private_key_env, str) or not fallback_signer_private_key_env.strip():
+        reason_codes.append("fallback_signer_private_key_env_missing")
+    elif fallback_signer_private_key_env != FALLBACK_SIGNER_SECRET_ENV:
+        reason_codes.append("fallback_signer_private_key_env_mismatch")
+
     signer_secret_present = report.get("signer_secret_present")
     if not isinstance(signer_secret_present, bool):
         reason_codes.append("signer_secret_present_invalid")
+
+    fallback_signer_secret_present = report.get("fallback_signer_secret_present")
+    if not isinstance(fallback_signer_secret_present, bool):
+        reason_codes.append("fallback_signer_secret_present_invalid")
+    elif fallback_signer_secret_present:
+        reason_codes.append("fallback_signer_secret_present_violation")
 
     signer_secret_hex_valid = report.get("signer_secret_hex_valid")
     if not isinstance(signer_secret_hex_valid, bool):
@@ -119,6 +132,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("primary_signer_secret_env_contract_mismatch")
         if contracts.get("secondary_signer_secret_env") != SECONDARY_SIGNER_SECRET_ENV:
             reason_codes.append("secondary_signer_secret_env_contract_mismatch")
+        if contracts.get("fallback_signer_secret_env") != FALLBACK_SIGNER_SECRET_ENV:
+            reason_codes.append("fallback_signer_secret_env_contract_mismatch")
+        if contracts.get("fallback_private_key_path_allowed") is not False:
+            reason_codes.append("fallback_private_key_path_allowed_contract_mismatch")
         if contracts.get("required_secret_hex_length") != REQUIRED_SECRET_HEX_LENGTH:
             reason_codes.append("required_secret_hex_length_contract_mismatch")
         if contracts.get("secret_source") != "env":
@@ -132,6 +149,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             "runtime_mode_contract",
             "signer_profile_contract",
             "signer_secret_contract",
+            "fallback_private_key_contract",
         }
         observed_ids: set[str] = set()
         for entry in checks:

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -156,12 +156,21 @@ def main() -> int:
     if summary.get("ci_fast_gate_eligible") is not True:
         print("expected deployment preflight contract-lane summary ci_fast_gate_eligible=true", file=sys.stderr)
         return 1
+    if summary.get("fallback_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+        print("expected deployment preflight summary fallback signer env marker", file=sys.stderr)
+        return 1
+    if summary.get("fallback_signer_secret_present") is not False:
+        print("expected deployment preflight summary fallback signer secret marker to remain false", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in deployment preflight summary", file=sys.stderr)
         return 1
     if contracts.get("ci_fast_gate_scope") != "ci-fast-gate":
         print("expected deployment preflight contracts ci_fast_gate_scope=ci-fast-gate", file=sys.stderr)
+        return 1
+    if contracts.get("fallback_private_key_path_allowed") is not False:
+        print("expected deployment preflight contracts to prohibit fallback private key paths", file=sys.stderr)
         return 1
     if policy.get("schema_version") != "kamn.kolme.local-live-deployment-preflight-policy-report.v1":
         print("unexpected deployment preflight contract-lane policy schema", file=sys.stderr)
@@ -178,6 +187,7 @@ def main() -> int:
         negative_summary["runtime_mode"] = "kolme-standard"
         negative_summary["status"] = "fail"
         negative_summary["reason_code"] = "checkpoint_failed_runtime_mode_contract"
+        negative_summary["fallback_signer_secret_present"] = True
         negative_report.write_text(json.dumps(negative_summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 
         no_go_result = run_policy_check(
@@ -196,6 +206,9 @@ def main() -> int:
         if "runtime_mode_mismatch" not in no_go_reason_codes:
             print("expected runtime_mode_mismatch in deployment preflight negative policy output", file=sys.stderr)
             return 1
+        if "fallback_signer_secret_present_violation" not in no_go_reason_codes:
+            print("expected fallback signer secret presence violation in deployment preflight negative policy output", file=sys.stderr)
+            return 1
         if no_go_policy.get("final_decision") != "NO-GO":
             print("expected deployment preflight negative policy final_decision NO-GO", file=sys.stderr)
             return 1
@@ -206,6 +219,7 @@ def main() -> int:
         "run_local_kolme_live_deployment_preflight_contract_lane.sh",
         "runtime_mode_mismatch",
         "checkpoint_failed_signer_secret_contract",
+        "fallback_signer_secret_present_violation",
         "Regression: #2226",
     ]
     ci_doc_markers = [
@@ -214,6 +228,7 @@ def main() -> int:
         "run_local_kolme_live_deployment_preflight_contract_lane.sh",
         "runtime_mode_mismatch",
         "checkpoint_failed_signer_secret_contract",
+        "fallback_signer_secret_present_violation",
         "Regression: #2226",
     ]
     readme_markers = [
@@ -222,6 +237,7 @@ def main() -> int:
         "run_local_kolme_live_deployment_preflight_contract_lane.sh",
         "runtime_mode_mismatch",
         "checkpoint_failed_signer_secret_contract",
+        "fallback_signer_secret_present_violation",
         "Regression: #2226",
     ]
 

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -13,6 +13,7 @@ PRIMARY_SIGNER_PROFILE="ops-primary"
 SECONDARY_SIGNER_PROFILE="ops-secondary"
 PRIMARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 SECONDARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+FALLBACK_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH=64
 
 while [ "$#" -gt 0 ]; do
@@ -117,6 +118,7 @@ record_check() {
 runtime_mode_command="runtime-mode must equal ${REQUIRED_RUNTIME_MODE}"
 signer_profile_command="signer profile must be ${PRIMARY_SIGNER_PROFILE} or ${SECONDARY_SIGNER_PROFILE}"
 signer_secret_command="selected signer secret env must exist and be ${REQUIRED_SECRET_HEX_LENGTH}-char hex"
+fallback_private_key_command="fallback signer secret env must remain unset"
 
 overall_status="ok"
 reason_code="dry_run_no_commands_executed"
@@ -124,10 +126,12 @@ budget_status="not_run"
 elapsed_seconds=0
 signer_secret_present="false"
 signer_secret_hex_valid="false"
+fallback_signer_secret_present="false"
 
 record_check "runtime_mode_contract" "$runtime_mode_command" "planned" "not_run"
 record_check "signer_profile_contract" "$signer_profile_command" "planned" "not_run"
 record_check "signer_secret_contract" "$signer_secret_command" "planned" "not_run"
+record_check "fallback_private_key_contract" "$fallback_private_key_command" "planned" "not_run"
 
 if [ "$MODE" = "run" ]; then
   : >"$CHECK_FILE"
@@ -137,6 +141,7 @@ if [ "$MODE" = "run" ]; then
     record_check "runtime_mode_contract" "$runtime_mode_command" "fail" "runtime_mode_mismatch"
     record_check "signer_profile_contract" "$signer_profile_command" "skipped" "runtime_mode_mismatch"
     record_check "signer_secret_contract" "$signer_secret_command" "skipped" "runtime_mode_mismatch"
+    record_check "fallback_private_key_contract" "$fallback_private_key_command" "skipped" "runtime_mode_mismatch"
     overall_status="fail"
     reason_code="checkpoint_failed_runtime_mode_contract"
   else
@@ -146,10 +151,25 @@ if [ "$MODE" = "run" ]; then
       echo "signer profile is invalid for deployment preflight: $SIGNER_PROFILE" >&2
       record_check "signer_profile_contract" "$signer_profile_command" "fail" "signer_profile_invalid"
       record_check "signer_secret_contract" "$signer_secret_command" "skipped" "signer_profile_invalid"
+      record_check "fallback_private_key_contract" "$fallback_private_key_command" "skipped" "signer_profile_invalid"
       overall_status="fail"
       reason_code="checkpoint_failed_signer_profile_contract"
     else
       record_check "signer_profile_contract" "$signer_profile_command" "pass" "signer_profile_validated"
+
+      fallback_signer_secret_value="${!FALLBACK_SIGNER_SECRET_ENV:-}"
+      if [ -n "$fallback_signer_secret_value" ]; then
+        fallback_signer_secret_present="true"
+      fi
+
+      if [ "$fallback_signer_secret_present" = "true" ]; then
+        echo "fallback signer secret env must not be set: $FALLBACK_SIGNER_SECRET_ENV" >&2
+        record_check "fallback_private_key_contract" "$fallback_private_key_command" "fail" "fallback_signer_secret_present_violation"
+        record_check "signer_secret_contract" "$signer_secret_command" "skipped" "fallback_signer_secret_present_violation"
+        overall_status="fail"
+        reason_code="checkpoint_failed_fallback_private_key_contract"
+      else
+        record_check "fallback_private_key_contract" "$fallback_private_key_command" "pass" "fallback_signer_secret_absent"
 
       signer_secret_value="${!selected_signer_secret_env:-}"
       if [ -n "$signer_secret_value" ]; then
@@ -173,6 +193,7 @@ if [ "$MODE" = "run" ]; then
         record_check "signer_secret_contract" "$signer_secret_command" "pass" "signer_secret_validated"
         reason_code="deployment_preflight_passed"
       fi
+      fi
     fi
   fi
 
@@ -188,7 +209,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" <<'PY'
 from __future__ import annotations
 
 import json
@@ -206,15 +227,17 @@ runtime_mode = sys.argv[8]
 signer_profile_selector_env = sys.argv[9]
 signer_profile = sys.argv[10]
 signer_private_key_env = sys.argv[11]
-signer_secret_present = sys.argv[12] == "true"
-signer_secret_hex_valid = sys.argv[13] == "true"
-checks_path = pathlib.Path(sys.argv[14])
-required_runtime_mode = sys.argv[15]
-primary_signer_profile = sys.argv[16]
-secondary_signer_profile = sys.argv[17]
-primary_signer_secret_env = sys.argv[18]
-secondary_signer_secret_env = sys.argv[19]
-required_secret_hex_length = int(sys.argv[20])
+fallback_signer_private_key_env = sys.argv[12]
+signer_secret_present = sys.argv[13] == "true"
+fallback_signer_secret_present = sys.argv[14] == "true"
+signer_secret_hex_valid = sys.argv[15] == "true"
+checks_path = pathlib.Path(sys.argv[16])
+required_runtime_mode = sys.argv[17]
+primary_signer_profile = sys.argv[18]
+secondary_signer_profile = sys.argv[19]
+primary_signer_secret_env = sys.argv[20]
+secondary_signer_secret_env = sys.argv[21]
+required_secret_hex_length = int(sys.argv[22])
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -247,7 +270,9 @@ summary = {
     "signer_profile_selector_env": signer_profile_selector_env,
     "signer_profile": signer_profile,
     "signer_private_key_env": signer_private_key_env,
+    "fallback_signer_private_key_env": fallback_signer_private_key_env,
     "signer_secret_present": signer_secret_present,
+    "fallback_signer_secret_present": fallback_signer_secret_present,
     "signer_secret_hex_valid": signer_secret_hex_valid,
     "contracts": {
         "ci_fast_gate_scope": "ci-fast-gate",
@@ -256,6 +281,8 @@ summary = {
         "supported_signer_profiles": [primary_signer_profile, secondary_signer_profile],
         "primary_signer_secret_env": primary_signer_secret_env,
         "secondary_signer_secret_env": secondary_signer_secret_env,
+        "fallback_signer_secret_env": fallback_signer_private_key_env,
+        "fallback_private_key_path_allowed": False,
         "required_secret_hex_length": required_secret_hex_length,
         "secret_source": "env",
     },

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -50,7 +50,9 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "signer_profile": "ops-primary",
   "signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+  "fallback_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
   "signer_secret_present": false,
+  "fallback_signer_secret_present": false,
   "signer_secret_hex_valid": false,
   "contracts": {
     "ci_fast_gate_scope": "ci-fast-gate",
@@ -62,6 +64,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     ],
     "primary_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "secondary_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
+    "fallback_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "fallback_private_key_path_allowed": false,
     "required_secret_hex_length": 64,
     "secret_source": "env"
   },
@@ -81,6 +85,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     {
       "id": "signer_secret_contract",
       "command": "selected signer secret env must exist and be 64-char hex",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "fallback_private_key_contract",
+      "command": "fallback signer secret env must remain unset",
       "status": "planned",
       "reason_code": "not_run"
     }
@@ -125,7 +135,9 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "signer_profile": "legacy",
   "signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+  "fallback_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
   "signer_secret_present": true,
+  "fallback_signer_secret_present": true,
   "signer_secret_hex_valid": true,
   "contracts": {
     "ci_fast_gate_scope": "local-only",
@@ -137,6 +149,8 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
     ],
     "primary_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "secondary_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
+    "fallback_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "fallback_private_key_path_allowed": true,
     "required_secret_hex_length": 64,
     "secret_source": "env"
   },
@@ -184,6 +198,16 @@ fi
 
 if ! grep -q "check_missing:signer_secret_contract" "$TMP_ERR"; then
   echo "expected missing signer_secret_contract check reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "fallback_signer_secret_present_violation" "$TMP_ERR"; then
+  echo "expected fallback signer secret presence violation reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "check_missing:fallback_private_key_contract" "$TMP_ERR"; then
+  echo "expected missing fallback_private_key_contract check reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -90,11 +90,17 @@ if summary.get("signer_profile") != "ops-primary":
     raise SystemExit("expected signer profile marker in deployment preflight summary")
 if summary.get("signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in deployment preflight summary")
+if summary.get("fallback_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key env marker in deployment preflight summary")
+if summary.get("fallback_signer_secret_present") is not False:
+    raise SystemExit("expected fallback signer secret presence marker to be false in deployment preflight summary")
 if summary.get("ci_fast_gate_eligible") is not True:
     raise SystemExit("expected deployment preflight summary to remain fast-gate eligible")
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "ci-fast-gate":
     raise SystemExit("expected deployment preflight contracts to set ci-fast-gate scope")
+if contracts.get("fallback_private_key_path_allowed") is not False:
+    raise SystemExit("expected deployment preflight contracts to prohibit fallback private key paths")
 PY
 
 set +e
@@ -111,6 +117,25 @@ fi
 
 if ! grep -q "signer secret env is required for selected profile" "$TMP_ERR"; then
   echo "expected deterministic missing signer secret message from deployment preflight lane" >&2
+  exit 1
+fi
+
+set +e
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK="2222222222222222222222222222222222222222222222222222222222222222" \
+bash "$RUNNER" \
+  --mode run \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+fallback_secret_exit_code=$?
+set -e
+
+if [ "$fallback_secret_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight run mode to fail closed when fallback signer secret env is present" >&2
+  exit 1
+fi
+
+if ! grep -q "fallback signer secret env must not be set" "$TMP_ERR"; then
+  echo "expected deterministic fallback signer secret rejection message from deployment preflight lane" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Removes residual fallback private-key semantics from the Kolme live deployment preflight operational surface.
Adds fail-closed policy/runner/contracts checks so fallback signer key markers force deterministic NO-GO decisions.

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`: added explicit `fallback_private_key_contract` check; run mode now fails when `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` is set.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`: enforces fallback marker fields/contracts and emits `fallback_signer_secret_present_violation` / contract drift reason codes.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`: added fallback marker assertions and negative-proof coverage.
- `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`: added regression checks for fallback marker fields and fail-closed behavior.
- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`: expanded fixtures to cover fallback contract fields and NO-GO reason expectations.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`, `docs/foundation/kolme-runtime-commit-client.md`, `docs/foundation/release-gonogo-checklist.md`: documented fallback-key prohibition markers and reason code.

## Risks & Compatibility
- Low: introduces stricter fail-closed behavior for deployments that set fallback signer key env markers.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised deployment preflight run-mode failure when fallback signer key marker env is set.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` |
| Functional  | ✅     | `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh` |
| Integration | ✅     | `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh` |
| Regression  | ✅     | fallback-marker negative proofs in lane/policy/contract + docs contract tests |

Closes #2240
Refs #2235
