### PR TITLE
feat(kolme): enforce multi-signer failover rotation policy (#2242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,11 +581,17 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_commit_command_profile_version=v1
 # runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE
 # runtime_signer_profile=ops-primary
+# runtime_signer_previous_profile=ops-primary
+# runtime_signer_failover_active=false
+# runtime_signer_rotation_epoch=1
+# runtime_signer_previous_rotation_epoch=1
 # runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
 
 # strict profile NO-GO drift/synthetic reason markers
 # runtime_commit_command_profile_mismatch
 # runtime_signer_profile_mismatch
+# runtime_signer_failover_profile_unchanged
+# runtime_signer_rotation_epoch_stale
 # runtime_signer_private_key_env_mismatch
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -275,10 +275,16 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_commit_command_profile_version=v1`
       - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
       - `runtime_signer_profile=ops-primary`
+      - `runtime_signer_previous_profile=ops-primary`
+      - `runtime_signer_failover_active=false`
+      - `runtime_signer_rotation_epoch=1`
+      - `runtime_signer_previous_rotation_epoch=1`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - strict profile NO-GO drift/synthetic reasons:
       - `runtime_commit_command_profile_mismatch`
       - `runtime_signer_profile_mismatch`
+      - `runtime_signer_failover_profile_unchanged`
+      - `runtime_signer_rotation_epoch_stale`
       - `runtime_signer_private_key_env_mismatch`
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -417,9 +417,15 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_command_profile_version=v1`
     - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
     - `runtime_signer_profile=ops-primary`
+    - `runtime_signer_previous_profile=ops-primary`
+    - `runtime_signer_failover_active=false`
+    - `runtime_signer_rotation_epoch=1`
+    - `runtime_signer_previous_rotation_epoch=1`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
   - NO-GO marker-drift proof must surface `runtime_commit_command_profile_mismatch` when profile marker contracts drift from `real-node-non-synthetic-v1`.
   - NO-GO signer-profile drift proof must surface `runtime_signer_profile_mismatch` when summary signer profile markers drift from `ops-primary`.
+  - NO-GO failover proof must surface `runtime_signer_failover_profile_unchanged` when failover is active but profile does not rotate.
+  - NO-GO stale-rotation proof must surface `runtime_signer_rotation_epoch_stale` when failover rotation epoch is not strictly increasing.
   - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
@@ -444,12 +450,22 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_commit_command_profile_version`
     - `runtime_signer_profile_selector_env`
     - `runtime_signer_profile`
+    - `runtime_signer_previous_profile`
+    - `runtime_signer_failover_active`
+    - `runtime_signer_rotation_epoch`
+    - `runtime_signer_previous_rotation_epoch`
     - `runtime_signer_private_key_env`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
   - real-node profile requires signer profile summary/contracts markers:
     - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
     - `runtime_signer_profile=ops-primary`
+    - `runtime_signer_previous_profile=ops-primary`
+    - `runtime_signer_failover_active=false`
+    - `runtime_signer_rotation_epoch=1`
+    - `runtime_signer_previous_rotation_epoch=1`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
+    - `contracts.runtime_signer_failover_requires_profile_change=true`
+    - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`; checker fails closed with `runtime_commit_real_signing_profile_marker_missing` when omitted.
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile command composition rejects in-memory fallback references at runner boundary:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -9,9 +9,18 @@ NON_SYNTHETIC_SUBMIT_PROBE_MARKER = "integration_kolme_fork_live_node_submit_rea
 IN_MEMORY_PROVIDER_MARKER = "InMemoryKolmeRuntimeCommitClient"
 REAL_SIGNING_PROFILE_MARKER = "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
 REAL_SIGNER_PROFILE_SELECTOR_ENV = "KAMN_KOLME_LIVE_SIGNER_PROFILE"
-REAL_SIGNER_PROFILE = "ops-primary"
-REAL_SIGNER_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
-REAL_SIGNER_PROFILE_COMMAND_MARKER = "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary"
+REAL_SIGNER_PROFILE_PRIMARY = "ops-primary"
+REAL_SIGNER_PROFILE_SECONDARY = "ops-secondary"
+REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+ALLOWED_SIGNER_PROFILES = (
+    REAL_SIGNER_PROFILE_PRIMARY,
+    REAL_SIGNER_PROFILE_SECONDARY,
+)
+SIGNER_PRIVATE_KEY_ENV_BY_PROFILE = {
+    REAL_SIGNER_PROFILE_PRIMARY: REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY,
+    REAL_SIGNER_PROFILE_SECONDARY: REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY,
+}
 NATIVE_PAYLOAD_PUBKEY_MARKER = "pubkey"
 NATIVE_PAYLOAD_NONCE_MARKER = "nonce"
 NATIVE_PAYLOAD_MESSAGES_MARKER = "messages"
@@ -92,15 +101,56 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("runtime_signer_profile_selector_env_mismatch")
 
     runtime_signer_profile = report.get("runtime_signer_profile")
+    expected_signer_private_key_env = ""
     if not isinstance(runtime_signer_profile, str) or not runtime_signer_profile.strip():
         reason_codes.append("runtime_signer_profile_missing")
-    elif runtime_signer_profile != REAL_SIGNER_PROFILE:
+    elif runtime_signer_profile not in ALLOWED_SIGNER_PROFILES:
         reason_codes.append("runtime_signer_profile_mismatch")
+    else:
+        expected_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[runtime_signer_profile]
+
+    runtime_signer_previous_profile = report.get("runtime_signer_previous_profile")
+    if not isinstance(runtime_signer_previous_profile, str) or not runtime_signer_previous_profile.strip():
+        reason_codes.append("runtime_signer_previous_profile_missing")
+    elif runtime_signer_previous_profile not in ALLOWED_SIGNER_PROFILES:
+        reason_codes.append("runtime_signer_previous_profile_mismatch")
+
+    runtime_signer_failover_active = report.get("runtime_signer_failover_active")
+    if not isinstance(runtime_signer_failover_active, bool):
+        reason_codes.append("runtime_signer_failover_active_invalid")
+
+    runtime_signer_rotation_epoch = report.get("runtime_signer_rotation_epoch")
+    if not isinstance(runtime_signer_rotation_epoch, int) or runtime_signer_rotation_epoch <= 0:
+        reason_codes.append("runtime_signer_rotation_epoch_invalid")
+
+    runtime_signer_previous_rotation_epoch = report.get("runtime_signer_previous_rotation_epoch")
+    if not isinstance(runtime_signer_previous_rotation_epoch, int) or runtime_signer_previous_rotation_epoch <= 0:
+        reason_codes.append("runtime_signer_previous_rotation_epoch_invalid")
+
+    if (
+        isinstance(runtime_signer_profile, str)
+        and runtime_signer_profile in ALLOWED_SIGNER_PROFILES
+        and isinstance(runtime_signer_previous_profile, str)
+        and runtime_signer_previous_profile in ALLOWED_SIGNER_PROFILES
+        and isinstance(runtime_signer_failover_active, bool)
+    ):
+        if runtime_signer_failover_active and runtime_signer_profile == runtime_signer_previous_profile:
+            reason_codes.append("runtime_signer_failover_profile_unchanged")
+        if (not runtime_signer_failover_active) and runtime_signer_profile != runtime_signer_previous_profile:
+            reason_codes.append("runtime_signer_profile_changed_without_failover")
+    if (
+        isinstance(runtime_signer_failover_active, bool)
+        and runtime_signer_failover_active
+        and isinstance(runtime_signer_rotation_epoch, int)
+        and isinstance(runtime_signer_previous_rotation_epoch, int)
+        and runtime_signer_rotation_epoch <= runtime_signer_previous_rotation_epoch
+    ):
+        reason_codes.append("runtime_signer_rotation_epoch_stale")
 
     runtime_signer_private_key_env = report.get("runtime_signer_private_key_env")
     if not isinstance(runtime_signer_private_key_env, str) or not runtime_signer_private_key_env.strip():
         reason_codes.append("runtime_signer_private_key_env_missing")
-    elif runtime_signer_private_key_env != REAL_SIGNER_PRIVATE_KEY_ENV:
+    elif expected_signer_private_key_env and runtime_signer_private_key_env != expected_signer_private_key_env:
         reason_codes.append("runtime_signer_private_key_env_mismatch")
 
     runtime_commit_command_profile = report.get("runtime_commit_command_profile")
@@ -141,9 +191,15 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and REAL_SIGNING_PROFILE_MARKER not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_real_signing_profile_marker_missing")
+        expected_profile_command_marker = ""
+        if isinstance(runtime_signer_profile, str) and runtime_signer_profile in ALLOWED_SIGNER_PROFILES:
+            expected_profile_command_marker = (
+                f"{REAL_SIGNER_PROFILE_SELECTOR_ENV}={runtime_signer_profile}"
+            )
         if (
             runtime_commit_command_profile == "real-node-non-synthetic-v1"
-            and REAL_SIGNER_PROFILE_COMMAND_MARKER not in runtime_commit_command
+            and expected_profile_command_marker
+            and expected_profile_command_marker not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_signer_profile_marker_missing")
         if (
@@ -180,10 +236,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_provider_client_contract_contract_mismatch")
         if contracts.get("runtime_signer_profile_selector_env") != REAL_SIGNER_PROFILE_SELECTOR_ENV:
             reason_codes.append("runtime_signer_profile_selector_env_contract_mismatch")
-        if contracts.get("runtime_signer_profile") != REAL_SIGNER_PROFILE:
+        if (
+            isinstance(runtime_signer_profile, str)
+            and runtime_signer_profile in ALLOWED_SIGNER_PROFILES
+            and contracts.get("runtime_signer_profile") != runtime_signer_profile
+        ):
             reason_codes.append("runtime_signer_profile_contract_mismatch")
-        if contracts.get("runtime_signer_private_key_env") != REAL_SIGNER_PRIVATE_KEY_ENV:
+        if expected_signer_private_key_env and contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
             reason_codes.append("runtime_signer_private_key_env_contract_mismatch")
+        if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
+            reason_codes.append("runtime_signer_failover_requires_profile_change_contract_mismatch")
+        if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
+            reason_codes.append("runtime_signer_rotation_epoch_contract_mismatch")
         if contracts.get("runtime_commit_endpoint") != "/broadcast/runtime-commit":
             reason_codes.append("runtime_commit_endpoint_mismatch")
         if contracts.get("runtime_commit_method") != "POST":

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -234,6 +234,18 @@ def main() -> int:
     if summary.get("runtime_signer_profile") != "ops-primary":
         print("expected signer profile marker in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_previous_profile") != "ops-primary":
+        print("expected signer previous profile marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_failover_active") is not False:
+        print("expected signer failover marker false in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_rotation_epoch") != 1:
+        print("expected signer rotation epoch marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_previous_rotation_epoch") != 1:
+        print("expected signer previous rotation epoch marker in contract-lane summary", file=sys.stderr)
+        return 1
     if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
         print("expected signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
@@ -249,6 +261,12 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_profile") != "ops-primary":
         print("expected contracts signer profile marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
+        print("expected contracts failover profile-change guard marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
+        print("expected contracts signer rotation epoch guard marker in contract-lane summary", file=sys.stderr)
         return 1
     if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
         print("expected contracts signer private key env marker in contract-lane summary", file=sys.stderr)
@@ -295,36 +313,40 @@ def main() -> int:
             print("expected NO-GO final decision for marker drift policy output", file=sys.stderr)
             return 1
 
-        signer_profile_drift_summary_file = negative_path / "signer_profile_drift_summary.json"
-        signer_profile_drift_policy_file = negative_path / "signer_profile_drift_policy.json"
-        signer_profile_drift_summary = dict(summary)
-        signer_profile_drift_summary["runtime_signer_profile"] = "ops-secondary"
-        signer_profile_drift_summary["runtime_signer_private_key_env"] = (
-            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
-        )
-        signer_profile_drift_summary_file.write_text(
-            json.dumps(signer_profile_drift_summary, sort_keys=True, indent=2) + "\n",
+        failover_stale_summary_file = negative_path / "failover_stale_summary.json"
+        failover_stale_policy_file = negative_path / "failover_stale_policy.json"
+        failover_stale_summary = dict(summary)
+        failover_stale_summary["runtime_signer_profile"] = "ops-primary"
+        failover_stale_summary["runtime_signer_previous_profile"] = "ops-primary"
+        failover_stale_summary["runtime_signer_failover_active"] = True
+        failover_stale_summary["runtime_signer_rotation_epoch"] = 3
+        failover_stale_summary["runtime_signer_previous_rotation_epoch"] = 3
+        failover_stale_summary_file.write_text(
+            json.dumps(failover_stale_summary, sort_keys=True, indent=2) + "\n",
             encoding="utf-8",
         )
 
-        signer_profile_drift_result = run_real_node_policy_check(
-            report_file=signer_profile_drift_summary_file,
-            output_json=signer_profile_drift_policy_file,
+        failover_stale_result = run_real_node_policy_check(
+            report_file=failover_stale_summary_file,
+            output_json=failover_stale_policy_file,
             expected_final_decision="NO-GO",
         )
-        if signer_profile_drift_result.returncode == 0:
-            print("expected signer profile drift negative proof to fail closed", file=sys.stderr)
+        if failover_stale_result.returncode == 0:
+            print("expected failover stale negative proof to fail closed", file=sys.stderr)
             return 1
-        signer_profile_drift_policy = json.loads(signer_profile_drift_policy_file.read_text(encoding="utf-8"))
-        signer_profile_drift_reason_codes = signer_profile_drift_policy.get("reason_codes")
-        if not isinstance(signer_profile_drift_reason_codes, list):
-            print("expected reason_codes list in signer profile drift policy output", file=sys.stderr)
+        failover_stale_policy = json.loads(failover_stale_policy_file.read_text(encoding="utf-8"))
+        failover_stale_reason_codes = failover_stale_policy.get("reason_codes")
+        if not isinstance(failover_stale_reason_codes, list):
+            print("expected reason_codes list in failover stale policy output", file=sys.stderr)
             return 1
-        if "runtime_signer_profile_mismatch" not in signer_profile_drift_reason_codes:
-            print("expected runtime_signer_profile_mismatch in signer profile drift policy output", file=sys.stderr)
+        if "runtime_signer_failover_profile_unchanged" not in failover_stale_reason_codes:
+            print("expected runtime_signer_failover_profile_unchanged in failover stale policy output", file=sys.stderr)
             return 1
-        if signer_profile_drift_policy.get("final_decision") != "NO-GO":
-            print("expected NO-GO final decision for signer profile drift policy output", file=sys.stderr)
+        if "runtime_signer_rotation_epoch_stale" not in failover_stale_reason_codes:
+            print("expected runtime_signer_rotation_epoch_stale in failover stale policy output", file=sys.stderr)
+            return 1
+        if failover_stale_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for failover stale policy output", file=sys.stderr)
             return 1
 
         synthetic_regression_summary_file = negative_path / "synthetic_regression_summary.json"
@@ -426,6 +448,8 @@ def main() -> int:
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
+        "runtime_signer_failover_profile_unchanged",
+        "runtime_signer_rotation_epoch_stale",
         "Regression: #2139",
     ]
     ci_doc_markers = [
@@ -434,6 +458,8 @@ def main() -> int:
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
+        "runtime_signer_failover_profile_unchanged",
+        "runtime_signer_rotation_epoch_stale",
         "Regression: #2139",
     ]
     readme_markers = [
@@ -442,6 +468,8 @@ def main() -> int:
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
+        "runtime_signer_failover_profile_unchanged",
+        "runtime_signer_rotation_epoch_stale",
         "Regression: #2139",
     ]
 

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -358,6 +358,10 @@ runtime_commit_native_payload_flag=""
 runtime_commit_command_profile="standard-default-v1"
 runtime_commit_policy_command_profile="standard-default-v1"
 runtime_commit_command_profile_version="v1"
+RUNTIME_SIGNER_PREVIOUS_PROFILE=""
+RUNTIME_SIGNER_FAILOVER_ACTIVE="false"
+RUNTIME_SIGNER_ROTATION_EPOCH="1"
+RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH="1"
 if [ "$RUNTIME_PROFILE" = "real-node" ]; then
   runtime_commit_non_synthetic_flag=" --require-non-synthetic-run-evidence"
   runtime_commit_native_payload_flag=" --require-native-payload-evidence"
@@ -366,6 +370,7 @@ if [ "$RUNTIME_PROFILE" = "real-node" ]; then
   RUNTIME_SIGNER_PROFILE_SELECTOR_ENV="KAMN_KOLME_LIVE_SIGNER_PROFILE"
   RUNTIME_SIGNER_PROFILE="ops-primary"
   RUNTIME_SIGNER_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+  RUNTIME_SIGNER_PREVIOUS_PROFILE="ops-primary"
 fi
 
 if [ -n "$RUNTIME_SIGNER_PROFILE" ]; then
@@ -632,7 +637,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" <<'PY'
 from __future__ import annotations
 
 import json
@@ -674,7 +679,11 @@ runtime_commit_policy_command_profile = sys.argv[32]
 runtime_commit_command_profile_version = sys.argv[33]
 runtime_signer_profile_selector_env = sys.argv[34]
 runtime_signer_profile = sys.argv[35]
-runtime_signer_private_key_env = sys.argv[36]
+runtime_signer_previous_profile = sys.argv[36]
+runtime_signer_failover_active = sys.argv[37] == "true"
+runtime_signer_rotation_epoch = int(sys.argv[38])
+runtime_signer_previous_rotation_epoch = int(sys.argv[39])
+runtime_signer_private_key_env = sys.argv[40]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -716,6 +725,10 @@ summary = {
     "runtime_commit_command_profile_version": runtime_commit_command_profile_version,
     "runtime_signer_profile_selector_env": runtime_signer_profile_selector_env,
     "runtime_signer_profile": runtime_signer_profile,
+    "runtime_signer_previous_profile": runtime_signer_previous_profile,
+    "runtime_signer_failover_active": runtime_signer_failover_active,
+    "runtime_signer_rotation_epoch": runtime_signer_rotation_epoch,
+    "runtime_signer_previous_rotation_epoch": runtime_signer_previous_rotation_epoch,
     "runtime_signer_private_key_env": runtime_signer_private_key_env,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
@@ -733,6 +746,8 @@ summary = {
         "runtime_profile": runtime_profile,
         "runtime_signer_profile_selector_env": runtime_signer_profile_selector_env,
         "runtime_signer_profile": runtime_signer_profile,
+        "runtime_signer_failover_requires_profile_change": True,
+        "runtime_signer_rotation_epoch_must_increase_on_failover": True,
         "runtime_signer_private_key_env": runtime_signer_private_key_env,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -60,6 +60,10 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
   "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "runtime_signer_profile": "ops-primary",
+  "runtime_signer_previous_profile": "ops-primary",
+  "runtime_signer_failover_active": false,
+  "runtime_signer_rotation_epoch": 1,
+  "runtime_signer_previous_rotation_epoch": 1,
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
@@ -81,6 +85,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
     "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
     "runtime_signer_profile": "ops-primary",
+    "runtime_signer_failover_requires_profile_change": true,
+    "runtime_signer_rotation_epoch_must_increase_on_failover": true,
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
@@ -173,7 +179,11 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "runtime_profile": "standard",
   "runtime_provider_client_contract": "InMemoryKolmeRuntimeCommitClient",
   "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
-  "runtime_signer_profile": "ops-secondary",
+  "runtime_signer_profile": "ops-primary",
+  "runtime_signer_previous_profile": "ops-primary",
+  "runtime_signer_failover_active": true,
+  "runtime_signer_rotation_epoch": 4,
+  "runtime_signer_previous_rotation_epoch": 4,
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
   "runtime_commit_command_profile": "standard-default-v1",
   "runtime_commit_policy_command_profile": "standard-default-v1",
@@ -185,7 +195,9 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
     "runtime_profile": "standard",
     "runtime_provider_client_contract": "InMemoryKolmeRuntimeCommitClient",
     "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
-    "runtime_signer_profile": "ops-secondary",
+    "runtime_signer_profile": "ops-primary",
+    "runtime_signer_failover_requires_profile_change": false,
+    "runtime_signer_rotation_epoch_must_increase_on_failover": false,
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
   },
   "checks": [
@@ -238,8 +250,13 @@ if ! grep -q "runtime_commit_policy_command_profile_mismatch" "$TMP_ERR"; then
   exit 1
 fi
 
-if ! grep -q "runtime_signer_profile_mismatch" "$TMP_ERR"; then
-  echo "expected signer profile mismatch reason for policy failure" >&2
+if ! grep -q "runtime_signer_failover_profile_unchanged" "$TMP_ERR"; then
+  echo "expected failover unchanged reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_rotation_epoch_stale" "$TMP_ERR"; then
+  echo "expected stale rotation epoch reason for policy failure" >&2
   exit 1
 fi
 
@@ -534,6 +551,14 @@ if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER
     raise SystemExit("expected signer profile selector env marker in runner-generated summary")
 if summary.get("runtime_signer_profile") != "ops-primary":
     raise SystemExit("expected signer profile marker in runner-generated summary")
+if summary.get("runtime_signer_previous_profile") != "ops-primary":
+    raise SystemExit("expected signer previous-profile marker in runner-generated summary")
+if summary.get("runtime_signer_failover_active") is not False:
+    raise SystemExit("expected signer failover-active marker false in runner-generated summary")
+if summary.get("runtime_signer_rotation_epoch") != 1:
+    raise SystemExit("expected signer rotation epoch marker in runner-generated summary")
+if summary.get("runtime_signer_previous_rotation_epoch") != 1:
+    raise SystemExit("expected signer previous rotation epoch marker in runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in runner-generated summary")
 checks = summary.get("checks")

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -68,7 +68,8 @@ required_coverage_markers=(
   "docs/ci/strategy.md"
   "README.md"
   "runtime_commit_command_profile_mismatch"
-  "runtime_signer_profile_mismatch"
+  "runtime_signer_failover_profile_unchanged"
+  "runtime_signer_rotation_epoch_stale"
   "runtime_commit_signer_profile_marker_missing"
   "runtime_commit_non_synthetic_submit_probe_missing"
   "runtime_commit_in_memory_provider_reference_detected"
@@ -132,6 +133,14 @@ if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER
     raise SystemExit("expected signer profile selector env marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_profile") != "ops-primary":
     raise SystemExit("expected signer profile marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_previous_profile") != "ops-primary":
+    raise SystemExit("expected signer previous profile marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_failover_active") is not False:
+    raise SystemExit("expected signer failover marker false in real-node profile contract-lane summary")
+if summary.get("runtime_signer_rotation_epoch") != 1:
+    raise SystemExit("expected signer rotation epoch marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_previous_rotation_epoch") != 1:
+    raise SystemExit("expected signer previous rotation epoch marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in real-node profile contract-lane summary")
 contracts = summary.get("contracts", {})
@@ -141,6 +150,10 @@ if contracts.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGN
     raise SystemExit("expected contracts signer profile selector env marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_profile") != "ops-primary":
     raise SystemExit("expected contracts signer profile marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
+    raise SystemExit("expected contracts failover profile-change guard marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
+    raise SystemExit("expected contracts rotation epoch guard marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected contracts signer private key env marker in real-node profile contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
@@ -166,8 +179,11 @@ pathlib.Path(sys.argv[2]).write_text(
 )
 
 signer_drift_summary = dict(base_summary)
-signer_drift_summary["runtime_signer_profile"] = "ops-secondary"
-signer_drift_summary["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+signer_drift_summary["runtime_signer_profile"] = "ops-primary"
+signer_drift_summary["runtime_signer_previous_profile"] = "ops-primary"
+signer_drift_summary["runtime_signer_failover_active"] = True
+signer_drift_summary["runtime_signer_rotation_epoch"] = 3
+signer_drift_summary["runtime_signer_previous_rotation_epoch"] = 3
 pathlib.Path(sys.argv[3]).write_text(
     json.dumps(signer_drift_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
@@ -238,8 +254,13 @@ if [ "$signer_drift_exit_code" -eq 0 ]; then
   exit 1
 fi
 
-if ! grep -q "runtime_signer_profile_mismatch" "$TMP_NEGATIVE_ERR"; then
-  echo "expected signer profile drift reason in negative proof output" >&2
+if ! grep -q "runtime_signer_failover_profile_unchanged" "$TMP_NEGATIVE_ERR"; then
+  echo "expected signer failover unchanged reason in negative proof output" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_rotation_epoch_stale" "$TMP_NEGATIVE_ERR"; then
+  echo "expected signer stale rotation epoch reason in negative proof output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This change adds deterministic signer failover/rotation policy guards to the real-node KAMN live runtime lane so signer drift is fail-closed for stale or non-rotating failovers. It also updates lane contracts/tests and operator docs to require the new markers and reason codes.

Closes #2242
Refs #2236

## Changes
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: accept allowed signer profiles (`ops-primary`/`ops-secondary`), enforce profile-to-key-env mapping, and add failover/rotation validation (`runtime_signer_failover_profile_unchanged`, `runtime_signer_rotation_epoch_stale`, `runtime_signer_profile_changed_without_failover`) plus contract booleans.
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: emit signer failover/rotation summary fields and contract guard markers.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: require new summary/contract markers and validate NO-GO stale failover negative proof.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: extend fixtures/assertions for new failover/rotation semantics and guard markers.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: assert new summary/contracts markers and stale failover reason codes.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: document new failover/rotation marker contracts and reason code proofs.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary "$tmp_runtime_summary" --runtime-commit-live-policy-report "$tmp_runtime_policy" --output-json "$tmp_summary" >/dev/null
# mutate summary => failover active with unchanged profile and stale rotation epoch
python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py \
  --report-file "$tmp_red" \
  --expected-final-decision GO \
  --ci-fast-gate PASS \
  --require-reason-code dry_run_no_commands_executed \
  --require-non-synthetic-run-evidence \
  --output-json "$tmp_policy"
```
Output:
```text
status=fail
final_decision=NO-GO
failed_checks=runtime_signer_failover_profile_unchanged,runtime_signer_rotation_epoch_stale
exit_code=1
```

### 🟢 Green Phase
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
```
Output:
```text
local KAMN live runtime real-node profile policy checker tests passed.
local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh && \
cargo test -p kamn-core --test kolme_devnet_ops_docs --test ci_strategy_docs && \
cargo fmt --check && \
cargo clippy -p kamn-core -- -D warnings
```
Output summary:
```text
- policy checker test: pass
- real-node profile contract lane test: pass
- docs contract tests: pass (ci_strategy_docs: 2/2, kolme_devnet_ops_docs: 75/75)
- cargo fmt --check: pass
- cargo clippy -p kamn-core -- -D warnings: pass
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Python policy/lane shell contract changes are exercised through lane checker tests. |
| Functional   | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | Validates profile/failover/rotation behavior against acceptance policy markers. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | Verifies checker+lane+contracts/docs interplay for real-node profile lane. |
| Regression   | ✅     | Negative stale failover proof in contract lane + checker bad fixture reasons | Locks in fail-closed reason codes for unchanged failover profile/stale epoch. |
| Performance  | N/A    | None                 | No runtime throughput or load-path changes in this task. |

## Risks & Rollback
- None expected for production runtime path; scope is local lane policy/checker/test/docs contracts.
- Rollback: revert commit `f006ae8` or this PR branch to restore prior signer policy semantics.

## Documentation Updates
- `README.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
