### PR TITLE
feat(kolme): add secondary signer live-path contract coverage (#2265)

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,9 @@ bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --
 # real-node profile marker for local endpoint/operator validation
 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
 
+# real-node secondary signer profile marker for local failover/operator validation
+bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --runtime-signer-profile ops-secondary --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
+
 # optional nested runtime finality follow-up pass-through
 KAMN_KOLME_LOCAL_HEAVY=1 \
 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-finality-command "printf 'finality=final\n'" --runtime-commit-finality-max-seconds 15 --runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json
@@ -587,6 +590,11 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_previous_rotation_epoch=1
 # runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
 
+# strict secondary signer summary marker contracts
+# runtime_signer_profile=ops-secondary
+# runtime_signer_previous_profile=ops-secondary
+# runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY
+
 # strict profile NO-GO drift/synthetic reason markers
 # runtime_commit_command_profile_mismatch
 # runtime_signer_profile_mismatch
@@ -605,9 +613,12 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 
 # strict profile signer marker
 # KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary
+# KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary
 
 # real-node profile contract lane (dry-run summary + policy + docs parity)
 bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json
+# real-node profile contract lane for secondary signer profile coverage
+bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --runtime-signer-profile ops-secondary --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json
 # real-node strict runtime evidence checker remains local-only and excluded from ci-fast-gate.
 
 # bounded contract lane (spawns local mock API server + pinned checkout fixture)

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -263,6 +263,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   - local KAMN live runtime integration run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds 210 --bootstrap-max-seconds 90 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+    - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --runtime-signer-profile ops-secondary --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
     - nested runtime step composes through `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` and captures runtime policy artifacts.
     - integration summary must emit `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
     - integration summary contracts must emit `runtime_profile` (`standard|real-node`) for deterministic operator/release evidence interpretation.
@@ -280,6 +281,10 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_rotation_epoch=1`
       - `runtime_signer_previous_rotation_epoch=1`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
+    - strict secondary signer summary marker contracts:
+      - `runtime_signer_profile=ops-secondary`
+      - `runtime_signer_previous_profile=ops-secondary`
+      - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
     - strict profile NO-GO drift/synthetic reasons:
       - `runtime_commit_command_profile_mismatch`
       - `runtime_signer_profile_mismatch`
@@ -295,7 +300,9 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`
     - strict profile signer marker:
       - `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`
+      - `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary`
     - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
+    - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --runtime-signer-profile ops-secondary --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
     - strict real-node runtime evidence marker path remains local-only and excluded from ci-fast-gate.
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
   - deployment preflight signer/runtime checks remain fast and ci-fast-gate eligible.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -404,6 +404,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds 210 --bootstrap-max-seconds 90 --localhost-signed-max-seconds 45 --conformance-max-seconds 180 --runtime-commit-max-seconds 30 --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Real-node profile contract marker (local endpoint/operator validation):
   - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+  - `bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --runtime-signer-profile ops-secondary --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Optional runtime finality pass-through to nested live runner:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-finality-command "printf 'finality=final\n'" --runtime-commit-finality-max-seconds 15 --runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Policy checker command:
@@ -422,6 +423,10 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_rotation_epoch=1`
     - `runtime_signer_previous_rotation_epoch=1`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
+  - GO proof also supports deterministic secondary signer markers:
+    - `runtime_signer_profile=ops-secondary`
+    - `runtime_signer_previous_profile=ops-secondary`
+    - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
   - NO-GO marker-drift proof must surface `runtime_commit_command_profile_mismatch` when profile marker contracts drift from `real-node-non-synthetic-v1`.
   - NO-GO signer-profile drift proof must surface `runtime_signer_profile_mismatch` when summary signer profile markers drift from `ops-primary`.
   - NO-GO failover proof must surface `runtime_signer_failover_profile_unchanged` when failover is active but profile does not rotate.
@@ -430,8 +435,10 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`.
+  - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary`.
 - Real-node profile contract lane command:
   - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
+  - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --runtime-signer-profile ops-secondary --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
 - Contract lane command:
   - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
 - Summary schema:
@@ -466,8 +473,15 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
+  - real-node profile accepts secondary signer summary/contracts markers for failover drills:
+    - `runtime_signer_profile=ops-secondary`
+    - `runtime_signer_previous_profile=ops-secondary`
+    - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
+    - `contracts.runtime_signer_failover_requires_profile_change=true`
+    - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`; checker fails closed with `runtime_commit_real_signing_profile_marker_missing` when omitted.
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
+  - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary` when `runtime_signer_profile=ops-secondary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile command composition rejects in-memory fallback references at runner boundary:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -17,6 +17,10 @@ CHECKER = ROOT_DIR / "scripts/kolme/check_local_kamn_live_runtime_real_node_prof
 DOC_FILE = ROOT_DIR / "docs/planning/kolme-devnet-ops.md"
 CI_DOC_FILE = ROOT_DIR / "docs/ci/strategy.md"
 README_FILE = ROOT_DIR / "README.md"
+SIGNER_PRIVATE_KEY_ENV_BY_PROFILE = {
+    "ops-primary": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+    "ops-secondary": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
+}
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -42,6 +46,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--fork-chain-version",
         default="v0.15.2",
         help="Required fork-info chain_version query value.",
+    )
+    parser.add_argument(
+        "--runtime-signer-profile",
+        default="ops-primary",
+        choices=sorted(SIGNER_PRIVATE_KEY_ENV_BY_PROFILE.keys()),
+        help="Signer profile marker expected from the real-node runtime lane.",
     )
     return parser
 
@@ -85,6 +95,10 @@ def main() -> int:
         print("max-seconds must be a positive integer", file=sys.stderr)
         return 1
     max_seconds = int(args.max_seconds)
+    expected_signer_profile = args.runtime_signer_profile
+    expected_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[expected_signer_profile]
+    alternate_signer_profile = "ops-secondary" if expected_signer_profile == "ops-primary" else "ops-primary"
+    alternate_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[alternate_signer_profile]
 
     if not RUNNER.is_file() or not RUNNER.stat().st_mode & 0o111:
         print("expected local KAMN live runtime integration runner to be executable", file=sys.stderr)
@@ -165,6 +179,8 @@ def main() -> int:
                 args.fork_chain_version,
                 "--runtime-provider-client-contract",
                 "KolmeRuntimeCommitLiveProvider",
+                "--runtime-signer-profile",
+                expected_signer_profile,
                 "--runtime-commit-live-summary",
                 str(runtime_commit_live_summary),
                 "--runtime-commit-live-policy-report",
@@ -213,7 +229,8 @@ def main() -> int:
     if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_commit_command:
         print("expected real signing profile marker in contract-lane summary command", file=sys.stderr)
         return 1
-    if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary" not in runtime_commit_command:
+    expected_signer_command_marker = f"KAMN_KOLME_LIVE_SIGNER_PROFILE={expected_signer_profile}"
+    if expected_signer_command_marker not in runtime_commit_command:
         print("expected signer profile marker in contract-lane summary command", file=sys.stderr)
         return 1
     if "InMemoryKolmeRuntimeCommitClient" in runtime_commit_command:
@@ -231,10 +248,10 @@ def main() -> int:
     if summary.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
         print("expected signer profile selector env marker in contract-lane summary", file=sys.stderr)
         return 1
-    if summary.get("runtime_signer_profile") != "ops-primary":
+    if summary.get("runtime_signer_profile") != expected_signer_profile:
         print("expected signer profile marker in contract-lane summary", file=sys.stderr)
         return 1
-    if summary.get("runtime_signer_previous_profile") != "ops-primary":
+    if summary.get("runtime_signer_previous_profile") != expected_signer_profile:
         print("expected signer previous profile marker in contract-lane summary", file=sys.stderr)
         return 1
     if summary.get("runtime_signer_failover_active") is not False:
@@ -246,7 +263,7 @@ def main() -> int:
     if summary.get("runtime_signer_previous_rotation_epoch") != 1:
         print("expected signer previous rotation epoch marker in contract-lane summary", file=sys.stderr)
         return 1
-    if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    if summary.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
     contracts = summary.get("contracts", {})
@@ -259,7 +276,7 @@ def main() -> int:
     if contracts.get("runtime_signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE":
         print("expected contracts signer profile selector env marker in contract-lane summary", file=sys.stderr)
         return 1
-    if contracts.get("runtime_signer_profile") != "ops-primary":
+    if contracts.get("runtime_signer_profile") != expected_signer_profile:
         print("expected contracts signer profile marker in contract-lane summary", file=sys.stderr)
         return 1
     if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
@@ -268,7 +285,7 @@ def main() -> int:
     if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
         print("expected contracts signer rotation epoch guard marker in contract-lane summary", file=sys.stderr)
         return 1
-    if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
+    if contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected contracts signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
     if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
@@ -316,8 +333,8 @@ def main() -> int:
         failover_stale_summary_file = negative_path / "failover_stale_summary.json"
         failover_stale_policy_file = negative_path / "failover_stale_policy.json"
         failover_stale_summary = dict(summary)
-        failover_stale_summary["runtime_signer_profile"] = "ops-primary"
-        failover_stale_summary["runtime_signer_previous_profile"] = "ops-primary"
+        failover_stale_summary["runtime_signer_profile"] = expected_signer_profile
+        failover_stale_summary["runtime_signer_previous_profile"] = expected_signer_profile
         failover_stale_summary["runtime_signer_failover_active"] = True
         failover_stale_summary["runtime_signer_rotation_epoch"] = 3
         failover_stale_summary["runtime_signer_previous_rotation_epoch"] = 3
@@ -347,6 +364,46 @@ def main() -> int:
             return 1
         if failover_stale_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for failover stale policy output", file=sys.stderr)
+            return 1
+
+        signer_key_env_drift_summary_file = negative_path / "signer_key_env_drift_summary.json"
+        signer_key_env_drift_policy_file = negative_path / "signer_key_env_drift_policy.json"
+        signer_key_env_drift_summary = dict(summary)
+        signer_key_env_drift_summary["runtime_signer_profile"] = expected_signer_profile
+        signer_key_env_drift_summary["runtime_signer_previous_profile"] = expected_signer_profile
+        signer_key_env_drift_summary["runtime_signer_private_key_env"] = alternate_signer_private_key_env
+        signer_key_env_drift_contracts = dict(summary.get("contracts", {}))
+        signer_key_env_drift_contracts["runtime_signer_profile"] = expected_signer_profile
+        signer_key_env_drift_contracts["runtime_signer_private_key_env"] = alternate_signer_private_key_env
+        signer_key_env_drift_summary["contracts"] = signer_key_env_drift_contracts
+        signer_key_env_drift_summary_file.write_text(
+            json.dumps(signer_key_env_drift_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        signer_key_env_drift_result = run_real_node_policy_check(
+            report_file=signer_key_env_drift_summary_file,
+            output_json=signer_key_env_drift_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if signer_key_env_drift_result.returncode == 0:
+            print("expected signer key env drift negative proof to fail closed", file=sys.stderr)
+            return 1
+        signer_key_env_drift_policy = json.loads(
+            signer_key_env_drift_policy_file.read_text(encoding="utf-8")
+        )
+        signer_key_env_drift_reason_codes = signer_key_env_drift_policy.get("reason_codes")
+        if not isinstance(signer_key_env_drift_reason_codes, list):
+            print("expected reason_codes list in signer key env drift policy output", file=sys.stderr)
+            return 1
+        if "runtime_signer_private_key_env_mismatch" not in signer_key_env_drift_reason_codes:
+            print(
+                "expected runtime_signer_private_key_env_mismatch in signer key env drift policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if signer_key_env_drift_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for signer key env drift policy output", file=sys.stderr)
             return 1
 
         synthetic_regression_summary_file = negative_path / "synthetic_regression_summary.json"
@@ -409,7 +466,7 @@ def main() -> int:
             "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider "
             "--require-non-synthetic-run-evidence "
             "--live-command \"KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 "
-            "KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
+            f"KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNER_PROFILE={expected_signer_profile} KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport "
             "-- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\\\n'\" "
             "--provider-hint InMemoryKolmeRuntimeCommitClient "
             "--output-json /tmp/runtime-summary.json --policy-output-json /tmp/runtime-policy.json"
@@ -444,32 +501,41 @@ def main() -> int:
 
     doc_markers = [
         "--runtime-profile real-node",
+        "--runtime-signer-profile ops-secondary",
         "check_local_kamn_live_runtime_real_node_profile_policy.py",
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
+        "runtime_signer_profile=ops-secondary",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
+        "runtime_signer_private_key_env_mismatch",
         "Regression: #2139",
     ]
     ci_doc_markers = [
         "--runtime-profile real-node",
+        "--runtime-signer-profile ops-secondary",
         "check_local_kamn_live_runtime_real_node_profile_policy.py",
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
+        "runtime_signer_profile=ops-secondary",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
+        "runtime_signer_private_key_env_mismatch",
         "Regression: #2139",
     ]
     readme_markers = [
         "--runtime-profile real-node",
+        "--runtime-signer-profile ops-secondary",
         "check_local_kamn_live_runtime_real_node_profile_policy.py",
         "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh",
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
+        "runtime_signer_profile=ops-secondary",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
+        "runtime_signer_private_key_env_mismatch",
         "Regression: #2139",
     ]
 

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -36,6 +36,7 @@ RUNTIME_COMMIT_MAX_SECONDS=30
 RUNTIME_SIGNER_PROFILE_SELECTOR_ENV=""
 RUNTIME_SIGNER_PROFILE=""
 RUNTIME_SIGNER_PRIVATE_KEY_ENV=""
+RUNTIME_SIGNER_PROFILE_OVERRIDE=""
 
 shell_escape() {
   printf "%q" "$1"
@@ -121,6 +122,14 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       RUNTIME_PROFILE="$2"
+      shift 2
+      ;;
+    --runtime-signer-profile)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --runtime-signer-profile" >&2
+        exit 1
+      fi
+      RUNTIME_SIGNER_PROFILE_OVERRIDE="$2"
       shift 2
       ;;
     --runtime-commit-finality-command)
@@ -253,6 +262,8 @@ Options:
                                       Required runtime provider contract marker forwarded to nested runtime finality evidence policy.
   --runtime-profile standard|real-node
                                       Runtime integration profile contract marker for local evidence interpretation.
+  --runtime-signer-profile ops-primary|ops-secondary
+                                      Optional signer profile override for real-node runtime profile summaries.
   --runtime-commit-finality-command <command>
                                       Optional finality command passed through to nested runtime-commit live lane.
   --runtime-commit-finality-max-seconds <n>
@@ -307,6 +318,16 @@ fi
 
 if [ "$RUNTIME_PROFILE" != "standard" ] && [ "$RUNTIME_PROFILE" != "real-node" ]; then
   echo "runtime-profile must be one of: standard, real-node" >&2
+  exit 1
+fi
+
+if [ -n "$RUNTIME_SIGNER_PROFILE_OVERRIDE" ] && [ "$RUNTIME_PROFILE" != "real-node" ]; then
+  echo "runtime-signer-profile is only valid when runtime-profile=real-node" >&2
+  exit 1
+fi
+
+if [ -n "$RUNTIME_SIGNER_PROFILE_OVERRIDE" ] && [ "$RUNTIME_SIGNER_PROFILE_OVERRIDE" != "ops-primary" ] && [ "$RUNTIME_SIGNER_PROFILE_OVERRIDE" != "ops-secondary" ]; then
+  echo "runtime-signer-profile must be one of: ops-primary, ops-secondary" >&2
   exit 1
 fi
 
@@ -368,9 +389,13 @@ if [ "$RUNTIME_PROFILE" = "real-node" ]; then
   runtime_commit_command_profile="real-node-non-synthetic-v1"
   runtime_commit_policy_command_profile="real-node-non-synthetic-v1"
   RUNTIME_SIGNER_PROFILE_SELECTOR_ENV="KAMN_KOLME_LIVE_SIGNER_PROFILE"
-  RUNTIME_SIGNER_PROFILE="ops-primary"
-  RUNTIME_SIGNER_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
-  RUNTIME_SIGNER_PREVIOUS_PROFILE="ops-primary"
+  RUNTIME_SIGNER_PROFILE="${RUNTIME_SIGNER_PROFILE_OVERRIDE:-ops-primary}"
+  if [ "$RUNTIME_SIGNER_PROFILE" = "ops-secondary" ]; then
+    RUNTIME_SIGNER_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+  else
+    RUNTIME_SIGNER_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+  fi
+  RUNTIME_SIGNER_PREVIOUS_PROFILE="$RUNTIME_SIGNER_PROFILE"
 fi
 
 if [ -n "$RUNTIME_SIGNER_PROFILE" ]; then

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -9,12 +9,16 @@ CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
 README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
+TMP_REPORT_OK_SECONDARY="$TMP_DIR/ok-report-secondary.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
 TMP_REPORT_INMEMORY="$TMP_DIR/inmemory-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
+TMP_POLICY_OUT_SECONDARY="$TMP_DIR/policy-report-secondary.json"
 TMP_INTEGRATION_POLICY_OUT="$TMP_DIR/integration-policy-report.json"
+TMP_INTEGRATION_POLICY_OUT_SECONDARY="$TMP_DIR/integration-policy-secondary-report.json"
 TMP_SUMMARY="$TMP_DIR/integration-summary.json"
+TMP_SUMMARY_SECONDARY="$TMP_DIR/integration-summary-secondary.json"
 TMP_RUNTIME_SUMMARY="$TMP_DIR/runtime-summary.json"
 TMP_RUNTIME_POLICY="$TMP_DIR/runtime-policy.json"
 TMP_ERR="$TMP_DIR/error.log"
@@ -163,6 +167,51 @@ if report.get("final_decision") != "GO":
     raise SystemExit("expected final_decision GO for valid real-node profile report")
 if report.get("reason_codes") != []:
     raise SystemExit("expected no reason codes for valid real-node profile report")
+PY
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_OK_SECONDARY" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_profile"] = "ops-secondary"
+report["runtime_signer_previous_profile"] = "ops-secondary"
+report["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+report["runtime_commit_command"] = str(report["runtime_commit_command"]).replace(
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
+)
+contracts = report.get("contracts", {})
+if isinstance(contracts, dict):
+    contracts["runtime_signer_profile"] = "ops-secondary"
+    contracts["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_OK_SECONDARY" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code dry_run_no_commands_executed \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT_SECONDARY" >/dev/null
+
+python3 - "$TMP_POLICY_OUT_SECONDARY" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
+    raise SystemExit("unexpected secondary real-node profile policy report schema")
+if report.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision GO for valid secondary real-node profile report")
+if report.get("reason_codes") != []:
+    raise SystemExit("expected no reason codes for valid secondary real-node profile report")
 PY
 
 cat >"$TMP_REPORT_BAD" <<'JSON'
@@ -516,6 +565,23 @@ python3 "$CHECKER" \
   --require-non-synthetic-run-evidence \
   --output-json "$TMP_INTEGRATION_POLICY_OUT" >/dev/null
 
+bash "$RUNNER" \
+  --mode dry-run \
+  --runtime-profile real-node \
+  --runtime-signer-profile ops-secondary \
+  --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \
+  --runtime-commit-live-summary "$TMP_RUNTIME_SUMMARY" \
+  --runtime-commit-live-policy-report "$TMP_RUNTIME_POLICY" \
+  --output-json "$TMP_SUMMARY_SECONDARY" >/dev/null
+
+python3 "$CHECKER" \
+  --report-file "$TMP_SUMMARY_SECONDARY" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code dry_run_no_commands_executed \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_INTEGRATION_POLICY_OUT_SECONDARY" >/dev/null
+
 python3 - "$TMP_SUMMARY" <<'PY'
 import json
 import pathlib
@@ -576,6 +642,32 @@ if "--require-native-payload-evidence" not in runtime_policy_command:
     raise SystemExit("expected native payload evidence marker in runner-generated runtime policy command")
 PY
 
+python3 - "$TMP_SUMMARY_SECONDARY" <<'PY'
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+runtime_commit_command = summary.get("runtime_commit_command")
+if not isinstance(runtime_commit_command, str):
+    raise SystemExit("expected runtime_commit_command string in secondary runner-generated summary")
+if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary" not in runtime_commit_command:
+    raise SystemExit("expected secondary signer profile marker in secondary runner-generated runtime commit command")
+if summary.get("runtime_signer_profile") != "ops-secondary":
+    raise SystemExit("expected secondary signer profile marker in secondary runner-generated summary")
+if summary.get("runtime_signer_previous_profile") != "ops-secondary":
+    raise SystemExit("expected secondary signer previous-profile marker in secondary runner-generated summary")
+if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
+    raise SystemExit("expected secondary signer private key env marker in secondary runner-generated summary")
+contracts = summary.get("contracts")
+if not isinstance(contracts, dict):
+    raise SystemExit("expected contracts object in secondary runner-generated summary")
+if contracts.get("runtime_signer_profile") != "ops-secondary":
+    raise SystemExit("expected contracts secondary signer profile marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
+    raise SystemExit("expected contracts secondary signer private key env marker in secondary runner-generated summary")
+PY
+
 python3 - "$TMP_INTEGRATION_POLICY_OUT" <<'PY'
 import json
 import pathlib
@@ -586,6 +678,18 @@ if policy.get("final_decision") != "GO":
     raise SystemExit("expected GO from real-node profile checker for runner-generated dry-run summary")
 if policy.get("reason_codes") != []:
     raise SystemExit("expected no reason codes for runner-generated real-node profile summary")
+PY
+
+python3 - "$TMP_INTEGRATION_POLICY_OUT_SECONDARY" <<'PY'
+import json
+import pathlib
+import sys
+
+policy = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if policy.get("final_decision") != "GO":
+    raise SystemExit("expected GO from real-node profile checker for secondary runner-generated dry-run summary")
+if policy.get("reason_codes") != []:
+    raise SystemExit("expected no reason codes for secondary runner-generated real-node profile summary")
 PY
 
 echo "local KAMN live runtime real-node profile policy checker tests passed."

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -15,9 +15,12 @@ TMP_DRIFT_REPORT="$(mktemp)"
 TMP_SIGNER_DRIFT_REPORT="$(mktemp)"
 TMP_SYNTHETIC_REPORT="$(mktemp)"
 TMP_INMEMORY_REPORT="$(mktemp)"
+TMP_SECONDARY_REPORT="$(mktemp)"
+TMP_SECONDARY_POLICY_REPORT="$(mktemp)"
+TMP_SECONDARY_KEY_ENV_DRIFT_REPORT="$(mktemp)"
 TMP_NEGATIVE_POLICY="$(mktemp)"
 TMP_NEGATIVE_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_REPORT" "$TMP_SECONDARY_POLICY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime real-node profile contract lane runner to be executable" >&2
@@ -64,9 +67,12 @@ required_coverage_markers=(
   "check_local_kamn_live_runtime_real_node_profile_policy.py"
   "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"
   "--require-non-synthetic-run-evidence"
+  "--runtime-signer-profile"
   "docs/planning/kolme-devnet-ops.md"
   "docs/ci/strategy.md"
   "README.md"
+  "runtime_signer_profile=ops-secondary"
+  "runtime_signer_private_key_env_mismatch"
   "runtime_commit_command_profile_mismatch"
   "runtime_signer_failover_profile_unchanged"
   "runtime_signer_rotation_epoch_stale"
@@ -87,12 +93,24 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include real-node runtime profile marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q -- "--runtime-signer-profile ops-secondary" "$docs_file"; then
+    echo "expected docs parity to include secondary signer profile invocation marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "check_local_kamn_live_runtime_real_node_profile_policy.py" "$docs_file"; then
     echo "expected docs parity to include real-node profile policy checker marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh" "$docs_file"; then
     echo "expected docs parity to include real-node profile contract lane marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_profile=ops-secondary" "$docs_file"; then
+    echo "expected docs parity to include secondary signer profile marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_private_key_env_mismatch" "$docs_file"; then
+    echo "expected docs parity to include signer private key mismatch reason marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "Regression: #2139" "$docs_file"; then
@@ -164,7 +182,41 @@ if policy.get("reason_codes") != []:
     raise SystemExit("expected no policy reason codes for real-node profile contract-lane dry-run composition")
 PY
 
-python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" <<'PY'
+bash "$RUNNER" \
+  --runtime-signer-profile ops-secondary \
+  --output-json "$TMP_SECONDARY_REPORT" \
+  --policy-output-json "$TMP_SECONDARY_POLICY_REPORT" >/dev/null
+
+python3 - "$TMP_SECONDARY_REPORT" "$TMP_SECONDARY_POLICY_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+runtime_commit_command = summary.get("runtime_commit_command")
+if not isinstance(runtime_commit_command, str):
+    raise SystemExit("expected runtime_commit_command in secondary signer contract-lane summary")
+if "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary" not in runtime_commit_command:
+    raise SystemExit("expected secondary signer profile marker in secondary signer contract-lane summary")
+if summary.get("runtime_signer_profile") != "ops-secondary":
+    raise SystemExit("expected secondary signer profile marker in contract-lane summary")
+if summary.get("runtime_signer_previous_profile") != "ops-secondary":
+    raise SystemExit("expected secondary signer previous-profile marker in contract-lane summary")
+if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
+    raise SystemExit("expected secondary signer private key env marker in contract-lane summary")
+contracts = summary.get("contracts", {})
+if contracts.get("runtime_signer_profile") != "ops-secondary":
+    raise SystemExit("expected contracts secondary signer profile marker in contract-lane summary")
+if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
+    raise SystemExit("expected contracts secondary signer private key env marker in contract-lane summary")
+if policy.get("final_decision") != "GO":
+    raise SystemExit("expected secondary signer policy final_decision GO")
+if policy.get("reason_codes") != []:
+    raise SystemExit("expected no policy reason codes for secondary signer dry-run composition")
+PY
+
+python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" <<'PY'
 import json
 import pathlib
 import sys
@@ -215,6 +267,22 @@ inmemory_summary["runtime_commit_command"] = (
 )
 pathlib.Path(sys.argv[5]).write_text(
     json.dumps(inmemory_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+secondary_key_env_drift_summary = dict(base_summary)
+secondary_key_env_drift_summary["runtime_signer_profile"] = "ops-secondary"
+secondary_key_env_drift_summary["runtime_signer_previous_profile"] = "ops-secondary"
+secondary_key_env_drift_summary["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+secondary_key_env_drift_summary["contracts"] = dict(base_summary.get("contracts", {}))
+secondary_key_env_drift_summary["contracts"]["runtime_signer_profile"] = "ops-secondary"
+secondary_key_env_drift_summary["contracts"]["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+secondary_key_env_drift_summary["runtime_commit_command"] = str(base_summary.get("runtime_commit_command", "")).replace(
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
+)
+pathlib.Path(sys.argv[6]).write_text(
+    json.dumps(secondary_key_env_drift_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
 PY
@@ -311,6 +379,26 @@ fi
 
 if ! grep -q "runtime_commit_in_memory_provider_reference_detected" "$TMP_NEGATIVE_ERR"; then
   echo "expected in-memory provider reference reason in negative proof output" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+secondary_key_env_exit_code=$?
+set -e
+
+if [ "$secondary_key_env_exit_code" -eq 0 ]; then
+  echo "expected secondary signer key-env drift negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_private_key_env_mismatch" "$TMP_NEGATIVE_ERR"; then
+  echo "expected signer private key env mismatch reason in secondary signer negative proof output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This task adds explicit `ops-secondary` signer-path coverage to the local-heavy real-node Kolme runtime lane contracts so failover behavior is proven end-to-end, not inferred from `ops-primary` only. It introduces deterministic signer-profile routing in the lane runner, extends contract/policy tests for secondary GO and key-env mismatch NO-GO proofs, and updates docs parity markers.

Closes #2265
Refs #2236

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
  - Added `--runtime-signer-profile ops-primary|ops-secondary` (real-node only).
  - Added fail-closed validation for invalid profile usage.
  - Routed profile-to-key-env mapping deterministically:
    - `ops-primary -> KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
    - `ops-secondary -> KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`
  - Added `--runtime-signer-profile` contract-lane option and dynamic signer expectations.
  - Added secondary key-env drift negative proof asserting `runtime_signer_private_key_env_mismatch`.
  - Extended docs marker parity requirements for secondary signer invocation/markers.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - Added secondary fixture GO validation and runner-generated secondary summary/policy GO checks.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
  - Added secondary contract-lane GO validation.
  - Added secondary key-env mismatch NO-GO regression proof.
  - Added docs parity checks for `--runtime-signer-profile ops-secondary` and secondary markers.
- Documentation updates:
  - `README.md`
  - `docs/ci/strategy.md`
  - `docs/planning/kolme-devnet-ops.md`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command (after adding failing-first secondary coverage assertions):
```bash
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
```
Observed failure before implementation:
```text
exit_code=2
```
Failure point required by new test path:
```text
bash ...run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --runtime-signer-profile ops-secondary ...
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
```
Output:
```text
local KAMN live runtime real-node profile policy checker tests passed.
local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh && \
cargo test -p kamn-core --test kolme_devnet_ops_docs --test ci_strategy_docs && \
cargo fmt --check && \
cargo clippy -p kamn-core -- -D warnings
```
Output summary:
```text
- policy checker lane test: pass
- real-node profile contract lane test: pass
- docs contract tests: pass (ci_strategy_docs: 2/2, kolme_devnet_ops_docs: 75/75)
- cargo fmt --check: pass
- cargo clippy -p kamn-core -- -D warnings: pass
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None | Lane/checker behavior is currently exercised through shell-based policy/contract harness tests in this scope. |
| Functional   | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | Added secondary-profile GO fixtures + runner-generated summary/policy assertions. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | Added secondary-profile contract-lane GO path and docs parity checks. |
| Regression   | ✅     | `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`, `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | Added explicit secondary key-env drift NO-GO proof for `runtime_signer_private_key_env_mismatch`. |
| Performance  | N/A    | None | No throughput changes; local-only bounded lane/runtime budgets preserved. |

## Risks & Rollback
- Risk: low/med; scope is local lane policy/contracts/docs and signer-profile selector wiring, no production network path change.
- Rollback: revert commit `bc747e0` if secondary signer contract rollout needs to be deferred.

## Documentation Updates
- `README.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
