### PR TITLE
feat(kolme): add key-source evidence schema markers (#2249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_failover_active=false
 # runtime_signer_rotation_epoch=1
 # runtime_signer_previous_rotation_epoch=1
+# runtime_signer_key_source_contract_version=v1
+# runtime_signer_key_source=env-local
 # runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
 
 # strict secondary signer summary marker contracts

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -280,6 +280,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_failover_active=false`
       - `runtime_signer_rotation_epoch=1`
       - `runtime_signer_previous_rotation_epoch=1`
+      - `runtime_signer_key_source_contract_version=v1`
+      - `runtime_signer_key_source=env-local`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - strict secondary signer summary marker contracts:
       - `runtime_signer_profile=ops-secondary`

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -245,10 +245,14 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - `runtime_commit_command_profile`
     - `runtime_commit_policy_command_profile`
     - `runtime_commit_command_profile_version`
+    - `runtime_signer_key_source_contract_version`
+    - `runtime_signer_key_source`
   - real-node summary/profile checker contract requires:
     - `runtime_commit_command_profile=real-node-non-synthetic-v1`
     - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
     - `runtime_commit_command_profile_version=v1`
+    - `runtime_signer_key_source_contract_version=v1`
+    - `runtime_signer_key_source=env-local`
   - marker/profile drift is fail-closed in `check_local_kamn_live_runtime_real_node_profile_policy.py`.
   - strict real-node checker additionally fails closed when runtime command surfaces omit fork-aligned signing profile marker:
     - `runtime_commit_real_signing_profile_marker_missing`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -422,6 +422,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_failover_active=false`
     - `runtime_signer_rotation_epoch=1`
     - `runtime_signer_previous_rotation_epoch=1`
+    - `runtime_signer_key_source_contract_version=v1`
+    - `runtime_signer_key_source=env-local`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
   - GO proof also supports deterministic secondary signer markers:
     - `runtime_signer_profile=ops-secondary`
@@ -461,6 +463,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_failover_active`
     - `runtime_signer_rotation_epoch`
     - `runtime_signer_previous_rotation_epoch`
+    - `runtime_signer_key_source_contract_version`
+    - `runtime_signer_key_source`
     - `runtime_signer_private_key_env`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
   - real-node profile requires signer profile summary/contracts markers:
@@ -470,6 +474,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_failover_active=false`
     - `runtime_signer_rotation_epoch=1`
     - `runtime_signer_previous_rotation_epoch=1`
+    - `runtime_signer_key_source_contract_version=v1`
+    - `runtime_signer_key_source=env-local`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -13,6 +13,8 @@ REAL_SIGNER_PROFILE_PRIMARY = "ops-primary"
 REAL_SIGNER_PROFILE_SECONDARY = "ops-secondary"
 REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
+ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 ALLOWED_SIGNER_PROFILES = (
     REAL_SIGNER_PROFILE_PRIMARY,
     REAL_SIGNER_PROFILE_SECONDARY,
@@ -147,6 +149,21 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     ):
         reason_codes.append("runtime_signer_rotation_epoch_stale")
 
+    runtime_signer_key_source_contract_version = report.get("runtime_signer_key_source_contract_version")
+    if not isinstance(runtime_signer_key_source_contract_version, str) or not runtime_signer_key_source_contract_version.strip():
+        reason_codes.append("runtime_signer_key_source_contract_version_missing")
+    elif runtime_signer_key_source_contract_version != REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION:
+        reason_codes.append("runtime_signer_key_source_contract_version_mismatch")
+
+    runtime_signer_key_source = report.get("runtime_signer_key_source")
+    expected_signer_key_source = ""
+    if not isinstance(runtime_signer_key_source, str) or not runtime_signer_key_source.strip():
+        reason_codes.append("runtime_signer_key_source_missing")
+    else:
+        expected_signer_key_source = runtime_signer_key_source.strip()
+        if expected_signer_key_source not in ALLOWED_SIGNER_KEY_SOURCES:
+            reason_codes.append("runtime_signer_key_source_invalid")
+
     runtime_signer_private_key_env = report.get("runtime_signer_private_key_env")
     if not isinstance(runtime_signer_private_key_env, str) or not runtime_signer_private_key_env.strip():
         reason_codes.append("runtime_signer_private_key_env_missing")
@@ -242,6 +259,14 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and contracts.get("runtime_signer_profile") != runtime_signer_profile
         ):
             reason_codes.append("runtime_signer_profile_contract_mismatch")
+        if (
+            isinstance(runtime_signer_key_source_contract_version, str)
+            and runtime_signer_key_source_contract_version == REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION
+            and contracts.get("runtime_signer_key_source_contract_version") != runtime_signer_key_source_contract_version
+        ):
+            reason_codes.append("runtime_signer_key_source_contract_version_contract_mismatch")
+        if expected_signer_key_source and contracts.get("runtime_signer_key_source") != expected_signer_key_source:
+            reason_codes.append("runtime_signer_key_source_contract_mismatch")
         if expected_signer_private_key_env and contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
             reason_codes.append("runtime_signer_private_key_env_contract_mismatch")
         if contracts.get("runtime_signer_failover_requires_profile_change") is not True:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -96,6 +96,8 @@ def main() -> int:
         return 1
     max_seconds = int(args.max_seconds)
     expected_signer_profile = args.runtime_signer_profile
+    expected_signer_key_source_contract_version = "v1"
+    expected_signer_key_source = "env-local"
     expected_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[expected_signer_profile]
     alternate_signer_profile = "ops-secondary" if expected_signer_profile == "ops-primary" else "ops-primary"
     alternate_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[alternate_signer_profile]
@@ -263,6 +265,12 @@ def main() -> int:
     if summary.get("runtime_signer_previous_rotation_epoch") != 1:
         print("expected signer previous rotation epoch marker in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_key_source_contract_version") != expected_signer_key_source_contract_version:
+        print("expected signer key-source contract version marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_key_source") != expected_signer_key_source:
+        print("expected signer key-source marker in contract-lane summary", file=sys.stderr)
+        return 1
     if summary.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
@@ -284,6 +292,12 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
         print("expected contracts signer rotation epoch guard marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_key_source_contract_version") != expected_signer_key_source_contract_version:
+        print("expected contracts signer key-source contract version marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_key_source") != expected_signer_key_source:
+        print("expected contracts signer key-source marker in contract-lane summary", file=sys.stderr)
         return 1
     if contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected contracts signer private key env marker in contract-lane summary", file=sys.stderr)
@@ -507,6 +521,8 @@ def main() -> int:
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
         "runtime_signer_profile=ops-secondary",
+        "runtime_signer_key_source_contract_version",
+        "runtime_signer_key_source",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_private_key_env_mismatch",
@@ -520,6 +536,8 @@ def main() -> int:
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
         "runtime_signer_profile=ops-secondary",
+        "runtime_signer_key_source_contract_version",
+        "runtime_signer_key_source",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_private_key_env_mismatch",
@@ -533,6 +551,8 @@ def main() -> int:
         "--require-non-synthetic-run-evidence",
         "runtime_signer_profile=ops-primary",
         "runtime_signer_profile=ops-secondary",
+        "runtime_signer_key_source_contract_version",
+        "runtime_signer_key_source",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_private_key_env_mismatch",

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -35,6 +35,8 @@ LOCALHOST_SIGNED_MAX_SECONDS=45
 RUNTIME_COMMIT_MAX_SECONDS=30
 RUNTIME_SIGNER_PROFILE_SELECTOR_ENV=""
 RUNTIME_SIGNER_PROFILE=""
+RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION=""
+RUNTIME_SIGNER_KEY_SOURCE=""
 RUNTIME_SIGNER_PRIVATE_KEY_ENV=""
 RUNTIME_SIGNER_PROFILE_OVERRIDE=""
 
@@ -389,6 +391,8 @@ if [ "$RUNTIME_PROFILE" = "real-node" ]; then
   runtime_commit_command_profile="real-node-non-synthetic-v1"
   runtime_commit_policy_command_profile="real-node-non-synthetic-v1"
   RUNTIME_SIGNER_PROFILE_SELECTOR_ENV="KAMN_KOLME_LIVE_SIGNER_PROFILE"
+  RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION="v1"
+  RUNTIME_SIGNER_KEY_SOURCE="env-local"
   RUNTIME_SIGNER_PROFILE="${RUNTIME_SIGNER_PROFILE_OVERRIDE:-ops-primary}"
   if [ "$RUNTIME_SIGNER_PROFILE" = "ops-secondary" ]; then
     RUNTIME_SIGNER_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
@@ -662,7 +666,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" <<'PY'
 from __future__ import annotations
 
 import json
@@ -708,7 +712,9 @@ runtime_signer_previous_profile = sys.argv[36]
 runtime_signer_failover_active = sys.argv[37] == "true"
 runtime_signer_rotation_epoch = int(sys.argv[38])
 runtime_signer_previous_rotation_epoch = int(sys.argv[39])
-runtime_signer_private_key_env = sys.argv[40]
+runtime_signer_key_source_contract_version = sys.argv[40]
+runtime_signer_key_source = sys.argv[41]
+runtime_signer_private_key_env = sys.argv[42]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -754,6 +760,8 @@ summary = {
     "runtime_signer_failover_active": runtime_signer_failover_active,
     "runtime_signer_rotation_epoch": runtime_signer_rotation_epoch,
     "runtime_signer_previous_rotation_epoch": runtime_signer_previous_rotation_epoch,
+    "runtime_signer_key_source_contract_version": runtime_signer_key_source_contract_version,
+    "runtime_signer_key_source": runtime_signer_key_source,
     "runtime_signer_private_key_env": runtime_signer_private_key_env,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
@@ -773,6 +781,8 @@ summary = {
         "runtime_signer_profile": runtime_signer_profile,
         "runtime_signer_failover_requires_profile_change": True,
         "runtime_signer_rotation_epoch_must_increase_on_failover": True,
+        "runtime_signer_key_source_contract_version": runtime_signer_key_source_contract_version,
+        "runtime_signer_key_source": runtime_signer_key_source,
         "runtime_signer_private_key_env": runtime_signer_private_key_env,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -68,6 +68,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_signer_failover_active": false,
   "runtime_signer_rotation_epoch": 1,
   "runtime_signer_previous_rotation_epoch": 1,
+  "runtime_signer_key_source_contract_version": "v1",
+  "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
@@ -91,6 +93,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_profile": "ops-primary",
     "runtime_signer_failover_requires_profile_change": true,
     "runtime_signer_rotation_epoch_must_increase_on_failover": true,
+    "runtime_signer_key_source_contract_version": "v1",
+    "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
@@ -314,6 +318,16 @@ if ! grep -q "runtime_signer_private_key_env_mismatch" "$TMP_ERR"; then
   exit 1
 fi
 
+if ! grep -q "runtime_signer_key_source_contract_version_missing" "$TMP_ERR"; then
+  echo "expected signer key-source contract version missing reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_key_source_missing" "$TMP_ERR"; then
+  echo "expected signer key-source missing reason for policy failure" >&2
+  exit 1
+fi
+
 if ! grep -q "runtime_commit_command_profile_version_mismatch" "$TMP_ERR"; then
   echo "expected runtime commit profile marker version mismatch reason for policy failure" >&2
   exit 1
@@ -344,6 +358,8 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
   "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "runtime_signer_profile": "ops-primary",
+  "runtime_signer_key_source_contract_version": "v1",
+  "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
@@ -365,6 +381,8 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
     "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
     "runtime_signer_profile": "ops-primary",
+    "runtime_signer_key_source_contract_version": "v1",
+    "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
@@ -459,6 +477,8 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
   "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "runtime_signer_profile": "ops-primary",
+  "runtime_signer_key_source_contract_version": "v1",
+  "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
@@ -480,6 +500,8 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
     "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
     "runtime_signer_profile": "ops-primary",
+    "runtime_signer_key_source_contract_version": "v1",
+    "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
@@ -625,6 +647,10 @@ if summary.get("runtime_signer_rotation_epoch") != 1:
     raise SystemExit("expected signer rotation epoch marker in runner-generated summary")
 if summary.get("runtime_signer_previous_rotation_epoch") != 1:
     raise SystemExit("expected signer previous rotation epoch marker in runner-generated summary")
+if summary.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected signer key-source contract version marker in runner-generated summary")
+if summary.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected signer key-source marker in runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in runner-generated summary")
 checks = summary.get("checks")
@@ -657,6 +683,10 @@ if summary.get("runtime_signer_profile") != "ops-secondary":
     raise SystemExit("expected secondary signer profile marker in secondary runner-generated summary")
 if summary.get("runtime_signer_previous_profile") != "ops-secondary":
     raise SystemExit("expected secondary signer previous-profile marker in secondary runner-generated summary")
+if summary.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected secondary signer key-source contract version marker in secondary runner-generated summary")
+if summary.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected secondary signer key-source marker in secondary runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected secondary signer private key env marker in secondary runner-generated summary")
 contracts = summary.get("contracts")
@@ -664,6 +694,10 @@ if not isinstance(contracts, dict):
     raise SystemExit("expected contracts object in secondary runner-generated summary")
 if contracts.get("runtime_signer_profile") != "ops-secondary":
     raise SystemExit("expected contracts secondary signer profile marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected contracts signer key-source contract version marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected contracts signer key-source marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in secondary runner-generated summary")
 PY

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -72,6 +72,8 @@ required_coverage_markers=(
   "docs/ci/strategy.md"
   "README.md"
   "runtime_signer_profile=ops-secondary"
+  "runtime_signer_key_source_contract_version"
+  "runtime_signer_key_source"
   "runtime_signer_private_key_env_mismatch"
   "runtime_commit_command_profile_mismatch"
   "runtime_signer_failover_profile_unchanged"
@@ -107,6 +109,14 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_profile=ops-secondary" "$docs_file"; then
     echo "expected docs parity to include secondary signer profile marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_key_source_contract_version" "$docs_file"; then
+    echo "expected docs parity to include signer key-source contract version marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_key_source" "$docs_file"; then
+    echo "expected docs parity to include signer key-source marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "runtime_signer_private_key_env_mismatch" "$docs_file"; then
@@ -159,6 +169,10 @@ if summary.get("runtime_signer_rotation_epoch") != 1:
     raise SystemExit("expected signer rotation epoch marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_previous_rotation_epoch") != 1:
     raise SystemExit("expected signer previous rotation epoch marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected signer key-source contract version marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected signer key-source marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in real-node profile contract-lane summary")
 contracts = summary.get("contracts", {})
@@ -172,6 +186,10 @@ if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
     raise SystemExit("expected contracts failover profile-change guard marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
     raise SystemExit("expected contracts rotation epoch guard marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected contracts signer key-source contract version marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected contracts signer key-source marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected contracts signer private key env marker in real-node profile contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
@@ -203,11 +221,19 @@ if summary.get("runtime_signer_profile") != "ops-secondary":
     raise SystemExit("expected secondary signer profile marker in contract-lane summary")
 if summary.get("runtime_signer_previous_profile") != "ops-secondary":
     raise SystemExit("expected secondary signer previous-profile marker in contract-lane summary")
+if summary.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected secondary signer key-source contract version marker in contract-lane summary")
+if summary.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected secondary signer key-source marker in contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected secondary signer private key env marker in contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_signer_profile") != "ops-secondary":
     raise SystemExit("expected contracts secondary signer profile marker in contract-lane summary")
+if contracts.get("runtime_signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected contracts secondary signer key-source contract version marker in contract-lane summary")
+if contracts.get("runtime_signer_key_source") != "env-local":
+    raise SystemExit("expected contracts secondary signer key-source marker in contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in contract-lane summary")
 if policy.get("final_decision") != "GO":


### PR DESCRIPTION
## Summary
This subtask extends the local Kolme real-node runtime evidence schema with explicit key-source contract markers (`runtime_signer_key_source_contract_version`, `runtime_signer_key_source`) and makes policy consumers fail closed on missing/malformed marker fields. It also propagates the markers through lane summaries/contracts, contract-lane checks, tests, and documentation.

Closes #2249
Refs #2239

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
  - Emits `runtime_signer_key_source_contract_version` and `runtime_signer_key_source` in summary/contracts.
  - Real-node profile now sets key-source markers deterministically (`v1`, `env-local`).
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`
  - Added fail-closed validation for missing/malformed key-source markers.
  - Added contract mismatch checks for key-source marker propagation in `contracts` payload.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`
  - Enforces key-source markers in summary/contracts for GO path.
  - Adds coverage marker parity requirements for key-source markers in docs.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - Adds key-source markers to GO fixtures.
  - Adds NO-GO assertion for missing key-source marker reason codes.
  - Verifies runner-generated primary/secondary summaries include key-source markers.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
  - Verifies key-source markers in primary/secondary contract-lane summaries/contracts.
  - Enforces docs parity for key-source marker references.
- Docs updates:
  - `README.md`
  - `docs/ci/strategy.md`
  - `docs/planning/kolme-devnet-ops.md`
  - `docs/foundation/kolme-runtime-commit-client.md`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
```
Output before implementation:
```text
expected signer key-source contract version missing reason for policy failure
exit_code=1
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
```
Output:
```text
local KAMN live runtime real-node profile policy checker tests passed.
local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh && \
cargo test -p kamn-core --test kolme_runtime_commit_client_docs --test kolme_devnet_ops_docs --test ci_strategy_docs && \
cargo fmt --check && \
cargo clippy -p kamn-core -- -D warnings
```
Output summary:
```text
- local real-node policy checker lane test: pass
- local real-node profile contract lane test: pass
- local runtime integration real-node profile test: pass
- local runtime integration contract lane test: pass
- docs tests: pass (ci_strategy_docs 2/2, kolme_devnet_ops_docs 75/75, kolme_runtime_commit_client_docs 2/2)
- cargo fmt --check: pass
- cargo clippy -p kamn-core -- -D warnings: pass
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None | Changes are lane/policy schema surface checks validated through existing script-based harnesses. |
| Functional   | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | Added key-source schema GO + missing-marker NO-GO assertions. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | Verified summary/contracts propagation and checker linkage. |
| Regression   | ✅     | key-source marker omission and contract mismatch checks in checker + contract-lane tests | Prevents silent drift of key-source schema contracts. |
| Performance  | N/A    | None | No runtime throughput change; local-only bounded lane budgets preserved. |

## Risks & Rollback
- Risk: low/med; schema extension and strict validation may fail older handcrafted fixtures without key-source markers.
- Rollback: revert commit `83717a6` if marker rollout sequencing needs to be staged.

## Documentation Updates
- `README.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`
- `docs/foundation/kolme-runtime-commit-client.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
