### PR TITLE
feat(kolme): enforce key-source profile matrix policy (#2250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_profile_mismatch
 # runtime_signer_failover_profile_unchanged
 # runtime_signer_rotation_epoch_stale
+# runtime_signer_key_source_profile_pair_disallowed
 # runtime_signer_private_key_env_mismatch
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -292,6 +292,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_profile_mismatch`
       - `runtime_signer_failover_profile_unchanged`
       - `runtime_signer_rotation_epoch_stale`
+      - `runtime_signer_key_source_profile_pair_disallowed`
       - `runtime_signer_private_key_env_mismatch`
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -433,6 +433,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO signer-profile drift proof must surface `runtime_signer_profile_mismatch` when summary signer profile markers drift from `ops-primary`.
   - NO-GO failover proof must surface `runtime_signer_failover_profile_unchanged` when failover is active but profile does not rotate.
   - NO-GO stale-rotation proof must surface `runtime_signer_rotation_epoch_stale` when failover rotation epoch is not strictly increasing.
+  - NO-GO key-source/profile matrix proof must surface `runtime_signer_key_source_profile_pair_disallowed` when signer profile/key-source pair is outside the strict allowlist.
   - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
@@ -485,6 +486,9 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
+  - key-source/profile allowlist matrix contracts:
+    - `ops-primary`: `env-local`, `managed-external`
+    - `ops-secondary`: `env-local` only
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`; checker fails closed with `runtime_commit_real_signing_profile_marker_missing` when omitted.
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary` when `runtime_signer_profile=ops-secondary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -14,11 +14,15 @@ REAL_SIGNER_PROFILE_SECONDARY = "ops-secondary"
 REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
-ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 ALLOWED_SIGNER_PROFILES = (
     REAL_SIGNER_PROFILE_PRIMARY,
     REAL_SIGNER_PROFILE_SECONDARY,
 )
+ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
+    REAL_SIGNER_PROFILE_PRIMARY: ("env-local", "managed-external"),
+    REAL_SIGNER_PROFILE_SECONDARY: ("env-local",),
+}
+ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 SIGNER_PRIVATE_KEY_ENV_BY_PROFILE = {
     REAL_SIGNER_PROFILE_PRIMARY: REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY,
     REAL_SIGNER_PROFILE_SECONDARY: REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY,
@@ -163,6 +167,14 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         expected_signer_key_source = runtime_signer_key_source.strip()
         if expected_signer_key_source not in ALLOWED_SIGNER_KEY_SOURCES:
             reason_codes.append("runtime_signer_key_source_invalid")
+    if (
+        isinstance(runtime_signer_profile, str)
+        and runtime_signer_profile in ALLOWED_SIGNER_PROFILES
+        and expected_signer_key_source
+        and expected_signer_key_source in ALLOWED_SIGNER_KEY_SOURCES
+        and expected_signer_key_source not in ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE[runtime_signer_profile]
+    ):
+        reason_codes.append("runtime_signer_key_source_profile_pair_disallowed")
 
     runtime_signer_private_key_env = report.get("runtime_signer_private_key_env")
     if not isinstance(runtime_signer_private_key_env, str) or not runtime_signer_private_key_env.strip():

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -420,6 +420,56 @@ def main() -> int:
             print("expected NO-GO final decision for signer key env drift policy output", file=sys.stderr)
             return 1
 
+        key_source_matrix_drift_summary_file = negative_path / "key_source_matrix_drift_summary.json"
+        key_source_matrix_drift_policy_file = negative_path / "key_source_matrix_drift_policy.json"
+        key_source_matrix_drift_summary = dict(summary)
+        key_source_matrix_drift_summary["runtime_signer_profile"] = "ops-secondary"
+        key_source_matrix_drift_summary["runtime_signer_previous_profile"] = "ops-secondary"
+        key_source_matrix_drift_summary["runtime_signer_key_source"] = "managed-external"
+        key_source_matrix_drift_summary["runtime_signer_private_key_env"] = (
+            SIGNER_PRIVATE_KEY_ENV_BY_PROFILE["ops-secondary"]
+        )
+        key_source_matrix_drift_summary["runtime_commit_command"] = runtime_commit_command.replace(
+            expected_signer_command_marker,
+            "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
+        )
+        key_source_matrix_drift_contracts = dict(summary.get("contracts", {}))
+        key_source_matrix_drift_contracts["runtime_signer_profile"] = "ops-secondary"
+        key_source_matrix_drift_contracts["runtime_signer_key_source"] = "managed-external"
+        key_source_matrix_drift_contracts["runtime_signer_private_key_env"] = (
+            SIGNER_PRIVATE_KEY_ENV_BY_PROFILE["ops-secondary"]
+        )
+        key_source_matrix_drift_summary["contracts"] = key_source_matrix_drift_contracts
+        key_source_matrix_drift_summary_file.write_text(
+            json.dumps(key_source_matrix_drift_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        key_source_matrix_drift_result = run_real_node_policy_check(
+            report_file=key_source_matrix_drift_summary_file,
+            output_json=key_source_matrix_drift_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if key_source_matrix_drift_result.returncode == 0:
+            print("expected disallowed key-source/profile pair negative proof to fail closed", file=sys.stderr)
+            return 1
+        key_source_matrix_drift_policy = json.loads(
+            key_source_matrix_drift_policy_file.read_text(encoding="utf-8")
+        )
+        key_source_matrix_drift_reason_codes = key_source_matrix_drift_policy.get("reason_codes")
+        if not isinstance(key_source_matrix_drift_reason_codes, list):
+            print("expected reason_codes list in key-source matrix drift policy output", file=sys.stderr)
+            return 1
+        if "runtime_signer_key_source_profile_pair_disallowed" not in key_source_matrix_drift_reason_codes:
+            print(
+                "expected runtime_signer_key_source_profile_pair_disallowed in key-source matrix drift policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if key_source_matrix_drift_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for key-source matrix drift policy output", file=sys.stderr)
+            return 1
+
         synthetic_regression_summary_file = negative_path / "synthetic_regression_summary.json"
         synthetic_regression_policy_file = negative_path / "synthetic_regression_policy.json"
         synthetic_regression_summary = dict(summary)
@@ -525,6 +575,7 @@ def main() -> int:
         "runtime_signer_key_source",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
+        "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
         "Regression: #2139",
     ]
@@ -540,6 +591,7 @@ def main() -> int:
         "runtime_signer_key_source",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
+        "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
         "Regression: #2139",
     ]
@@ -555,6 +607,7 @@ def main() -> int:
         "runtime_signer_key_source",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
+        "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
         "Regression: #2139",
     ]

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -10,6 +10,8 @@ README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_OK_SECONDARY="$TMP_DIR/ok-report-secondary.json"
+TMP_REPORT_OK_MANAGED="$TMP_DIR/ok-report-managed.json"
+TMP_REPORT_KEY_SOURCE_PAIR_BAD="$TMP_DIR/key-source-pair-bad-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
 TMP_REPORT_INMEMORY="$TMP_DIR/inmemory-report.json"
@@ -217,6 +219,66 @@ if report.get("final_decision") != "GO":
 if report.get("reason_codes") != []:
     raise SystemExit("expected no reason codes for valid secondary real-node profile report")
 PY
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_OK_MANAGED" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_key_source"] = "managed-external"
+contracts = report.get("contracts", {})
+if isinstance(contracts, dict):
+    contracts["runtime_signer_key_source"] = "managed-external"
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_OK_MANAGED" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code dry_run_no_commands_executed \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >/dev/null
+
+python3 - "$TMP_REPORT_OK_SECONDARY" "$TMP_REPORT_KEY_SOURCE_PAIR_BAD" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_key_source"] = "managed-external"
+contracts = report.get("contracts", {})
+if isinstance(contracts, dict):
+    contracts["runtime_signer_key_source"] = "managed-external"
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_KEY_SOURCE_PAIR_BAD" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+key_source_pair_bad_exit_code=$?
+set -e
+
+if [ "$key_source_pair_bad_exit_code" -eq 0 ]; then
+  echo "expected disallowed key-source/profile pair proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$TMP_ERR"; then
+  echo "expected disallowed key-source/profile pair reason for policy failure" >&2
+  exit 1
+fi
 
 cat >"$TMP_REPORT_BAD" <<'JSON'
 {

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -18,9 +18,10 @@ TMP_INMEMORY_REPORT="$(mktemp)"
 TMP_SECONDARY_REPORT="$(mktemp)"
 TMP_SECONDARY_POLICY_REPORT="$(mktemp)"
 TMP_SECONDARY_KEY_ENV_DRIFT_REPORT="$(mktemp)"
+TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT="$(mktemp)"
 TMP_NEGATIVE_POLICY="$(mktemp)"
 TMP_NEGATIVE_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_REPORT" "$TMP_SECONDARY_POLICY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_REPORT" "$TMP_SECONDARY_POLICY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime real-node profile contract lane runner to be executable" >&2
@@ -74,6 +75,7 @@ required_coverage_markers=(
   "runtime_signer_profile=ops-secondary"
   "runtime_signer_key_source_contract_version"
   "runtime_signer_key_source"
+  "runtime_signer_key_source_profile_pair_disallowed"
   "runtime_signer_private_key_env_mismatch"
   "runtime_commit_command_profile_mismatch"
   "runtime_signer_failover_profile_unchanged"
@@ -117,6 +119,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_key_source" "$docs_file"; then
     echo "expected docs parity to include signer key-source marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$docs_file"; then
+    echo "expected docs parity to include signer key-source/profile pair disallowed reason marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "runtime_signer_private_key_env_mismatch" "$docs_file"; then
@@ -242,7 +248,7 @@ if policy.get("reason_codes") != []:
     raise SystemExit("expected no policy reason codes for secondary signer dry-run composition")
 PY
 
-python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" <<'PY'
+python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" <<'PY'
 import json
 import pathlib
 import sys
@@ -309,6 +315,24 @@ secondary_key_env_drift_summary["runtime_commit_command"] = str(base_summary.get
 )
 pathlib.Path(sys.argv[6]).write_text(
     json.dumps(secondary_key_env_drift_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+key_source_matrix_drift_summary = dict(base_summary)
+key_source_matrix_drift_summary["runtime_signer_profile"] = "ops-secondary"
+key_source_matrix_drift_summary["runtime_signer_previous_profile"] = "ops-secondary"
+key_source_matrix_drift_summary["runtime_signer_key_source"] = "managed-external"
+key_source_matrix_drift_summary["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+key_source_matrix_drift_summary["contracts"] = dict(base_summary.get("contracts", {}))
+key_source_matrix_drift_summary["contracts"]["runtime_signer_profile"] = "ops-secondary"
+key_source_matrix_drift_summary["contracts"]["runtime_signer_key_source"] = "managed-external"
+key_source_matrix_drift_summary["contracts"]["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+key_source_matrix_drift_summary["runtime_commit_command"] = str(base_summary.get("runtime_commit_command", "")).replace(
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
+)
+pathlib.Path(sys.argv[7]).write_text(
+    json.dumps(key_source_matrix_drift_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
 PY
@@ -425,6 +449,26 @@ fi
 
 if ! grep -q "runtime_signer_private_key_env_mismatch" "$TMP_NEGATIVE_ERR"; then
   echo "expected signer private key env mismatch reason in secondary signer negative proof output" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+key_source_matrix_exit_code=$?
+set -e
+
+if [ "$key_source_matrix_exit_code" -eq 0 ]; then
+  echo "expected disallowed signer key-source/profile pair negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$TMP_NEGATIVE_ERR"; then
+  echo "expected signer key-source/profile pair disallowed reason in negative proof output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This change implements a deterministic signer-profile/key-source allowlist matrix in the real-node Kolme policy checker and wires regression coverage so disallowed profile/source pairs fail closed with stable reason codes. It preserves current local runtime behavior while making policy decisions explicit and auditable.

Closes #2250
Refs #2239

## Changes
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`
  - Added explicit allowlist matrix:
    - `ops-primary`: `env-local`, `managed-external`
    - `ops-secondary`: `env-local`
  - Added fail-closed reason code for disallowed pairs:
    - `runtime_signer_key_source_profile_pair_disallowed`
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`
  - Added negative proof for disallowed matrix pair (`ops-secondary` + `managed-external`).
  - Added docs marker parity requirement for new matrix reason code.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - Added GO proof for allowed pair (`ops-primary` + `managed-external`).
  - Added NO-GO proof for disallowed pair (`ops-secondary` + `managed-external`) with deterministic reason assertion.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
  - Added contract-lane negative proof for disallowed matrix pair and reason assertion.
  - Added docs parity checks for matrix reason marker.
- Docs updates:
  - `README.md`
  - `docs/ci/strategy.md`
  - `docs/planning/kolme-devnet-ops.md`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
```
Output before implementation:
```text
expected disallowed key-source/profile pair reason for policy failure
exit_code=1
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
```
Output:
```text
local KAMN live runtime real-node profile policy checker tests passed.
local KAMN live runtime real-node profile contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh && \
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh && \
cargo test -p kamn-core --test kolme_runtime_commit_client_docs --test kolme_devnet_ops_docs --test ci_strategy_docs && \
cargo fmt --check && \
cargo clippy -p kamn-core -- -D warnings
```
Output summary:
```text
- real-node profile checker lane test: pass
- real-node profile contract lane test: pass
- real-node integration profile and integration contract lane tests: pass
- docs tests: pass (ci_strategy_docs 2/2, kolme_devnet_ops_docs 75/75, kolme_runtime_commit_client_docs 2/2)
- cargo fmt --check: pass
- cargo clippy -p kamn-core -- -D warnings: pass
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None | Matrix logic is validated through policy/contract harness tests in this task scope. |
| Functional   | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | Added allowed/disallowed matrix pair validations with deterministic reasons. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | Added contract-lane disallowed pair proof and checker linkage assertions. |
| Regression   | ✅     | checker + contract lane negative proofs for disallowed pair reason drift | Prevents silent reintroduction of unsafe profile/source pair acceptance. |
| Performance  | N/A    | None | No added runtime lanes or budget expansion; local-only boundaries preserved. |

## Risks & Rollback
- Risk: low/med; stricter policy may fail previously tolerated `ops-secondary + managed-external` fixtures.
- Rollback: revert commit `7d9c9a9` if matrix policy rollout sequencing needs to be staged.

## Documentation Updates
- `README.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
