### PR TITLE
refactor(kolme): migrate runtime transport contracts to kamn-kolme (#2277)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -96,7 +96,6 @@ use kamn_kolme::{
     KolmeProviderReceiptIdentityError as KamnKolmeProviderReceiptIdentityError,
     KolmeRuntimeProviderOutcome as KamnKolmeRuntimeProviderOutcome,
     KolmeTlsPolicyError as KamnKolmeTlsPolicyError,
-    KolmeTransportIoClassification as KamnKolmeTransportIoClassification,
     KolmeTransportRequestPolicyError as KamnKolmeTransportRequestPolicyError,
     KolmeWebsocketFrame as KamnKolmeWebsocketFrame,
     KolmeWebsocketPolicyError as KamnKolmeWebsocketPolicyError,
@@ -132,18 +131,17 @@ pub use api_codec::{
     KolmeApiNextNonceResponse,
 };
 pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
-pub use errors::{
-    KolmeRuntimeCommitError, KolmeRuntimeCommitProviderError, KolmeRuntimeCommitTransportErrorKind,
-};
+pub use errors::KolmeRuntimeCommitError;
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
 pub use http_transport::KolmeRuntimeCommitHttpTransport;
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
-pub use interfaces::{
-    KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitClient,
-    KolmeRuntimeCommitFinalityTransport, KolmeRuntimeCommitNotificationsConnection,
-    KolmeRuntimeCommitNotificationsConnector, KolmeRuntimeCommitProvider,
-    KolmeRuntimeCommitProviderTransport,
+pub use interfaces::{KolmeRuntimeCommitClient, KolmeRuntimeCommitProvider};
+pub use kamn_kolme::{
+    KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitFinalityTransport,
+    KolmeRuntimeCommitNotificationsConnection, KolmeRuntimeCommitNotificationsConnector,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderTransport,
+    KolmeRuntimeCommitTransportErrorKind,
 };
 pub use live_provider::KolmeRuntimeCommitLiveProvider;
 pub use notifications_consumer::KolmeRuntimeCommitNotificationsConsumer;

--- a/crates/kamn-core/src/kolme_runtime_commit/errors.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/errors.rs
@@ -1,62 +1,10 @@
 //! Runtime-commit error ownership.
 
 use super::{
-    commit_finality_label_contract, KamnKolmeTransportIoClassification, KolmeCommitReceiptFinality,
+    commit_finality_label_contract, KolmeCommitReceiptFinality,
+    KolmeRuntimeCommitTransportErrorKind,
 };
 use std::fmt;
-
-/// Typed transport error class emitted when adapter-backed provider calls fail.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitTransportErrorKind {
-    /// Provider call timed out.
-    Timeout,
-    /// Provider transport/channel is unavailable.
-    Unavailable,
-    /// Provider response payload is malformed.
-    MalformedResponse,
-}
-
-/// Provider-facing error for runtime commit adapter wiring.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KolmeRuntimeCommitProviderError {
-    /// Provider call timed out before a response.
-    Timeout,
-    /// Provider transport/channel is unavailable.
-    Unavailable {
-        /// Provider-specific availability failure reason.
-        reason: String,
-    },
-    /// Provider emitted malformed payload/shape.
-    MalformedResponse {
-        /// Provider-specific malformed payload reason.
-        reason: String,
-    },
-}
-
-impl fmt::Display for KolmeRuntimeCommitProviderError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Timeout => write!(f, "provider request timed out"),
-            Self::Unavailable { reason } => write!(f, "provider unavailable: {reason}"),
-            Self::MalformedResponse { reason } => {
-                write!(f, "provider malformed response: {reason}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for KolmeRuntimeCommitProviderError {}
-
-impl From<KamnKolmeTransportIoClassification> for KolmeRuntimeCommitProviderError {
-    fn from(value: KamnKolmeTransportIoClassification) -> Self {
-        match value {
-            KamnKolmeTransportIoClassification::Timeout => Self::Timeout,
-            KamnKolmeTransportIoClassification::Unavailable { reason } => {
-                Self::Unavailable { reason }
-            }
-        }
-    }
-}
 
 /// Error returned by runtime commit request validation or submission.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kamn-core/src/kolme_runtime_commit/interfaces.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/interfaces.rs
@@ -14,26 +14,6 @@ pub trait KolmeRuntimeCommitClient {
     ) -> Result<KolmeRuntimeCommitOutcome, KolmeRuntimeCommitError>;
 }
 
-/// Transport connection abstraction for consuming notifications text messages.
-pub trait KolmeRuntimeCommitNotificationsConnection {
-    /// Reads the next notifications text message.
-    ///
-    /// Returns `Ok(None)` when the current websocket connection is closed.
-    fn read_text_message(&mut self) -> Result<Option<String>, KolmeRuntimeCommitProviderError>;
-}
-
-/// Connector abstraction for establishing notifications websocket connections.
-pub trait KolmeRuntimeCommitNotificationsConnector {
-    /// Concrete connection type returned by the connector.
-    type Connection: KolmeRuntimeCommitNotificationsConnection;
-
-    /// Connects to one websocket notifications URL.
-    fn connect(
-        &mut self,
-        notifications_url: &str,
-    ) -> Result<Self::Connection, KolmeRuntimeCommitProviderError>;
-}
-
 /// Provider interface consumed by the adapter-backed runtime commit client.
 pub trait KolmeRuntimeCommitProvider {
     /// Submits canonical wire payload with deterministic idempotency key.
@@ -42,38 +22,4 @@ pub trait KolmeRuntimeCommitProvider {
         wire_payload: &str,
         idempotency_key: &str,
     ) -> Result<KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderError>;
-}
-
-/// Transport abstraction used by the live provider bridge to reach Kolme backends.
-pub trait KolmeRuntimeCommitProviderTransport {
-    /// Submits one runtime commit payload to the configured provider endpoint.
-    fn submit_runtime_commit(
-        &mut self,
-        base_url: &str,
-        submit_path: &str,
-        wire_payload: &str,
-        idempotency_key: &str,
-    ) -> Result<String, KolmeRuntimeCommitProviderError>;
-}
-
-/// Transport abstraction for querying runtime commit finality from a live backend.
-pub trait KolmeRuntimeCommitFinalityTransport {
-    /// Fetches one finality response payload for the provided commit identifier.
-    fn fetch_runtime_commit_finality(
-        &mut self,
-        base_url: &str,
-        status_path: &str,
-        commit_id: &str,
-    ) -> Result<String, KolmeRuntimeCommitProviderError>;
-}
-
-/// Transport abstraction for querying `/block/{height}` fallback responses.
-pub trait KolmeRuntimeCommitBlockFallbackTransport {
-    /// Fetches one block response payload for the provided height.
-    fn fetch_block_by_height(
-        &mut self,
-        base_url: &str,
-        block_path_template: &str,
-        height: u64,
-    ) -> Result<String, KolmeRuntimeCommitProviderError>;
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs
@@ -23,6 +23,9 @@ const RUNTIME_PIPELINE_SRC: &str = include_str!("../src/kolme_runtime_commit/run
 const RUNTIME_ERRORS_SRC: &str = include_str!("../src/kolme_runtime_commit/errors.rs");
 const RUNTIME_OUTCOMES_SRC: &str = include_str!("../src/kolme_runtime_commit/outcomes.rs");
 const RUNTIME_INTERFACES_SRC: &str = include_str!("../src/kolme_runtime_commit/interfaces.rs");
+const KAMN_KOLME_LIB_SRC: &str = include_str!("../../kamn-kolme/src/lib.rs");
+const KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC: &str =
+    include_str!("../../kamn-kolme/src/runtime_transport_contracts.rs");
 
 #[test]
 fn unit_runtime_commit_extraction_boundary_removes_local_finality_glue_wrappers() {
@@ -317,7 +320,7 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
         .contains("is_kolme_valid_transport_wire_payload_input_contract("));
     assert!(RUNTIME_HTTP_TRANSPORT_SRC
         .contains("normalize_kolme_broadcast_submit_path_input_contract("));
-    assert!(RUNTIME_ERRORS_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
+    assert!(!RUNTIME_ERRORS_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod request_envelope;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod runtime_pipeline;"));
     assert!(RUNTIME_COMMIT_SRC.contains("mod in_memory_client;"));
@@ -353,11 +356,13 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_COMMIT_SRC
         .contains("pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use notifications_websocket::{"));
-    assert!(RUNTIME_COMMIT_SRC.contains("pub use errors::{"));
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use errors::KolmeRuntimeCommitError;"));
     assert!(RUNTIME_COMMIT_SRC.contains("pub use outcomes::{"));
-    assert!(RUNTIME_COMMIT_SRC.contains("pub use interfaces::{"));
-    assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
-    assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
+    assert!(RUNTIME_COMMIT_SRC
+        .contains("pub use interfaces::{KolmeRuntimeCommitClient, KolmeRuntimeCommitProvider};"));
+    assert!(RUNTIME_COMMIT_SRC.contains("pub use kamn_kolme::{"));
+    assert!(!RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
+    assert!(!RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
     assert!(RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitError"));
     assert!(RUNTIME_OUTCOMES_SRC.contains("pub struct KolmeRuntimeCommitReceipt"));
     assert!(RUNTIME_OUTCOMES_SRC.contains("pub enum KolmeRuntimeCommitOutcome"));
@@ -365,10 +370,45 @@ fn regression_runtime_commit_extraction_boundary_keeps_direct_helper_delegation(
     assert!(RUNTIME_OUTCOMES_SRC.contains("pub enum KolmeRuntimeCommitProviderOutcome"));
     assert!(RUNTIME_OUTCOMES_SRC.contains("pub enum KolmeRuntimeCommitNotificationEvent"));
     assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitClient"));
-    assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitNotificationsConnection"));
-    assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitNotificationsConnector"));
     assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitProvider"));
-    assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitProviderTransport"));
-    assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitFinalityTransport"));
-    assert!(RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitBlockFallbackTransport"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitNotificationsConnection"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitNotificationsConnector"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitProviderTransport"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitFinalityTransport"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitBlockFallbackTransport"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub enum KolmeRuntimeCommitProviderError"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("impl From<KolmeTransportIoClassification> for KolmeRuntimeCommitProviderError"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub trait KolmeRuntimeCommitNotificationsConnection"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub trait KolmeRuntimeCommitNotificationsConnector"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub trait KolmeRuntimeCommitProviderTransport"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub trait KolmeRuntimeCommitFinalityTransport"));
+    assert!(KAMN_KOLME_RUNTIME_TRANSPORT_CONTRACTS_SRC
+        .contains("pub trait KolmeRuntimeCommitBlockFallbackTransport"));
+}
+
+#[test]
+fn regression_issue_2277_transport_error_and_trait_ownership_moves_to_kamn_kolme() {
+    // Regression: #2277
+    assert!(!RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind"));
+    assert!(!RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitProviderError"));
+    assert!(!RUNTIME_ERRORS_SRC.contains("impl From<KamnKolmeTransportIoClassification>"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitNotificationsConnection"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitNotificationsConnector"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitProviderTransport"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitFinalityTransport"));
+    assert!(!RUNTIME_INTERFACES_SRC.contains("pub trait KolmeRuntimeCommitBlockFallbackTransport"));
+    assert!(KAMN_KOLME_LIB_SRC.contains("pub mod runtime_transport_contracts;"));
+    assert!(KAMN_KOLME_LIB_SRC.contains("KolmeRuntimeCommitProviderError"));
+    assert!(KAMN_KOLME_LIB_SRC.contains("KolmeRuntimeCommitTransportErrorKind"));
+    assert!(KAMN_KOLME_LIB_SRC.contains("KolmeRuntimeCommitProviderTransport"));
+    assert!(KAMN_KOLME_LIB_SRC.contains("KolmeRuntimeCommitFinalityTransport"));
+    assert!(KAMN_KOLME_LIB_SRC.contains("KolmeRuntimeCommitBlockFallbackTransport"));
 }

--- a/crates/kamn-kolme/src/lib.rs
+++ b/crates/kamn-kolme/src/lib.rs
@@ -21,6 +21,7 @@ pub mod provider_response_policy;
 pub mod receipt_finality;
 pub mod runtime_lifecycle_policy;
 pub mod runtime_request_identity_policy;
+pub mod runtime_transport_contracts;
 pub mod tls_policy;
 pub mod transport;
 pub mod transport_request_policy;
@@ -109,6 +110,12 @@ pub use runtime_request_identity_policy::{
     is_valid_runtime_state_root_input, normalize_runtime_commit_request_fields,
     normalize_runtime_commit_signed_envelope_fields, render_runtime_commit_wire_payload,
     render_signed_envelope_wire_payload,
+};
+pub use runtime_transport_contracts::{
+    KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitFinalityTransport,
+    KolmeRuntimeCommitNotificationsConnection, KolmeRuntimeCommitNotificationsConnector,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderTransport,
+    KolmeRuntimeCommitTransportErrorKind,
 };
 pub use tls_policy::{
     classify_tls_failure_reason, parse_tls_ca_file_env_value, resolve_tls_ca_file_env_result,

--- a/crates/kamn-kolme/src/runtime_transport_contracts.rs
+++ b/crates/kamn-kolme/src/runtime_transport_contracts.rs
@@ -1,0 +1,109 @@
+//! Runtime transport-facing contracts shared across Kolme runtime adapters.
+
+use crate::KolmeTransportIoClassification;
+use std::fmt;
+
+/// Typed transport error class emitted when provider transport calls fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitTransportErrorKind {
+    /// Provider call timed out.
+    Timeout,
+    /// Provider transport/channel is unavailable.
+    Unavailable,
+    /// Provider response payload is malformed.
+    MalformedResponse,
+}
+
+/// Provider-facing error for runtime commit adapter wiring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KolmeRuntimeCommitProviderError {
+    /// Provider call timed out before a response.
+    Timeout,
+    /// Provider transport/channel is unavailable.
+    Unavailable {
+        /// Provider-specific availability failure reason.
+        reason: String,
+    },
+    /// Provider emitted malformed payload/shape.
+    MalformedResponse {
+        /// Provider-specific malformed payload reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for KolmeRuntimeCommitProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "provider request timed out"),
+            Self::Unavailable { reason } => write!(f, "provider unavailable: {reason}"),
+            Self::MalformedResponse { reason } => {
+                write!(f, "provider malformed response: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KolmeRuntimeCommitProviderError {}
+
+impl From<KolmeTransportIoClassification> for KolmeRuntimeCommitProviderError {
+    fn from(value: KolmeTransportIoClassification) -> Self {
+        match value {
+            KolmeTransportIoClassification::Timeout => Self::Timeout,
+            KolmeTransportIoClassification::Unavailable { reason } => Self::Unavailable { reason },
+        }
+    }
+}
+
+/// Transport connection abstraction for consuming notifications text messages.
+pub trait KolmeRuntimeCommitNotificationsConnection {
+    /// Reads the next notifications text message.
+    ///
+    /// Returns `Ok(None)` when the current websocket connection is closed.
+    fn read_text_message(&mut self) -> Result<Option<String>, KolmeRuntimeCommitProviderError>;
+}
+
+/// Connector abstraction for establishing notifications websocket connections.
+pub trait KolmeRuntimeCommitNotificationsConnector {
+    /// Concrete connection type returned by the connector.
+    type Connection: KolmeRuntimeCommitNotificationsConnection;
+
+    /// Connects to one websocket notifications URL.
+    fn connect(
+        &mut self,
+        notifications_url: &str,
+    ) -> Result<Self::Connection, KolmeRuntimeCommitProviderError>;
+}
+
+/// Transport abstraction used by the live provider bridge to reach Kolme backends.
+pub trait KolmeRuntimeCommitProviderTransport {
+    /// Submits one runtime commit payload to the configured provider endpoint.
+    fn submit_runtime_commit(
+        &mut self,
+        base_url: &str,
+        submit_path: &str,
+        wire_payload: &str,
+        idempotency_key: &str,
+    ) -> Result<String, KolmeRuntimeCommitProviderError>;
+}
+
+/// Transport abstraction for querying runtime commit finality from a live backend.
+pub trait KolmeRuntimeCommitFinalityTransport {
+    /// Fetches one finality response payload for the provided commit identifier.
+    fn fetch_runtime_commit_finality(
+        &mut self,
+        base_url: &str,
+        status_path: &str,
+        commit_id: &str,
+    ) -> Result<String, KolmeRuntimeCommitProviderError>;
+}
+
+/// Transport abstraction for querying `/block/{height}` fallback responses.
+pub trait KolmeRuntimeCommitBlockFallbackTransport {
+    /// Fetches one block response payload for the provided height.
+    fn fetch_block_by_height(
+        &mut self,
+        base_url: &str,
+        block_path_template: &str,
+        height: u64,
+    ) -> Result<String, KolmeRuntimeCommitProviderError>;
+}

--- a/crates/kamn-kolme/tests/runtime_transport_contracts.rs
+++ b/crates/kamn-kolme/tests/runtime_transport_contracts.rs
@@ -1,0 +1,62 @@
+use kamn_kolme::{
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitTransportErrorKind,
+    KolmeTransportIoClassification,
+};
+
+#[test]
+fn unit_runtime_transport_contracts_map_transport_io_classification_to_provider_error() {
+    assert_eq!(
+        KolmeRuntimeCommitProviderError::from(KolmeTransportIoClassification::Timeout),
+        KolmeRuntimeCommitProviderError::Timeout
+    );
+    assert_eq!(
+        KolmeRuntimeCommitProviderError::from(KolmeTransportIoClassification::Unavailable {
+            reason: "transport io error: reset by peer".to_owned(),
+        }),
+        KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "transport io error: reset by peer".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn functional_runtime_transport_contracts_provider_error_display_is_deterministic() {
+    assert_eq!(
+        KolmeRuntimeCommitProviderError::Timeout.to_string(),
+        "provider request timed out"
+    );
+    assert_eq!(
+        KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial tcp refused".to_owned(),
+        }
+        .to_string(),
+        "provider unavailable: dial tcp refused"
+    );
+    assert_eq!(
+        KolmeRuntimeCommitProviderError::MalformedResponse {
+            reason: "missing status field".to_owned(),
+        }
+        .to_string(),
+        "provider malformed response: missing status field"
+    );
+}
+
+#[test]
+fn regression_issue_2277_runtime_transport_contract_error_kind_shape_stays_stable() {
+    // Regression: #2277
+    assert_eq!(
+        format!("{:?}", KolmeRuntimeCommitTransportErrorKind::Timeout),
+        "Timeout"
+    );
+    assert_eq!(
+        format!("{:?}", KolmeRuntimeCommitTransportErrorKind::Unavailable),
+        "Unavailable"
+    );
+    assert_eq!(
+        format!(
+            "{:?}",
+            KolmeRuntimeCommitTransportErrorKind::MalformedResponse
+        ),
+        "MalformedResponse"
+    );
+}

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -114,6 +114,7 @@ contributors can locate runtime/domain ownership responsibilities quickly.
     `crates/kamn-kolme/src/api_codec.rs`, `crates/kamn-kolme/src/receipt_finality.rs`,
     `crates/kamn-kolme/src/runtime_lifecycle_policy.rs`,
     `crates/kamn-kolme/src/runtime_request_identity_policy.rs`,
+    `crates/kamn-kolme/src/runtime_transport_contracts.rs`,
     `crates/kamn-kolme/src/endpoint_policy.rs`, `crates/kamn-kolme/src/block_scan_policy.rs`,
     `crates/kamn-kolme/src/notification_policy.rs`, `crates/kamn-kolme/src/websocket_policy.rs`,
     `crates/kamn-kolme/src/http_response_policy.rs`, `crates/kamn-kolme/src/tls_policy.rs`,
@@ -124,8 +125,9 @@ contributors can locate runtime/domain ownership responsibilities quickly.
   - `kamn-kolme` is the dedicated home for runtime-commit transport/codec/finality
     contracts (including direct signed payload validation, receipt-to-commit
     finality mapping and parse helpers, lifecycle/finality, deterministic
-    request identity, and JSON escape serialization policy). `kamn-core`
-    retains temporary compatibility exports until full migration is complete.
+    request identity, JSON escape serialization policy, and runtime transport
+    error/trait contracts). `kamn-core` retains temporary compatibility exports
+    until full migration is complete.
 - Runtime/data-flow ownership:
   - New runtime-commit submissions should target `kamn-kolme` contracts first,
     then map back to `kamn-core` compatibility paths only where migration is

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -6,15 +6,23 @@ handling.
 
 ## Scope Delivered
 
-- Added provider-facing adapter interfaces in `kamn-core`:
+- Provider-facing transport/error contracts are canonically owned in
+  `kamn-kolme` (`runtime_transport_contracts`) and re-exported through the
+  `kamn-core` compatibility surface:
   - `KolmeRuntimeCommitProvider`
   - `KolmeRuntimeCommitProviderOutcome`
   - `KolmeRuntimeCommitProviderReceipt`
   - `KolmeRuntimeCommitProviderError`
+  - `KolmeRuntimeCommitProviderTransport`
+  - `KolmeRuntimeCommitFinalityTransport`
+  - `KolmeRuntimeCommitBlockFallbackTransport`
+  - `KolmeRuntimeCommitNotificationsConnection`
+  - `KolmeRuntimeCommitNotificationsConnector`
   - `KolmeRuntimeCommitHttpTransport`
-- Added adapter-backed runtime commit client:
+- Added adapter-backed runtime commit client in `kamn-core`:
   - `AdapterBackedKolmeRuntimeCommitClient<P>`
-- Added typed transport error classification:
+- Added typed transport error classification (canonical in `kamn-kolme`,
+  compatibility export in `kamn-core`):
   - `KolmeRuntimeCommitTransportErrorKind::{Timeout, Unavailable, MalformedResponse}`
 - Extended runtime commit error contracts:
   - `KolmeRuntimeCommitError::ProviderTransport`


### PR DESCRIPTION
## Summary
This PR completes the #2277 boundary slice by moving runtime transport error/trait contracts into `kamn-kolme` and converting `kamn-core` to a compatibility facade for those contracts. The change reduces ownership leakage in `kamn-core` while preserving existing runtime call-sites and behavior.

Closes #2277
Refs #2274
Refs #2273

## Changes
- `crates/kamn-kolme/src/runtime_transport_contracts.rs`: added canonical ownership for:
  - `KolmeRuntimeCommitTransportErrorKind`
  - `KolmeRuntimeCommitProviderError` (+ `From<KolmeTransportIoClassification>`)
  - `KolmeRuntimeCommitNotificationsConnection`
  - `KolmeRuntimeCommitNotificationsConnector`
  - `KolmeRuntimeCommitProviderTransport`
  - `KolmeRuntimeCommitFinalityTransport`
  - `KolmeRuntimeCommitBlockFallbackTransport`
- `crates/kamn-kolme/src/lib.rs`: exported `runtime_transport_contracts` module/contracts.
- `crates/kamn-kolme/tests/runtime_transport_contracts.rs`: added unit/functional/regression contract coverage for new module.
- `crates/kamn-core/src/kolme_runtime_commit/errors.rs`: retained `KolmeRuntimeCommitError`; removed moved transport/provider error ownership.
- `crates/kamn-core/src/kolme_runtime_commit/interfaces.rs`: retained core-owned client/provider traits; removed moved transport trait ownership.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: re-exported moved contracts from `kamn-kolme` as compatibility facade.
- `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs`: updated boundary assertions and added regression marker for #2277 ownership migration.
- `docs/foundation/kolme-runtime-commit-client.md`: documented canonical ownership shift to `kamn-kolme` runtime transport contracts.
- `docs/architecture/kamn-core-module-map.md`: updated extraction boundary module list and ownership notes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary regression_issue_2277_transport_error_and_trait_ownership_moves_to_kamn_kolme -- --exact`

Observed failure:
`assertion failed: !RUNTIME_ERRORS_SRC.contains("pub enum KolmeRuntimeCommitTransportErrorKind")`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary regression_issue_2277_transport_error_and_trait_ownership_moves_to_kamn_kolme -- --exact`
- `cargo test -p kamn-core --test kolme_runtime_commit_extraction_boundary`
- `cargo test -p kamn-kolme --test runtime_transport_contracts`

Result:
All passing.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test kolme_runtime_commit_client`
- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
- `cargo test -p kamn-core --test kolme_runtime_commit_fork_finality_resolver`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo test -p kamn-core --test engineering_hardening_wave_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-kolme -p kamn-core --tests -- -D warnings`

Result:
All passing.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `crates/kamn-kolme/tests/runtime_transport_contracts.rs` | |
| Functional   | ✅     | `crates/kamn-kolme/tests/runtime_transport_contracts.rs` | |
| Integration  | ✅     | `crates/kamn-core/tests/kolme_runtime_commit_client.rs`, `crates/kamn-core/tests/kolme_runtime_commit_notifications.rs`, `crates/kamn-core/tests/kolme_runtime_commit_fork_finality_resolver.rs` | |
| Regression   | ✅     | `crates/kamn-core/tests/kolme_runtime_commit_extraction_boundary.rs` (`Regression: #2277`) | |
| Performance  | N/A    | None | No throughput-path behavior change in this slice; existing runtime budget checks remain unchanged. |

## Risks & Rollback
- Potential risk: compatibility export drift if downstream consumers import moved types directly from old module internals.
- Rollback plan: revert commit `refactor(kolme): migrate runtime transport contracts to kamn-kolme (#2277)` to restore previous ownership location in `kamn-core`.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/architecture/kamn-core-module-map.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-kolme -p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (task-relevant runtime + docs + lint/fmt)
- [x] Docs updated
