### PR TITLE
fix(node): reject fallback signer key env path (#2279)

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -26,6 +26,8 @@ const KOLME_LIVE_SIGNER_KEY_SOURCE_ENV_LOCAL: &str = "env-local";
 const KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_ENV: &str = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX";
 const KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY_ENV: &str =
     "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY";
+const KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK_ENV: &str =
+    "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK";
 const KOLME_LIVE_NATIVE_CREATED_AT: &str = "2026-02-12T00:00:00Z";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -904,23 +906,70 @@ fn resolve_kolme_live_signer_selection(
     })
 }
 
+trait KolmeLiveSignerSecretProvider {
+    fn ensure_no_fallback_private_key_path(&self) -> Result<(), ConfigError>;
+
+    fn read_private_key_hex(
+        &self,
+        selection: &KolmeLiveSignerSelection,
+    ) -> Result<String, ConfigError>;
+}
+
+struct EnvKolmeLiveSignerSecretProvider;
+
+impl KolmeLiveSignerSecretProvider for EnvKolmeLiveSignerSecretProvider {
+    fn ensure_no_fallback_private_key_path(&self) -> Result<(), ConfigError> {
+        match env::var(KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK_ENV) {
+            Ok(_) => Err(ConfigError::RuntimeKolmeLive(format!(
+                "{KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK_ENV} must remain unset (fallback_signer_secret_present_violation)"
+            ))),
+            Err(env::VarError::NotPresent) => Ok(()),
+            Err(env::VarError::NotUnicode(_)) => Err(ConfigError::RuntimeKolmeLive(format!(
+                "{KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK_ENV} must be valid utf-8 when present (fallback_signer_secret_present_violation)"
+            ))),
+        }
+    }
+
+    fn read_private_key_hex(
+        &self,
+        selection: &KolmeLiveSignerSelection,
+    ) -> Result<String, ConfigError> {
+        match env::var(selection.private_key_env) {
+            Ok(private_key_hex) => Ok(private_key_hex),
+            Err(env::VarError::NotPresent) => Err(ConfigError::RuntimeKolmeLive(format!(
+                "{} must be set for signer profile {}",
+                selection.private_key_env, selection.profile
+            ))),
+            Err(env::VarError::NotUnicode(_)) => Err(ConfigError::RuntimeKolmeLive(format!(
+                "{} must be valid utf-8 for signer profile {}",
+                selection.private_key_env, selection.profile
+            ))),
+        }
+    }
+}
+
+fn read_kolme_live_signer_private_key_hex_with_provider<P: KolmeLiveSignerSecretProvider>(
+    strict_signer_profile: Option<&str>,
+    strict_signer_key_source: Option<&str>,
+    provider: &P,
+) -> Result<(String, KolmeLiveSignerSelection), ConfigError> {
+    let selection =
+        resolve_kolme_live_signer_selection(strict_signer_profile, strict_signer_key_source)?;
+    provider.ensure_no_fallback_private_key_path()?;
+    let private_key_hex = provider.read_private_key_hex(&selection)?;
+    Ok((private_key_hex, selection))
+}
+
 fn read_kolme_live_signer_private_key_hex(
     strict_signer_profile: Option<&str>,
     strict_signer_key_source: Option<&str>,
 ) -> Result<(String, KolmeLiveSignerSelection), ConfigError> {
-    let selection =
-        resolve_kolme_live_signer_selection(strict_signer_profile, strict_signer_key_source)?;
-    match env::var(selection.private_key_env) {
-        Ok(private_key_hex) => Ok((private_key_hex, selection)),
-        Err(env::VarError::NotPresent) => Err(ConfigError::RuntimeKolmeLive(format!(
-            "{} must be set for signer profile {}",
-            selection.private_key_env, selection.profile
-        ))),
-        Err(env::VarError::NotUnicode(_)) => Err(ConfigError::RuntimeKolmeLive(format!(
-            "{} must be valid utf-8 for signer profile {}",
-            selection.private_key_env, selection.profile
-        ))),
-    }
+    let provider = EnvKolmeLiveSignerSecretProvider;
+    read_kolme_live_signer_private_key_hex_with_provider(
+        strict_signer_profile,
+        strict_signer_key_source,
+        &provider,
+    )
 }
 
 fn escape_kolme_json_string(value: &str) -> String {
@@ -2785,6 +2834,32 @@ mod tests {
                 if message.contains("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX must be set")
             ),
             "missing primary signer private key env must fail closed"
+        );
+    }
+
+    #[test]
+    fn regression_issue_2279_kolme_live_signer_rejects_fallback_private_key_env_path() {
+        // Regression: #2279
+        let _lock = signer_env_lock()
+            .lock()
+            .expect("signer env lock should guard test mutation");
+        let _profile_env_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+        let _primary_key_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+            Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+        );
+        let _fallback_key_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+            Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY),
+        );
+        assert!(
+            matches!(
+                build_kolme_live_signing_key(Some("ops-primary"), Some("env-local")),
+                Err(ConfigError::RuntimeKolmeLive(message))
+                if message.contains("fallback_signer_secret_present_violation")
+            ),
+            "fallback signer private key env path must fail closed"
         );
     }
 

--- a/docs/foundation/key-management-and-encryption.md
+++ b/docs/foundation/key-management-and-encryption.md
@@ -47,5 +47,17 @@ cargo test -p kamn-core --test key_management_and_encryption_docs
 - `final_decision` must match derived policy from report booleans.
 - `evidence_key` and `reason_key` must match deterministic lane/decision keys.
 
+## Kolme Live Signer Provider Contracts
+- Production signer secret loading is provider-backed (`KolmeLiveSignerSecretProvider`)
+  with explicit fail-closed checks before private-key material is read.
+- Strict signer profiles remain bounded to `ops-primary` and `ops-secondary`.
+- Supported strict key source remains `env-local` for node runtime signer loading.
+- `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` must remain unset in
+  production signer flows; presence triggers deterministic
+  `fallback_signer_secret_present_violation` rejection.
+- Profile-selected signer key env contracts remain explicit:
+  - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
+  - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
+
 ## Regression Marker
 - replay/stale key activation drift is rejected (`Regression: #931`)

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -526,6 +526,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `signer_profile_contract`: profile must be `ops-primary` or `ops-secondary`.
   - `signer_secret_contract`: selected signer secret env must be present and 64-char hex.
   - `fallback_private_key_contract`: fallback signer secret env must remain unset.
+  - node runtime signer-provider guard (`KolmeLiveSignerSecretProvider`) rejects fallback env-key presence before key decode/signing.
   - summary fields include deterministic signer custody markers:
     - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
     - `signer_profile`


### PR DESCRIPTION
## Summary
This PR hardens the node runtime signer path by introducing provider-backed signer-secret loading and enforcing fail-closed rejection of fallback signer env-key usage. It closes the production fallback-key gap without changing current supported signer profile/key-source contracts.

Closes #2279
Refs #2275
Refs #2273

## Changes
- `crates/kamn-node/src/main.rs`:
  - added `KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` contract constant.
  - introduced signer-secret provider abstraction:
    - `KolmeLiveSignerSecretProvider` trait
    - `EnvKolmeLiveSignerSecretProvider` implementation
    - `read_kolme_live_signer_private_key_hex_with_provider(...)`
  - updated signer key loading to enforce fail-closed fallback-path rejection before private-key decode/signing.
  - added regression test `regression_issue_2279_kolme_live_signer_rejects_fallback_private_key_env_path`.
- `docs/foundation/key-management-and-encryption.md`:
  - documented production signer-provider contract and fallback-key fail-closed behavior.
- `docs/planning/kolme-devnet-ops.md`:
  - documented node runtime signer-provider fallback guard in deployment preflight checkpoints.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node regression_issue_2279_kolme_live_signer_rejects_fallback_private_key_env_path`

Observed failure:
`fallback signer private key env path must fail closed`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node regression_issue_2279_kolme_live_signer_rejects_fallback_private_key_env_path`
- `cargo test -p kamn-node`

Result:
All passing.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test key_management_and_encryption_docs`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-node --tests -- -D warnings`

Result:
All passing.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `crates/kamn-node/src/main.rs` signer key-loading tests | |
| Functional   | ✅     | `cargo test -p kamn-node` runtime signer contract behavior | |
| Integration  | ✅     | `cargo test -p kamn-node` (`execute`/runtime path suites) | |
| Regression   | ✅     | `regression_issue_2279_kolme_live_signer_rejects_fallback_private_key_env_path` | |
| Performance  | N/A    | None | No throughput-path change; this is signer policy hardening only. |

## Risks & Rollback
- Potential risk: environments that still set fallback signer env variable now fail fast by design.
- Rollback plan: revert commit `fix(node): reject fallback signer key env path (#2279)`.

## Documentation Updates
- `docs/foundation/key-management-and-encryption.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-node --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (task-relevant runtime + docs + lint/fmt)
- [x] Docs updated
