### PR TITLE
fix: deterministic live-provider error taxonomy for KAMN runtime integration (#2296)

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -275,6 +275,21 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
   - real-node checker fails closed when in-memory provider references appear in strict command/policy surfaces:
     - `runtime_commit_in_memory_provider_reference_detected`
     - `runtime_commit_policy_check_in_memory_provider_reference_detected`
+  - runtime failure taxonomy contract (summary + policy, version `v1`):
+    - `runtime_commit_nested_reason_code` captures nested runtime lane `reason_code` (or deterministic `report_missing` / `report_invalid_json` / `reason_code_missing` diagnostics).
+    - `runtime_commit_failure_taxonomy` and `runtime_commit_failure_diagnostic_hint` provide deterministic operator-triage surfaces.
+    - policy checker `check_local_kamn_live_runtime_integration_policy.py` fails closed on taxonomy drift (`runtime_commit_failure_taxonomy_mismatch:<expected>`).
+  - runtime failure taxonomy/remediation map:
+    - `transport.preflight.timeout`: verify `--base-url` reachability and preflight endpoint latency.
+    - `transport.preflight.failed`: inspect preflight health output and provider-hint wiring.
+    - `transport.submit.timeout`: increase `--runtime-commit-max-seconds` or reduce submit command latency.
+    - `transport.submit.failed`: inspect runtime submit command stderr and live output artifact.
+    - `finality.timeout`: increase `--runtime-commit-finality-max-seconds`; validate notifications/block fallback endpoint responsiveness.
+    - `finality.failed`: inspect finality command output and endpoint contract markers.
+    - `policy.rejected`: inspect nested runtime policy report `final_decision` and `reason_codes`.
+    - `budget.exceeded`: increase `--max-seconds` or reduce local-heavy prerequisite/runtime cost.
+    - `runtime.summary.unavailable`: ensure nested runtime summary artifact exists and contains a valid `reason_code`.
+    - `runtime.unknown`: inspect nested reason + endpoint/finality artifact logs for unmapped failure signatures.
 - Local fork process lifecycle lane:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --integration-runtime-commit-finality-command "printf 'finality=final\n'" --integration-runtime-commit-finality-max-seconds 15 --integration-runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
 - Real-process wrapper lane with lifecycle run intent:

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -6,6 +6,64 @@ import json
 from pathlib import Path
 
 
+ALLOWED_RUNTIME_COMMIT_FAILURE_TAXONOMIES = {
+    "none",
+    "policy.rejected",
+    "budget.exceeded",
+    "transport.preflight.timeout",
+    "transport.preflight.failed",
+    "transport.submit.timeout",
+    "transport.submit.failed",
+    "finality.timeout",
+    "finality.failed",
+    "runtime.summary.unavailable",
+    "runtime.unknown",
+}
+
+NESTED_RUNTIME_REASON_TO_TAXONOMY = {
+    "live_preflight_timeout": "transport.preflight.timeout",
+    "live_preflight_failed": "transport.preflight.failed",
+    "live_runtime_commit_command_timeout": "transport.submit.timeout",
+    "live_runtime_commit_command_failed": "transport.submit.failed",
+    "live_finality_command_timeout": "finality.timeout",
+    "live_finality_command_failed": "finality.failed",
+    "live_runtime_commit_budget_exceeded": "budget.exceeded",
+}
+
+
+def expected_runtime_commit_failure_taxonomy(
+    status: object,
+    reason_code: object,
+    runtime_commit_reason_code: object,
+    runtime_commit_policy_reason_code: object,
+    runtime_commit_nested_reason_code: object,
+) -> str:
+    if status == "ok":
+        return "none"
+
+    if reason_code == "runtime_commit_policy_failed":
+        return "policy.rejected"
+
+    if reason_code == "runtime_integration_budget_exceeded":
+        return "budget.exceeded"
+
+    if reason_code != "runtime_commit_endpoint_failed":
+        return "none"
+
+    if runtime_commit_reason_code == "runtime_commit_endpoint_timeout":
+        return "transport.submit.timeout"
+
+    if (
+        runtime_commit_policy_reason_code == "runtime_commit_endpoint_failed"
+        and runtime_commit_nested_reason_code in ("report_missing", "report_invalid_json", "reason_code_missing")
+    ):
+        return "runtime.summary.unavailable"
+
+    if isinstance(runtime_commit_nested_reason_code, str):
+        return NESTED_RUNTIME_REASON_TO_TAXONOMY.get(runtime_commit_nested_reason_code, "runtime.unknown")
+    return "runtime.unknown"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Validate local KAMN live runtime integration summary policy."
@@ -75,9 +133,31 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(runtime_commit_live_policy_report, str) or not runtime_commit_live_policy_report.strip():
         reason_codes.append("runtime_commit_live_policy_report_missing")
 
+    runtime_commit_reason_code = report.get("runtime_commit_reason_code")
+    if not isinstance(runtime_commit_reason_code, str) or not runtime_commit_reason_code.strip():
+        reason_codes.append("runtime_commit_reason_code_missing")
+
     runtime_commit_policy_reason_code = report.get("runtime_commit_policy_reason_code")
     if not isinstance(runtime_commit_policy_reason_code, str) or not runtime_commit_policy_reason_code.strip():
         reason_codes.append("runtime_commit_policy_reason_code_missing")
+
+    runtime_commit_nested_reason_code = report.get("runtime_commit_nested_reason_code")
+    if not isinstance(runtime_commit_nested_reason_code, str) or not runtime_commit_nested_reason_code.strip():
+        reason_codes.append("runtime_commit_nested_reason_code_missing")
+
+    runtime_commit_failure_taxonomy_version = report.get("runtime_commit_failure_taxonomy_version")
+    if runtime_commit_failure_taxonomy_version != "v1":
+        reason_codes.append("runtime_commit_failure_taxonomy_version_mismatch")
+
+    runtime_commit_failure_taxonomy = report.get("runtime_commit_failure_taxonomy")
+    if not isinstance(runtime_commit_failure_taxonomy, str) or not runtime_commit_failure_taxonomy.strip():
+        reason_codes.append("runtime_commit_failure_taxonomy_missing")
+    elif runtime_commit_failure_taxonomy not in ALLOWED_RUNTIME_COMMIT_FAILURE_TAXONOMIES:
+        reason_codes.append("runtime_commit_failure_taxonomy_invalid")
+
+    runtime_commit_failure_diagnostic_hint = report.get("runtime_commit_failure_diagnostic_hint")
+    if not isinstance(runtime_commit_failure_diagnostic_hint, str) or not runtime_commit_failure_diagnostic_hint.strip():
+        reason_codes.append("runtime_commit_failure_diagnostic_hint_missing")
 
     contracts = report.get("contracts")
     if not isinstance(contracts, dict):
@@ -95,6 +175,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_commit_finality_primary_endpoint_mismatch")
         if contracts.get("runtime_commit_finality_fallback_endpoint") != "/block/{height}":
             reason_codes.append("runtime_commit_finality_fallback_endpoint_mismatch")
+        if contracts.get("runtime_commit_failure_taxonomy_version") != "v1":
+            reason_codes.append("runtime_commit_failure_taxonomy_contract_version_mismatch")
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:
@@ -155,6 +237,21 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         observed_final_decision = "NO-GO"
         if reason_code in ("dry_run_no_commands_executed", "live_runtime_integration_passed"):
             reason_codes.append("fail_status_reason_code_mismatch")
+
+    expected_failure_taxonomy = expected_runtime_commit_failure_taxonomy(
+        status,
+        reason_code,
+        runtime_commit_reason_code,
+        runtime_commit_policy_reason_code,
+        runtime_commit_nested_reason_code,
+    )
+    if (
+        isinstance(runtime_commit_failure_taxonomy, str)
+        and runtime_commit_failure_taxonomy.strip()
+        and runtime_commit_failure_taxonomy in ALLOWED_RUNTIME_COMMIT_FAILURE_TAXONOMIES
+        and runtime_commit_failure_taxonomy != expected_failure_taxonomy
+    ):
+        reason_codes.append(f"runtime_commit_failure_taxonomy_mismatch:{expected_failure_taxonomy}")
 
     for required_reason_code in args.require_reason_code:
         if reason_code != required_reason_code:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 import tempfile
@@ -158,6 +159,97 @@ def main() -> int:
             check=True,
             stdout=subprocess.DEVNULL,
         )
+
+        summary_payload = json.loads(Path(args.output_json).read_text(encoding="utf-8"))
+        if summary_payload.get("runtime_commit_failure_taxonomy_version") != "v1":
+            print("expected runtime commit failure taxonomy version marker v1 in summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_commit_failure_taxonomy") != "none":
+            print("expected dry-run summary to classify runtime commit failure taxonomy as none", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_commit_nested_reason_code") != "not_run":
+            print("expected dry-run summary to classify nested runtime reason as not_run", file=sys.stderr)
+            return 1
+        diagnostic_hint = summary_payload.get("runtime_commit_failure_diagnostic_hint")
+        if not isinstance(diagnostic_hint, str) or not diagnostic_hint.strip():
+            print("expected runtime commit failure diagnostic hint marker in summary", file=sys.stderr)
+            return 1
+
+        # Regression: #2296
+        failure_payload = dict(summary_payload)
+        failure_payload["mode"] = "run"
+        failure_payload["status"] = "fail"
+        failure_payload["reason_code"] = "runtime_commit_endpoint_failed"
+        failure_payload["budget_status"] = "within_budget"
+        failure_payload["runtime_commit_reason_code"] = "runtime_commit_endpoint_failed"
+        failure_payload["runtime_commit_policy_reason_code"] = "runtime_commit_endpoint_failed"
+        failure_payload["runtime_commit_nested_reason_code"] = "live_finality_command_timeout"
+        failure_payload["runtime_commit_failure_taxonomy"] = "finality.timeout"
+        failure_payload["runtime_commit_failure_diagnostic_hint"] = (
+            "Inspect runtime finality command output and verify notifications/block fallback endpoint contracts."
+        )
+        failure_report = temp_path / "runtime_failure_summary.json"
+        failure_policy_output = temp_path / "runtime_failure_policy.json"
+        failure_report.write_text(json.dumps(failure_payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+        subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(failure_report),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "runtime_commit_endpoint_failed",
+                "--output-json",
+                str(failure_policy_output),
+            ],
+            cwd=ROOT_DIR,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+        taxonomy_drift_payload = dict(failure_payload)
+        taxonomy_drift_payload["runtime_commit_failure_taxonomy"] = "transport.submit.failed"
+        taxonomy_drift_report = temp_path / "runtime_failure_taxonomy_drift_summary.json"
+        taxonomy_drift_report.write_text(
+            json.dumps(taxonomy_drift_payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        taxonomy_drift_run = subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(taxonomy_drift_report),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "runtime_commit_endpoint_failed",
+                "--output-json",
+                str(failure_policy_output),
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if taxonomy_drift_run.returncode == 0:
+            print("expected checker to fail when runtime commit failure taxonomy drifts", file=sys.stderr)
+            return 1
+        drift_output = f"{taxonomy_drift_run.stdout}\n{taxonomy_drift_run.stderr}"
+        if "runtime_commit_failure_taxonomy_mismatch:finality.timeout" not in drift_output:
+            print(
+                "expected runtime commit taxonomy mismatch reason for drifted failure taxonomy",
+                file=sys.stderr,
+            )
+            return 1
 
     doc_text = DOC_FILE.read_text(encoding="utf-8")
     readme_text = README_FILE.read_text(encoding="utf-8")

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -739,6 +739,115 @@ for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
         }
     )
 
+
+def read_nested_runtime_reason_code(mode_value: str, summary_path: str) -> str:
+    if mode_value == "dry-run":
+        return "not_run"
+
+    path = pathlib.Path(summary_path)
+    if not path.exists():
+        return "report_missing"
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return "report_invalid_json"
+
+    nested_value = payload.get("reason_code")
+    if isinstance(nested_value, str) and nested_value.strip():
+        return nested_value
+    return "reason_code_missing"
+
+
+NESTED_RUNTIME_REASON_TO_TAXONOMY = {
+    "live_preflight_timeout": "transport.preflight.timeout",
+    "live_preflight_failed": "transport.preflight.failed",
+    "live_runtime_commit_command_timeout": "transport.submit.timeout",
+    "live_runtime_commit_command_failed": "transport.submit.failed",
+    "live_finality_command_timeout": "finality.timeout",
+    "live_finality_command_failed": "finality.failed",
+    "live_runtime_commit_budget_exceeded": "budget.exceeded",
+}
+
+NESTED_RUNTIME_REASON_TO_HINT = {
+    "live_preflight_timeout": "Verify live-node reachability and preflight latency at the configured --base-url endpoint.",
+    "live_preflight_failed": "Inspect preflight health output and provider-hint wiring before submit/finality checks.",
+    "live_runtime_commit_command_timeout": "Increase --runtime-commit-max-seconds or reduce submit command latency.",
+    "live_runtime_commit_command_failed": "Inspect runtime commit command stderr in runtime_commit_output_file for transport/provider errors.",
+    "live_finality_command_timeout": "Increase --runtime-commit-finality-max-seconds and verify finality endpoint responsiveness.",
+    "live_finality_command_failed": "Inspect runtime finality command output and verify notifications/block fallback endpoint contracts.",
+    "live_runtime_commit_budget_exceeded": "Increase --max-seconds or reduce prerequisite/runtime command cost for local-heavy runs.",
+}
+
+
+def classify_runtime_commit_failure(
+    mode_value: str,
+    status_value: str,
+    reason_value: str,
+    runtime_reason_value: str,
+    runtime_policy_reason_value: str,
+    nested_runtime_reason_value: str,
+) -> tuple[str, str]:
+    if status_value == "ok":
+        if mode_value == "dry-run":
+            return "none", "Dry-run mode does not execute runtime commit submit/finality checks."
+        return "none", "No runtime commit failure observed."
+
+    if reason_value == "runtime_commit_policy_failed":
+        return (
+            "policy.rejected",
+            "Inspect runtime_commit_live_policy_report for final_decision and reason_codes.",
+        )
+
+    if reason_value == "runtime_integration_budget_exceeded":
+        return (
+            "budget.exceeded",
+            "Increase --max-seconds or reduce prerequisite/runtime lane execution time.",
+        )
+
+    if reason_value != "runtime_commit_endpoint_failed":
+        return (
+            "none",
+            "Runtime commit endpoint was not the terminal failure path; inspect prerequisite check reason codes.",
+        )
+
+    if runtime_reason_value == "runtime_commit_endpoint_timeout":
+        return (
+            "transport.submit.timeout",
+            "Increase --runtime-commit-max-seconds or inspect runtime commit endpoint command latency.",
+        )
+
+    if runtime_policy_reason_value == "runtime_commit_endpoint_failed" and nested_runtime_reason_value in (
+        "report_missing",
+        "report_invalid_json",
+        "reason_code_missing",
+    ):
+        return (
+            "runtime.summary.unavailable",
+            "Ensure runtime_commit_live_summary is written and contains a valid reason_code field.",
+        )
+
+    mapped_taxonomy = NESTED_RUNTIME_REASON_TO_TAXONOMY.get(nested_runtime_reason_value)
+    if mapped_taxonomy is not None:
+        mapped_hint = NESTED_RUNTIME_REASON_TO_HINT[nested_runtime_reason_value]
+        return mapped_taxonomy, mapped_hint
+
+    return (
+        "runtime.unknown",
+        f"Inspect nested runtime reason_code={nested_runtime_reason_value} and runtime command artifacts.",
+    )
+
+
+runtime_commit_nested_reason_code = read_nested_runtime_reason_code(mode, runtime_commit_live_summary)
+runtime_commit_failure_taxonomy, runtime_commit_failure_diagnostic_hint = classify_runtime_commit_failure(
+    mode,
+    status,
+    reason_code,
+    runtime_commit_reason_code,
+    runtime_commit_policy_reason_code,
+    runtime_commit_nested_reason_code,
+)
+
 summary = {
     "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
     "mode": mode,
@@ -779,6 +888,10 @@ summary = {
     "conformance_reason_code": conformance_reason_code,
     "runtime_commit_reason_code": runtime_commit_reason_code,
     "runtime_commit_policy_reason_code": runtime_commit_policy_reason_code,
+    "runtime_commit_nested_reason_code": runtime_commit_nested_reason_code,
+    "runtime_commit_failure_taxonomy_version": "v1",
+    "runtime_commit_failure_taxonomy": runtime_commit_failure_taxonomy,
+    "runtime_commit_failure_diagnostic_hint": runtime_commit_failure_diagnostic_hint,
     "contracts": {
         "ci_fast_gate_scope": "local-only",
         "runtime_provider_client_contract": runtime_provider_client_contract,
@@ -794,6 +907,7 @@ summary = {
         "runtime_commit_method": "POST",
         "runtime_commit_finality_primary_endpoint": "/notifications",
         "runtime_commit_finality_fallback_endpoint": "/block/{height}",
+        "runtime_commit_failure_taxonomy_version": "v1",
     },
     "checks": checks,
     "artifact_paths": [

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -128,12 +128,14 @@ required_coverage_markers=(
   "check_local_kamn_live_runtime_integration_policy.py"
   "run_localhost_signed_integration_contract_lane.sh"
   "run_local_runtime_commit_live_finality_evidence_contract_lane.sh"
+  "runtime_commit_failure_taxonomy_mismatch:finality.timeout"
   "Regression: #1489"
   "Regression: #1971"
   "Regression: #2101"
   "Regression: #2112"
   "Regression: #2113"
   "Regression: #2114"
+  "Regression: #2296"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -242,6 +244,15 @@ if summary.get("status") != "ok":
     raise SystemExit("expected local KAMN live runtime integration contract-lane summary status ok")
 if summary.get("reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected dry_run_no_commands_executed reason code in contract-lane summary")
+if summary.get("runtime_commit_failure_taxonomy_version") != "v1":
+    raise SystemExit("expected runtime commit failure taxonomy version marker in contract-lane summary")
+if summary.get("runtime_commit_failure_taxonomy") != "none":
+    raise SystemExit("expected runtime commit failure taxonomy none marker in dry-run contract-lane summary")
+if summary.get("runtime_commit_nested_reason_code") != "not_run":
+    raise SystemExit("expected runtime commit nested reason marker not_run in dry-run contract-lane summary")
+diagnostic_hint = summary.get("runtime_commit_failure_diagnostic_hint")
+if not isinstance(diagnostic_hint, str) or not diagnostic_hint.strip():
+    raise SystemExit("expected runtime commit failure diagnostic hint marker in contract-lane summary")
 runtime_policy_report = summary.get("runtime_commit_live_policy_report")
 if not isinstance(runtime_policy_report, str) or not runtime_policy_report:
     raise SystemExit("expected runtime commit live policy report marker in contract-lane summary")


### PR DESCRIPTION
Closes #2296

## Summary
Add deterministic runtime live-provider failure taxonomy to the local KAMN runtime integration summary and enforce taxonomy consistency in the integration policy checker. This makes transport/finality failures actionable and fail-closed under taxonomy drift.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: derive `runtime_commit_nested_reason_code` from nested runtime summary, classify failures into deterministic `runtime_commit_failure_taxonomy`, and emit actionable `runtime_commit_failure_diagnostic_hint`.
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`: validate taxonomy fields/version and enforce reason-code-to-taxonomy consistency (`runtime_commit_failure_taxonomy_mismatch:<expected>`).
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: add regression coverage for taxonomy success + drift-fail behavior (`Regression: #2296`).
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: assert taxonomy markers in dry-run summary and ensure contract-lane coverage markers include taxonomy drift checks.
- `docs/foundation/kolme-runtime-commit-client.md`: document taxonomy/remediation mapping and policy fail-closed behavior.

## Risks & Compatibility
- None. Changes are additive to summary schema usage and policy validation; existing dry-run/run paths remain intact.

## Validation
- [ ] `cargo fmt --check` — not run (non-Rust change set)
- [ ] `cargo clippy -- -D warnings` — not run (non-Rust change set)
- [x] Unit tests pass
- [x] Integration tests pass (local lane contract/profile)
- [x] Manual verification: validated runner summary/policy behavior for dry-run and synthetic failure-taxonomy drift scenario

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` |
| Functional  | ✅     | taxonomy classification + mismatch rejection in contract lane |
| Integration | ✅     | `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` |
| Regression  | ✅     | `Regression: #2296` taxonomy-drift check in contract lane implementation |
