### PR TITLE
fix: reject simulated runtime profile in production run lanes (#2298)

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -256,6 +256,9 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
 - Local KAMN runtime integration lane:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --runtime-profile real-node --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-commit-finality-command "printf 'finality=final\n'" --runtime-commit-finality-max-seconds 15 --runtime-commit-finality-output-file /tmp/kolme-local-runtime-commit-live-finality-output.txt --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
   - runner default profile is `real-node`; passing `--runtime-profile real-node` explicitly keeps command-surface contracts deterministic.
+  - simulation-mode constraint matrix:
+    - `runtime-profile=standard` is dry-run only; run mode fails closed before execution.
+    - `runtime-profile=real-node` is required for run mode and production/integration evidence lanes.
   - runtime step composes through `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` and captures nested runtime evidence policy artifacts.
   - integration summary emits deterministic runtime evidence profile markers:
     - `runtime_commit_command_profile`

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -129,6 +129,14 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif runtime_provider_client_contract != "KolmeRuntimeCommitLiveProvider":
         reason_codes.append("runtime_provider_client_contract_mismatch")
 
+    runtime_profile = report.get("runtime_profile")
+    if not isinstance(runtime_profile, str) or not runtime_profile.strip():
+        reason_codes.append("runtime_profile_missing")
+    elif runtime_profile not in ("standard", "real-node"):
+        reason_codes.append("runtime_profile_invalid")
+    elif mode == "run" and runtime_profile != "real-node":
+        reason_codes.append("runtime_profile_run_mode_mismatch")
+
     runtime_commit_live_policy_report = report.get("runtime_commit_live_policy_report")
     if not isinstance(runtime_commit_live_policy_report, str) or not runtime_commit_live_policy_report.strip():
         reason_codes.append("runtime_commit_live_policy_report_missing")
@@ -167,6 +175,9 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("ci_fast_gate_scope_mismatch")
         if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
             reason_codes.append("runtime_provider_client_contract_contract_mismatch")
+        if isinstance(runtime_profile, str) and runtime_profile in ("standard", "real-node"):
+            if contracts.get("runtime_profile") != runtime_profile:
+                reason_codes.append("runtime_profile_contract_mismatch")
         if contracts.get("runtime_commit_endpoint") != "/broadcast/runtime-commit":
             reason_codes.append("runtime_commit_endpoint_mismatch")
         if contracts.get("runtime_commit_method") != "POST":

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -251,6 +251,49 @@ def main() -> int:
             )
             return 1
 
+        # Regression: #2298
+        simulated_profile_payload = dict(failure_payload)
+        simulated_profile_payload["runtime_profile"] = "standard"
+        contracts = simulated_profile_payload.get("contracts")
+        if isinstance(contracts, dict):
+            contracts["runtime_profile"] = "standard"
+        simulated_profile_report = temp_path / "runtime_failure_simulated_profile_summary.json"
+        simulated_profile_report.write_text(
+            json.dumps(simulated_profile_payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        simulated_profile_run = subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(simulated_profile_report),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "runtime_commit_endpoint_failed",
+                "--output-json",
+                str(failure_policy_output),
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if simulated_profile_run.returncode == 0:
+            print("expected checker to fail when run-mode uses simulated standard runtime profile", file=sys.stderr)
+            return 1
+        simulated_profile_output = f"{simulated_profile_run.stdout}\n{simulated_profile_run.stderr}"
+        if "runtime_profile_run_mode_mismatch" not in simulated_profile_output:
+            print(
+                "expected run-mode simulated profile mismatch reason for policy failure",
+                file=sys.stderr,
+            )
+            return 1
+
     doc_text = DOC_FILE.read_text(encoding="utf-8")
     readme_text = README_FILE.read_text(encoding="utf-8")
     if "run_local_kamn_live_runtime_integration_lane.sh" not in doc_text:

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -329,6 +329,11 @@ if [ "$RUNTIME_PROFILE" != "standard" ] && [ "$RUNTIME_PROFILE" != "real-node" ]
   exit 1
 fi
 
+if [ "$MODE" = "run" ] && [ "$RUNTIME_PROFILE" != "real-node" ]; then
+  echo "run mode requires runtime-profile=real-node; standard profile is dry-run only" >&2
+  exit 1
+fi
+
 if [ -n "$RUNTIME_SIGNER_PROFILE_OVERRIDE" ] && [ "$RUNTIME_PROFILE" != "real-node" ]; then
   echo "runtime-signer-profile is only valid when runtime-profile=real-node" >&2
   exit 1

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -129,6 +129,7 @@ required_coverage_markers=(
   "run_localhost_signed_integration_contract_lane.sh"
   "run_local_runtime_commit_live_finality_evidence_contract_lane.sh"
   "runtime_commit_failure_taxonomy_mismatch:finality.timeout"
+  "runtime_profile_run_mode_mismatch"
   "Regression: #1489"
   "Regression: #1971"
   "Regression: #2101"
@@ -136,6 +137,7 @@ required_coverage_markers=(
   "Regression: #2113"
   "Regression: #2114"
   "Regression: #2296"
+  "Regression: #2298"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -244,6 +246,8 @@ if summary.get("status") != "ok":
     raise SystemExit("expected local KAMN live runtime integration contract-lane summary status ok")
 if summary.get("reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected dry_run_no_commands_executed reason code in contract-lane summary")
+if summary.get("runtime_profile") != "real-node":
+    raise SystemExit("expected runtime_profile=real-node in contract-lane summary")
 if summary.get("runtime_commit_failure_taxonomy_version") != "v1":
     raise SystemExit("expected runtime commit failure taxonomy version marker in contract-lane summary")
 if summary.get("runtime_commit_failure_taxonomy") != "none":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -181,4 +181,25 @@ if ! grep -q "requires explicit local-only opt-in" "$TMP_ERR"; then
   exit 1
 fi
 
+set +e
+bash "$RUNNER" \
+  --mode run \
+  --runtime-profile standard \
+  --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \
+  --runtime-commit-live-summary "$TMP_RUNTIME_SUMMARY" \
+  --runtime-commit-live-policy-report "$TMP_RUNTIME_POLICY" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+run_standard_profile_code=$?
+set -e
+
+if [ "$run_standard_profile_code" -eq 0 ]; then
+  echo "expected run mode with standard runtime profile to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "run mode requires runtime-profile=real-node" "$TMP_ERR"; then
+  echo "expected deterministic run-mode profile gate failure message for standard runtime profile" >&2
+  exit 1
+fi
+
 echo "local KAMN live runtime integration real-node profile tests passed."


### PR DESCRIPTION
Closes #2298

## Summary
Fail closed when local KAMN runtime integration is invoked in `run` mode with `runtime-profile=standard` and enforce matching policy rejection contracts. This prevents simulated-signature profile paths from being used in production/integration run-mode lanes while preserving explicit dry-run non-production scope.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: added run-mode gate requiring `runtime-profile=real-node`; `standard` remains dry-run only.
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`: added `runtime_profile` validation and `runtime_profile_run_mode_mismatch` fail-closed reason.
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: added `Regression: #2298` policy proof for run-mode simulated profile mismatch.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: expanded coverage markers and runtime profile assertions.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: added negative test proving run-mode `standard` profile rejection.
- `docs/foundation/kolme-runtime-commit-client.md`: documented simulation-mode profile constraint matrix.

## Risks & Compatibility
- Low. This intentionally tightens run-mode gating; dry-run simulation/testing paths remain available.

## Validation
- [ ] `cargo fmt --check` — not run (non-Rust change set)
- [ ] `cargo clippy -- -D warnings` — not run (non-Rust change set)
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual verification: run-mode `standard` profile now exits fail-closed with deterministic error

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_integration_policy.py scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py` |
| Functional  | ✅     | `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` |
| Integration | ✅     | `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` |
| Regression  | ✅     | `Regression: #2298` policy mismatch proof in local contract lane implementation |
