### PR TITLE
feat(kolme): enforce signer provenance and rotation preflight contracts (#2300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,10 +639,12 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-
 
 # sample signer custody evidence marker for run mode
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json
+# sample signer provenance evidence marker for run mode
+printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json
 
 # deployment preflight run mode (fast-gate eligible, no local-heavy gate required)
 KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 \
-bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
+bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
 
 # deployment preflight policy checker contract
 python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json
@@ -653,6 +655,16 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # deterministic preflight marker contracts
 # signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE
 # fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
+# signer_key_source_contract_version=v1
+# signer_key_source=env-local
+# signer_provenance_file
+# signer_provenance_present
+# signer_provenance_sha256_valid
+# signer_rotation_epoch
+# signer_previous_rotation_epoch
+# signer_rotation_freshness_max_delta
+# signer_rotation_delta_epochs
+# signer_rotation_fresh
 # required_approvals=2
 # received_approvals=2
 # contracts.ci_fast_gate_scope=ci-fast-gate
@@ -660,6 +672,12 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.fallback_private_key_path_allowed=false
 # contracts.approval_quorum_required=2
 # contracts.custody_evidence_required=true
+# contracts.signer_provenance_required=true
+# contracts.signer_provenance_sha256_required=true
+# contracts.signer_key_source_contract_version=v1
+# contracts.signer_key_source=env-local
+# contracts.signer_rotation_freshness_max_delta=2
+# contracts.signer_rotation_stale_rejected=true
 
 # strict preflight NO-GO drift reasons
 # runtime_mode_mismatch
@@ -668,14 +686,23 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # checkpoint_failed_signer_secret_contract
 # checkpoint_failed_signer_quorum_contract
 # checkpoint_failed_custody_evidence_contract
+# checkpoint_failed_signer_provenance_contract
+# checkpoint_failed_signer_rotation_freshness_contract
 # signer_quorum_shortfall
 # custody_evidence_missing
 # custody_evidence_sha256_invalid
+# signer_key_source_contract_version_mismatch
+# signer_key_source_invalid
+# signer_key_source_profile_pair_disallowed
+# signer_provenance_missing
+# signer_provenance_sha256_invalid
+# signer_rotation_epoch_stale
 
 # schema: kamn.kolme.local-live-deployment-preflight-summary.v1
 # schema: kamn.kolme.local-live-deployment-preflight-policy-report.v1
 # Regression: #2225
 # Regression: #2226
+# Regression: #2300
 ```
 
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -384,12 +384,23 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   - deployment preflight signer/runtime checks remain fast and ci-fast-gate eligible.
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
-    - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+    - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+    - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - deterministic marker contracts:
       - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
       - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+      - `signer_key_source_contract_version=v1`
+      - `signer_key_source=env-local`
+      - `signer_provenance_file`
+      - `signer_provenance_present`
+      - `signer_provenance_sha256_valid`
+      - `signer_rotation_epoch`
+      - `signer_previous_rotation_epoch`
+      - `signer_rotation_freshness_max_delta`
+      - `signer_rotation_delta_epochs`
+      - `signer_rotation_fresh`
       - `required_approvals=2`
       - `received_approvals=2`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
@@ -397,6 +408,12 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `contracts.fallback_private_key_path_allowed=false`
       - `contracts.approval_quorum_required=2`
       - `contracts.custody_evidence_required=true`
+      - `contracts.signer_provenance_required=true`
+      - `contracts.signer_provenance_sha256_required=true`
+      - `contracts.signer_key_source_contract_version=v1`
+      - `contracts.signer_key_source=env-local`
+      - `contracts.signer_rotation_freshness_max_delta=2`
+      - `contracts.signer_rotation_stale_rejected=true`
     - fail-closed drift reasons:
       - `runtime_mode_mismatch`
       - `signer_profile_mismatch`
@@ -404,10 +421,19 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `checkpoint_failed_signer_secret_contract`
       - `checkpoint_failed_signer_quorum_contract`
       - `checkpoint_failed_custody_evidence_contract`
+      - `checkpoint_failed_signer_provenance_contract`
+      - `checkpoint_failed_signer_rotation_freshness_contract`
       - `signer_quorum_shortfall`
       - `custody_evidence_missing`
       - `custody_evidence_sha256_invalid`
+      - `signer_key_source_contract_version_mismatch`
+      - `signer_key_source_invalid`
+      - `signer_key_source_profile_pair_disallowed`
+      - `signer_provenance_missing`
+      - `signer_provenance_sha256_invalid`
+      - `signer_rotation_epoch_stale`
     - deployment preflight contract lane parity remains fail-closed (`Regression: #2226`).
+    - deployment preflight signer provenance + rotation freshness parity remains fail-closed (`Regression: #2300`).
   - local fork process lifecycle integration run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --max-seconds 300 --startup-max-seconds 45 --integration-max-seconds 240 --integration-bootstrap-max-seconds 90 --integration-conformance-max-seconds 180 --integration-runtime-commit-max-seconds 30 --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
     - process lifecycle integration command composition must include `--runtime-commit-live-policy-report` for nested integration evidence lineage.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -536,7 +536,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Deployment preflight run mode:
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
-  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+  - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Deployment preflight policy checker command:
   - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
 - Deployment preflight contract lane command:
@@ -551,13 +552,25 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `fallback_private_key_contract`: fallback signer secret env must remain unset.
   - `signer_quorum_contract`: received approvals must satisfy required approvals threshold.
   - `custody_evidence_contract`: signer custody evidence file and sha256 marker must be present.
+  - `signer_provenance_contract`: signer provenance evidence file and sha256 marker must be present.
+  - `signer_rotation_freshness_contract`: signer rotation metadata must satisfy freshness threshold.
   - node runtime signer-provider guard (`KolmeLiveSignerSecretProvider`) rejects fallback env-key presence before key decode/signing.
-  - summary fields include deterministic signer custody markers:
+  - summary fields include deterministic signer custody/provenance markers:
     - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
     - `signer_profile`
     - `signer_private_key_env`
     - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
     - `fallback_signer_secret_present=false`
+    - `signer_key_source_contract_version=v1`
+    - `signer_key_source=env-local`
+    - `signer_provenance_file`
+    - `signer_provenance_present`
+    - `signer_provenance_sha256_valid`
+    - `signer_rotation_epoch`
+    - `signer_previous_rotation_epoch`
+    - `signer_rotation_freshness_max_delta`
+    - `signer_rotation_delta_epochs`
+    - `signer_rotation_fresh`
     - `required_approvals=2`
     - `received_approvals`
     - `custody_evidence_file`
@@ -572,6 +585,12 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `contracts.approval_quorum_source=local-operator-attestations`
     - `contracts.custody_evidence_required=true`
     - `contracts.custody_evidence_sha256_required=true`
+    - `contracts.signer_provenance_required=true`
+    - `contracts.signer_provenance_sha256_required=true`
+    - `contracts.signer_key_source_contract_version=v1`
+    - `contracts.signer_key_source=env-local`
+    - `contracts.signer_rotation_freshness_max_delta=2`
+    - `contracts.signer_rotation_stale_rejected=true`
 - Fail-closed reasons include:
   - `runtime_mode_mismatch`
   - `signer_profile_mismatch`
@@ -580,14 +599,23 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `checkpoint_failed_signer_secret_contract`
   - `checkpoint_failed_signer_quorum_contract`
   - `checkpoint_failed_custody_evidence_contract`
+  - `checkpoint_failed_signer_provenance_contract`
+  - `checkpoint_failed_signer_rotation_freshness_contract`
   - `signer_quorum_shortfall`
   - `custody_evidence_missing`
   - `custody_evidence_sha256_invalid`
+  - `signer_key_source_contract_version_mismatch`
+  - `signer_key_source_invalid`
+  - `signer_key_source_profile_pair_disallowed`
+  - `signer_provenance_missing`
+  - `signer_provenance_sha256_invalid`
+  - `signer_rotation_epoch_stale`
 - Cost policy:
   - lane is lightweight and `ci_fast_gate_eligible=true`.
   - no local-heavy opt-in is required for deployment preflight checks.
   - docs/command/policy parity for this lane remains fail-closed (`Regression: #2225`).
   - deployment preflight contract lane parity remains fail-closed (`Regression: #2226`).
+  - signer provenance + rotation freshness marker parity remains fail-closed (`Regression: #2300`).
 
 ## Live Provider Operator Runbook (Issue #2114)
 
@@ -606,6 +634,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `export KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=<64-hex-private-key>`
   - `unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
+  - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
 
 ### Execution Flow
 
@@ -653,6 +682,10 @@ Operator checkpoints:
   - verify `--received-approvals` is greater than or equal to `--required-approvals`.
 - `reason_code=checkpoint_failed_custody_evidence_contract`:
   - verify `--custody-evidence-file` exists and its sha256 can be emitted in summary markers.
+- `reason_code=checkpoint_failed_signer_provenance_contract`:
+  - verify `--signer-provenance-file` exists and signer key-source markers remain `--signer-key-source env-local --signer-key-source-contract-version v1`.
+- `reason_code=checkpoint_failed_signer_rotation_freshness_contract`:
+  - verify `--signer-rotation-epoch`, `--signer-previous-rotation-epoch`, and `--signer-rotation-freshness-max-delta` satisfy the freshness delta contract.
 - `ci_fast_gate_eligibility_violation` or `ci_fast_gate_scope_mismatch` from policy checker:
   - verify summary still emits `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
 

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -13,6 +13,12 @@ PRIMARY_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 SECONDARY_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 FALLBACK_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH = 64
+SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
+ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
+ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
+    PRIMARY_SIGNER_PROFILE: ("env-local", "managed-external"),
+    SECONDARY_SIGNER_PROFILE: ("env-local",),
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -96,6 +102,78 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif expected_signer_env and signer_private_key_env != expected_signer_env:
         reason_codes.append("signer_private_key_env_mismatch")
 
+    signer_key_source_contract_version = report.get("signer_key_source_contract_version")
+    if not isinstance(signer_key_source_contract_version, str) or not signer_key_source_contract_version.strip():
+        reason_codes.append("signer_key_source_contract_version_missing")
+    elif signer_key_source_contract_version != SIGNER_KEY_SOURCE_CONTRACT_VERSION:
+        reason_codes.append("signer_key_source_contract_version_mismatch")
+
+    signer_key_source = report.get("signer_key_source")
+    if not isinstance(signer_key_source, str) or not signer_key_source.strip():
+        reason_codes.append("signer_key_source_missing")
+    elif signer_key_source not in ALLOWED_SIGNER_KEY_SOURCES:
+        reason_codes.append("signer_key_source_invalid")
+    elif (
+        isinstance(signer_profile, str)
+        and signer_profile in ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE
+        and signer_key_source not in ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE[signer_profile]
+    ):
+        reason_codes.append("signer_key_source_profile_pair_disallowed")
+
+    signer_provenance_file = report.get("signer_provenance_file")
+    if not isinstance(signer_provenance_file, str):
+        reason_codes.append("signer_provenance_file_invalid")
+
+    signer_provenance_present = report.get("signer_provenance_present")
+    if not isinstance(signer_provenance_present, bool):
+        reason_codes.append("signer_provenance_present_invalid")
+
+    signer_provenance_sha256 = report.get("signer_provenance_sha256")
+    if not isinstance(signer_provenance_sha256, str):
+        reason_codes.append("signer_provenance_sha256_invalid")
+
+    signer_provenance_sha256_valid = report.get("signer_provenance_sha256_valid")
+    if not isinstance(signer_provenance_sha256_valid, bool):
+        reason_codes.append("signer_provenance_sha256_valid_invalid")
+
+    signer_rotation_epoch = report.get("signer_rotation_epoch")
+    if not isinstance(signer_rotation_epoch, int) or signer_rotation_epoch <= 0:
+        reason_codes.append("signer_rotation_epoch_invalid")
+
+    signer_previous_rotation_epoch = report.get("signer_previous_rotation_epoch")
+    if not isinstance(signer_previous_rotation_epoch, int) or signer_previous_rotation_epoch <= 0:
+        reason_codes.append("signer_previous_rotation_epoch_invalid")
+
+    signer_rotation_freshness_max_delta = report.get("signer_rotation_freshness_max_delta")
+    if not isinstance(signer_rotation_freshness_max_delta, int) or signer_rotation_freshness_max_delta < 0:
+        reason_codes.append("signer_rotation_freshness_max_delta_invalid")
+
+    signer_rotation_delta_epochs = report.get("signer_rotation_delta_epochs")
+    if not isinstance(signer_rotation_delta_epochs, int):
+        reason_codes.append("signer_rotation_delta_epochs_invalid")
+    elif signer_rotation_delta_epochs < 0:
+        reason_codes.append("signer_rotation_epoch_invalid")
+    elif (
+        isinstance(signer_rotation_epoch, int)
+        and signer_rotation_epoch > 0
+        and isinstance(signer_previous_rotation_epoch, int)
+        and signer_previous_rotation_epoch > 0
+        and signer_rotation_delta_epochs != signer_rotation_epoch - signer_previous_rotation_epoch
+    ):
+        reason_codes.append("signer_rotation_delta_epochs_mismatch")
+    elif (
+        isinstance(signer_rotation_freshness_max_delta, int)
+        and signer_rotation_freshness_max_delta >= 0
+        and signer_rotation_delta_epochs > signer_rotation_freshness_max_delta
+    ):
+        reason_codes.append("signer_rotation_epoch_stale")
+
+    signer_rotation_fresh = report.get("signer_rotation_fresh")
+    if not isinstance(signer_rotation_fresh, bool):
+        reason_codes.append("signer_rotation_fresh_invalid")
+    elif "signer_rotation_epoch_stale" in reason_codes and signer_rotation_fresh:
+        reason_codes.append("signer_rotation_fresh_contract_mismatch")
+
     fallback_signer_private_key_env = report.get("fallback_signer_private_key_env")
     if not isinstance(fallback_signer_private_key_env, str) or not fallback_signer_private_key_env.strip():
         reason_codes.append("fallback_signer_private_key_env_missing")
@@ -175,6 +253,26 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("custody_evidence_required_contract_mismatch")
         if contracts.get("custody_evidence_sha256_required") is not True:
             reason_codes.append("custody_evidence_sha256_required_contract_mismatch")
+        if contracts.get("signer_provenance_required") is not True:
+            reason_codes.append("signer_provenance_required_contract_mismatch")
+        if contracts.get("signer_provenance_sha256_required") is not True:
+            reason_codes.append("signer_provenance_sha256_required_contract_mismatch")
+        if contracts.get("signer_key_source_contract_version") != SIGNER_KEY_SOURCE_CONTRACT_VERSION:
+            reason_codes.append("signer_key_source_contract_version_contract_mismatch")
+        if isinstance(signer_key_source, str) and signer_key_source and contracts.get("signer_key_source") != signer_key_source:
+            reason_codes.append("signer_key_source_contract_mismatch")
+        if contracts.get("signer_key_source_allowed_for_ops_primary") != ["env-local", "managed-external"]:
+            reason_codes.append("signer_key_source_allowed_for_ops_primary_contract_mismatch")
+        if contracts.get("signer_key_source_allowed_for_ops_secondary") != ["env-local"]:
+            reason_codes.append("signer_key_source_allowed_for_ops_secondary_contract_mismatch")
+        if (
+            isinstance(signer_rotation_freshness_max_delta, int)
+            and signer_rotation_freshness_max_delta >= 0
+            and contracts.get("signer_rotation_freshness_max_delta") != signer_rotation_freshness_max_delta
+        ):
+            reason_codes.append("signer_rotation_freshness_max_delta_contract_mismatch")
+        if contracts.get("signer_rotation_stale_rejected") is not True:
+            reason_codes.append("signer_rotation_stale_rejected_contract_mismatch")
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:
@@ -187,6 +285,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             "fallback_private_key_contract",
             "signer_quorum_contract",
             "custody_evidence_contract",
+            "signer_provenance_contract",
+            "signer_rotation_freshness_contract",
         }
         observed_ids: set[str] = set()
         for entry in checks:
@@ -241,6 +341,20 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("custody_evidence_sha256_invalid")
         if isinstance(custody_evidence_file, str) and custody_evidence_present is True and not custody_evidence_file.strip():
             reason_codes.append("custody_evidence_file_missing")
+        if signer_provenance_present is not True:
+            reason_codes.append("signer_provenance_missing")
+        if signer_provenance_sha256_valid is not True:
+            reason_codes.append("signer_provenance_sha256_invalid")
+        if isinstance(signer_provenance_file, str) and signer_provenance_present is True and not signer_provenance_file.strip():
+            reason_codes.append("signer_provenance_file_missing")
+        if (
+            isinstance(signer_rotation_delta_epochs, int)
+            and isinstance(signer_rotation_freshness_max_delta, int)
+            and signer_rotation_delta_epochs > signer_rotation_freshness_max_delta
+        ):
+            reason_codes.append("signer_rotation_epoch_stale")
+        if signer_rotation_fresh is not True:
+            reason_codes.append("signer_rotation_fresh_violation")
 
     for required_reason_code in args.require_reason_code:
         if reason_code != required_reason_code:

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -173,6 +173,27 @@ def main() -> int:
     if summary.get("fallback_signer_secret_present") is not False:
         print("expected deployment preflight summary fallback signer secret marker to remain false", file=sys.stderr)
         return 1
+    if summary.get("signer_key_source_contract_version") != "v1":
+        print("expected deployment preflight summary signer key-source contract version marker", file=sys.stderr)
+        return 1
+    if summary.get("signer_key_source") != "env-local":
+        print("expected deployment preflight summary signer key-source marker", file=sys.stderr)
+        return 1
+    if summary.get("signer_rotation_epoch") != 1:
+        print("expected deployment preflight summary signer rotation epoch marker", file=sys.stderr)
+        return 1
+    if summary.get("signer_previous_rotation_epoch") != 1:
+        print("expected deployment preflight summary signer previous rotation epoch marker", file=sys.stderr)
+        return 1
+    if summary.get("signer_rotation_freshness_max_delta") != 2:
+        print("expected deployment preflight summary signer rotation freshness threshold marker", file=sys.stderr)
+        return 1
+    if summary.get("signer_rotation_delta_epochs") != 0:
+        print("expected deployment preflight summary signer rotation delta marker", file=sys.stderr)
+        return 1
+    if summary.get("signer_rotation_fresh") is not False:
+        print("expected deployment preflight summary signer rotation freshness marker false in dry-run", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in deployment preflight summary", file=sys.stderr)
@@ -188,6 +209,24 @@ def main() -> int:
         return 1
     if contracts.get("custody_evidence_required") is not True:
         print("expected deployment preflight contracts custody_evidence_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("signer_provenance_required") is not True:
+        print("expected deployment preflight contracts signer_provenance_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("signer_provenance_sha256_required") is not True:
+        print("expected deployment preflight contracts signer_provenance_sha256_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("signer_key_source_contract_version") != "v1":
+        print("expected deployment preflight contracts signer_key_source_contract_version=v1", file=sys.stderr)
+        return 1
+    if contracts.get("signer_key_source") != "env-local":
+        print("expected deployment preflight contracts signer_key_source=env-local", file=sys.stderr)
+        return 1
+    if contracts.get("signer_rotation_freshness_max_delta") != 2:
+        print("expected deployment preflight contracts signer_rotation_freshness_max_delta=2", file=sys.stderr)
+        return 1
+    if contracts.get("signer_rotation_stale_rejected") is not True:
+        print("expected deployment preflight contracts signer_rotation_stale_rejected=true", file=sys.stderr)
         return 1
     if policy.get("schema_version") != "kamn.kolme.local-live-deployment-preflight-policy-report.v1":
         print("unexpected deployment preflight contract-lane policy schema", file=sys.stderr)
@@ -274,6 +313,114 @@ def main() -> int:
             print("expected signer quorum negative policy final_decision NO-GO", file=sys.stderr)
             return 1
 
+        provenance_negative_report = temp_path / "signer_provenance_negative_summary.json"
+        provenance_negative_policy = temp_path / "signer_provenance_negative_policy.json"
+        provenance_negative_summary = dict(summary)
+        provenance_negative_summary["mode"] = "run"
+        provenance_negative_summary["status"] = "fail"
+        provenance_negative_summary["reason_code"] = "checkpoint_failed_signer_provenance_contract"
+        provenance_negative_summary["signer_secret_present"] = True
+        provenance_negative_summary["signer_secret_hex_valid"] = True
+        provenance_negative_summary["required_approvals"] = 2
+        provenance_negative_summary["received_approvals"] = 2
+        provenance_negative_summary["custody_evidence_file"] = "/tmp/custody-evidence.json"
+        provenance_negative_summary["custody_evidence_present"] = True
+        provenance_negative_summary["custody_evidence_sha256"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        provenance_negative_summary["custody_evidence_sha256_valid"] = True
+        provenance_negative_summary["signer_provenance_file"] = ""
+        provenance_negative_summary["signer_provenance_present"] = False
+        provenance_negative_summary["signer_provenance_sha256"] = ""
+        provenance_negative_summary["signer_provenance_sha256_valid"] = False
+        provenance_negative_summary["signer_key_source_contract_version"] = "v0"
+        provenance_negative_summary["signer_key_source"] = "legacy-local"
+        provenance_negative_summary["signer_rotation_epoch"] = 1
+        provenance_negative_summary["signer_previous_rotation_epoch"] = 1
+        provenance_negative_summary["signer_rotation_freshness_max_delta"] = 2
+        provenance_negative_summary["signer_rotation_delta_epochs"] = 0
+        provenance_negative_summary["signer_rotation_fresh"] = False
+        provenance_negative_report.write_text(
+            json.dumps(provenance_negative_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        provenance_no_go_result = run_policy_check(
+            report_file=provenance_negative_report,
+            output_json=provenance_negative_policy,
+            expected_final_decision="NO-GO",
+            required_reason_code="checkpoint_failed_signer_provenance_contract",
+        )
+        if provenance_no_go_result.returncode == 0:
+            print("expected signer provenance negative proof to fail closed", file=sys.stderr)
+            return 1
+        provenance_no_go_policy = json.loads(provenance_negative_policy.read_text(encoding="utf-8"))
+        provenance_no_go_reason_codes = provenance_no_go_policy.get("reason_codes")
+        if not isinstance(provenance_no_go_reason_codes, list):
+            print("expected reason_codes list in signer provenance negative policy output", file=sys.stderr)
+            return 1
+        if "signer_provenance_missing" not in provenance_no_go_reason_codes:
+            print("expected signer_provenance_missing in signer provenance negative policy output", file=sys.stderr)
+            return 1
+        if "signer_key_source_contract_version_mismatch" not in provenance_no_go_reason_codes:
+            print("expected signer_key_source_contract_version_mismatch in signer provenance negative policy output", file=sys.stderr)
+            return 1
+        if provenance_no_go_policy.get("final_decision") != "NO-GO":
+            print("expected signer provenance negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
+        rotation_negative_report = temp_path / "signer_rotation_negative_summary.json"
+        rotation_negative_policy = temp_path / "signer_rotation_negative_policy.json"
+        rotation_negative_summary = dict(summary)
+        rotation_negative_summary["mode"] = "run"
+        rotation_negative_summary["status"] = "fail"
+        rotation_negative_summary["reason_code"] = "checkpoint_failed_signer_rotation_freshness_contract"
+        rotation_negative_summary["signer_secret_present"] = True
+        rotation_negative_summary["signer_secret_hex_valid"] = True
+        rotation_negative_summary["required_approvals"] = 2
+        rotation_negative_summary["received_approvals"] = 2
+        rotation_negative_summary["custody_evidence_file"] = "/tmp/custody-evidence.json"
+        rotation_negative_summary["custody_evidence_present"] = True
+        rotation_negative_summary["custody_evidence_sha256"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        rotation_negative_summary["custody_evidence_sha256_valid"] = True
+        rotation_negative_summary["signer_provenance_file"] = "/tmp/provenance-evidence.json"
+        rotation_negative_summary["signer_provenance_present"] = True
+        rotation_negative_summary["signer_provenance_sha256"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        rotation_negative_summary["signer_provenance_sha256_valid"] = True
+        rotation_negative_summary["signer_key_source_contract_version"] = "v1"
+        rotation_negative_summary["signer_key_source"] = "env-local"
+        rotation_negative_summary["signer_rotation_epoch"] = 8
+        rotation_negative_summary["signer_previous_rotation_epoch"] = 3
+        rotation_negative_summary["signer_rotation_freshness_max_delta"] = 2
+        rotation_negative_summary["signer_rotation_delta_epochs"] = 5
+        rotation_negative_summary["signer_rotation_fresh"] = False
+        rotation_negative_report.write_text(
+            json.dumps(rotation_negative_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        rotation_no_go_result = run_policy_check(
+            report_file=rotation_negative_report,
+            output_json=rotation_negative_policy,
+            expected_final_decision="NO-GO",
+            required_reason_code="checkpoint_failed_signer_rotation_freshness_contract",
+        )
+        if rotation_no_go_result.returncode == 0:
+            print("expected signer rotation negative proof to fail closed", file=sys.stderr)
+            return 1
+        rotation_no_go_policy = json.loads(rotation_negative_policy.read_text(encoding="utf-8"))
+        rotation_no_go_reason_codes = rotation_no_go_policy.get("reason_codes")
+        if not isinstance(rotation_no_go_reason_codes, list):
+            print("expected reason_codes list in signer rotation negative policy output", file=sys.stderr)
+            return 1
+        if "signer_rotation_epoch_stale" not in rotation_no_go_reason_codes:
+            print("expected signer_rotation_epoch_stale in signer rotation negative policy output", file=sys.stderr)
+            return 1
+        if "signer_rotation_fresh_violation" not in rotation_no_go_reason_codes:
+            print("expected signer_rotation_fresh_violation in signer rotation negative policy output", file=sys.stderr)
+            return 1
+        if rotation_no_go_policy.get("final_decision") != "NO-GO":
+            print("expected signer rotation negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
     doc_markers = [
         "run_local_kolme_live_deployment_preflight_lane.sh",
         "check_local_kolme_live_deployment_preflight_policy.py",
@@ -283,10 +430,17 @@ def main() -> int:
         "fallback_signer_secret_present_violation",
         "checkpoint_failed_signer_quorum_contract",
         "checkpoint_failed_custody_evidence_contract",
+        "checkpoint_failed_signer_provenance_contract",
+        "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
+        "signer_key_source_contract_version",
+        "signer_key_source",
+        "signer_provenance_file",
+        "signer_rotation_epoch_stale",
         "Regression: #2226",
+        "Regression: #2300",
     ]
     ci_doc_markers = [
         "run_local_kolme_live_deployment_preflight_lane.sh",
@@ -297,10 +451,17 @@ def main() -> int:
         "fallback_signer_secret_present_violation",
         "checkpoint_failed_signer_quorum_contract",
         "checkpoint_failed_custody_evidence_contract",
+        "checkpoint_failed_signer_provenance_contract",
+        "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
+        "signer_key_source_contract_version",
+        "signer_key_source",
+        "signer_provenance_file",
+        "signer_rotation_epoch_stale",
         "Regression: #2226",
+        "Regression: #2300",
     ]
     readme_markers = [
         "run_local_kolme_live_deployment_preflight_lane.sh",
@@ -311,10 +472,17 @@ def main() -> int:
         "fallback_signer_secret_present_violation",
         "checkpoint_failed_signer_quorum_contract",
         "checkpoint_failed_custody_evidence_contract",
+        "checkpoint_failed_signer_provenance_contract",
+        "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
+        "signer_key_source_contract_version",
+        "signer_key_source",
+        "signer_provenance_file",
+        "signer_rotation_epoch_stale",
         "Regression: #2226",
+        "Regression: #2300",
     ]
 
     missing_markers: list[str] = []

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -9,6 +9,12 @@ MAX_SECONDS=12
 REQUIRED_APPROVALS=2
 RECEIVED_APPROVALS=0
 CUSTODY_EVIDENCE_FILE=""
+SIGNER_PROVENANCE_FILE=""
+SIGNER_KEY_SOURCE_CONTRACT_VERSION="v1"
+SIGNER_KEY_SOURCE="env-local"
+SIGNER_ROTATION_EPOCH=1
+SIGNER_PREVIOUS_ROTATION_EPOCH=1
+SIGNER_ROTATION_FRESHNESS_MAX_DELTA=2
 
 REQUIRED_RUNTIME_MODE="kolme-live"
 SIGNER_PROFILE_SELECTOR_ENV="KAMN_KOLME_LIVE_SIGNER_PROFILE"
@@ -18,6 +24,7 @@ PRIMARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 SECONDARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 FALLBACK_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH=64
+SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED="v1"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -85,6 +92,54 @@ while [ "$#" -gt 0 ]; do
       CUSTODY_EVIDENCE_FILE="$2"
       shift 2
       ;;
+    --signer-provenance-file)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --signer-provenance-file" >&2
+        exit 1
+      fi
+      SIGNER_PROVENANCE_FILE="$2"
+      shift 2
+      ;;
+    --signer-key-source-contract-version)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --signer-key-source-contract-version" >&2
+        exit 1
+      fi
+      SIGNER_KEY_SOURCE_CONTRACT_VERSION="$2"
+      shift 2
+      ;;
+    --signer-key-source)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --signer-key-source" >&2
+        exit 1
+      fi
+      SIGNER_KEY_SOURCE="$2"
+      shift 2
+      ;;
+    --signer-rotation-epoch)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --signer-rotation-epoch" >&2
+        exit 1
+      fi
+      SIGNER_ROTATION_EPOCH="$2"
+      shift 2
+      ;;
+    --signer-previous-rotation-epoch)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --signer-previous-rotation-epoch" >&2
+        exit 1
+      fi
+      SIGNER_PREVIOUS_ROTATION_EPOCH="$2"
+      shift 2
+      ;;
+    --signer-rotation-freshness-max-delta)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --signer-rotation-freshness-max-delta" >&2
+        exit 1
+      fi
+      SIGNER_ROTATION_FRESHNESS_MAX_DELTA="$2"
+      shift 2
+      ;;
     --help|-h)
       cat <<'USAGE'
 Usage: run_local_kolme_live_deployment_preflight_lane.sh [options]
@@ -98,6 +153,15 @@ Options:
   --required-approvals <n>            Required signer approvals threshold (run-mode fail-closed).
   --received-approvals <n>            Received signer approvals count (run-mode fail-closed).
   --custody-evidence-file <path>      Required signer custody evidence file in run mode.
+  --signer-provenance-file <path>     Required signer provenance evidence file in run mode.
+  --signer-key-source-contract-version <value>
+                                      Signer key-source contract version (default: v1).
+  --signer-key-source <value>         Signer key-source marker (env-local|managed-external).
+  --signer-rotation-epoch <n>         Current signer rotation epoch marker.
+  --signer-previous-rotation-epoch <n>
+                                      Previous signer rotation epoch marker.
+  --signer-rotation-freshness-max-delta <n>
+                                      Maximum allowed rotation epoch delta before stale rejection.
 USAGE
       exit 0
       ;;
@@ -125,6 +189,21 @@ fi
 
 if ! [[ "$RECEIVED_APPROVALS" =~ ^[0-9]+$ ]]; then
   echo "received-approvals must be a non-negative integer" >&2
+  exit 1
+fi
+
+if ! [[ "$SIGNER_ROTATION_EPOCH" =~ ^[0-9]+$ ]] || [ "$SIGNER_ROTATION_EPOCH" -le 0 ]; then
+  echo "signer-rotation-epoch must be a positive integer" >&2
+  exit 1
+fi
+
+if ! [[ "$SIGNER_PREVIOUS_ROTATION_EPOCH" =~ ^[0-9]+$ ]] || [ "$SIGNER_PREVIOUS_ROTATION_EPOCH" -le 0 ]; then
+  echo "signer-previous-rotation-epoch must be a positive integer" >&2
+  exit 1
+fi
+
+if ! [[ "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" =~ ^[0-9]+$ ]]; then
+  echo "signer-rotation-freshness-max-delta must be a non-negative integer" >&2
   exit 1
 fi
 
@@ -161,6 +240,8 @@ signer_secret_command="selected signer secret env must exist and be ${REQUIRED_S
 fallback_private_key_command="fallback signer secret env must remain unset"
 signer_quorum_command="received approvals must satisfy required approvals threshold"
 custody_evidence_command="signer custody evidence file and sha256 marker must be present"
+signer_provenance_command="signer provenance evidence file and sha256 marker must be present"
+signer_rotation_freshness_command="signer rotation metadata must satisfy freshness threshold"
 
 overall_status="ok"
 reason_code="dry_run_no_commands_executed"
@@ -172,6 +253,11 @@ fallback_signer_secret_present="false"
 custody_evidence_present="false"
 custody_evidence_sha256=""
 custody_evidence_sha256_valid="false"
+signer_provenance_present="false"
+signer_provenance_sha256=""
+signer_provenance_sha256_valid="false"
+signer_rotation_delta_epochs=0
+signer_rotation_fresh="false"
 
 record_check "runtime_mode_contract" "$runtime_mode_command" "planned" "not_run"
 record_check "signer_profile_contract" "$signer_profile_command" "planned" "not_run"
@@ -179,6 +265,8 @@ record_check "signer_secret_contract" "$signer_secret_command" "planned" "not_ru
 record_check "fallback_private_key_contract" "$fallback_private_key_command" "planned" "not_run"
 record_check "signer_quorum_contract" "$signer_quorum_command" "planned" "not_run"
 record_check "custody_evidence_contract" "$custody_evidence_command" "planned" "not_run"
+record_check "signer_provenance_contract" "$signer_provenance_command" "planned" "not_run"
+record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "planned" "not_run"
 
 if [ "$MODE" = "run" ]; then
   : >"$CHECK_FILE"
@@ -191,6 +279,8 @@ if [ "$MODE" = "run" ]; then
     record_check "fallback_private_key_contract" "$fallback_private_key_command" "skipped" "runtime_mode_mismatch"
     record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "runtime_mode_mismatch"
     record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "runtime_mode_mismatch"
+    record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "runtime_mode_mismatch"
+    record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "runtime_mode_mismatch"
     overall_status="fail"
     reason_code="checkpoint_failed_runtime_mode_contract"
   else
@@ -203,6 +293,8 @@ if [ "$MODE" = "run" ]; then
       record_check "fallback_private_key_contract" "$fallback_private_key_command" "skipped" "signer_profile_invalid"
       record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_profile_invalid"
       record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_profile_invalid"
+      record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_profile_invalid"
+      record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_profile_invalid"
       overall_status="fail"
       reason_code="checkpoint_failed_signer_profile_contract"
     else
@@ -219,67 +311,139 @@ if [ "$MODE" = "run" ]; then
         record_check "signer_secret_contract" "$signer_secret_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "fallback_signer_secret_present_violation"
+        record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "fallback_signer_secret_present_violation"
+        record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "fallback_signer_secret_present_violation"
         overall_status="fail"
         reason_code="checkpoint_failed_fallback_private_key_contract"
       else
         record_check "fallback_private_key_contract" "$fallback_private_key_command" "pass" "fallback_signer_secret_absent"
 
-      signer_secret_value="${!selected_signer_secret_env:-}"
-      if [ -n "$signer_secret_value" ]; then
-        signer_secret_present="true"
-      fi
-      if [[ "$signer_secret_value" =~ ^[0-9a-fA-F]{64}$ ]]; then
-        signer_secret_hex_valid="true"
-      fi
+        signer_secret_value="${!selected_signer_secret_env:-}"
+        if [ -n "$signer_secret_value" ]; then
+          signer_secret_present="true"
+        fi
+        if [[ "$signer_secret_value" =~ ^[0-9a-fA-F]{64}$ ]]; then
+          signer_secret_hex_valid="true"
+        fi
 
-      if [ "$signer_secret_present" != "true" ]; then
-        echo "signer secret env is required for selected profile: $selected_signer_secret_env" >&2
-        record_check "signer_secret_contract" "$signer_secret_command" "fail" "signer_secret_missing"
-        record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_secret_missing"
-        record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_secret_missing"
-        overall_status="fail"
-        reason_code="checkpoint_failed_signer_secret_contract"
-      elif [ "$signer_secret_hex_valid" != "true" ]; then
-        echo "signer secret env must be ${REQUIRED_SECRET_HEX_LENGTH} hex characters: $selected_signer_secret_env" >&2
-        record_check "signer_secret_contract" "$signer_secret_command" "fail" "signer_secret_invalid_hex"
-        record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_secret_invalid_hex"
-        record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_secret_invalid_hex"
-        overall_status="fail"
-        reason_code="checkpoint_failed_signer_secret_contract"
-      else
-        record_check "signer_secret_contract" "$signer_secret_command" "pass" "signer_secret_validated"
-        if [ "$RECEIVED_APPROVALS" -lt "$REQUIRED_APPROVALS" ]; then
-          echo "signer quorum approvals below required threshold: required=$REQUIRED_APPROVALS received=$RECEIVED_APPROVALS" >&2
-          record_check "signer_quorum_contract" "$signer_quorum_command" "fail" "signer_quorum_shortfall"
-          record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_quorum_shortfall"
+        if [ "$signer_secret_present" != "true" ]; then
+          echo "signer secret env is required for selected profile: $selected_signer_secret_env" >&2
+          record_check "signer_secret_contract" "$signer_secret_command" "fail" "signer_secret_missing"
+          record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_secret_missing"
+          record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_secret_missing"
+          record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_secret_missing"
+          record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_secret_missing"
           overall_status="fail"
-          reason_code="checkpoint_failed_signer_quorum_contract"
+          reason_code="checkpoint_failed_signer_secret_contract"
+        elif [ "$signer_secret_hex_valid" != "true" ]; then
+          echo "signer secret env must be ${REQUIRED_SECRET_HEX_LENGTH} hex characters: $selected_signer_secret_env" >&2
+          record_check "signer_secret_contract" "$signer_secret_command" "fail" "signer_secret_invalid_hex"
+          record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_secret_invalid_hex"
+          record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_secret_invalid_hex"
+          record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_secret_invalid_hex"
+          record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_secret_invalid_hex"
+          overall_status="fail"
+          reason_code="checkpoint_failed_signer_secret_contract"
         else
-          record_check "signer_quorum_contract" "$signer_quorum_command" "pass" "signer_quorum_validated"
-          if [ -n "$CUSTODY_EVIDENCE_FILE" ] && [ -f "$CUSTODY_EVIDENCE_FILE" ]; then
-            custody_evidence_present="true"
-            custody_evidence_sha256="$(sha256sum "$CUSTODY_EVIDENCE_FILE" | awk '{print $1}')"
-            if [[ "$custody_evidence_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
-              custody_evidence_sha256_valid="true"
+          record_check "signer_secret_contract" "$signer_secret_command" "pass" "signer_secret_validated"
+          if [ "$RECEIVED_APPROVALS" -lt "$REQUIRED_APPROVALS" ]; then
+            echo "signer quorum approvals below required threshold: required=$REQUIRED_APPROVALS received=$RECEIVED_APPROVALS" >&2
+            record_check "signer_quorum_contract" "$signer_quorum_command" "fail" "signer_quorum_shortfall"
+            record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_quorum_shortfall"
+            record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_quorum_shortfall"
+            record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_quorum_shortfall"
+            overall_status="fail"
+            reason_code="checkpoint_failed_signer_quorum_contract"
+          else
+            record_check "signer_quorum_contract" "$signer_quorum_command" "pass" "signer_quorum_validated"
+            if [ -n "$CUSTODY_EVIDENCE_FILE" ] && [ -f "$CUSTODY_EVIDENCE_FILE" ]; then
+              custody_evidence_present="true"
+              custody_evidence_sha256="$(sha256sum "$CUSTODY_EVIDENCE_FILE" | awk '{print $1}')"
+              if [[ "$custody_evidence_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+                custody_evidence_sha256_valid="true"
+              fi
+            fi
+
+            if [ "$custody_evidence_present" != "true" ]; then
+              echo "signer custody evidence file is required for selected profile" >&2
+              record_check "custody_evidence_contract" "$custody_evidence_command" "fail" "custody_evidence_missing"
+              record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "custody_evidence_missing"
+              record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "custody_evidence_missing"
+              overall_status="fail"
+              reason_code="checkpoint_failed_custody_evidence_contract"
+            elif [ "$custody_evidence_sha256_valid" != "true" ]; then
+              echo "signer custody evidence sha256 marker is invalid: $CUSTODY_EVIDENCE_FILE" >&2
+              record_check "custody_evidence_contract" "$custody_evidence_command" "fail" "custody_evidence_sha256_invalid"
+              record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "custody_evidence_sha256_invalid"
+              record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "custody_evidence_sha256_invalid"
+              overall_status="fail"
+              reason_code="checkpoint_failed_custody_evidence_contract"
+            else
+              record_check "custody_evidence_contract" "$custody_evidence_command" "pass" "custody_evidence_validated"
+
+              signer_provenance_reason=""
+              signer_provenance_message=""
+              if [ "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" != "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" ]; then
+                signer_provenance_reason="signer_key_source_contract_version_mismatch"
+                signer_provenance_message="signer key source contract version must remain ${SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED}: $SIGNER_KEY_SOURCE_CONTRACT_VERSION"
+              elif [ "$SIGNER_KEY_SOURCE" != "env-local" ] && [ "$SIGNER_KEY_SOURCE" != "managed-external" ]; then
+                signer_provenance_reason="signer_key_source_invalid"
+                signer_provenance_message="signer key source is unsupported: $SIGNER_KEY_SOURCE"
+              elif [ "$SIGNER_PROFILE" = "$SECONDARY_SIGNER_PROFILE" ] && [ "$SIGNER_KEY_SOURCE" != "env-local" ]; then
+                signer_provenance_reason="signer_key_source_profile_pair_disallowed"
+                signer_provenance_message="signer key source/profile pair is not allowed: profile=$SIGNER_PROFILE source=$SIGNER_KEY_SOURCE"
+              else
+                if [ -n "$SIGNER_PROVENANCE_FILE" ] && [ -f "$SIGNER_PROVENANCE_FILE" ]; then
+                  signer_provenance_present="true"
+                  signer_provenance_sha256="$(sha256sum "$SIGNER_PROVENANCE_FILE" | awk '{print $1}')"
+                  if [[ "$signer_provenance_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+                    signer_provenance_sha256_valid="true"
+                  fi
+                fi
+                if [ "$signer_provenance_present" != "true" ]; then
+                  signer_provenance_reason="signer_provenance_missing"
+                  signer_provenance_message="signer provenance evidence file is required for selected profile"
+                elif [ "$signer_provenance_sha256_valid" != "true" ]; then
+                  signer_provenance_reason="signer_provenance_sha256_invalid"
+                  signer_provenance_message="signer provenance evidence sha256 marker is invalid: $SIGNER_PROVENANCE_FILE"
+                fi
+              fi
+
+              if [ -n "$signer_provenance_reason" ]; then
+                echo "$signer_provenance_message" >&2
+                record_check "signer_provenance_contract" "$signer_provenance_command" "fail" "$signer_provenance_reason"
+                record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "$signer_provenance_reason"
+                overall_status="fail"
+                reason_code="checkpoint_failed_signer_provenance_contract"
+              else
+                record_check "signer_provenance_contract" "$signer_provenance_command" "pass" "signer_provenance_validated"
+
+                signer_rotation_delta_epochs="$(( SIGNER_ROTATION_EPOCH - SIGNER_PREVIOUS_ROTATION_EPOCH ))"
+                signer_rotation_reason=""
+                signer_rotation_message=""
+                if [ "$signer_rotation_delta_epochs" -lt 0 ]; then
+                  signer_rotation_reason="signer_rotation_epoch_invalid"
+                  signer_rotation_message="signer rotation epoch must be greater than or equal to previous rotation epoch"
+                elif [ "$signer_rotation_delta_epochs" -gt "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" ]; then
+                  signer_rotation_reason="signer_rotation_epoch_stale"
+                  signer_rotation_message="signer rotation metadata exceeded freshness threshold: delta=$signer_rotation_delta_epochs max=$SIGNER_ROTATION_FRESHNESS_MAX_DELTA"
+                fi
+
+                if [ -n "$signer_rotation_reason" ]; then
+                  echo "$signer_rotation_message" >&2
+                  signer_rotation_fresh="false"
+                  record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "fail" "$signer_rotation_reason"
+                  overall_status="fail"
+                  reason_code="checkpoint_failed_signer_rotation_freshness_contract"
+                else
+                  signer_rotation_fresh="true"
+                  record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "pass" "signer_rotation_freshness_validated"
+                  reason_code="deployment_preflight_passed"
+                fi
+              fi
             fi
           fi
-
-          if [ "$custody_evidence_present" != "true" ]; then
-            echo "signer custody evidence file is required for selected profile" >&2
-            record_check "custody_evidence_contract" "$custody_evidence_command" "fail" "custody_evidence_missing"
-            overall_status="fail"
-            reason_code="checkpoint_failed_custody_evidence_contract"
-          elif [ "$custody_evidence_sha256_valid" != "true" ]; then
-            echo "signer custody evidence sha256 marker is invalid: $CUSTODY_EVIDENCE_FILE" >&2
-            record_check "custody_evidence_contract" "$custody_evidence_command" "fail" "custody_evidence_sha256_invalid"
-            overall_status="fail"
-            reason_code="checkpoint_failed_custody_evidence_contract"
-          else
-            record_check "custody_evidence_contract" "$custody_evidence_command" "pass" "custody_evidence_validated"
-            reason_code="deployment_preflight_passed"
-          fi
         fi
-      fi
       fi
     fi
   fi
@@ -296,7 +460,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" <<'PY'
 from __future__ import annotations
 
 import json
@@ -331,6 +495,18 @@ custody_evidence_file = sys.argv[25]
 custody_evidence_present = sys.argv[26] == "true"
 custody_evidence_sha256 = sys.argv[27]
 custody_evidence_sha256_valid = sys.argv[28] == "true"
+signer_provenance_file = sys.argv[29]
+signer_provenance_present = sys.argv[30] == "true"
+signer_provenance_sha256 = sys.argv[31]
+signer_provenance_sha256_valid = sys.argv[32] == "true"
+signer_key_source_contract_version = sys.argv[33]
+signer_key_source = sys.argv[34]
+signer_key_source_contract_version_supported = sys.argv[35]
+signer_rotation_epoch = int(sys.argv[36])
+signer_previous_rotation_epoch = int(sys.argv[37])
+signer_rotation_freshness_max_delta = int(sys.argv[38])
+signer_rotation_delta_epochs = int(sys.argv[39])
+signer_rotation_fresh = sys.argv[40] == "true"
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -373,6 +549,17 @@ summary = {
     "custody_evidence_present": custody_evidence_present,
     "custody_evidence_sha256": custody_evidence_sha256,
     "custody_evidence_sha256_valid": custody_evidence_sha256_valid,
+    "signer_provenance_file": signer_provenance_file,
+    "signer_provenance_present": signer_provenance_present,
+    "signer_provenance_sha256": signer_provenance_sha256,
+    "signer_provenance_sha256_valid": signer_provenance_sha256_valid,
+    "signer_key_source_contract_version": signer_key_source_contract_version,
+    "signer_key_source": signer_key_source,
+    "signer_rotation_epoch": signer_rotation_epoch,
+    "signer_previous_rotation_epoch": signer_previous_rotation_epoch,
+    "signer_rotation_freshness_max_delta": signer_rotation_freshness_max_delta,
+    "signer_rotation_delta_epochs": signer_rotation_delta_epochs,
+    "signer_rotation_fresh": signer_rotation_fresh,
     "contracts": {
         "ci_fast_gate_scope": "ci-fast-gate",
         "required_runtime_mode": required_runtime_mode,
@@ -388,6 +575,14 @@ summary = {
         "approval_quorum_source": "local-operator-attestations",
         "custody_evidence_required": True,
         "custody_evidence_sha256_required": True,
+        "signer_provenance_required": True,
+        "signer_provenance_sha256_required": True,
+        "signer_key_source_contract_version": signer_key_source_contract_version_supported,
+        "signer_key_source": signer_key_source,
+        "signer_key_source_allowed_for_ops_primary": ["env-local", "managed-external"],
+        "signer_key_source_allowed_for_ops_secondary": ["env-local"],
+        "signer_rotation_freshness_max_delta": signer_rotation_freshness_max_delta,
+        "signer_rotation_stale_rejected": True,
     },
     "checks": checks,
     "artifact_paths": [],
@@ -402,6 +597,8 @@ echo "lane_mode=$MODE"
 echo "reason_code=$reason_code"
 echo "budget_status=$budget_status"
 echo "ci_fast_gate_eligible=true"
+echo "signer_key_source=$SIGNER_KEY_SOURCE"
+echo "signer_rotation_delta_epochs=$signer_rotation_delta_epochs"
 echo "summary_file=$(realpath "$OUTPUT_JSON")"
 
 if [ "$overall_status" != "ok" ]; then

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -60,6 +60,17 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "custody_evidence_present": false,
   "custody_evidence_sha256": "",
   "custody_evidence_sha256_valid": false,
+  "signer_provenance_file": "",
+  "signer_provenance_present": false,
+  "signer_provenance_sha256": "",
+  "signer_provenance_sha256_valid": false,
+  "signer_key_source_contract_version": "v1",
+  "signer_key_source": "env-local",
+  "signer_rotation_epoch": 1,
+  "signer_previous_rotation_epoch": 1,
+  "signer_rotation_freshness_max_delta": 2,
+  "signer_rotation_delta_epochs": 0,
+  "signer_rotation_fresh": false,
   "contracts": {
     "ci_fast_gate_scope": "ci-fast-gate",
     "required_runtime_mode": "kolme-live",
@@ -77,7 +88,20 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "approval_quorum_required": 2,
     "approval_quorum_source": "local-operator-attestations",
     "custody_evidence_required": true,
-    "custody_evidence_sha256_required": true
+    "custody_evidence_sha256_required": true,
+    "signer_provenance_required": true,
+    "signer_provenance_sha256_required": true,
+    "signer_key_source_contract_version": "v1",
+    "signer_key_source": "env-local",
+    "signer_key_source_allowed_for_ops_primary": [
+      "env-local",
+      "managed-external"
+    ],
+    "signer_key_source_allowed_for_ops_secondary": [
+      "env-local"
+    ],
+    "signer_rotation_freshness_max_delta": 2,
+    "signer_rotation_stale_rejected": true
   },
   "checks": [
     {
@@ -113,6 +137,18 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     {
       "id": "custody_evidence_contract",
       "command": "signer custody evidence file and sha256 marker must be present",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "signer_provenance_contract",
+      "command": "signer provenance evidence file and sha256 marker must be present",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "signer_rotation_freshness_contract",
+      "command": "signer rotation metadata must satisfy freshness threshold",
       "status": "planned",
       "reason_code": "not_run"
     }
@@ -167,6 +203,17 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "custody_evidence_present": false,
   "custody_evidence_sha256": "",
   "custody_evidence_sha256_valid": false,
+  "signer_provenance_file": "",
+  "signer_provenance_present": false,
+  "signer_provenance_sha256": "",
+  "signer_provenance_sha256_valid": false,
+  "signer_key_source_contract_version": "v0",
+  "signer_key_source": "legacy-local",
+  "signer_rotation_epoch": 7,
+  "signer_previous_rotation_epoch": 1,
+  "signer_rotation_freshness_max_delta": 2,
+  "signer_rotation_delta_epochs": 6,
+  "signer_rotation_fresh": false,
   "contracts": {
     "ci_fast_gate_scope": "local-only",
     "required_runtime_mode": "kolme-live",
@@ -184,7 +231,19 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
     "approval_quorum_required": 2,
     "approval_quorum_source": "local-operator-attestations",
     "custody_evidence_required": true,
-    "custody_evidence_sha256_required": true
+    "custody_evidence_sha256_required": true,
+    "signer_provenance_required": false,
+    "signer_provenance_sha256_required": false,
+    "signer_key_source_contract_version": "v0",
+    "signer_key_source": "legacy-local",
+    "signer_key_source_allowed_for_ops_primary": [
+      "legacy-local"
+    ],
+    "signer_key_source_allowed_for_ops_secondary": [
+      "legacy-local"
+    ],
+    "signer_rotation_freshness_max_delta": 4,
+    "signer_rotation_stale_rejected": false
   },
   "checks": [
     {
@@ -233,6 +292,11 @@ if ! grep -q "check_missing:signer_secret_contract" "$TMP_ERR"; then
   exit 1
 fi
 
+if ! grep -q "check_missing:signer_provenance_contract" "$TMP_ERR"; then
+  echo "expected missing signer_provenance_contract check reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
 if ! grep -q "fallback_signer_secret_present_violation" "$TMP_ERR"; then
   echo "expected fallback signer secret presence violation reason for deployment preflight policy failure" >&2
   exit 1
@@ -260,6 +324,31 @@ fi
 
 if ! grep -q "check_missing:custody_evidence_contract" "$TMP_ERR"; then
   echo "expected missing custody_evidence_contract check reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "check_missing:signer_rotation_freshness_contract" "$TMP_ERR"; then
+  echo "expected missing signer_rotation_freshness_contract check reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_key_source_contract_version_mismatch" "$TMP_ERR"; then
+  echo "expected signer key-source contract version mismatch reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_key_source_invalid" "$TMP_ERR"; then
+  echo "expected signer key-source invalid reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_provenance_missing" "$TMP_ERR"; then
+  echo "expected signer provenance missing reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_rotation_epoch_stale" "$TMP_ERR"; then
+  echo "expected signer rotation stale reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
@@ -70,9 +70,16 @@ required_coverage_markers=(
   "checkpoint_failed_signer_secret_contract"
   "checkpoint_failed_signer_quorum_contract"
   "checkpoint_failed_custody_evidence_contract"
+  "checkpoint_failed_signer_provenance_contract"
+  "checkpoint_failed_signer_rotation_freshness_contract"
+  "signer_key_source_contract_version"
+  "signer_key_source"
+  "signer_provenance_file"
+  "signer_rotation_epoch_stale"
   "signer_quorum_shortfall"
   "custody_evidence_missing"
   "Regression: #2226"
+  "Regression: #2300"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q -- "$marker" "$CONTRACT_IMPL"; then
@@ -96,6 +103,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "Regression: #2226" "$docs_file"; then
     echo "expected docs parity to include deployment preflight contract-lane regression marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2300" "$docs_file"; then
+    echo "expected docs parity to include signer provenance/rotation regression marker in $docs_file" >&2
     exit 1
   fi
 done

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -9,9 +9,11 @@ README_FILE="$ROOT_DIR/README.md"
 TMP_SUMMARY="$(mktemp)"
 TMP_ERR="$(mktemp)"
 TMP_CUSTODY="$(mktemp)"
-trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY"' EXIT
+TMP_PROVENANCE="$(mktemp)"
+trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY" "$TMP_PROVENANCE"' EXIT
 
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" >"$TMP_CUSTODY"
+printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" >"$TMP_PROVENANCE"
 
 extract_value() {
   local output="$1"
@@ -105,6 +107,18 @@ if summary.get("received_approvals") != 0:
     raise SystemExit("expected deployment preflight summary received_approvals=0 for dry-run")
 if summary.get("custody_evidence_present") is not False:
     raise SystemExit("expected deployment preflight summary custody evidence marker to be false in dry-run")
+if summary.get("signer_provenance_present") is not False:
+    raise SystemExit("expected deployment preflight summary signer provenance marker to be false in dry-run")
+if summary.get("signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected deployment preflight summary signer key-source contract version marker")
+if summary.get("signer_key_source") != "env-local":
+    raise SystemExit("expected deployment preflight summary signer key-source marker")
+if summary.get("signer_rotation_epoch") != 1:
+    raise SystemExit("expected deployment preflight summary signer rotation epoch marker")
+if summary.get("signer_previous_rotation_epoch") != 1:
+    raise SystemExit("expected deployment preflight summary signer previous rotation epoch marker")
+if summary.get("signer_rotation_freshness_max_delta") != 2:
+    raise SystemExit("expected deployment preflight summary signer rotation freshness max delta marker")
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "ci-fast-gate":
     raise SystemExit("expected deployment preflight contracts to set ci-fast-gate scope")
@@ -114,6 +128,18 @@ if contracts.get("custody_evidence_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer custody evidence")
 if contracts.get("approval_quorum_required") != 2:
     raise SystemExit("expected deployment preflight contracts approval quorum requirement marker")
+if contracts.get("signer_provenance_required") is not True:
+    raise SystemExit("expected deployment preflight contracts to require signer provenance evidence")
+if contracts.get("signer_provenance_sha256_required") is not True:
+    raise SystemExit("expected deployment preflight contracts to require signer provenance sha256 evidence")
+if contracts.get("signer_key_source_contract_version") != "v1":
+    raise SystemExit("expected deployment preflight contracts signer key-source contract version marker")
+if contracts.get("signer_key_source") != "env-local":
+    raise SystemExit("expected deployment preflight contracts signer key-source marker")
+if contracts.get("signer_rotation_freshness_max_delta") != 2:
+    raise SystemExit("expected deployment preflight contracts signer rotation freshness max delta marker")
+if contracts.get("signer_rotation_stale_rejected") is not True:
+    raise SystemExit("expected deployment preflight contracts signer rotation stale rejection marker")
 PY
 
 set +e
@@ -193,12 +219,59 @@ if ! grep -q "signer custody evidence file is required for selected profile" "$T
   exit 1
 fi
 
+set +e
 KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
 bash "$RUNNER" \
   --mode run \
   --required-approvals 2 \
   --received-approvals 2 \
   --custody-evidence-file "$TMP_CUSTODY" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+missing_provenance_exit_code=$?
+set -e
+
+if [ "$missing_provenance_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight run mode to fail closed when signer provenance evidence is missing" >&2
+  exit 1
+fi
+
+if ! grep -q "signer provenance evidence file is required for selected profile" "$TMP_ERR"; then
+  echo "expected deterministic missing signer provenance evidence message from deployment preflight lane" >&2
+  exit 1
+fi
+
+set +e
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
+bash "$RUNNER" \
+  --mode run \
+  --required-approvals 2 \
+  --received-approvals 2 \
+  --custody-evidence-file "$TMP_CUSTODY" \
+  --signer-provenance-file "$TMP_PROVENANCE" \
+  --signer-rotation-epoch 8 \
+  --signer-previous-rotation-epoch 3 \
+  --signer-rotation-freshness-max-delta 2 \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+stale_rotation_exit_code=$?
+set -e
+
+if [ "$stale_rotation_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight run mode to fail closed when signer rotation metadata is stale" >&2
+  exit 1
+fi
+
+if ! grep -q "signer rotation metadata exceeded freshness threshold" "$TMP_ERR"; then
+  echo "expected deterministic signer rotation stale message from deployment preflight lane" >&2
+  exit 1
+fi
+
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
+bash "$RUNNER" \
+  --mode run \
+  --required-approvals 2 \
+  --received-approvals 2 \
+  --custody-evidence-file "$TMP_CUSTODY" \
+  --signer-provenance-file "$TMP_PROVENANCE" \
   --output-json "$TMP_SUMMARY" >/dev/null
 
 python3 - "$TMP_SUMMARY" <<'PY'
@@ -217,6 +290,12 @@ if summary.get("required_approvals") != 2 or summary.get("received_approvals") !
     raise SystemExit("expected deployment preflight run summary to capture signer quorum counts")
 if summary.get("custody_evidence_present") is not True:
     raise SystemExit("expected deployment preflight run summary custody evidence marker true")
+if summary.get("signer_provenance_present") is not True:
+    raise SystemExit("expected deployment preflight run summary signer provenance marker true")
+if summary.get("signer_provenance_sha256_valid") is not True:
+    raise SystemExit("expected deployment preflight run summary signer provenance sha256 marker true")
+if summary.get("signer_rotation_fresh") is not True:
+    raise SystemExit("expected deployment preflight run summary signer rotation freshness marker true")
 PY
 
 echo "local Kolme live deployment preflight lane tests passed."


### PR DESCRIPTION
Closes #2300

## Summary
Add fail-closed signer provenance and signer rotation freshness enforcement to the local Kolme live deployment preflight lane and policy checker so signer source controls are auditable and stale key rotations are rejected.

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`: add provenance/rotation CLI args, checks, reason codes, and contract summary fields.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`: validate key-source contract, provenance evidence, rotation freshness, and required check IDs in run mode.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`: add contract assertions and negative fixtures for new provenance/freshness controls.
- `scripts/kolme/test_*preflight*`: extend red/green coverage for missing provenance and stale rotation failures.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: update contract docs and regression markers for the new controls.

## Risks & Compatibility
- Existing run invocations may need to provide `--signer-provenance-file` and rotation metadata where run mode enforcement is expected.
- No runtime API break outside the preflight contract lane inputs.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised dry-run/run pass/fail paths for provenance and rotation freshness in lane + policy scripts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Policy checker and lane tests cover pass/fail and reason-code assertions. |
| Functional  | ✅ | Run-mode preflight now fails closed on missing provenance and stale rotation. |
| Integration | ✅ | Contract lane + docs/README contract tests verify marker and command-surface parity. |
| Regression  | ✅ | Added `Regression: #2300` markers and negative fixtures for stale/missing evidence paths. |

## Red/Green Evidence
- Red: `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` failed when `signer_provenance_contract` and rotation checks were required but not implemented.
- Green: bash/python syntax checks, three Kolme preflight test lanes, docs contract tests, README/CI contract tests, `cargo fmt --check`, and `cargo clippy -- -D warnings` all pass locally.
