### PR TITLE
feat(kolme): enforce quorum evidence deployment preflight contracts (#2301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,10 +641,20 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json
 # sample signer provenance evidence marker for run mode
 printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json
+# sample signer quorum evidence bundle for run mode
+custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
+{
+  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "required_approvals": 2,
+  "received_approvals": 2,
+  "approved_signers": ["ops-primary", "ops-secondary"],
+  "custody_evidence_sha256": "$custody_sha"
+}
+JSON
 
 # deployment preflight run mode (fast-gate eligible, no local-heavy gate required)
 KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 \
-bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
+bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
 
 # deployment preflight policy checker contract
 python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json
@@ -667,10 +677,23 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # signer_rotation_fresh
 # required_approvals=2
 # received_approvals=2
+# quorum_evidence_file
+# quorum_evidence_present
+# quorum_evidence_sha256_valid
+# quorum_evidence_schema_valid
+# quorum_evidence_approval_count
+# quorum_evidence_signers_unique
+# quorum_evidence_matches_threshold
+# quorum_evidence_custody_sha256_match
 # contracts.ci_fast_gate_scope=ci-fast-gate
 # contracts.required_runtime_mode=kolme-live
 # contracts.fallback_private_key_path_allowed=false
 # contracts.approval_quorum_required=2
+# contracts.quorum_evidence_required=true
+# contracts.quorum_evidence_sha256_required=true
+# contracts.quorum_evidence_schema_version=kamn.kolme.signer-quorum-evidence.v1
+# contracts.quorum_evidence_signer_uniqueness_required=true
+# contracts.quorum_evidence_custody_sha256_match_required=true
 # contracts.custody_evidence_required=true
 # contracts.signer_provenance_required=true
 # contracts.signer_provenance_sha256_required=true
@@ -685,10 +708,17 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # fallback_signer_secret_present_violation
 # checkpoint_failed_signer_secret_contract
 # checkpoint_failed_signer_quorum_contract
+# checkpoint_failed_quorum_evidence_contract
 # checkpoint_failed_custody_evidence_contract
 # checkpoint_failed_signer_provenance_contract
 # checkpoint_failed_signer_rotation_freshness_contract
 # signer_quorum_shortfall
+# quorum_evidence_missing
+# quorum_evidence_sha256_invalid
+# quorum_evidence_schema_invalid
+# quorum_evidence_signers_not_unique
+# quorum_evidence_approvals_mismatch
+# quorum_evidence_custody_sha256_mismatch
 # custody_evidence_missing
 # custody_evidence_sha256_invalid
 # signer_key_source_contract_version_mismatch
@@ -703,6 +733,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # Regression: #2225
 # Regression: #2226
 # Regression: #2300
+# Regression: #2301
 ```
 
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`

--- a/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
+++ b/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
@@ -67,6 +67,19 @@ fn runbook_contains_signer_incident_recovery_contract_lanes() {
 }
 
 #[test]
+fn runbook_contains_kolme_multi_signer_deployment_preflight_contract_lane() {
+    assert!(
+        RUNBOOK.contains("## Kolme Multi-Signer Deployment Preflight Contract Lane (Issue #2301)")
+    );
+    assert!(RUNBOOK.contains("run_local_kolme_live_deployment_preflight_lane.sh"));
+    assert!(RUNBOOK.contains("check_local_kolme_live_deployment_preflight_policy.py"));
+    assert!(RUNBOOK.contains("run_local_kolme_live_deployment_preflight_contract_lane.sh"));
+    assert!(RUNBOOK.contains("kamn.kolme.signer-quorum-evidence.v1"));
+    assert!(RUNBOOK.contains("checkpoint_failed_quorum_evidence_contract"));
+    assert!(RUNBOOK.contains("quorum_evidence_custody_sha256_mismatch"));
+}
+
+#[test]
 fn runbook_contains_live_network_pilot_rollback_evidence_gate() {
     assert!(RUNBOOK.contains("## Live-Network Pilot Rollback Evidence Gate"));
     assert!(RUNBOOK.contains("run_live_network_pilot_deep_lane.sh"));
@@ -146,5 +159,13 @@ fn regression_requires_signer_incident_recovery_fail_closed_guard() {
     // Regression: #989
     assert!(RUNBOOK.contains(
         "runbook-step drift, revocation propagation gaps, stale deep-lane artifacts, or cadence violations force `NO-GO` (`Regression: #989`)."
+    ));
+}
+
+#[test]
+fn regression_requires_kolme_multi_signer_preflight_fail_closed_guard() {
+    // Regression: #2301
+    assert!(RUNBOOK.contains(
+        "signer quorum/custody/provenance drift, quorum evidence schema drift, or contract-lane/docs parity drift force `NO-GO` (`Regression: #2301`)."
     ));
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -385,7 +385,16 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
     - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
-    - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+    - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
+{
+  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "required_approvals": 2,
+  "received_approvals": 2,
+  "approved_signers": ["ops-primary", "ops-secondary"],
+  "custody_evidence_sha256": "$custody_sha"
+}
+JSON`
+    - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - deterministic marker contracts:
@@ -403,10 +412,23 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `signer_rotation_fresh`
       - `required_approvals=2`
       - `received_approvals=2`
+      - `quorum_evidence_file`
+      - `quorum_evidence_present`
+      - `quorum_evidence_sha256_valid`
+      - `quorum_evidence_schema_valid`
+      - `quorum_evidence_approval_count`
+      - `quorum_evidence_signers_unique`
+      - `quorum_evidence_matches_threshold`
+      - `quorum_evidence_custody_sha256_match`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
       - `contracts.required_runtime_mode=kolme-live`
       - `contracts.fallback_private_key_path_allowed=false`
       - `contracts.approval_quorum_required=2`
+      - `contracts.quorum_evidence_required=true`
+      - `contracts.quorum_evidence_sha256_required=true`
+      - `contracts.quorum_evidence_schema_version=kamn.kolme.signer-quorum-evidence.v1`
+      - `contracts.quorum_evidence_signer_uniqueness_required=true`
+      - `contracts.quorum_evidence_custody_sha256_match_required=true`
       - `contracts.custody_evidence_required=true`
       - `contracts.signer_provenance_required=true`
       - `contracts.signer_provenance_sha256_required=true`
@@ -420,10 +442,17 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `fallback_signer_secret_present_violation`
       - `checkpoint_failed_signer_secret_contract`
       - `checkpoint_failed_signer_quorum_contract`
+      - `checkpoint_failed_quorum_evidence_contract`
       - `checkpoint_failed_custody_evidence_contract`
       - `checkpoint_failed_signer_provenance_contract`
       - `checkpoint_failed_signer_rotation_freshness_contract`
       - `signer_quorum_shortfall`
+      - `quorum_evidence_missing`
+      - `quorum_evidence_sha256_invalid`
+      - `quorum_evidence_schema_invalid`
+      - `quorum_evidence_signers_not_unique`
+      - `quorum_evidence_approvals_mismatch`
+      - `quorum_evidence_custody_sha256_mismatch`
       - `custody_evidence_missing`
       - `custody_evidence_sha256_invalid`
       - `signer_key_source_contract_version_mismatch`
@@ -434,6 +463,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `signer_rotation_epoch_stale`
     - deployment preflight contract lane parity remains fail-closed (`Regression: #2226`).
     - deployment preflight signer provenance + rotation freshness parity remains fail-closed (`Regression: #2300`).
+    - deployment preflight signer quorum evidence parity remains fail-closed (`Regression: #2301`).
   - local fork process lifecycle integration run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --serve-command "python3 /tmp/mock_kolme_api.py 3000 v0.15.2" --max-seconds 300 --startup-max-seconds 45 --integration-max-seconds 240 --integration-bootstrap-max-seconds 90 --integration-conformance-max-seconds 180 --integration-runtime-commit-max-seconds 30 --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json`
     - process lifecycle integration command composition must include `--runtime-commit-live-policy-report` for nested integration evidence lineage.

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -94,6 +94,41 @@ Signer incident response requires deterministic lane reports, fail-closed policy
 - Regression policy:
   - runbook-step drift, revocation propagation gaps, stale deep-lane artifacts, or cadence violations force `NO-GO` (`Regression: #989`).
 
+## Kolme Multi-Signer Deployment Preflight Contract Lane (Issue #2301)
+Local Kolme deployment gates require deterministic multi-signer quorum and custody evidence before live runtime operations proceed.
+
+- Deployment preflight lane command:
+  - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+- Quorum/custody/provenance evidence preparation:
+  - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
+  - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+  - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
+{
+  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "required_approvals": 2,
+  "received_approvals": 2,
+  "approved_signers": ["ops-primary", "ops-secondary"],
+  "custody_evidence_sha256": "$custody_sha"
+}
+JSON`
+- Deployment preflight run mode:
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+- Deployment preflight policy checker:
+  - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+- Deployment preflight contract lane:
+  - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+- Required schema/reason markers:
+  - `kamn.kolme.local-live-deployment-preflight-summary.v1`
+  - `kamn.kolme.local-live-deployment-preflight-policy-report.v1`
+  - `kamn.kolme.signer-quorum-evidence.v1`
+  - `checkpoint_failed_signer_quorum_contract`
+  - `checkpoint_failed_quorum_evidence_contract`
+  - `checkpoint_failed_custody_evidence_contract`
+  - `quorum_evidence_missing`
+  - `quorum_evidence_custody_sha256_mismatch`
+- Regression policy:
+  - signer quorum/custody/provenance drift, quorum evidence schema drift, or contract-lane/docs parity drift force `NO-GO` (`Regression: #2301`).
+
 ## Deployment SLO Evidence and Rollback Automation Contract
 Deterministic deployment SLO/rollback policy checks are enforced through a bounded deployment lane:
 
@@ -192,6 +227,9 @@ bash scripts/signer/test_run_signer_incident_recovery_lane.sh
 bash scripts/signer/test_check_signer_incident_recovery_policy.sh
 bash scripts/signer/test_run_signer_incident_recovery_contract_lane.sh
 bash scripts/signer/test_run_signer_incident_recovery_deep_lane.sh
+bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
 bash scripts/governance/test_run_governance_lifecycle_rollback_lane.sh
 bash scripts/governance/test_check_governance_lifecycle_rollback_policy.sh
 bash scripts/governance/test_run_governance_lifecycle_rollback_contract_lane.sh

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -537,7 +537,16 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Deployment preflight run mode:
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
   - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
-  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+  - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
+{
+  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "required_approvals": 2,
+  "received_approvals": 2,
+  "approved_signers": ["ops-primary", "ops-secondary"],
+  "custody_evidence_sha256": "$custody_sha"
+}
+JSON`
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Deployment preflight policy checker command:
   - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
 - Deployment preflight contract lane command:
@@ -551,6 +560,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `signer_secret_contract`: selected signer secret env must be present and 64-char hex.
   - `fallback_private_key_contract`: fallback signer secret env must remain unset.
   - `signer_quorum_contract`: received approvals must satisfy required approvals threshold.
+  - `quorum_evidence_contract`: quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match.
   - `custody_evidence_contract`: signer custody evidence file and sha256 marker must be present.
   - `signer_provenance_contract`: signer provenance evidence file and sha256 marker must be present.
   - `signer_rotation_freshness_contract`: signer rotation metadata must satisfy freshness threshold.
@@ -573,6 +583,14 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `signer_rotation_fresh`
     - `required_approvals=2`
     - `received_approvals`
+    - `quorum_evidence_file`
+    - `quorum_evidence_present`
+    - `quorum_evidence_sha256_valid`
+    - `quorum_evidence_schema_valid`
+    - `quorum_evidence_approval_count`
+    - `quorum_evidence_signers_unique`
+    - `quorum_evidence_matches_threshold`
+    - `quorum_evidence_custody_sha256_match`
     - `custody_evidence_file`
     - `custody_evidence_present`
     - `custody_evidence_sha256_valid`
@@ -583,6 +601,12 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `contracts.fallback_private_key_path_allowed=false`
     - `contracts.approval_quorum_required=2`
     - `contracts.approval_quorum_source=local-operator-attestations`
+    - `contracts.quorum_evidence_required=true`
+    - `contracts.quorum_evidence_sha256_required=true`
+    - `contracts.quorum_evidence_schema_version=kamn.kolme.signer-quorum-evidence.v1`
+    - `contracts.quorum_evidence_signer_uniqueness_required=true`
+    - `contracts.quorum_evidence_custody_sha256_match_required=true`
+    - `contracts.quorum_evidence_source=operator-attestation-bundle`
     - `contracts.custody_evidence_required=true`
     - `contracts.custody_evidence_sha256_required=true`
     - `contracts.signer_provenance_required=true`
@@ -598,10 +622,17 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `fallback_signer_secret_present_violation`
   - `checkpoint_failed_signer_secret_contract`
   - `checkpoint_failed_signer_quorum_contract`
+  - `checkpoint_failed_quorum_evidence_contract`
   - `checkpoint_failed_custody_evidence_contract`
   - `checkpoint_failed_signer_provenance_contract`
   - `checkpoint_failed_signer_rotation_freshness_contract`
   - `signer_quorum_shortfall`
+  - `quorum_evidence_missing`
+  - `quorum_evidence_sha256_invalid`
+  - `quorum_evidence_schema_invalid`
+  - `quorum_evidence_signers_not_unique`
+  - `quorum_evidence_approvals_mismatch`
+  - `quorum_evidence_custody_sha256_mismatch`
   - `custody_evidence_missing`
   - `custody_evidence_sha256_invalid`
   - `signer_key_source_contract_version_mismatch`
@@ -616,6 +647,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - docs/command/policy parity for this lane remains fail-closed (`Regression: #2225`).
   - deployment preflight contract lane parity remains fail-closed (`Regression: #2226`).
   - signer provenance + rotation freshness marker parity remains fail-closed (`Regression: #2300`).
+  - signer quorum evidence schema + custody digest parity remains fail-closed (`Regression: #2301`).
 
 ## Live Provider Operator Runbook (Issue #2114)
 
@@ -635,6 +667,15 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
   - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+  - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
+{
+  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "required_approvals": 2,
+  "received_approvals": 2,
+  "approved_signers": ["ops-primary", "ops-secondary"],
+  "custody_evidence_sha256": "$custody_sha"
+}
+JSON`
 
 ### Execution Flow
 
@@ -680,6 +721,8 @@ Operator checkpoints:
   - verify signer profile and selected signer secret env are set with a valid 64-hex key.
 - `reason_code=checkpoint_failed_signer_quorum_contract`:
   - verify `--received-approvals` is greater than or equal to `--required-approvals`.
+- `reason_code=checkpoint_failed_quorum_evidence_contract`:
+  - verify `--quorum-evidence-file` exists, `schema_version=kamn.kolme.signer-quorum-evidence.v1`, signer IDs are unique, approval counts match `--received-approvals`, and custody digest matches `--custody-evidence-file`.
 - `reason_code=checkpoint_failed_custody_evidence_contract`:
   - verify `--custody-evidence-file` exists and its sha256 can be emitted in summary markers.
 - `reason_code=checkpoint_failed_signer_provenance_contract`:

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -14,6 +14,7 @@ SECONDARY_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 FALLBACK_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH = 64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
+QUORUM_EVIDENCE_SCHEMA_VERSION = "kamn.kolme.signer-quorum-evidence.v1"
 ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
     PRIMARY_SIGNER_PROFILE: ("env-local", "managed-external"),
@@ -202,6 +203,42 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(received_approvals, int) or received_approvals < 0:
         reason_codes.append("received_approvals_invalid")
 
+    quorum_evidence_file = report.get("quorum_evidence_file")
+    if not isinstance(quorum_evidence_file, str):
+        reason_codes.append("quorum_evidence_file_invalid")
+
+    quorum_evidence_present = report.get("quorum_evidence_present")
+    if not isinstance(quorum_evidence_present, bool):
+        reason_codes.append("quorum_evidence_present_invalid")
+
+    quorum_evidence_sha256 = report.get("quorum_evidence_sha256")
+    if not isinstance(quorum_evidence_sha256, str):
+        reason_codes.append("quorum_evidence_sha256_invalid")
+
+    quorum_evidence_sha256_valid = report.get("quorum_evidence_sha256_valid")
+    if not isinstance(quorum_evidence_sha256_valid, bool):
+        reason_codes.append("quorum_evidence_sha256_valid_invalid")
+
+    quorum_evidence_schema_valid = report.get("quorum_evidence_schema_valid")
+    if not isinstance(quorum_evidence_schema_valid, bool):
+        reason_codes.append("quorum_evidence_schema_valid_invalid")
+
+    quorum_evidence_approval_count = report.get("quorum_evidence_approval_count")
+    if not isinstance(quorum_evidence_approval_count, int) or quorum_evidence_approval_count < 0:
+        reason_codes.append("quorum_evidence_approval_count_invalid")
+
+    quorum_evidence_signers_unique = report.get("quorum_evidence_signers_unique")
+    if not isinstance(quorum_evidence_signers_unique, bool):
+        reason_codes.append("quorum_evidence_signers_unique_invalid")
+
+    quorum_evidence_matches_threshold = report.get("quorum_evidence_matches_threshold")
+    if not isinstance(quorum_evidence_matches_threshold, bool):
+        reason_codes.append("quorum_evidence_matches_threshold_invalid")
+
+    quorum_evidence_custody_sha256_match = report.get("quorum_evidence_custody_sha256_match")
+    if not isinstance(quorum_evidence_custody_sha256_match, bool):
+        reason_codes.append("quorum_evidence_custody_sha256_match_invalid")
+
     custody_evidence_file = report.get("custody_evidence_file")
     if not isinstance(custody_evidence_file, str):
         reason_codes.append("custody_evidence_file_invalid")
@@ -249,6 +286,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("approval_quorum_required_contract_mismatch")
         if contracts.get("approval_quorum_source") != "local-operator-attestations":
             reason_codes.append("approval_quorum_source_contract_mismatch")
+        if contracts.get("quorum_evidence_required") is not True:
+            reason_codes.append("quorum_evidence_required_contract_mismatch")
+        if contracts.get("quorum_evidence_sha256_required") is not True:
+            reason_codes.append("quorum_evidence_sha256_required_contract_mismatch")
+        if contracts.get("quorum_evidence_schema_version") != QUORUM_EVIDENCE_SCHEMA_VERSION:
+            reason_codes.append("quorum_evidence_schema_version_contract_mismatch")
+        if contracts.get("quorum_evidence_signer_uniqueness_required") is not True:
+            reason_codes.append("quorum_evidence_signer_uniqueness_required_contract_mismatch")
+        if contracts.get("quorum_evidence_custody_sha256_match_required") is not True:
+            reason_codes.append("quorum_evidence_custody_sha256_match_required_contract_mismatch")
+        if contracts.get("quorum_evidence_source") != "operator-attestation-bundle":
+            reason_codes.append("quorum_evidence_source_contract_mismatch")
         if contracts.get("custody_evidence_required") is not True:
             reason_codes.append("custody_evidence_required_contract_mismatch")
         if contracts.get("custody_evidence_sha256_required") is not True:
@@ -284,6 +333,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             "signer_secret_contract",
             "fallback_private_key_contract",
             "signer_quorum_contract",
+            "quorum_evidence_contract",
             "custody_evidence_contract",
             "signer_provenance_contract",
             "signer_rotation_freshness_contract",
@@ -335,6 +385,26 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         if isinstance(required_approvals, int) and isinstance(received_approvals, int):
             if received_approvals < required_approvals:
                 reason_codes.append("signer_quorum_shortfall")
+        if quorum_evidence_present is not True:
+            reason_codes.append("quorum_evidence_missing")
+        if quorum_evidence_sha256_valid is not True:
+            reason_codes.append("quorum_evidence_sha256_invalid")
+        if quorum_evidence_schema_valid is not True:
+            reason_codes.append("quorum_evidence_schema_invalid")
+        if quorum_evidence_signers_unique is not True:
+            reason_codes.append("quorum_evidence_signers_not_unique")
+        if quorum_evidence_matches_threshold is not True:
+            reason_codes.append("quorum_evidence_approvals_mismatch")
+        if quorum_evidence_custody_sha256_match is not True:
+            reason_codes.append("quorum_evidence_custody_sha256_mismatch")
+        if isinstance(quorum_evidence_file, str) and quorum_evidence_present is True and not quorum_evidence_file.strip():
+            reason_codes.append("quorum_evidence_file_missing")
+        if (
+            isinstance(quorum_evidence_approval_count, int)
+            and isinstance(received_approvals, int)
+            and quorum_evidence_approval_count != received_approvals
+        ):
+            reason_codes.append("quorum_evidence_approval_count_mismatch")
         if custody_evidence_present is not True:
             reason_codes.append("custody_evidence_missing")
         if custody_evidence_sha256_valid is not True:

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -194,6 +194,12 @@ def main() -> int:
     if summary.get("signer_rotation_fresh") is not False:
         print("expected deployment preflight summary signer rotation freshness marker false in dry-run", file=sys.stderr)
         return 1
+    if summary.get("quorum_evidence_present") is not False:
+        print("expected deployment preflight summary quorum evidence marker false in dry-run", file=sys.stderr)
+        return 1
+    if summary.get("quorum_evidence_matches_threshold") is not False:
+        print("expected deployment preflight summary quorum threshold marker false in dry-run", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in deployment preflight summary", file=sys.stderr)
@@ -206,6 +212,21 @@ def main() -> int:
         return 1
     if contracts.get("approval_quorum_required") != 2:
         print("expected deployment preflight contracts approval_quorum_required=2", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_required") is not True:
+        print("expected deployment preflight contracts quorum_evidence_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_sha256_required") is not True:
+        print("expected deployment preflight contracts quorum_evidence_sha256_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_schema_version") != "kamn.kolme.signer-quorum-evidence.v1":
+        print("expected deployment preflight contracts quorum_evidence_schema_version marker", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_signer_uniqueness_required") is not True:
+        print("expected deployment preflight contracts quorum_evidence_signer_uniqueness_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_custody_sha256_match_required") is not True:
+        print("expected deployment preflight contracts quorum_evidence_custody_sha256_match_required=true", file=sys.stderr)
         return 1
     if contracts.get("custody_evidence_required") is not True:
         print("expected deployment preflight contracts custody_evidence_required=true", file=sys.stderr)
@@ -311,6 +332,58 @@ def main() -> int:
             return 1
         if quorum_no_go_policy.get("final_decision") != "NO-GO":
             print("expected signer quorum negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
+        quorum_evidence_negative_report = temp_path / "quorum_evidence_negative_summary.json"
+        quorum_evidence_negative_policy = temp_path / "quorum_evidence_negative_policy.json"
+        quorum_evidence_negative_summary = dict(summary)
+        quorum_evidence_negative_summary["mode"] = "run"
+        quorum_evidence_negative_summary["status"] = "fail"
+        quorum_evidence_negative_summary["reason_code"] = "checkpoint_failed_quorum_evidence_contract"
+        quorum_evidence_negative_summary["signer_secret_present"] = True
+        quorum_evidence_negative_summary["signer_secret_hex_valid"] = True
+        quorum_evidence_negative_summary["required_approvals"] = 2
+        quorum_evidence_negative_summary["received_approvals"] = 2
+        quorum_evidence_negative_summary["custody_evidence_file"] = "/tmp/custody-evidence.json"
+        quorum_evidence_negative_summary["custody_evidence_present"] = True
+        quorum_evidence_negative_summary["custody_evidence_sha256"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        quorum_evidence_negative_summary["custody_evidence_sha256_valid"] = True
+        quorum_evidence_negative_summary["quorum_evidence_file"] = ""
+        quorum_evidence_negative_summary["quorum_evidence_present"] = False
+        quorum_evidence_negative_summary["quorum_evidence_sha256"] = ""
+        quorum_evidence_negative_summary["quorum_evidence_sha256_valid"] = False
+        quorum_evidence_negative_summary["quorum_evidence_schema_valid"] = False
+        quorum_evidence_negative_summary["quorum_evidence_approval_count"] = 0
+        quorum_evidence_negative_summary["quorum_evidence_signers_unique"] = False
+        quorum_evidence_negative_summary["quorum_evidence_matches_threshold"] = False
+        quorum_evidence_negative_summary["quorum_evidence_custody_sha256_match"] = False
+        quorum_evidence_negative_report.write_text(
+            json.dumps(quorum_evidence_negative_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        quorum_evidence_no_go_result = run_policy_check(
+            report_file=quorum_evidence_negative_report,
+            output_json=quorum_evidence_negative_policy,
+            expected_final_decision="NO-GO",
+            required_reason_code="checkpoint_failed_quorum_evidence_contract",
+        )
+        if quorum_evidence_no_go_result.returncode == 0:
+            print("expected quorum evidence negative proof to fail closed", file=sys.stderr)
+            return 1
+        quorum_evidence_no_go_policy = json.loads(quorum_evidence_negative_policy.read_text(encoding="utf-8"))
+        quorum_evidence_no_go_reason_codes = quorum_evidence_no_go_policy.get("reason_codes")
+        if not isinstance(quorum_evidence_no_go_reason_codes, list):
+            print("expected reason_codes list in quorum evidence negative policy output", file=sys.stderr)
+            return 1
+        if "quorum_evidence_missing" not in quorum_evidence_no_go_reason_codes:
+            print("expected quorum_evidence_missing in quorum evidence negative policy output", file=sys.stderr)
+            return 1
+        if "quorum_evidence_approvals_mismatch" not in quorum_evidence_no_go_reason_codes:
+            print("expected quorum_evidence_approvals_mismatch in quorum evidence negative policy output", file=sys.stderr)
+            return 1
+        if quorum_evidence_no_go_policy.get("final_decision") != "NO-GO":
+            print("expected quorum evidence negative policy final_decision NO-GO", file=sys.stderr)
             return 1
 
         provenance_negative_report = temp_path / "signer_provenance_negative_summary.json"
@@ -429,10 +502,14 @@ def main() -> int:
         "checkpoint_failed_signer_secret_contract",
         "fallback_signer_secret_present_violation",
         "checkpoint_failed_signer_quorum_contract",
+        "checkpoint_failed_quorum_evidence_contract",
         "checkpoint_failed_custody_evidence_contract",
         "checkpoint_failed_signer_provenance_contract",
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
+        "quorum_evidence_missing",
+        "quorum_evidence_approvals_mismatch",
+        "quorum_evidence_custody_sha256_mismatch",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -441,6 +518,7 @@ def main() -> int:
         "signer_rotation_epoch_stale",
         "Regression: #2226",
         "Regression: #2300",
+        "Regression: #2301",
     ]
     ci_doc_markers = [
         "run_local_kolme_live_deployment_preflight_lane.sh",
@@ -450,10 +528,14 @@ def main() -> int:
         "checkpoint_failed_signer_secret_contract",
         "fallback_signer_secret_present_violation",
         "checkpoint_failed_signer_quorum_contract",
+        "checkpoint_failed_quorum_evidence_contract",
         "checkpoint_failed_custody_evidence_contract",
         "checkpoint_failed_signer_provenance_contract",
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
+        "quorum_evidence_missing",
+        "quorum_evidence_approvals_mismatch",
+        "quorum_evidence_custody_sha256_mismatch",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -462,6 +544,7 @@ def main() -> int:
         "signer_rotation_epoch_stale",
         "Regression: #2226",
         "Regression: #2300",
+        "Regression: #2301",
     ]
     readme_markers = [
         "run_local_kolme_live_deployment_preflight_lane.sh",
@@ -471,10 +554,14 @@ def main() -> int:
         "checkpoint_failed_signer_secret_contract",
         "fallback_signer_secret_present_violation",
         "checkpoint_failed_signer_quorum_contract",
+        "checkpoint_failed_quorum_evidence_contract",
         "checkpoint_failed_custody_evidence_contract",
         "checkpoint_failed_signer_provenance_contract",
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
+        "quorum_evidence_missing",
+        "quorum_evidence_approvals_mismatch",
+        "quorum_evidence_custody_sha256_mismatch",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -483,6 +570,7 @@ def main() -> int:
         "signer_rotation_epoch_stale",
         "Regression: #2226",
         "Regression: #2300",
+        "Regression: #2301",
     ]
 
     missing_markers: list[str] = []

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -8,6 +8,7 @@ SIGNER_PROFILE=""
 MAX_SECONDS=12
 REQUIRED_APPROVALS=2
 RECEIVED_APPROVALS=0
+QUORUM_EVIDENCE_FILE=""
 CUSTODY_EVIDENCE_FILE=""
 SIGNER_PROVENANCE_FILE=""
 SIGNER_KEY_SOURCE_CONTRACT_VERSION="v1"
@@ -25,6 +26,7 @@ SECONDARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 FALLBACK_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH=64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED="v1"
+QUORUM_EVIDENCE_SCHEMA_VERSION="kamn.kolme.signer-quorum-evidence.v1"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -82,6 +84,14 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       RECEIVED_APPROVALS="$2"
+      shift 2
+      ;;
+    --quorum-evidence-file)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --quorum-evidence-file" >&2
+        exit 1
+      fi
+      QUORUM_EVIDENCE_FILE="$2"
       shift 2
       ;;
     --custody-evidence-file)
@@ -152,6 +162,7 @@ Options:
   --max-seconds <n>                   Max total runtime budget for run mode.
   --required-approvals <n>            Required signer approvals threshold (run-mode fail-closed).
   --received-approvals <n>            Received signer approvals count (run-mode fail-closed).
+  --quorum-evidence-file <path>       Required quorum evidence bundle in run mode.
   --custody-evidence-file <path>      Required signer custody evidence file in run mode.
   --signer-provenance-file <path>     Required signer provenance evidence file in run mode.
   --signer-key-source-contract-version <value>
@@ -239,6 +250,7 @@ signer_profile_command="signer profile must be ${PRIMARY_SIGNER_PROFILE} or ${SE
 signer_secret_command="selected signer secret env must exist and be ${REQUIRED_SECRET_HEX_LENGTH}-char hex"
 fallback_private_key_command="fallback signer secret env must remain unset"
 signer_quorum_command="received approvals must satisfy required approvals threshold"
+quorum_evidence_command="quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match"
 custody_evidence_command="signer custody evidence file and sha256 marker must be present"
 signer_provenance_command="signer provenance evidence file and sha256 marker must be present"
 signer_rotation_freshness_command="signer rotation metadata must satisfy freshness threshold"
@@ -250,6 +262,14 @@ elapsed_seconds=0
 signer_secret_present="false"
 signer_secret_hex_valid="false"
 fallback_signer_secret_present="false"
+quorum_evidence_present="false"
+quorum_evidence_sha256=""
+quorum_evidence_sha256_valid="false"
+quorum_evidence_schema_valid="false"
+quorum_evidence_approval_count=0
+quorum_evidence_signers_unique="false"
+quorum_evidence_matches_threshold="false"
+quorum_evidence_custody_sha256_match="false"
 custody_evidence_present="false"
 custody_evidence_sha256=""
 custody_evidence_sha256_valid="false"
@@ -264,6 +284,7 @@ record_check "signer_profile_contract" "$signer_profile_command" "planned" "not_
 record_check "signer_secret_contract" "$signer_secret_command" "planned" "not_run"
 record_check "fallback_private_key_contract" "$fallback_private_key_command" "planned" "not_run"
 record_check "signer_quorum_contract" "$signer_quorum_command" "planned" "not_run"
+record_check "quorum_evidence_contract" "$quorum_evidence_command" "planned" "not_run"
 record_check "custody_evidence_contract" "$custody_evidence_command" "planned" "not_run"
 record_check "signer_provenance_contract" "$signer_provenance_command" "planned" "not_run"
 record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "planned" "not_run"
@@ -278,6 +299,7 @@ if [ "$MODE" = "run" ]; then
     record_check "signer_secret_contract" "$signer_secret_command" "skipped" "runtime_mode_mismatch"
     record_check "fallback_private_key_contract" "$fallback_private_key_command" "skipped" "runtime_mode_mismatch"
     record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "runtime_mode_mismatch"
+    record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "runtime_mode_mismatch"
     record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "runtime_mode_mismatch"
     record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "runtime_mode_mismatch"
     record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "runtime_mode_mismatch"
@@ -292,6 +314,7 @@ if [ "$MODE" = "run" ]; then
       record_check "signer_secret_contract" "$signer_secret_command" "skipped" "signer_profile_invalid"
       record_check "fallback_private_key_contract" "$fallback_private_key_command" "skipped" "signer_profile_invalid"
       record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_profile_invalid"
+      record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "signer_profile_invalid"
       record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_profile_invalid"
       record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_profile_invalid"
       record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_profile_invalid"
@@ -310,6 +333,7 @@ if [ "$MODE" = "run" ]; then
         record_check "fallback_private_key_contract" "$fallback_private_key_command" "fail" "fallback_signer_secret_present_violation"
         record_check "signer_secret_contract" "$signer_secret_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "fallback_signer_secret_present_violation"
+        record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "fallback_signer_secret_present_violation"
@@ -330,6 +354,7 @@ if [ "$MODE" = "run" ]; then
           echo "signer secret env is required for selected profile: $selected_signer_secret_env" >&2
           record_check "signer_secret_contract" "$signer_secret_command" "fail" "signer_secret_missing"
           record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_secret_missing"
+          record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "signer_secret_missing"
           record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_secret_missing"
           record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_secret_missing"
           record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_secret_missing"
@@ -339,6 +364,7 @@ if [ "$MODE" = "run" ]; then
           echo "signer secret env must be ${REQUIRED_SECRET_HEX_LENGTH} hex characters: $selected_signer_secret_env" >&2
           record_check "signer_secret_contract" "$signer_secret_command" "fail" "signer_secret_invalid_hex"
           record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "signer_secret_invalid_hex"
+          record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "signer_secret_invalid_hex"
           record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_secret_invalid_hex"
           record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_secret_invalid_hex"
           record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_secret_invalid_hex"
@@ -349,6 +375,7 @@ if [ "$MODE" = "run" ]; then
           if [ "$RECEIVED_APPROVALS" -lt "$REQUIRED_APPROVALS" ]; then
             echo "signer quorum approvals below required threshold: required=$REQUIRED_APPROVALS received=$RECEIVED_APPROVALS" >&2
             record_check "signer_quorum_contract" "$signer_quorum_command" "fail" "signer_quorum_shortfall"
+            record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "signer_quorum_shortfall"
             record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_quorum_shortfall"
             record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_quorum_shortfall"
             record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_quorum_shortfall"
@@ -367,6 +394,7 @@ if [ "$MODE" = "run" ]; then
             if [ "$custody_evidence_present" != "true" ]; then
               echo "signer custody evidence file is required for selected profile" >&2
               record_check "custody_evidence_contract" "$custody_evidence_command" "fail" "custody_evidence_missing"
+              record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "custody_evidence_missing"
               record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "custody_evidence_missing"
               record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "custody_evidence_missing"
               overall_status="fail"
@@ -374,6 +402,7 @@ if [ "$MODE" = "run" ]; then
             elif [ "$custody_evidence_sha256_valid" != "true" ]; then
               echo "signer custody evidence sha256 marker is invalid: $CUSTODY_EVIDENCE_FILE" >&2
               record_check "custody_evidence_contract" "$custody_evidence_command" "fail" "custody_evidence_sha256_invalid"
+              record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "custody_evidence_sha256_invalid"
               record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "custody_evidence_sha256_invalid"
               record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "custody_evidence_sha256_invalid"
               overall_status="fail"
@@ -381,64 +410,231 @@ if [ "$MODE" = "run" ]; then
             else
               record_check "custody_evidence_contract" "$custody_evidence_command" "pass" "custody_evidence_validated"
 
-              signer_provenance_reason=""
-              signer_provenance_message=""
-              if [ "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" != "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" ]; then
-                signer_provenance_reason="signer_key_source_contract_version_mismatch"
-                signer_provenance_message="signer key source contract version must remain ${SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED}: $SIGNER_KEY_SOURCE_CONTRACT_VERSION"
-              elif [ "$SIGNER_KEY_SOURCE" != "env-local" ] && [ "$SIGNER_KEY_SOURCE" != "managed-external" ]; then
-                signer_provenance_reason="signer_key_source_invalid"
-                signer_provenance_message="signer key source is unsupported: $SIGNER_KEY_SOURCE"
-              elif [ "$SIGNER_PROFILE" = "$SECONDARY_SIGNER_PROFILE" ] && [ "$SIGNER_KEY_SOURCE" != "env-local" ]; then
-                signer_provenance_reason="signer_key_source_profile_pair_disallowed"
-                signer_provenance_message="signer key source/profile pair is not allowed: profile=$SIGNER_PROFILE source=$SIGNER_KEY_SOURCE"
-              else
-                if [ -n "$SIGNER_PROVENANCE_FILE" ] && [ -f "$SIGNER_PROVENANCE_FILE" ]; then
-                  signer_provenance_present="true"
-                  signer_provenance_sha256="$(sha256sum "$SIGNER_PROVENANCE_FILE" | awk '{print $1}')"
-                  if [[ "$signer_provenance_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
-                    signer_provenance_sha256_valid="true"
-                  fi
-                fi
-                if [ "$signer_provenance_present" != "true" ]; then
-                  signer_provenance_reason="signer_provenance_missing"
-                  signer_provenance_message="signer provenance evidence file is required for selected profile"
-                elif [ "$signer_provenance_sha256_valid" != "true" ]; then
-                  signer_provenance_reason="signer_provenance_sha256_invalid"
-                  signer_provenance_message="signer provenance evidence sha256 marker is invalid: $SIGNER_PROVENANCE_FILE"
+              quorum_evidence_reason=""
+              quorum_evidence_message=""
+              if [ -n "$QUORUM_EVIDENCE_FILE" ] && [ -f "$QUORUM_EVIDENCE_FILE" ]; then
+                quorum_evidence_present="true"
+                quorum_evidence_sha256="$(sha256sum "$QUORUM_EVIDENCE_FILE" | awk '{print $1}')"
+                if [[ "$quorum_evidence_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+                  quorum_evidence_sha256_valid="true"
                 fi
               fi
 
-              if [ -n "$signer_provenance_reason" ]; then
-                echo "$signer_provenance_message" >&2
-                record_check "signer_provenance_contract" "$signer_provenance_command" "fail" "$signer_provenance_reason"
-                record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "$signer_provenance_reason"
-                overall_status="fail"
-                reason_code="checkpoint_failed_signer_provenance_contract"
+              if [ "$quorum_evidence_present" != "true" ]; then
+                quorum_evidence_reason="quorum_evidence_missing"
+                quorum_evidence_message="signer quorum evidence file is required for selected profile"
+              elif [ "$quorum_evidence_sha256_valid" != "true" ]; then
+                quorum_evidence_reason="quorum_evidence_sha256_invalid"
+                quorum_evidence_message="signer quorum evidence sha256 marker is invalid: $QUORUM_EVIDENCE_FILE"
               else
-                record_check "signer_provenance_contract" "$signer_provenance_command" "pass" "signer_provenance_validated"
+                quorum_evidence_parse_output="$(
+                  python3 - "$QUORUM_EVIDENCE_FILE" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$custody_evidence_sha256" <<'PY'
+from __future__ import annotations
 
-                signer_rotation_delta_epochs="$(( SIGNER_ROTATION_EPOCH - SIGNER_PREVIOUS_ROTATION_EPOCH ))"
-                signer_rotation_reason=""
-                signer_rotation_message=""
-                if [ "$signer_rotation_delta_epochs" -lt 0 ]; then
-                  signer_rotation_reason="signer_rotation_epoch_invalid"
-                  signer_rotation_message="signer rotation epoch must be greater than or equal to previous rotation epoch"
-                elif [ "$signer_rotation_delta_epochs" -gt "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" ]; then
-                  signer_rotation_reason="signer_rotation_epoch_stale"
-                  signer_rotation_message="signer rotation metadata exceeded freshness threshold: delta=$signer_rotation_delta_epochs max=$SIGNER_ROTATION_FRESHNESS_MAX_DELTA"
+import json
+import pathlib
+import sys
+
+payload_path = pathlib.Path(sys.argv[1])
+expected_schema = sys.argv[2]
+required_approvals = int(sys.argv[3])
+received_approvals = int(sys.argv[4])
+custody_sha256 = sys.argv[5]
+
+result = {
+    "schema_valid": False,
+    "approval_count": 0,
+    "signers_unique": False,
+    "matches_threshold": False,
+    "custody_sha256_match": False,
+    "reason_code": "quorum_evidence_schema_invalid",
+}
+
+try:
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+except Exception:
+    payload = None
+
+if isinstance(payload, dict):
+    schema_valid = payload.get("schema_version") == expected_schema
+    approved_signers_raw = payload.get("approved_signers")
+    normalized_signers: list[str] = []
+    if isinstance(approved_signers_raw, list):
+        for item in approved_signers_raw:
+            if isinstance(item, str) and item.strip():
+                normalized_signers.append(item.strip())
+    approval_count = len(normalized_signers)
+    signers_unique = approval_count > 0 and len(set(normalized_signers)) == approval_count
+    required_matches = payload.get("required_approvals") == required_approvals
+    received_matches = payload.get("received_approvals") == received_approvals
+    matches_threshold = (
+        required_matches
+        and received_matches
+        and approval_count == received_approvals
+        and received_approvals >= required_approvals
+    )
+    custody_field = payload.get("custody_evidence_sha256")
+    custody_match = isinstance(custody_field, str) and custody_field == custody_sha256
+
+    result["schema_valid"] = schema_valid
+    result["approval_count"] = approval_count
+    result["signers_unique"] = signers_unique
+    result["matches_threshold"] = matches_threshold
+    result["custody_sha256_match"] = custody_match
+
+    if not schema_valid:
+        result["reason_code"] = "quorum_evidence_schema_invalid"
+    elif not signers_unique:
+        result["reason_code"] = "quorum_evidence_signers_not_unique"
+    elif not matches_threshold:
+        result["reason_code"] = "quorum_evidence_approvals_mismatch"
+    elif not custody_match:
+        result["reason_code"] = "quorum_evidence_custody_sha256_mismatch"
+    else:
+        result["reason_code"] = "ok"
+
+for key in (
+    "schema_valid",
+    "approval_count",
+    "signers_unique",
+    "matches_threshold",
+    "custody_sha256_match",
+    "reason_code",
+):
+    print(f"{key}={result[key]}")
+PY
+                )"
+
+                parsed_quorum_reason_code=""
+                while IFS='=' read -r key value; do
+                  case "$key" in
+                    schema_valid)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_schema_valid="true"
+                      else
+                        quorum_evidence_schema_valid="false"
+                      fi
+                      ;;
+                    approval_count)
+                      if [[ "$value" =~ ^[0-9]+$ ]]; then
+                        quorum_evidence_approval_count="$value"
+                      else
+                        quorum_evidence_approval_count=0
+                      fi
+                      ;;
+                    signers_unique)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_signers_unique="true"
+                      else
+                        quorum_evidence_signers_unique="false"
+                      fi
+                      ;;
+                    matches_threshold)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_matches_threshold="true"
+                      else
+                        quorum_evidence_matches_threshold="false"
+                      fi
+                      ;;
+                    custody_sha256_match)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_custody_sha256_match="true"
+                      else
+                        quorum_evidence_custody_sha256_match="false"
+                      fi
+                      ;;
+                    reason_code)
+                      parsed_quorum_reason_code="$value"
+                      ;;
+                  esac
+                done <<<"$quorum_evidence_parse_output"
+
+                if [ "$parsed_quorum_reason_code" != "ok" ]; then
+                  quorum_evidence_reason="$parsed_quorum_reason_code"
+                  if [ "$parsed_quorum_reason_code" = "quorum_evidence_schema_invalid" ]; then
+                    quorum_evidence_message="signer quorum evidence schema is invalid: $QUORUM_EVIDENCE_FILE"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_signers_not_unique" ]; then
+                    quorum_evidence_message="signer quorum evidence signers must be unique: $QUORUM_EVIDENCE_FILE"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_approvals_mismatch" ]; then
+                    quorum_evidence_message="signer quorum evidence approvals must match received approvals and threshold"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_custody_sha256_mismatch" ]; then
+                    quorum_evidence_message="signer quorum evidence custody digest must match custody evidence sha256"
+                  else
+                    quorum_evidence_reason="quorum_evidence_schema_invalid"
+                    quorum_evidence_message="signer quorum evidence schema is invalid: $QUORUM_EVIDENCE_FILE"
+                  fi
+                fi
+              fi
+
+              if [ -n "$quorum_evidence_reason" ]; then
+                echo "$quorum_evidence_message" >&2
+                record_check "quorum_evidence_contract" "$quorum_evidence_command" "fail" "$quorum_evidence_reason"
+                record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "$quorum_evidence_reason"
+                record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "$quorum_evidence_reason"
+                overall_status="fail"
+                reason_code="checkpoint_failed_quorum_evidence_contract"
+              else
+                record_check "quorum_evidence_contract" "$quorum_evidence_command" "pass" "quorum_evidence_validated"
+
+                signer_provenance_reason=""
+                signer_provenance_message=""
+                if [ "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" != "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" ]; then
+                  signer_provenance_reason="signer_key_source_contract_version_mismatch"
+                  signer_provenance_message="signer key source contract version must remain ${SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED}: $SIGNER_KEY_SOURCE_CONTRACT_VERSION"
+                elif [ "$SIGNER_KEY_SOURCE" != "env-local" ] && [ "$SIGNER_KEY_SOURCE" != "managed-external" ]; then
+                  signer_provenance_reason="signer_key_source_invalid"
+                  signer_provenance_message="signer key source is unsupported: $SIGNER_KEY_SOURCE"
+                elif [ "$SIGNER_PROFILE" = "$SECONDARY_SIGNER_PROFILE" ] && [ "$SIGNER_KEY_SOURCE" != "env-local" ]; then
+                  signer_provenance_reason="signer_key_source_profile_pair_disallowed"
+                  signer_provenance_message="signer key source/profile pair is not allowed: profile=$SIGNER_PROFILE source=$SIGNER_KEY_SOURCE"
+                else
+                  if [ -n "$SIGNER_PROVENANCE_FILE" ] && [ -f "$SIGNER_PROVENANCE_FILE" ]; then
+                    signer_provenance_present="true"
+                    signer_provenance_sha256="$(sha256sum "$SIGNER_PROVENANCE_FILE" | awk '{print $1}')"
+                    if [[ "$signer_provenance_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+                      signer_provenance_sha256_valid="true"
+                    fi
+                  fi
+                  if [ "$signer_provenance_present" != "true" ]; then
+                    signer_provenance_reason="signer_provenance_missing"
+                    signer_provenance_message="signer provenance evidence file is required for selected profile"
+                  elif [ "$signer_provenance_sha256_valid" != "true" ]; then
+                    signer_provenance_reason="signer_provenance_sha256_invalid"
+                    signer_provenance_message="signer provenance evidence sha256 marker is invalid: $SIGNER_PROVENANCE_FILE"
+                  fi
                 fi
 
-                if [ -n "$signer_rotation_reason" ]; then
-                  echo "$signer_rotation_message" >&2
-                  signer_rotation_fresh="false"
-                  record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "fail" "$signer_rotation_reason"
+                if [ -n "$signer_provenance_reason" ]; then
+                  echo "$signer_provenance_message" >&2
+                  record_check "signer_provenance_contract" "$signer_provenance_command" "fail" "$signer_provenance_reason"
+                  record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "$signer_provenance_reason"
                   overall_status="fail"
-                  reason_code="checkpoint_failed_signer_rotation_freshness_contract"
+                  reason_code="checkpoint_failed_signer_provenance_contract"
                 else
-                  signer_rotation_fresh="true"
-                  record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "pass" "signer_rotation_freshness_validated"
-                  reason_code="deployment_preflight_passed"
+                  record_check "signer_provenance_contract" "$signer_provenance_command" "pass" "signer_provenance_validated"
+
+                  signer_rotation_delta_epochs="$(( SIGNER_ROTATION_EPOCH - SIGNER_PREVIOUS_ROTATION_EPOCH ))"
+                  signer_rotation_reason=""
+                  signer_rotation_message=""
+                  if [ "$signer_rotation_delta_epochs" -lt 0 ]; then
+                    signer_rotation_reason="signer_rotation_epoch_invalid"
+                    signer_rotation_message="signer rotation epoch must be greater than or equal to previous rotation epoch"
+                  elif [ "$signer_rotation_delta_epochs" -gt "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" ]; then
+                    signer_rotation_reason="signer_rotation_epoch_stale"
+                    signer_rotation_message="signer rotation metadata exceeded freshness threshold: delta=$signer_rotation_delta_epochs max=$SIGNER_ROTATION_FRESHNESS_MAX_DELTA"
+                  fi
+
+                  if [ -n "$signer_rotation_reason" ]; then
+                    echo "$signer_rotation_message" >&2
+                    signer_rotation_fresh="false"
+                    record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "fail" "$signer_rotation_reason"
+                    overall_status="fail"
+                    reason_code="checkpoint_failed_signer_rotation_freshness_contract"
+                  else
+                    signer_rotation_fresh="true"
+                    record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "pass" "signer_rotation_freshness_validated"
+                    reason_code="deployment_preflight_passed"
+                  fi
                 fi
               fi
             fi
@@ -460,7 +656,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" <<'PY'
 from __future__ import annotations
 
 import json
@@ -491,22 +687,32 @@ secondary_signer_secret_env = sys.argv[21]
 required_secret_hex_length = int(sys.argv[22])
 required_approvals = int(sys.argv[23])
 received_approvals = int(sys.argv[24])
-custody_evidence_file = sys.argv[25]
-custody_evidence_present = sys.argv[26] == "true"
-custody_evidence_sha256 = sys.argv[27]
-custody_evidence_sha256_valid = sys.argv[28] == "true"
-signer_provenance_file = sys.argv[29]
-signer_provenance_present = sys.argv[30] == "true"
-signer_provenance_sha256 = sys.argv[31]
-signer_provenance_sha256_valid = sys.argv[32] == "true"
-signer_key_source_contract_version = sys.argv[33]
-signer_key_source = sys.argv[34]
-signer_key_source_contract_version_supported = sys.argv[35]
-signer_rotation_epoch = int(sys.argv[36])
-signer_previous_rotation_epoch = int(sys.argv[37])
-signer_rotation_freshness_max_delta = int(sys.argv[38])
-signer_rotation_delta_epochs = int(sys.argv[39])
-signer_rotation_fresh = sys.argv[40] == "true"
+quorum_evidence_file = sys.argv[25]
+quorum_evidence_present = sys.argv[26] == "true"
+quorum_evidence_sha256 = sys.argv[27]
+quorum_evidence_sha256_valid = sys.argv[28] == "true"
+quorum_evidence_schema_valid = sys.argv[29] == "true"
+quorum_evidence_approval_count = int(sys.argv[30])
+quorum_evidence_signers_unique = sys.argv[31] == "true"
+quorum_evidence_matches_threshold = sys.argv[32] == "true"
+quorum_evidence_custody_sha256_match = sys.argv[33] == "true"
+quorum_evidence_schema_version = sys.argv[34]
+custody_evidence_file = sys.argv[35]
+custody_evidence_present = sys.argv[36] == "true"
+custody_evidence_sha256 = sys.argv[37]
+custody_evidence_sha256_valid = sys.argv[38] == "true"
+signer_provenance_file = sys.argv[39]
+signer_provenance_present = sys.argv[40] == "true"
+signer_provenance_sha256 = sys.argv[41]
+signer_provenance_sha256_valid = sys.argv[42] == "true"
+signer_key_source_contract_version = sys.argv[43]
+signer_key_source = sys.argv[44]
+signer_key_source_contract_version_supported = sys.argv[45]
+signer_rotation_epoch = int(sys.argv[46])
+signer_previous_rotation_epoch = int(sys.argv[47])
+signer_rotation_freshness_max_delta = int(sys.argv[48])
+signer_rotation_delta_epochs = int(sys.argv[49])
+signer_rotation_fresh = sys.argv[50] == "true"
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -545,6 +751,15 @@ summary = {
     "signer_secret_hex_valid": signer_secret_hex_valid,
     "required_approvals": required_approvals,
     "received_approvals": received_approvals,
+    "quorum_evidence_file": quorum_evidence_file,
+    "quorum_evidence_present": quorum_evidence_present,
+    "quorum_evidence_sha256": quorum_evidence_sha256,
+    "quorum_evidence_sha256_valid": quorum_evidence_sha256_valid,
+    "quorum_evidence_schema_valid": quorum_evidence_schema_valid,
+    "quorum_evidence_approval_count": quorum_evidence_approval_count,
+    "quorum_evidence_signers_unique": quorum_evidence_signers_unique,
+    "quorum_evidence_matches_threshold": quorum_evidence_matches_threshold,
+    "quorum_evidence_custody_sha256_match": quorum_evidence_custody_sha256_match,
     "custody_evidence_file": custody_evidence_file,
     "custody_evidence_present": custody_evidence_present,
     "custody_evidence_sha256": custody_evidence_sha256,
@@ -573,6 +788,12 @@ summary = {
         "secret_source": "env",
         "approval_quorum_required": required_approvals,
         "approval_quorum_source": "local-operator-attestations",
+        "quorum_evidence_required": True,
+        "quorum_evidence_sha256_required": True,
+        "quorum_evidence_schema_version": quorum_evidence_schema_version,
+        "quorum_evidence_signer_uniqueness_required": True,
+        "quorum_evidence_custody_sha256_match_required": True,
+        "quorum_evidence_source": "operator-attestation-bundle",
         "custody_evidence_required": True,
         "custody_evidence_sha256_required": True,
         "signer_provenance_required": True,

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -56,6 +56,15 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "signer_secret_hex_valid": false,
   "required_approvals": 2,
   "received_approvals": 0,
+  "quorum_evidence_file": "",
+  "quorum_evidence_present": false,
+  "quorum_evidence_sha256": "",
+  "quorum_evidence_sha256_valid": false,
+  "quorum_evidence_schema_valid": false,
+  "quorum_evidence_approval_count": 0,
+  "quorum_evidence_signers_unique": false,
+  "quorum_evidence_matches_threshold": false,
+  "quorum_evidence_custody_sha256_match": false,
   "custody_evidence_file": "",
   "custody_evidence_present": false,
   "custody_evidence_sha256": "",
@@ -87,6 +96,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "secret_source": "env",
     "approval_quorum_required": 2,
     "approval_quorum_source": "local-operator-attestations",
+    "quorum_evidence_required": true,
+    "quorum_evidence_sha256_required": true,
+    "quorum_evidence_schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+    "quorum_evidence_signer_uniqueness_required": true,
+    "quorum_evidence_custody_sha256_match_required": true,
+    "quorum_evidence_source": "operator-attestation-bundle",
     "custody_evidence_required": true,
     "custody_evidence_sha256_required": true,
     "signer_provenance_required": true,
@@ -131,6 +146,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     {
       "id": "signer_quorum_contract",
       "command": "received approvals must satisfy required approvals threshold",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "quorum_evidence_contract",
+      "command": "quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match",
       "status": "planned",
       "reason_code": "not_run"
     },
@@ -199,6 +220,15 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "signer_secret_hex_valid": true,
   "required_approvals": 2,
   "received_approvals": 1,
+  "quorum_evidence_file": "",
+  "quorum_evidence_present": false,
+  "quorum_evidence_sha256": "",
+  "quorum_evidence_sha256_valid": false,
+  "quorum_evidence_schema_valid": false,
+  "quorum_evidence_approval_count": 0,
+  "quorum_evidence_signers_unique": false,
+  "quorum_evidence_matches_threshold": false,
+  "quorum_evidence_custody_sha256_match": false,
   "custody_evidence_file": "",
   "custody_evidence_present": false,
   "custody_evidence_sha256": "",
@@ -230,6 +260,12 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
     "secret_source": "env",
     "approval_quorum_required": 2,
     "approval_quorum_source": "local-operator-attestations",
+    "quorum_evidence_required": true,
+    "quorum_evidence_sha256_required": true,
+    "quorum_evidence_schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+    "quorum_evidence_signer_uniqueness_required": true,
+    "quorum_evidence_custody_sha256_match_required": true,
+    "quorum_evidence_source": "operator-attestation-bundle",
     "custody_evidence_required": true,
     "custody_evidence_sha256_required": true,
     "signer_provenance_required": false,
@@ -322,6 +358,11 @@ if ! grep -q "check_missing:signer_quorum_contract" "$TMP_ERR"; then
   exit 1
 fi
 
+if ! grep -q "check_missing:quorum_evidence_contract" "$TMP_ERR"; then
+  echo "expected missing quorum_evidence_contract check reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
 if ! grep -q "check_missing:custody_evidence_contract" "$TMP_ERR"; then
   echo "expected missing custody_evidence_contract check reason for deployment preflight policy failure" >&2
   exit 1
@@ -349,6 +390,11 @@ fi
 
 if ! grep -q "signer_rotation_epoch_stale" "$TMP_ERR"; then
   echo "expected signer rotation stale reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "quorum_evidence_missing" "$TMP_ERR"; then
+  echo "expected quorum evidence missing reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
@@ -69,6 +69,7 @@ required_coverage_markers=(
   "runtime_mode_mismatch"
   "checkpoint_failed_signer_secret_contract"
   "checkpoint_failed_signer_quorum_contract"
+  "checkpoint_failed_quorum_evidence_contract"
   "checkpoint_failed_custody_evidence_contract"
   "checkpoint_failed_signer_provenance_contract"
   "checkpoint_failed_signer_rotation_freshness_contract"
@@ -77,9 +78,13 @@ required_coverage_markers=(
   "signer_provenance_file"
   "signer_rotation_epoch_stale"
   "signer_quorum_shortfall"
+  "quorum_evidence_missing"
+  "quorum_evidence_approvals_mismatch"
+  "quorum_evidence_custody_sha256_mismatch"
   "custody_evidence_missing"
   "Regression: #2226"
   "Regression: #2300"
+  "Regression: #2301"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q -- "$marker" "$CONTRACT_IMPL"; then
@@ -107,6 +112,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "Regression: #2300" "$docs_file"; then
     echo "expected docs parity to include signer provenance/rotation regression marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2301" "$docs_file"; then
+    echo "expected docs parity to include signer quorum/custody regression marker in $docs_file" >&2
     exit 1
   fi
 done

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -10,10 +10,24 @@ TMP_SUMMARY="$(mktemp)"
 TMP_ERR="$(mktemp)"
 TMP_CUSTODY="$(mktemp)"
 TMP_PROVENANCE="$(mktemp)"
-trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY" "$TMP_PROVENANCE"' EXIT
+TMP_QUORUM="$(mktemp)"
+trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY" "$TMP_PROVENANCE" "$TMP_QUORUM"' EXIT
 
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" >"$TMP_CUSTODY"
 printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" >"$TMP_PROVENANCE"
+TMP_CUSTODY_SHA="$(sha256sum "$TMP_CUSTODY" | awk '{print $1}')"
+cat >"$TMP_QUORUM" <<JSON
+{
+  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "required_approvals": 2,
+  "received_approvals": 2,
+  "approved_signers": [
+    "ops-primary",
+    "ops-secondary"
+  ],
+  "custody_evidence_sha256": "$TMP_CUSTODY_SHA"
+}
+JSON
 
 extract_value() {
   local output="$1"
@@ -105,6 +119,10 @@ if summary.get("required_approvals") != 2:
     raise SystemExit("expected deployment preflight summary required_approvals=2")
 if summary.get("received_approvals") != 0:
     raise SystemExit("expected deployment preflight summary received_approvals=0 for dry-run")
+if summary.get("quorum_evidence_present") is not False:
+    raise SystemExit("expected deployment preflight summary quorum evidence marker to be false in dry-run")
+if summary.get("quorum_evidence_matches_threshold") is not False:
+    raise SystemExit("expected deployment preflight summary quorum threshold marker to be false in dry-run")
 if summary.get("custody_evidence_present") is not False:
     raise SystemExit("expected deployment preflight summary custody evidence marker to be false in dry-run")
 if summary.get("signer_provenance_present") is not False:
@@ -128,6 +146,16 @@ if contracts.get("custody_evidence_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer custody evidence")
 if contracts.get("approval_quorum_required") != 2:
     raise SystemExit("expected deployment preflight contracts approval quorum requirement marker")
+if contracts.get("quorum_evidence_required") is not True:
+    raise SystemExit("expected deployment preflight contracts to require quorum evidence")
+if contracts.get("quorum_evidence_sha256_required") is not True:
+    raise SystemExit("expected deployment preflight contracts to require quorum evidence sha256")
+if contracts.get("quorum_evidence_schema_version") != "kamn.kolme.signer-quorum-evidence.v1":
+    raise SystemExit("expected deployment preflight contracts quorum evidence schema marker")
+if contracts.get("quorum_evidence_signer_uniqueness_required") is not True:
+    raise SystemExit("expected deployment preflight contracts quorum signer uniqueness requirement marker")
+if contracts.get("quorum_evidence_custody_sha256_match_required") is not True:
+    raise SystemExit("expected deployment preflight contracts quorum custody sha256 match requirement marker")
 if contracts.get("signer_provenance_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer provenance evidence")
 if contracts.get("signer_provenance_sha256_required") is not True:
@@ -227,6 +255,28 @@ bash "$RUNNER" \
   --received-approvals 2 \
   --custody-evidence-file "$TMP_CUSTODY" \
   --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+missing_quorum_evidence_exit_code=$?
+set -e
+
+if [ "$missing_quorum_evidence_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight run mode to fail closed when signer quorum evidence is missing" >&2
+  exit 1
+fi
+
+if ! grep -q "signer quorum evidence file is required for selected profile" "$TMP_ERR"; then
+  echo "expected deterministic missing signer quorum evidence message from deployment preflight lane" >&2
+  exit 1
+fi
+
+set +e
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
+bash "$RUNNER" \
+  --mode run \
+  --required-approvals 2 \
+  --received-approvals 2 \
+  --custody-evidence-file "$TMP_CUSTODY" \
+  --quorum-evidence-file "$TMP_QUORUM" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
 missing_provenance_exit_code=$?
 set -e
 
@@ -247,6 +297,7 @@ bash "$RUNNER" \
   --required-approvals 2 \
   --received-approvals 2 \
   --custody-evidence-file "$TMP_CUSTODY" \
+  --quorum-evidence-file "$TMP_QUORUM" \
   --signer-provenance-file "$TMP_PROVENANCE" \
   --signer-rotation-epoch 8 \
   --signer-previous-rotation-epoch 3 \
@@ -271,6 +322,7 @@ bash "$RUNNER" \
   --required-approvals 2 \
   --received-approvals 2 \
   --custody-evidence-file "$TMP_CUSTODY" \
+  --quorum-evidence-file "$TMP_QUORUM" \
   --signer-provenance-file "$TMP_PROVENANCE" \
   --output-json "$TMP_SUMMARY" >/dev/null
 
@@ -288,6 +340,16 @@ if summary.get("reason_code") != "deployment_preflight_passed":
     raise SystemExit("expected deployment preflight run summary pass reason code")
 if summary.get("required_approvals") != 2 or summary.get("received_approvals") != 2:
     raise SystemExit("expected deployment preflight run summary to capture signer quorum counts")
+if summary.get("quorum_evidence_present") is not True:
+    raise SystemExit("expected deployment preflight run summary quorum evidence marker true")
+if summary.get("quorum_evidence_sha256_valid") is not True:
+    raise SystemExit("expected deployment preflight run summary quorum evidence sha256 marker true")
+if summary.get("quorum_evidence_schema_valid") is not True:
+    raise SystemExit("expected deployment preflight run summary quorum evidence schema marker true")
+if summary.get("quorum_evidence_matches_threshold") is not True:
+    raise SystemExit("expected deployment preflight run summary quorum threshold marker true")
+if summary.get("quorum_evidence_custody_sha256_match") is not True:
+    raise SystemExit("expected deployment preflight run summary quorum custody sha256 match marker true")
 if summary.get("custody_evidence_present") is not True:
     raise SystemExit("expected deployment preflight run summary custody evidence marker true")
 if summary.get("signer_provenance_present") is not True:


### PR DESCRIPTION
Closes #2301

## Summary
Enforce deterministic multi-signer quorum evidence in the local Kolme live deployment preflight path so deployment approval thresholds are backed by structured attestation data and custody digest linkage, not only numeric flags.

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`: add `--quorum-evidence-file`, `quorum_evidence_contract`, fail-closed quorum evidence parsing/validation, new checkpoint reason codes, and summary/contract markers.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`: validate quorum evidence summary fields, required contract keys, expected check IDs, and run-mode NO-GO reasons.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`: extend positive/negative contract-lane assertions with quorum evidence coverage and docs parity markers.
- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`: add red/green assertions for quorum evidence checks/reasons.
- `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`: add deterministic quorum evidence fixture + missing quorum evidence fail-closed test + run-path assertions.
- `scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`: enforce quorum evidence markers and new regression marker in docs parity.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: add quorum evidence command surface, marker contracts, fail reasons, and `Regression: #2301`.
- `docs/foundation/upgrade-rollback-runbook.md`, `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs`: add runbook section and rustdoc contract coverage for the multi-signer preflight lane.

## Risks & Compatibility
- Run-mode preflight now requires `--quorum-evidence-file` in addition to custody/provenance evidence.
- Existing operator scripts that only set quorum counts must provide a quorum evidence bundle to remain GO-path compliant.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised dry-run and run-mode fail/pass cases for quorum evidence, custody, provenance, and rotation freshness.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Policy checker validates quorum evidence field/contract invariants and expected check IDs. |
| Functional  | ✅ | Runner fails closed on missing/invalid quorum evidence and custody digest mismatch paths. |
| Integration | ✅ | Contract lane validates summary/policy/docs parity and negative proofs for runtime, quorum, quorum evidence, provenance, and rotation. |
| Regression  | ✅ | Added `Regression: #2301` markers and docs/runbook contract assertions to prevent drift. |

## Red/Green Evidence
- Red: `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` failed with `expected missing quorum_evidence_contract check reason for deployment preflight policy failure`.
- Green:
  - `bash -n scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`
  - `python3 -m py_compile scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`
  - `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
  - `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`
  - `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
  - `cargo test -p kamn-core --test kolme_devnet_ops_docs`
  - `cargo test -p kamn-core --test ci_strategy_docs`
  - `cargo test -p kamn-core --test upgrade_rollback_runbook_docs`
  - `bash scripts/ci/test_readme_contract.sh`
  - `bash scripts/ci/test_ci_strategy_contract.sh`
  - `bash scripts/ci/test_ci_tools_command_surface_contract.sh`
  - `cargo fmt --check`
  - `cargo clippy -- -D warnings`
