### PR TITLE
fix(kolme): fail closed fallback signer env across runtime entrypoints (#2302)

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,9 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_key_source_contract_version=v1
 # runtime_signer_key_source=env-local
 # runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
+# runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
+# runtime_signer_fallback_private_key_present=false
+# contracts.runtime_signer_fallback_private_key_allowed=false
 
 # strict secondary signer summary marker contracts
 # runtime_signer_profile=ops-secondary
@@ -604,6 +607,7 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_rotation_epoch_stale
 # runtime_signer_key_source_profile_pair_disallowed
 # runtime_signer_private_key_env_mismatch
+# runtime_signer_fallback_private_key_present_violation
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing
 # runtime_commit_signer_profile_marker_missing
@@ -628,6 +632,9 @@ bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.s
 bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json
 # schema: kamn.kolme.local-kamn-live-runtime-integration-summary.v1
 # local-only CI boundary marker: ci_fast_gate_eligible=false (contracts.ci_fast_gate_scope=local-only)
+# fallback signer runtime guard marker:
+# fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)
+# Regression: #2302
 # Regression: #2139
 ```
 

--- a/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
+++ b/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
@@ -80,6 +80,16 @@ fn runbook_contains_kolme_multi_signer_deployment_preflight_contract_lane() {
 }
 
 #[test]
+fn runbook_contains_kolme_fallback_signer_runtime_deploy_guard() {
+    assert!(RUNBOOK.contains("## Kolme Fallback Signer Runtime/Deploy Guard (Issue #2302)"));
+    assert!(RUNBOOK.contains("test_run_local_kamn_live_runtime_integration_real_node_profile.sh"));
+    assert!(RUNBOOK.contains("test_check_local_kamn_live_runtime_real_node_profile_policy.sh"));
+    assert!(RUNBOOK.contains("test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"));
+    assert!(RUNBOOK.contains("runtime_signer_fallback_private_key_present_violation"));
+    assert!(RUNBOOK.contains("contracts.runtime_signer_fallback_private_key_allowed=false"));
+}
+
+#[test]
 fn runbook_contains_live_network_pilot_rollback_evidence_gate() {
     assert!(RUNBOOK.contains("## Live-Network Pilot Rollback Evidence Gate"));
     assert!(RUNBOOK.contains("run_live_network_pilot_deep_lane.sh"));
@@ -167,5 +177,13 @@ fn regression_requires_kolme_multi_signer_preflight_fail_closed_guard() {
     // Regression: #2301
     assert!(RUNBOOK.contains(
         "signer quorum/custody/provenance drift, quorum evidence schema drift, or contract-lane/docs parity drift force `NO-GO` (`Regression: #2301`)."
+    ));
+}
+
+#[test]
+fn regression_requires_kolme_fallback_signer_fail_closed_guard() {
+    // Regression: #2302
+    assert!(RUNBOOK.contains(
+        "fallback signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2302`)."
     ));
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -356,7 +356,9 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_key_source_contract_version=v1`
       - `runtime_signer_key_source=env-local`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
-    - strict secondary signer summary marker contracts:
+      - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+      - `runtime_signer_fallback_private_key_present=false`
+      - strict secondary signer summary marker contracts:
       - `runtime_signer_profile=ops-secondary`
       - `runtime_signer_previous_profile=ops-secondary`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
@@ -367,6 +369,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_rotation_epoch_stale`
       - `runtime_signer_key_source_profile_pair_disallowed`
       - `runtime_signer_private_key_env_mismatch`
+      - `runtime_signer_fallback_private_key_present_violation`
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`
       - `runtime_commit_signer_profile_marker_missing`
@@ -377,10 +380,13 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - strict profile signer marker:
       - `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`
       - `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary`
+    - strict profile fallback-key guard marker:
+      - `fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)`
     - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
     - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --runtime-signer-profile ops-secondary --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
     - strict real-node runtime evidence marker path remains local-only and excluded from ci-fast-gate.
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
+    - fallback signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2302`).
   - deployment preflight signer/runtime checks remain fast and ci-fast-gate eligible.
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -129,6 +129,30 @@ JSON`
 - Regression policy:
   - signer quorum/custody/provenance drift, quorum evidence schema drift, or contract-lane/docs parity drift force `NO-GO` (`Regression: #2301`).
 
+## Kolme Fallback Signer Runtime/Deploy Guard (Issue #2302)
+Fallback private-key surfaces are forbidden in deployment preflight and runtime launch paths; checks fail closed with deterministic remediation guidance.
+
+- Deployment preflight fallback guard:
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+- Runtime integration fallback guard:
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --runtime-profile real-node --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
+- Contract/policy coverage:
+  - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
+  - `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
+  - `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
+  - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
+- Required schema/reason markers:
+  - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `runtime_signer_fallback_private_key_present=false`
+  - `runtime_signer_fallback_private_key_present_violation`
+  - `contracts.runtime_signer_fallback_private_key_allowed=false`
+- Incident response and remediation:
+  - deterministic error output must identify violating source and command-level remediation:
+    - `fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)`
+  - runbook response order: freeze launch -> unset fallback env -> re-run deployment preflight -> re-run runtime integration lane -> archive updated evidence.
+- Regression policy:
+  - fallback signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2302`).
+
 ## Deployment SLO Evidence and Rollback Automation Contract
 Deterministic deployment SLO/rollback policy checks are enforced through a bounded deployment lane:
 
@@ -230,6 +254,10 @@ bash scripts/signer/test_run_signer_incident_recovery_deep_lane.sh
 bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
 bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
 bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
 bash scripts/governance/test_run_governance_lifecycle_rollback_lane.sh
 bash scripts/governance/test_check_governance_lifecycle_rollback_policy.sh
 bash scripts/governance/test_run_governance_lifecycle_rollback_contract_lane.sh

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -447,6 +447,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_key_source_contract_version=v1`
     - `runtime_signer_key_source=env-local`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
+    - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `runtime_signer_fallback_private_key_present=false`
   - GO proof also supports deterministic secondary signer markers:
     - `runtime_signer_profile=ops-secondary`
     - `runtime_signer_previous_profile=ops-secondary`
@@ -457,6 +459,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO stale-rotation proof must surface `runtime_signer_rotation_epoch_stale` when failover rotation epoch is not strictly increasing.
   - NO-GO key-source/profile matrix proof must surface `runtime_signer_key_source_profile_pair_disallowed` when signer profile/key-source pair is outside the strict allowlist.
   - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
+  - NO-GO fallback signer key proof must surface `runtime_signer_fallback_private_key_present_violation` when `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` is present.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`.
@@ -490,6 +493,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_key_source_contract_version`
     - `runtime_signer_key_source`
     - `runtime_signer_private_key_env`
+    - `runtime_signer_fallback_private_key_env`
+    - `runtime_signer_fallback_private_key_present`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
   - real-node profile requires signer profile summary/contracts markers:
     - `runtime_signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
@@ -501,8 +506,11 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_key_source_contract_version=v1`
     - `runtime_signer_key_source=env-local`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
+    - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `runtime_signer_fallback_private_key_present=false`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
+    - `contracts.runtime_signer_fallback_private_key_allowed=false`
   - real-node profile accepts secondary signer summary/contracts markers for failover drills:
     - `runtime_signer_profile=ops-secondary`
     - `runtime_signer_previous_profile=ops-secondary`
@@ -517,6 +525,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary` when `runtime_signer_profile=ops-secondary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile command composition rejects in-memory fallback references at runner boundary:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
+  - real-node profile run-mode boundary rejects fallback signer secret env and prints remediation:
+    - `fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)`
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:
     - `runtime_commit_in_memory_provider_reference_detected`
     - `runtime_commit_policy_check_in_memory_provider_reference_detected`
@@ -528,6 +538,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - run mode fails closed without explicit local-only opt-in.
   - lane default budget is bounded to 210 seconds with per-stage budget caps.
   - local KAMN live runtime integration run-mode execution remains excluded from PR fast-gate workflow routing.
+  - fallback signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2302`).
   - real-node profile policy + contract lane docs parity markers remain fail-closed (`Regression: #2139`).
 
 ## Local Kolme Live Deployment Preflight Lane (Issue #2225)

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -5,6 +5,8 @@ import argparse
 import json
 from pathlib import Path
 
+RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+
 
 ALLOWED_RUNTIME_COMMIT_FAILURE_TAXONOMIES = {
     "none",
@@ -167,6 +169,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(runtime_commit_failure_diagnostic_hint, str) or not runtime_commit_failure_diagnostic_hint.strip():
         reason_codes.append("runtime_commit_failure_diagnostic_hint_missing")
 
+    runtime_signer_fallback_private_key_env = report.get("runtime_signer_fallback_private_key_env")
+    if not isinstance(runtime_signer_fallback_private_key_env, str) or not runtime_signer_fallback_private_key_env.strip():
+        reason_codes.append("runtime_signer_fallback_private_key_env_missing")
+    elif runtime_signer_fallback_private_key_env != RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
+        reason_codes.append("runtime_signer_fallback_private_key_env_mismatch")
+
+    runtime_signer_fallback_private_key_present = report.get("runtime_signer_fallback_private_key_present")
+    if not isinstance(runtime_signer_fallback_private_key_present, bool):
+        reason_codes.append("runtime_signer_fallback_private_key_present_invalid")
+    elif runtime_signer_fallback_private_key_present:
+        reason_codes.append("runtime_signer_fallback_private_key_present_violation")
+
     contracts = report.get("contracts")
     if not isinstance(contracts, dict):
         reason_codes.append("contracts_missing")
@@ -188,6 +202,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_commit_finality_fallback_endpoint_mismatch")
         if contracts.get("runtime_commit_failure_taxonomy_version") != "v1":
             reason_codes.append("runtime_commit_failure_taxonomy_contract_version_mismatch")
+        if contracts.get("runtime_signer_fallback_private_key_env") != RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
+            reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
+        if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+            reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:
@@ -197,6 +215,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             "bootstrap_readiness",
             "localhost_signed_integration",
             "live_api_conformance",
+            "runtime_signer_fallback_private_key_contract",
             "runtime_commit_endpoint",
             "runtime_commit_policy",
         }

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -13,6 +13,7 @@ REAL_SIGNER_PROFILE_PRIMARY = "ops-primary"
 REAL_SIGNER_PROFILE_SECONDARY = "ops-secondary"
 REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
+REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
 ALLOWED_SIGNER_PROFILES = (
     REAL_SIGNER_PROFILE_PRIMARY,
@@ -182,6 +183,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif expected_signer_private_key_env and runtime_signer_private_key_env != expected_signer_private_key_env:
         reason_codes.append("runtime_signer_private_key_env_mismatch")
 
+    runtime_signer_fallback_private_key_env = report.get("runtime_signer_fallback_private_key_env")
+    if not isinstance(runtime_signer_fallback_private_key_env, str) or not runtime_signer_fallback_private_key_env.strip():
+        reason_codes.append("runtime_signer_fallback_private_key_env_missing")
+    elif runtime_signer_fallback_private_key_env != REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
+        reason_codes.append("runtime_signer_fallback_private_key_env_mismatch")
+
+    runtime_signer_fallback_private_key_present = report.get("runtime_signer_fallback_private_key_present")
+    if not isinstance(runtime_signer_fallback_private_key_present, bool):
+        reason_codes.append("runtime_signer_fallback_private_key_present_invalid")
+    elif runtime_signer_fallback_private_key_present:
+        reason_codes.append("runtime_signer_fallback_private_key_present_violation")
+
     runtime_commit_command_profile = report.get("runtime_commit_command_profile")
     if not isinstance(runtime_commit_command_profile, str) or not runtime_commit_command_profile.strip():
         reason_codes.append("runtime_commit_command_profile_missing")
@@ -281,6 +294,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_key_source_contract_mismatch")
         if expected_signer_private_key_env and contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
             reason_codes.append("runtime_signer_private_key_env_contract_mismatch")
+        if contracts.get("runtime_signer_fallback_private_key_env") != REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
+            reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
+        if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+            reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
             reason_codes.append("runtime_signer_failover_requires_profile_change_contract_mismatch")
         if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
@@ -302,6 +319,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             "bootstrap_readiness",
             "localhost_signed_integration",
             "live_api_conformance",
+            "runtime_signer_fallback_private_key_contract",
             "runtime_commit_endpoint",
             "runtime_commit_policy",
         }

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -16,6 +16,7 @@ RUNNER = ROOT_DIR / "scripts/kolme/run_local_kamn_live_runtime_integration_lane.
 CHECKER = ROOT_DIR / "scripts/kolme/check_local_kamn_live_runtime_integration_policy.py"
 DOC_FILE = ROOT_DIR / "docs/planning/kolme-devnet-ops.md"
 README_FILE = ROOT_DIR / "README.md"
+FALLBACK_SIGNER_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -174,6 +175,38 @@ def main() -> int:
         if not isinstance(diagnostic_hint, str) or not diagnostic_hint.strip():
             print("expected runtime commit failure diagnostic hint marker in summary", file=sys.stderr)
             return 1
+        if summary_payload.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
+            print("expected fallback signer private key env marker in summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_signer_fallback_private_key_present") is not False:
+            print("expected fallback signer private key presence marker false in dry-run summary", file=sys.stderr)
+            return 1
+        contracts_payload = summary_payload.get("contracts")
+        if not isinstance(contracts_payload, dict):
+            print("expected contracts object in dry-run summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
+            print("expected contracts fallback signer private key env marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_fallback_private_key_allowed") is not False:
+            print("expected contracts fallback signer private key allowed=false marker in summary", file=sys.stderr)
+            return 1
+        checks_payload = summary_payload.get("checks")
+        if not isinstance(checks_payload, list):
+            print("expected checks list in dry-run summary", file=sys.stderr)
+            return 1
+        fallback_checks = [
+            check
+            for check in checks_payload
+            if isinstance(check, dict)
+            and check.get("id") == "runtime_signer_fallback_private_key_contract"
+        ]
+        if len(fallback_checks) != 1:
+            print("expected one runtime_signer_fallback_private_key_contract check in summary", file=sys.stderr)
+            return 1
+        if fallback_checks[0].get("status") != "planned":
+            print("expected fallback signer check planned in dry-run summary", file=sys.stderr)
+            return 1
 
         # Regression: #2296
         failure_payload = dict(summary_payload)
@@ -294,6 +327,93 @@ def main() -> int:
             )
             return 1
 
+        # Regression: #2302
+        fallback_violation_payload = dict(summary_payload)
+        fallback_violation_payload["mode"] = "run"
+        fallback_violation_payload["status"] = "fail"
+        fallback_violation_payload["reason_code"] = "runtime_signer_fallback_private_key_present_violation"
+        fallback_violation_payload["runtime_signer_fallback_private_key_present"] = True
+        fallback_violation_payload["bootstrap_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_violation_payload["localhost_signed_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_violation_payload["conformance_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_violation_payload["runtime_commit_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_violation_payload["runtime_commit_policy_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_violation_checks = [
+            {
+                "id": "bootstrap_readiness",
+                "command": "bash scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh --mode run",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "localhost_signed_integration",
+                "command": "bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed.json",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "live_api_conformance",
+                "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "runtime_signer_fallback_private_key_contract",
+                "command": "fallback signer secret env must remain unset for real-node runtime profile",
+                "status": "fail",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "runtime_commit_endpoint",
+                "command": summary_payload.get("runtime_commit_command", ""),
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "runtime_commit_policy",
+                "command": "python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/runtime-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/runtime-policy.json",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+        ]
+        fallback_violation_payload["checks"] = fallback_violation_checks
+        fallback_violation_report = temp_path / "runtime_fallback_violation_summary.json"
+        fallback_violation_report.write_text(
+            json.dumps(fallback_violation_payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        fallback_violation_run = subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(fallback_violation_report),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "runtime_signer_fallback_private_key_present_violation",
+                "--output-json",
+                str(failure_policy_output),
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if fallback_violation_run.returncode == 0:
+            print("expected checker to fail when fallback signer private key marker is present", file=sys.stderr)
+            return 1
+        fallback_violation_output = f"{fallback_violation_run.stdout}\n{fallback_violation_run.stderr}"
+        if "runtime_signer_fallback_private_key_present_violation" not in fallback_violation_output:
+            print(
+                "expected fallback signer private key violation reason for policy failure",
+                file=sys.stderr,
+            )
+            return 1
+
     doc_text = DOC_FILE.read_text(encoding="utf-8")
     readme_text = README_FILE.read_text(encoding="utf-8")
     if "run_local_kamn_live_runtime_integration_lane.sh" not in doc_text:
@@ -355,6 +475,19 @@ def main() -> int:
     if "Regression: #2101" not in doc_text:
         print("expected Kolme devnet ops doc to include runtime finality contract composition regression marker", file=sys.stderr)
         return 1
+    # Regression: #2302
+    if "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" not in doc_text:
+        print("expected Kolme devnet ops doc to include fallback signer private key env marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_fallback_private_key_present=false" not in doc_text:
+        print("expected Kolme devnet ops doc to include fallback signer private key presence marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_fallback_private_key_present_violation" not in doc_text:
+        print("expected Kolme devnet ops doc to include fallback signer private key violation marker", file=sys.stderr)
+        return 1
+    if "Regression: #2302" not in doc_text:
+        print("expected Kolme devnet ops doc to include fallback signer runtime regression marker", file=sys.stderr)
+        return 1
     if "run_local_kamn_live_runtime_integration_contract_lane.sh" not in readme_text:
         print("expected README to reference local KAMN live runtime integration contract lane", file=sys.stderr)
         return 1
@@ -390,6 +523,18 @@ def main() -> int:
             "expected README to reference live provider operator runbook section marker",
             file=sys.stderr,
         )
+        return 1
+    if "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" not in readme_text:
+        print("expected README to include fallback signer private key env marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_fallback_private_key_present=false" not in readme_text:
+        print("expected README to include fallback signer private key presence marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_fallback_private_key_present_violation" not in readme_text:
+        print("expected README to include fallback signer private key violation marker", file=sys.stderr)
+        return 1
+    if "Regression: #2302" not in readme_text:
+        print("expected README to include fallback signer runtime regression marker", file=sys.stderr)
         return 1
 
     elapsed_seconds = int(time.monotonic() - start_epoch)

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -21,6 +21,7 @@ SIGNER_PRIVATE_KEY_ENV_BY_PROFILE = {
     "ops-primary": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "ops-secondary": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
 }
+FALLBACK_SIGNER_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -274,6 +275,33 @@ def main() -> int:
     if summary.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
+        print("expected fallback signer private key env marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_fallback_private_key_present") is not False:
+        print("expected fallback signer private key presence marker false in contract-lane summary", file=sys.stderr)
+        return 1
+    checks = summary.get("checks")
+    if not isinstance(checks, list):
+        print("expected checks list in real-node profile contract-lane summary", file=sys.stderr)
+        return 1
+    fallback_signer_checks = [
+        check
+        for check in checks
+        if isinstance(check, dict) and check.get("id") == "runtime_signer_fallback_private_key_contract"
+    ]
+    if len(fallback_signer_checks) != 1:
+        print(
+            "expected one runtime_signer_fallback_private_key_contract check in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
+    if fallback_signer_checks[0].get("status") != "planned":
+        print(
+            "expected runtime_signer_fallback_private_key_contract planned status in dry-run contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in real-node profile contract-lane summary", file=sys.stderr)
@@ -301,6 +329,12 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected contracts signer private key env marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
+        print("expected contracts fallback signer private key env marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+        print("expected contracts fallback signer private key allowed=false marker in contract-lane summary", file=sys.stderr)
         return 1
     if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
         print("unexpected real-node profile policy schema in contract-lane output", file=sys.stderr)
@@ -418,6 +452,87 @@ def main() -> int:
             return 1
         if signer_key_env_drift_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for signer key env drift policy output", file=sys.stderr)
+            return 1
+
+        # Regression: #2302
+        fallback_signer_violation_summary_file = negative_path / "fallback_signer_violation_summary.json"
+        fallback_signer_violation_policy_file = negative_path / "fallback_signer_violation_policy.json"
+        fallback_signer_violation_summary = dict(summary)
+        fallback_signer_violation_summary["mode"] = "run"
+        fallback_signer_violation_summary["status"] = "fail"
+        fallback_signer_violation_summary["reason_code"] = "runtime_signer_fallback_private_key_present_violation"
+        fallback_signer_violation_summary["runtime_signer_fallback_private_key_present"] = True
+        fallback_signer_violation_summary["bootstrap_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_signer_violation_summary["localhost_signed_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_signer_violation_summary["conformance_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_signer_violation_summary["runtime_commit_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_signer_violation_summary["runtime_commit_policy_reason_code"] = "fallback_signer_secret_present_violation"
+        fallback_signer_violation_summary["checks"] = [
+            {
+                "id": "bootstrap_readiness",
+                "command": "bash scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh --mode run",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "localhost_signed_integration",
+                "command": "bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json /tmp/localhost-signed.json",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "live_api_conformance",
+                "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "runtime_signer_fallback_private_key_contract",
+                "command": "fallback signer secret env must remain unset for real-node runtime profile",
+                "status": "fail",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "runtime_commit_endpoint",
+                "command": runtime_commit_command,
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+            {
+                "id": "runtime_commit_policy",
+                "command": "python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/runtime-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-non-synthetic-run-evidence --require-native-payload-evidence --output-json /tmp/runtime-policy.json",
+                "status": "skipped",
+                "reason_code": "fallback_signer_secret_present_violation",
+            },
+        ]
+        fallback_signer_violation_summary_file.write_text(
+            json.dumps(fallback_signer_violation_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        fallback_signer_violation_result = run_real_node_policy_check(
+            report_file=fallback_signer_violation_summary_file,
+            output_json=fallback_signer_violation_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if fallback_signer_violation_result.returncode == 0:
+            print("expected fallback signer violation negative proof to fail closed", file=sys.stderr)
+            return 1
+        fallback_signer_violation_policy = json.loads(
+            fallback_signer_violation_policy_file.read_text(encoding="utf-8")
+        )
+        fallback_signer_violation_reason_codes = fallback_signer_violation_policy.get("reason_codes")
+        if not isinstance(fallback_signer_violation_reason_codes, list):
+            print("expected reason_codes list in fallback signer violation policy output", file=sys.stderr)
+            return 1
+        if "runtime_signer_fallback_private_key_present_violation" not in fallback_signer_violation_reason_codes:
+            print(
+                "expected runtime_signer_fallback_private_key_present_violation in fallback signer policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if fallback_signer_violation_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for fallback signer violation policy output", file=sys.stderr)
             return 1
 
         key_source_matrix_drift_summary_file = negative_path / "key_source_matrix_drift_summary.json"
@@ -573,10 +688,14 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "runtime_signer_fallback_private_key_present=false",
+        "runtime_signer_fallback_private_key_present_violation",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
+        "Regression: #2302",
         "Regression: #2139",
     ]
     ci_doc_markers = [
@@ -589,10 +708,14 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "runtime_signer_fallback_private_key_present=false",
+        "runtime_signer_fallback_private_key_present_violation",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
+        "Regression: #2302",
         "Regression: #2139",
     ]
     readme_markers = [
@@ -605,10 +728,14 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "runtime_signer_fallback_private_key_present=false",
+        "runtime_signer_fallback_private_key_present_violation",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
+        "Regression: #2302",
         "Regression: #2139",
     ]
 

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -39,6 +39,7 @@ RUNTIME_SIGNER_PROFILE=""
 RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION=""
 RUNTIME_SIGNER_KEY_SOURCE=""
 RUNTIME_SIGNER_PRIVATE_KEY_ENV=""
+RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 RUNTIME_SIGNER_PROFILE_OVERRIDE=""
 
 if [ "${1:-}" != "--manifest-impl" ]; then
@@ -499,6 +500,7 @@ PY
 bootstrap_command="bash scripts/kolme/run_local_kolme_fork_bootstrap_readiness_lane.sh --mode run --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --max-seconds ${BOOTSTRAP_MAX_SECONDS} --probe-max-seconds 20 --output-json ${BOOTSTRAP_REPORT}"
 localhost_signed_command="bash scripts/sdk/run_localhost_signed_integration_contract_lane.sh --output-json ${LOCALHOST_SIGNED_REPORT}"
 conformance_command="bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --max-seconds ${CONFORMANCE_MAX_SECONDS} --probe-max-seconds 30 --native-max-seconds 120 --output-json ${CONFORMANCE_REPORT}"
+runtime_signer_fallback_private_key_command="fallback signer secret env must remain unset for real-node runtime profile"
 runtime_commit_command="$RUNTIME_COMMIT_COMMAND"
 runtime_commit_policy_command="python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file ${RUNTIME_COMMIT_LIVE_SUMMARY} --expected-final-decision GO --ci-fast-gate PASS --output-json ${RUNTIME_COMMIT_LIVE_POLICY_REPORT}"
 if [ "$RUNTIME_PROFILE" = "real-node" ]; then
@@ -514,10 +516,12 @@ localhost_signed_reason_code="not_run"
 conformance_reason_code="not_run"
 runtime_commit_reason_code="not_run"
 runtime_commit_policy_reason_code="not_run"
+runtime_signer_fallback_private_key_present="false"
 
 record_check "bootstrap_readiness" "$bootstrap_command" "planned" "not_run"
 record_check "localhost_signed_integration" "$localhost_signed_command" "planned" "not_run"
 record_check "live_api_conformance" "$conformance_command" "planned" "not_run"
+record_check "runtime_signer_fallback_private_key_contract" "$runtime_signer_fallback_private_key_command" "planned" "not_run"
 record_check "runtime_commit_endpoint" "$runtime_commit_command" "planned" "not_run"
 record_check "runtime_commit_policy" "$runtime_commit_policy_command" "planned" "not_run"
 
@@ -525,20 +529,41 @@ if [ "$MODE" = "run" ]; then
   : >"$CHECK_FILE"
   start_epoch="$(date +%s)"
 
-  if ! "$LOCAL_HEAVY_GUARD"; then
-    record_check "bootstrap_readiness" "$bootstrap_command" "fail" "local_opt_in_missing"
-    record_check "localhost_signed_integration" "$localhost_signed_command" "skipped" "local_opt_in_missing"
-    record_check "live_api_conformance" "$conformance_command" "skipped" "local_opt_in_missing"
-    record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "local_opt_in_missing"
-    record_check "runtime_commit_policy" "$runtime_commit_policy_command" "skipped" "local_opt_in_missing"
+  if [ "$RUNTIME_PROFILE" = "real-node" ] && [ -n "${!RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV:-}" ]; then
+    runtime_signer_fallback_private_key_present="true"
+    echo "fallback signer secret env must not be set: $RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV (remediation: unset $RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV)" >&2
+    record_check "bootstrap_readiness" "$bootstrap_command" "skipped" "fallback_signer_secret_present_violation"
+    record_check "localhost_signed_integration" "$localhost_signed_command" "skipped" "fallback_signer_secret_present_violation"
+    record_check "live_api_conformance" "$conformance_command" "skipped" "fallback_signer_secret_present_violation"
+    record_check "runtime_signer_fallback_private_key_contract" "$runtime_signer_fallback_private_key_command" "fail" "fallback_signer_secret_present_violation"
+    record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "fallback_signer_secret_present_violation"
+    record_check "runtime_commit_policy" "$runtime_commit_policy_command" "skipped" "fallback_signer_secret_present_violation"
     overall_status="fail"
-    reason_code="local_opt_in_missing"
-    bootstrap_reason_code="local_opt_in_missing"
-    localhost_signed_reason_code="local_opt_in_missing"
-    conformance_reason_code="local_opt_in_missing"
-    runtime_commit_reason_code="local_opt_in_missing"
-    runtime_commit_policy_reason_code="local_opt_in_missing"
+    reason_code="runtime_signer_fallback_private_key_present_violation"
+    bootstrap_reason_code="fallback_signer_secret_present_violation"
+    localhost_signed_reason_code="fallback_signer_secret_present_violation"
+    conformance_reason_code="fallback_signer_secret_present_violation"
+    runtime_commit_reason_code="fallback_signer_secret_present_violation"
+    runtime_commit_policy_reason_code="fallback_signer_secret_present_violation"
   else
+    record_check "runtime_signer_fallback_private_key_contract" "$runtime_signer_fallback_private_key_command" "pass" "fallback_signer_secret_absent"
+  fi
+
+  if [ "$overall_status" = "ok" ]; then
+    if ! "$LOCAL_HEAVY_GUARD"; then
+      record_check "bootstrap_readiness" "$bootstrap_command" "fail" "local_opt_in_missing"
+      record_check "localhost_signed_integration" "$localhost_signed_command" "skipped" "local_opt_in_missing"
+      record_check "live_api_conformance" "$conformance_command" "skipped" "local_opt_in_missing"
+      record_check "runtime_commit_endpoint" "$runtime_commit_command" "skipped" "local_opt_in_missing"
+      record_check "runtime_commit_policy" "$runtime_commit_policy_command" "skipped" "local_opt_in_missing"
+      overall_status="fail"
+      reason_code="local_opt_in_missing"
+      bootstrap_reason_code="local_opt_in_missing"
+      localhost_signed_reason_code="local_opt_in_missing"
+      conformance_reason_code="local_opt_in_missing"
+      runtime_commit_reason_code="local_opt_in_missing"
+      runtime_commit_policy_reason_code="local_opt_in_missing"
+    else
     if KAMN_KOLME_LOCAL_HEAVY=1 bash "$BOOTSTRAP_RUNNER" \
       --mode run \
       --checkout-path "$CHECKOUT_PATH" \
@@ -663,6 +688,7 @@ if [ "$MODE" = "run" ]; then
         reason_code="runtime_commit_endpoint_failed"
       fi
     fi
+    fi
   fi
 
   elapsed_seconds="$(( $(date +%s) - start_epoch ))"
@@ -677,7 +703,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" <<'PY'
 from __future__ import annotations
 
 import json
@@ -726,6 +752,8 @@ runtime_signer_previous_rotation_epoch = int(sys.argv[39])
 runtime_signer_key_source_contract_version = sys.argv[40]
 runtime_signer_key_source = sys.argv[41]
 runtime_signer_private_key_env = sys.argv[42]
+runtime_signer_fallback_private_key_env = sys.argv[43]
+runtime_signer_fallback_private_key_present = sys.argv[44] == "true"
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -883,6 +911,8 @@ summary = {
     "runtime_signer_key_source_contract_version": runtime_signer_key_source_contract_version,
     "runtime_signer_key_source": runtime_signer_key_source,
     "runtime_signer_private_key_env": runtime_signer_private_key_env,
+    "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
+    "runtime_signer_fallback_private_key_present": runtime_signer_fallback_private_key_present,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
     "runtime_commit_finality_output_file": runtime_commit_finality_output_file if runtime_commit_finality_command else "",
@@ -908,6 +938,8 @@ summary = {
         "runtime_signer_key_source_contract_version": runtime_signer_key_source_contract_version,
         "runtime_signer_key_source": runtime_signer_key_source,
         "runtime_signer_private_key_env": runtime_signer_private_key_env,
+        "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
+        "runtime_signer_fallback_private_key_allowed": False,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",
         "runtime_commit_finality_primary_endpoint": "/notifications",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -73,6 +73,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_signer_key_source_contract_version": "v1",
   "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+  "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_private_key_present": false,
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
@@ -98,6 +100,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_key_source_contract_version": "v1",
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+    "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_private_key_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -119,6 +123,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     {
       "id": "live_api_conformance",
       "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_signer_fallback_private_key_contract",
+      "command": "fallback signer secret env must remain unset for real-node runtime profile",
       "status": "planned",
       "reason_code": "not_run"
     },
@@ -423,6 +433,8 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
   "runtime_signer_key_source_contract_version": "v1",
   "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+  "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_private_key_present": false,
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
@@ -446,6 +458,8 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
     "runtime_signer_key_source_contract_version": "v1",
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+    "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_private_key_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -467,6 +481,12 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
     {
       "id": "live_api_conformance",
       "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_signer_fallback_private_key_contract",
+      "command": "fallback signer secret env must remain unset for real-node runtime profile",
       "status": "planned",
       "reason_code": "not_run"
     },
@@ -542,6 +562,8 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
   "runtime_signer_key_source_contract_version": "v1",
   "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+  "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_private_key_present": false,
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
@@ -565,6 +587,8 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     "runtime_signer_key_source_contract_version": "v1",
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+    "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_private_key_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -586,6 +610,12 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     {
       "id": "live_api_conformance",
       "command": "bash scripts/kolme/run_local_kolme_live_api_conformance_harness.sh --mode run",
+      "status": "planned",
+      "reason_code": "not_run"
+    },
+    {
+      "id": "runtime_signer_fallback_private_key_contract",
+      "command": "fallback signer secret env must remain unset for real-node runtime profile",
       "status": "planned",
       "reason_code": "not_run"
     },
@@ -715,9 +745,22 @@ if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected signer key-source marker in runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in runner-generated summary")
+if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key env marker in runner-generated summary")
+if summary.get("runtime_signer_fallback_private_key_present") is not False:
+    raise SystemExit("expected fallback signer private key presence marker false in runner-generated summary")
 checks = summary.get("checks")
 if not isinstance(checks, list) or not checks:
     raise SystemExit("expected checks list in runner-generated summary")
+fallback_key_checks = [
+    check
+    for check in checks
+    if isinstance(check, dict) and check.get("id") == "runtime_signer_fallback_private_key_contract"
+]
+if len(fallback_key_checks) != 1:
+    raise SystemExit("expected exactly one runtime_signer_fallback_private_key_contract check in runner-generated summary")
+if fallback_key_checks[0].get("status") != "planned":
+    raise SystemExit("expected runtime_signer_fallback_private_key_contract check to remain planned in dry-run summary")
 runtime_policy_checks = [
     check for check in checks if isinstance(check, dict) and check.get("id") == "runtime_commit_policy"
 ]
@@ -762,6 +805,14 @@ if contracts.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected contracts signer key-source marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in secondary runner-generated summary")
+if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key env marker in secondary runner-generated summary")
+if summary.get("runtime_signer_fallback_private_key_present") is not False:
+    raise SystemExit("expected fallback signer private key presence marker false in secondary runner-generated summary")
+if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected contracts fallback signer private key env marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+    raise SystemExit("expected contracts fallback signer private key allowed=false marker in secondary runner-generated summary")
 PY
 
 python3 - "$TMP_INTEGRATION_POLICY_OUT" <<'PY'

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -128,14 +128,19 @@ required_coverage_markers=(
   "check_local_kamn_live_runtime_integration_policy.py"
   "run_localhost_signed_integration_contract_lane.sh"
   "run_local_runtime_commit_live_finality_evidence_contract_lane.sh"
+  "runtime_signer_fallback_private_key_contract"
+  "runtime_signer_fallback_private_key_present_violation"
   "runtime_commit_failure_taxonomy_mismatch:finality.timeout"
   "runtime_profile_run_mode_mismatch"
+  "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+  "runtime_signer_fallback_private_key_present=false"
   "Regression: #1489"
   "Regression: #1971"
   "Regression: #2101"
   "Regression: #2112"
   "Regression: #2113"
   "Regression: #2114"
+  "Regression: #2302"
   "Regression: #2296"
   "Regression: #2298"
 )
@@ -190,6 +195,26 @@ if ! grep -q "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" 
   exit 1
 fi
 
+if ! grep -q "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fallback signer private key env marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_present=false" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fallback signer private key presence marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_present_violation" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fallback signer private key violation marker" >&2
+  exit 1
+fi
+
+if ! grep -q "Regression: #2302" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fallback signer runtime regression marker" >&2
+  exit 1
+fi
+
 if ! grep -q "check_local_kamn_live_runtime_integration_policy.py" "$README_FILE"; then
   echo "expected README to reference local KAMN live runtime integration policy checker" >&2
   exit 1
@@ -225,6 +250,26 @@ if ! grep -q "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" 
   exit 1
 fi
 
+if ! grep -q "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$README_FILE"; then
+  echo "expected README to include fallback signer private key env marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_present=false" "$README_FILE"; then
+  echo "expected README to include fallback signer private key presence marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_present_violation" "$README_FILE"; then
+  echo "expected README to include fallback signer private key violation marker" >&2
+  exit 1
+fi
+
+if ! grep -q "Regression: #2302" "$README_FILE"; then
+  echo "expected README to include fallback signer runtime regression marker" >&2
+  exit 1
+fi
+
 # Regression: #1489
 if ! grep -q "Regression: #1489" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to include local KAMN live runtime integration regression marker" >&2
@@ -248,6 +293,10 @@ if summary.get("reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected dry_run_no_commands_executed reason code in contract-lane summary")
 if summary.get("runtime_profile") != "real-node":
     raise SystemExit("expected runtime_profile=real-node in contract-lane summary")
+if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key env marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_private_key_present") is not False:
+    raise SystemExit("expected fallback signer private key presence marker false in contract-lane summary")
 if summary.get("runtime_commit_failure_taxonomy_version") != "v1":
     raise SystemExit("expected runtime commit failure taxonomy version marker in contract-lane summary")
 if summary.get("runtime_commit_failure_taxonomy") != "none":
@@ -268,6 +317,11 @@ if not isinstance(checks, list) or not any(
     for check in checks
 ):
     raise SystemExit("expected runtime commit policy planned check marker in contract-lane summary")
+if not any(
+    check.get("id") == "runtime_signer_fallback_private_key_contract" and check.get("status") == "planned"
+    for check in checks
+):
+    raise SystemExit("expected fallback signer private key planned check marker in contract-lane summary")
 if summary.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
     raise SystemExit("expected runtime provider client contract marker in contract-lane summary")
 if summary.get("ci_fast_gate_eligible") is not False:
@@ -275,6 +329,10 @@ if summary.get("ci_fast_gate_eligible") is not False:
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "local-only":
     raise SystemExit("expected local-only fast-gate scope contract marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected contracts fallback signer private key env marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+    raise SystemExit("expected contracts fallback signer private key allowed=false marker in contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("unexpected local KAMN live runtime integration contract-lane policy schema")
 if policy.get("final_decision") != "GO":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -182,6 +182,59 @@ if ! grep -q "requires explicit local-only opt-in" "$TMP_ERR"; then
 fi
 
 set +e
+KAMN_KOLME_LOCAL_HEAVY=1 \
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK="2222222222222222222222222222222222222222222222222222222222222222" \
+bash "$RUNNER" \
+  --mode run \
+  --runtime-profile real-node \
+  --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \
+  --runtime-commit-live-summary "$TMP_RUNTIME_SUMMARY" \
+  --runtime-commit-live-policy-report "$TMP_RUNTIME_POLICY" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+run_fallback_key_present_code=$?
+set -e
+
+if [ "$run_fallback_key_present_code" -eq 0 ]; then
+  echo "expected real-node profile run mode to fail closed when fallback signer key env is present" >&2
+  exit 1
+fi
+
+if ! grep -q "fallback signer secret env must not be set" "$TMP_ERR"; then
+  echo "expected deterministic fallback signer key rejection message for real-node profile run mode" >&2
+  exit 1
+fi
+
+python3 - "$TMP_SUMMARY" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if summary.get("reason_code") != "runtime_signer_fallback_private_key_present_violation":
+    raise SystemExit("expected fallback signer private key violation reason code in real-node profile run summary")
+if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key env marker in real-node profile run summary")
+if summary.get("runtime_signer_fallback_private_key_present") is not True:
+    raise SystemExit("expected fallback signer private key presence marker true in real-node profile run summary")
+checks = summary.get("checks")
+if not isinstance(checks, list):
+    raise SystemExit("expected checks list in real-node profile run summary")
+fallback_checks = [
+    check
+    for check in checks
+    if isinstance(check, dict) and check.get("id") == "runtime_signer_fallback_private_key_contract"
+]
+if len(fallback_checks) != 1:
+    raise SystemExit("expected exactly one fallback signer private key contract check in run summary")
+if fallback_checks[0].get("status") != "fail":
+    raise SystemExit("expected fallback signer private key contract check status fail in run summary")
+if fallback_checks[0].get("reason_code") != "fallback_signer_secret_present_violation":
+    raise SystemExit("expected fallback signer private key contract check reason in run summary")
+PY
+
+set +e
 bash "$RUNNER" \
   --mode run \
   --runtime-profile standard \

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -15,13 +15,14 @@ TMP_DRIFT_REPORT="$(mktemp)"
 TMP_SIGNER_DRIFT_REPORT="$(mktemp)"
 TMP_SYNTHETIC_REPORT="$(mktemp)"
 TMP_INMEMORY_REPORT="$(mktemp)"
+TMP_FALLBACK_PRESENT_REPORT="$(mktemp)"
 TMP_SECONDARY_REPORT="$(mktemp)"
 TMP_SECONDARY_POLICY_REPORT="$(mktemp)"
 TMP_SECONDARY_KEY_ENV_DRIFT_REPORT="$(mktemp)"
 TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT="$(mktemp)"
 TMP_NEGATIVE_POLICY="$(mktemp)"
 TMP_NEGATIVE_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_REPORT" "$TMP_SECONDARY_POLICY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_FALLBACK_PRESENT_REPORT" "$TMP_SECONDARY_REPORT" "$TMP_SECONDARY_POLICY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" "$TMP_NEGATIVE_POLICY" "$TMP_NEGATIVE_ERR"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime real-node profile contract lane runner to be executable" >&2
@@ -75,6 +76,9 @@ required_coverage_markers=(
   "runtime_signer_profile=ops-secondary"
   "runtime_signer_key_source_contract_version"
   "runtime_signer_key_source"
+  "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+  "runtime_signer_fallback_private_key_present=false"
+  "runtime_signer_fallback_private_key_present_violation"
   "runtime_signer_key_source_profile_pair_disallowed"
   "runtime_signer_private_key_env_mismatch"
   "runtime_commit_command_profile_mismatch"
@@ -83,6 +87,7 @@ required_coverage_markers=(
   "runtime_commit_signer_profile_marker_missing"
   "runtime_commit_non_synthetic_submit_probe_missing"
   "runtime_commit_in_memory_provider_reference_detected"
+  "Regression: #2302"
   "Regression: #2139"
 )
 for marker in "${required_coverage_markers[@]}"; do
@@ -121,12 +126,28 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include signer key-source marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$docs_file"; then
+    echo "expected docs parity to include fallback signer private key env marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_fallback_private_key_present=false" "$docs_file"; then
+    echo "expected docs parity to include fallback signer private key presence marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_fallback_private_key_present_violation" "$docs_file"; then
+    echo "expected docs parity to include fallback signer private key violation marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$docs_file"; then
     echo "expected docs parity to include signer key-source/profile pair disallowed reason marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "runtime_signer_private_key_env_mismatch" "$docs_file"; then
     echo "expected docs parity to include signer private key mismatch reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2302" "$docs_file"; then
+    echo "expected docs parity to include fallback signer runtime regression marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "Regression: #2139" "$docs_file"; then
@@ -181,6 +202,18 @@ if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected signer key-source marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key env marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_fallback_private_key_present") is not False:
+    raise SystemExit("expected fallback signer private key presence marker false in real-node profile contract-lane summary")
+checks = summary.get("checks", [])
+if not any(
+    isinstance(check, dict)
+    and check.get("id") == "runtime_signer_fallback_private_key_contract"
+    and check.get("status") == "planned"
+    for check in checks
+):
+    raise SystemExit("expected fallback signer private key planned check marker in real-node profile contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_profile") != "real-node":
     raise SystemExit("expected contracts.runtime_profile=real-node in real-node profile contract-lane summary")
@@ -198,6 +231,10 @@ if contracts.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected contracts signer key-source marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected contracts signer private key env marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected contracts fallback signer private key env marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+    raise SystemExit("expected contracts fallback signer private key allowed=false marker in real-node profile contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
     raise SystemExit("unexpected real-node profile contract-lane policy schema")
 if policy.get("final_decision") != "GO":
@@ -233,6 +270,10 @@ if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected secondary signer key-source marker in contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected secondary signer private key env marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected secondary signer fallback private key env marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_private_key_present") is not False:
+    raise SystemExit("expected secondary signer fallback private key presence marker false in contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_signer_profile") != "ops-secondary":
     raise SystemExit("expected contracts secondary signer profile marker in contract-lane summary")
@@ -242,13 +283,17 @@ if contracts.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected contracts secondary signer key-source marker in contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected contracts secondary signer fallback private key env marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
+    raise SystemExit("expected contracts secondary signer fallback private key allowed=false marker in contract-lane summary")
 if policy.get("final_decision") != "GO":
     raise SystemExit("expected secondary signer policy final_decision GO")
 if policy.get("reason_codes") != []:
     raise SystemExit("expected no policy reason codes for secondary signer dry-run composition")
 PY
 
-python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" <<'PY'
+python3 - "$TMP_REPORT" "$TMP_DRIFT_REPORT" "$TMP_SIGNER_DRIFT_REPORT" "$TMP_SYNTHETIC_REPORT" "$TMP_INMEMORY_REPORT" "$TMP_FALLBACK_PRESENT_REPORT" "$TMP_SECONDARY_KEY_ENV_DRIFT_REPORT" "$TMP_KEY_SOURCE_MATRIX_DRIFT_REPORT" <<'PY'
 import json
 import pathlib
 import sys
@@ -302,6 +347,21 @@ pathlib.Path(sys.argv[5]).write_text(
     encoding="utf-8",
 )
 
+fallback_present_summary = dict(base_summary)
+fallback_present_summary["mode"] = "run"
+fallback_present_summary["status"] = "fail"
+fallback_present_summary["reason_code"] = "runtime_signer_fallback_private_key_present_violation"
+fallback_present_summary["runtime_signer_fallback_private_key_present"] = True
+fallback_present_summary["bootstrap_reason_code"] = "fallback_signer_secret_present_violation"
+fallback_present_summary["localhost_signed_reason_code"] = "fallback_signer_secret_present_violation"
+fallback_present_summary["conformance_reason_code"] = "fallback_signer_secret_present_violation"
+fallback_present_summary["runtime_commit_reason_code"] = "fallback_signer_secret_present_violation"
+fallback_present_summary["runtime_commit_policy_reason_code"] = "fallback_signer_secret_present_violation"
+pathlib.Path(sys.argv[6]).write_text(
+    json.dumps(fallback_present_summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
 secondary_key_env_drift_summary = dict(base_summary)
 secondary_key_env_drift_summary["runtime_signer_profile"] = "ops-secondary"
 secondary_key_env_drift_summary["runtime_signer_previous_profile"] = "ops-secondary"
@@ -313,7 +373,7 @@ secondary_key_env_drift_summary["runtime_commit_command"] = str(base_summary.get
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
 )
-pathlib.Path(sys.argv[6]).write_text(
+pathlib.Path(sys.argv[7]).write_text(
     json.dumps(secondary_key_env_drift_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
@@ -331,7 +391,7 @@ key_source_matrix_drift_summary["runtime_commit_command"] = str(base_summary.get
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
 )
-pathlib.Path(sys.argv[7]).write_text(
+pathlib.Path(sys.argv[8]).write_text(
     json.dumps(key_source_matrix_drift_summary, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
 )
@@ -429,6 +489,26 @@ fi
 
 if ! grep -q "runtime_commit_in_memory_provider_reference_detected" "$TMP_NEGATIVE_ERR"; then
   echo "expected in-memory provider reference reason in negative proof output" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_FALLBACK_PRESENT_REPORT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_NEGATIVE_POLICY" >"$TMP_NEGATIVE_ERR" 2>&1
+fallback_present_exit_code=$?
+set -e
+
+if [ "$fallback_present_exit_code" -eq 0 ]; then
+  echo "expected fallback signer private key presence negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_present_violation" "$TMP_NEGATIVE_ERR"; then
+  echo "expected fallback signer private key violation reason in negative proof output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This hardens local Kolme runtime launch surfaces so fallback signer private-key env usage fails closed with deterministic diagnostics and policy evidence. It extends the fallback-key rejection path into runtime lane execution, wrapper/manifest contract coverage, and runbook/operator docs so drift is caught early.

Closes #2302

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: added run-mode guard for `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`, deterministic remediation message, checkpoint wiring, and summary/contracts markers (`runtime_signer_fallback_private_key_env`, `runtime_signer_fallback_private_key_present`, `runtime_signer_fallback_private_key_allowed=false`).
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`: added fallback-key env/presence policy validation and fallback checkpoint ID coverage.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: added real-node fallback-key env/presence policy validation and contract/checkpoint enforcement.
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: added fallback-key regression proof and docs parity enforcement markers.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: added fallback-key regression proof and docs parity marker enforcement.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: added deterministic summary assertion for fallback-key run-mode rejection.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: updated fixtures for new fallback markers/checkpoint and summary/contracts expectations.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: added fallback-key coverage and docs parity assertions.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: added fallback-key coverage markers, summary/contracts assertions, and negative proof.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: documented fallback-key runtime guard markers/reasons and regression contract.
- `docs/foundation/upgrade-rollback-runbook.md`: added issue #2302 fallback signer runtime/deploy guard section and validation commands.
- `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs`: added runbook section and regression marker assertions for #2302.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`

Failure before implementation:
- `expected deterministic fallback signer key rejection message for real-node profile run mode`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`

Result:
- all passed locally.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test upgrade_rollback_runbook_docs`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --test upgrade_rollback_runbook_docs -- -D warnings`

Result:
- all passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Policy validations in `check_local_kamn_live_runtime_integration_policy.py` and `check_local_kamn_live_runtime_real_node_profile_policy.py` with fixture coverage in `test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | |
| Functional   | ✅ | Runtime lane fallback rejection behavior in `test_run_local_kamn_live_runtime_integration_real_node_profile.sh` | |
| Integration  | ✅ | Wrapper/manifest contract-lane paths in `test_run_local_kamn_live_runtime_integration_contract_lane.sh` and `test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | |
| Regression   | ✅ | Added #2302 regression markers/proofs in contract-lane python and runbook docs test (`upgrade_rollback_runbook_docs.rs`) | |
| Performance  | N/A | Policy checks only; no runtime hot-path or throughput change | Not applicable by scope |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert this PR to restore prior runtime-lane behavior and docs/tests; no state migration required.

## Documentation Updates
- `README.md`
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`
- `docs/foundation/upgrade-rollback-runbook.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-core --test upgrade_rollback_runbook_docs`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant local suite)
- [x] Docs updated
