### PR TITLE
feat(kolme): enforce runtime signer attestation contracts (#2325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,8 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
 # runtime_signer_fallback_private_key_present=false
 # runtime_signer_raw_private_key_present=false
+# runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1
+# runtime_signer_attestation_bundle
 # contracts.runtime_signer_fallback_private_key_allowed=false
 # contracts.runtime_signer_managed_external_raw_private_key_allowed=false
 
@@ -616,6 +618,8 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_private_key_env_mismatch
 # runtime_signer_fallback_private_key_present_violation
 # runtime_signer_managed_external_raw_private_key_present_violation
+# runtime_signer_attestation_approved_signers_not_unique
+# runtime_signer_attestation_quorum_shortfall
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing
 # runtime_commit_signer_profile_marker_missing
@@ -646,6 +650,7 @@ bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --ou
 # managed-external signer raw private key env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF)
 # Regression: #2302
 # Regression: #2324
+# Regression: #2325
 # Regression: #2139
 ```
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -361,6 +361,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
       - `runtime_signer_fallback_private_key_present=false`
       - `runtime_signer_raw_private_key_present=false`
+      - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
+      - `runtime_signer_attestation_bundle`
       - strict secondary signer summary marker contracts:
       - `runtime_signer_profile=ops-secondary`
       - `runtime_signer_previous_profile=ops-secondary`
@@ -374,6 +376,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_private_key_env_mismatch`
       - `runtime_signer_fallback_private_key_present_violation`
       - `runtime_signer_managed_external_raw_private_key_present_violation`
+      - `runtime_signer_attestation_approved_signers_not_unique`
+      - `runtime_signer_attestation_quorum_shortfall`
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`
       - `runtime_commit_signer_profile_marker_missing`
@@ -394,6 +398,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
     - fallback signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2302`).
     - managed-external raw signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2324`).
+    - runtime signer-attestation schema + quorum/uniqueness policy checks remain fail-closed across runtime launch + policy/contract lanes (`Regression: #2325`).
   - deployment preflight signer/runtime checks remain fast and ci-fast-gate eligible.
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -516,6 +516,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
     - `runtime_signer_fallback_private_key_present=false`
     - `runtime_signer_raw_private_key_present=false`
+    - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
+    - `runtime_signer_attestation_bundle`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
     - `contracts.runtime_signer_fallback_private_key_allowed=false`
@@ -541,6 +543,9 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:
     - `runtime_commit_in_memory_provider_reference_detected`
     - `runtime_commit_policy_check_in_memory_provider_reference_detected`
+  - real-node signer-attestation checker fails closed on malformed attestations:
+    - `runtime_signer_attestation_approved_signers_not_unique`
+    - `runtime_signer_attestation_quorum_shortfall`
   - integration summary emits `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` for explicit PR-fast-gate exclusion enforcement.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.
@@ -551,6 +556,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - local KAMN live runtime integration run-mode execution remains excluded from PR fast-gate workflow routing.
   - fallback signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2302`).
   - managed-external raw signer key path remains fail-closed across runtime launch + wrapper/manifest entry points (`Regression: #2324`).
+  - runtime signer-attestation schema + quorum/uniqueness policy checks remain fail-closed across runtime launch + policy/contract lanes (`Regression: #2325`).
   - real-node profile policy + contract lane docs parity markers remain fail-closed (`Regression: #2139`).
 
 ## Local Kolme Live Deployment Preflight Lane (Issue #2225)

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -21,6 +21,7 @@ RUNTIME_SIGNER_KEY_REF_ENV_BY_PROFILE = {
     RUNTIME_SIGNER_PROFILE_PRIMARY: "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
     RUNTIME_SIGNER_PROFILE_SECONDARY: "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY",
 }
+RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION = "kamn.kolme.runtime-signer-attestation.v1"
 
 
 ALLOWED_RUNTIME_COMMIT_FAILURE_TAXONOMIES = {
@@ -46,6 +47,44 @@ NESTED_RUNTIME_REASON_TO_TAXONOMY = {
     "live_finality_command_failed": "finality.failed",
     "live_runtime_commit_budget_exceeded": "budget.exceeded",
 }
+
+
+def evaluate_runtime_signer_attestation_bundle(
+    attestation_bundle: object, runtime_signer_profile: object
+) -> list[str]:
+    reason_codes: list[str] = []
+    if not isinstance(attestation_bundle, dict):
+        return ["runtime_signer_attestation_bundle_missing"]
+
+    if attestation_bundle.get("schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_attestation_schema_invalid")
+
+    required_approvals = attestation_bundle.get("required_approvals")
+    if not isinstance(required_approvals, int) or required_approvals <= 0:
+        reason_codes.append("runtime_signer_attestation_required_approvals_invalid")
+
+    approved_signers = attestation_bundle.get("approved_signers")
+    normalized_signers: list[str] = []
+    if not isinstance(approved_signers, list) or not approved_signers:
+        reason_codes.append("runtime_signer_attestation_approved_signers_invalid")
+    else:
+        for entry in approved_signers:
+            if not isinstance(entry, str) or not entry.strip():
+                reason_codes.append("runtime_signer_attestation_approved_signers_invalid")
+                break
+            normalized_signers.append(entry.strip())
+        if len(set(normalized_signers)) != len(normalized_signers):
+            reason_codes.append("runtime_signer_attestation_approved_signers_not_unique")
+        if isinstance(required_approvals, int) and len(normalized_signers) < required_approvals:
+            reason_codes.append("runtime_signer_attestation_quorum_shortfall")
+        if (
+            isinstance(runtime_signer_profile, str)
+            and runtime_signer_profile.strip()
+            and runtime_signer_profile not in normalized_signers
+        ):
+            reason_codes.append("runtime_signer_attestation_profile_not_approved")
+
+    return reason_codes
 
 
 def expected_runtime_commit_failure_taxonomy(
@@ -203,6 +242,22 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif normalized_runtime_signer_key_source == "managed-external" and runtime_signer_raw_private_key_present:
         reason_codes.append("runtime_signer_managed_external_raw_private_key_present_violation")
 
+    runtime_signer_attestation_schema_version = report.get("runtime_signer_attestation_schema_version")
+    if (
+        not isinstance(runtime_signer_attestation_schema_version, str)
+        or not runtime_signer_attestation_schema_version.strip()
+    ):
+        reason_codes.append("runtime_signer_attestation_schema_version_missing")
+    elif runtime_signer_attestation_schema_version != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_attestation_schema_version_mismatch")
+
+    reason_codes.extend(
+        evaluate_runtime_signer_attestation_bundle(
+            report.get("runtime_signer_attestation_bundle"),
+            runtime_signer_profile,
+        )
+    )
+
     runtime_commit_live_policy_report = report.get("runtime_commit_live_policy_report")
     if not isinstance(runtime_commit_live_policy_report, str) or not runtime_commit_live_policy_report.strip():
         reason_codes.append("runtime_commit_live_policy_report_missing")
@@ -284,6 +339,16 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_managed_external_raw_private_key_allowed_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
+            reason_codes.append("runtime_signer_attestation_schema_version_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_signer_uniqueness_required") is not True:
+            reason_codes.append("runtime_signer_attestation_signer_uniqueness_required_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_threshold_required") is not True:
+            reason_codes.append("runtime_signer_attestation_threshold_required_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
+            reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_required_approvals") != 1:
+            reason_codes.append("runtime_signer_attestation_required_approvals_contract_mismatch")
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -37,6 +37,45 @@ SIGNER_KEY_REF_ENV_BY_PROFILE = {
 NATIVE_PAYLOAD_PUBKEY_MARKER = "pubkey"
 NATIVE_PAYLOAD_NONCE_MARKER = "nonce"
 NATIVE_PAYLOAD_MESSAGES_MARKER = "messages"
+RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION = "kamn.kolme.runtime-signer-attestation.v1"
+
+
+def evaluate_runtime_signer_attestation_bundle(
+    attestation_bundle: object, runtime_signer_profile: object
+) -> list[str]:
+    reason_codes: list[str] = []
+    if not isinstance(attestation_bundle, dict):
+        return ["runtime_signer_attestation_bundle_missing"]
+
+    if attestation_bundle.get("schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_attestation_schema_invalid")
+
+    required_approvals = attestation_bundle.get("required_approvals")
+    if not isinstance(required_approvals, int) or required_approvals <= 0:
+        reason_codes.append("runtime_signer_attestation_required_approvals_invalid")
+
+    approved_signers = attestation_bundle.get("approved_signers")
+    normalized_signers: list[str] = []
+    if not isinstance(approved_signers, list) or not approved_signers:
+        reason_codes.append("runtime_signer_attestation_approved_signers_invalid")
+    else:
+        for entry in approved_signers:
+            if not isinstance(entry, str) or not entry.strip():
+                reason_codes.append("runtime_signer_attestation_approved_signers_invalid")
+                break
+            normalized_signers.append(entry.strip())
+        if len(set(normalized_signers)) != len(normalized_signers):
+            reason_codes.append("runtime_signer_attestation_approved_signers_not_unique")
+        if isinstance(required_approvals, int) and len(normalized_signers) < required_approvals:
+            reason_codes.append("runtime_signer_attestation_quorum_shortfall")
+        if (
+            isinstance(runtime_signer_profile, str)
+            and runtime_signer_profile.strip()
+            and runtime_signer_profile not in normalized_signers
+        ):
+            reason_codes.append("runtime_signer_attestation_profile_not_approved")
+
+    return reason_codes
 
 
 def parse_args() -> argparse.Namespace:
@@ -215,6 +254,22 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif expected_signer_key_source == "managed-external" and runtime_signer_raw_private_key_present:
         reason_codes.append("runtime_signer_managed_external_raw_private_key_present_violation")
 
+    runtime_signer_attestation_schema_version = report.get("runtime_signer_attestation_schema_version")
+    if (
+        not isinstance(runtime_signer_attestation_schema_version, str)
+        or not runtime_signer_attestation_schema_version.strip()
+    ):
+        reason_codes.append("runtime_signer_attestation_schema_version_missing")
+    elif runtime_signer_attestation_schema_version != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_attestation_schema_version_mismatch")
+
+    reason_codes.extend(
+        evaluate_runtime_signer_attestation_bundle(
+            report.get("runtime_signer_attestation_bundle"),
+            runtime_signer_profile,
+        )
+    )
+
     runtime_commit_command_profile = report.get("runtime_commit_command_profile")
     if not isinstance(runtime_commit_command_profile, str) or not runtime_commit_command_profile.strip():
         reason_codes.append("runtime_commit_command_profile_missing")
@@ -322,6 +377,16 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_managed_external_raw_private_key_allowed_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
+            reason_codes.append("runtime_signer_attestation_schema_version_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_signer_uniqueness_required") is not True:
+            reason_codes.append("runtime_signer_attestation_signer_uniqueness_required_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_threshold_required") is not True:
+            reason_codes.append("runtime_signer_attestation_threshold_required_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
+            reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
+        if contracts.get("runtime_signer_attestation_required_approvals") != 1:
+            reason_codes.append("runtime_signer_attestation_required_approvals_contract_mismatch")
         if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
             reason_codes.append("runtime_signer_failover_requires_profile_change_contract_mismatch")
         if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -187,6 +187,22 @@ def main() -> int:
         if summary_payload.get("runtime_signer_raw_private_key_present") is not False:
             print("expected runtime signer raw private key presence marker false in dry-run summary", file=sys.stderr)
             return 1
+        if summary_payload.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+            print("expected runtime signer attestation schema marker in dry-run summary", file=sys.stderr)
+            return 1
+        runtime_signer_attestation_bundle = summary_payload.get("runtime_signer_attestation_bundle")
+        if not isinstance(runtime_signer_attestation_bundle, dict):
+            print("expected runtime signer attestation bundle in dry-run summary", file=sys.stderr)
+            return 1
+        if runtime_signer_attestation_bundle.get("schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+            print("expected runtime signer attestation bundle schema marker in dry-run summary", file=sys.stderr)
+            return 1
+        if runtime_signer_attestation_bundle.get("required_approvals") != 1:
+            print("expected runtime signer attestation required approvals marker in dry-run summary", file=sys.stderr)
+            return 1
+        if runtime_signer_attestation_bundle.get("approved_signers") != ["ops-primary"]:
+            print("expected runtime signer attestation approved signers marker in dry-run summary", file=sys.stderr)
+            return 1
         contracts_payload = summary_payload.get("contracts")
         if not isinstance(contracts_payload, dict):
             print("expected contracts object in dry-run summary", file=sys.stderr)
@@ -202,6 +218,21 @@ def main() -> int:
             return 1
         if contracts_payload.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
             print("expected contracts managed-external raw private key allowed=false marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+            print("expected contracts runtime signer attestation schema marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_attestation_signer_uniqueness_required") is not True:
+            print("expected contracts runtime signer attestation signer-uniqueness marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_attestation_threshold_required") is not True:
+            print("expected contracts runtime signer attestation threshold marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_attestation_profile_membership_required") is not True:
+            print("expected contracts runtime signer attestation profile-membership marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_attestation_required_approvals") != 1:
+            print("expected contracts runtime signer attestation required approvals marker in summary", file=sys.stderr)
             return 1
         checks_payload = summary_payload.get("checks")
         if not isinstance(checks_payload, list):
@@ -560,6 +591,101 @@ def main() -> int:
             )
             return 1
 
+        attestation_duplicate_signers_payload = dict(summary_payload)
+        attestation_duplicate_signers_bundle = dict(
+            attestation_duplicate_signers_payload.get("runtime_signer_attestation_bundle", {})
+        )
+        attestation_duplicate_signers_bundle["approved_signers"] = ["ops-primary", "ops-primary"]
+        attestation_duplicate_signers_payload["runtime_signer_attestation_bundle"] = (
+            attestation_duplicate_signers_bundle
+        )
+        attestation_duplicate_signers_report = temp_path / "runtime_attestation_duplicate_signers_summary.json"
+        attestation_duplicate_signers_report.write_text(
+            json.dumps(attestation_duplicate_signers_payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        attestation_duplicate_signers_run = subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(attestation_duplicate_signers_report),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "dry_run_no_commands_executed",
+                "--output-json",
+                str(failure_policy_output),
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if attestation_duplicate_signers_run.returncode == 0:
+            print("expected checker to fail when attestation bundle has duplicate approved signers", file=sys.stderr)
+            return 1
+        attestation_duplicate_signers_output = (
+            f"{attestation_duplicate_signers_run.stdout}\n"
+            f"{attestation_duplicate_signers_run.stderr}"
+        )
+        if "runtime_signer_attestation_approved_signers_not_unique" not in attestation_duplicate_signers_output:
+            print(
+                "expected runtime signer attestation duplicate signer reason for policy failure",
+                file=sys.stderr,
+            )
+            return 1
+
+        attestation_quorum_shortfall_payload = dict(summary_payload)
+        attestation_quorum_shortfall_bundle = dict(
+            attestation_quorum_shortfall_payload.get("runtime_signer_attestation_bundle", {})
+        )
+        attestation_quorum_shortfall_bundle["required_approvals"] = 2
+        attestation_quorum_shortfall_bundle["approved_signers"] = ["ops-primary"]
+        attestation_quorum_shortfall_payload["runtime_signer_attestation_bundle"] = (
+            attestation_quorum_shortfall_bundle
+        )
+        attestation_quorum_shortfall_report = temp_path / "runtime_attestation_quorum_shortfall_summary.json"
+        attestation_quorum_shortfall_report.write_text(
+            json.dumps(attestation_quorum_shortfall_payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        attestation_quorum_shortfall_run = subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(attestation_quorum_shortfall_report),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                "dry_run_no_commands_executed",
+                "--output-json",
+                str(failure_policy_output),
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if attestation_quorum_shortfall_run.returncode == 0:
+            print("expected checker to fail when attestation quorum thresholds drift", file=sys.stderr)
+            return 1
+        attestation_quorum_shortfall_output = (
+            f"{attestation_quorum_shortfall_run.stdout}\n"
+            f"{attestation_quorum_shortfall_run.stderr}"
+        )
+        if "runtime_signer_attestation_quorum_shortfall" not in attestation_quorum_shortfall_output:
+            print(
+                "expected runtime signer attestation quorum shortfall reason for policy failure",
+                file=sys.stderr,
+            )
+            return 1
+
     doc_text = DOC_FILE.read_text(encoding="utf-8")
     readme_text = README_FILE.read_text(encoding="utf-8")
     if "run_local_kamn_live_runtime_integration_lane.sh" not in doc_text:
@@ -634,17 +760,32 @@ def main() -> int:
     if "runtime_signer_raw_private_key_present=false" not in doc_text:
         print("expected Kolme devnet ops doc to include runtime signer raw private key presence marker", file=sys.stderr)
         return 1
+    if "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1" not in doc_text:
+        print("expected Kolme devnet ops doc to include runtime signer attestation schema marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_attestation_bundle" not in doc_text:
+        print("expected Kolme devnet ops doc to include runtime signer attestation bundle marker", file=sys.stderr)
+        return 1
     if "runtime_signer_fallback_private_key_present_violation" not in doc_text:
         print("expected Kolme devnet ops doc to include fallback signer private key violation marker", file=sys.stderr)
         return 1
     if "runtime_signer_managed_external_raw_private_key_present_violation" not in doc_text:
         print("expected Kolme devnet ops doc to include managed-external raw signer key violation marker", file=sys.stderr)
         return 1
+    if "runtime_signer_attestation_approved_signers_not_unique" not in doc_text:
+        print("expected Kolme devnet ops doc to include runtime signer attestation duplicate signer reason marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_attestation_quorum_shortfall" not in doc_text:
+        print("expected Kolme devnet ops doc to include runtime signer attestation quorum shortfall reason marker", file=sys.stderr)
+        return 1
     if "Regression: #2302" not in doc_text:
         print("expected Kolme devnet ops doc to include fallback signer runtime regression marker", file=sys.stderr)
         return 1
     if "Regression: #2324" not in doc_text:
         print("expected Kolme devnet ops doc to include managed-external raw signer key regression marker", file=sys.stderr)
+        return 1
+    if "Regression: #2325" not in doc_text:
+        print("expected Kolme devnet ops doc to include runtime signer attestation regression marker", file=sys.stderr)
         return 1
     if "run_local_kamn_live_runtime_integration_contract_lane.sh" not in readme_text:
         print("expected README to reference local KAMN live runtime integration contract lane", file=sys.stderr)
@@ -694,17 +835,32 @@ def main() -> int:
     if "runtime_signer_raw_private_key_present=false" not in readme_text:
         print("expected README to include runtime signer raw private key presence marker", file=sys.stderr)
         return 1
+    if "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1" not in readme_text:
+        print("expected README to include runtime signer attestation schema marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_attestation_bundle" not in readme_text:
+        print("expected README to include runtime signer attestation bundle marker", file=sys.stderr)
+        return 1
     if "runtime_signer_fallback_private_key_present_violation" not in readme_text:
         print("expected README to include fallback signer private key violation marker", file=sys.stderr)
         return 1
     if "runtime_signer_managed_external_raw_private_key_present_violation" not in readme_text:
         print("expected README to include managed-external raw signer key violation marker", file=sys.stderr)
         return 1
+    if "runtime_signer_attestation_approved_signers_not_unique" not in readme_text:
+        print("expected README to include runtime signer attestation duplicate signer reason marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_attestation_quorum_shortfall" not in readme_text:
+        print("expected README to include runtime signer attestation quorum shortfall reason marker", file=sys.stderr)
+        return 1
     if "Regression: #2302" not in readme_text:
         print("expected README to include fallback signer runtime regression marker", file=sys.stderr)
         return 1
     if "Regression: #2324" not in readme_text:
         print("expected README to include managed-external raw signer key regression marker", file=sys.stderr)
+        return 1
+    if "Regression: #2325" not in readme_text:
+        print("expected README to include runtime signer attestation regression marker", file=sys.stderr)
         return 1
 
     elapsed_seconds = int(time.monotonic() - start_epoch)

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -292,6 +292,23 @@ def main() -> int:
     if summary.get("runtime_signer_raw_private_key_present") is not False:
         print("expected runtime signer raw private key presence marker false in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+        print("expected runtime signer attestation schema marker in contract-lane summary", file=sys.stderr)
+        return 1
+    runtime_signer_attestation_bundle = summary.get("runtime_signer_attestation_bundle")
+    if not isinstance(runtime_signer_attestation_bundle, dict):
+        print("expected runtime signer attestation bundle in contract-lane summary", file=sys.stderr)
+        return 1
+    if runtime_signer_attestation_bundle.get("schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+        print("expected runtime signer attestation bundle schema marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if runtime_signer_attestation_bundle.get("required_approvals") != 1:
+        print("expected runtime signer attestation required approvals marker in contract-lane summary", file=sys.stderr)
+        return 1
+    expected_attestation_signers = [expected_signer_profile]
+    if runtime_signer_attestation_bundle.get("approved_signers") != expected_attestation_signers:
+        print("expected runtime signer attestation approved signers marker in contract-lane summary", file=sys.stderr)
+        return 1
     checks = summary.get("checks")
     if not isinstance(checks, list):
         print("expected checks list in real-node profile contract-lane summary", file=sys.stderr)
@@ -352,6 +369,21 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
         print("expected contracts managed-external raw private key allowed=false marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+        print("expected contracts runtime signer attestation schema marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_attestation_signer_uniqueness_required") is not True:
+        print("expected contracts runtime signer attestation signer uniqueness marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_attestation_threshold_required") is not True:
+        print("expected contracts runtime signer attestation threshold marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
+        print("expected contracts runtime signer attestation profile membership marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_attestation_required_approvals") != 1:
+        print("expected contracts runtime signer attestation required approvals marker in contract-lane summary", file=sys.stderr)
         return 1
     if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
         print("unexpected real-node profile policy schema in contract-lane output", file=sys.stderr)
@@ -674,6 +706,106 @@ def main() -> int:
             )
             return 1
 
+        attestation_duplicate_signers_summary_file = negative_path / "attestation_duplicate_signers_summary.json"
+        attestation_duplicate_signers_policy_file = negative_path / "attestation_duplicate_signers_policy.json"
+        attestation_duplicate_signers_summary = dict(summary)
+        attestation_duplicate_signers_bundle = dict(
+            attestation_duplicate_signers_summary.get("runtime_signer_attestation_bundle", {})
+        )
+        attestation_duplicate_signers_bundle["approved_signers"] = [
+            expected_signer_profile,
+            expected_signer_profile,
+        ]
+        attestation_duplicate_signers_summary["runtime_signer_attestation_bundle"] = (
+            attestation_duplicate_signers_bundle
+        )
+        attestation_duplicate_signers_summary_file.write_text(
+            json.dumps(attestation_duplicate_signers_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        attestation_duplicate_signers_result = run_real_node_policy_check(
+            report_file=attestation_duplicate_signers_summary_file,
+            output_json=attestation_duplicate_signers_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if attestation_duplicate_signers_result.returncode == 0:
+            print("expected duplicate signer attestation proof to fail closed", file=sys.stderr)
+            return 1
+        attestation_duplicate_signers_policy = json.loads(
+            attestation_duplicate_signers_policy_file.read_text(encoding="utf-8")
+        )
+        attestation_duplicate_signers_reason_codes = attestation_duplicate_signers_policy.get(
+            "reason_codes"
+        )
+        if not isinstance(attestation_duplicate_signers_reason_codes, list):
+            print(
+                "expected reason_codes list in duplicate signer attestation policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if "runtime_signer_attestation_approved_signers_not_unique" not in attestation_duplicate_signers_reason_codes:
+            print(
+                "expected runtime_signer_attestation_approved_signers_not_unique in duplicate signer attestation policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if attestation_duplicate_signers_policy.get("final_decision") != "NO-GO":
+            print(
+                "expected NO-GO final decision for duplicate signer attestation policy output",
+                file=sys.stderr,
+            )
+            return 1
+
+        attestation_quorum_shortfall_summary_file = negative_path / "attestation_quorum_shortfall_summary.json"
+        attestation_quorum_shortfall_policy_file = negative_path / "attestation_quorum_shortfall_policy.json"
+        attestation_quorum_shortfall_summary = dict(summary)
+        attestation_quorum_shortfall_bundle = dict(
+            attestation_quorum_shortfall_summary.get("runtime_signer_attestation_bundle", {})
+        )
+        attestation_quorum_shortfall_bundle["required_approvals"] = 2
+        attestation_quorum_shortfall_bundle["approved_signers"] = [expected_signer_profile]
+        attestation_quorum_shortfall_summary["runtime_signer_attestation_bundle"] = (
+            attestation_quorum_shortfall_bundle
+        )
+        attestation_quorum_shortfall_summary_file.write_text(
+            json.dumps(attestation_quorum_shortfall_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        attestation_quorum_shortfall_result = run_real_node_policy_check(
+            report_file=attestation_quorum_shortfall_summary_file,
+            output_json=attestation_quorum_shortfall_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if attestation_quorum_shortfall_result.returncode == 0:
+            print("expected attestation quorum shortfall proof to fail closed", file=sys.stderr)
+            return 1
+        attestation_quorum_shortfall_policy = json.loads(
+            attestation_quorum_shortfall_policy_file.read_text(encoding="utf-8")
+        )
+        attestation_quorum_shortfall_reason_codes = attestation_quorum_shortfall_policy.get(
+            "reason_codes"
+        )
+        if not isinstance(attestation_quorum_shortfall_reason_codes, list):
+            print(
+                "expected reason_codes list in attestation quorum shortfall policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if "runtime_signer_attestation_quorum_shortfall" not in attestation_quorum_shortfall_reason_codes:
+            print(
+                "expected runtime_signer_attestation_quorum_shortfall in attestation quorum shortfall policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if attestation_quorum_shortfall_policy.get("final_decision") != "NO-GO":
+            print(
+                "expected NO-GO final decision for attestation quorum shortfall policy output",
+                file=sys.stderr,
+            )
+            return 1
+
         key_source_matrix_drift_summary_file = negative_path / "key_source_matrix_drift_summary.json"
         key_source_matrix_drift_policy_file = negative_path / "key_source_matrix_drift_policy.json"
         key_source_matrix_drift_summary = dict(summary)
@@ -827,17 +959,22 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
+        "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
         "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
         "runtime_signer_fallback_private_key_present=false",
         "runtime_signer_raw_private_key_present=false",
         "runtime_signer_fallback_private_key_present_violation",
         "runtime_signer_managed_external_raw_private_key_present_violation",
+        "runtime_signer_attestation_approved_signers_not_unique",
+        "runtime_signer_attestation_quorum_shortfall",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
         "Regression: #2302",
+        "Regression: #2325",
         "Regression: #2324",
         "Regression: #2139",
     ]
@@ -851,17 +988,22 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
+        "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
         "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
         "runtime_signer_fallback_private_key_present=false",
         "runtime_signer_raw_private_key_present=false",
         "runtime_signer_fallback_private_key_present_violation",
         "runtime_signer_managed_external_raw_private_key_present_violation",
+        "runtime_signer_attestation_approved_signers_not_unique",
+        "runtime_signer_attestation_quorum_shortfall",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
         "Regression: #2302",
+        "Regression: #2325",
         "Regression: #2324",
         "Regression: #2139",
     ]
@@ -875,17 +1017,22 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
+        "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
         "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
         "runtime_signer_fallback_private_key_present=false",
         "runtime_signer_raw_private_key_present=false",
         "runtime_signer_fallback_private_key_present_violation",
         "runtime_signer_managed_external_raw_private_key_present_violation",
+        "runtime_signer_attestation_approved_signers_not_unique",
+        "runtime_signer_attestation_quorum_shortfall",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
         "Regression: #2302",
+        "Regression: #2325",
         "Regression: #2324",
         "Regression: #2139",
     ]

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -48,6 +48,7 @@ RUNTIME_SIGNER_PRIVATE_KEY_ENV_PRIMARY="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 RUNTIME_SIGNER_PRIVATE_KEY_ENV_SECONDARY="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 RUNTIME_SIGNER_KEY_REF_ENV_PRIMARY="KAMN_KOLME_LIVE_SIGNER_KEY_REF"
 RUNTIME_SIGNER_KEY_REF_ENV_SECONDARY="KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION="kamn.kolme.runtime-signer-attestation.v1"
 
 if [ "${1:-}" != "--manifest-impl" ]; then
   exec bash "$ROOT_DIR/scripts/kolme/run_lane_dispatch.sh" --lane-wrapper "$SCRIPT_NAME" -- "$@"
@@ -775,7 +776,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" <<'PY'
 from __future__ import annotations
 
 import json
@@ -828,6 +829,7 @@ runtime_signer_key_reference_env = sys.argv[43]
 runtime_signer_fallback_private_key_env = sys.argv[44]
 runtime_signer_fallback_private_key_present = sys.argv[45] == "true"
 runtime_signer_raw_private_key_present = sys.argv[46] == "true"
+runtime_signer_attestation_schema_version = sys.argv[47]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -961,6 +963,18 @@ runtime_commit_failure_taxonomy, runtime_commit_failure_diagnostic_hint = classi
     runtime_commit_nested_reason_code,
 )
 
+runtime_signer_attestation_approved_signers: list[str] = []
+if isinstance(runtime_signer_profile, str) and runtime_signer_profile.strip():
+    runtime_signer_attestation_approved_signers = [runtime_signer_profile]
+runtime_signer_attestation_required_approvals = 1
+runtime_signer_attestation_bundle = {
+    "schema_version": runtime_signer_attestation_schema_version,
+    "required_approvals": runtime_signer_attestation_required_approvals,
+    "approved_signers": runtime_signer_attestation_approved_signers,
+    "signer_profile": runtime_signer_profile,
+    "signer_key_source": runtime_signer_key_source,
+}
+
 summary = {
     "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
     "mode": mode,
@@ -995,6 +1009,8 @@ summary = {
     "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
     "runtime_signer_fallback_private_key_present": runtime_signer_fallback_private_key_present,
     "runtime_signer_raw_private_key_present": runtime_signer_raw_private_key_present,
+    "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
+    "runtime_signer_attestation_bundle": runtime_signer_attestation_bundle,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
     "runtime_commit_finality_output_file": runtime_commit_finality_output_file if runtime_commit_finality_command else "",
@@ -1024,6 +1040,11 @@ summary = {
         "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
         "runtime_signer_fallback_private_key_allowed": False,
         "runtime_signer_managed_external_raw_private_key_allowed": False,
+        "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
+        "runtime_signer_attestation_signer_uniqueness_required": True,
+        "runtime_signer_attestation_threshold_required": True,
+        "runtime_signer_attestation_profile_membership_required": True,
+        "runtime_signer_attestation_required_approvals": runtime_signer_attestation_required_approvals,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",
         "runtime_commit_finality_primary_endpoint": "/notifications",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -12,6 +12,8 @@ TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_OK_SECONDARY="$TMP_DIR/ok-report-secondary.json"
 TMP_REPORT_OK_MANAGED="$TMP_DIR/ok-report-managed.json"
 TMP_REPORT_KEY_SOURCE_PAIR_BAD="$TMP_DIR/key-source-pair-bad-report.json"
+TMP_REPORT_ATTESTATION_DUPLICATE="$TMP_DIR/attestation-duplicate-report.json"
+TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL="$TMP_DIR/attestation-quorum-shortfall-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
 TMP_REPORT_INMEMORY="$TMP_DIR/inmemory-report.json"
@@ -77,6 +79,16 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
   "runtime_signer_fallback_private_key_present": false,
   "runtime_signer_raw_private_key_present": false,
+  "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+  "runtime_signer_attestation_bundle": {
+    "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+    "required_approvals": 1,
+    "approved_signers": [
+      "ops-primary"
+    ],
+    "signer_profile": "ops-primary",
+    "signer_key_source": "env-local"
+  },
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
@@ -106,6 +118,11 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
     "runtime_signer_fallback_private_key_allowed": false,
     "runtime_signer_managed_external_raw_private_key_allowed": false,
+    "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+    "runtime_signer_attestation_signer_uniqueness_required": true,
+    "runtime_signer_attestation_threshold_required": true,
+    "runtime_signer_attestation_profile_membership_required": true,
+    "runtime_signer_attestation_required_approvals": 1,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -209,6 +226,10 @@ report["runtime_commit_command"] = str(report["runtime_commit_command"]).replace
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
 )
+attestation_bundle = report.get("runtime_signer_attestation_bundle", {})
+if isinstance(attestation_bundle, dict):
+    attestation_bundle["approved_signers"] = ["ops-secondary"]
+    attestation_bundle["signer_profile"] = "ops-secondary"
 contracts = report.get("contracts", {})
 if isinstance(contracts, dict):
     contracts["runtime_signer_profile"] = "ops-secondary"
@@ -299,6 +320,73 @@ fi
 
 if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$TMP_ERR"; then
   echo "expected disallowed key-source/profile pair reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_ATTESTATION_DUPLICATE" "$TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL" <<'PY'
+import json
+import pathlib
+import sys
+
+base_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+duplicate_report = dict(base_report)
+duplicate_bundle = dict(duplicate_report.get("runtime_signer_attestation_bundle", {}))
+duplicate_bundle["approved_signers"] = ["ops-primary", "ops-primary"]
+duplicate_report["runtime_signer_attestation_bundle"] = duplicate_bundle
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(duplicate_report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+quorum_shortfall_report = dict(base_report)
+quorum_shortfall_bundle = dict(quorum_shortfall_report.get("runtime_signer_attestation_bundle", {}))
+quorum_shortfall_bundle["required_approvals"] = 2
+quorum_shortfall_bundle["approved_signers"] = ["ops-primary"]
+quorum_shortfall_report["runtime_signer_attestation_bundle"] = quorum_shortfall_bundle
+pathlib.Path(sys.argv[3]).write_text(
+    json.dumps(quorum_shortfall_report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_ATTESTATION_DUPLICATE" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+attestation_duplicate_exit_code=$?
+set -e
+
+if [ "$attestation_duplicate_exit_code" -eq 0 ]; then
+  echo "expected duplicate attestation signer proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_attestation_approved_signers_not_unique" "$TMP_ERR"; then
+  echo "expected duplicate attestation signer reason for policy failure" >&2
+  exit 1
+fi
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+attestation_quorum_shortfall_exit_code=$?
+set -e
+
+if [ "$attestation_quorum_shortfall_exit_code" -eq 0 ]; then
+  echo "expected attestation quorum shortfall proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_attestation_quorum_shortfall" "$TMP_ERR"; then
+  echo "expected attestation quorum shortfall reason for policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -77,12 +77,16 @@ required_coverage_markers=(
   "runtime_signer_profile=ops-secondary"
   "runtime_signer_key_source_contract_version"
   "runtime_signer_key_source"
+  "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
+  "runtime_signer_attestation_bundle"
   "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF"
   "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
   "runtime_signer_fallback_private_key_present=false"
   "runtime_signer_raw_private_key_present=false"
   "runtime_signer_fallback_private_key_present_violation"
   "runtime_signer_managed_external_raw_private_key_present_violation"
+  "runtime_signer_attestation_approved_signers_not_unique"
+  "runtime_signer_attestation_quorum_shortfall"
   "runtime_signer_key_source_profile_pair_disallowed"
   "runtime_signer_private_key_env_mismatch"
   "runtime_commit_command_profile_mismatch"
@@ -92,6 +96,7 @@ required_coverage_markers=(
   "runtime_commit_non_synthetic_submit_probe_missing"
   "runtime_commit_in_memory_provider_reference_detected"
   "Regression: #2302"
+  "Regression: #2325"
   "Regression: #2324"
   "Regression: #2139"
 )
@@ -131,6 +136,14 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include signer key-source marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1" "$docs_file"; then
+    echo "expected docs parity to include runtime signer attestation schema marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_attestation_bundle" "$docs_file"; then
+    echo "expected docs parity to include runtime signer attestation bundle marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF" "$docs_file"; then
     echo "expected docs parity to include signer key reference env marker in $docs_file" >&2
     exit 1
@@ -155,6 +168,14 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include managed-external raw signer key violation marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q "runtime_signer_attestation_approved_signers_not_unique" "$docs_file"; then
+    echo "expected docs parity to include runtime signer attestation duplicate-signer reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_attestation_quorum_shortfall" "$docs_file"; then
+    echo "expected docs parity to include runtime signer attestation quorum-shortfall reason marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$docs_file"; then
     echo "expected docs parity to include signer key-source/profile pair disallowed reason marker in $docs_file" >&2
     exit 1
@@ -165,6 +186,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "Regression: #2302" "$docs_file"; then
     echo "expected docs parity to include fallback signer runtime regression marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2325" "$docs_file"; then
+    echo "expected docs parity to include runtime signer attestation regression marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "Regression: #2324" "$docs_file"; then
@@ -231,6 +256,17 @@ if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected fallback signer private key presence marker false in real-node profile contract-lane summary")
 if summary.get("runtime_signer_raw_private_key_present") is not False:
     raise SystemExit("expected runtime signer raw private key presence marker false in real-node profile contract-lane summary")
+if summary.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+    raise SystemExit("expected runtime signer attestation schema marker in real-node profile contract-lane summary")
+attestation_bundle = summary.get("runtime_signer_attestation_bundle")
+if not isinstance(attestation_bundle, dict):
+    raise SystemExit("expected runtime signer attestation bundle in real-node profile contract-lane summary")
+if attestation_bundle.get("schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+    raise SystemExit("expected runtime signer attestation bundle schema marker in real-node profile contract-lane summary")
+if attestation_bundle.get("required_approvals") != 1:
+    raise SystemExit("expected runtime signer attestation required approvals marker in real-node profile contract-lane summary")
+if attestation_bundle.get("approved_signers") != ["ops-primary"]:
+    raise SystemExit("expected runtime signer attestation approved signer marker in real-node profile contract-lane summary")
 checks = summary.get("checks", [])
 if not any(
     isinstance(check, dict)
@@ -264,6 +300,12 @@ if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
     raise SystemExit("expected contracts managed-external raw private key allowed=false marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
+    raise SystemExit("expected contracts runtime signer attestation schema marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_attestation_signer_uniqueness_required") is not True:
+    raise SystemExit("expected contracts runtime signer attestation signer-uniqueness requirement marker")
+if contracts.get("runtime_signer_attestation_threshold_required") is not True:
+    raise SystemExit("expected contracts runtime signer attestation threshold requirement marker")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
     raise SystemExit("unexpected real-node profile contract-lane policy schema")
 if policy.get("final_decision") != "GO":


### PR DESCRIPTION
## Summary
Adds a runtime signer attestation schema contract and deterministic quorum validation across local KAMN live runtime policy paths. This closes the schema/governance gap by enforcing signer uniqueness, threshold, and profile-membership checks with stable reason codes and docs parity markers.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`: emit `runtime_signer_attestation_schema_version` and `runtime_signer_attestation_bundle` in summary/contracts.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: add attestation evaluator and contract mismatch reason codes.
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`: add attestation evaluator and contract mismatch reason codes.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: add GO assertions and NO-GO negative proofs for duplicate signer and quorum shortfall.
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: add GO assertions and NO-GO negative proofs for duplicate signer and quorum shortfall.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: extend fixtures and add attestation-focused negative tests.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: enforce attestation coverage and docs parity markers.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: add signer-attestation schema/reason/regression markers for contract-lane docs parity.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`

Observed failing output before implementation:
`expected runtime signer attestation schema marker in real-node profile contract-lane summary`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`

Result:
- all commands passed locally.

### 🔁 Regression
Commands:
- `cargo test -p kamn-node managed_external`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
- all commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | None | Policy/contract-lane scripts use existing harness style; no Rust module API changes in this task |
| Functional   | ✅ | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | Added attestation schema/threshold/duplicate-signer behavior checks |
| Integration  | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` | Verified cross-lane summary→policy→contract docs parity behavior |
| Regression   | ✅ | contract-lane negative proofs and policy reason-code assertions include `Regression: #2325` markers | Guards duplicate signer and quorum shortfall drift |
| Performance  | N/A | None | Evaluator-only logic; no throughput-sensitive runtime path changes |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `29aa61d` from `main` if attestation contracts must be temporarily disabled.

## Documentation Updates
- Updated `docs/planning/kolme-devnet-ops.md`.
- Updated `docs/ci/strategy.md`.
- Updated `README.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2325
Refs #2320
