### PR TITLE
test(kolme): enforce rust matrix evidence-bundle contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,10 @@ python3 scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py --report
 
 # bounded contract lane (dry-run + local-only run + fail-closed policy checks)
 bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json --policy-output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json
+# evidence bundle marker contract: evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1
+# evidence bundle payload contract: evidence_bundle includes schema linkage, status, reason_code, budget_status, command_count, artifact_paths
+# Regression: #1541
+# Regression: #2329
 ```
 
 ### Run Local Kolme API Probe Lane

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -329,7 +329,12 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - fork pin manifest + expected commit drift contracts remain fail-closed (`Regression: #2328`).
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_fork_smoke_evidence_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --smoke-command "cargo test -p merkle-map --test version -- --exact load_from_zero_example" --max-seconds 120 --output-json /tmp/kolme-local-fork-smoke-evidence-summary.json`
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --max-seconds 120 --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json`
+    - `python3 scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py --report-file /tmp/kolme-local-fork-rust-test-matrix-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json`
     - `bash scripts/kolme/run_local_kolme_fork_rust_test_matrix_contract_lane.sh --output-json /tmp/kolme-local-fork-rust-test-matrix-summary.json --policy-output-json /tmp/kolme-local-fork-rust-test-matrix-policy.json`
+    - evidence bundle marker contract: `evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1`
+    - evidence bundle payload contract: `evidence_bundle` must include summary linkage and budget/command artifacts for policy parity checks
+    - Regression: #1541
+    - Regression: #2329
   - local Kolme API probe/smoke run-mode commands remain excluded from ci-fast-gate.
     - `bash scripts/kolme/run_local_kolme_api_probe_lane.sh --mode run --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --max-seconds 30 --output-json /tmp/kolme-local-api-probe-summary.json`
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_api_smoke_lane.sh --mode run --base-url http://127.0.0.1:3000 --smoke-command "curl --silent --show-error --fail http://127.0.0.1:3000/healthz" --max-seconds 60 --output-json /tmp/kolme-local-api-smoke-summary.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -341,9 +341,13 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - portable cargo profile support (`--cargo-profile portable`) rewrites cargo invocations with `RUSTFLAGS=''` for linker-portable local execution.
   - bounded per-command timeout guard with deterministic pass/fail reason codes.
   - per-command stdout/stderr artifact capture for audit review.
+  - evidence bundle marker contract: `evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1`.
+  - evidence bundle payload contract: `evidence_bundle` includes `schema_version`, `summary_schema_version`, `status`, `reason_code`, `budget_status`, `command_count`, and `artifact_paths`.
 - Cost policy:
   - run mode fails closed without explicit local-only opt-in.
   - run mode remains local/manual and is excluded from PR fast-gate workflow routing.
+  - Regression: #1541
+  - Regression: #2329
 
 ## Deterministic Local Kolme API Probe Lane (Issue #1439)
 

--- a/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py
@@ -5,6 +5,9 @@ import argparse
 import json
 from pathlib import Path
 
+SUMMARY_SCHEMA_VERSION = "kamn.kolme.local-fork-rust-test-matrix-summary.v1"
+EVIDENCE_BUNDLE_SCHEMA_VERSION = "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1"
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -21,7 +24,7 @@ def parse_args() -> argparse.Namespace:
 def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, list[str]]:
     reason_codes: list[str] = []
 
-    if report.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-summary.v1":
+    if report.get("schema_version") != SUMMARY_SCHEMA_VERSION:
         reason_codes.append("report_schema_invalid")
 
     mode = report.get("mode")
@@ -58,6 +61,30 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     budget_status = report.get("budget_status")
     if budget_status not in ("not_run", "within_budget", "exceeded_budget"):
         reason_codes.append("budget_status_invalid")
+
+    evidence_bundle_schema_version = report.get("evidence_bundle_schema_version")
+    if evidence_bundle_schema_version != EVIDENCE_BUNDLE_SCHEMA_VERSION:
+        reason_codes.append("evidence_bundle_schema_invalid")
+
+    evidence_bundle = report.get("evidence_bundle")
+    if not isinstance(evidence_bundle, dict):
+        reason_codes.append("evidence_bundle_missing")
+    else:
+        if evidence_bundle.get("schema_version") != EVIDENCE_BUNDLE_SCHEMA_VERSION:
+            reason_codes.append("evidence_bundle_schema_invalid")
+        if evidence_bundle.get("summary_schema_version") != report.get("schema_version"):
+            reason_codes.append("evidence_bundle_summary_schema_mismatch")
+        if evidence_bundle.get("status") != status:
+            reason_codes.append("evidence_bundle_status_mismatch")
+        if evidence_bundle.get("reason_code") != reason_code:
+            reason_codes.append("evidence_bundle_reason_code_mismatch")
+        if evidence_bundle.get("budget_status") != budget_status:
+            reason_codes.append("evidence_bundle_budget_status_mismatch")
+        if evidence_bundle.get("command_count") != command_count:
+            reason_codes.append("evidence_bundle_command_count_mismatch")
+        bundle_artifact_paths = evidence_bundle.get("artifact_paths")
+        if not isinstance(bundle_artifact_paths, list) or not bundle_artifact_paths:
+            reason_codes.append("evidence_bundle_artifact_paths_missing")
 
     checkpoints = report.get("checkpoints")
     if not isinstance(checkpoints, list) or not checkpoints:

--- a/scripts/kolme/contracts/local_fork_rust_test_matrix_contract_lane.py
+++ b/scripts/kolme/contracts/local_fork_rust_test_matrix_contract_lane.py
@@ -14,8 +14,24 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 RUNNER = ROOT_DIR / "scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh"
 CHECKER = ROOT_DIR / "scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py"
 DOC_FILE = ROOT_DIR / "docs/planning/kolme-devnet-ops.md"
+CI_DOC_FILE = ROOT_DIR / "docs/ci/strategy.md"
+README_FILE = ROOT_DIR / "README.md"
 MAX_SECONDS_ENV = "KAMN_KOLME_LOCAL_FORK_RUST_MATRIX_MAX_SECONDS"
 DEFAULT_MAX_SECONDS = 120
+EVIDENCE_BUNDLE_SCHEMA_MARKER = (
+    "evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1"
+)
+# Regression: #1541
+# Regression: #2329
+REQUIRED_DOC_MARKERS = [
+    "run_local_kolme_fork_rust_test_matrix_lane.sh",
+    "check_local_kolme_fork_rust_test_matrix_policy.py",
+    "run_local_kolme_fork_rust_test_matrix_contract_lane.sh",
+    EVIDENCE_BUNDLE_SCHEMA_MARKER,
+    "evidence_bundle",
+    "Regression: #1541",
+    "Regression: #2329",
+]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -62,9 +78,11 @@ def main() -> int:
     if not CHECKER.is_file() or not CHECKER.stat().st_mode & 0o111:
         print("expected local fork rust test matrix policy checker to be executable", file=sys.stderr)
         return 1
-    if not DOC_FILE.is_file():
-        print("expected Kolme devnet ops documentation to exist", file=sys.stderr)
-        return 1
+    docs_files = [DOC_FILE, CI_DOC_FILE, README_FILE]
+    for docs_file in docs_files:
+        if not docs_file.is_file():
+            print(f"expected docs parity file to exist: {docs_file}", file=sys.stderr)
+            return 1
 
     start_epoch = time.monotonic()
 
@@ -151,31 +169,15 @@ def main() -> int:
         stdout=subprocess.DEVNULL,
     )
 
-    doc_text = DOC_FILE.read_text(encoding="utf-8")
-    if "run_local_kolme_fork_rust_test_matrix_lane.sh" not in doc_text:
-        print(
-            "expected Kolme devnet ops doc to reference local fork rust test matrix lane runner",
-            file=sys.stderr,
-        )
-        return 1
-    if "check_local_kolme_fork_rust_test_matrix_policy.py" not in doc_text:
-        print(
-            "expected Kolme devnet ops doc to reference local fork rust test matrix policy checker",
-            file=sys.stderr,
-        )
-        return 1
-    if "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" not in doc_text:
-        print(
-            "expected Kolme devnet ops doc to reference local fork rust test matrix contract lane",
-            file=sys.stderr,
-        )
-        return 1
-    if "Regression: #1541" not in doc_text:
-        print(
-            "expected Kolme devnet ops doc to include local fork rust test matrix regression marker",
-            file=sys.stderr,
-        )
-        return 1
+    for docs_file in docs_files:
+        doc_text = docs_file.read_text(encoding="utf-8")
+        for marker in REQUIRED_DOC_MARKERS:
+            if marker not in doc_text:
+                print(
+                    f"expected docs parity marker '{marker}' in {docs_file}",
+                    file=sys.stderr,
+                )
+                return 1
 
     elapsed_seconds = int(time.monotonic() - start_epoch)
     if elapsed_seconds > max_seconds:

--- a/scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh
@@ -365,6 +365,19 @@ summary = {
         metadata_report,
         command_output_dir,
     ],
+    "evidence_bundle_schema_version": "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1",
+    "evidence_bundle": {
+        "schema_version": "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1",
+        "summary_schema_version": "kamn.kolme.local-fork-rust-test-matrix-summary.v1",
+        "status": status,
+        "reason_code": reason_code,
+        "budget_status": budget_status,
+        "command_count": len(commands),
+        "artifact_paths": [
+            metadata_report,
+            command_output_dir,
+        ],
+    },
 }
 
 output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh
@@ -27,6 +27,19 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "command_count": 2,
   "cargo_profile": "strict",
   "budget_status": "not_run",
+  "evidence_bundle_schema_version": "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1",
+  "evidence_bundle": {
+    "schema_version": "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1",
+    "summary_schema_version": "kamn.kolme.local-fork-rust-test-matrix-summary.v1",
+    "status": "ok",
+    "reason_code": "dry_run_no_commands_executed",
+    "budget_status": "not_run",
+    "command_count": 2,
+    "artifact_paths": [
+      "/tmp/meta.json",
+      "/tmp/matrix-logs"
+    ]
+  },
   "checkpoints": [
     {
       "id": "fork_sync_metadata",
@@ -83,6 +96,18 @@ cat >"$TMP_REPORT_BAD" <<'JSON'
   "command_count": 1,
   "cargo_profile": "strict",
   "budget_status": "exceeded_budget",
+  "evidence_bundle_schema_version": "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v0",
+  "evidence_bundle": {
+    "schema_version": "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v0",
+    "summary_schema_version": "kamn.kolme.local-fork-rust-test-matrix-summary.v1",
+    "status": "fail",
+    "reason_code": "fork_rust_test_command_timeout",
+    "budget_status": "exceeded_budget",
+    "command_count": 1,
+    "artifact_paths": [
+      "/tmp/meta.json"
+    ]
+  },
   "checkpoints": [
     {
       "id": "fork_sync_metadata",
@@ -121,6 +146,11 @@ fi
 
 if ! grep -q "observed_final_decision_mismatch" "$TMP_ERR"; then
   echo "expected mismatch reason code for failing policy decision" >&2
+  exit 1
+fi
+
+if ! grep -q "evidence_bundle_schema_invalid" "$TMP_ERR"; then
+  echo "expected evidence_bundle_schema_invalid reason marker for invalid evidence bundle schema" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh
@@ -7,6 +7,7 @@ CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.
 MANIFEST="$ROOT_DIR/scripts/framework/manifests/kolme_local_fork_rust_test_matrix_contract_lane.json"
 CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/local_fork_rust_test_matrix_contract_lane.py"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
 README_FILE="$ROOT_DIR/README.md"
 TMP_REPORT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
@@ -56,7 +57,10 @@ fi
 required_coverage_markers=(
   "run_local_kolme_fork_rust_test_matrix_lane.sh"
   "check_local_kolme_fork_rust_test_matrix_policy.py"
+  "evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1"
+  "evidence_bundle"
   "Regression: #1541"
+  "Regression: #2329"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -65,20 +69,28 @@ for marker in "${required_coverage_markers[@]}"; do
   fi
 done
 
-if ! grep -q "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" "$DOC_FILE"; then
-  echo "expected Kolme devnet ops doc to reference fork rust test matrix contract lane" >&2
-  exit 1
-fi
-
-if ! grep -q "check_local_kolme_fork_rust_test_matrix_policy.py" "$DOC_FILE"; then
-  echo "expected Kolme devnet ops doc to reference fork rust test matrix policy checker" >&2
-  exit 1
-fi
-
-if ! grep -q "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" "$README_FILE"; then
-  echo "expected README to reference fork rust test matrix contract lane" >&2
-  exit 1
-fi
+for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
+  if ! grep -q "run_local_kolme_fork_rust_test_matrix_contract_lane.sh" "$docs_file"; then
+    echo "expected docs parity to reference fork rust test matrix contract lane in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "check_local_kolme_fork_rust_test_matrix_policy.py" "$docs_file"; then
+    echo "expected docs parity to reference fork rust test matrix policy checker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1" "$docs_file"; then
+    echo "expected docs parity to include evidence bundle schema marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "evidence_bundle" "$docs_file"; then
+    echo "expected docs parity to include evidence_bundle marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2329" "$docs_file"; then
+    echo "expected docs parity to include local rust matrix evidence regression marker in $docs_file" >&2
+    exit 1
+  fi
+done
 
 if ! grep -q "Regression: #1541" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to include fork rust test matrix regression marker" >&2

--- a/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh
@@ -118,6 +118,15 @@ if report.get("local_only_enforced") is not True:
     raise SystemExit("expected local_only_enforced=true in local fork rust test matrix summary")
 if report.get("command_count") != 2:
     raise SystemExit("expected command_count=2 for dry-run matrix")
+if report.get("evidence_bundle_schema_version") != "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1":
+    raise SystemExit("expected evidence bundle schema marker in local fork rust test matrix summary")
+bundle = report.get("evidence_bundle")
+if not isinstance(bundle, dict):
+    raise SystemExit("expected evidence_bundle object in local fork rust test matrix summary")
+if bundle.get("schema_version") != "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1":
+    raise SystemExit("expected evidence bundle schema version in local fork rust test matrix summary")
+if bundle.get("summary_schema_version") != report.get("schema_version"):
+    raise SystemExit("expected evidence bundle summary schema marker in local fork rust test matrix summary")
 checkpoints = report.get("checkpoints")
 if not isinstance(checkpoints, list) or len(checkpoints) < 3:
     raise SystemExit("expected metadata + command checkpoint entries in matrix summary")
@@ -179,6 +188,15 @@ if report.get("status") != "ok":
     raise SystemExit("expected ok status for run mode matrix summary")
 if report.get("budget_status") != "within_budget":
     raise SystemExit("expected within_budget for run mode matrix summary")
+if report.get("evidence_bundle_schema_version") != "kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1":
+    raise SystemExit("expected evidence bundle schema marker in run mode matrix summary")
+bundle = report.get("evidence_bundle")
+if not isinstance(bundle, dict):
+    raise SystemExit("expected evidence_bundle object in run mode matrix summary")
+if bundle.get("budget_status") != report.get("budget_status"):
+    raise SystemExit("expected evidence bundle budget status marker in run mode matrix summary")
+if bundle.get("command_count") != report.get("command_count"):
+    raise SystemExit("expected evidence bundle command_count marker in run mode matrix summary")
 log_files = sorted(out_dir.glob("command-*.log"))
 if len(log_files) != 2:
     raise SystemExit("expected two command output files in matrix output directory")


### PR DESCRIPTION
Closes #2329

## Summary
Adds explicit evidence-bundle schema/linkage contracts to the local Kolme fork Rust test matrix lane, policy checker, contract-lane implementation, and docs parity markers. This closes drift between summary payload shape and policy/contract/documentation expectations.

## Changes
- `scripts/kolme/run_local_kolme_fork_rust_test_matrix_lane.sh`: emits `evidence_bundle_schema_version` and `evidence_bundle` payload in summary.
- `scripts/kolme/check_local_kolme_fork_rust_test_matrix_policy.py`: validates evidence-bundle schema/linkage/status/reason/budget/command/artifact parity and emits deterministic reason markers.
- `scripts/kolme/contracts/local_fork_rust_test_matrix_contract_lane.py`: enforces docs parity markers across planning/CI/README, including `Regression: #2329`.
- `scripts/kolme/test_*rust_test_matrix*`: Red-to-Green assertions for evidence-bundle contracts and docs parity.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: added explicit evidence-bundle schema/payload markers and regression references.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh`
  - failed with: `expected evidence_bundle_schema_invalid reason marker for invalid evidence bundle schema`
- `bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh`
  - failed with: `expected local fork rust test matrix contract implementation to include coverage marker: evidence_bundle_schema_version=kamn.kolme.local-fork-rust-test-matrix-evidence-bundle.v1`

### 🟢 Green Phase
- `bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh`
  - `local fork rust test matrix lane tests passed.`
- `bash scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh`
  - `local fork rust test matrix policy checker tests passed.`
- `bash scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh`
  - `local fork rust test matrix contract lane tests passed.`

### 🔁 Regression
- `bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`
  - `local fork real-process contract lane tests passed.`
- `cargo fmt --check`
  - pass
- `cargo clippy -- -D warnings`
  - pass

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Shell/Python lane contract change; behavior covered by lane/policy tests |
| Functional   | ✅     | `scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_lane.sh`; `scripts/kolme/test_check_local_kolme_fork_rust_test_matrix_policy.sh` | |
| Integration  | ✅     | `scripts/kolme/test_run_local_kolme_fork_rust_test_matrix_contract_lane.sh` | |
| Regression   | ✅     | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh` + explicit `Regression: #2329` markers | |
| Performance  | N/A    | None                 | No throughput/runtime-path change beyond existing bounded contract lanes |

## Risks & Rollback
- None expected; changes are additive contract checks and docs parity.
- Rollback: revert commit `98d4699` if any downstream lane unexpectedly depends on missing evidence-bundle fields.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
