### PR TITLE
fix(kolme): enforce live provider marker in lifecycle lane (#2341)

### DIFF
--- a/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py
@@ -65,6 +65,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_commit_method_mismatch")
         if contracts.get("integration_runner") != "run_local_kamn_live_runtime_integration_lane.sh":
             reason_codes.append("integration_runner_mismatch")
+        if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+            reason_codes.append("runtime_provider_client_contract_contract_mismatch")
         if contracts.get("integration_runtime_commit_live_policy_report_option") != "--runtime-commit-live-policy-report":
             reason_codes.append("integration_runtime_commit_live_policy_report_option_mismatch")
         if contracts.get("rollback_evidence_option") != "--rollback-evidence-file":
@@ -176,6 +178,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
                 and "--runtime-profile real-node" not in command
             ):
                 reason_codes.append("kamn_live_integration_runtime_profile_marker_missing")
+            if (
+                check_id == "kamn_live_integration"
+                and isinstance(command, str)
+                and "--runtime-provider-client-contract KolmeRuntimeCommitLiveProvider" not in command
+            ):
+                reason_codes.append("kamn_live_integration_runtime_provider_marker_missing")
             if (
                 check_id == "rollback_evidence"
                 and isinstance(command, str)

--- a/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh
+++ b/scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh
@@ -25,6 +25,7 @@ INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND=""
 INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS=15
 INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-live-finality-output.txt"
 INTEGRATION_RUNTIME_COMMIT_LIVE_POLICY_REPORT="/tmp/kolme-local-runtime-commit-live-policy.json"
+INTEGRATION_RUNTIME_PROVIDER_CLIENT_CONTRACT="KolmeRuntimeCommitLiveProvider"
 ROLLBACK_EVIDENCE_FILE="/tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json"
 RECOVERY_EVIDENCE_FILE="/tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json"
 PROCESS_PID=""
@@ -412,6 +413,7 @@ graceful_teardown() {
 serve_command_planned="${SERVE_COMMAND:-<required-in-run-mode>}"
 readiness_command="curl --silent --show-error --fail ${BASE_URL%/}/healthz && curl --silent --show-error --fail ${BASE_URL%/}/fork-info?chain_version=${FORK_CHAIN_VERSION}"
 integration_command="bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --runtime-profile real-node --checkout-path ${CHECKOUT_PATH} --expected-remote-url ${EXPECTED_REMOTE_URL} --expected-ref ${EXPECTED_REF} --base-url ${BASE_URL} --fork-chain-version ${FORK_CHAIN_VERSION} --max-seconds ${INTEGRATION_MAX_SECONDS} --bootstrap-max-seconds ${INTEGRATION_BOOTSTRAP_MAX_SECONDS} --conformance-max-seconds ${INTEGRATION_CONFORMANCE_MAX_SECONDS} --runtime-commit-max-seconds ${INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS} --output-json ${INTEGRATION_REPORT}"
+integration_command="${integration_command} --runtime-provider-client-contract ${INTEGRATION_RUNTIME_PROVIDER_CLIENT_CONTRACT}"
 integration_command="${integration_command} --runtime-commit-live-policy-report $(shell_escape "${INTEGRATION_RUNTIME_COMMIT_LIVE_POLICY_REPORT}")"
 if [ -n "$INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND" ]; then
   integration_command="${integration_command} --runtime-commit-finality-command $(shell_escape "${INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND}") --runtime-commit-finality-max-seconds ${INTEGRATION_RUNTIME_COMMIT_FINALITY_MAX_SECONDS} --runtime-commit-finality-output-file $(shell_escape "${INTEGRATION_RUNTIME_COMMIT_FINALITY_OUTPUT_FILE}")"
@@ -517,6 +519,7 @@ if [ "$MODE" = "run" ]; then
           --conformance-max-seconds "$INTEGRATION_CONFORMANCE_MAX_SECONDS"
           --runtime-commit-max-seconds "$INTEGRATION_RUNTIME_COMMIT_MAX_SECONDS"
           --output-json "$INTEGRATION_REPORT"
+          --runtime-provider-client-contract "$INTEGRATION_RUNTIME_PROVIDER_CLIENT_CONTRACT"
           --runtime-commit-live-policy-report "$INTEGRATION_RUNTIME_COMMIT_LIVE_POLICY_REPORT"
         )
         if [ -n "$INTEGRATION_RUNTIME_COMMIT_FINALITY_COMMAND" ]; then
@@ -693,6 +696,7 @@ summary = {
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",
         "integration_runner": "run_local_kamn_live_runtime_integration_lane.sh",
+        "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
         "integration_runtime_commit_live_policy_report_option": "--runtime-commit-live-policy-report",
         "rollback_evidence_option": "--rollback-evidence-file",
         "recovery_evidence_option": "--recovery-evidence-file",

--- a/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
@@ -221,6 +221,10 @@ if len(integration_commands) != 1:
 integration_command = integration_commands[0]
 if "--runtime-profile real-node" not in integration_command:
     raise SystemExit("expected nested integration command to include explicit real-node runtime profile marker")
+if "--runtime-provider-client-contract KolmeRuntimeCommitLiveProvider" not in integration_command:
+    raise SystemExit(
+        "expected nested integration command to include explicit live runtime provider contract marker"
+    )
 if "--runtime-commit-finality-command" not in integration_command:
     raise SystemExit("expected nested integration command to include runtime finality command pass-through")
 if "--runtime-commit-finality-max-seconds 11" not in integration_command:
@@ -237,6 +241,13 @@ if summary.get("integration_runtime_commit_live_policy_report") != str(runtime_p
     raise SystemExit("expected summary to expose runtime policy report path")
 if str(runtime_policy_report_path) not in summary.get("artifact_paths", []):
     raise SystemExit("expected process lifecycle summary artifact paths to include runtime policy report path")
+contracts = summary.get("contracts")
+if not isinstance(contracts, dict):
+    raise SystemExit("expected process lifecycle summary contracts object")
+if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+    raise SystemExit(
+        "expected process lifecycle summary contracts to include live runtime provider contract marker"
+    )
 rollback_evidence_path = pathlib.Path(sys.argv[4]).resolve()
 recovery_evidence_path = pathlib.Path(sys.argv[5]).resolve()
 if summary.get("rollback_evidence_file") != str(rollback_evidence_path):


### PR DESCRIPTION
## Summary
This change closes a policy gap in local Kolme process lifecycle orchestration by making the live runtime provider contract explicit and verifiable end-to-end. The lifecycle lane now always passes the explicit live provider marker into nested integration, and the policy checker rejects summaries that drift from that marker.

Closes #2341.

## Changes
- `scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh`: added explicit nested argument `--runtime-provider-client-contract KolmeRuntimeCommitLiveProvider` and surfaced `contracts.runtime_provider_client_contract` in summary output.
- `scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py`: added policy enforcement for provider contract marker in both `contracts` and `kamn_live_integration` command string.
- `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`: added regression assertions for the explicit nested provider marker and summary contracts marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`

Output:
`expected nested integration command to include explicit live runtime provider contract marker`

### 🟢 Green Phase
Command:
`bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`

Output:
`local fork process lifecycle contract lane tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
All listed commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Shell/Python lane-policy wiring change; no Rust unit surface modified. |
| Functional   | ✅     | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | Validates lifecycle lane command composition and summary contracts for explicit live provider marker. |
| Integration  | ✅     | Existing integration lane coverage re-run | Re-ran dependent local integration contract lanes and real-node profile policy checks. |
| Regression   | ✅     | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | New assertions reproduce and prevent provider-marker omission regression (#2341). |
| Performance  | N/A    | None                 | No runtime/perf path changes; policy/contract marker enforcement only. |

## Risks & Rollback
- No breaking API changes; lane contract became stricter by requiring explicit provider marker.
- Rollback plan: revert commit `d40d830` if downstream tooling requires temporary compatibility with implicit provider defaults.

## Documentation Updates
- None required: behavior changes are enforced in contract-lane and policy artifacts; no user-facing CLI surface changed beyond explicit propagation already accepted by nested lane.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
