### PR TITLE
fix(kolme): fail closed on simulated signing profiles (#2344)

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -264,6 +264,7 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - `runtime_commit_command_profile`
     - `runtime_commit_policy_command_profile`
     - `runtime_commit_command_profile_version`
+    - `runtime_signing_profile`
     - `runtime_signer_key_source_contract_version`
     - `runtime_signer_key_source`
   - real-node summary/profile checker contract requires:
@@ -275,6 +276,9 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
   - marker/profile drift is fail-closed in `check_local_kamn_live_runtime_real_node_profile_policy.py`.
   - strict real-node checker additionally fails closed when runtime command surfaces omit fork-aligned signing profile marker:
     - `runtime_commit_real_signing_profile_marker_missing`
+  - strict real-node checker also fails closed when simulated/non-secp signing-profile values appear in runtime command surfaces:
+    - `runtime_commit_signing_profile_value_disallowed`
+    - `runtime_commit_simulated_signing_profile_detected`
   - real-node runner composition rejects in-memory fallback references:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
   - real-node checker fails closed when in-memory provider references appear in strict command/policy surfaces:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 NON_SYNTHETIC_SUBMIT_PROBE_MARKER = "integration_kolme_fork_live_node_submit_reaches_endpoint"
 IN_MEMORY_PROVIDER_MARKER = "InMemoryKolmeRuntimeCommitClient"
-REAL_SIGNING_PROFILE_MARKER = "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
+REAL_SIGNING_PROFILE_ENV = "KAMN_KOLME_LIVE_SIGNING_PROFILE"
+REAL_SIGNING_PROFILE_VALUE = "kolme-fork-secp256k1-v1"
+REAL_SIGNING_PROFILE_MARKER = f"{REAL_SIGNING_PROFILE_ENV}={REAL_SIGNING_PROFILE_VALUE}"
+REAL_SIGNING_PROFILE_PATTERN = re.compile(rf"{REAL_SIGNING_PROFILE_ENV}=([^\s\"']+)")
 REAL_SIGNER_PROFILE_SELECTOR_ENV = "KAMN_KOLME_LIVE_SIGNER_PROFILE"
 REAL_SIGNER_PROFILE_PRIMARY = "ops-primary"
 REAL_SIGNER_PROFILE_SECONDARY = "ops-secondary"
@@ -139,6 +143,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("runtime_profile_missing")
     elif runtime_profile != "real-node":
         reason_codes.append("runtime_profile_mismatch")
+
+    runtime_signing_profile = report.get("runtime_signing_profile")
+    if not isinstance(runtime_signing_profile, str) or not runtime_signing_profile.strip():
+        reason_codes.append("runtime_signing_profile_missing")
+    elif runtime_signing_profile != REAL_SIGNING_PROFILE_VALUE:
+        reason_codes.append("runtime_signing_profile_mismatch")
 
     runtime_provider_client_contract = report.get("runtime_provider_client_contract")
     if not isinstance(runtime_provider_client_contract, str) or not runtime_provider_client_contract.strip():
@@ -292,6 +302,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(runtime_commit_command, str) or not runtime_commit_command.strip():
         reason_codes.append("runtime_commit_command_missing")
     else:
+        observed_signing_profile_values = [
+            observed_value.rstrip("\\")
+            for observed_value in REAL_SIGNING_PROFILE_PATTERN.findall(runtime_commit_command)
+        ]
         if "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" not in runtime_commit_command:
             reason_codes.append("runtime_commit_contract_lane_missing")
         if "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider" not in runtime_commit_command:
@@ -308,6 +322,19 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and REAL_SIGNING_PROFILE_MARKER not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_real_signing_profile_marker_missing")
+        if (
+            runtime_commit_command_profile == "real-node-non-synthetic-v1"
+            and any(
+                observed_signing_profile and observed_signing_profile != REAL_SIGNING_PROFILE_VALUE
+                for observed_signing_profile in observed_signing_profile_values
+            )
+        ):
+            reason_codes.append("runtime_commit_signing_profile_value_disallowed")
+        if (
+            runtime_commit_command_profile == "real-node-non-synthetic-v1"
+            and any("simulated" in observed_signing_profile.lower() for observed_signing_profile in observed_signing_profile_values)
+        ):
+            reason_codes.append("runtime_commit_simulated_signing_profile_detected")
         expected_profile_command_marker = ""
         if isinstance(runtime_signer_profile, str) and runtime_signer_profile in ALLOWED_SIGNER_PROFILES:
             expected_profile_command_marker = (
@@ -349,6 +376,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("ci_fast_gate_scope_mismatch")
         if contracts.get("runtime_profile") != "real-node":
             reason_codes.append("runtime_profile_contract_mismatch")
+        if contracts.get("runtime_signing_profile") != REAL_SIGNING_PROFILE_VALUE:
+            reason_codes.append("runtime_signing_profile_contract_mismatch")
         if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
             reason_codes.append("runtime_provider_client_contract_contract_mismatch")
         if contracts.get("runtime_signer_profile_selector_env") != REAL_SIGNER_PROFILE_SELECTOR_ENV:

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh
@@ -18,6 +18,7 @@ LOCALHOST_SIGNED_REPORT="/tmp/localhost-signed-integration-contract-report.json"
 RUNTIME_COMMIT_OUTPUT_FILE="/tmp/kolme-local-runtime-commit-endpoint-output.txt"
 RUNTIME_COMMIT_LIVE_SUMMARY="/tmp/kolme-local-runtime-commit-live-summary.json"
 RUNTIME_COMMIT_LIVE_POLICY_REPORT="/tmp/kolme-local-runtime-commit-live-policy.json"
+RUNTIME_SIGNING_PROFILE="kolme-fork-secp256k1-v1"
 RUNTIME_PROVIDER_CLIENT_CONTRACT="KolmeRuntimeCommitLiveProvider"
 RUNTIME_PROFILE="real-node"
 RUNTIME_COMMIT_FINALITY_COMMAND=""
@@ -460,7 +461,7 @@ fi
 if [ "$RUNTIME_SIGNER_KEY_SOURCE" = "managed-external" ] && [ -n "$RUNTIME_SIGNER_KEY_REF_ENV" ] && [ -n "$RUNTIME_SIGNER_PROFILE" ]; then
   default_runtime_commit_live_submit_command_prefix="${default_runtime_commit_live_submit_command_prefix} ${RUNTIME_SIGNER_KEY_REF_ENV}=secure:aws-kms:role-operator/key-live-${RUNTIME_SIGNER_PROFILE}"
 fi
-default_runtime_commit_live_submit_command="${default_runtime_commit_live_submit_command_prefix} KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\n{\"pubkey\":\"proof\",\"nonce\":1,\"messages\":[]}\\n'"
+default_runtime_commit_live_submit_command="${default_runtime_commit_live_submit_command_prefix} KAMN_KOLME_LIVE_SIGNING_PROFILE=${RUNTIME_SIGNING_PROFILE} cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint && printf 'status=submitted\\n{\"pubkey\":\"proof\",\"nonce\":1,\"messages\":[]}\\n'"
 
 default_runtime_commit_command="KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_SUMMARY}") --policy-output-json $(shell_escape "${RUNTIME_COMMIT_LIVE_POLICY_REPORT}") --live-output-file $(shell_escape "${RUNTIME_COMMIT_OUTPUT_FILE}") --finality-output-file $(shell_escape "${RUNTIME_COMMIT_FINALITY_OUTPUT_FILE}") --max-seconds ${RUNTIME_COMMIT_MAX_SECONDS} --expected-provider-client-contract $(shell_escape "${RUNTIME_PROVIDER_CLIENT_CONTRACT}")${runtime_commit_non_synthetic_flag}${runtime_commit_native_payload_flag} --live-command $(shell_escape "${default_runtime_commit_live_submit_command}") --finality-command $(shell_escape "${effective_runtime_commit_finality_command}") --finality-max-seconds ${RUNTIME_COMMIT_FINALITY_MAX_SECONDS}"
 if [ -z "$RUNTIME_COMMIT_COMMAND" ]; then
@@ -470,6 +471,11 @@ fi
 
 if [ "$RUNTIME_PROFILE" = "real-node" ] && [[ "$RUNTIME_COMMIT_COMMAND" == *"InMemoryKolmeRuntimeCommitClient"* ]]; then
   echo "runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node" >&2
+  exit 1
+fi
+
+if [ "$RUNTIME_PROFILE" = "real-node" ] && [[ "$RUNTIME_COMMIT_COMMAND" == *"KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated"* ]]; then
+  echo "runtime-commit-command must not reference simulated signing profile marker when runtime-profile=real-node" >&2
   exit 1
 fi
 
@@ -776,7 +782,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$RUNTIME_SIGNING_PROFILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -830,6 +836,7 @@ runtime_signer_fallback_private_key_env = sys.argv[44]
 runtime_signer_fallback_private_key_present = sys.argv[45] == "true"
 runtime_signer_raw_private_key_present = sys.argv[46] == "true"
 runtime_signer_attestation_schema_version = sys.argv[47]
+runtime_signing_profile = sys.argv[48]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -993,6 +1000,7 @@ summary = {
     "runtime_commit_command": runtime_commit_command,
     "runtime_provider_client_contract": runtime_provider_client_contract,
     "runtime_profile": runtime_profile,
+    "runtime_signing_profile": runtime_signing_profile,
     "runtime_commit_command_profile": runtime_commit_command_profile,
     "runtime_commit_policy_command_profile": runtime_commit_policy_command_profile,
     "runtime_commit_command_profile_version": runtime_commit_command_profile_version,
@@ -1029,6 +1037,7 @@ summary = {
         "ci_fast_gate_scope": "local-only",
         "runtime_provider_client_contract": runtime_provider_client_contract,
         "runtime_profile": runtime_profile,
+        "runtime_signing_profile": runtime_signing_profile,
         "runtime_signer_profile_selector_env": runtime_signer_profile_selector_env,
         "runtime_signer_profile": runtime_signer_profile,
         "runtime_signer_failover_requires_profile_change": True,

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -16,6 +16,7 @@ TMP_REPORT_ATTESTATION_DUPLICATE="$TMP_DIR/attestation-duplicate-report.json"
 TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL="$TMP_DIR/attestation-quorum-shortfall-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
+TMP_REPORT_SIMULATED="$TMP_DIR/simulated-signing-profile-report.json"
 TMP_REPORT_INMEMORY="$TMP_DIR/inmemory-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
 TMP_POLICY_OUT_SECONDARY="$TMP_DIR/policy-report-secondary.json"
@@ -65,6 +66,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "base_url": "http://127.0.0.1:3000",
   "fork_chain_version": "v0.15.2",
   "runtime_profile": "real-node",
+  "runtime_signing_profile": "kolme-fork-secp256k1-v1",
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
   "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "runtime_signer_profile": "ops-primary",
@@ -106,6 +108,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "contracts": {
     "ci_fast_gate_scope": "local-only",
     "runtime_profile": "real-node",
+    "runtime_signing_profile": "kolme-fork-secp256k1-v1",
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
     "runtime_signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
     "runtime_signer_profile": "ops-primary",
@@ -644,6 +647,42 @@ if ! grep -q "runtime_commit_signer_profile_marker_missing" "$TMP_ERR"; then
   exit 1
 fi
 
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_SIMULATED" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+command = str(report.get("runtime_commit_command", ""))
+report["runtime_commit_command"] = (
+    f"{command} KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated-v1"
+)
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_SIMULATED" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+simulated_signing_profile_exit_code=$?
+set -e
+
+if [ "$simulated_signing_profile_exit_code" -eq 0 ]; then
+  echo "expected real-node profile policy checker to fail for simulated signing profile marker drift" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_simulated_signing_profile_detected" "$TMP_ERR"; then
+  echo "expected simulated signing profile detection reason for policy failure" >&2
+  exit 1
+fi
+
 cat >"$TMP_REPORT_INMEMORY" <<'JSON'
 {
   "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
@@ -843,6 +882,8 @@ if summary.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected signer key-source contract version marker in runner-generated summary")
 if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected signer key-source marker in runner-generated summary")
+if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected runtime signing profile marker in runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
@@ -892,6 +933,8 @@ if summary.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected secondary signer key-source contract version marker in secondary runner-generated summary")
 if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected secondary signer key-source marker in secondary runner-generated summary")
+if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected runtime signing profile marker in secondary runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected secondary signer private key env marker in secondary runner-generated summary")
 contracts = summary.get("contracts")
@@ -903,6 +946,8 @@ if contracts.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected contracts signer key-source contract version marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected contracts signer key-source marker in secondary runner-generated summary")
+if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected contracts runtime signing profile marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in secondary runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -110,6 +110,8 @@ if summary.get("runtime_signer_profile") != "ops-primary":
     raise SystemExit("expected signer profile marker for real-node profile")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker for real-node profile")
+if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected runtime signing profile marker for real-node profile")
 contracts = summary.get("contracts", {})
 if not isinstance(contracts, dict):
     raise SystemExit("expected contracts object in integration summary")
@@ -123,6 +125,8 @@ if contracts.get("runtime_signer_profile") != "ops-primary":
     raise SystemExit("expected contracts signer profile marker in integration summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected contracts signer private key env marker in integration summary")
+if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected contracts runtime signing profile marker in integration summary")
 checks = summary.get("checks", [])
 if not isinstance(checks, list) or not checks:
     raise SystemExit("expected checks list in integration summary")
@@ -157,6 +161,28 @@ fi
 
 if ! grep -q "must not reference InMemoryKolmeRuntimeCommitClient" "$TMP_ERR"; then
   echo "expected deterministic in-memory provider rejection message for real-node profile dry-run" >&2
+  exit 1
+fi
+
+set +e
+bash "$RUNNER" \
+  --mode dry-run \
+  --runtime-profile real-node \
+  --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \
+  --runtime-commit-command "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --live-command \"KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated-v1 printf 'runtime=simulated\\n'\" --output-json $TMP_RUNTIME_SUMMARY --policy-output-json $TMP_RUNTIME_POLICY" \
+  --runtime-commit-live-summary "$TMP_RUNTIME_SUMMARY" \
+  --runtime-commit-live-policy-report "$TMP_RUNTIME_POLICY" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+dry_run_simulated_signing_profile_exit_code=$?
+set -e
+
+if [ "$dry_run_simulated_signing_profile_exit_code" -eq 0 ]; then
+  echo "expected real-node profile dry-run to fail closed when runtime commit command references simulated signing profile marker" >&2
+  exit 1
+fi
+
+if ! grep -q "must not reference simulated signing profile marker" "$TMP_ERR"; then
+  echo "expected deterministic simulated signing profile rejection message for real-node profile dry-run" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This change hardens real-node signer policy to fail closed on simulated signing-profile drift and makes secp256k1 signing mode explicit in integration summary/contracts. It closes a production-parity gap where conflicting signing-profile markers could slip through command surfaces.

Closes #2344.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`:
  - Added explicit `runtime_signing_profile` contract marker (`kolme-fork-secp256k1-v1`) in summary and contracts.
  - Added fail-closed guard rejecting `KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated*` in real-node runtime commands.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`:
  - Requires `runtime_signing_profile` in summary/contracts for real-node profile policy GO path.
  - Detects and rejects disallowed/simulated signing-profile values in runtime command surfaces.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`:
  - Added assertions for summary/contracts `runtime_signing_profile`.
  - Added regression path proving simulated signing-profile command is rejected fail-closed.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`:
  - Added simulated signing-profile drift fixture and required reason code assertion.
  - Added runner-generated summary assertions for `runtime_signing_profile` markers.
- `docs/foundation/kolme-runtime-commit-client.md`:
  - Documented `runtime_signing_profile` marker contract and new fail-closed reason codes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands and failing outputs:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
  - `expected runtime signing profile marker for real-node profile`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - `expected simulated signing profile detection reason for policy failure`

### 🟢 Green Phase
Commands and passing outputs:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
  - `local KAMN live runtime integration real-node profile tests passed.`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - `local KAMN live runtime real-node profile policy checker tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
All listed commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Change scope is shell/Python contract-lane policy wiring; no standalone Rust unit target changed. |
| Functional   | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | Validates policy reason-codes and GO/NO-GO behavior for signer-profile contracts and simulated drift. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` | Validates runner command composition and fail-closed behavior in real-node integration path. |
| Regression   | ✅     | Same two tests above + existing contract-lane re-runs | Prevents simulated signing-profile marker reintroduction (`Regression: #2337` lineage in story scope). |
| Performance  | N/A    | None                 | No throughput/path-length changes; only policy/contract guard checks. |

## Risks & Rollback
- Risk: stricter command validation may fail previously permissive local command overrides that included simulated markers.
- Rollback: revert commit `5bc4071` to restore previous permissive behavior while retaining prior provider-profile guards.

## Documentation Updates
- `docs/foundation/kolme-runtime-commit-client.md`: added runtime_signing_profile marker contract and fail-closed simulated-mode reason codes.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
