### PR TITLE
feat(kolme): expand secp256k1 parity fixture matrix (#2345)

### DIFF
--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1089,6 +1089,22 @@ Operator checkpoints:
   - lane default budget is bounded to 120 seconds via `KAMN_KOLME_FAST_GATE_NATIVE_PARITY_MAX_SECONDS`.
   - local-heavy run-mode parity commands remain excluded from PR fast-gate workflow routing.
 
+## Secp256k1 Signature Parity Fixture Lane (Issue #2345)
+
+- Fixture-backed matrix runner:
+  - `python3 scripts/kolme/run_signature_parity_matrix.py --fixture fixtures/kolme_commit/signature_parity_vectors.json --output-json /tmp/kolme-signature-parity-matrix-report.json`
+- Policy checker:
+  - `python3 scripts/kolme/check_signature_parity_policy.py --report-file /tmp/kolme-signature-parity-matrix-report.json --expected-final-decision GO --ci-fast-gate PASS --require-vector-id kolme_fork_primary_alpha --require-vector-id kolme_fork_secondary_beta --require-vector-id kolme_fork_primary_alpha_bad_signature --require-vector-id kolme_fork_secondary_beta_bad_recovery --require-vector-id kolme_fork_primary_alpha_bad_pubkey --output-json /tmp/kolme-signature-parity-policy-report.json`
+- Contract lane wrapper:
+  - `bash scripts/kolme/run_signature_parity_contract_lane.sh --output-json /tmp/kolme-signature-parity-matrix-report.json --policy-output-json /tmp/kolme-signature-parity-policy-report.json`
+- Deterministic negative-vector checkpoints:
+  - `kolme_fork_primary_alpha_bad_signature` must emit `parity_signature_mismatch`.
+  - `kolme_fork_secondary_beta_bad_recovery` must emit `parity_recovery_id_mismatch`.
+  - `kolme_fork_primary_alpha_bad_pubkey` must emit `parity_pubkey_mismatch`.
+- Policy fail-closed checkpoints:
+  - NO-GO cases must include deterministic `reason_codes`.
+  - unknown/unrecognized case-level reason codes are rejected.
+
 ## Deterministic Local Bootstrap Health Checks (Issues #1417, #1691)
 
 - Bootstrap health-check runner:

--- a/fixtures/kolme_commit/signature_parity_vectors.json
+++ b/fixtures/kolme_commit/signature_parity_vectors.json
@@ -31,6 +31,30 @@
       "required_reason_codes": [
         "parity_signature_mismatch"
       ]
+    },
+    {
+      "vector_id": "kolme_fork_secondary_beta_bad_recovery",
+      "private_key_hex": "838c3528422eb527b4c108b8f6d1e5f629543c304ea49cf608c67794424291c4",
+      "message": "{\"pubkey\":\"pk-parity-2\",\"nonce\":29,\"created\":\"2026-02-12T00:00:00Z\",\"messages\":[{\"type\":\"note\",\"value\":\"beta\"}]}",
+      "expected_signature_hex": "82fd55f830720136beec1331778895a23fc9c1ddf6ec50fe4de376d33f88c5dc08501b8037653ffff3e5e46433a7ab0cce8f5ed4574b05eaee25ce44a95c4ad3",
+      "expected_recovery_id": 1,
+      "expected_pubkey_hex": "032ea4599f4e21cba5d319a16770864db05f33c4de2ef5c82b6f8135e915fa0d7e",
+      "expected_final_decision": "NO-GO",
+      "required_reason_codes": [
+        "parity_recovery_id_mismatch"
+      ]
+    },
+    {
+      "vector_id": "kolme_fork_primary_alpha_bad_pubkey",
+      "private_key_hex": "658c3528422eb527b4c108b8f6d1e5f629543c304ea49cf608c67794424291c4",
+      "message": "{\"pubkey\":\"pk-parity-1\",\"nonce\":11,\"created\":\"2026-02-12T00:00:00Z\",\"messages\":[{\"type\":\"note\",\"value\":\"alpha\"}]}",
+      "expected_signature_hex": "6242ce6924ca946ebc4b2fb5372f4b51c624716ad4142173d91cf10a5ac1e2bf69e85c802702a0a553121e5261487628c5484bbcfa7f3c603d6f6cf9df03671c",
+      "expected_recovery_id": 1,
+      "expected_pubkey_hex": "0364eb26609d15e709227b9ddc46c11a738b210bb237949aa86d7d490a35ae0f0a",
+      "expected_final_decision": "NO-GO",
+      "required_reason_codes": [
+        "parity_pubkey_mismatch"
+      ]
     }
   ]
 }

--- a/scripts/kolme/check_signature_parity_policy.py
+++ b/scripts/kolme/check_signature_parity_policy.py
@@ -5,6 +5,15 @@ import argparse
 import json
 from pathlib import Path
 
+ALLOWED_CASE_REASON_CODES = {
+    "parity_signature_mismatch",
+    "parity_recovery_id_mismatch",
+    "parity_pubkey_mismatch",
+    "parity_probe_failed",
+    "vector_payload_invalid",
+    "expected_final_decision_invalid",
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -60,6 +69,30 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             observed_decision = entry.get("observed_final_decision")
             if observed_decision not in ("GO", "NO-GO"):
                 reason_codes.append(f"case_observed_final_decision_invalid:{vector_id}")
+            case_reason_codes = entry.get("reason_codes")
+            normalized_case_reason_codes: list[str] = []
+            if not isinstance(case_reason_codes, list):
+                reason_codes.append(f"case_reason_codes_invalid:{vector_id}")
+            else:
+                for case_reason_code in case_reason_codes:
+                    if not isinstance(case_reason_code, str) or not case_reason_code.strip():
+                        reason_codes.append(f"case_reason_codes_invalid:{vector_id}")
+                        continue
+                    normalized_case_reason_codes.append(case_reason_code)
+                for case_reason_code in normalized_case_reason_codes:
+                    if (
+                        case_reason_code not in ALLOWED_CASE_REASON_CODES
+                        and not case_reason_code.startswith("missing_field:")
+                    ):
+                        reason_codes.append(f"case_reason_code_unrecognized:{vector_id}:{case_reason_code}")
+            if observed_decision == "NO-GO" and not normalized_case_reason_codes:
+                reason_codes.append(f"case_reason_codes_missing:{vector_id}")
+            missing_required_reason_codes = entry.get("missing_required_reason_codes")
+            if isinstance(missing_required_reason_codes, list):
+                if missing_required_reason_codes:
+                    reason_codes.append(f"case_missing_required_reason_codes_present:{vector_id}")
+            elif missing_required_reason_codes is not None:
+                reason_codes.append(f"case_missing_required_reason_codes_invalid:{vector_id}")
 
         for required_vector_id in args.require_vector_id:
             if required_vector_id not in observed_vector_ids:

--- a/scripts/kolme/contracts/signature_parity_contract_lane.py
+++ b/scripts/kolme/contracts/signature_parity_contract_lane.py
@@ -25,6 +25,8 @@ REQUIRED_VECTOR_IDS = (
     "kolme_fork_primary_alpha",
     "kolme_fork_secondary_beta",
     "kolme_fork_primary_alpha_bad_signature",
+    "kolme_fork_secondary_beta_bad_recovery",
+    "kolme_fork_primary_alpha_bad_pubkey",
 )
 
 
@@ -146,24 +148,33 @@ def main() -> int:
         if not isinstance(cases, list) or len(cases) < 3:
             print("expected at least three signature parity vectors in matrix report", file=sys.stderr)
             return 1
-        bad_vector_cases = [
-            case
-            for case in cases
-            if isinstance(case, dict)
-            and case.get("vector_id") == "kolme_fork_primary_alpha_bad_signature"
-        ]
-        if len(bad_vector_cases) != 1:
-            print("expected one known-bad signature parity vector case in matrix report", file=sys.stderr)
-            return 1
-        # Regression: #2299
-        bad_vector_case = bad_vector_cases[0]
-        if bad_vector_case.get("observed_final_decision") != "NO-GO":
-            print("expected known-bad signature vector to observe NO-GO decision", file=sys.stderr)
-            return 1
-        reason_codes = bad_vector_case.get("reason_codes", [])
-        if not isinstance(reason_codes, list) or "parity_signature_mismatch" not in reason_codes:
-            print("expected known-bad signature vector to emit parity_signature_mismatch reason", file=sys.stderr)
-            return 1
+        expected_negative_vectors = {
+            "kolme_fork_primary_alpha_bad_signature": "parity_signature_mismatch",
+            "kolme_fork_secondary_beta_bad_recovery": "parity_recovery_id_mismatch",
+            "kolme_fork_primary_alpha_bad_pubkey": "parity_pubkey_mismatch",
+        }
+        for vector_id, required_reason_code in expected_negative_vectors.items():
+            bad_vector_cases = [
+                case
+                for case in cases
+                if isinstance(case, dict)
+                and case.get("vector_id") == vector_id
+            ]
+            if len(bad_vector_cases) != 1:
+                print(f"expected one known-bad signature parity vector case in matrix report: {vector_id}", file=sys.stderr)
+                return 1
+            # Regression: #2299
+            bad_vector_case = bad_vector_cases[0]
+            if bad_vector_case.get("observed_final_decision") != "NO-GO":
+                print(f"expected known-bad signature vector to observe NO-GO decision: {vector_id}", file=sys.stderr)
+                return 1
+            reason_codes = bad_vector_case.get("reason_codes", [])
+            if not isinstance(reason_codes, list) or required_reason_code not in reason_codes:
+                print(
+                    f"expected known-bad signature vector to emit {required_reason_code} reason: {vector_id}",
+                    file=sys.stderr,
+                )
+                return 1
 
         policy_payload = json.loads(policy_report.read_text(encoding="utf-8"))
         if policy_payload.get("schema_version") != "kamn.kolme.signature-parity-policy-report.v1":

--- a/scripts/kolme/test_check_signature_parity_policy.sh
+++ b/scripts/kolme/test_check_signature_parity_policy.sh
@@ -5,9 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECKER="$ROOT_DIR/scripts/kolme/check_signature_parity_policy.py"
 TMP_REPORT_GO="$(mktemp)"
 TMP_REPORT_BAD="$(mktemp)"
+TMP_REPORT_REASON_BAD="$(mktemp)"
 TMP_POLICY="$(mktemp)"
 TMP_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT_GO" "$TMP_REPORT_BAD" "$TMP_POLICY" "$TMP_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT_GO" "$TMP_REPORT_BAD" "$TMP_REPORT_REASON_BAD" "$TMP_POLICY" "$TMP_ERR"' EXIT
 
 if [ ! -x "$CHECKER" ]; then
   echo "expected signature parity policy checker to be executable" >&2
@@ -20,24 +21,50 @@ cat >"$TMP_REPORT_GO" <<'JSON'
   "status": "pass",
   "fixture": "/tmp/signature-vectors.json",
   "source_contract": "njfio/kolme_fork-secp256k1-v1",
-  "vector_count": 3,
+  "vector_count": 5,
   "failed_count": 0,
   "failed_vector_ids": [],
   "cases": [
     {
       "vector_id": "kolme_fork_primary_alpha",
       "observed_final_decision": "GO",
-      "passed": true
+      "passed": true,
+      "reason_codes": [],
+      "missing_required_reason_codes": []
     },
     {
       "vector_id": "kolme_fork_secondary_beta",
       "observed_final_decision": "GO",
-      "passed": true
+      "passed": true,
+      "reason_codes": [],
+      "missing_required_reason_codes": []
     },
     {
       "vector_id": "kolme_fork_primary_alpha_bad_signature",
       "observed_final_decision": "NO-GO",
-      "passed": true
+      "passed": true,
+      "reason_codes": [
+        "parity_signature_mismatch"
+      ],
+      "missing_required_reason_codes": []
+    },
+    {
+      "vector_id": "kolme_fork_secondary_beta_bad_recovery",
+      "observed_final_decision": "NO-GO",
+      "passed": true,
+      "reason_codes": [
+        "parity_recovery_id_mismatch"
+      ],
+      "missing_required_reason_codes": []
+    },
+    {
+      "vector_id": "kolme_fork_primary_alpha_bad_pubkey",
+      "observed_final_decision": "NO-GO",
+      "passed": true,
+      "reason_codes": [
+        "parity_pubkey_mismatch"
+      ],
+      "missing_required_reason_codes": []
     }
   ]
 }
@@ -50,6 +77,8 @@ python3 "$CHECKER" \
   --require-vector-id kolme_fork_primary_alpha \
   --require-vector-id kolme_fork_secondary_beta \
   --require-vector-id kolme_fork_primary_alpha_bad_signature \
+  --require-vector-id kolme_fork_secondary_beta_bad_recovery \
+  --require-vector-id kolme_fork_primary_alpha_bad_pubkey \
   --output-json "$TMP_POLICY" >/dev/null
 
 python3 - "$TMP_POLICY" <<'PY'
@@ -100,6 +129,47 @@ fi
 
 if ! grep -q "cases_missing" "$TMP_ERR"; then
   echo "expected cases_missing reason in signature parity policy output" >&2
+  exit 1
+fi
+
+cat >"$TMP_REPORT_REASON_BAD" <<'JSON'
+{
+  "schema_version": "kamn.kolme.signature-parity-matrix-report.v1",
+  "status": "fail",
+  "fixture": "/tmp/signature-vectors.json",
+  "source_contract": "njfio/kolme_fork-secp256k1-v1",
+  "vector_count": 1,
+  "failed_count": 1,
+  "failed_vector_ids": [
+    "kolme_fork_primary_alpha_bad_signature"
+  ],
+  "cases": [
+    {
+      "vector_id": "kolme_fork_primary_alpha_bad_signature",
+      "observed_final_decision": "NO-GO",
+      "passed": false,
+      "reason_codes": []
+    }
+  ]
+}
+JSON
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_REASON_BAD" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY" >"$TMP_ERR" 2>&1
+reason_bad_exit_code=$?
+set -e
+
+if [ "$reason_bad_exit_code" -eq 0 ]; then
+  echo "expected parity policy checker to fail when NO-GO cases omit deterministic reason codes" >&2
+  exit 1
+fi
+
+if ! grep -q "case_reason_codes_missing:kolme_fork_primary_alpha_bad_signature" "$TMP_ERR"; then
+  echo "expected case_reason_codes_missing reason in signature parity policy output" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_signature_parity_contract_lane.sh
+++ b/scripts/kolme/test_run_signature_parity_contract_lane.sh
@@ -78,6 +78,8 @@ required_impl_markers=(
   "check_signature_parity_policy.py"
   "fixtures/kolme_commit/signature_parity_vectors.json"
   "parity_signature_mismatch"
+  "parity_recovery_id_mismatch"
+  "parity_pubkey_mismatch"
   "Regression: #2299"
 )
 for marker in "${required_impl_markers[@]}"; do
@@ -129,19 +131,27 @@ if report.get("source_contract") != "njfio/kolme_fork-secp256k1-v1":
 cases = report.get("cases", [])
 if not isinstance(cases, list) or not cases:
     raise SystemExit("expected signature parity cases in matrix report")
-bad_cases = [
-    case
-    for case in cases
-    if isinstance(case, dict)
-    and case.get("vector_id") == "kolme_fork_primary_alpha_bad_signature"
-]
-if len(bad_cases) != 1:
-    raise SystemExit("expected one bad signature vector case in matrix report")
-bad_case = bad_cases[0]
-if bad_case.get("observed_final_decision") != "NO-GO":
-    raise SystemExit("expected bad signature vector observed_final_decision NO-GO")
-if "parity_signature_mismatch" not in bad_case.get("reason_codes", []):
-    raise SystemExit("expected bad signature vector reason_codes to include parity_signature_mismatch")
+expected_negative_vectors = {
+    "kolme_fork_primary_alpha_bad_signature": "parity_signature_mismatch",
+    "kolme_fork_secondary_beta_bad_recovery": "parity_recovery_id_mismatch",
+    "kolme_fork_primary_alpha_bad_pubkey": "parity_pubkey_mismatch",
+}
+for vector_id, required_reason_code in expected_negative_vectors.items():
+    bad_cases = [
+        case
+        for case in cases
+        if isinstance(case, dict)
+        and case.get("vector_id") == vector_id
+    ]
+    if len(bad_cases) != 1:
+        raise SystemExit(f"expected one bad parity vector case in matrix report: {vector_id}")
+    bad_case = bad_cases[0]
+    if bad_case.get("observed_final_decision") != "NO-GO":
+        raise SystemExit(f"expected bad parity vector observed_final_decision NO-GO: {vector_id}")
+    if required_reason_code not in bad_case.get("reason_codes", []):
+        raise SystemExit(
+            f"expected bad parity vector reason_codes to include {required_reason_code}: {vector_id}"
+        )
 if policy.get("schema_version") != "kamn.kolme.signature-parity-policy-report.v1":
     raise SystemExit("unexpected signature parity policy report schema")
 if policy.get("final_decision") != "GO":

--- a/scripts/kolme/test_run_signature_parity_matrix.sh
+++ b/scripts/kolme/test_run_signature_parity_matrix.sh
@@ -30,22 +30,27 @@ if report.get("schema_version") != "kamn.kolme.signature-parity-matrix-report.v1
     raise SystemExit("unexpected signature parity matrix report schema")
 if report.get("status") != "pass":
     raise SystemExit("expected signature parity matrix report status pass")
-if report.get("vector_count", 0) < 3:
-    raise SystemExit("expected at least three signature parity vectors")
+if report.get("vector_count", 0) < 5:
+    raise SystemExit("expected at least five signature parity vectors")
 cases = report.get("cases", [])
-bad_cases = [
-    case
-    for case in cases
-    if isinstance(case, dict)
-    and case.get("vector_id") == "kolme_fork_primary_alpha_bad_signature"
-]
-if len(bad_cases) != 1:
-    raise SystemExit("expected exactly one known-bad signature vector case")
-bad_case = bad_cases[0]
-if bad_case.get("observed_final_decision") != "NO-GO":
-    raise SystemExit("expected known-bad signature vector decision NO-GO")
-if "parity_signature_mismatch" not in bad_case.get("reason_codes", []):
-    raise SystemExit("expected known-bad signature vector reason parity_signature_mismatch")
+expected_negative_vectors = {
+    "kolme_fork_primary_alpha_bad_signature": "parity_signature_mismatch",
+    "kolme_fork_secondary_beta_bad_recovery": "parity_recovery_id_mismatch",
+    "kolme_fork_primary_alpha_bad_pubkey": "parity_pubkey_mismatch",
+}
+for vector_id, required_reason_code in expected_negative_vectors.items():
+    matching_cases = [
+        case for case in cases if isinstance(case, dict) and case.get("vector_id") == vector_id
+    ]
+    if len(matching_cases) != 1:
+        raise SystemExit(f"expected exactly one known-bad parity vector case: {vector_id}")
+    bad_case = matching_cases[0]
+    if bad_case.get("observed_final_decision") != "NO-GO":
+        raise SystemExit(f"expected known-bad parity vector decision NO-GO: {vector_id}")
+    if required_reason_code not in bad_case.get("reason_codes", []):
+        raise SystemExit(
+            f"expected known-bad parity vector reason {required_reason_code}: {vector_id}"
+        )
 PY
 
 python3 "$RUNNER" --fixture "$FIXTURE" --max-cases 1 --output-json "$TMP_REPORT" >/dev/null


### PR DESCRIPTION
## Summary
This expands the secp256k1 parity fixture matrix with deterministic negative vectors and hardens parity policy to fail closed when NO-GO vector cases do not carry explicit reason codes. It improves early drift detection against kolme_fork signing expectations while keeping execution bounded and local.

Closes #2345.

## Changes
- `fixtures/kolme_commit/signature_parity_vectors.json`:
  - Added negative vectors for recovery-id mismatch and pubkey mismatch.
  - Kept deterministic `required_reason_codes` per negative vector.
- `scripts/kolme/check_signature_parity_policy.py`:
  - Enforces case-level `reason_codes` validity.
  - Fails closed when NO-GO cases omit deterministic reason codes.
  - Rejects unrecognized case reason codes and non-empty `missing_required_reason_codes` payloads.
- `scripts/kolme/contracts/signature_parity_contract_lane.py`:
  - Requires new negative vector IDs and validates deterministic reason mapping for each.
- `scripts/kolme/test_run_signature_parity_matrix.sh`:
  - Requires >=5 vectors and validates all negative vectors + reason codes.
- `scripts/kolme/test_check_signature_parity_policy.sh`:
  - Added policy regression asserting NO-GO case without reason codes fails closed.
  - Updated GO fixture to include all required vectors and deterministic case reason fields.
- `scripts/kolme/test_run_signature_parity_contract_lane.sh`:
  - Extended contract-lane assertions for all negative vectors and reason codes.
- `docs/planning/kolme-devnet-ops.md`:
  - Added secp256k1 parity fixture execution commands and fail-closed checkpoints.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands and failing outputs:
- `bash scripts/kolme/test_run_signature_parity_matrix.sh`
  - `expected at least five signature parity vectors`
- `bash scripts/kolme/test_check_signature_parity_policy.sh`
  - `expected parity policy checker to fail when NO-GO cases omit deterministic reason codes`

### 🟢 Green Phase
Commands and passing outputs:
- `bash scripts/kolme/test_run_signature_parity_matrix.sh`
  - `signature parity matrix runner tests passed.`
- `bash scripts/kolme/test_check_signature_parity_policy.sh`
  - `signature parity policy checker tests passed.`
- `bash scripts/kolme/test_run_signature_parity_contract_lane.sh`
  - `signature parity contract lane tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_run_signature_parity_matrix.sh`
- `bash scripts/kolme/test_check_signature_parity_policy.sh`
- `bash scripts/kolme/test_run_signature_parity_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
All listed commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Scope is fixture/policy/contract script behavior; no isolated Rust unit targets changed. |
| Functional   | ✅     | `scripts/kolme/test_run_signature_parity_matrix.sh`, `scripts/kolme/test_check_signature_parity_policy.sh` | Validates fixture matrix behavior and deterministic policy reason-code enforcement. |
| Integration  | ✅     | `scripts/kolme/test_run_signature_parity_contract_lane.sh` | Validates contract lane + policy + fixture wiring end-to-end. |
| Regression   | ✅     | Same tests above | Guards parity drift vectors and NO-GO reason-code omission failure mode (`Regression: #2337` story lineage). |
| Performance  | N/A    | None                 | No runtime-path algorithm changes; bounded matrix lane remains unchanged in budget controls. |

## Risks & Rollback
- Risk: stricter policy may fail existing ad-hoc parity reports that omit case-level reason fields.
- Rollback: revert commit `368371d` to restore previous permissive policy behavior.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`: added secp parity fixture execution + policy/contract checkpoints.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
