### PR TITLE
test(kolme): enforce runtime signing profile contract parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_previous_rotation_epoch=1
 # runtime_signer_key_source_contract_version=v1
 # runtime_signer_key_source=env-local
+# runtime_signing_profile=kolme-fork-secp256k1-v1
 # runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
 # runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF
 # runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
@@ -624,6 +625,8 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_rotation_epoch_stale
 # runtime_signer_key_source_profile_pair_disallowed
 # runtime_signer_private_key_env_mismatch
+# runtime_signing_profile_mismatch
+# runtime_signing_profile_contract_mismatch
 # runtime_signer_fallback_private_key_present_violation
 # runtime_signer_managed_external_raw_private_key_present_violation
 # runtime_signer_attestation_approved_signers_not_unique

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -379,6 +379,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_previous_rotation_epoch=1`
       - `runtime_signer_key_source_contract_version=v1`
       - `runtime_signer_key_source=env-local`
+      - `runtime_signing_profile=kolme-fork-secp256k1-v1`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
       - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
       - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
@@ -397,6 +398,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_rotation_epoch_stale`
       - `runtime_signer_key_source_profile_pair_disallowed`
       - `runtime_signer_private_key_env_mismatch`
+      - `runtime_signing_profile_mismatch`
+      - `runtime_signing_profile_contract_mismatch`
       - `runtime_signer_fallback_private_key_present_violation`
       - `runtime_signer_managed_external_raw_private_key_present_violation`
       - `runtime_signer_attestation_approved_signers_not_unique`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -451,6 +451,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_previous_rotation_epoch=1`
     - `runtime_signer_key_source_contract_version=v1`
     - `runtime_signer_key_source=env-local`
+    - `runtime_signing_profile=kolme-fork-secp256k1-v1`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
@@ -466,6 +467,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO stale-rotation proof must surface `runtime_signer_rotation_epoch_stale` when failover rotation epoch is not strictly increasing.
   - NO-GO key-source/profile matrix proof must surface `runtime_signer_key_source_profile_pair_disallowed` when signer profile/key-source pair is outside the strict allowlist.
   - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
+  - NO-GO runtime-signing-profile drift proof must surface `runtime_signing_profile_mismatch` when summary runtime signing profile markers drift from `kolme-fork-secp256k1-v1`.
+  - NO-GO runtime-signing-profile contract drift proof must surface `runtime_signing_profile_contract_mismatch` when contracts runtime signing profile markers drift from `kolme-fork-secp256k1-v1`.
   - NO-GO fallback signer key proof must surface `runtime_signer_fallback_private_key_present_violation` when `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` is present.
   - NO-GO managed-external raw signer key proof must surface `runtime_signer_managed_external_raw_private_key_present_violation` when `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX` is present while `runtime_signer_key_source=managed-external`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_non_synthetic_submit_probe_missing` when `runtime_commit_command` omits `integration_kolme_fork_live_node_submit_reaches_endpoint`.

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -272,6 +272,9 @@ def main() -> int:
     if summary.get("runtime_signer_key_source") != expected_signer_key_source:
         print("expected signer key-source marker in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+        print("expected runtime signing profile marker in contract-lane summary", file=sys.stderr)
+        return 1
     if summary.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
@@ -354,6 +357,9 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_key_source") != expected_signer_key_source:
         print("expected contracts signer key-source marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+        print("expected contracts runtime signing profile marker in contract-lane summary", file=sys.stderr)
         return 1
     if contracts.get("runtime_signer_private_key_env") != expected_signer_private_key_env:
         print("expected contracts signer private key env marker in contract-lane summary", file=sys.stderr)
@@ -501,6 +507,90 @@ def main() -> int:
             return 1
         if signer_key_env_drift_policy.get("final_decision") != "NO-GO":
             print("expected NO-GO final decision for signer key env drift policy output", file=sys.stderr)
+            return 1
+
+        signing_profile_drift_summary_file = negative_path / "signing_profile_drift_summary.json"
+        signing_profile_drift_policy_file = negative_path / "signing_profile_drift_policy.json"
+        signing_profile_drift_summary = dict(summary)
+        signing_profile_drift_summary["runtime_signing_profile"] = "simulated-signing-v0"
+        signing_profile_drift_summary_file.write_text(
+            json.dumps(signing_profile_drift_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        signing_profile_drift_result = run_real_node_policy_check(
+            report_file=signing_profile_drift_summary_file,
+            output_json=signing_profile_drift_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if signing_profile_drift_result.returncode == 0:
+            print("expected runtime signing profile drift negative proof to fail closed", file=sys.stderr)
+            return 1
+        signing_profile_drift_policy = json.loads(
+            signing_profile_drift_policy_file.read_text(encoding="utf-8")
+        )
+        signing_profile_drift_reason_codes = signing_profile_drift_policy.get("reason_codes")
+        if not isinstance(signing_profile_drift_reason_codes, list):
+            print("expected reason_codes list in runtime signing profile drift policy output", file=sys.stderr)
+            return 1
+        if "runtime_signing_profile_mismatch" not in signing_profile_drift_reason_codes:
+            print(
+                "expected runtime_signing_profile_mismatch in runtime signing profile drift policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if signing_profile_drift_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for runtime signing profile drift policy output", file=sys.stderr)
+            return 1
+
+        signing_profile_contract_drift_summary_file = negative_path / "signing_profile_contract_drift_summary.json"
+        signing_profile_contract_drift_policy_file = negative_path / "signing_profile_contract_drift_policy.json"
+        signing_profile_contract_drift_summary = dict(summary)
+        signing_profile_contract_drift_contracts = dict(summary.get("contracts", {}))
+        signing_profile_contract_drift_contracts["runtime_signing_profile"] = "simulated-signing-v0"
+        signing_profile_contract_drift_summary["contracts"] = signing_profile_contract_drift_contracts
+        signing_profile_contract_drift_summary_file.write_text(
+            json.dumps(signing_profile_contract_drift_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        signing_profile_contract_drift_result = run_real_node_policy_check(
+            report_file=signing_profile_contract_drift_summary_file,
+            output_json=signing_profile_contract_drift_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if signing_profile_contract_drift_result.returncode == 0:
+            print(
+                "expected runtime signing profile contract drift negative proof to fail closed",
+                file=sys.stderr,
+            )
+            return 1
+        signing_profile_contract_drift_policy = json.loads(
+            signing_profile_contract_drift_policy_file.read_text(encoding="utf-8")
+        )
+        signing_profile_contract_drift_reason_codes = signing_profile_contract_drift_policy.get(
+            "reason_codes"
+        )
+        if not isinstance(signing_profile_contract_drift_reason_codes, list):
+            print(
+                "expected reason_codes list in runtime signing profile contract drift policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if (
+            "runtime_signing_profile_contract_mismatch"
+            not in signing_profile_contract_drift_reason_codes
+        ):
+            print(
+                "expected runtime_signing_profile_contract_mismatch in runtime signing profile contract drift policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if signing_profile_contract_drift_policy.get("final_decision") != "NO-GO":
+            print(
+                "expected NO-GO final decision for runtime signing profile contract drift policy output",
+                file=sys.stderr,
+            )
             return 1
 
         # Regression: #2302
@@ -1007,6 +1097,7 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signing_profile=kolme-fork-secp256k1-v1",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
@@ -1022,6 +1113,8 @@ def main() -> int:
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
+        "runtime_signing_profile_mismatch",
+        "runtime_signing_profile_contract_mismatch",
         "Regression: #2302",
         "Regression: #2325",
         "Regression: #2327",
@@ -1038,6 +1131,7 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signing_profile=kolme-fork-secp256k1-v1",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
@@ -1053,6 +1147,8 @@ def main() -> int:
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
+        "runtime_signing_profile_mismatch",
+        "runtime_signing_profile_contract_mismatch",
         "Regression: #2302",
         "Regression: #2325",
         "Regression: #2327",
@@ -1069,6 +1165,7 @@ def main() -> int:
         "runtime_signer_profile=ops-secondary",
         "runtime_signer_key_source_contract_version",
         "runtime_signer_key_source",
+        "runtime_signing_profile=kolme-fork-secp256k1-v1",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
@@ -1084,6 +1181,8 @@ def main() -> int:
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
         "runtime_signer_private_key_env_mismatch",
+        "runtime_signing_profile_mismatch",
+        "runtime_signing_profile_contract_mismatch",
         "Regression: #2302",
         "Regression: #2325",
         "Regression: #2327",

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -442,6 +442,13 @@ if "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider" not in r
     raise SystemExit("expected runtime commit command to include live provider contract pass-through")
 if "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" not in runtime_command:
     raise SystemExit("expected runtime commit command to include real signing profile marker")
+if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected integration summary to include runtime_signing_profile marker")
+contracts = summary.get("contracts", {})
+if not isinstance(contracts, dict):
+    raise SystemExit("expected integration summary contracts object")
+if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected integration summary contracts to include runtime_signing_profile marker")
 if str(finality_output_path) not in summary.get("artifact_paths", []):
     raise SystemExit("expected integration summary artifact paths to include runtime finality output file")
 if str(policy_output_path) not in summary.get("artifact_paths", []):

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -75,6 +75,7 @@ required_coverage_markers=(
   "docs/ci/strategy.md"
   "README.md"
   "runtime_signer_profile=ops-secondary"
+  "runtime_signing_profile"
   "runtime_signer_key_source_contract_version"
   "runtime_signer_key_source"
   "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
@@ -128,6 +129,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_profile=ops-secondary" "$docs_file"; then
     echo "expected docs parity to include secondary signer profile marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signing_profile=kolme-fork-secp256k1-v1" "$docs_file"; then
+    echo "expected docs parity to include runtime signing profile marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "runtime_signer_key_source_contract_version" "$docs_file"; then
@@ -188,6 +193,14 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_private_key_env_mismatch" "$docs_file"; then
     echo "expected docs parity to include signer private key mismatch reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signing_profile_mismatch" "$docs_file"; then
+    echo "expected docs parity to include runtime signing profile mismatch reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signing_profile_contract_mismatch" "$docs_file"; then
+    echo "expected docs parity to include runtime signing profile contract mismatch reason marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "Regression: #2302" "$docs_file"; then
@@ -256,6 +269,8 @@ if summary.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected signer key-source contract version marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected signer key-source marker in real-node profile contract-lane summary")
+if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected runtime_signing_profile marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
@@ -300,6 +315,8 @@ if contracts.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected contracts signer key-source contract version marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected contracts signer key-source marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected contracts runtime_signing_profile marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected contracts signer private key env marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
@@ -349,6 +366,8 @@ if summary.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected secondary signer key-source contract version marker in contract-lane summary")
 if summary.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected secondary signer key-source marker in contract-lane summary")
+if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected runtime_signing_profile marker in secondary contract-lane summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected secondary signer private key env marker in contract-lane summary")
 if summary.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
@@ -366,6 +385,8 @@ if contracts.get("runtime_signer_key_source_contract_version") != "v1":
     raise SystemExit("expected contracts secondary signer key-source contract version marker in contract-lane summary")
 if contracts.get("runtime_signer_key_source") != "env-local":
     raise SystemExit("expected contracts secondary signer key-source marker in contract-lane summary")
+if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
+    raise SystemExit("expected contracts runtime_signing_profile marker in secondary contract-lane summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in contract-lane summary")
 if contracts.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":


### PR DESCRIPTION
## Summary
Enforced runtime signing profile parity in the local KAMN real-node runtime contract lane. The lane now fail-closes if summary/contracts signing-profile markers drift, and docs parity markers are synchronized across planning/CI/README surfaces.

## Changes
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: added strict `runtime_signing_profile` assertions for summary/contracts, added NO-GO negative proofs for `runtime_signing_profile_mismatch` and `runtime_signing_profile_contract_mismatch`, and extended docs marker enforcement.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: RED/GREEN assertions for signing profile marker coverage and docs parity strings.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: assert `runtime_signing_profile` appears in integration summary/contracts.
- `docs/planning/kolme-devnet-ops.md`: added strict real-node runtime signing-profile marker/reason-code references.
- `docs/ci/strategy.md`: added strict real-node runtime signing-profile marker/reason-code references.
- `README.md`: added strict real-node runtime signing-profile marker/reason-code references.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`

Failure:
`expected local KAMN live runtime real-node profile contract implementation to include coverage marker: runtime_signing_profile`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`

Result:
- All commands passed.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Result:
- Both commands passed.

## Test Matrix (Mandatory)
| Category      | Status   | Tests Added/Modified                                                                                         | Justification if N/A |
|--------------|----------|---------------------------------------------------------------------------------------------------------------|----------------------|
| Unit         | N/A      | None                                                                                                          | Lane/docs contract task; no Rust unit surface changed |
| Functional   | ✅       | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`                         |                      |
| Integration  | ✅       | `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` |                      |
| Regression   | ✅       | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`                              |                      |
| Performance  | N/A      | None                                                                                                          | No perf-sensitive path changes |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to restore previous lane/doc marker behavior.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `docs/ci/strategy.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2346
