### PR TITLE
docs: publish live-provider rollback marker parity (#2343)

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,9 +637,14 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing
 # runtime_commit_signer_profile_marker_missing
+# runtime_commit_in_memory_provider_reference_detected
+# runtime_commit_policy_check_in_memory_provider_reference_detected
 
 # strict profile non-synthetic submit probe marker
 # integration_kolme_fork_live_node_submit_reaches_endpoint
+
+# strict profile provider checkpoint marker
+# runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider
 
 # strict profile real-signing marker
 # KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -365,6 +365,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `scripts/framework/manifests/kolme_local_kamn_live_runtime_integration_lane.json`
     - nested runtime step composes through `run_local_runtime_commit_live_finality_evidence_contract_lane.sh` and captures runtime policy artifacts.
     - integration summary must emit `ci_fast_gate_eligible=false` and `contracts.ci_fast_gate_scope=local-only`.
+    - integration summary must emit `runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider`.
     - integration summary contracts must emit `runtime_profile` (`standard|real-node`) for deterministic operator/release evidence interpretation.
     - operator workflow reference: `Live Provider Operator Runbook (Issue #2114)` in `docs/planning/kolme-devnet-ops.md`.
     - `python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json`
@@ -410,6 +411,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`
       - `runtime_commit_signer_profile_marker_missing`
+      - `runtime_commit_in_memory_provider_reference_detected`
+      - `runtime_commit_policy_check_in_memory_provider_reference_detected`
     - strict profile non-synthetic submit probe marker:
       - `integration_kolme_fork_live_node_submit_reaches_endpoint`
     - strict profile real-signing marker:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -767,6 +767,10 @@ Operator checkpoints:
   - re-run bootstrap lane directly and inspect checkout/probe markers.
 - `reason_code=runtime_commit_policy_failed`:
   - inspect `/tmp/kolme-local-runtime-commit-live-policy.json` for provider marker or evidence mismatch.
+- `reason_code=runtime_commit_in_memory_provider_reference_detected`:
+  - treat as rollback condition; execute the process lifecycle lane with explicit `--rollback-evidence-file` and `--recovery-evidence-file` outputs before retrying runtime integration.
+- `reason_code=runtime_commit_policy_check_in_memory_provider_reference_detected`:
+  - treat as rollback condition; execute the process lifecycle lane with explicit `--rollback-evidence-file` and `--recovery-evidence-file` outputs before retrying runtime integration.
 - `reason_code=checkpoint_failed_signer_secret_contract`:
   - verify signer profile and selected signer secret env are set with a valid 64-hex key.
 - `reason_code=checkpoint_failed_signer_quorum_contract`:

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -203,6 +203,19 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include runtime signing profile contract mismatch reason marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q "runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider" "$docs_file"; then
+    echo "expected docs parity to include runtime provider contract checkpoint marker in $docs_file" >&2
+    exit 1
+  fi
+  # Regression: #2337
+  if ! grep -q "runtime_commit_in_memory_provider_reference_detected" "$docs_file"; then
+    echo "expected docs parity to include in-memory provider rollback trigger marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_commit_policy_check_in_memory_provider_reference_detected" "$docs_file"; then
+    echo "expected docs parity to include policy in-memory provider rollback trigger marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "Regression: #2302" "$docs_file"; then
     echo "expected docs parity to include fallback signer runtime regression marker in $docs_file" >&2
     exit 1


### PR DESCRIPTION
## Summary
Publishes explicit live-provider rollback trigger markers and provider checkpoint markers across the operator runbook, CI strategy, and README, and enforces that parity through fail-closed docs contract checks.

Closes #2343

## Changes
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: extended docs parity checks to require:
  - `runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider`
  - `runtime_commit_in_memory_provider_reference_detected`
  - `runtime_commit_policy_check_in_memory_provider_reference_detected`
  - with `Regression: #2337` marker coverage.
- `docs/ci/strategy.md`: added explicit live-provider checkpoint marker and in-memory provider rollback-trigger reason markers to local KAMN runtime integration policy section.
- `README.md`: added strict-profile provider checkpoint marker and rollback-trigger reason markers in runtime integration contract marker block.
- `docs/planning/kolme-devnet-ops.md`: expanded troubleshooting with explicit rollback-condition actions for in-memory provider reason codes.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: Confirmed RED->GREEN docs parity for runbook/strategy/README provider and rollback markers.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | N/A (docs-focused task; no code-unit logic change beyond shell doc-contract assertions) |
| Functional  | ✅     | `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` |
| Integration | ✅     | `bash scripts/ci/test_readme_contract.sh`, `bash scripts/ci/test_ci_strategy_contract.sh`, `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh` |
| Regression  | ✅     | provider rollback-trigger marker drift rejection in `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` (`Regression: #2337`) |
