### PR TITLE
fix(kolme): harden deployment preflight fallback signer env contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # deterministic preflight marker contracts
 # signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE
 # fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
+# fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
 # signer_key_source_contract_version=v1
 # signer_key_source=env-local
 # signer_provenance_file
@@ -736,6 +737,8 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.ci_fast_gate_scope=ci-fast-gate
 # contracts.required_runtime_mode=kolme-live
 # contracts.fallback_private_key_path_allowed=false
+# contracts.fallback_signer_secret_rejected_profile_class=production
+# contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract
 # contracts.approval_quorum_required=2
 # contracts.quorum_evidence_required=true
 # contracts.quorum_evidence_sha256_required=true
@@ -759,6 +762,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # runtime_mode_mismatch
 # signer_profile_mismatch
 # fallback_signer_secret_present_violation
+# fallback_signer_secret_checkpoint_reason_mismatch
 # checkpoint_failed_signer_secret_contract
 # checkpoint_failed_signer_quorum_contract
 # checkpoint_failed_quorum_evidence_contract

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -454,6 +454,7 @@ JSON`
     - deterministic marker contracts:
       - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
       - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+      - `fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
       - `signer_key_source_contract_version=v1`
       - `signer_key_source=env-local`
       - `signer_provenance_file`
@@ -479,6 +480,8 @@ JSON`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
       - `contracts.required_runtime_mode=kolme-live`
       - `contracts.fallback_private_key_path_allowed=false`
+      - `contracts.fallback_signer_secret_rejected_profile_class=production`
+      - `contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract`
       - `contracts.approval_quorum_required=2`
       - `contracts.quorum_evidence_required=true`
       - `contracts.quorum_evidence_sha256_required=true`
@@ -501,6 +504,7 @@ JSON`
       - `runtime_mode_mismatch`
       - `signer_profile_mismatch`
       - `fallback_signer_secret_present_violation`
+      - `fallback_signer_secret_checkpoint_reason_mismatch`
       - `checkpoint_failed_signer_secret_contract`
       - `checkpoint_failed_signer_quorum_contract`
       - `checkpoint_failed_quorum_evidence_contract`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -611,6 +611,7 @@ JSON`
     - `signer_profile`
     - `signer_private_key_env`
     - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
     - `fallback_signer_secret_present=false`
     - `signer_key_source_contract_version=v1`
     - `signer_key_source=env-local`
@@ -642,6 +643,8 @@ JSON`
     - `contracts.required_runtime_mode=kolme-live`
     - `contracts.required_secret_hex_length=64`
     - `contracts.fallback_private_key_path_allowed=false`
+    - `contracts.fallback_signer_secret_rejected_profile_class=production`
+    - `contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract`
     - `contracts.approval_quorum_required=2`
     - `contracts.approval_quorum_source=local-operator-attestations`
     - `contracts.quorum_evidence_required=true`
@@ -668,6 +671,7 @@ JSON`
   - `signer_profile_mismatch`
   - `signer_private_key_env_mismatch`
   - `fallback_signer_secret_present_violation`
+  - `fallback_signer_secret_checkpoint_reason_mismatch`
   - `checkpoint_failed_signer_secret_contract`
   - `checkpoint_failed_signer_quorum_contract`
   - `checkpoint_failed_quorum_evidence_contract`

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -131,6 +131,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif signer_profile not in (PRIMARY_SIGNER_PROFILE, SECONDARY_SIGNER_PROFILE):
         reason_codes.append("signer_profile_mismatch")
 
+    signer_profile_class = report.get("signer_profile_class")
+    if not isinstance(signer_profile_class, str) or not signer_profile_class.strip():
+        reason_codes.append("signer_profile_class_missing")
+    elif signer_profile_class not in ("production", "unknown"):
+        reason_codes.append("signer_profile_class_invalid")
+    elif (
+        isinstance(signer_profile, str)
+        and signer_profile in (PRIMARY_SIGNER_PROFILE, SECONDARY_SIGNER_PROFILE)
+        and signer_profile_class != "production"
+    ):
+        reason_codes.append("signer_profile_class_mismatch")
+
     signer_private_key_env = report.get("signer_private_key_env")
     expected_signer_env = ""
     if signer_profile == PRIMARY_SIGNER_PROFILE:
@@ -220,6 +232,13 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif fallback_signer_private_key_env != FALLBACK_SIGNER_SECRET_ENV:
         reason_codes.append("fallback_signer_private_key_env_mismatch")
 
+    fallback_signer_secret_remediation = report.get("fallback_signer_secret_remediation")
+    expected_fallback_remediation = f"unset {FALLBACK_SIGNER_SECRET_ENV}"
+    if not isinstance(fallback_signer_secret_remediation, str) or not fallback_signer_secret_remediation.strip():
+        reason_codes.append("fallback_signer_secret_remediation_missing")
+    elif fallback_signer_secret_remediation != expected_fallback_remediation:
+        reason_codes.append("fallback_signer_secret_remediation_mismatch")
+
     signer_secret_present = report.get("signer_secret_present")
     if not isinstance(signer_secret_present, bool):
         reason_codes.append("signer_secret_present_invalid")
@@ -229,6 +248,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("fallback_signer_secret_present_invalid")
     elif fallback_signer_secret_present:
         reason_codes.append("fallback_signer_secret_present_violation")
+        if reason_code != "checkpoint_failed_fallback_private_key_contract":
+            reason_codes.append("fallback_signer_secret_checkpoint_reason_mismatch")
 
     signer_secret_hex_valid = report.get("signer_secret_hex_valid")
     if not isinstance(signer_secret_hex_valid, bool):
@@ -334,6 +355,16 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("secondary_signer_secret_env_contract_mismatch")
         if contracts.get("fallback_signer_secret_env") != FALLBACK_SIGNER_SECRET_ENV:
             reason_codes.append("fallback_signer_secret_env_contract_mismatch")
+        if contracts.get("fallback_signer_secret_rejected_profile_class") != "production":
+            reason_codes.append("fallback_signer_secret_rejected_profile_class_contract_mismatch")
+        if contracts.get("fallback_signer_secret_rejected_profiles") != [PRIMARY_SIGNER_PROFILE, SECONDARY_SIGNER_PROFILE]:
+            reason_codes.append("fallback_signer_secret_rejected_profiles_contract_mismatch")
+        if contracts.get("fallback_signer_secret_remediation") != expected_fallback_remediation:
+            reason_codes.append("fallback_signer_secret_remediation_contract_mismatch")
+        if contracts.get("fallback_signer_secret_rejection_reason_code") != "fallback_signer_secret_present_violation":
+            reason_codes.append("fallback_signer_secret_rejection_reason_code_contract_mismatch")
+        if contracts.get("fallback_signer_secret_checkpoint_reason_code") != "checkpoint_failed_fallback_private_key_contract":
+            reason_codes.append("fallback_signer_secret_checkpoint_reason_code_contract_mismatch")
         if contracts.get("fallback_private_key_path_allowed") is not False:
             reason_codes.append("fallback_private_key_path_allowed_contract_mismatch")
         if contracts.get("required_secret_hex_length") != REQUIRED_SECRET_HEX_LENGTH:

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -170,6 +170,12 @@ def main() -> int:
     if summary.get("fallback_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
         print("expected deployment preflight summary fallback signer env marker", file=sys.stderr)
         return 1
+    if summary.get("signer_profile_class") != "production":
+        print("expected deployment preflight summary signer profile class marker", file=sys.stderr)
+        return 1
+    if summary.get("fallback_signer_secret_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+        print("expected deployment preflight summary fallback signer remediation marker", file=sys.stderr)
+        return 1
     if summary.get("fallback_signer_secret_present") is not False:
         print("expected deployment preflight summary fallback signer secret marker to remain false", file=sys.stderr)
         return 1
@@ -225,6 +231,21 @@ def main() -> int:
         return 1
     if contracts.get("fallback_private_key_path_allowed") is not False:
         print("expected deployment preflight contracts to prohibit fallback private key paths", file=sys.stderr)
+        return 1
+    if contracts.get("fallback_signer_secret_rejected_profile_class") != "production":
+        print("expected deployment preflight contracts fallback signer rejection profile class marker", file=sys.stderr)
+        return 1
+    if contracts.get("fallback_signer_secret_rejected_profiles") != ["ops-primary", "ops-secondary"]:
+        print("expected deployment preflight contracts fallback signer rejected profiles marker", file=sys.stderr)
+        return 1
+    if contracts.get("fallback_signer_secret_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+        print("expected deployment preflight contracts fallback signer remediation marker", file=sys.stderr)
+        return 1
+    if contracts.get("fallback_signer_secret_rejection_reason_code") != "fallback_signer_secret_present_violation":
+        print("expected deployment preflight contracts fallback signer rejection reason marker", file=sys.stderr)
+        return 1
+    if contracts.get("fallback_signer_secret_checkpoint_reason_code") != "checkpoint_failed_fallback_private_key_contract":
+        print("expected deployment preflight contracts fallback signer checkpoint reason marker", file=sys.stderr)
         return 1
     if contracts.get("approval_quorum_required") != 2:
         print("expected deployment preflight contracts approval_quorum_required=2", file=sys.stderr)
@@ -317,6 +338,12 @@ def main() -> int:
             return 1
         if "fallback_signer_secret_present_violation" not in no_go_reason_codes:
             print("expected fallback signer secret presence violation in deployment preflight negative policy output", file=sys.stderr)
+            return 1
+        if "fallback_signer_secret_checkpoint_reason_mismatch" not in no_go_reason_codes:
+            print(
+                "expected fallback signer secret checkpoint reason mismatch in deployment preflight negative policy output",
+                file=sys.stderr,
+            )
             return 1
         if no_go_policy.get("final_decision") != "NO-GO":
             print("expected deployment preflight negative policy final_decision NO-GO", file=sys.stderr)
@@ -672,6 +699,10 @@ def main() -> int:
         "runtime_mode_mismatch",
         "checkpoint_failed_signer_secret_contract",
         "fallback_signer_secret_present_violation",
+        "fallback_signer_secret_checkpoint_reason_mismatch",
+        "fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "contracts.fallback_signer_secret_rejected_profile_class=production",
+        "contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract",
         "checkpoint_failed_signer_quorum_contract",
         "checkpoint_failed_quorum_evidence_contract",
         "checkpoint_failed_custody_evidence_contract",
@@ -705,6 +736,10 @@ def main() -> int:
         "runtime_mode_mismatch",
         "checkpoint_failed_signer_secret_contract",
         "fallback_signer_secret_present_violation",
+        "fallback_signer_secret_checkpoint_reason_mismatch",
+        "fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "contracts.fallback_signer_secret_rejected_profile_class=production",
+        "contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract",
         "checkpoint_failed_signer_quorum_contract",
         "checkpoint_failed_quorum_evidence_contract",
         "checkpoint_failed_custody_evidence_contract",
@@ -738,6 +773,10 @@ def main() -> int:
         "runtime_mode_mismatch",
         "checkpoint_failed_signer_secret_contract",
         "fallback_signer_secret_present_violation",
+        "fallback_signer_secret_checkpoint_reason_mismatch",
+        "fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "contracts.fallback_signer_secret_rejected_profile_class=production",
+        "contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract",
         "checkpoint_failed_signer_quorum_contract",
         "checkpoint_failed_quorum_evidence_contract",
         "checkpoint_failed_custody_evidence_contract",

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -24,6 +24,7 @@ SECONDARY_SIGNER_PROFILE="ops-secondary"
 PRIMARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 SECONDARY_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 FALLBACK_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+FALLBACK_SIGNER_SECRET_REMEDIATION="unset ${FALLBACK_SIGNER_SECRET_ENV}"
 REQUIRED_SECRET_HEX_LENGTH=64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED="v1"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION="kamn.kolme.runtime-signer-attestation.v1"
@@ -249,7 +250,7 @@ record_check() {
 runtime_mode_command="runtime-mode must equal ${REQUIRED_RUNTIME_MODE}"
 signer_profile_command="signer profile must be ${PRIMARY_SIGNER_PROFILE} or ${SECONDARY_SIGNER_PROFILE}"
 signer_secret_command="selected signer secret env must exist and be ${REQUIRED_SECRET_HEX_LENGTH}-char hex"
-fallback_private_key_command="fallback signer secret env must remain unset"
+fallback_private_key_command="fallback signer secret env must remain unset for production signer profiles (remediation: ${FALLBACK_SIGNER_SECRET_REMEDIATION})"
 signer_quorum_command="received approvals must satisfy required approvals threshold"
 quorum_evidence_command="quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match"
 custody_evidence_command="signer custody evidence file and sha256 marker must be present"
@@ -332,7 +333,7 @@ if [ "$MODE" = "run" ]; then
       fi
 
       if [ "$fallback_signer_secret_present" = "true" ]; then
-        echo "fallback signer secret env must not be set: $FALLBACK_SIGNER_SECRET_ENV" >&2
+        echo "fallback signer secret env must not be set: $FALLBACK_SIGNER_SECRET_ENV (remediation: $FALLBACK_SIGNER_SECRET_REMEDIATION)" >&2
         record_check "fallback_private_key_contract" "$fallback_private_key_command" "fail" "fallback_signer_secret_present_violation"
         record_check "signer_secret_contract" "$signer_secret_command" "skipped" "fallback_signer_secret_present_violation"
         record_check "signer_quorum_contract" "$signer_quorum_command" "skipped" "fallback_signer_secret_present_violation"
@@ -753,6 +754,8 @@ if mode == "dry-run" and not runtime_signer_attestation_approved_signers:
 runtime_signer_attestation_profile_approved = (
     isinstance(signer_profile, str) and signer_profile in runtime_signer_attestation_approved_signers
 )
+signer_profile_class = "production" if signer_profile in (primary_signer_profile, secondary_signer_profile) else "unknown"
+fallback_signer_secret_remediation = f"unset {fallback_signer_private_key_env}"
 
 runtime_signer_attestation_bundle = {
     "schema_version": runtime_signer_attestation_schema_version,
@@ -792,8 +795,10 @@ summary = {
     "runtime_mode": runtime_mode,
     "signer_profile_selector_env": signer_profile_selector_env,
     "signer_profile": signer_profile,
+    "signer_profile_class": signer_profile_class,
     "signer_private_key_env": signer_private_key_env,
     "fallback_signer_private_key_env": fallback_signer_private_key_env,
+    "fallback_signer_secret_remediation": fallback_signer_secret_remediation,
     "signer_secret_present": signer_secret_present,
     "fallback_signer_secret_present": fallback_signer_secret_present,
     "signer_secret_hex_valid": signer_secret_hex_valid,
@@ -834,6 +839,11 @@ summary = {
         "primary_signer_secret_env": primary_signer_secret_env,
         "secondary_signer_secret_env": secondary_signer_secret_env,
         "fallback_signer_secret_env": fallback_signer_private_key_env,
+        "fallback_signer_secret_rejected_profile_class": "production",
+        "fallback_signer_secret_rejected_profiles": [primary_signer_profile, secondary_signer_profile],
+        "fallback_signer_secret_remediation": fallback_signer_secret_remediation,
+        "fallback_signer_secret_rejection_reason_code": "fallback_signer_secret_present_violation",
+        "fallback_signer_secret_checkpoint_reason_code": "checkpoint_failed_fallback_private_key_contract",
         "fallback_private_key_path_allowed": False,
         "required_secret_hex_length": required_secret_hex_length,
         "secret_source": "env",

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -49,8 +49,10 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_mode": "kolme-live",
   "signer_profile_selector_env": "KAMN_KOLME_LIVE_SIGNER_PROFILE",
   "signer_profile": "ops-primary",
+  "signer_profile_class": "production",
   "signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "fallback_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "fallback_signer_secret_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
   "signer_secret_present": false,
   "fallback_signer_secret_present": false,
   "signer_secret_hex_valid": false,
@@ -103,6 +105,14 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "primary_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "secondary_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY",
     "fallback_signer_secret_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "fallback_signer_secret_rejected_profile_class": "production",
+    "fallback_signer_secret_rejected_profiles": [
+      "ops-primary",
+      "ops-secondary"
+    ],
+    "fallback_signer_secret_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "fallback_signer_secret_rejection_reason_code": "fallback_signer_secret_present_violation",
+    "fallback_signer_secret_checkpoint_reason_code": "checkpoint_failed_fallback_private_key_contract",
     "fallback_private_key_path_allowed": false,
     "required_secret_hex_length": 64,
     "secret_source": "env",
@@ -369,6 +379,16 @@ fi
 
 if ! grep -q "fallback_signer_secret_present_violation" "$TMP_ERR"; then
   echo "expected fallback signer secret presence violation reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "fallback_signer_secret_checkpoint_reason_mismatch" "$TMP_ERR"; then
+  echo "expected fallback signer secret checkpoint reason mismatch for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "fallback_signer_secret_remediation_missing" "$TMP_ERR"; then
+  echo "expected fallback signer secret remediation missing reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
@@ -69,6 +69,10 @@ required_coverage_markers=(
   "runtime_mode_mismatch"
   "checkpoint_failed_signer_secret_contract"
   "checkpoint_failed_signer_quorum_contract"
+  "fallback_signer_secret_checkpoint_reason_mismatch"
+  "fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+  "contracts.fallback_signer_secret_rejected_profile_class=production"
+  "contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract"
   "checkpoint_failed_quorum_evidence_contract"
   "checkpoint_failed_custody_evidence_contract"
   "checkpoint_failed_signer_provenance_contract"
@@ -127,6 +131,22 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_attestation_quorum_shortfall" "$docs_file"; then
     echo "expected docs parity to include runtime signer attestation quorum shortfall reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "fallback_signer_secret_checkpoint_reason_mismatch" "$docs_file"; then
+    echo "expected docs parity to include fallback signer secret checkpoint reason mismatch marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$docs_file"; then
+    echo "expected docs parity to include fallback signer secret remediation marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.fallback_signer_secret_rejected_profile_class=production" "$docs_file"; then
+    echo "expected docs parity to include fallback signer rejected profile class marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract" "$docs_file"; then
+    echo "expected docs parity to include fallback signer checkpoint reason marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "Regression: #2226" "$docs_file"; then

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -18,7 +18,7 @@ printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" >"$TMP_PR
 TMP_CUSTODY_SHA="$(sha256sum "$TMP_CUSTODY" | awk '{print $1}')"
 cat >"$TMP_QUORUM" <<JSON
 {
-  "schema_version": "kamn.kolme.signer-quorum-evidence.v1",
+  "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
   "required_approvals": 2,
   "received_approvals": 2,
   "approved_signers": [
@@ -107,10 +107,14 @@ if summary.get("signer_profile_selector_env") != "KAMN_KOLME_LIVE_SIGNER_PROFILE
     raise SystemExit("expected signer profile selector env marker in deployment preflight summary")
 if summary.get("signer_profile") != "ops-primary":
     raise SystemExit("expected signer profile marker in deployment preflight summary")
+if summary.get("signer_profile_class") != "production":
+    raise SystemExit("expected signer profile class marker in deployment preflight summary")
 if summary.get("signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in deployment preflight summary")
 if summary.get("fallback_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
     raise SystemExit("expected fallback signer private key env marker in deployment preflight summary")
+if summary.get("fallback_signer_secret_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer remediation marker in deployment preflight summary")
 if summary.get("fallback_signer_secret_present") is not False:
     raise SystemExit("expected fallback signer secret presence marker to be false in deployment preflight summary")
 if summary.get("ci_fast_gate_eligible") is not True:
@@ -142,6 +146,16 @@ if contracts.get("ci_fast_gate_scope") != "ci-fast-gate":
     raise SystemExit("expected deployment preflight contracts to set ci-fast-gate scope")
 if contracts.get("fallback_private_key_path_allowed") is not False:
     raise SystemExit("expected deployment preflight contracts to prohibit fallback private key paths")
+if contracts.get("fallback_signer_secret_rejected_profile_class") != "production":
+    raise SystemExit("expected deployment preflight contracts to scope fallback signer secret rejection to production profiles")
+if contracts.get("fallback_signer_secret_rejected_profiles") != ["ops-primary", "ops-secondary"]:
+    raise SystemExit("expected deployment preflight contracts to define fallback signer secret rejected profiles")
+if contracts.get("fallback_signer_secret_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected deployment preflight contracts fallback signer remediation marker")
+if contracts.get("fallback_signer_secret_rejection_reason_code") != "fallback_signer_secret_present_violation":
+    raise SystemExit("expected deployment preflight contracts fallback signer rejection reason marker")
+if contracts.get("fallback_signer_secret_checkpoint_reason_code") != "checkpoint_failed_fallback_private_key_contract":
+    raise SystemExit("expected deployment preflight contracts fallback signer checkpoint reason marker")
 if contracts.get("custody_evidence_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer custody evidence")
 if contracts.get("approval_quorum_required") != 2:
@@ -150,7 +164,7 @@ if contracts.get("quorum_evidence_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require quorum evidence")
 if contracts.get("quorum_evidence_sha256_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require quorum evidence sha256")
-if contracts.get("quorum_evidence_schema_version") != "kamn.kolme.signer-quorum-evidence.v1":
+if contracts.get("quorum_evidence_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
     raise SystemExit("expected deployment preflight contracts quorum evidence schema marker")
 if contracts.get("quorum_evidence_signer_uniqueness_required") is not True:
     raise SystemExit("expected deployment preflight contracts quorum signer uniqueness requirement marker")
@@ -224,6 +238,11 @@ fi
 
 if ! grep -q "fallback signer secret env must not be set" "$TMP_ERR"; then
   echo "expected deterministic fallback signer secret rejection message from deployment preflight lane" >&2
+  exit 1
+fi
+
+if ! grep -q "remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$TMP_ERR"; then
+  echo "expected deterministic fallback signer remediation marker from deployment preflight lane" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Hardens local Kolme live deployment preflight policy so fallback signer env usage has deterministic remediation markers and deterministic checkpoint-reason validation. This closes a fail-closed coverage gap where fallback presence could be detected without enforcing the expected fallback checkpoint reason mapping.

Closes #2365

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`
  - Added deterministic fallback remediation marker wiring.
  - Added production-profile fallback contract metadata in summary/contracts.
  - Added remediation text to fallback signer rejection stderr.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`
  - Added fallback remediation marker validation.
  - Added fallback checkpoint reason mapping enforcement (`fallback_signer_secret_checkpoint_reason_mismatch`).
  - Added contract-field validation for fallback profile scope/remediation/reason-code markers.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`
  - Added assertions for new summary/contracts markers.
  - Added negative-proof assertion for fallback checkpoint-reason mismatch reason code.
  - Extended docs parity marker enforcement.
- Tests/docs parity:
  - `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
  - `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`
  - `scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
  - `README.md`
  - `docs/ci/strategy.md`
  - `docs/planning/kolme-devnet-ops.md`

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`

Failing output excerpt:
`expected fallback signer secret checkpoint reason mismatch for deployment preflight policy failure`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`

Outputs:
- `local Kolme live deployment preflight policy checker tests passed.`
- `local Kolme live deployment preflight lane tests passed.`
- `local Kolme live deployment preflight contract lane tests passed.`

### 🔁 Regression
Commands:
- `bash scripts/ci/test_readme_contract.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Outputs:
- `README contract tests passed.`
- `CI strategy contract tests passed.`
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` | |
| Functional   | ✅ | `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh` | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh` | |
| Regression   | ✅ | Added fallback checkpoint-reason mismatch + remediation marker parity assertions (`Regression: #2337` lineage in wave-14 scope) | |
| Performance  | N/A | | Policy/lane contract marker hardening only; no runtime throughput path changes |

## Risks & Rollback
- Risk: Low. Changes are deterministic preflight policy/contract marker enforcement and docs parity only.
- Rollback: Revert commit `99149f4` if downstream preflight consumers require temporary marker compatibility relaxation.

## Documentation Updates
- `README.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
