### PR TITLE
fix(kolme): enforce quorum metadata contracts in deployment preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,8 @@ custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')
   "required_approvals": 2,
   "received_approvals": 2,
   "approved_signers": ["ops-primary", "ops-secondary"],
+  "signer_roles": {"ops-primary": "primary", "ops-secondary": "secondary"},
+  "signer_rotation_epochs": {"ops-primary": 3, "ops-secondary": 2},
   "custody_evidence_sha256": "$custody_sha"
 }
 JSON
@@ -738,6 +740,10 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # quorum_evidence_signers_unique
 # quorum_evidence_matches_threshold
 # quorum_evidence_custody_sha256_match
+# quorum_evidence_signer_roles_present
+# quorum_evidence_signer_roles_valid
+# quorum_evidence_rotation_metadata_present
+# quorum_evidence_rotation_metadata_valid
 # runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1
 # runtime_signer_attestation_bundle
 # contracts.ci_fast_gate_scope=ci-fast-gate
@@ -752,6 +758,8 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.quorum_evidence_schema_version=kamn.kolme.runtime-signer-attestation.v1
 # contracts.quorum_evidence_signer_uniqueness_required=true
 # contracts.quorum_evidence_custody_sha256_match_required=true
+# contracts.quorum_evidence_signer_roles_required=true
+# contracts.quorum_evidence_rotation_metadata_required=true
 # contracts.runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1
 # contracts.runtime_signer_attestation_signer_uniqueness_required=true
 # contracts.runtime_signer_attestation_threshold_required=true
@@ -781,6 +789,10 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # quorum_evidence_sha256_invalid
 # quorum_evidence_schema_invalid
 # quorum_evidence_signers_not_unique
+# quorum_evidence_signer_roles_missing
+# quorum_evidence_signer_roles_invalid
+# quorum_evidence_rotation_metadata_missing
+# quorum_evidence_rotation_metadata_invalid
 # quorum_evidence_approvals_mismatch
 # quorum_evidence_custody_sha256_mismatch
 # runtime_signer_attestation_approved_signers_not_unique

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -451,6 +451,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   "required_approvals": 2,
   "received_approvals": 2,
   "approved_signers": ["ops-primary", "ops-secondary"],
+  "signer_roles": {"ops-primary": "primary", "ops-secondary": "secondary"},
+  "signer_rotation_epochs": {"ops-primary": 3, "ops-secondary": 2},
   "custody_evidence_sha256": "$custody_sha"
 }
 JSON`
@@ -481,6 +483,10 @@ JSON`
       - `quorum_evidence_signers_unique`
       - `quorum_evidence_matches_threshold`
       - `quorum_evidence_custody_sha256_match`
+      - `quorum_evidence_signer_roles_present`
+      - `quorum_evidence_signer_roles_valid`
+      - `quorum_evidence_rotation_metadata_present`
+      - `quorum_evidence_rotation_metadata_valid`
       - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
       - `runtime_signer_attestation_bundle`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
@@ -495,6 +501,8 @@ JSON`
       - `contracts.quorum_evidence_schema_version=kamn.kolme.runtime-signer-attestation.v1`
       - `contracts.quorum_evidence_signer_uniqueness_required=true`
       - `contracts.quorum_evidence_custody_sha256_match_required=true`
+      - `contracts.quorum_evidence_signer_roles_required=true`
+      - `contracts.quorum_evidence_rotation_metadata_required=true`
       - `contracts.runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
       - `contracts.runtime_signer_attestation_signer_uniqueness_required=true`
       - `contracts.runtime_signer_attestation_threshold_required=true`
@@ -523,6 +531,10 @@ JSON`
       - `quorum_evidence_sha256_invalid`
       - `quorum_evidence_schema_invalid`
       - `quorum_evidence_signers_not_unique`
+      - `quorum_evidence_signer_roles_missing`
+      - `quorum_evidence_signer_roles_invalid`
+      - `quorum_evidence_rotation_metadata_missing`
+      - `quorum_evidence_rotation_metadata_invalid`
       - `quorum_evidence_approvals_mismatch`
       - `quorum_evidence_custody_sha256_mismatch`
       - `runtime_signer_attestation_approved_signers_not_unique`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -590,6 +590,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   "required_approvals": 2,
   "received_approvals": 2,
   "approved_signers": ["ops-primary", "ops-secondary"],
+  "signer_roles": {"ops-primary": "primary", "ops-secondary": "secondary"},
+  "signer_rotation_epochs": {"ops-primary": 3, "ops-secondary": 2},
   "custody_evidence_sha256": "$custody_sha"
 }
 JSON`
@@ -639,6 +641,10 @@ JSON`
     - `quorum_evidence_signers_unique`
     - `quorum_evidence_matches_threshold`
     - `quorum_evidence_custody_sha256_match`
+    - `quorum_evidence_signer_roles_present`
+    - `quorum_evidence_signer_roles_valid`
+    - `quorum_evidence_rotation_metadata_present`
+    - `quorum_evidence_rotation_metadata_valid`
     - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
     - `runtime_signer_attestation_bundle`
     - `custody_evidence_file`
@@ -659,6 +665,8 @@ JSON`
     - `contracts.quorum_evidence_schema_version=kamn.kolme.runtime-signer-attestation.v1`
     - `contracts.quorum_evidence_signer_uniqueness_required=true`
     - `contracts.quorum_evidence_custody_sha256_match_required=true`
+    - `contracts.quorum_evidence_signer_roles_required=true`
+    - `contracts.quorum_evidence_rotation_metadata_required=true`
     - `contracts.quorum_evidence_source=operator-attestation-bundle`
     - `contracts.runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
     - `contracts.runtime_signer_attestation_signer_uniqueness_required=true`
@@ -690,6 +698,10 @@ JSON`
   - `quorum_evidence_sha256_invalid`
   - `quorum_evidence_schema_invalid`
   - `quorum_evidence_signers_not_unique`
+  - `quorum_evidence_signer_roles_missing`
+  - `quorum_evidence_signer_roles_invalid`
+  - `quorum_evidence_rotation_metadata_missing`
+  - `quorum_evidence_rotation_metadata_invalid`
   - `quorum_evidence_approvals_mismatch`
   - `quorum_evidence_custody_sha256_mismatch`
   - `runtime_signer_attestation_approved_signers_not_unique`
@@ -738,6 +750,8 @@ JSON`
   "required_approvals": 2,
   "received_approvals": 2,
   "approved_signers": ["ops-primary", "ops-secondary"],
+  "signer_roles": {"ops-primary": "primary", "ops-secondary": "secondary"},
+  "signer_rotation_epochs": {"ops-primary": 3, "ops-secondary": 2},
   "custody_evidence_sha256": "$custody_sha"
 }
 JSON`

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -299,6 +299,22 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(quorum_evidence_custody_sha256_match, bool):
         reason_codes.append("quorum_evidence_custody_sha256_match_invalid")
 
+    quorum_evidence_signer_roles_present = report.get("quorum_evidence_signer_roles_present")
+    if not isinstance(quorum_evidence_signer_roles_present, bool):
+        reason_codes.append("quorum_evidence_signer_roles_present_invalid")
+
+    quorum_evidence_signer_roles_valid = report.get("quorum_evidence_signer_roles_valid")
+    if not isinstance(quorum_evidence_signer_roles_valid, bool):
+        reason_codes.append("quorum_evidence_signer_roles_valid_invalid")
+
+    quorum_evidence_rotation_metadata_present = report.get("quorum_evidence_rotation_metadata_present")
+    if not isinstance(quorum_evidence_rotation_metadata_present, bool):
+        reason_codes.append("quorum_evidence_rotation_metadata_present_invalid")
+
+    quorum_evidence_rotation_metadata_valid = report.get("quorum_evidence_rotation_metadata_valid")
+    if not isinstance(quorum_evidence_rotation_metadata_valid, bool):
+        reason_codes.append("quorum_evidence_rotation_metadata_valid_invalid")
+
     runtime_signer_attestation_schema_version = report.get("runtime_signer_attestation_schema_version")
     if (
         not isinstance(runtime_signer_attestation_schema_version, str)
@@ -388,6 +404,14 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("quorum_evidence_signer_uniqueness_required_contract_mismatch")
         if contracts.get("quorum_evidence_custody_sha256_match_required") is not True:
             reason_codes.append("quorum_evidence_custody_sha256_match_required_contract_mismatch")
+        if contracts.get("quorum_evidence_signer_roles_required") is not True:
+            reason_codes.append("quorum_evidence_signer_roles_required_contract_mismatch")
+        if contracts.get("quorum_evidence_signer_roles_allowed") != ["primary", "secondary"]:
+            reason_codes.append("quorum_evidence_signer_roles_allowed_contract_mismatch")
+        if contracts.get("quorum_evidence_rotation_metadata_required") is not True:
+            reason_codes.append("quorum_evidence_rotation_metadata_required_contract_mismatch")
+        if contracts.get("quorum_evidence_rotation_metadata_positive_epochs_required") is not True:
+            reason_codes.append("quorum_evidence_rotation_metadata_positive_epochs_required_contract_mismatch")
         if contracts.get("quorum_evidence_source") != "operator-attestation-bundle":
             reason_codes.append("quorum_evidence_source_contract_mismatch")
         if contracts.get("runtime_signer_attestation_schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
@@ -499,6 +523,14 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("quorum_evidence_approvals_mismatch")
         if quorum_evidence_custody_sha256_match is not True:
             reason_codes.append("quorum_evidence_custody_sha256_mismatch")
+        if quorum_evidence_signer_roles_present is not True:
+            reason_codes.append("quorum_evidence_signer_roles_missing")
+        if quorum_evidence_signer_roles_valid is not True:
+            reason_codes.append("quorum_evidence_signer_roles_invalid")
+        if quorum_evidence_rotation_metadata_present is not True:
+            reason_codes.append("quorum_evidence_rotation_metadata_missing")
+        if quorum_evidence_rotation_metadata_valid is not True:
+            reason_codes.append("quorum_evidence_rotation_metadata_invalid")
         if isinstance(quorum_evidence_file, str) and quorum_evidence_present is True and not quorum_evidence_file.strip():
             reason_codes.append("quorum_evidence_file_missing")
         if (

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -206,6 +206,18 @@ def main() -> int:
     if summary.get("quorum_evidence_matches_threshold") is not False:
         print("expected deployment preflight summary quorum threshold marker false in dry-run", file=sys.stderr)
         return 1
+    if summary.get("quorum_evidence_signer_roles_present") is not False:
+        print("expected deployment preflight summary quorum signer-role metadata marker false in dry-run", file=sys.stderr)
+        return 1
+    if summary.get("quorum_evidence_signer_roles_valid") is not False:
+        print("expected deployment preflight summary quorum signer-role metadata validity marker false in dry-run", file=sys.stderr)
+        return 1
+    if summary.get("quorum_evidence_rotation_metadata_present") is not False:
+        print("expected deployment preflight summary quorum rotation metadata marker false in dry-run", file=sys.stderr)
+        return 1
+    if summary.get("quorum_evidence_rotation_metadata_valid") is not False:
+        print("expected deployment preflight summary quorum rotation metadata validity marker false in dry-run", file=sys.stderr)
+        return 1
     if summary.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
         print("expected deployment preflight summary runtime signer attestation schema marker", file=sys.stderr)
         return 1
@@ -264,6 +276,18 @@ def main() -> int:
         return 1
     if contracts.get("quorum_evidence_custody_sha256_match_required") is not True:
         print("expected deployment preflight contracts quorum_evidence_custody_sha256_match_required=true", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_signer_roles_required") is not True:
+        print("expected deployment preflight contracts quorum signer-role metadata requirement marker", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_signer_roles_allowed") != ["primary", "secondary"]:
+        print("expected deployment preflight contracts quorum signer-role allowlist marker", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_rotation_metadata_required") is not True:
+        print("expected deployment preflight contracts quorum rotation metadata requirement marker", file=sys.stderr)
+        return 1
+    if contracts.get("quorum_evidence_rotation_metadata_positive_epochs_required") is not True:
+        print("expected deployment preflight contracts quorum rotation positive-epoch requirement marker", file=sys.stderr)
         return 1
     if contracts.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
         print("expected deployment preflight contracts runtime signer attestation schema marker", file=sys.stderr)
@@ -456,6 +480,63 @@ def main() -> int:
             return 1
         if quorum_evidence_no_go_policy.get("final_decision") != "NO-GO":
             print("expected quorum evidence negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
+        quorum_metadata_negative_report = temp_path / "quorum_metadata_negative_summary.json"
+        quorum_metadata_negative_policy = temp_path / "quorum_metadata_negative_policy.json"
+        quorum_metadata_negative_summary = dict(summary)
+        quorum_metadata_negative_summary["mode"] = "run"
+        quorum_metadata_negative_summary["status"] = "fail"
+        quorum_metadata_negative_summary["reason_code"] = "checkpoint_failed_quorum_evidence_contract"
+        quorum_metadata_negative_summary["signer_secret_present"] = True
+        quorum_metadata_negative_summary["signer_secret_hex_valid"] = True
+        quorum_metadata_negative_summary["required_approvals"] = 2
+        quorum_metadata_negative_summary["received_approvals"] = 2
+        quorum_metadata_negative_summary["quorum_evidence_present"] = True
+        quorum_metadata_negative_summary["quorum_evidence_sha256_valid"] = True
+        quorum_metadata_negative_summary["quorum_evidence_schema_valid"] = True
+        quorum_metadata_negative_summary["quorum_evidence_approval_count"] = 2
+        quorum_metadata_negative_summary["quorum_evidence_signers_unique"] = True
+        quorum_metadata_negative_summary["quorum_evidence_matches_threshold"] = True
+        quorum_metadata_negative_summary["quorum_evidence_custody_sha256_match"] = True
+        quorum_metadata_negative_summary["quorum_evidence_signer_roles_present"] = False
+        quorum_metadata_negative_summary["quorum_evidence_signer_roles_valid"] = False
+        quorum_metadata_negative_summary["quorum_evidence_rotation_metadata_present"] = False
+        quorum_metadata_negative_summary["quorum_evidence_rotation_metadata_valid"] = False
+        quorum_metadata_negative_summary["custody_evidence_present"] = True
+        quorum_metadata_negative_summary["custody_evidence_sha256_valid"] = True
+        quorum_metadata_negative_summary["signer_provenance_present"] = True
+        quorum_metadata_negative_summary["signer_provenance_sha256_valid"] = True
+        quorum_metadata_negative_summary["signer_rotation_fresh"] = True
+        quorum_metadata_negative_report.write_text(
+            json.dumps(quorum_metadata_negative_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        quorum_metadata_no_go_result = run_policy_check(
+            report_file=quorum_metadata_negative_report,
+            output_json=quorum_metadata_negative_policy,
+            expected_final_decision="NO-GO",
+            required_reason_code="checkpoint_failed_quorum_evidence_contract",
+        )
+        if quorum_metadata_no_go_result.returncode == 0:
+            print("expected quorum metadata negative proof to fail closed", file=sys.stderr)
+            return 1
+        quorum_metadata_no_go_policy = json.loads(
+            quorum_metadata_negative_policy.read_text(encoding="utf-8")
+        )
+        quorum_metadata_no_go_reason_codes = quorum_metadata_no_go_policy.get("reason_codes")
+        if not isinstance(quorum_metadata_no_go_reason_codes, list):
+            print("expected reason_codes list in quorum metadata negative policy output", file=sys.stderr)
+            return 1
+        if "quorum_evidence_signer_roles_missing" not in quorum_metadata_no_go_reason_codes:
+            print("expected quorum_evidence_signer_roles_missing in quorum metadata negative policy output", file=sys.stderr)
+            return 1
+        if "quorum_evidence_rotation_metadata_missing" not in quorum_metadata_no_go_reason_codes:
+            print("expected quorum_evidence_rotation_metadata_missing in quorum metadata negative policy output", file=sys.stderr)
+            return 1
+        if quorum_metadata_no_go_policy.get("final_decision") != "NO-GO":
+            print("expected quorum metadata negative policy final_decision NO-GO", file=sys.stderr)
             return 1
 
         attestation_duplicate_report = temp_path / "attestation_duplicate_summary.json"
@@ -710,8 +791,18 @@ def main() -> int:
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
         "quorum_evidence_missing",
+        "quorum_evidence_signer_roles_missing",
+        "quorum_evidence_signer_roles_invalid",
+        "quorum_evidence_rotation_metadata_missing",
+        "quorum_evidence_rotation_metadata_invalid",
         "quorum_evidence_approvals_mismatch",
         "quorum_evidence_custody_sha256_mismatch",
+        "quorum_evidence_signer_roles_present",
+        "quorum_evidence_signer_roles_valid",
+        "quorum_evidence_rotation_metadata_present",
+        "quorum_evidence_rotation_metadata_valid",
+        "contracts.quorum_evidence_signer_roles_required=true",
+        "contracts.quorum_evidence_rotation_metadata_required=true",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_attestation_schema_invalid",
@@ -724,6 +815,7 @@ def main() -> int:
         "signer_provenance_file",
         "signer_rotation_epoch_stale",
         "Regression: #2226",
+        "Regression: #2337",
         "Regression: #2300",
         "Regression: #2301",
         "Regression: #2326",
@@ -747,8 +839,18 @@ def main() -> int:
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
         "quorum_evidence_missing",
+        "quorum_evidence_signer_roles_missing",
+        "quorum_evidence_signer_roles_invalid",
+        "quorum_evidence_rotation_metadata_missing",
+        "quorum_evidence_rotation_metadata_invalid",
         "quorum_evidence_approvals_mismatch",
         "quorum_evidence_custody_sha256_mismatch",
+        "quorum_evidence_signer_roles_present",
+        "quorum_evidence_signer_roles_valid",
+        "quorum_evidence_rotation_metadata_present",
+        "quorum_evidence_rotation_metadata_valid",
+        "contracts.quorum_evidence_signer_roles_required=true",
+        "contracts.quorum_evidence_rotation_metadata_required=true",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_attestation_schema_invalid",
@@ -761,6 +863,7 @@ def main() -> int:
         "signer_provenance_file",
         "signer_rotation_epoch_stale",
         "Regression: #2226",
+        "Regression: #2337",
         "Regression: #2300",
         "Regression: #2301",
         "Regression: #2326",
@@ -784,8 +887,18 @@ def main() -> int:
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
         "quorum_evidence_missing",
+        "quorum_evidence_signer_roles_missing",
+        "quorum_evidence_signer_roles_invalid",
+        "quorum_evidence_rotation_metadata_missing",
+        "quorum_evidence_rotation_metadata_invalid",
         "quorum_evidence_approvals_mismatch",
         "quorum_evidence_custody_sha256_mismatch",
+        "quorum_evidence_signer_roles_present",
+        "quorum_evidence_signer_roles_valid",
+        "quorum_evidence_rotation_metadata_present",
+        "quorum_evidence_rotation_metadata_valid",
+        "contracts.quorum_evidence_signer_roles_required=true",
+        "contracts.quorum_evidence_rotation_metadata_required=true",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_attestation_schema_invalid",
@@ -798,6 +911,7 @@ def main() -> int:
         "signer_provenance_file",
         "signer_rotation_epoch_stale",
         "Regression: #2226",
+        "Regression: #2337",
         "Regression: #2300",
         "Regression: #2301",
         "Regression: #2326",

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -272,6 +272,10 @@ quorum_evidence_approval_count=0
 quorum_evidence_signers_unique="false"
 quorum_evidence_matches_threshold="false"
 quorum_evidence_custody_sha256_match="false"
+quorum_evidence_signer_roles_present="false"
+quorum_evidence_signer_roles_valid="false"
+quorum_evidence_rotation_metadata_present="false"
+quorum_evidence_rotation_metadata_valid="false"
 custody_evidence_present="false"
 custody_evidence_sha256=""
 custody_evidence_sha256_valid="false"
@@ -452,6 +456,10 @@ result = {
     "signers_unique": False,
     "matches_threshold": False,
     "custody_sha256_match": False,
+    "signer_roles_present": False,
+    "signer_roles_valid": False,
+    "rotation_metadata_present": False,
+    "rotation_metadata_valid": False,
     "profile_approved": False,
     "approved_signers_csv": "",
     "reason_code": "quorum_evidence_schema_invalid",
@@ -480,6 +488,36 @@ if isinstance(payload, dict):
         and approval_count == received_approvals
         and received_approvals >= required_approvals
     )
+    signer_roles_raw = payload.get("signer_roles")
+    signer_roles_present = False
+    signer_roles_valid = False
+    if isinstance(signer_roles_raw, dict):
+        signer_roles_present = approval_count > 0 and all(
+            signer in signer_roles_raw for signer in normalized_signers
+        )
+        if signer_roles_present:
+            signer_roles_valid = True
+            for signer in normalized_signers:
+                role_value = signer_roles_raw.get(signer)
+                if role_value not in ("primary", "secondary"):
+                    signer_roles_valid = False
+                    break
+
+    signer_rotation_epochs_raw = payload.get("signer_rotation_epochs")
+    rotation_metadata_present = False
+    rotation_metadata_valid = False
+    if isinstance(signer_rotation_epochs_raw, dict):
+        rotation_metadata_present = approval_count > 0 and all(
+            signer in signer_rotation_epochs_raw for signer in normalized_signers
+        )
+        if rotation_metadata_present:
+            rotation_metadata_valid = True
+            for signer in normalized_signers:
+                epoch_value = signer_rotation_epochs_raw.get(signer)
+                if not isinstance(epoch_value, int) or epoch_value <= 0:
+                    rotation_metadata_valid = False
+                    break
+
     custody_field = payload.get("custody_evidence_sha256")
     custody_match = isinstance(custody_field, str) and custody_field == custody_sha256
     profile_approved = runtime_signer_profile in normalized_signers
@@ -489,6 +527,10 @@ if isinstance(payload, dict):
     result["signers_unique"] = signers_unique
     result["matches_threshold"] = matches_threshold
     result["custody_sha256_match"] = custody_match
+    result["signer_roles_present"] = signer_roles_present
+    result["signer_roles_valid"] = signer_roles_valid
+    result["rotation_metadata_present"] = rotation_metadata_present
+    result["rotation_metadata_valid"] = rotation_metadata_valid
     result["profile_approved"] = profile_approved
     result["approved_signers_csv"] = ",".join(normalized_signers)
 
@@ -496,6 +538,14 @@ if isinstance(payload, dict):
         result["reason_code"] = "runtime_signer_attestation_schema_invalid"
     elif not signers_unique:
         result["reason_code"] = "runtime_signer_attestation_approved_signers_not_unique"
+    elif not signer_roles_present:
+        result["reason_code"] = "quorum_evidence_signer_roles_missing"
+    elif not signer_roles_valid:
+        result["reason_code"] = "quorum_evidence_signer_roles_invalid"
+    elif not rotation_metadata_present:
+        result["reason_code"] = "quorum_evidence_rotation_metadata_missing"
+    elif not rotation_metadata_valid:
+        result["reason_code"] = "quorum_evidence_rotation_metadata_invalid"
     elif not matches_threshold:
         result["reason_code"] = "runtime_signer_attestation_quorum_shortfall"
     elif not profile_approved:
@@ -511,6 +561,10 @@ for key in (
     "signers_unique",
     "matches_threshold",
     "custody_sha256_match",
+    "signer_roles_present",
+    "signer_roles_valid",
+    "rotation_metadata_present",
+    "rotation_metadata_valid",
     "profile_approved",
     "approved_signers_csv",
     "reason_code",
@@ -557,6 +611,34 @@ PY
                         quorum_evidence_custody_sha256_match="false"
                       fi
                       ;;
+                    signer_roles_present)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_signer_roles_present="true"
+                      else
+                        quorum_evidence_signer_roles_present="false"
+                      fi
+                      ;;
+                    signer_roles_valid)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_signer_roles_valid="true"
+                      else
+                        quorum_evidence_signer_roles_valid="false"
+                      fi
+                      ;;
+                    rotation_metadata_present)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_rotation_metadata_present="true"
+                      else
+                        quorum_evidence_rotation_metadata_present="false"
+                      fi
+                      ;;
+                    rotation_metadata_valid)
+                      if [ "$value" = "True" ] || [ "$value" = "true" ]; then
+                        quorum_evidence_rotation_metadata_valid="true"
+                      else
+                        quorum_evidence_rotation_metadata_valid="false"
+                      fi
+                      ;;
                     profile_approved)
                       if [ "$value" = "True" ] || [ "$value" = "true" ]; then
                         runtime_signer_attestation_profile_approved="true"
@@ -579,6 +661,14 @@ PY
                     quorum_evidence_message="runtime signer attestation schema is invalid: $QUORUM_EVIDENCE_FILE"
                   elif [ "$parsed_quorum_reason_code" = "runtime_signer_attestation_approved_signers_not_unique" ]; then
                     quorum_evidence_message="runtime signer attestation approved_signers must be unique: $QUORUM_EVIDENCE_FILE"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_signer_roles_missing" ]; then
+                    quorum_evidence_message="runtime signer attestation signer_roles metadata must include all approved_signers"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_signer_roles_invalid" ]; then
+                    quorum_evidence_message="runtime signer attestation signer_roles metadata contains invalid role values"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_rotation_metadata_missing" ]; then
+                    quorum_evidence_message="runtime signer attestation signer_rotation_epochs metadata must include all approved_signers"
+                  elif [ "$parsed_quorum_reason_code" = "quorum_evidence_rotation_metadata_invalid" ]; then
+                    quorum_evidence_message="runtime signer attestation signer_rotation_epochs metadata must contain positive integer epochs"
                   elif [ "$parsed_quorum_reason_code" = "runtime_signer_attestation_quorum_shortfall" ]; then
                     quorum_evidence_message="runtime signer attestation approvals must satisfy required approvals threshold"
                   elif [ "$parsed_quorum_reason_code" = "runtime_signer_attestation_profile_not_approved" ]; then
@@ -682,7 +772,7 @@ PY
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$runtime_signer_attestation_approved_signers_csv" "$runtime_signer_attestation_profile_approved" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$quorum_evidence_signer_roles_present" "$quorum_evidence_signer_roles_valid" "$quorum_evidence_rotation_metadata_present" "$quorum_evidence_rotation_metadata_valid" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$runtime_signer_attestation_approved_signers_csv" "$runtime_signer_attestation_profile_approved" <<'PY'
 from __future__ import annotations
 
 import json
@@ -722,26 +812,30 @@ quorum_evidence_approval_count = int(sys.argv[30])
 quorum_evidence_signers_unique = sys.argv[31] == "true"
 quorum_evidence_matches_threshold = sys.argv[32] == "true"
 quorum_evidence_custody_sha256_match = sys.argv[33] == "true"
-quorum_evidence_schema_version = sys.argv[34]
-custody_evidence_file = sys.argv[35]
-custody_evidence_present = sys.argv[36] == "true"
-custody_evidence_sha256 = sys.argv[37]
-custody_evidence_sha256_valid = sys.argv[38] == "true"
-signer_provenance_file = sys.argv[39]
-signer_provenance_present = sys.argv[40] == "true"
-signer_provenance_sha256 = sys.argv[41]
-signer_provenance_sha256_valid = sys.argv[42] == "true"
-signer_key_source_contract_version = sys.argv[43]
-signer_key_source = sys.argv[44]
-signer_key_source_contract_version_supported = sys.argv[45]
-signer_rotation_epoch = int(sys.argv[46])
-signer_previous_rotation_epoch = int(sys.argv[47])
-signer_rotation_freshness_max_delta = int(sys.argv[48])
-signer_rotation_delta_epochs = int(sys.argv[49])
-signer_rotation_fresh = sys.argv[50] == "true"
-runtime_signer_attestation_schema_version = sys.argv[51]
-runtime_signer_attestation_approved_signers_csv = sys.argv[52]
-runtime_signer_attestation_profile_approved = sys.argv[53] == "true"
+quorum_evidence_signer_roles_present = sys.argv[34] == "true"
+quorum_evidence_signer_roles_valid = sys.argv[35] == "true"
+quorum_evidence_rotation_metadata_present = sys.argv[36] == "true"
+quorum_evidence_rotation_metadata_valid = sys.argv[37] == "true"
+quorum_evidence_schema_version = sys.argv[38]
+custody_evidence_file = sys.argv[39]
+custody_evidence_present = sys.argv[40] == "true"
+custody_evidence_sha256 = sys.argv[41]
+custody_evidence_sha256_valid = sys.argv[42] == "true"
+signer_provenance_file = sys.argv[43]
+signer_provenance_present = sys.argv[44] == "true"
+signer_provenance_sha256 = sys.argv[45]
+signer_provenance_sha256_valid = sys.argv[46] == "true"
+signer_key_source_contract_version = sys.argv[47]
+signer_key_source = sys.argv[48]
+signer_key_source_contract_version_supported = sys.argv[49]
+signer_rotation_epoch = int(sys.argv[50])
+signer_previous_rotation_epoch = int(sys.argv[51])
+signer_rotation_freshness_max_delta = int(sys.argv[52])
+signer_rotation_delta_epochs = int(sys.argv[53])
+signer_rotation_fresh = sys.argv[54] == "true"
+runtime_signer_attestation_schema_version = sys.argv[55]
+runtime_signer_attestation_approved_signers_csv = sys.argv[56]
+runtime_signer_attestation_profile_approved = sys.argv[57] == "true"
 
 runtime_signer_attestation_approved_signers: list[str] = [
     entry.strip()
@@ -813,6 +907,10 @@ summary = {
     "quorum_evidence_signers_unique": quorum_evidence_signers_unique,
     "quorum_evidence_matches_threshold": quorum_evidence_matches_threshold,
     "quorum_evidence_custody_sha256_match": quorum_evidence_custody_sha256_match,
+    "quorum_evidence_signer_roles_present": quorum_evidence_signer_roles_present,
+    "quorum_evidence_signer_roles_valid": quorum_evidence_signer_roles_valid,
+    "quorum_evidence_rotation_metadata_present": quorum_evidence_rotation_metadata_present,
+    "quorum_evidence_rotation_metadata_valid": quorum_evidence_rotation_metadata_valid,
     "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
     "runtime_signer_attestation_bundle": runtime_signer_attestation_bundle,
     "runtime_signer_attestation_profile_approved": runtime_signer_attestation_profile_approved,
@@ -854,6 +952,10 @@ summary = {
         "quorum_evidence_schema_version": quorum_evidence_schema_version,
         "quorum_evidence_signer_uniqueness_required": True,
         "quorum_evidence_custody_sha256_match_required": True,
+        "quorum_evidence_signer_roles_required": True,
+        "quorum_evidence_signer_roles_allowed": ["primary", "secondary"],
+        "quorum_evidence_rotation_metadata_required": True,
+        "quorum_evidence_rotation_metadata_positive_epochs_required": True,
         "quorum_evidence_source": "operator-attestation-bundle",
         "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
         "runtime_signer_attestation_signer_uniqueness_required": True,

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -67,6 +67,10 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "quorum_evidence_signers_unique": false,
   "quorum_evidence_matches_threshold": false,
   "quorum_evidence_custody_sha256_match": false,
+  "quorum_evidence_signer_roles_present": false,
+  "quorum_evidence_signer_roles_valid": false,
+  "quorum_evidence_rotation_metadata_present": false,
+  "quorum_evidence_rotation_metadata_valid": false,
   "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
   "runtime_signer_attestation_bundle": {
     "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
@@ -123,6 +127,13 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "quorum_evidence_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
     "quorum_evidence_signer_uniqueness_required": true,
     "quorum_evidence_custody_sha256_match_required": true,
+    "quorum_evidence_signer_roles_required": true,
+    "quorum_evidence_signer_roles_allowed": [
+      "primary",
+      "secondary"
+    ],
+    "quorum_evidence_rotation_metadata_required": true,
+    "quorum_evidence_rotation_metadata_positive_epochs_required": true,
     "quorum_evidence_source": "operator-attestation-bundle",
     "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
     "runtime_signer_attestation_signer_uniqueness_required": true,
@@ -449,6 +460,16 @@ fi
 
 if ! grep -q "quorum_evidence_missing" "$TMP_ERR"; then
   echo "expected quorum evidence missing reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "quorum_evidence_signer_roles_missing" "$TMP_ERR"; then
+  echo "expected quorum evidence signer-roles missing reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "quorum_evidence_rotation_metadata_missing" "$TMP_ERR"; then
+  echo "expected quorum evidence rotation metadata missing reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
@@ -83,8 +83,18 @@ required_coverage_markers=(
   "signer_rotation_epoch_stale"
   "signer_quorum_shortfall"
   "quorum_evidence_missing"
+  "quorum_evidence_signer_roles_missing"
+  "quorum_evidence_signer_roles_invalid"
+  "quorum_evidence_rotation_metadata_missing"
+  "quorum_evidence_rotation_metadata_invalid"
   "quorum_evidence_approvals_mismatch"
   "quorum_evidence_custody_sha256_mismatch"
+  "quorum_evidence_signer_roles_present"
+  "quorum_evidence_signer_roles_valid"
+  "quorum_evidence_rotation_metadata_present"
+  "quorum_evidence_rotation_metadata_valid"
+  "contracts.quorum_evidence_signer_roles_required=true"
+  "contracts.quorum_evidence_rotation_metadata_required=true"
   "custody_evidence_missing"
   "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
   "runtime_signer_attestation_bundle"
@@ -92,6 +102,7 @@ required_coverage_markers=(
   "runtime_signer_attestation_quorum_shortfall"
   "runtime_signer_attestation_schema_invalid"
   "Regression: #2226"
+  "Regression: #2337"
   "Regression: #2300"
   "Regression: #2301"
   "Regression: #2326"
@@ -133,6 +144,30 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include runtime signer attestation quorum shortfall reason marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q "quorum_evidence_signer_roles_missing" "$docs_file"; then
+    echo "expected docs parity to include quorum signer-role metadata missing reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "quorum_evidence_rotation_metadata_missing" "$docs_file"; then
+    echo "expected docs parity to include quorum rotation metadata missing reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "quorum_evidence_signer_roles_present" "$docs_file"; then
+    echo "expected docs parity to include quorum signer-role metadata presence marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "quorum_evidence_rotation_metadata_present" "$docs_file"; then
+    echo "expected docs parity to include quorum rotation metadata presence marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.quorum_evidence_signer_roles_required=true" "$docs_file"; then
+    echo "expected docs parity to include quorum signer-role requirement marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.quorum_evidence_rotation_metadata_required=true" "$docs_file"; then
+    echo "expected docs parity to include quorum rotation metadata requirement marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "fallback_signer_secret_checkpoint_reason_mismatch" "$docs_file"; then
     echo "expected docs parity to include fallback signer secret checkpoint reason mismatch marker in $docs_file" >&2
     exit 1
@@ -151,6 +186,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "Regression: #2226" "$docs_file"; then
     echo "expected docs parity to include deployment preflight contract-lane regression marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "Regression: #2337" "$docs_file"; then
+    echo "expected docs parity to include quorum metadata drift regression marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "Regression: #2300" "$docs_file"; then

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -25,7 +25,15 @@ cat >"$TMP_QUORUM" <<JSON
     "ops-primary",
     "ops-secondary"
   ],
-  "custody_evidence_sha256": "$TMP_CUSTODY_SHA"
+  "custody_evidence_sha256": "$TMP_CUSTODY_SHA",
+  "signer_roles": {
+    "ops-primary": "primary",
+    "ops-secondary": "secondary"
+  },
+  "signer_rotation_epochs": {
+    "ops-primary": 3,
+    "ops-secondary": 2
+  }
 }
 JSON
 
@@ -127,6 +135,14 @@ if summary.get("quorum_evidence_present") is not False:
     raise SystemExit("expected deployment preflight summary quorum evidence marker to be false in dry-run")
 if summary.get("quorum_evidence_matches_threshold") is not False:
     raise SystemExit("expected deployment preflight summary quorum threshold marker to be false in dry-run")
+if summary.get("quorum_evidence_signer_roles_present") is not False:
+    raise SystemExit("expected deployment preflight summary signer-roles metadata marker to be false in dry-run")
+if summary.get("quorum_evidence_signer_roles_valid") is not False:
+    raise SystemExit("expected deployment preflight summary signer-roles metadata validity marker to be false in dry-run")
+if summary.get("quorum_evidence_rotation_metadata_present") is not False:
+    raise SystemExit("expected deployment preflight summary rotation metadata marker to be false in dry-run")
+if summary.get("quorum_evidence_rotation_metadata_valid") is not False:
+    raise SystemExit("expected deployment preflight summary rotation metadata validity marker to be false in dry-run")
 if summary.get("custody_evidence_present") is not False:
     raise SystemExit("expected deployment preflight summary custody evidence marker to be false in dry-run")
 if summary.get("signer_provenance_present") is not False:
@@ -170,6 +186,14 @@ if contracts.get("quorum_evidence_signer_uniqueness_required") is not True:
     raise SystemExit("expected deployment preflight contracts quorum signer uniqueness requirement marker")
 if contracts.get("quorum_evidence_custody_sha256_match_required") is not True:
     raise SystemExit("expected deployment preflight contracts quorum custody sha256 match requirement marker")
+if contracts.get("quorum_evidence_signer_roles_required") is not True:
+    raise SystemExit("expected deployment preflight contracts quorum signer-role metadata requirement marker")
+if contracts.get("quorum_evidence_signer_roles_allowed") != ["primary", "secondary"]:
+    raise SystemExit("expected deployment preflight contracts quorum signer-role allowlist marker")
+if contracts.get("quorum_evidence_rotation_metadata_required") is not True:
+    raise SystemExit("expected deployment preflight contracts quorum rotation metadata requirement marker")
+if contracts.get("quorum_evidence_rotation_metadata_positive_epochs_required") is not True:
+    raise SystemExit("expected deployment preflight contracts quorum rotation positive epoch requirement marker")
 if contracts.get("signer_provenance_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer provenance evidence")
 if contracts.get("signer_provenance_sha256_required") is not True:
@@ -369,6 +393,14 @@ if summary.get("quorum_evidence_matches_threshold") is not True:
     raise SystemExit("expected deployment preflight run summary quorum threshold marker true")
 if summary.get("quorum_evidence_custody_sha256_match") is not True:
     raise SystemExit("expected deployment preflight run summary quorum custody sha256 match marker true")
+if summary.get("quorum_evidence_signer_roles_present") is not True:
+    raise SystemExit("expected deployment preflight run summary signer-roles metadata marker true")
+if summary.get("quorum_evidence_signer_roles_valid") is not True:
+    raise SystemExit("expected deployment preflight run summary signer-roles metadata validity marker true")
+if summary.get("quorum_evidence_rotation_metadata_present") is not True:
+    raise SystemExit("expected deployment preflight run summary rotation metadata marker true")
+if summary.get("quorum_evidence_rotation_metadata_valid") is not True:
+    raise SystemExit("expected deployment preflight run summary rotation metadata validity marker true")
 if summary.get("custody_evidence_present") is not True:
     raise SystemExit("expected deployment preflight run summary custody evidence marker true")
 if summary.get("signer_provenance_present") is not True:


### PR DESCRIPTION
## Summary
This change extends local Kolme deployment preflight quorum evidence contracts to require signer role and rotation metadata. It enforces fail-closed policy behavior for missing/invalid metadata and aligns tests and documentation so operator guidance matches runtime contract behavior.

Closes #2368

## Changes
- scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh: parse and validate signer_roles/signer_rotation_epochs; emit new summary booleans, reason codes, and contract markers.
- scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py: enforce new metadata booleans/contracts and fail-closed reason codes.
- scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py: add negative-metadata policy assertions and docs parity markers.
- scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh: add RED/GO coverage for new reason codes and contracts.
- scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh: update quorum fixtures and assert new summary/contracts fields in dry-run/run paths.
- scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh: assert new implementation and docs marker coverage.
- README.md: update sample quorum bundle and deployment-preflight marker lists.
- docs/ci/strategy.md: update CI strategy marker contracts and fail-closed reason list.
- docs/planning/kolme-devnet-ops.md: update runbook quorum bundle examples and marker parity lists.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
  - failed with missing reason code coverage (`quorum_evidence_signer_roles_missing`) during metadata-contract RED phase.
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
  - failed with docs parity drift: `expected docs parity to include quorum signer-role metadata missing reason marker in /home/n/Code/kamn/docs/planning/kolme-devnet-ops.md`.

### 🟢 Green Phase
- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` -> pass
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh` -> pass
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh` -> pass
- `bash scripts/ci/test_readme_contract.sh` -> pass
- `bash scripts/ci/test_ci_strategy_contract.sh` -> pass
- `cargo fmt --check` -> pass
- `cargo clippy -- -D warnings` -> pass

### 🔁 Regression
- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh && bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh && bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh && bash scripts/ci/test_readme_contract.sh && bash scripts/ci/test_ci_strategy_contract.sh`
  - pass (all commands successful)

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` | |
| Functional   | ✅ | `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh` | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh` (lane + policy + docs parity composition) | |
| Regression   | ✅ | docs parity + fail-closed reason markers (`Regression: #2337`) across README/CI/devnet runbook and contract lane | |
| Performance  | N/A | None | No runtime path/perf budget logic changed; only metadata validation + docs/test parity. |

## Risks & Rollback
- No breaking API changes outside deployment-preflight summary/policy contract surface.
- Rollback plan: revert commit `c370347` to restore prior quorum metadata requirements if unexpected downstream coupling appears.

## Documentation Updates
- README.md
- docs/ci/strategy.md
- docs/planning/kolme-devnet-ops.md

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
