### PR TITLE
fix(kolme): add split-brain signer profile regression checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,7 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_commit_non_synthetic_submit_probe_missing
 # runtime_commit_real_signing_profile_marker_missing
 # runtime_commit_signer_profile_marker_missing
+# runtime_commit_signer_profile_split_brain_detected
 # runtime_commit_in_memory_provider_reference_detected
 # runtime_commit_policy_check_in_memory_provider_reference_detected
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -419,6 +419,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`
       - `runtime_commit_signer_profile_marker_missing`
+      - `runtime_commit_signer_profile_split_brain_detected`
       - `runtime_commit_in_memory_provider_reference_detected`
       - `runtime_commit_policy_check_in_memory_provider_reference_detected`
     - strict profile non-synthetic submit probe marker:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -465,6 +465,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO signer-profile drift proof must surface `runtime_signer_profile_mismatch` when summary signer profile markers drift from `ops-primary`.
   - NO-GO failover proof must surface `runtime_signer_failover_profile_unchanged` when failover is active but profile does not rotate.
   - NO-GO stale-rotation proof must surface `runtime_signer_rotation_epoch_stale` when failover rotation epoch is not strictly increasing.
+  - NO-GO split-brain proof must surface `runtime_commit_signer_profile_split_brain_detected` when runtime command composition includes conflicting signer profile selectors.
   - NO-GO key-source/profile matrix proof must surface `runtime_signer_key_source_profile_pair_disallowed` when signer profile/key-source pair is outside the strict allowlist.
   - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
   - NO-GO signer key-source command marker proof must surface `runtime_commit_signer_key_source_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_KEY_SOURCE=<env-local|managed-external>`.
@@ -478,6 +479,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO synthetic-command regression proof must surface `runtime_commit_real_signing_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`.
   - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary`.
+  - NO-GO synthetic-command regression proof must surface `runtime_commit_signer_profile_split_brain_detected` when `runtime_commit_command` includes conflicting `KAMN_KOLME_LIVE_SIGNER_PROFILE` selectors in one command composition.
 - Real-node profile contract lane command:
   - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
   - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --runtime-signer-profile ops-secondary --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -15,6 +15,9 @@ REAL_SIGNING_PROFILE_PATTERN = re.compile(rf"{REAL_SIGNING_PROFILE_ENV}=([^\s\"'
 REAL_SIGNER_PROFILE_SELECTOR_ENV = "KAMN_KOLME_LIVE_SIGNER_PROFILE"
 REAL_SIGNER_PROFILE_PRIMARY = "ops-primary"
 REAL_SIGNER_PROFILE_SECONDARY = "ops-secondary"
+REAL_SIGNER_PROFILE_SELECTOR_PATTERN = re.compile(
+    rf"{REAL_SIGNER_PROFILE_SELECTOR_ENV}=([^\s\"']+)"
+)
 REAL_SIGNER_PRIVATE_KEY_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
 REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 REAL_SIGNER_KEY_REF_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_KEY_REF"
@@ -306,6 +309,10 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             observed_value.rstrip("\\")
             for observed_value in REAL_SIGNING_PROFILE_PATTERN.findall(runtime_commit_command)
         ]
+        observed_signer_profile_values = [
+            observed_value.rstrip("\\")
+            for observed_value in REAL_SIGNER_PROFILE_SELECTOR_PATTERN.findall(runtime_commit_command)
+        ]
         if "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" not in runtime_commit_command:
             reason_codes.append("runtime_commit_contract_lane_missing")
         if "--expected-provider-client-contract KolmeRuntimeCommitLiveProvider" not in runtime_commit_command:
@@ -346,6 +353,14 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             and expected_profile_command_marker not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_signer_profile_marker_missing")
+        if runtime_commit_command_profile == "real-node-non-synthetic-v1":
+            observed_allowed_signer_profiles = {
+                observed_profile
+                for observed_profile in observed_signer_profile_values
+                if observed_profile in ALLOWED_SIGNER_PROFILES
+            }
+            if len(observed_allowed_signer_profiles) > 1:
+                reason_codes.append("runtime_commit_signer_profile_split_brain_detected")
         expected_key_source_command_marker = ""
         if expected_signer_key_source:
             expected_key_source_command_marker = (

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -503,6 +503,52 @@ def main() -> int:
             print("expected no reason codes in forced failover scenario matrix policy output", file=sys.stderr)
             return 1
 
+        split_brain_summary_file = negative_path / "split_brain_negative_summary.json"
+        split_brain_policy_file = negative_path / "split_brain_negative_policy.json"
+        split_brain_summary = dict(forced_failover_go_summary)
+        forced_failover_command = split_brain_summary.get("runtime_commit_command")
+        if not isinstance(forced_failover_command, str):
+            print(
+                "expected runtime_commit_command marker in split-brain negative summary fixture",
+                file=sys.stderr,
+            )
+            return 1
+        split_brain_summary["runtime_commit_command"] = forced_failover_command.replace(
+            f"KAMN_KOLME_LIVE_SIGNER_PROFILE={alternate_signer_profile}",
+            (
+                f"KAMN_KOLME_LIVE_SIGNER_PROFILE={alternate_signer_profile} "
+                f"KAMN_KOLME_LIVE_SIGNER_PROFILE={expected_signer_profile}"
+            ),
+            1,
+        )
+        split_brain_summary_file.write_text(
+            json.dumps(split_brain_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        split_brain_result = run_real_node_policy_check(
+            report_file=split_brain_summary_file,
+            output_json=split_brain_policy_file,
+            expected_final_decision="NO-GO",
+        )
+        if split_brain_result.returncode == 0:
+            print("expected split-brain signer-profile negative proof to fail closed", file=sys.stderr)
+            return 1
+        split_brain_policy = json.loads(split_brain_policy_file.read_text(encoding="utf-8"))
+        split_brain_reason_codes = split_brain_policy.get("reason_codes")
+        if not isinstance(split_brain_reason_codes, list):
+            print("expected reason_codes list in split-brain policy output", file=sys.stderr)
+            return 1
+        if "runtime_commit_signer_profile_split_brain_detected" not in split_brain_reason_codes:
+            print(
+                "expected runtime_commit_signer_profile_split_brain_detected in split-brain policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if split_brain_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision for split-brain policy output", file=sys.stderr)
+            return 1
+
         failover_stale_summary_file = negative_path / "failover_stale_summary.json"
         failover_stale_policy_file = negative_path / "failover_stale_policy.json"
         failover_stale_summary = dict(summary)
@@ -1369,6 +1415,7 @@ def main() -> int:
         "runtime_signer_attestation_schema_invalid",
         "runtime_signer_attestation_approved_signers_not_unique",
         "runtime_signer_attestation_quorum_shortfall",
+        "runtime_commit_signer_profile_split_brain_detected",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
@@ -1410,6 +1457,7 @@ def main() -> int:
         "runtime_signer_attestation_schema_invalid",
         "runtime_signer_attestation_approved_signers_not_unique",
         "runtime_signer_attestation_quorum_shortfall",
+        "runtime_commit_signer_profile_split_brain_detected",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",
@@ -1451,6 +1499,7 @@ def main() -> int:
         "runtime_signer_attestation_schema_invalid",
         "runtime_signer_attestation_approved_signers_not_unique",
         "runtime_signer_attestation_quorum_shortfall",
+        "runtime_commit_signer_profile_split_brain_detected",
         "runtime_signer_failover_profile_unchanged",
         "runtime_signer_rotation_epoch_stale",
         "runtime_signer_key_source_profile_pair_disallowed",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -15,6 +15,7 @@ TMP_REPORT_KEY_SOURCE_MARKER_MISSING="$TMP_DIR/key-source-marker-missing-report.
 TMP_REPORT_MANAGED_KEY_REF_MISSING="$TMP_DIR/managed-key-ref-missing-report.json"
 TMP_REPORT_MANAGED_PRIVATE_KEY_COMMAND="$TMP_DIR/managed-private-key-command-report.json"
 TMP_REPORT_KEY_SOURCE_PAIR_BAD="$TMP_DIR/key-source-pair-bad-report.json"
+TMP_REPORT_SPLIT_BRAIN="$TMP_DIR/split-brain-report.json"
 TMP_REPORT_ATTESTATION_DUPLICATE="$TMP_DIR/attestation-duplicate-report.json"
 TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL="$TMP_DIR/attestation-quorum-shortfall-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
@@ -444,6 +445,52 @@ fi
 
 if ! grep -q "runtime_signer_key_source_profile_pair_disallowed" "$TMP_ERR"; then
   echo "expected disallowed key-source/profile pair reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK_SECONDARY" "$TMP_REPORT_SPLIT_BRAIN" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_failover_active"] = True
+report["runtime_signer_previous_profile"] = "ops-primary"
+report["runtime_signer_rotation_epoch"] = 2
+report["runtime_signer_previous_rotation_epoch"] = 1
+command = str(report.get("runtime_commit_command", ""))
+report["runtime_commit_command"] = command.replace(
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
+    "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
+    1,
+)
+attestation_bundle = dict(report.get("runtime_signer_attestation_bundle", {}))
+attestation_bundle["approved_signers"] = ["ops-primary", "ops-secondary"]
+attestation_bundle["signer_profile"] = "ops-secondary"
+report["runtime_signer_attestation_bundle"] = attestation_bundle
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_SPLIT_BRAIN" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+split_brain_exit_code=$?
+set -e
+
+if [ "$split_brain_exit_code" -eq 0 ]; then
+  echo "expected split-brain signer profile proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_signer_profile_split_brain_detected" "$TMP_ERR"; then
+  echo "expected split-brain signer profile reason for policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -98,12 +98,14 @@ required_coverage_markers=(
   "runtime_commit_managed_external_signer_key_reference_marker_missing"
   "runtime_commit_managed_external_private_key_command_marker_detected"
   "runtime_commit_command_profile_mismatch"
+  "runtime_commit_signer_profile_split_brain_detected"
   "runtime_signer_failover_profile_unchanged"
   "runtime_signer_rotation_epoch_stale"
   "runtime_commit_signer_profile_marker_missing"
   "runtime_commit_non_synthetic_submit_probe_missing"
   "runtime_commit_in_memory_provider_reference_detected"
   "forced_failover_go_summary"
+  "split_brain_negative_summary"
   "Regression: #2302"
   "Regression: #2337"
   "Regression: #2325"
@@ -201,6 +203,10 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_attestation_quorum_shortfall" "$docs_file"; then
     echo "expected docs parity to include runtime signer attestation quorum-shortfall reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_commit_signer_profile_split_brain_detected" "$docs_file"; then
+    echo "expected docs parity to include split-brain signer profile reason marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "runtime_signer_attestation_schema_invalid" "$docs_file"; then


### PR DESCRIPTION
## Summary
This change adds deterministic split-brain signer-selection regression enforcement to the real-node runtime profile policy path and contract lane. It keeps stale-rotation fail-closed behavior in place while extending negative fixture coverage and docs parity markers.

Closes #2369

## Changes
- scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py: detect conflicting `KAMN_KOLME_LIVE_SIGNER_PROFILE` markers in one runtime command and emit `runtime_commit_signer_profile_split_brain_detected`.
- scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py: add split-brain negative summary/policy proof and assert fail-closed NO-GO reason code.
- scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh: add split-brain RED/GREEN fixture path and reason assertion.
- scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh: require split-brain coverage marker and docs parity marker.
- README.md: add split-brain reason marker in strict real-node NO-GO list.
- docs/ci/strategy.md: add split-brain reason marker in real-node strict NO-GO matrix.
- docs/planning/kolme-devnet-ops.md: add split-brain proof expectations and reason marker in operator runbook.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - failed with `expected split-brain signer profile reason for policy failure` after adding split-brain fixture assertion, proving missing policy coverage.

### 🟢 Green Phase
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` -> pass
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` -> pass
- `bash scripts/ci/test_readme_contract.sh` -> pass
- `bash scripts/ci/test_ci_strategy_contract.sh` -> pass
- `cargo fmt --check` -> pass
- `cargo clippy -- -D warnings` -> pass

### 🔁 Regression
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh && bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh && bash scripts/ci/test_readme_contract.sh && bash scripts/ci/test_ci_strategy_contract.sh`
  - pass (all commands successful)

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` | |
| Functional   | ✅ | split-brain fixture + reason-code assertion in real-node policy checker test | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` and contract-lane negative scenario proof | |
| Regression   | ✅ | docs parity + fail-closed marker enforcement including `Regression: #2337` | |
| Performance  | N/A | None | No runtime budget algorithm changed; only marker validation and fixture/docs parity updates. |

## Risks & Rollback
- No protocol/chain behavior changes; this is policy/contract/docs strictness for real-node runtime evidence.
- Rollback plan: revert commit `b8398c8` if split-brain detection causes unexpected false positives in operator command composition.

## Documentation Updates
- README.md
- docs/ci/strategy.md
- docs/planning/kolme-devnet-ops.md

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
