### PR TITLE
fix(kolme): enforce rollback lineage in live-node bundle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode dry-run 
 
 # explicit local-only bundle execution
 KAMN_KOLME_LOCAL_HEAVY=1 \
-bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json
+bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json
 
 # policy checker contract
 python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json
@@ -838,6 +838,12 @@ python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report
 bash scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json --policy-output-json /tmp/kolme-local-live-node-validation-bundle-policy.json
 # schema: kamn.kolme.local-live-node-validation-bundle-summary.v1
 # policy schema: kamn.kolme.local-live-node-validation-bundle-policy-report.v1
+# rollback_evidence_file
+# recovery_evidence_file
+# rollback_evidence_file_missing
+# contracts.rollback_recovery_artifact_lineage_required=true
+# contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file
+# contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file
 # Regression: #2134
 ```
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -562,10 +562,17 @@ JSON`
     - `python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py --report-file /tmp/kolme-local-fork-process-lifecycle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-process-lifecycle-policy.json`
     - `bash scripts/kolme/run_local_kolme_fork_process_lifecycle_contract_lane.sh --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json --policy-output-json /tmp/kolme-local-fork-process-lifecycle-policy.json`
   - local live-node validation bundle run-mode commands remain excluded from ci-fast-gate.
-    - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
+    - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
     - `python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
     - `bash scripts/kolme/run_local_live_node_validation_bundle_contract_lane.sh --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json --policy-output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
     - bundle policy GO decisions require `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` and complete nested evidence lineage.
+    - bundle summary/policy lineage markers remain fail-closed:
+      - `rollback_evidence_file`
+      - `recovery_evidence_file`
+      - `rollback_evidence_file_missing`
+      - `contracts.rollback_recovery_artifact_lineage_required=true`
+      - `contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file`
+      - `contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file`
   - local fork profile preflight run-mode commands remain excluded from ci-fast-gate.
     - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_profile_preflight_lane.sh --mode run --checkout-path /tmp/kolme_fork --max-seconds 45 --output-json /tmp/kolme-local-fork-profile-preflight-summary.json`
     - `python3 scripts/kolme/check_local_kolme_fork_profile_preflight_policy.py --report-file /tmp/kolme-local-fork-profile-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code profile_preflight_passed --output-json /tmp/kolme-local-fork-profile-preflight-policy.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -822,7 +822,7 @@ Operator checkpoints:
 - Deterministic local validation bundle plan:
   - `bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode dry-run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
 - Explicit local-only validation bundle execution:
-  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
+  - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode run --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
 - Policy checker command:
   - `python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
 - Contract lane command:
@@ -836,6 +836,13 @@ Operator checkpoints:
   - `integration_policy`: local KAMN live runtime integration policy decision checkpoint.
   - `process_lifecycle_bundle`: local fork process lifecycle lane command composition with rollback/recovery linkage.
   - `process_lifecycle_policy`: local fork process lifecycle policy decision checkpoint.
+  - rollback/recovery lineage markers:
+    - `rollback_evidence_file`
+    - `recovery_evidence_file`
+    - `rollback_evidence_file_missing`
+    - `contracts.rollback_recovery_artifact_lineage_required=true`
+    - `contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file`
+    - `contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file`
 - Decision contract:
   - policy returns GO only when schema, checkpoint markers, artifact lineage, and local-only boundary markers stay aligned with summary contracts.
   - policy fails closed to NO-GO on schema/evidence drift, missing checkpoints, provider marker drift, or `ci_fast_gate_scope` mismatch.

--- a/scripts/kolme/check_local_live_node_validation_bundle_policy.py
+++ b/scripts/kolme/check_local_live_node_validation_bundle_policy.py
@@ -93,12 +93,32 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("process_lifecycle_runner_missing")
         if "--integration-runtime-commit-live-policy-report" not in process_command:
             reason_codes.append("process_lifecycle_policy_report_marker_missing")
+        if "--rollback-evidence-file" not in process_command:
+            reason_codes.append("process_lifecycle_rollback_marker_missing")
+        if "--recovery-evidence-file" not in process_command:
+            reason_codes.append("process_lifecycle_recovery_marker_missing")
 
     process_policy_command = report.get("process_lifecycle_policy_command")
     if not isinstance(process_policy_command, str) or not process_policy_command.strip():
         reason_codes.append("process_lifecycle_policy_command_missing")
     elif "check_local_kolme_fork_process_lifecycle_policy.py" not in process_policy_command:
         reason_codes.append("process_lifecycle_policy_command_marker_missing")
+
+    rollback_evidence_file = report.get("rollback_evidence_file")
+    if not isinstance(rollback_evidence_file, str) or not rollback_evidence_file.strip():
+        reason_codes.append("rollback_evidence_file_missing")
+        rollback_evidence_file = ""
+
+    recovery_evidence_file = report.get("recovery_evidence_file")
+    if not isinstance(recovery_evidence_file, str) or not recovery_evidence_file.strip():
+        reason_codes.append("recovery_evidence_file_missing")
+        recovery_evidence_file = ""
+
+    if isinstance(process_command, str) and process_command.strip():
+        if rollback_evidence_file and f"--rollback-evidence-file {rollback_evidence_file}" not in process_command:
+            reason_codes.append("process_lifecycle_rollback_marker_path_mismatch")
+        if recovery_evidence_file and f"--recovery-evidence-file {recovery_evidence_file}" not in process_command:
+            reason_codes.append("process_lifecycle_recovery_marker_path_mismatch")
 
     required_report_paths = [
         ("integration_report", report.get("integration_report")),
@@ -122,6 +142,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_provider_client_contract_contract_mismatch")
         if contracts.get("bundle_contract") != "live_node_release_bundle_v1":
             reason_codes.append("bundle_contract_mismatch")
+        if contracts.get("rollback_recovery_artifact_lineage_required") is not True:
+            reason_codes.append("rollback_recovery_artifact_lineage_required_contract_mismatch")
+        if contracts.get("process_lifecycle_rollback_evidence_option") != "--rollback-evidence-file":
+            reason_codes.append("process_lifecycle_rollback_evidence_option_contract_mismatch")
+        if contracts.get("process_lifecycle_recovery_evidence_option") != "--recovery-evidence-file":
+            reason_codes.append("process_lifecycle_recovery_evidence_option_contract_mismatch")
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:
@@ -170,15 +196,48 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
                 and "--integration-runtime-commit-live-policy-report" not in command
             ):
                 reason_codes.append("process_lifecycle_bundle_policy_report_marker_missing")
+            if (
+                check_id == "process_lifecycle_bundle"
+                and isinstance(command, str)
+                and "--rollback-evidence-file" not in command
+            ):
+                reason_codes.append("process_lifecycle_bundle_rollback_marker_missing")
+            if (
+                check_id == "process_lifecycle_bundle"
+                and isinstance(command, str)
+                and "--recovery-evidence-file" not in command
+            ):
+                reason_codes.append("process_lifecycle_bundle_recovery_marker_missing")
+            if (
+                check_id == "process_lifecycle_bundle"
+                and isinstance(command, str)
+                and rollback_evidence_file
+                and f"--rollback-evidence-file {rollback_evidence_file}" not in command
+            ):
+                reason_codes.append("process_lifecycle_bundle_rollback_marker_path_mismatch")
+            if (
+                check_id == "process_lifecycle_bundle"
+                and isinstance(command, str)
+                and recovery_evidence_file
+                and f"--recovery-evidence-file {recovery_evidence_file}" not in command
+            ):
+                reason_codes.append("process_lifecycle_bundle_recovery_marker_path_mismatch")
         missing_ids = sorted(expected_ids - observed_ids)
         for missing_id in missing_ids:
             reason_codes.append(f"check_missing:{missing_id}")
 
+    required_artifact_paths = list(required_report_paths)
+    required_artifact_paths.extend(
+        [
+            ("rollback_evidence_file", rollback_evidence_file),
+            ("recovery_evidence_file", recovery_evidence_file),
+        ]
+    )
     artifact_paths = report.get("artifact_paths")
     if not isinstance(artifact_paths, list) or not artifact_paths:
         reason_codes.append("artifact_paths_missing")
     else:
-        for field_name, value in required_report_paths:
+        for field_name, value in required_artifact_paths:
             if isinstance(value, str) and value.strip() and value not in artifact_paths:
                 reason_codes.append(f"{field_name}_artifact_missing")
 

--- a/scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py
+++ b/scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py
@@ -179,6 +179,34 @@ def main() -> int:
     if summary.get("ci_fast_gate_eligible") is not False:
         print("expected local-only fast-gate exclusion marker in bundle summary", file=sys.stderr)
         return 1
+    rollback_evidence_file = summary.get("rollback_evidence_file")
+    if not isinstance(rollback_evidence_file, str) or not rollback_evidence_file.strip():
+        print("expected rollback_evidence_file marker in bundle summary", file=sys.stderr)
+        return 1
+    recovery_evidence_file = summary.get("recovery_evidence_file")
+    if not isinstance(recovery_evidence_file, str) or not recovery_evidence_file.strip():
+        print("expected recovery_evidence_file marker in bundle summary", file=sys.stderr)
+        return 1
+    process_lifecycle_command = summary.get("process_lifecycle_command")
+    if not isinstance(process_lifecycle_command, str) or not process_lifecycle_command.strip():
+        print("expected process_lifecycle_command marker in bundle summary", file=sys.stderr)
+        return 1
+    if f"--rollback-evidence-file {rollback_evidence_file}" not in process_lifecycle_command:
+        print("expected rollback evidence option/path marker in process lifecycle command", file=sys.stderr)
+        return 1
+    if f"--recovery-evidence-file {recovery_evidence_file}" not in process_lifecycle_command:
+        print("expected recovery evidence option/path marker in process lifecycle command", file=sys.stderr)
+        return 1
+    artifact_paths = summary.get("artifact_paths")
+    if not isinstance(artifact_paths, list):
+        print("expected artifact_paths list in bundle summary", file=sys.stderr)
+        return 1
+    if rollback_evidence_file not in artifact_paths:
+        print("expected rollback evidence artifact path marker in bundle summary", file=sys.stderr)
+        return 1
+    if recovery_evidence_file not in artifact_paths:
+        print("expected recovery evidence artifact path marker in bundle summary", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected bundle summary contracts object", file=sys.stderr)
@@ -189,6 +217,15 @@ def main() -> int:
     if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
         print("expected runtime provider contract marker in bundle summary", file=sys.stderr)
         return 1
+    if contracts.get("rollback_recovery_artifact_lineage_required") is not True:
+        print("expected rollback/recovery lineage required contract marker in bundle summary", file=sys.stderr)
+        return 1
+    if contracts.get("process_lifecycle_rollback_evidence_option") != "--rollback-evidence-file":
+        print("expected rollback evidence option contract marker in bundle summary", file=sys.stderr)
+        return 1
+    if contracts.get("process_lifecycle_recovery_evidence_option") != "--recovery-evidence-file":
+        print("expected recovery evidence option contract marker in bundle summary", file=sys.stderr)
+        return 1
     if policy.get("schema_version") != "kamn.kolme.local-live-node-validation-bundle-policy-report.v1":
         print("unexpected local live-node validation bundle policy report schema", file=sys.stderr)
         return 1
@@ -196,22 +233,92 @@ def main() -> int:
         print("expected bundle policy final_decision GO", file=sys.stderr)
         return 1
 
+    with tempfile.TemporaryDirectory(prefix="kolme-live-node-bundle-negative-") as negative_dir:
+        negative_path = Path(negative_dir)
+        rollback_missing_summary_file = negative_path / "rollback_missing_summary.json"
+        rollback_missing_policy_file = negative_path / "rollback_missing_policy.json"
+        rollback_missing_summary = dict(summary)
+        rollback_missing_summary["rollback_evidence_file"] = ""
+        rollback_missing_summary_file.write_text(
+            json.dumps(rollback_missing_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        rollback_missing_result = subprocess.run(
+            [
+                "python3",
+                str(CHECKER),
+                "--report-file",
+                str(rollback_missing_summary_file),
+                "--expected-final-decision",
+                "NO-GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--output-json",
+                str(rollback_missing_policy_file),
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if rollback_missing_result.returncode == 0:
+            print("expected rollback lineage negative proof to fail closed", file=sys.stderr)
+            return 1
+        rollback_missing_policy = json.loads(rollback_missing_policy_file.read_text(encoding="utf-8"))
+        rollback_missing_reason_codes = rollback_missing_policy.get("reason_codes")
+        if not isinstance(rollback_missing_reason_codes, list):
+            print("expected reason_codes list in rollback lineage negative policy output", file=sys.stderr)
+            return 1
+        if "rollback_evidence_file_missing" not in rollback_missing_reason_codes:
+            print(
+                "expected rollback_evidence_file_missing in rollback lineage negative policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if rollback_missing_policy.get("final_decision") != "NO-GO":
+            print("expected NO-GO final decision in rollback lineage negative policy output", file=sys.stderr)
+            return 1
+
     doc_markers = [
         "run_local_live_node_validation_bundle_lane.sh",
         "check_local_live_node_validation_bundle_policy.py",
         "run_local_live_node_validation_bundle_contract_lane.sh",
+        "rollback_evidence_file",
+        "recovery_evidence_file",
+        "--rollback-evidence-file",
+        "--recovery-evidence-file",
+        "rollback_evidence_file_missing",
+        "contracts.rollback_recovery_artifact_lineage_required=true",
+        "contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file",
+        "contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file",
         "Regression: #2134",
     ]
     ci_doc_markers = [
         "run_local_live_node_validation_bundle_lane.sh",
         "check_local_live_node_validation_bundle_policy.py",
         "run_local_live_node_validation_bundle_contract_lane.sh",
+        "rollback_evidence_file",
+        "recovery_evidence_file",
+        "--rollback-evidence-file",
+        "--recovery-evidence-file",
+        "rollback_evidence_file_missing",
+        "contracts.rollback_recovery_artifact_lineage_required=true",
+        "contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file",
+        "contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file",
         "Regression: #2134",
     ]
     readme_markers = [
         "run_local_live_node_validation_bundle_lane.sh",
         "check_local_live_node_validation_bundle_policy.py",
         "run_local_live_node_validation_bundle_contract_lane.sh",
+        "rollback_evidence_file",
+        "recovery_evidence_file",
+        "--rollback-evidence-file",
+        "--recovery-evidence-file",
+        "rollback_evidence_file_missing",
+        "contracts.rollback_recovery_artifact_lineage_required=true",
+        "contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file",
+        "contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file",
         "Regression: #2134",
     ]
 

--- a/scripts/kolme/run_local_live_node_validation_bundle_lane.sh
+++ b/scripts/kolme/run_local_live_node_validation_bundle_lane.sh
@@ -565,6 +565,8 @@ summary = {
     "integration_runtime_commit_live_summary": integration_runtime_live_summary,
     "process_lifecycle_report": process_report,
     "process_lifecycle_policy_report": process_policy_report,
+    "rollback_evidence_file": rollback_evidence_file,
+    "recovery_evidence_file": recovery_evidence_file,
     "checks": checks,
     "artifact_paths": [
         integration_report,
@@ -580,6 +582,9 @@ summary = {
         "ci_fast_gate_scope": "local-only",
         "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
         "bundle_contract": "live_node_release_bundle_v1",
+        "rollback_recovery_artifact_lineage_required": True,
+        "process_lifecycle_rollback_evidence_option": "--rollback-evidence-file",
+        "process_lifecycle_recovery_evidence_option": "--recovery-evidence-file",
     },
 }
 

--- a/scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh
+++ b/scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh
@@ -48,7 +48,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "fork_chain_version": "v0.15.2",
   "integration_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --runtime-profile real-node --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json",
   "integration_policy_command": "python3 scripts/kolme/check_local_kamn_live_runtime_integration_policy.py --report-file /tmp/kolme-local-kamn-live-runtime-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-kamn-live-runtime-integration-policy.json",
-  "process_lifecycle_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json",
+  "process_lifecycle_command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json",
   "process_lifecycle_policy_command": "python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py --report-file /tmp/kolme-local-fork-process-lifecycle-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-fork-process-lifecycle-policy.json",
   "integration_report": "/tmp/kolme-local-kamn-live-runtime-integration-summary.json",
   "integration_policy_report": "/tmp/kolme-local-kamn-live-runtime-integration-policy.json",
@@ -56,6 +56,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "integration_runtime_commit_live_summary": "/tmp/kolme-local-runtime-commit-live-summary.json",
   "process_lifecycle_report": "/tmp/kolme-local-fork-process-lifecycle-summary.json",
   "process_lifecycle_policy_report": "/tmp/kolme-local-fork-process-lifecycle-policy.json",
+  "rollback_evidence_file": "/tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json",
+  "recovery_evidence_file": "/tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json",
   "checks": [
     {
       "id": "integration_bundle",
@@ -71,7 +73,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     },
     {
       "id": "process_lifecycle_bundle",
-      "command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json",
+      "command": "KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh --mode run --integration-runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --rollback-evidence-file /tmp/kolme-local-fork-process-lifecycle-rollback-evidence.json --recovery-evidence-file /tmp/kolme-local-fork-process-lifecycle-recovery-evidence.json --output-json /tmp/kolme-local-fork-process-lifecycle-summary.json",
       "status": "planned",
       "reason_code": "not_run"
     },
@@ -95,7 +97,10 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "contracts": {
     "ci_fast_gate_scope": "local-only",
     "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
-    "bundle_contract": "live_node_release_bundle_v1"
+    "bundle_contract": "live_node_release_bundle_v1",
+    "rollback_recovery_artifact_lineage_required": true,
+    "process_lifecycle_rollback_evidence_option": "--rollback-evidence-file",
+    "process_lifecycle_recovery_evidence_option": "--recovery-evidence-file"
   }
 }
 JSON
@@ -202,6 +207,11 @@ fi
 
 if ! grep -q "runtime_provider_client_contract_contract_mismatch" "$TMP_ERR"; then
   echo "expected runtime provider contract mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "rollback_evidence_file_missing" "$TMP_ERR"; then
+  echo "expected rollback evidence lineage reason for policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
+++ b/scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
@@ -57,6 +57,12 @@ required_coverage_markers=(
   "run_local_live_node_validation_bundle_lane.sh"
   "check_local_live_node_validation_bundle_policy.py"
   "run_local_live_node_validation_bundle_contract_lane.sh"
+  "rollback_evidence_file"
+  "recovery_evidence_file"
+  "rollback_evidence_file_missing"
+  "contracts.rollback_recovery_artifact_lineage_required=true"
+  "contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file"
+  "contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file"
   "docs/planning/kolme-devnet-ops.md"
   "docs/ci/strategy.md"
   "README.md"
@@ -82,6 +88,30 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include bundle contract lane marker in $docs_file" >&2
     exit 1
   fi
+  if ! grep -q "rollback_evidence_file" "$docs_file"; then
+    echo "expected docs parity to include rollback evidence marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "recovery_evidence_file" "$docs_file"; then
+    echo "expected docs parity to include recovery evidence marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "rollback_evidence_file_missing" "$docs_file"; then
+    echo "expected docs parity to include rollback lineage reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.rollback_recovery_artifact_lineage_required=true" "$docs_file"; then
+    echo "expected docs parity to include rollback/recovery lineage contract marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.process_lifecycle_rollback_evidence_option=--rollback-evidence-file" "$docs_file"; then
+    echo "expected docs parity to include process lifecycle rollback option contract marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.process_lifecycle_recovery_evidence_option=--recovery-evidence-file" "$docs_file"; then
+    echo "expected docs parity to include process lifecycle recovery option contract marker in $docs_file" >&2
+    exit 1
+  fi
   if ! grep -q "Regression: #2134" "$docs_file"; then
     echo "expected docs parity to include bundle workflow regression marker in $docs_file" >&2
     exit 1
@@ -105,11 +135,27 @@ if summary.get("reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected dry_run_no_commands_executed reason code in bundle contract-lane summary")
 if summary.get("ci_fast_gate_eligible") is not False:
     raise SystemExit("expected local-only fast-gate exclusion marker in bundle contract-lane summary")
+rollback_evidence_file = summary.get("rollback_evidence_file")
+if not isinstance(rollback_evidence_file, str) or not rollback_evidence_file:
+    raise SystemExit("expected rollback_evidence_file marker in bundle contract-lane summary")
+recovery_evidence_file = summary.get("recovery_evidence_file")
+if not isinstance(recovery_evidence_file, str) or not recovery_evidence_file:
+    raise SystemExit("expected recovery_evidence_file marker in bundle contract-lane summary")
+if rollback_evidence_file not in summary.get("artifact_paths", []):
+    raise SystemExit("expected rollback evidence artifact path marker in bundle contract-lane summary")
+if recovery_evidence_file not in summary.get("artifact_paths", []):
+    raise SystemExit("expected recovery evidence artifact path marker in bundle contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "local-only":
     raise SystemExit("expected local-only fast-gate scope contract marker in bundle contract-lane summary")
 if contracts.get("runtime_provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
     raise SystemExit("expected runtime provider contract marker in bundle contract-lane summary")
+if contracts.get("rollback_recovery_artifact_lineage_required") is not True:
+    raise SystemExit("expected rollback/recovery lineage required contract marker in bundle contract-lane summary")
+if contracts.get("process_lifecycle_rollback_evidence_option") != "--rollback-evidence-file":
+    raise SystemExit("expected process lifecycle rollback option contract marker in bundle contract-lane summary")
+if contracts.get("process_lifecycle_recovery_evidence_option") != "--recovery-evidence-file":
+    raise SystemExit("expected process lifecycle recovery option contract marker in bundle contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-live-node-validation-bundle-policy-report.v1":
     raise SystemExit("unexpected local live-node validation bundle contract-lane policy schema")
 if policy.get("final_decision") != "GO":

--- a/scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh
+++ b/scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh
@@ -138,6 +138,20 @@ if "run_local_kolme_fork_process_lifecycle_lane.sh" not in process_command:
     raise SystemExit("expected process lifecycle command marker in bundle summary")
 if "--integration-runtime-commit-live-policy-report" not in process_command:
     raise SystemExit("expected integration runtime policy pass-through marker in process lifecycle command")
+if f"--rollback-evidence-file {expected_artifacts[6]}" not in process_command:
+    raise SystemExit("expected rollback evidence pass-through marker in process lifecycle command")
+if f"--recovery-evidence-file {expected_artifacts[7]}" not in process_command:
+    raise SystemExit("expected recovery evidence pass-through marker in process lifecycle command")
+if report.get("rollback_evidence_file") != expected_artifacts[6]:
+    raise SystemExit("expected rollback_evidence_file marker in bundle summary")
+if report.get("recovery_evidence_file") != expected_artifacts[7]:
+    raise SystemExit("expected recovery_evidence_file marker in bundle summary")
+if contracts.get("rollback_recovery_artifact_lineage_required") is not True:
+    raise SystemExit("expected rollback/recovery lineage required contract marker in bundle summary contracts")
+if contracts.get("process_lifecycle_rollback_evidence_option") != "--rollback-evidence-file":
+    raise SystemExit("expected process lifecycle rollback option contract marker in bundle summary contracts")
+if contracts.get("process_lifecycle_recovery_evidence_option") != "--recovery-evidence-file":
+    raise SystemExit("expected process lifecycle recovery option contract marker in bundle summary contracts")
 
 checks = report.get("checks")
 if not isinstance(checks, list) or len(checks) != 4:


### PR DESCRIPTION
## Summary
This change makes the local live-node validation bundle policy fail closed on rollback/recovery artifact lineage. The checker now requires rollback/recovery evidence paths, command markers, and contract markers to align so deployment go/no-go cannot pass with incomplete rollback lineage metadata.

Closes #2370

## Changes
- `scripts/kolme/check_local_live_node_validation_bundle_policy.py`: added rollback/recovery summary, command-marker, contract-marker, process-lifecycle-bundle, and artifact-path lineage checks.
- `scripts/kolme/run_local_live_node_validation_bundle_lane.sh`: emits rollback/recovery summary fields plus explicit lineage contract fields.
- `scripts/kolme/contracts/local_live_node_validation_bundle_contract_lane.py`: added assertions and negative proof for missing rollback lineage reason.
- `scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh`: expanded GO/BAD fixtures and asserts lineage failure reason.
- `scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh`: expanded required marker and contract coverage checks.
- `scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh`: verifies runner pass-through/summary/contract lineage markers.
- `README.md`, `docs/ci/strategy.md`, `docs/planning/kolme-devnet-ops.md`: docs parity updated for new fields/markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh
```
Failing output before implementation:
```text
expected rollback evidence lineage reason for policy failure
```

### 🟢 Green Phase
Command:
```bash
bash scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh
```
Passing output:
```text
local live-node validation bundle policy checker tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh
bash scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh
bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh
bash scripts/ci/test_readme_contract.sh
bash scripts/ci/test_ci_strategy_contract.sh
cargo fmt --check
cargo clippy -- -D warnings
```
Pass summary:
```text
local live-node validation bundle lane tests passed.
local live-node validation bundle policy checker tests passed.
local live-node validation bundle contract lane tests passed.
README contract tests passed.
CI strategy contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status     | Tests Added/Modified                                                   | Justification if N/A |
|--------------|------------|------------------------------------------------------------------------|----------------------|
| Unit         | N/A        | N/A                                                                    | Shell/Python contract-lane policy flow; no isolated Rust unit surface in this issue |
| Functional   | ✅         | `scripts/kolme/test_check_local_live_node_validation_bundle_policy.sh` |                      |
| Integration  | ✅         | `scripts/kolme/test_run_local_live_node_validation_bundle_lane.sh`     |                      |
| Regression   | ✅         | `scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh` |                |
| Performance  | N/A        | N/A                                                                    | No throughput/latency path changed; policy validation only |

## Risks & Rollback
- Breaking change risk: low; policy is stricter and fail-closed for rollback lineage metadata.
- Rollback plan: revert this commit to restore previous (less strict) policy marker requirements.

## Documentation Updates
- `README.md`
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
