### PR TITLE
fix(deploy): enforce bounded mttr rehearsal contracts

### DIFF
--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -45,6 +45,11 @@ fn checklist_contains_staging_rehearsal_contract() {
     assert!(CHECKLIST.contains("check_staging_rehearsal_policy.sh"));
     assert!(CHECKLIST.contains("run_staging_rehearsal_contract_lane.sh"));
     assert!(CHECKLIST.contains("run_staging_rehearsal_deep_lane.sh"));
+    assert!(CHECKLIST.contains("--recovery-time-seconds"));
+    assert!(CHECKLIST.contains("--max-allowed-recovery-time-seconds"));
+    assert!(CHECKLIST.contains("mttr-threshold-exceeded"));
+    assert!(CHECKLIST.contains("mttr_within_bound"));
+    assert!(CHECKLIST.contains("Regression: #2337"));
 }
 
 #[test]

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -73,7 +73,7 @@ Go/no-go decisions are captured as machine-readable JSON so release policy check
 Staging rehearsal automation must verify deploy and rollback outcomes before release decisions are accepted.
 
 - Rehearsal bundle generator:
-  - `bash scripts/deploy/generate_staging_rehearsal_bundle.sh --output-file /tmp/staging-rehearsal.json --release-candidate v1.1.0-rc.1 --deploy-status PASS --rollback-status PASS --rollback-target-hash state-hash-expected --post-rollback-hash state-hash-expected --evidence-complete true --ci-fast-gate PASS`
+  - `bash scripts/deploy/generate_staging_rehearsal_bundle.sh --output-file /tmp/staging-rehearsal.json --release-candidate v1.1.0-rc.1 --deploy-status PASS --rollback-status PASS --rollback-target-hash state-hash-expected --post-rollback-hash state-hash-expected --recovery-time-seconds 420 --max-allowed-recovery-time-seconds 900 --evidence-complete true --ci-fast-gate PASS`
 - Rehearsal policy checker:
   - `bash scripts/deploy/check_staging_rehearsal_policy.sh --bundle-file /tmp/staging-rehearsal.json`
 - Fast contract lane:
@@ -87,6 +87,8 @@ Staging rehearsal automation must verify deploy and rollback outcomes before rel
   - `bash scripts/deploy/run_staging_rehearsal_deep_lane.sh`
 - Regression policy:
   - rollback target hash mismatch and incomplete rehearsal evidence force `NO-GO` (`Regression: #623`).
+  - MTTR evidence drift and out-of-bound recovery time force `NO-GO` (`Regression: #2337`).
+  - bounded MTTR policy emits deterministic markers: `recovery_time_seconds`, `max_allowed_recovery_time_seconds`, `mttr_within_bound`, and reason code `mttr-threshold-exceeded`.
 
 ## Durable Guard Migration + Recovery Matrix Evidence (Issue #691)
 Durable guard schema evolution and restart invariants must be proven before a release is approved.

--- a/scripts/deploy/run_staging_rehearsal_contract_lane.sh
+++ b/scripts/deploy/run_staging_rehearsal_contract_lane.sh
@@ -17,6 +17,8 @@ generator_output="$(
     --rollback-status PASS \
     --rollback-target-hash "state-hash-contract" \
     --post-rollback-hash "state-hash-contract" \
+    --recovery-time-seconds 420 \
+    --max-allowed-recovery-time-seconds 900 \
     --evidence-complete true \
     --ci-fast-gate PASS
 )"
@@ -29,6 +31,10 @@ fi
 policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$STAGING_REHEARSAL_REPORT")"
 if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=GO$"; then
   echo "expected rehearsal contract lane policy check decision to be GO" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^mttr_within_bound=true$"; then
+  echo "expected rehearsal contract lane policy check to confirm bounded MTTR evidence" >&2
   exit 1
 fi
 

--- a/scripts/deploy/run_staging_rehearsal_deep_lane.sh
+++ b/scripts/deploy/run_staging_rehearsal_deep_lane.sh
@@ -18,20 +18,26 @@ generator_output="$(
     --release-candidate "v1.1.0-deep" \
     --deploy-status PASS \
     --rollback-status PASS \
-    --rollback-target-hash "state-hash-expected" \
-    --post-rollback-hash "state-hash-observed" \
+    --rollback-target-hash "state-hash-stable" \
+    --post-rollback-hash "state-hash-stable" \
+    --recovery-time-seconds 1500 \
+    --max-allowed-recovery-time-seconds 900 \
     --evidence-complete true \
     --ci-fast-gate PASS
 )"
 
 if ! printf '%s\n' "$generator_output" | grep -q "^final_decision=NO-GO$"; then
-  echo "expected deep-lane rollback mismatch scenario decision to be NO-GO" >&2
+  echo "expected deep-lane MTTR-bound breach scenario decision to be NO-GO" >&2
   exit 1
 fi
 
 policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$STAGING_REHEARSAL_REPORT")"
 if ! printf '%s\n' "$policy_output" | grep -q "^final_decision=NO-GO$"; then
   echo "expected deep-lane policy check decision to be NO-GO" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q "^mttr_within_bound=false$"; then
+  echo "expected deep-lane policy check to report out-of-bound MTTR evidence" >&2
   exit 1
 fi
 

--- a/scripts/deploy/staging_rehearsal_contract.py
+++ b/scripts/deploy/staging_rehearsal_contract.py
@@ -39,11 +39,29 @@ def _parse_bool(field_name: str, raw_value: str) -> bool:
     fail(f"{field_name} must be true or false")
 
 
+def _parse_non_negative_int(field_name: str, raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        fail(f"{field_name} must be an integer")
+    if parsed < 0:
+        fail(f"{field_name} must be >= 0")
+    return parsed
+
+
+def _parse_positive_int(field_name: str, raw_value: str) -> int:
+    parsed = _parse_non_negative_int(field_name, raw_value)
+    if parsed == 0:
+        fail(f"{field_name} must be > 0")
+    return parsed
+
+
 def _compute_decision_reasons(
     *,
     deploy_status: str,
     rollback_status: str,
     rollback_hash_match: bool,
+    mttr_within_bound: bool,
     evidence_complete: bool,
     ci_fast_gate: str,
 ) -> list[str]:
@@ -54,6 +72,8 @@ def _compute_decision_reasons(
         decision_reasons.append("rollback-failed")
     if not rollback_hash_match:
         decision_reasons.append("rollback target hash mismatch")
+    if not mttr_within_bound:
+        decision_reasons.append("mttr-threshold-exceeded")
     if not evidence_complete:
         decision_reasons.append("incomplete evidence")
     if ci_fast_gate != "PASS":
@@ -69,6 +89,8 @@ def generate_bundle(args: argparse.Namespace) -> int:
         args.rollback_status,
         args.rollback_target_hash,
         args.post_rollback_hash,
+        args.recovery_time_seconds,
+        args.max_allowed_recovery_time_seconds,
         args.evidence_complete,
         args.ci_fast_gate,
     )
@@ -78,13 +100,21 @@ def generate_bundle(args: argparse.Namespace) -> int:
     deploy_status = _parse_pass_fail("deploy-status", args.deploy_status)
     rollback_status = _parse_pass_fail("rollback-status", args.rollback_status)
     ci_fast_gate = _parse_pass_fail("ci-fast-gate", args.ci_fast_gate)
+    recovery_time_seconds = _parse_non_negative_int(
+        "recovery-time-seconds", args.recovery_time_seconds
+    )
+    max_allowed_recovery_time_seconds = _parse_positive_int(
+        "max-allowed-recovery-time-seconds", args.max_allowed_recovery_time_seconds
+    )
     evidence_complete = _parse_bool("evidence-complete", args.evidence_complete)
     rollback_hash_match = args.rollback_target_hash == args.post_rollback_hash
+    mttr_within_bound = recovery_time_seconds <= max_allowed_recovery_time_seconds
 
     decision_reasons = _compute_decision_reasons(
         deploy_status=deploy_status,
         rollback_status=rollback_status,
         rollback_hash_match=rollback_hash_match,
+        mttr_within_bound=mttr_within_bound,
         evidence_complete=evidence_complete,
         ci_fast_gate=ci_fast_gate,
     )
@@ -103,6 +133,9 @@ def generate_bundle(args: argparse.Namespace) -> int:
             "rollback_target_hash": args.rollback_target_hash,
             "post_rollback_hash": args.post_rollback_hash,
             "rollback_hash_match": rollback_hash_match,
+            "recovery_time_seconds": recovery_time_seconds,
+            "max_allowed_recovery_time_seconds": max_allowed_recovery_time_seconds,
+            "mttr_within_bound": mttr_within_bound,
             "evidence_complete": evidence_complete,
             "ci_fast_gate": ci_fast_gate,
         },
@@ -171,6 +204,26 @@ def check_bundle(args: argparse.Namespace) -> int:
     if not isinstance(rollback_hash_match, bool):
         fail("rehearsal.rollback_hash_match must be a boolean")
 
+    recovery_time_seconds = _require_rehearsal_field(rehearsal, "recovery_time_seconds")
+    if not isinstance(recovery_time_seconds, int) or isinstance(recovery_time_seconds, bool):
+        fail("rehearsal.recovery_time_seconds must be an integer")
+    if recovery_time_seconds < 0:
+        fail("rehearsal.recovery_time_seconds must be >= 0")
+
+    max_allowed_recovery_time_seconds = _require_rehearsal_field(
+        rehearsal, "max_allowed_recovery_time_seconds"
+    )
+    if not isinstance(max_allowed_recovery_time_seconds, int) or isinstance(
+        max_allowed_recovery_time_seconds, bool
+    ):
+        fail("rehearsal.max_allowed_recovery_time_seconds must be an integer")
+    if max_allowed_recovery_time_seconds <= 0:
+        fail("rehearsal.max_allowed_recovery_time_seconds must be > 0")
+
+    mttr_within_bound = _require_rehearsal_field(rehearsal, "mttr_within_bound")
+    if not isinstance(mttr_within_bound, bool):
+        fail("rehearsal.mttr_within_bound must be a boolean")
+
     evidence_complete = _require_rehearsal_field(rehearsal, "evidence_complete")
     if not isinstance(evidence_complete, bool):
         fail("rehearsal.evidence_complete must be a boolean")
@@ -186,10 +239,21 @@ def check_bundle(args: argparse.Namespace) -> int:
             f"but hashes compare as {derived_hash_match}"
         )
 
+    derived_mttr_within_bound = recovery_time_seconds <= max_allowed_recovery_time_seconds
+    if mttr_within_bound != derived_mttr_within_bound:
+        fail(
+            "mttr bound mismatch: "
+            f"declared mttr_within_bound={mttr_within_bound} "
+            f"but recovery_time_seconds={recovery_time_seconds} "
+            f"and max_allowed_recovery_time_seconds={max_allowed_recovery_time_seconds} "
+            f"compare as {derived_mttr_within_bound}"
+        )
+
     decision_reasons = _compute_decision_reasons(
         deploy_status=deploy_status,
         rollback_status=rollback_status,
         rollback_hash_match=rollback_hash_match,
+        mttr_within_bound=mttr_within_bound,
         evidence_complete=evidence_complete,
         ci_fast_gate=ci_fast_gate,
     )
@@ -209,6 +273,9 @@ def check_bundle(args: argparse.Namespace) -> int:
     print(f"bundle_file={bundle_path}")
     print(f"final_decision={actual_decision}")
     print(f"rollback_hash_match={str(rollback_hash_match).lower()}")
+    print(f"recovery_time_seconds={recovery_time_seconds}")
+    print(f"max_allowed_recovery_time_seconds={max_allowed_recovery_time_seconds}")
+    print(f"mttr_within_bound={str(mttr_within_bound).lower()}")
     print(f"evidence_complete={str(evidence_complete).lower()}")
     return 0
 
@@ -226,6 +293,8 @@ def build_parser() -> argparse.ArgumentParser:
     generate.add_argument("--rollback-status")
     generate.add_argument("--rollback-target-hash")
     generate.add_argument("--post-rollback-hash")
+    generate.add_argument("--recovery-time-seconds")
+    generate.add_argument("--max-allowed-recovery-time-seconds")
     generate.add_argument("--evidence-complete")
     generate.add_argument("--ci-fast-gate")
     generate.set_defaults(handler=generate_bundle)

--- a/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
+++ b/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
@@ -42,6 +42,8 @@ go_generate_output="$(
     --rollback-status PASS \
     --rollback-target-hash "state-hash-abc" \
     --post-rollback-hash "state-hash-abc" \
+    --recovery-time-seconds 420 \
+    --max-allowed-recovery-time-seconds 900 \
     --evidence-complete true \
     --ci-fast-gate PASS
 )"
@@ -52,6 +54,7 @@ assert_eq "$(extract_value "$go_generate_output" "final_decision")" "GO" "expect
 go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
 assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO rehearsal policy check to pass"
 assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO rehearsal policy check decision"
+assert_eq "$(extract_value "$go_policy_output" "mttr_within_bound")" "true" "expected GO rehearsal policy check to report bounded MTTR"
 
 no_go_bundle="$TMP_DIR/rehearsal-no-go.json"
 no_go_generate_output="$(
@@ -62,6 +65,8 @@ no_go_generate_output="$(
     --rollback-status PASS \
     --rollback-target-hash "state-hash-expected" \
     --post-rollback-hash "state-hash-observed" \
+    --recovery-time-seconds 420 \
+    --max-allowed-recovery-time-seconds 900 \
     --evidence-complete true \
     --ci-fast-gate PASS
 )"
@@ -71,6 +76,28 @@ assert_eq "$(extract_value "$no_go_generate_output" "final_decision")" "NO-GO" "
 no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$no_go_bundle")"
 assert_eq "$(extract_value "$no_go_policy_output" "status")" "ok" "expected NO-GO rehearsal policy check to pass"
 assert_eq "$(extract_value "$no_go_policy_output" "final_decision")" "NO-GO" "expected NO-GO rehearsal policy check decision"
+
+mttr_no_go_bundle="$TMP_DIR/rehearsal-no-go-mttr.json"
+mttr_no_go_generate_output="$(
+  bash "$GENERATOR" \
+    --output-file "$mttr_no_go_bundle" \
+    --release-candidate "v1.1.0-rc.3" \
+    --deploy-status PASS \
+    --rollback-status PASS \
+    --rollback-target-hash "state-hash-stable" \
+    --post-rollback-hash "state-hash-stable" \
+    --recovery-time-seconds 1200 \
+    --max-allowed-recovery-time-seconds 900 \
+    --evidence-complete true \
+    --ci-fast-gate PASS
+)"
+
+assert_eq "$(extract_value "$mttr_no_go_generate_output" "final_decision")" "NO-GO" "expected MTTR bound breach to force NO-GO"
+
+mttr_no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$mttr_no_go_bundle")"
+assert_eq "$(extract_value "$mttr_no_go_policy_output" "status")" "ok" "expected MTTR NO-GO rehearsal policy check to pass"
+assert_eq "$(extract_value "$mttr_no_go_policy_output" "final_decision")" "NO-GO" "expected MTTR NO-GO rehearsal policy check decision"
+assert_eq "$(extract_value "$mttr_no_go_policy_output" "mttr_within_bound")" "false" "expected MTTR NO-GO rehearsal policy check to report out-of-bound recovery time"
 
 tampered_bundle="$TMP_DIR/rehearsal-tampered.json"
 cp "$no_go_bundle" "$tampered_bundle"
@@ -103,6 +130,35 @@ fi
 # Regression: #623
 if ! printf '%s\n' "$tampered_output" | grep -q "rollback target hash mismatch"; then
   echo "expected rollback mismatch regression guard to be enforced" >&2
+  exit 1
+fi
+
+tampered_mttr_bundle="$TMP_DIR/rehearsal-tampered-mttr.json"
+cp "$go_bundle" "$tampered_mttr_bundle"
+python3 - "$tampered_mttr_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["rehearsal"]["mttr_within_bound"] = False
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_mttr_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_mttr_bundle" 2>&1)"
+tampered_mttr_code=$?
+set -e
+
+if [ "$tampered_mttr_code" -eq 0 ]; then
+  echo "expected tampered MTTR rehearsal bundle to fail policy validation" >&2
+  exit 1
+fi
+
+# Regression: #2337
+if ! printf '%s\n' "$tampered_mttr_output" | grep -q "mttr bound mismatch"; then
+  echo "expected explicit MTTR bound mismatch regression guard to be enforced" >&2
   exit 1
 fi
 

--- a/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
+++ b/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
@@ -34,4 +34,24 @@ if ! grep -q "staging-rehearsal-report.json" "$DEEP_SCRIPT"; then
   exit 1
 fi
 
+if ! grep -Fq -- "--recovery-time-seconds" "$FAST_SCRIPT"; then
+  echo "expected staging rehearsal fast-lane runner to pass deterministic MTTR evidence markers" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "--max-allowed-recovery-time-seconds" "$FAST_SCRIPT"; then
+  echo "expected staging rehearsal fast-lane runner to pass bounded MTTR contract markers" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "--recovery-time-seconds" "$DEEP_SCRIPT"; then
+  echo "expected staging rehearsal deep-lane runner to pass deterministic MTTR evidence markers" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "--max-allowed-recovery-time-seconds" "$DEEP_SCRIPT"; then
+  echo "expected staging rehearsal deep-lane runner to pass bounded MTTR contract markers" >&2
+  exit 1
+fi
+
 echo "staging rehearsal contract lane script tests passed."


### PR DESCRIPTION
## Summary
This change adds deterministic bounded-MTTR evidence markers to the staging deployment rehearsal contract flow and makes the policy checker fail closed when MTTR metadata drifts. It closes an operational readiness gap by requiring recovery-time bounds in generator output, contract lane wrappers, and release checklist docs parity.

Closes #2371

## Changes
- `scripts/deploy/staging_rehearsal_contract.py`: added `--recovery-time-seconds` and `--max-allowed-recovery-time-seconds`, emits `recovery_time_seconds`/`max_allowed_recovery_time_seconds`/`mttr_within_bound`, enforces fail-closed `mttr bound mismatch`, and applies `mttr-threshold-exceeded` in NO-GO reason derivation.
- `scripts/deploy/test_generate_staging_rehearsal_bundle.sh`: added GO bounded-MTTR assertions, MTTR-breach NO-GO scenario, and tampered MTTR drift regression guard (`Regression: #2337`).
- `scripts/deploy/run_staging_rehearsal_contract_lane.sh`: passes deterministic MTTR args and asserts `mttr_within_bound=true` in policy output.
- `scripts/deploy/run_staging_rehearsal_deep_lane.sh`: exercises MTTR breach scenario and asserts `mttr_within_bound=false`.
- `scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`: enforces fast/deep wrapper marker presence for MTTR args.
- `docs/foundation/release-gonogo-checklist.md`: updated staging rehearsal command and regression markers for MTTR bounds.
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`: expanded docs-contract assertions for MTTR markers and regression tag.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
```
Failing output before implementation:
```text
staging_rehearsal_contract.py: error: unrecognized arguments: --recovery-time-seconds 420 --max-allowed-recovery-time-seconds 900
```

### 🟢 Green Phase
Command:
```bash
bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
```
Passing output:
```text
staging rehearsal bundle tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
bash scripts/deploy/run_staging_rehearsal_deep_lane.sh
cargo test -p kamn-core --test release_gonogo_checklist_docs
cargo fmt --check
cargo clippy -- -D warnings
```
Pass summary:
```text
staging rehearsal bundle tests passed.
staging rehearsal contract lane script tests passed.
staging rehearsal contract lane tests passed.
staging rehearsal deep lane tests passed.
58 passed; 0 failed (release_gonogo_checklist_docs)
```

## Test Matrix (Mandatory)
| Category      | Status     | Tests Added/Modified                                           | Justification if N/A |
|--------------|------------|----------------------------------------------------------------|----------------------|
| Unit         | N/A        | N/A                                                            | Shared deploy shell/python contract flow for this issue |
| Functional   | ✅         | `scripts/deploy/test_generate_staging_rehearsal_bundle.sh`     |                      |
| Integration  | ✅         | `scripts/deploy/run_staging_rehearsal_deep_lane.sh`            |                      |
| Regression   | ✅         | `scripts/deploy/test_generate_staging_rehearsal_bundle.sh` (`Regression: #2337`) |            |
| Performance  | ✅         | existing fast-lane wrapper contract checks remain lightweight (`scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`) | |

## Risks & Rollback
- Risk: low; this tightens policy and can convert previously accepted bundles into explicit NO-GO when MTTR metadata is missing/inconsistent.
- Rollback plan: revert this commit to restore the previous rehearsal schema/policy behavior.

## Documentation Updates
- `docs/foundation/release-gonogo-checklist.md`
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
