### PR TITLE
refactor(kolme): route signature parity wrapper via dispatcher

### DIFF
--- a/scripts/kolme/run_signature_parity_contract_lane.sh
+++ b/scripts/kolme/run_signature_parity_contract_lane.sh
@@ -1,16 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-MANIFEST_PATH="$ROOT_DIR/scripts/framework/manifests/kolme_signature_parity_contract_lane.json"
-
-if [ "${1:-}" = "--resolve-manifest-path" ]; then
-  echo "$MANIFEST_PATH"
-  exit 0
-fi
-
-exec bash "$ROOT_DIR/scripts/framework/run_manifest_lane.sh" \
-  --manifest "$MANIFEST_PATH" \
-  --phase contract \
-  -- \
-  "$@"
+run_contract_lane_dispatch.sh

--- a/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
+++ b/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
@@ -36,6 +36,7 @@ lane_wrappers=(
   "run_runtime_commit_adapter_contract_lane.sh"
   "run_runtime_commit_contract_lane.sh"
   "run_runtime_commit_replay_contract_lane.sh"
+  "run_signature_parity_contract_lane.sh"
   "run_snapshot_drift_contract_lane.sh"
   "run_triadic_devnet_smoke_contract_lane.sh"
   "run_version_compatibility_contract_lane.sh"

--- a/scripts/kolme/test_run_signature_parity_contract_lane.sh
+++ b/scripts/kolme/test_run_signature_parity_contract_lane.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUNNER="$ROOT_DIR/scripts/kolme/run_signature_parity_contract_lane.sh"
+DISPATCHER="$ROOT_DIR/scripts/kolme/run_contract_lane_dispatch.sh"
 MATRIX_RUNNER="$ROOT_DIR/scripts/kolme/run_signature_parity_matrix.py"
 CHECKER="$ROOT_DIR/scripts/kolme/check_signature_parity_policy.py"
 CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/signature_parity_contract_lane.py"
@@ -16,6 +17,11 @@ trap 'rm -f "$TMP_REPORT" "$TMP_POLICY"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected signature parity contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected signature parity contract lane dispatcher to be executable" >&2
   exit 1
 fi
 
@@ -44,13 +50,19 @@ if [ ! -f "$FIXTURE" ]; then
   exit 1
 fi
 
-if ! grep -q "run_manifest_lane.sh" "$RUNNER"; then
-  echo "expected signature parity contract lane runner to dispatch through run_manifest_lane.sh" >&2
+if [ ! -L "$RUNNER" ]; then
+  echo "expected signature parity contract lane runner to be a symlink to shared dispatcher" >&2
   exit 1
 fi
 
-if ! grep -q "kolme_signature_parity_contract_lane.json" "$RUNNER"; then
-  echo "expected signature parity contract lane runner to pin deterministic manifest path" >&2
+if [ "$(readlink "$RUNNER")" != "run_contract_lane_dispatch.sh" ]; then
+  echo "expected signature parity contract lane runner symlink target to be run_contract_lane_dispatch.sh" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$RUNNER")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST" ]; then
+  echo "expected signature parity contract lane dispatcher to resolve deterministic manifest path" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This change migrates the selected signature-parity contract wrapper to the shared Kolme contract-lane dispatcher so that wrapper routing is consolidated and dispatcher bypass drift is rejected. It also upgrades dispatch contract tests to assert symlink routing and deterministic manifest resolution.

Closes #2373

## Changes
- `scripts/kolme/run_signature_parity_contract_lane.sh`: converted from custom manifest wrapper to symlinked dispatcher wrapper (`run_contract_lane_dispatch.sh`).
- `scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`: added `run_signature_parity_contract_lane.sh` to shared-dispatcher symlink matrix coverage.
- `scripts/kolme/test_run_signature_parity_contract_lane.sh`: replaced direct-wrapper-content checks with dispatcher-routing checks:
  - runner must be a symlink to `run_contract_lane_dispatch.sh`
  - dispatcher must resolve `kolme_signature_parity_contract_lane.json` deterministically

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
```
Failing output before implementation:
```text
expected lane wrapper to be a symlink to shared dispatcher: /home/n/Code/kamn/scripts/kolme/run_signature_parity_contract_lane.sh
```

### 🟢 Green Phase
Command:
```bash
bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
```
Passing output:
```text
Kolme contract lane dispatcher wrapper matrix tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/kolme/test_run_signature_parity_contract_lane.sh
bash scripts/ci/test_kolme_command_surface_coverage_contract.sh
bash scripts/ci/test_kolme_command_surface_asymmetry_contract.sh
cargo fmt --check
cargo clippy -- -D warnings
```
Pass summary:
```text
Kolme contract lane dispatcher wrapper matrix tests passed.
signature parity contract lane tests passed.
kolme command-surface coverage contract tests passed.
kolme command-surface asymmetry contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status     | Tests Added/Modified                                                   | Justification if N/A |
|--------------|------------|------------------------------------------------------------------------|----------------------|
| Unit         | ✅         | `scripts/kolme/test_run_signature_parity_contract_lane.sh` dispatcher argument/manifest resolution assertions | |
| Functional   | ✅         | `scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`          |                      |
| Integration  | ✅         | `scripts/ci/test_kolme_command_surface_coverage_contract.sh`, `scripts/ci/test_kolme_command_surface_asymmetry_contract.sh` | |
| Regression   | ✅         | dispatcher bypass drift rejection via shared wrapper matrix (`Regression: #2337`) | |
| Performance  | ✅         | no new heavy lanes; migration is wrapper-routing only                  |                      |

## Risks & Rollback
- Risk: low; wrapper execution path is equivalent and still manifest-driven.
- Rollback plan: restore `scripts/kolme/run_signature_parity_contract_lane.sh` standalone wrapper implementation.

## Documentation Updates
- None required for this selected-family migration; command surfaces remain unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
