### PR TITLE
fix(kolme): fail closed on in-memory live-provider references

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -252,6 +252,9 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
   - linkage drift fails closed with deterministic reason codes: `request_payload_evidence_marker_missing`, `finality_evidence_artifact_path_missing`, `request_finality_evidence_linkage_missing`.
   - native payload markers `native_payload_pubkey_marker_present`, `native_payload_nonce_marker_present`, and `native_payload_messages_marker_present` must pass when strict real-node evidence checks are enabled.
   - default live command composition emits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1` and policy fails closed when the signing-profile marker is absent.
+  - provider hint contract remains live-only for this lane (`kolme-fork-local`); in-memory provider references fail closed with:
+    - `provider_hint_in_memory_provider_reference_detected`
+    - `live_command_in_memory_provider_reference_detected`
   - summary emits synthetic-command classification markers: `live_command_synthetic`, `finality_command_synthetic`, and `synthetic_evidence_classification_version=v1`.
   - use `--require-non-synthetic-run-evidence` in `check_local_runtime_commit_live_evidence_policy.py` when validating real-node run evidence to fail closed on marker-only command paths.
   - use `--require-native-payload-evidence` in `check_local_runtime_commit_live_evidence_policy.py` when validating real-node run evidence to fail closed on missing native payload markers.

--- a/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
+++ b/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
@@ -34,6 +34,7 @@ def parse_args() -> argparse.Namespace:
 
 def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, list[str]]:
     reason_codes: list[str] = []
+    in_memory_provider_marker = "InMemoryKolmeRuntimeCommitClient"
 
     if report.get("schema_version") != "kamn.kolme.local-runtime-commit-live-summary.v1":
         reason_codes.append("schema_version_mismatch")
@@ -55,6 +56,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
 
     if report.get("provider_client_contract") != args.expected_provider_client_contract:
         reason_codes.append("provider_client_contract_mismatch")
+
+    provider_hint = report.get("provider_hint")
+    if not isinstance(provider_hint, str) or not provider_hint.strip():
+        reason_codes.append("provider_hint_missing")
+    elif in_memory_provider_marker in provider_hint:
+        reason_codes.append("provider_hint_in_memory_provider_reference_detected")
 
     if report.get("provider_submit_profile_contract") != "kolme_fork_broadcast_profile":
         reason_codes.append("provider_submit_profile_contract_mismatch")
@@ -82,6 +89,12 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("provider_signing_profile_marker_present_invalid")
     elif provider_signing_profile_marker_present is False:
         reason_codes.append("provider_signing_profile_marker_missing")
+
+    live_command = report.get("live_command")
+    if not isinstance(live_command, str) or not live_command.strip():
+        reason_codes.append("live_command_missing")
+    elif in_memory_provider_marker in live_command:
+        reason_codes.append("live_command_in_memory_provider_reference_detected")
 
     if report.get("submit_evidence_marker") != "status=submitted":
         reason_codes.append("submit_evidence_marker_mismatch")

--- a/scripts/kolme/run_local_runtime_commit_live_lane_impl.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane_impl.sh
@@ -195,6 +195,11 @@ if [ -z "$PROVIDER_HINT" ]; then
   exit 1
 fi
 
+if [[ "$PROVIDER_HINT" == *"InMemoryKolmeRuntimeCommitClient"* ]]; then
+  echo "provider-hint must not reference InMemoryKolmeRuntimeCommitClient" >&2
+  exit 1
+fi
+
 if [ ! -x "$LOCAL_HEAVY_GUARD" ]; then
   echo "expected shared local-heavy opt-in guard helper to be executable" >&2
   exit 1
@@ -202,6 +207,11 @@ fi
 
 if [ -z "$LIVE_COMMAND" ]; then
   LIVE_COMMAND="$(default_live_command)"
+fi
+
+if [[ "$LIVE_COMMAND" == *"InMemoryKolmeRuntimeCommitClient"* ]]; then
+  echo "live-command must not reference InMemoryKolmeRuntimeCommitClient" >&2
+  exit 1
 fi
 
 PROVIDER_CLIENT_CONTRACT="KolmeRuntimeCommitLiveProvider"

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -15,7 +15,8 @@ TMP_FINALITY_OUTPUT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
 TMP_POLICY_ERR="$(mktemp)"
 TMP_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_ERR"' EXIT
+TMP_IN_MEMORY_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_ERR" "$TMP_IN_MEMORY_REPORT"' EXIT
 
 extract_value() {
   local output="$1"
@@ -209,6 +210,61 @@ checker_output="$(
     --output-json "$TMP_POLICY_REPORT"
 )"
 assert_eq "$(extract_value "$checker_output" "status")" "ok" "expected live evidence policy checker to pass dry-run report"
+
+set +e
+bash "$RUNNER" \
+  --mode dry-run \
+  --provider-hint InMemoryKolmeRuntimeCommitClient \
+  --output-json "$TMP_REPORT" \
+  --live-output-file "$TMP_OUTPUT" >"$TMP_ERR" 2>&1
+in_memory_hint_code=$?
+set -e
+
+if [ "$in_memory_hint_code" -eq 0 ]; then
+  echo "expected dry-run mode to fail closed when provider-hint references InMemoryKolmeRuntimeCommitClient" >&2
+  exit 1
+fi
+if ! grep -q "provider-hint must not reference InMemoryKolmeRuntimeCommitClient" "$TMP_ERR"; then
+  echo "expected deterministic in-memory provider-hint rejection message" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" "$TMP_IN_MEMORY_REPORT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+source = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+source["provider_hint"] = "InMemoryKolmeRuntimeCommitClient"
+source["live_command"] = (
+    "KAMN_KOLME_LIVE_PROVIDER_HINT=InMemoryKolmeRuntimeCommitClient "
+    + str(source.get("live_command", ""))
+)
+pathlib.Path(sys.argv[2]).write_text(json.dumps(source, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_IN_MEMORY_REPORT" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS >"$TMP_POLICY_ERR" 2>&1
+in_memory_policy_code=$?
+set -e
+
+if [ "$in_memory_policy_code" -eq 0 ]; then
+  echo "expected evidence policy checker to fail when provider_hint/live_command reference InMemoryKolmeRuntimeCommitClient" >&2
+  exit 1
+fi
+if ! grep -q "provider_hint_in_memory_provider_reference_detected" "$TMP_POLICY_ERR"; then
+  echo "expected provider_hint_in_memory_provider_reference_detected failure reason from evidence policy checker" >&2
+  exit 1
+fi
+if ! grep -q "live_command_in_memory_provider_reference_detected" "$TMP_POLICY_ERR"; then
+  echo "expected live_command_in_memory_provider_reference_detected failure reason from evidence policy checker" >&2
+  exit 1
+fi
 
 set +e
 KAMN_KOLME_LOCAL_HEAVY=1 \


### PR DESCRIPTION
## Summary
This change hardens the local runtime-commit live provider path by rejecting explicit in-memory provider references at both runner and policy-checker layers. It closes a live-profile drift gap where provider hints/commands could still reference `InMemoryKolmeRuntimeCommitClient` without fail-closed behavior.

Closes #2393

## Changes
- `scripts/kolme/run_local_runtime_commit_live_lane_impl.sh`: fail closed when `--provider-hint` or `--live-command` contains `InMemoryKolmeRuntimeCommitClient`
- `scripts/kolme/check_local_runtime_commit_live_evidence_policy.py`: added deterministic policy failures for in-memory provider references in `provider_hint` and `live_command`
- `scripts/kolme/test_run_local_runtime_commit_live_lane.sh`: added RED/GREEN regression assertions for in-memory provider-hint and checker reason codes
- `docs/foundation/kolme-runtime-commit-client.md`: documented new fail-closed reason codes for live provider-hint contract

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
expected dry-run mode to fail closed when provider-hint references InMemoryKolmeRuntimeCommitClient
```

### 🟢 Green Phase
```bash
$ bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
local runtime commit live lane tests passed.
```

### 🔁 Regression
```bash
$ bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
local runtime commit live lane tests passed.

$ bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh
local runtime-commit live finality evidence contract lane tests passed.

$ bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
local KAMN live runtime integration contract lane tests passed.

$ bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
local KAMN live runtime real-node profile policy checker tests passed.

$ bash scripts/ci/test_ci_strategy_contract.sh
CI strategy contract tests passed.

$ cargo fmt --check
(no diffs)

$ cargo clippy -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
```

## Test Matrix (Mandatory)
| Category      | Status  | Tests Added/Modified | Justification if N/A |
|--------------|---------|----------------------|----------------------|
| Unit         | ✅      | `scripts/kolme/test_run_local_runtime_commit_live_lane.sh` (policy reason-code assertions) | |
| Functional   | ✅      | `scripts/kolme/test_run_local_runtime_commit_live_lane.sh` | |
| Integration  | ✅      | `scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Regression   | ✅      | in-memory provider-hint/command reintroduction guards in runtime live lane checks | |
| Performance  | N/A     | None | Change is guard/policy logic only; no throughput path change |

## Risks & Rollback
- Risk: low-to-medium; stricter provider-hint and live-command validation can block previously tolerated misconfigurations.
- Rollback plan: revert this PR commit to restore prior runtime live lane/provider checker behavior.

## Documentation Updates
- Updated `docs/foundation/kolme-runtime-commit-client.md` with new in-memory provider drift reason codes.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
