### PR TITLE
fix(kolme): enforce secp256k1 signer profile in runtime live command assembly

### DIFF
--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -252,6 +252,8 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
   - linkage drift fails closed with deterministic reason codes: `request_payload_evidence_marker_missing`, `finality_evidence_artifact_path_missing`, `request_finality_evidence_linkage_missing`.
   - native payload markers `native_payload_pubkey_marker_present`, `native_payload_nonce_marker_present`, and `native_payload_messages_marker_present` must pass when strict real-node evidence checks are enabled.
   - default live command composition emits `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1` and policy fails closed when the signing-profile marker is absent.
+  - runner enforces `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1` on custom live-command overrides and rejects simulated signing-profile references.
+  - policy checker fails closed on simulated signing-profile references with `provider_signing_profile_simulated_detected`.
   - provider hint contract remains live-only for this lane (`kolme-fork-local`); in-memory provider references fail closed with:
     - `provider_hint_in_memory_provider_reference_detected`
     - `live_command_in_memory_provider_reference_detected`

--- a/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
+++ b/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py
@@ -95,6 +95,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("live_command_missing")
     elif in_memory_provider_marker in live_command:
         reason_codes.append("live_command_in_memory_provider_reference_detected")
+    elif "KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated" in live_command:
+        reason_codes.append("provider_signing_profile_simulated_detected")
 
     if report.get("submit_evidence_marker") != "status=submitted":
         reason_codes.append("submit_evidence_marker_mismatch")

--- a/scripts/kolme/run_local_runtime_commit_live_lane_impl.sh
+++ b/scripts/kolme/run_local_runtime_commit_live_lane_impl.sh
@@ -209,6 +209,17 @@ if [ -z "$LIVE_COMMAND" ]; then
   LIVE_COMMAND="$(default_live_command)"
 fi
 
+EXPECTED_SIGNING_PROFILE_MARKER="KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
+if [[ "$LIVE_COMMAND" != *"$EXPECTED_SIGNING_PROFILE_MARKER"* ]]; then
+  echo "live-command must set KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" >&2
+  exit 1
+fi
+
+if [[ "$LIVE_COMMAND" == *"KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated"* ]]; then
+  echo "live-command must not reference simulated signing profiles" >&2
+  exit 1
+fi
+
 if [[ "$LIVE_COMMAND" == *"InMemoryKolmeRuntimeCommitClient"* ]]; then
   echo "live-command must not reference InMemoryKolmeRuntimeCommitClient" >&2
   exit 1
@@ -221,7 +232,7 @@ PROVIDER_COMMAND_MARKER_PRESENT="false"
 if [[ "$LIVE_COMMAND" == *"$PROVIDER_COMMAND_MARKER"* ]]; then
   PROVIDER_COMMAND_MARKER_PRESENT="true"
 fi
-PROVIDER_SIGNING_PROFILE_MARKER="KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1"
+PROVIDER_SIGNING_PROFILE_MARKER="$EXPECTED_SIGNING_PROFILE_MARKER"
 PROVIDER_SIGNING_PROFILE_MARKER_PRESENT="false"
 if [[ "$LIVE_COMMAND" == *"$PROVIDER_SIGNING_PROFILE_MARKER"* ]]; then
   PROVIDER_SIGNING_PROFILE_MARKER_PRESENT="true"

--- a/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
+++ b/scripts/kolme/test_run_local_runtime_commit_live_lane.sh
@@ -16,7 +16,8 @@ TMP_POLICY_REPORT="$(mktemp)"
 TMP_POLICY_ERR="$(mktemp)"
 TMP_ERR="$(mktemp)"
 TMP_IN_MEMORY_REPORT="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_ERR" "$TMP_IN_MEMORY_REPORT"' EXIT
+TMP_SIMULATED_PROFILE_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_OUTPUT" "$TMP_FINALITY_OUTPUT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_ERR" "$TMP_IN_MEMORY_REPORT" "$TMP_SIMULATED_PROFILE_REPORT"' EXIT
 
 extract_value() {
   local output="$1"
@@ -267,10 +268,58 @@ if ! grep -q "live_command_in_memory_provider_reference_detected" "$TMP_POLICY_E
 fi
 
 set +e
+bash "$RUNNER" \
+  --mode dry-run \
+  --live-command "KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated-v1 printf 'status=submitted\n'" \
+  --output-json "$TMP_REPORT" \
+  --live-output-file "$TMP_OUTPUT" >"$TMP_ERR" 2>&1
+simulated_profile_code=$?
+set -e
+
+if [ "$simulated_profile_code" -eq 0 ]; then
+  echo "expected dry-run mode to fail closed when live-command includes simulated signing profile marker" >&2
+  exit 1
+fi
+if ! grep -q "live-command must set KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1" "$TMP_ERR"; then
+  echo "expected deterministic signer profile rejection message for simulated live-command marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" "$TMP_SIMULATED_PROFILE_REPORT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+source = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+source["live_command"] = "KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated-v1 printf 'status=submitted\\n'"
+source["provider_signing_profile_marker_present"] = False
+pathlib.Path(sys.argv[2]).write_text(json.dumps(source, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_SIMULATED_PROFILE_REPORT" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS >"$TMP_POLICY_ERR" 2>&1
+simulated_profile_policy_code=$?
+set -e
+
+if [ "$simulated_profile_policy_code" -eq 0 ]; then
+  echo "expected evidence policy checker to fail when live_command includes simulated signing profile marker" >&2
+  exit 1
+fi
+if ! grep -q "provider_signing_profile_simulated_detected" "$TMP_POLICY_ERR"; then
+  echo "expected provider_signing_profile_simulated_detected failure reason from evidence policy checker" >&2
+  exit 1
+fi
+
+set +e
 KAMN_KOLME_LOCAL_HEAVY=1 \
   bash "$RUNNER" \
     --mode run \
-    --live-command "printf 'status=submitted\n'" \
+    --live-command "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 printf 'status=submitted\n'" \
     --max-seconds 5 \
     --base-url "http://127.0.0.1:1" \
     --output-json "$TMP_REPORT" \
@@ -311,7 +360,7 @@ run_output="$(
     bash "$RUNNER" \
       --mode run \
       --skip-preflight \
-    --live-command "printf 'status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n'" \
+    --live-command "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 printf 'status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:1\nfinality=final\n'" \
     --max-seconds 5 \
     --output-json "$TMP_REPORT" \
     --live-output-file "$TMP_OUTPUT"
@@ -464,7 +513,7 @@ KAMN_KOLME_LOCAL_HEAVY=1 \
   bash "$RUNNER" \
     --mode run \
     --skip-preflight \
-    --live-command "sleep 2" \
+    --live-command "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 sleep 2" \
     --max-seconds 1 \
     --output-json "$TMP_REPORT" \
     --live-output-file "$TMP_OUTPUT" >"$TMP_ERR" 2>&1
@@ -503,7 +552,7 @@ run_missing_submit_evidence_output="$(
     bash "$RUNNER" \
       --mode run \
       --skip-preflight \
-      --live-command "printf 'integration_kolme_fork_live_node_submit_reaches_endpoint\n'" \
+      --live-command "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 printf 'integration_kolme_fork_live_node_submit_reaches_endpoint\n'" \
       --finality-command "printf 'finality=final\n'" \
       --max-seconds 5 \
       --finality-max-seconds 3 \
@@ -535,7 +584,7 @@ KAMN_KOLME_LOCAL_HEAVY=1 \
   bash "$RUNNER" \
     --mode run \
     --skip-preflight \
-    --live-command "printf 'status=submitted\n'" \
+    --live-command "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 printf 'status=submitted\n'" \
     --finality-command "sleep 2" \
     --finality-max-seconds 1 \
     --max-seconds 5 \


### PR DESCRIPTION
## Summary
This change enforces real secp256k1 signer-profile usage in local runtime commit live command assembly and policy evaluation. Runtime live lane custom command overrides now fail closed unless they include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`, and simulated profile markers are explicitly rejected.

Closes #2396

## Changes
- `scripts/kolme/run_local_runtime_commit_live_lane_impl.sh`
  - fail closed when custom `--live-command` does not include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`
  - fail closed when simulated signer profile markers are present
- `scripts/kolme/check_local_runtime_commit_live_evidence_policy.py`
  - added `provider_signing_profile_simulated_detected` reason code for simulated signer-profile drift in `live_command`
- `scripts/kolme/test_run_local_runtime_commit_live_lane.sh`
  - added RED/GREEN regression assertions for simulated signer-profile rejection at runner and policy layers
  - updated runtime command fixtures to include required signer-profile marker where needed
- `docs/foundation/kolme-runtime-commit-client.md`
  - documented new signer-profile enforcement and simulated-marker fail-closed reason code

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
$ bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
expected dry-run mode to fail closed when live-command includes simulated signing profile marker
```

### 🟢 Green Phase
```bash
$ bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
local runtime commit live lane tests passed.
```

### 🔁 Regression
```bash
$ bash scripts/kolme/test_run_local_runtime_commit_live_lane.sh
local runtime commit live lane tests passed.

$ bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh
local runtime-commit live finality evidence contract lane tests passed.

$ bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
local KAMN live runtime integration contract lane tests passed.

$ bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
local KAMN live runtime real-node profile policy checker tests passed.

$ bash scripts/ci/test_ci_strategy_contract.sh
CI strategy contract tests passed.

$ cargo fmt --check
(no diffs)

$ cargo clippy -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
```

## Test Matrix (Mandatory)
| Category      | Status  | Tests Added/Modified | Justification if N/A |
|--------------|---------|----------------------|----------------------|
| Unit         | ✅      | `scripts/kolme/test_run_local_runtime_commit_live_lane.sh` (policy reason-code assertions) | |
| Functional   | ✅      | `scripts/kolme/test_run_local_runtime_commit_live_lane.sh` signer-profile command contract checks | |
| Integration  | ✅      | `scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Regression   | ✅      | simulated signing-profile reintroduction guard via `provider_signing_profile_simulated_detected` | |
| Performance  | N/A     | None | profile/policy contract changes only |

## Risks & Rollback
- Risk: low-to-medium; stricter command validation can block malformed local command overrides that previously ran.
- Rollback plan: revert this PR commit to restore prior signer-profile validation behavior.

## Documentation Updates
- Updated `docs/foundation/kolme-runtime-commit-client.md` signer-profile contract guidance.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
