### PR TITLE
fix(kolme): block fallback signer key command markers in real-node lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signer_key_source_profile_pair_disallowed
 # runtime_signer_private_key_env_mismatch
 # runtime_commit_signer_key_source_marker_missing
+# runtime_commit_fallback_private_key_command_marker_detected
 # runtime_commit_managed_external_signer_key_reference_marker_missing
 # runtime_commit_managed_external_private_key_command_marker_detected
 # runtime_signing_profile_mismatch
@@ -674,6 +675,8 @@ bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --ou
 # local-only CI boundary marker: ci_fast_gate_eligible=false (contracts.ci_fast_gate_scope=local-only)
 # fallback signer runtime guard marker:
 # fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)
+# fallback signer command marker guard:
+# runtime-commit-command must not include fallback signer private key marker KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=... when runtime-profile=real-node
 # managed-external signer runtime guard marker:
 # managed-external signer raw private key env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF)
 # Regression: #2302

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -416,6 +416,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_key_source_profile_pair_disallowed`
       - `runtime_signer_private_key_env_mismatch`
       - `runtime_commit_signer_key_source_marker_missing`
+      - `runtime_commit_fallback_private_key_command_marker_detected`
       - `runtime_commit_managed_external_signer_key_reference_marker_missing`
       - `runtime_commit_managed_external_private_key_command_marker_detected`
       - `runtime_signing_profile_mismatch`
@@ -441,6 +442,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary`
     - strict profile fallback-key guard marker:
       - `fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)`
+    - strict profile fallback-key command marker guard:
+      - `runtime-commit-command must not include fallback signer private key marker KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=... when runtime-profile=real-node`
     - strict profile managed-external raw-key guard marker:
       - `managed-external signer raw private key env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF)`
     - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -469,6 +469,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - NO-GO key-source/profile matrix proof must surface `runtime_signer_key_source_profile_pair_disallowed` when signer profile/key-source pair is outside the strict allowlist.
   - NO-GO signer-key-env drift proof must surface `runtime_signer_private_key_env_mismatch` when signer key env marker drifts from `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`.
   - NO-GO signer key-source command marker proof must surface `runtime_commit_signer_key_source_marker_missing` when `runtime_commit_command` omits `KAMN_KOLME_LIVE_SIGNER_KEY_SOURCE=<env-local|managed-external>`.
+  - NO-GO fallback signer key command marker proof must surface `runtime_commit_fallback_private_key_command_marker_detected` when `runtime_commit_command` includes `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=...`.
   - NO-GO managed-external key-reference command marker proof must surface `runtime_commit_managed_external_signer_key_reference_marker_missing` when managed-external command composition omits `KAMN_KOLME_LIVE_SIGNER_KEY_REF=...`.
   - NO-GO managed-external private key command marker proof must surface `runtime_commit_managed_external_private_key_command_marker_detected` when managed-external command composition includes `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=...`.
   - NO-GO runtime-signing-profile drift proof must surface `runtime_signing_profile_mismatch` when summary runtime signing profile markers drift from `kolme-fork-secp256k1-v1`.
@@ -553,6 +554,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary` when `runtime_signer_profile=ops-secondary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile command composition rejects in-memory fallback references at runner boundary:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
+  - real-node profile command composition rejects fallback signer private-key command markers at runner boundary:
+    - `runtime-commit-command must not include fallback signer private key marker KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=... when runtime-profile=real-node`
   - real-node profile run-mode boundary rejects fallback signer secret env and prints remediation:
     - `fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)`
   - real-node profile managed-external boundary rejects raw signer secret env and prints remediation:

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -187,6 +187,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_commit_real_signing_profile_marker_missing")
         if "KAMN_KOLME_LIVE_SIGNING_PROFILE=simulated" in runtime_commit_command:
             reason_codes.append("runtime_commit_simulated_signing_profile_detected")
+        if f"{RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV}=" in runtime_commit_command:
+            reason_codes.append("runtime_commit_fallback_private_key_command_marker_detected")
 
     runtime_provider_client_contract = report.get("runtime_provider_client_contract")
     if not isinstance(runtime_provider_client_contract, str) or not runtime_provider_client_contract.strip():
@@ -354,6 +356,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
         if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
+        if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+            reason_codes.append("runtime_signer_fallback_private_key_command_marker_allowed_contract_mismatch")
         if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_managed_external_raw_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_attestation_schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -392,6 +392,11 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             )
         if (
             runtime_commit_command_profile == "real-node-non-synthetic-v1"
+            and f"{REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV}=" in runtime_commit_command
+        ):
+            reason_codes.append("runtime_commit_fallback_private_key_command_marker_detected")
+        if (
+            runtime_commit_command_profile == "real-node-non-synthetic-v1"
             and NATIVE_PAYLOAD_PUBKEY_MARKER not in runtime_commit_command
         ):
             reason_codes.append("runtime_commit_native_payload_pubkey_marker_missing")
@@ -448,6 +453,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
         if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
+        if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+            reason_codes.append("runtime_signer_fallback_private_key_command_marker_allowed_contract_mismatch")
         if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_managed_external_raw_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_attestation_schema_version") != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -213,6 +213,12 @@ def main() -> int:
         if contracts_payload.get("runtime_signer_fallback_private_key_allowed") is not False:
             print("expected contracts fallback signer private key allowed=false marker in summary", file=sys.stderr)
             return 1
+        if contracts_payload.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+            print(
+                "expected contracts fallback signer private key command marker allowed=false marker in summary",
+                file=sys.stderr,
+            )
+            return 1
         if contracts_payload.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
             print("expected contracts signer key reference env marker in summary", file=sys.stderr)
             return 1

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -379,6 +379,12 @@ def main() -> int:
     if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
         print("expected contracts fallback signer private key allowed=false marker in contract-lane summary", file=sys.stderr)
         return 1
+    if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+        print(
+            "expected contracts fallback signer private key command marker allowed=false marker in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
     if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
         print("expected contracts managed-external raw private key allowed=false marker in contract-lane summary", file=sys.stderr)
         return 1

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
@@ -482,6 +482,11 @@ if [ "$RUNTIME_PROFILE" = "real-node" ] && [ -n "$RUNTIME_SIGNER_KEY_SOURCE" ]; 
   fi
 fi
 
+if [ "$RUNTIME_PROFILE" = "real-node" ] && [[ "$RUNTIME_COMMIT_COMMAND" == *"${RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV}="* ]]; then
+  echo "runtime-commit-command must not include fallback signer private key marker ${RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV}=... when runtime-profile=real-node" >&2
+  exit 1
+fi
+
 if [ "$RUNTIME_PROFILE" = "real-node" ] && [ "$RUNTIME_SIGNER_KEY_SOURCE" = "managed-external" ]; then
   expected_runtime_signer_key_reference_marker_prefix="${RUNTIME_SIGNER_KEY_REF_ENV}="
   if [[ "$RUNTIME_COMMIT_COMMAND" != *"$expected_runtime_signer_key_reference_marker_prefix"* ]]; then
@@ -1063,6 +1068,7 @@ summary = {
         "runtime_signer_key_reference_env": runtime_signer_key_reference_env,
         "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
         "runtime_signer_fallback_private_key_allowed": False,
+        "runtime_signer_fallback_private_key_command_marker_allowed": False,
         "runtime_signer_managed_external_raw_private_key_allowed": False,
         "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
         "runtime_signer_attestation_signer_uniqueness_required": True,

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -12,6 +12,7 @@ TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_OK_SECONDARY="$TMP_DIR/ok-report-secondary.json"
 TMP_REPORT_OK_MANAGED="$TMP_DIR/ok-report-managed.json"
 TMP_REPORT_KEY_SOURCE_MARKER_MISSING="$TMP_DIR/key-source-marker-missing-report.json"
+TMP_REPORT_FALLBACK_COMMAND_MARKER="$TMP_DIR/fallback-command-marker-report.json"
 TMP_REPORT_MANAGED_KEY_REF_MISSING="$TMP_DIR/managed-key-ref-missing-report.json"
 TMP_REPORT_MANAGED_PRIVATE_KEY_COMMAND="$TMP_DIR/managed-private-key-command-report.json"
 TMP_REPORT_KEY_SOURCE_PAIR_BAD="$TMP_DIR/key-source-pair-bad-report.json"
@@ -124,6 +125,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_key_reference_env": "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
     "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
     "runtime_signer_fallback_private_key_allowed": false,
+    "runtime_signer_fallback_private_key_command_marker_allowed": false,
     "runtime_signer_managed_external_raw_private_key_allowed": false,
     "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
     "runtime_signer_attestation_signer_uniqueness_required": true,
@@ -335,6 +337,43 @@ fi
 
 if ! grep -q "runtime_commit_signer_key_source_marker_missing" "$TMP_ERR"; then
   echo "expected signer key-source command marker missing reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_FALLBACK_COMMAND_MARKER" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_commit_command"] = str(report.get("runtime_commit_command", "")).replace(
+    "KAMN_KOLME_LIVE_SIGNER_KEY_SOURCE=env-local ",
+    "KAMN_KOLME_LIVE_SIGNER_KEY_SOURCE=env-local KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=2222222222222222222222222222222222222222222222222222222222222222 ",
+    1,
+)
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_FALLBACK_COMMAND_MARKER" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+fallback_command_marker_exit_code=$?
+set -e
+
+if [ "$fallback_command_marker_exit_code" -eq 0 ]; then
+  echo "expected fallback signer private key command marker negative proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_fallback_private_key_command_marker_detected" "$TMP_ERR"; then
+  echo "expected fallback signer private key command marker detected reason for policy failure" >&2
   exit 1
 fi
 
@@ -731,6 +770,7 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
     "runtime_signer_fallback_private_key_allowed": false,
+    "runtime_signer_fallback_private_key_command_marker_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -896,6 +936,7 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
     "runtime_signer_fallback_private_key_allowed": false,
+    "runtime_signer_fallback_private_key_command_marker_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -1126,6 +1167,10 @@ if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_
     raise SystemExit("expected contracts fallback signer private key env marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+    raise SystemExit(
+        "expected contracts fallback signer private key command marker allowed=false marker in secondary runner-generated summary"
+    )
 PY
 
 python3 - "$TMP_INTEGRATION_POLICY_OUT" <<'PY'

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -16,7 +16,8 @@ TMP_REPORT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
 TMP_POLICY_ERR="$(mktemp)"
 TMP_SIMULATED_SUMMARY="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_SIMULATED_SUMMARY"' EXIT
+TMP_FALLBACK_SUMMARY="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_SIMULATED_SUMMARY" "$TMP_FALLBACK_SUMMARY"' EXIT
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local KAMN live runtime integration contract lane runner to be executable" >&2
@@ -401,6 +402,10 @@ if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_
     raise SystemExit("expected contracts fallback signer private key env marker in contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+    raise SystemExit(
+        "expected contracts fallback signer private key command marker allowed=false marker in contract-lane summary"
+    )
 if contracts.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
     raise SystemExit("expected contracts signer key reference env marker in contract-lane summary")
 if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
@@ -450,11 +455,48 @@ if ! grep -q "runtime_commit_simulated_signing_profile_detected" "$TMP_POLICY_ER
   exit 1
 fi
 
+python3 - "$TMP_REPORT" "$TMP_FALLBACK_SUMMARY" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary_path = pathlib.Path(sys.argv[1])
+fallback_path = pathlib.Path(sys.argv[2])
+payload = json.loads(summary_path.read_text(encoding="utf-8"))
+runtime_command = str(payload.get("runtime_commit_command", ""))
+payload["runtime_commit_command"] = (
+    "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=2222222222222222222222222222222222222222222222222222222222222222 "
+    f"{runtime_command}"
+)
+fallback_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_FALLBACK_SUMMARY" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_REPORT" >"$TMP_POLICY_ERR" 2>&1
+fallback_marker_policy_code=$?
+set -e
+
+if [ "$fallback_marker_policy_code" -eq 0 ]; then
+  echo "expected runtime integration policy checker to fail when runtime command includes fallback signer private key marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_commit_fallback_private_key_command_marker_detected" "$TMP_POLICY_ERR"; then
+  echo "expected runtime_commit_fallback_private_key_command_marker_detected reason for runtime integration policy failure" >&2
+  exit 1
+fi
+
 TMP_DIRECT_SUMMARY="$(mktemp)"
 TMP_DIRECT_RUNTIME_OUTPUT="$(mktemp)"
 TMP_DIRECT_RUNTIME_POLICY="$(mktemp)"
 TMP_DIRECT_RUNTIME_FINALITY_OUTPUT="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_SIMULATED_SUMMARY" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_RUNTIME_OUTPUT" "$TMP_DIRECT_RUNTIME_POLICY" "$TMP_DIRECT_RUNTIME_FINALITY_OUTPUT"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_POLICY_ERR" "$TMP_SIMULATED_SUMMARY" "$TMP_FALLBACK_SUMMARY" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_RUNTIME_OUTPUT" "$TMP_DIRECT_RUNTIME_POLICY" "$TMP_DIRECT_RUNTIME_FINALITY_OUTPUT"' EXIT
 
 bash "$ROOT_DIR/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh" \
   --mode dry-run \

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUNNER="$ROOT_DIR/scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh"
+RUNNER_IMPL="$ROOT_DIR/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
 README_FILE="$ROOT_DIR/README.md"
@@ -33,8 +34,8 @@ if [ ! -x "$RUNNER" ]; then
   exit 1
 fi
 
-if ! grep -q -- "--runtime-profile" "$RUNNER"; then
-  echo "expected local KAMN live runtime integration runner to expose runtime profile option" >&2
+if ! grep -q -- "--runtime-profile" "$RUNNER_IMPL"; then
+  echo "expected local KAMN live runtime integration implementation to expose runtime profile option" >&2
   exit 1
 fi
 
@@ -183,6 +184,28 @@ fi
 
 if ! grep -q "must not reference simulated signing profile marker" "$TMP_ERR"; then
   echo "expected deterministic simulated signing profile rejection message for real-node profile dry-run" >&2
+  exit 1
+fi
+
+set +e
+bash "$RUNNER" \
+  --mode dry-run \
+  --runtime-profile real-node \
+  --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider \
+  --runtime-commit-command "KAMN_KOLME_LOCAL_HEAVY=1 KAMN_KOLME_LIVE_SIGNER_KEY_SOURCE=env-local KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=2222222222222222222222222222222222222222222222222222222222222222 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --expected-provider-client-contract KolmeRuntimeCommitLiveProvider --live-command \"KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 printf 'runtime=real\\n'\" --output-json $TMP_RUNTIME_SUMMARY --policy-output-json $TMP_RUNTIME_POLICY" \
+  --runtime-commit-live-summary "$TMP_RUNTIME_SUMMARY" \
+  --runtime-commit-live-policy-report "$TMP_RUNTIME_POLICY" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+dry_run_fallback_command_marker_exit_code=$?
+set -e
+
+if [ "$dry_run_fallback_command_marker_exit_code" -eq 0 ]; then
+  echo "expected real-node profile dry-run to fail closed when runtime commit command includes fallback signer private key marker" >&2
+  exit 1
+fi
+
+if ! grep -q "must not include fallback signer private key marker" "$TMP_ERR"; then
+  echo "expected deterministic fallback signer private key command marker rejection message for real-node profile dry-run" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -380,6 +380,10 @@ if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_
     raise SystemExit("expected contracts fallback signer private key env marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+    raise SystemExit(
+        "expected contracts fallback signer private key command marker allowed=false marker in real-node profile contract-lane summary"
+    )
 if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
     raise SystemExit("expected contracts managed-external raw private key allowed=false marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
@@ -450,6 +454,10 @@ if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_
     raise SystemExit("expected contracts secondary signer fallback private key env marker in contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts secondary signer fallback private key allowed=false marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
+    raise SystemExit(
+        "expected contracts secondary signer fallback private key command marker allowed=false marker in contract-lane summary"
+    )
 if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
     raise SystemExit("expected contracts secondary signer managed-external raw private key allowed=false marker in contract-lane summary")
 if policy.get("final_decision") != "GO":


### PR DESCRIPTION
## Summary
This change hardens the real-node runtime integration path by fail-closing fallback private-key command-marker injection in runtime commit command composition. It extends both runtime integration policy checkers and contract surfaces so fallback command-marker drift is rejected deterministically.

Closes #2399

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh`: reject `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK=...` in real-node `--runtime-commit-command`; emit deterministic boundary failure message.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: add reason code `runtime_commit_fallback_private_key_command_marker_detected`; require contract marker `runtime_signer_fallback_private_key_command_marker_allowed=false`.
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`: add reason code `runtime_commit_fallback_private_key_command_marker_detected`; require contract marker `runtime_signer_fallback_private_key_command_marker_allowed=false`.
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: assert new fallback command-marker contract key.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: assert new fallback command-marker contract key.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: add negative proof for fallback command-marker detection and fixture contract marker parity.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: add negative proof for fallback command-marker policy rejection.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: add dry-run negative proof for fallback command-marker guard; align option-marker assertion with lane impl path.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: assert new fallback command-marker contract key in primary/secondary paths.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `README.md`: add reason-code and guard-marker documentation for fallback command-marker fail-closed behavior.

## Risks & Compatibility
- Breaking behavior for invalid real-node command composition: runtime commands that include fallback signer key command markers now fail closed.
- No dependency or API surface expansion.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified dry-run guard rejects fallback command-marker injection; verified policy reason-code surfaces and contract marker parity.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Policy checker fixture validations in `test_check_local_kamn_live_runtime_real_node_profile_policy.sh`. |
| Functional  | ✅ | Real-node lane guard behavior in `test_run_local_kamn_live_runtime_integration_real_node_profile.sh`. |
| Integration | ✅ | Contract lane + policy composition in `test_run_local_kamn_live_runtime_integration_contract_lane.sh` and `test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`. |
| Regression  | ✅ | Fallback command-marker drift now fails closed with deterministic reason code and runner boundary rejection. |

## Commands Run
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
