### PR TITLE
fix(kolme): enforce failover attestation and production quorum minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
 # contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract
 # contracts.approval_quorum_required=2
+# contracts.approval_quorum_minimum=2
 # contracts.quorum_evidence_required=true
 # contracts.quorum_evidence_sha256_required=true
 # contracts.quorum_evidence_schema_version=kamn.kolme.runtime-signer-attestation.v1
@@ -795,6 +796,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # reason_code=checkpoint_failed_signer_provenance_contract
 # reason_code=checkpoint_failed_signer_rotation_freshness_contract
 # signer_quorum_shortfall
+# signer_quorum_minimum_not_met
 # quorum_evidence_missing
 # quorum_evidence_sha256_invalid
 # quorum_evidence_schema_invalid

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -510,6 +510,7 @@ JSON`
       - `contracts.fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
       - `contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract`
       - `contracts.approval_quorum_required=2`
+      - `contracts.approval_quorum_minimum=2`
       - `contracts.quorum_evidence_required=true`
       - `contracts.quorum_evidence_sha256_required=true`
       - `contracts.quorum_evidence_schema_version=kamn.kolme.runtime-signer-attestation.v1`
@@ -547,6 +548,7 @@ JSON`
       - `reason_code=checkpoint_failed_signer_provenance_contract`
       - `reason_code=checkpoint_failed_signer_rotation_freshness_contract`
       - `signer_quorum_shortfall`
+      - `signer_quorum_minimum_not_met`
       - `quorum_evidence_missing`
       - `quorum_evidence_sha256_invalid`
       - `quorum_evidence_schema_invalid`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -664,6 +664,7 @@ JSON`
     - `contracts.fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
     - `contracts.fallback_signer_secret_checkpoint_reason_code=checkpoint_failed_fallback_private_key_contract`
     - `contracts.approval_quorum_required=2`
+    - `contracts.approval_quorum_minimum=2`
     - `contracts.approval_quorum_source=local-operator-attestations`
     - `contracts.quorum_evidence_required=true`
     - `contracts.quorum_evidence_sha256_required=true`
@@ -699,6 +700,7 @@ JSON`
   - `checkpoint_failed_signer_provenance_contract`
   - `checkpoint_failed_signer_rotation_freshness_contract`
   - `signer_quorum_shortfall`
+  - `signer_quorum_minimum_not_met`
   - `quorum_evidence_missing`
   - `quorum_evidence_sha256_invalid`
   - `quorum_evidence_schema_invalid`

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -22,6 +22,7 @@ RUNTIME_SIGNER_KEY_REF_ENV_BY_PROFILE = {
     RUNTIME_SIGNER_PROFILE_SECONDARY: "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY",
 }
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION = "kamn.kolme.runtime-signer-attestation.v1"
+RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS = 2
 RUNTIME_REAL_SIGNING_PROFILE_VALUE = "kolme-fork-secp256k1-v1"
 RUNTIME_REAL_SIGNING_PROFILE_MARKER = (
     f"KAMN_KOLME_LIVE_SIGNING_PROFILE={RUNTIME_REAL_SIGNING_PROFILE_VALUE}"
@@ -221,6 +222,47 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         expected_runtime_signer_private_key_env = RUNTIME_SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[runtime_signer_profile]
         expected_runtime_signer_key_reference_env = RUNTIME_SIGNER_KEY_REF_ENV_BY_PROFILE[runtime_signer_profile]
 
+    runtime_signer_previous_profile = report.get("runtime_signer_previous_profile")
+    if not isinstance(runtime_signer_previous_profile, str) or not runtime_signer_previous_profile.strip():
+        reason_codes.append("runtime_signer_previous_profile_missing")
+    elif runtime_signer_previous_profile not in ALLOWED_RUNTIME_SIGNER_PROFILES:
+        reason_codes.append("runtime_signer_previous_profile_invalid")
+
+    runtime_signer_failover_active = report.get("runtime_signer_failover_active")
+    if not isinstance(runtime_signer_failover_active, bool):
+        reason_codes.append("runtime_signer_failover_active_invalid")
+
+    runtime_signer_rotation_epoch = report.get("runtime_signer_rotation_epoch")
+    if not isinstance(runtime_signer_rotation_epoch, int) or runtime_signer_rotation_epoch <= 0:
+        reason_codes.append("runtime_signer_rotation_epoch_invalid")
+
+    runtime_signer_previous_rotation_epoch = report.get("runtime_signer_previous_rotation_epoch")
+    if (
+        not isinstance(runtime_signer_previous_rotation_epoch, int)
+        or runtime_signer_previous_rotation_epoch <= 0
+    ):
+        reason_codes.append("runtime_signer_previous_rotation_epoch_invalid")
+
+    if (
+        isinstance(runtime_signer_profile, str)
+        and runtime_signer_profile in ALLOWED_RUNTIME_SIGNER_PROFILES
+        and isinstance(runtime_signer_previous_profile, str)
+        and runtime_signer_previous_profile in ALLOWED_RUNTIME_SIGNER_PROFILES
+        and isinstance(runtime_signer_failover_active, bool)
+    ):
+        if runtime_signer_failover_active and runtime_signer_profile == runtime_signer_previous_profile:
+            reason_codes.append("runtime_signer_failover_profile_unchanged")
+        if (not runtime_signer_failover_active) and runtime_signer_profile != runtime_signer_previous_profile:
+            reason_codes.append("runtime_signer_profile_changed_without_failover")
+    if (
+        isinstance(runtime_signer_failover_active, bool)
+        and runtime_signer_failover_active
+        and isinstance(runtime_signer_rotation_epoch, int)
+        and isinstance(runtime_signer_previous_rotation_epoch, int)
+        and runtime_signer_rotation_epoch <= runtime_signer_previous_rotation_epoch
+    ):
+        reason_codes.append("runtime_signer_rotation_epoch_stale")
+
     runtime_signer_key_source = report.get("runtime_signer_key_source")
     normalized_runtime_signer_key_source = ""
     if not isinstance(runtime_signer_key_source, str) or not runtime_signer_key_source.strip():
@@ -268,12 +310,40 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif runtime_signer_attestation_schema_version != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
         reason_codes.append("runtime_signer_attestation_schema_version_mismatch")
 
+    runtime_signer_attestation_bundle = report.get("runtime_signer_attestation_bundle")
     reason_codes.extend(
         evaluate_runtime_signer_attestation_bundle(
-            report.get("runtime_signer_attestation_bundle"),
+            runtime_signer_attestation_bundle,
             runtime_signer_profile,
         )
     )
+
+    runtime_signer_attestation_required_approvals: int | None = None
+    runtime_signer_attestation_approved_signers: list[str] = []
+    if isinstance(runtime_signer_attestation_bundle, dict):
+        required_approvals_value = runtime_signer_attestation_bundle.get("required_approvals")
+        if isinstance(required_approvals_value, int):
+            runtime_signer_attestation_required_approvals = required_approvals_value
+
+        approved_signers_value = runtime_signer_attestation_bundle.get("approved_signers")
+        if isinstance(approved_signers_value, list):
+            for entry in approved_signers_value:
+                if isinstance(entry, str) and entry.strip():
+                    runtime_signer_attestation_approved_signers.append(entry.strip())
+
+    if isinstance(runtime_signer_failover_active, bool) and runtime_signer_failover_active:
+        if (
+            not isinstance(runtime_signer_attestation_required_approvals, int)
+            or runtime_signer_attestation_required_approvals
+            < RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
+        ):
+            reason_codes.append("runtime_signer_failover_attestation_required_approvals_insufficient")
+        if (
+            isinstance(runtime_signer_previous_profile, str)
+            and runtime_signer_previous_profile.strip()
+            and runtime_signer_previous_profile not in runtime_signer_attestation_approved_signers
+        ):
+            reason_codes.append("runtime_signer_failover_attestation_previous_profile_not_approved")
 
     runtime_commit_live_policy_report = report.get("runtime_commit_live_policy_report")
     if not isinstance(runtime_commit_live_policy_report, str) or not runtime_commit_live_policy_report.strip():
@@ -368,8 +438,34 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_attestation_threshold_required_contract_mismatch")
         if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
             reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
-        if contracts.get("runtime_signer_attestation_required_approvals") != 1:
+        expected_runtime_signer_attestation_required_approvals = (
+            RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
+            if runtime_signer_failover_active is True
+            else 1
+        )
+        if (
+            contracts.get("runtime_signer_attestation_required_approvals")
+            != expected_runtime_signer_attestation_required_approvals
+        ):
             reason_codes.append("runtime_signer_attestation_required_approvals_contract_mismatch")
+        if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
+            reason_codes.append("runtime_signer_failover_requires_profile_change_contract_mismatch")
+        if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:
+            reason_codes.append("runtime_signer_rotation_epoch_contract_mismatch")
+        if (
+            contracts.get("runtime_signer_failover_attestation_min_required_approvals")
+            != RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
+        ):
+            reason_codes.append(
+                "runtime_signer_failover_attestation_min_required_approvals_contract_mismatch"
+            )
+        if (
+            contracts.get("runtime_signer_failover_attestation_previous_profile_membership_required")
+            is not True
+        ):
+            reason_codes.append(
+                "runtime_signer_failover_attestation_previous_profile_membership_contract_mismatch"
+            )
 
     checks = report.get("checks")
     if not isinstance(checks, list) or not checks:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -45,6 +45,7 @@ NATIVE_PAYLOAD_PUBKEY_MARKER = "pubkey"
 NATIVE_PAYLOAD_NONCE_MARKER = "nonce"
 NATIVE_PAYLOAD_MESSAGES_MARKER = "messages"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION = "kamn.kolme.runtime-signer-attestation.v1"
+RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS = 2
 
 
 def evaluate_runtime_signer_attestation_bundle(
@@ -276,12 +277,40 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif runtime_signer_attestation_schema_version != RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION:
         reason_codes.append("runtime_signer_attestation_schema_version_mismatch")
 
+    runtime_signer_attestation_bundle = report.get("runtime_signer_attestation_bundle")
     reason_codes.extend(
         evaluate_runtime_signer_attestation_bundle(
-            report.get("runtime_signer_attestation_bundle"),
+            runtime_signer_attestation_bundle,
             runtime_signer_profile,
         )
     )
+
+    runtime_signer_attestation_required_approvals: int | None = None
+    runtime_signer_attestation_approved_signers: list[str] = []
+    if isinstance(runtime_signer_attestation_bundle, dict):
+        required_approvals_value = runtime_signer_attestation_bundle.get("required_approvals")
+        if isinstance(required_approvals_value, int):
+            runtime_signer_attestation_required_approvals = required_approvals_value
+
+        approved_signers_value = runtime_signer_attestation_bundle.get("approved_signers")
+        if isinstance(approved_signers_value, list):
+            for entry in approved_signers_value:
+                if isinstance(entry, str) and entry.strip():
+                    runtime_signer_attestation_approved_signers.append(entry.strip())
+
+    if isinstance(runtime_signer_failover_active, bool) and runtime_signer_failover_active:
+        if (
+            not isinstance(runtime_signer_attestation_required_approvals, int)
+            or runtime_signer_attestation_required_approvals
+            < RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
+        ):
+            reason_codes.append("runtime_signer_failover_attestation_required_approvals_insufficient")
+        if (
+            isinstance(runtime_signer_previous_profile, str)
+            and runtime_signer_previous_profile.strip()
+            and runtime_signer_previous_profile not in runtime_signer_attestation_approved_signers
+        ):
+            reason_codes.append("runtime_signer_failover_attestation_previous_profile_not_approved")
 
     runtime_commit_command_profile = report.get("runtime_commit_command_profile")
     if not isinstance(runtime_commit_command_profile, str) or not runtime_commit_command_profile.strip():
@@ -465,8 +494,30 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_attestation_threshold_required_contract_mismatch")
         if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
             reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
-        if contracts.get("runtime_signer_attestation_required_approvals") != 1:
+        expected_runtime_signer_attestation_required_approvals = (
+            RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
+            if runtime_signer_failover_active is True
+            else 1
+        )
+        if (
+            contracts.get("runtime_signer_attestation_required_approvals")
+            != expected_runtime_signer_attestation_required_approvals
+        ):
             reason_codes.append("runtime_signer_attestation_required_approvals_contract_mismatch")
+        if (
+            contracts.get("runtime_signer_failover_attestation_min_required_approvals")
+            != RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
+        ):
+            reason_codes.append(
+                "runtime_signer_failover_attestation_min_required_approvals_contract_mismatch"
+            )
+        if (
+            contracts.get("runtime_signer_failover_attestation_previous_profile_membership_required")
+            is not True
+        ):
+            reason_codes.append(
+                "runtime_signer_failover_attestation_previous_profile_membership_contract_mismatch"
+            )
         if contracts.get("runtime_signer_failover_requires_profile_change") is not True:
             reason_codes.append("runtime_signer_failover_requires_profile_change_contract_mismatch")
         if contracts.get("runtime_signer_rotation_epoch_must_increase_on_failover") is not True:

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -21,6 +21,7 @@ ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
     PRIMARY_SIGNER_PROFILE: ("env-local", "managed-external"),
     SECONDARY_SIGNER_PROFILE: ("env-local",),
 }
+MIN_PRODUCTION_REQUIRED_APPROVALS = 2
 
 
 def evaluate_runtime_signer_attestation_bundle(
@@ -258,6 +259,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     required_approvals = report.get("required_approvals")
     if not isinstance(required_approvals, int) or required_approvals <= 0:
         reason_codes.append("required_approvals_invalid")
+    elif signer_profile_class == "production" and required_approvals < MIN_PRODUCTION_REQUIRED_APPROVALS:
+        reason_codes.append("signer_quorum_minimum_not_met")
 
     received_approvals = report.get("received_approvals")
     if not isinstance(received_approvals, int) or received_approvals < 0:
@@ -392,6 +395,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("approval_quorum_required_contract_invalid")
         elif isinstance(required_approvals, int) and approval_quorum_required != required_approvals:
             reason_codes.append("approval_quorum_required_contract_mismatch")
+        if contracts.get("approval_quorum_minimum") != MIN_PRODUCTION_REQUIRED_APPROVALS:
+            reason_codes.append("approval_quorum_minimum_contract_mismatch")
         if contracts.get("approval_quorum_source") != "local-operator-attestations":
             reason_codes.append("approval_quorum_source_contract_mismatch")
         if contracts.get("quorum_evidence_required") is not True:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -403,6 +403,18 @@ def main() -> int:
     if contracts.get("runtime_signer_attestation_required_approvals") != 1:
         print("expected contracts runtime signer attestation required approvals marker in contract-lane summary", file=sys.stderr)
         return 1
+    if contracts.get("runtime_signer_failover_attestation_min_required_approvals") != 2:
+        print(
+            "expected contracts runtime signer failover attestation minimum approvals marker in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
+    if contracts.get("runtime_signer_failover_attestation_previous_profile_membership_required") is not True:
+        print(
+            "expected contracts runtime signer failover previous-profile attestation membership marker in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
     if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
         print("unexpected real-node profile policy schema in contract-lane output", file=sys.stderr)
         return 1
@@ -469,6 +481,7 @@ def main() -> int:
             expected_signer_profile,
             alternate_signer_profile,
         ]
+        forced_failover_go_attestation_bundle["required_approvals"] = 2
         forced_failover_go_attestation_bundle["signer_profile"] = alternate_signer_profile
         forced_failover_go_summary["runtime_signer_attestation_bundle"] = (
             forced_failover_go_attestation_bundle
@@ -481,6 +494,7 @@ def main() -> int:
         forced_failover_go_contracts["runtime_signer_key_reference_env"] = (
             SIGNER_KEY_REF_ENV_BY_PROFILE[alternate_signer_profile]
         )
+        forced_failover_go_contracts["runtime_signer_attestation_required_approvals"] = 2
         forced_failover_go_summary["contracts"] = forced_failover_go_contracts
         forced_failover_go_summary_file.write_text(
             json.dumps(forced_failover_go_summary, sort_keys=True, indent=2) + "\n",

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -262,6 +262,9 @@ def main() -> int:
     if contracts.get("approval_quorum_required") != 2:
         print("expected deployment preflight contracts approval_quorum_required=2", file=sys.stderr)
         return 1
+    if contracts.get("approval_quorum_minimum") != 2:
+        print("expected deployment preflight contracts approval_quorum_minimum=2", file=sys.stderr)
+        return 1
     if contracts.get("quorum_evidence_required") is not True:
         print("expected deployment preflight contracts quorum_evidence_required=true", file=sys.stderr)
         return 1
@@ -414,6 +417,47 @@ def main() -> int:
             return 1
         if quorum_no_go_policy.get("final_decision") != "NO-GO":
             print("expected signer quorum negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
+        quorum_minimum_negative_report = temp_path / "signer_quorum_minimum_negative_summary.json"
+        quorum_minimum_negative_policy = temp_path / "signer_quorum_minimum_negative_policy.json"
+        quorum_minimum_negative_summary = dict(summary)
+        quorum_minimum_negative_summary["mode"] = "run"
+        quorum_minimum_negative_summary["status"] = "fail"
+        quorum_minimum_negative_summary["reason_code"] = "checkpoint_failed_signer_quorum_contract"
+        quorum_minimum_negative_summary["signer_secret_present"] = True
+        quorum_minimum_negative_summary["signer_secret_hex_valid"] = True
+        quorum_minimum_negative_summary["required_approvals"] = 1
+        quorum_minimum_negative_summary["received_approvals"] = 1
+        quorum_minimum_negative_summary["contracts"] = dict(contracts)
+        quorum_minimum_negative_summary["contracts"]["approval_quorum_required"] = 1
+        quorum_minimum_negative_summary["contracts"]["runtime_signer_attestation_required_approvals"] = 1
+        quorum_minimum_negative_report.write_text(
+            json.dumps(quorum_minimum_negative_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        quorum_minimum_no_go_result = run_policy_check(
+            report_file=quorum_minimum_negative_report,
+            output_json=quorum_minimum_negative_policy,
+            expected_final_decision="NO-GO",
+            required_reason_code="checkpoint_failed_signer_quorum_contract",
+        )
+        if quorum_minimum_no_go_result.returncode == 0:
+            print("expected signer quorum minimum negative proof to fail closed", file=sys.stderr)
+            return 1
+        quorum_minimum_no_go_policy = json.loads(
+            quorum_minimum_negative_policy.read_text(encoding="utf-8")
+        )
+        quorum_minimum_no_go_reason_codes = quorum_minimum_no_go_policy.get("reason_codes")
+        if not isinstance(quorum_minimum_no_go_reason_codes, list):
+            print("expected reason_codes list in signer quorum minimum negative policy output", file=sys.stderr)
+            return 1
+        if "signer_quorum_minimum_not_met" not in quorum_minimum_no_go_reason_codes:
+            print("expected signer_quorum_minimum_not_met in signer quorum minimum negative policy output", file=sys.stderr)
+            return 1
+        if quorum_minimum_no_go_policy.get("final_decision") != "NO-GO":
+            print("expected signer quorum minimum negative policy final_decision NO-GO", file=sys.stderr)
             return 1
 
         quorum_evidence_negative_report = temp_path / "quorum_evidence_negative_summary.json"
@@ -790,6 +834,7 @@ def main() -> int:
         "checkpoint_failed_signer_provenance_contract",
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
+        "signer_quorum_minimum_not_met",
         "quorum_evidence_missing",
         "quorum_evidence_signer_roles_missing",
         "quorum_evidence_signer_roles_invalid",
@@ -803,6 +848,7 @@ def main() -> int:
         "quorum_evidence_rotation_metadata_valid",
         "contracts.quorum_evidence_signer_roles_required=true",
         "contracts.quorum_evidence_rotation_metadata_required=true",
+        "contracts.approval_quorum_minimum=2",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_attestation_schema_invalid",
@@ -838,6 +884,7 @@ def main() -> int:
         "checkpoint_failed_signer_provenance_contract",
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
+        "signer_quorum_minimum_not_met",
         "quorum_evidence_missing",
         "quorum_evidence_signer_roles_missing",
         "quorum_evidence_signer_roles_invalid",
@@ -851,6 +898,7 @@ def main() -> int:
         "quorum_evidence_rotation_metadata_valid",
         "contracts.quorum_evidence_signer_roles_required=true",
         "contracts.quorum_evidence_rotation_metadata_required=true",
+        "contracts.approval_quorum_minimum=2",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_attestation_schema_invalid",
@@ -886,6 +934,7 @@ def main() -> int:
         "checkpoint_failed_signer_provenance_contract",
         "checkpoint_failed_signer_rotation_freshness_contract",
         "signer_quorum_shortfall",
+        "signer_quorum_minimum_not_met",
         "quorum_evidence_missing",
         "quorum_evidence_signer_roles_missing",
         "quorum_evidence_signer_roles_invalid",
@@ -899,6 +948,7 @@ def main() -> int:
         "quorum_evidence_rotation_metadata_valid",
         "contracts.quorum_evidence_signer_roles_required=true",
         "contracts.quorum_evidence_rotation_metadata_required=true",
+        "contracts.approval_quorum_minimum=2",
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_attestation_schema_invalid",

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
@@ -1062,6 +1062,8 @@ summary = {
         "runtime_signer_profile": runtime_signer_profile,
         "runtime_signer_failover_requires_profile_change": True,
         "runtime_signer_rotation_epoch_must_increase_on_failover": True,
+        "runtime_signer_failover_attestation_min_required_approvals": 2,
+        "runtime_signer_failover_attestation_previous_profile_membership_required": True,
         "runtime_signer_key_source_contract_version": runtime_signer_key_source_contract_version,
         "runtime_signer_key_source": runtime_signer_key_source,
         "runtime_signer_private_key_env": runtime_signer_private_key_env,

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -16,6 +16,7 @@ SIGNER_KEY_SOURCE="env-local"
 SIGNER_ROTATION_EPOCH=1
 SIGNER_PREVIOUS_ROTATION_EPOCH=1
 SIGNER_ROTATION_FRESHNESS_MAX_DELTA=2
+MIN_PRODUCTION_REQUIRED_APPROVALS=2
 
 REQUIRED_RUNTIME_MODE="kolme-live"
 SIGNER_PROFILE_SELECTOR_ENV="KAMN_KOLME_LIVE_SIGNER_PROFILE"
@@ -380,7 +381,16 @@ if [ "$MODE" = "run" ]; then
           reason_code="checkpoint_failed_signer_secret_contract"
         else
           record_check "signer_secret_contract" "$signer_secret_command" "pass" "signer_secret_validated"
-          if [ "$RECEIVED_APPROVALS" -lt "$REQUIRED_APPROVALS" ]; then
+          if [ "$REQUIRED_APPROVALS" -lt "$MIN_PRODUCTION_REQUIRED_APPROVALS" ]; then
+            echo "required approvals must be at least ${MIN_PRODUCTION_REQUIRED_APPROVALS} for production signer profiles: required=$REQUIRED_APPROVALS" >&2
+            record_check "signer_quorum_contract" "$signer_quorum_command" "fail" "signer_quorum_minimum_not_met"
+            record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "signer_quorum_minimum_not_met"
+            record_check "custody_evidence_contract" "$custody_evidence_command" "skipped" "signer_quorum_minimum_not_met"
+            record_check "signer_provenance_contract" "$signer_provenance_command" "skipped" "signer_quorum_minimum_not_met"
+            record_check "signer_rotation_freshness_contract" "$signer_rotation_freshness_command" "skipped" "signer_quorum_minimum_not_met"
+            overall_status="fail"
+            reason_code="checkpoint_failed_signer_quorum_contract"
+          elif [ "$RECEIVED_APPROVALS" -lt "$REQUIRED_APPROVALS" ]; then
             echo "signer quorum approvals below required threshold: required=$REQUIRED_APPROVALS received=$RECEIVED_APPROVALS" >&2
             record_check "signer_quorum_contract" "$signer_quorum_command" "fail" "signer_quorum_shortfall"
             record_check "quorum_evidence_contract" "$quorum_evidence_command" "skipped" "signer_quorum_shortfall"
@@ -945,6 +955,7 @@ summary = {
         "fallback_private_key_path_allowed": False,
         "required_secret_hex_length": required_secret_hex_length,
         "secret_source": "env",
+        "approval_quorum_minimum": 2,
         "approval_quorum_required": required_approvals,
         "approval_quorum_source": "local-operator-attestations",
         "quorum_evidence_required": True,

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -17,6 +17,7 @@ TMP_REPORT_MANAGED_KEY_REF_MISSING="$TMP_DIR/managed-key-ref-missing-report.json
 TMP_REPORT_MANAGED_PRIVATE_KEY_COMMAND="$TMP_DIR/managed-private-key-command-report.json"
 TMP_REPORT_KEY_SOURCE_PAIR_BAD="$TMP_DIR/key-source-pair-bad-report.json"
 TMP_REPORT_SPLIT_BRAIN="$TMP_DIR/split-brain-report.json"
+TMP_REPORT_FAILOVER_ATTESTATION_QUORUM_INSUFFICIENT="$TMP_DIR/failover-attestation-quorum-insufficient-report.json"
 TMP_REPORT_ATTESTATION_DUPLICATE="$TMP_DIR/attestation-duplicate-report.json"
 TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL="$TMP_DIR/attestation-quorum-shortfall-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
@@ -119,6 +120,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_profile": "ops-primary",
     "runtime_signer_failover_requires_profile_change": true,
     "runtime_signer_rotation_epoch_must_increase_on_failover": true,
+    "runtime_signer_failover_attestation_min_required_approvals": 2,
+    "runtime_signer_failover_attestation_previous_profile_membership_required": true,
     "runtime_signer_key_source_contract_version": "v1",
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
@@ -530,6 +533,46 @@ fi
 
 if ! grep -q "runtime_commit_signer_profile_split_brain_detected" "$TMP_ERR"; then
   echo "expected split-brain signer profile reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_FAILOVER_ATTESTATION_QUORUM_INSUFFICIENT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_failover_active"] = True
+report["runtime_signer_previous_profile"] = "ops-secondary"
+report["runtime_signer_rotation_epoch"] = 2
+report["runtime_signer_previous_rotation_epoch"] = 1
+attestation_bundle = dict(report.get("runtime_signer_attestation_bundle", {}))
+attestation_bundle["required_approvals"] = 1
+attestation_bundle["approved_signers"] = ["ops-primary", "ops-secondary"]
+report["runtime_signer_attestation_bundle"] = attestation_bundle
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_FAILOVER_ATTESTATION_QUORUM_INSUFFICIENT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+failover_attestation_quorum_exit_code=$?
+set -e
+
+if [ "$failover_attestation_quorum_exit_code" -eq 0 ]; then
+  echo "expected failover attestation quorum minimum proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_failover_attestation_required_approvals_insufficient" "$TMP_ERR"; then
+  echo "expected failover attestation minimum approvals reason for policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -9,6 +9,7 @@ CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
 README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
+TMP_REPORT_QUORUM_MINIMUM="$TMP_DIR/quorum-minimum-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
 TMP_SUMMARY="$TMP_DIR/summary.json"
@@ -120,6 +121,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "fallback_private_key_path_allowed": false,
     "required_secret_hex_length": 64,
     "secret_source": "env",
+    "approval_quorum_minimum": 2,
     "approval_quorum_required": 2,
     "approval_quorum_source": "local-operator-attestations",
     "quorum_evidence_required": true,
@@ -236,6 +238,46 @@ if report.get("final_decision") != "GO":
 if report.get("reason_codes") != []:
     raise SystemExit("expected no reason codes for valid deployment preflight report")
 PY
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_QUORUM_MINIMUM" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["required_approvals"] = 1
+report["received_approvals"] = 0
+bundle = dict(report.get("runtime_signer_attestation_bundle", {}))
+bundle["required_approvals"] = 1
+report["runtime_signer_attestation_bundle"] = bundle
+contracts = dict(report.get("contracts", {}))
+contracts["approval_quorum_required"] = 1
+contracts["runtime_signer_attestation_required_approvals"] = 1
+report["contracts"] = contracts
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_QUORUM_MINIMUM" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+quorum_minimum_exit_code=$?
+set -e
+
+if [ "$quorum_minimum_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight policy checker to fail when production required approvals drop below multi-signer minimum" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_quorum_minimum_not_met" "$TMP_ERR"; then
+  echo "expected signer_quorum_minimum_not_met reason for deployment preflight policy failure" >&2
+  exit 1
+fi
 
 cat >"$TMP_REPORT_BAD" <<'JSON'
 {

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -11,7 +11,8 @@ TMP_ERR="$(mktemp)"
 TMP_CUSTODY="$(mktemp)"
 TMP_PROVENANCE="$(mktemp)"
 TMP_QUORUM="$(mktemp)"
-trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY" "$TMP_PROVENANCE" "$TMP_QUORUM"' EXIT
+TMP_QUORUM_SINGLE="$(mktemp)"
+trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY" "$TMP_PROVENANCE" "$TMP_QUORUM" "$TMP_QUORUM_SINGLE"' EXIT
 
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" >"$TMP_CUSTODY"
 printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" >"$TMP_PROVENANCE"
@@ -33,6 +34,24 @@ cat >"$TMP_QUORUM" <<JSON
   "signer_rotation_epochs": {
     "ops-primary": 3,
     "ops-secondary": 2
+  }
+}
+JSON
+
+cat >"$TMP_QUORUM_SINGLE" <<JSON
+{
+  "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+  "required_approvals": 1,
+  "received_approvals": 1,
+  "approved_signers": [
+    "ops-primary"
+  ],
+  "custody_evidence_sha256": "$TMP_CUSTODY_SHA",
+  "signer_roles": {
+    "ops-primary": "primary"
+  },
+  "signer_rotation_epochs": {
+    "ops-primary": 3
   }
 }
 JSON
@@ -176,6 +195,8 @@ if contracts.get("custody_evidence_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer custody evidence")
 if contracts.get("approval_quorum_required") != 2:
     raise SystemExit("expected deployment preflight contracts approval quorum requirement marker")
+if contracts.get("approval_quorum_minimum") != 2:
+    raise SystemExit("expected deployment preflight contracts approval quorum minimum marker")
 if contracts.get("quorum_evidence_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require quorum evidence")
 if contracts.get("quorum_evidence_sha256_required") is not True:
@@ -222,6 +243,29 @@ fi
 
 if ! grep -q "signer secret env is required for selected profile" "$TMP_ERR"; then
   echo "expected deterministic missing signer secret message from deployment preflight lane" >&2
+  exit 1
+fi
+
+set +e
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
+bash "$RUNNER" \
+  --mode run \
+  --required-approvals 1 \
+  --received-approvals 1 \
+  --custody-evidence-file "$TMP_CUSTODY" \
+  --quorum-evidence-file "$TMP_QUORUM_SINGLE" \
+  --signer-provenance-file "$TMP_PROVENANCE" \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+minimum_quorum_exit_code=$?
+set -e
+
+if [ "$minimum_quorum_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight run mode to fail closed when required approvals are below production multi-signer minimum" >&2
+  exit 1
+fi
+
+if ! grep -q "required approvals must be at least 2 for production signer profiles" "$TMP_ERR"; then
+  echo "expected deterministic production multi-signer minimum quorum message from deployment preflight lane" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This change hardens multi-signer quorum/failover evidence handling across runtime integration and deployment preflight lanes. It adds fail-closed policy enforcement for failover attestation semantics and enforces a production multi-signer minimum quorum in deployment preflight decisions.

Closes #2400

## Changes
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`:
  - Validate failover markers (`runtime_signer_previous_profile`, `runtime_signer_failover_active`, rotation metadata).
  - Enforce failover attestation invariants:
    - `runtime_signer_failover_attestation_required_approvals_insufficient`
    - `runtime_signer_failover_attestation_previous_profile_not_approved`
  - Validate failover contract markers and dynamic attestation required-approvals contract behavior.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`:
  - Enforce failover attestation minimum approvals and previous-profile attestation membership.
  - Validate failover attestation contract markers and dynamic required-approvals contract behavior.
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh`:
  - Emit failover attestation contract markers:
    - `runtime_signer_failover_attestation_min_required_approvals=2`
    - `runtime_signer_failover_attestation_previous_profile_membership_required=true`
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`:
  - Fail closed when production `required_approvals < 2` with deterministic reason `signer_quorum_minimum_not_met`.
  - Emit contract marker `approval_quorum_minimum=2`.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`:
  - Enforce production minimum quorum reason `signer_quorum_minimum_not_met`.
  - Validate `approval_quorum_minimum=2` contract marker.
- Contract/test updates:
  - `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`
  - `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`
  - `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
  - `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`
- Docs parity updates:
  - `docs/planning/kolme-devnet-ops.md`
  - `docs/ci/strategy.md`
  - `README.md`

## Risks & Compatibility
- Deployment preflight run-mode behavior is stricter: production runs with `required_approvals < 2` now fail closed.
- Runtime policy evaluation is stricter for failover evidence semantics.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: failover/quorum negative proofs and docs parity validated via contract lanes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Runtime/deployment policy fixture checks and failover/quorum negative proofs. |
| Functional  | ✅ | Deployment preflight lane minimum-quorum fail-closed behavior validated. |
| Integration | ✅ | Runtime real-node + deployment preflight contract lanes validated with policy composition. |
| Regression  | ✅ | Failover/quorum drift proofs now fail closed with deterministic reasons/contracts parity. |

## Commands Run
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`
- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
- `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
