### PR TITLE
feat(ci): add Kolme command-surface soft budget trend contracts

### DIFF
--- a/.ci/kolme-command-surface-baseline.env
+++ b/.ci/kolme-command-surface-baseline.env
@@ -1,0 +1,7 @@
+# Baseline snapshot for Kolme non-test command-surface shell scripts.
+# Updated: 2026-02-13 (local measurement on mainline before issue #2402 changes)
+
+SCRIPT_COUNT_BASELINE=56
+SHELL_LINE_TOTAL_BASELINE=12958
+DUPLICATE_BASENAME_BASELINE=0
+DUPLICATE_CONTENT_BASELINE=0

--- a/.ci/kolme-command-surface-soft-budget.env
+++ b/.ci/kolme-command-surface-soft-budget.env
@@ -1,0 +1,7 @@
+# Soft budget thresholds for Kolme non-test command-surface shell scripts.
+# Exceeded thresholds indicate command-surface growth that requires review.
+
+SCRIPT_COUNT_MAX=72
+SHELL_LINE_TOTAL_MAX=15000
+DUPLICATE_BASENAME_MAX=0
+DUPLICATE_CONTENT_MAX=0

--- a/.ci/kolme-command-surface-trend-thresholds.env
+++ b/.ci/kolme-command-surface-trend-thresholds.env
@@ -1,0 +1,7 @@
+# Trend thresholds for Kolme non-test command-surface script growth.
+# Warning is advisory; fail can be enforced in trend report generation.
+
+COMMAND_SURFACE_SCRIPT_COUNT_WARN_DELTA_MAX=4
+COMMAND_SURFACE_SCRIPT_COUNT_FAIL_DELTA_MAX=8
+COMMAND_SURFACE_SHELL_LINE_TOTAL_WARN_DELTA_MAX=1200
+COMMAND_SURFACE_SHELL_LINE_TOTAL_FAIL_DELTA_MAX=2400

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -8,12 +8,16 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
 - Fast-gate delta baseline/thresholds: `.ci/fast-gate-budget-delta.env`
 - Script-surface budgets: `.ci/script-surface-budget.env`
 - Script-surface delta baseline: `.ci/script-surface-baseline.env`
+- Kolme command-surface soft budget: `.ci/kolme-command-surface-soft-budget.env`
+- Kolme command-surface baseline: `.ci/kolme-command-surface-baseline.env`
+- Kolme command-surface trend thresholds: `.ci/kolme-command-surface-trend-thresholds.env`
 
 ## Enforcers
 - Runtime budget gate: `scripts/ci/evaluate_budget.sh`
 - Fast-gate delta report generator: `scripts/ci/generate_fast_gate_budget_delta_report.sh`
 - Fast-gate delta threshold gate: `scripts/ci/check_fast_gate_budget_delta_threshold.sh`
 - Script surface gate: `scripts/ci/check_script_duplication_budget.sh`
+- Kolme harness+command-surface trend report: `scripts/ci/generate_kolme_test_harness_loc_trend_report.sh`
 - CI helper regression suite: `scripts/ci/test_ci_tools.sh`
 
 ## Fast-Gate Delta Policy
@@ -84,6 +88,26 @@ bash scripts/ci/test_generate_fast_gate_budget_delta_report.sh
 bash scripts/ci/test_check_fast_gate_budget_delta_threshold.sh
 bash scripts/ci/test_ci_tools.sh
 ```
+
+Kolme harness + command-surface trend validation:
+
+```bash
+bash scripts/ci/generate_kolme_test_harness_loc_report.sh --output-json /tmp/kolme-test-harness-loc-report.json
+bash scripts/ci/check_kolme_test_harness_loc_soft_budget.sh --report-file /tmp/kolme-test-harness-loc-report.json --output-json /tmp/kolme-test-harness-loc-soft-budget-report.json
+bash scripts/ci/generate_kolme_test_harness_loc_trend_report.sh --output-json /tmp/kolme-test-harness-loc-trend-report.json
+```
+
+Deterministic command-surface drift markers in trend artifacts:
+- `command_surface_trend_status=within|warn|fail|invalid`
+- `command_surface_policy_decision=GO|WARN|NO-GO`
+- `command_surface_script_count_trend_warn_delta_exceeded`
+- `command_surface_script_count_trend_fail_delta_exceeded`
+- `command_surface_shell_line_total_trend_warn_delta_exceeded`
+- `command_surface_shell_line_total_trend_fail_delta_exceeded`
+- `command_surface_budget_status_fail`
+
+Optional hard-fail mode for command-surface drift:
+- `bash scripts/ci/generate_kolme_test_harness_loc_trend_report.sh --enforce-command-surface-fail --output-json /tmp/kolme-test-harness-loc-trend-report.json`
 
 ## Artifact Contract
 `check_script_duplication_budget.py` supports `--output-json` and writes:

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -801,6 +801,9 @@ Test-harness growth advisory (non-blocking):
 
 Kolme harness trend policy (warning-to-fail escalation contract):
 - trend thresholds file: `.ci/kolme-test-harness-loc-trend-thresholds.env`
+- command-surface soft budget file: `.ci/kolme-command-surface-soft-budget.env`
+- command-surface baseline file: `.ci/kolme-command-surface-baseline.env`
+- command-surface trend thresholds file: `.ci/kolme-command-surface-trend-thresholds.env`
 - policy wrapper:
   - `bash scripts/ci/check_kolme_test_harness_loc_soft_budget.sh --report-file /tmp/kolme-test-harness-loc-report.json --output-json /tmp/kolme-test-harness-loc-soft-budget-report.json`
 - trend report generator:
@@ -808,9 +811,12 @@ Kolme harness trend policy (warning-to-fail escalation contract):
 - policy emits deterministic escalation markers:
   - `trend_status=within|warn|fail`
   - `policy_decision=GO|WARN|NO-GO`
+  - `command_surface_trend_status=within|warn|fail|invalid`
+  - `command_surface_policy_decision=GO|WARN|NO-GO`
   - `reason_codes=...` (soft-budget and/or trend threshold reason markers)
 - optional enforcement mode for hard-fail gating:
   - `--enforce-trend-fail` exits non-zero when `trend_status=fail`.
+  - `--enforce-command-surface-fail` exits non-zero when `command_surface_policy_decision=NO-GO`.
 
 Policy:
 - Warning at 90% of configured budget.
@@ -860,6 +866,11 @@ Fast-mode CI tooling regression coverage includes:
     - `reason_codes=harness_shell_line_total_trend_warn_delta_exceeded`
     - `reason_codes=harness_script_count_trend_fail_delta_exceeded`
     - `reason_codes=harness_shell_line_total_trend_fail_delta_exceeded`
+    - `reason_codes=command_surface_script_count_trend_warn_delta_exceeded`
+    - `reason_codes=command_surface_shell_line_total_trend_warn_delta_exceeded`
+    - `reason_codes=command_surface_script_count_trend_fail_delta_exceeded`
+    - `reason_codes=command_surface_shell_line_total_trend_fail_delta_exceeded`
+    - `reason_codes=command_surface_budget_status_fail`
 - Retry helper (`test_run_with_retry.sh`)
 - Invariant harness runner (`test_run_invariant_harness.sh`)
 - Selector matrix runner with output-env isolation (`test_select_targets.sh`, `Regression: #463`)

--- a/scripts/ci/generate_kolme_test_harness_loc_trend_report.sh
+++ b/scripts/ci/generate_kolme_test_harness_loc_trend_report.sh
@@ -4,9 +4,18 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPORT_SCRIPT="$ROOT_DIR/scripts/ci/generate_kolme_test_harness_loc_report.sh"
 CHECK_SCRIPT="$ROOT_DIR/scripts/ci/check_kolme_test_harness_loc_soft_budget.sh"
+COMMAND_SURFACE_SCRIPT="$ROOT_DIR/scripts/ci/check_script_duplication_budget.py"
+DEFAULT_COMMAND_SURFACE_BUDGET_FILE="$ROOT_DIR/.ci/kolme-command-surface-soft-budget.env"
+DEFAULT_COMMAND_SURFACE_BASELINE_FILE="$ROOT_DIR/.ci/kolme-command-surface-baseline.env"
+DEFAULT_COMMAND_SURFACE_TREND_THRESHOLD_FILE="$ROOT_DIR/.ci/kolme-command-surface-trend-thresholds.env"
 
 output_json=""
 input_report_file=""
+input_command_surface_report_file=""
+command_surface_budget_file="$DEFAULT_COMMAND_SURFACE_BUDGET_FILE"
+command_surface_baseline_file="$DEFAULT_COMMAND_SURFACE_BASELINE_FILE"
+command_surface_trend_threshold_file="$DEFAULT_COMMAND_SURFACE_TREND_THRESHOLD_FILE"
+enforce_command_surface_fail=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -17,6 +26,26 @@ while [ "$#" -gt 0 ]; do
     --report-file)
       input_report_file="${2:-}"
       shift 2
+      ;;
+    --command-surface-report-file)
+      input_command_surface_report_file="${2:-}"
+      shift 2
+      ;;
+    --command-surface-budget-file)
+      command_surface_budget_file="${2:-}"
+      shift 2
+      ;;
+    --command-surface-baseline-file)
+      command_surface_baseline_file="${2:-}"
+      shift 2
+      ;;
+    --command-surface-trend-threshold-file)
+      command_surface_trend_threshold_file="${2:-}"
+      shift 2
+      ;;
+    --enforce-command-surface-fail)
+      enforce_command_surface_fail=1
+      shift
       ;;
     *)
       echo "unknown argument: $1" >&2
@@ -47,35 +76,270 @@ policy_file="$tmp_dir/kolme-test-harness-loc-soft-budget-report.json"
 
 bash "$CHECK_SCRIPT" --report-file "$report_file" --output-json "$policy_file" >/dev/null
 
+command_surface_report_file="$input_command_surface_report_file"
+command_surface_checker_exit_code=0
+if [ -z "$command_surface_report_file" ]; then
+  command_surface_report_file="$tmp_dir/kolme-command-surface-budget-report.json"
+  set +e
+  python3 "$COMMAND_SURFACE_SCRIPT" \
+    --scripts-root "$ROOT_DIR/scripts/kolme" \
+    --budget-file "$command_surface_budget_file" \
+    --baseline-file "$command_surface_baseline_file" \
+    --output-json "$command_surface_report_file" >/dev/null
+  command_surface_checker_exit_code=$?
+  set -e
+  if [ ! -f "$command_surface_report_file" ]; then
+    echo "command-surface checker did not emit report: $command_surface_report_file" >&2
+    exit 1
+  fi
+else
+  if [ ! -f "$command_surface_report_file" ]; then
+    echo "command-surface report file not found: $command_surface_report_file" >&2
+    exit 2
+  fi
+fi
+
+if [ ! -f "$command_surface_trend_threshold_file" ]; then
+  echo "command-surface trend threshold file not found: $command_surface_trend_threshold_file" >&2
+  exit 2
+fi
+
 output_dir="$(dirname "$output_json")"
 mkdir -p "$output_dir"
 
-python3 - "$report_file" "$policy_file" "$output_json" <<'PY'
+python3 - "$report_file" "$policy_file" "$command_surface_report_file" "$command_surface_trend_threshold_file" "$output_json" "$command_surface_checker_exit_code" "$enforce_command_surface_fail" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 report_path = Path(sys.argv[1])
 policy_path = Path(sys.argv[2])
-output_path = Path(sys.argv[3])
+command_surface_report_path = Path(sys.argv[3])
+command_surface_threshold_path = Path(sys.argv[4])
+output_path = Path(sys.argv[5])
+command_surface_checker_exit_code = int(sys.argv[6])
+enforce_command_surface_fail = sys.argv[7] == "1"
 
 report = json.loads(report_path.read_text(encoding="utf-8"))
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
+command_surface_reason_codes: list[str] = []
+command_surface_status = "fail"
+command_surface_trend_status = "invalid"
+command_surface_policy_decision = "NO-GO"
+command_surface_script_count = -1
+command_surface_shell_line_total = -1
+command_surface_delta_script_count = 0
+command_surface_delta_shell_line_total = 0
+command_surface_warn_delta_script_count_max = 0
+command_surface_fail_delta_script_count_max = 0
+command_surface_warn_delta_shell_line_total_max = 0
+command_surface_fail_delta_shell_line_total_max = 0
+
+def parse_env_thresholds(path: Path) -> dict[str, int]:
+    values: dict[str, int] = {}
+    raw_map: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"invalid threshold line: {raw_line}")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"invalid threshold line: {raw_line}")
+        raw_map[key] = value
+
+    required = (
+        "COMMAND_SURFACE_SCRIPT_COUNT_WARN_DELTA_MAX",
+        "COMMAND_SURFACE_SCRIPT_COUNT_FAIL_DELTA_MAX",
+        "COMMAND_SURFACE_SHELL_LINE_TOTAL_WARN_DELTA_MAX",
+        "COMMAND_SURFACE_SHELL_LINE_TOTAL_FAIL_DELTA_MAX",
+    )
+    for key in required:
+        if key not in raw_map:
+            raise ValueError(f"missing threshold key: {key}")
+        if not raw_map[key].isdigit():
+            raise ValueError(f"threshold value must be non-negative integer: {key}")
+        values[key] = int(raw_map[key])
+
+    if values["COMMAND_SURFACE_SCRIPT_COUNT_FAIL_DELTA_MAX"] < values["COMMAND_SURFACE_SCRIPT_COUNT_WARN_DELTA_MAX"]:
+        raise ValueError("COMMAND_SURFACE_SCRIPT_COUNT_FAIL_DELTA_MAX must be >= COMMAND_SURFACE_SCRIPT_COUNT_WARN_DELTA_MAX")
+    if values["COMMAND_SURFACE_SHELL_LINE_TOTAL_FAIL_DELTA_MAX"] < values["COMMAND_SURFACE_SHELL_LINE_TOTAL_WARN_DELTA_MAX"]:
+        raise ValueError("COMMAND_SURFACE_SHELL_LINE_TOTAL_FAIL_DELTA_MAX must be >= COMMAND_SURFACE_SHELL_LINE_TOTAL_WARN_DELTA_MAX")
+    return values
+
+try:
+    command_surface_thresholds = parse_env_thresholds(command_surface_threshold_path)
+except ValueError:
+    command_surface_thresholds = {}
+    command_surface_reason_codes.append("command_surface_trend_threshold_file_invalid")
+
+try:
+    command_surface_report = json.loads(command_surface_report_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError:
+    command_surface_report = {}
+    command_surface_reason_codes.append("command_surface_report_json_invalid")
+
+if command_surface_report.get("schema_version") != "kamn.ci.script-surface-budget-report.v1":
+    command_surface_reason_codes.append("command_surface_report_schema_mismatch")
+
+raw_command_surface_status = command_surface_report.get("status")
+if raw_command_surface_status in ("pass", "fail"):
+    command_surface_status = raw_command_surface_status
+else:
+    command_surface_reason_codes.append("command_surface_status_invalid")
+
+metrics = command_surface_report.get("metrics")
+deltas = command_surface_report.get("deltas")
+if isinstance(metrics, dict):
+    if isinstance(metrics.get("script_count"), int):
+        command_surface_script_count = metrics["script_count"]
+    else:
+        command_surface_reason_codes.append("command_surface_script_count_invalid")
+    if isinstance(metrics.get("shell_line_total"), int):
+        command_surface_shell_line_total = metrics["shell_line_total"]
+    else:
+        command_surface_reason_codes.append("command_surface_shell_line_total_invalid")
+else:
+    command_surface_reason_codes.append("command_surface_metrics_missing")
+
+if isinstance(deltas, dict):
+    if isinstance(deltas.get("script_count"), int):
+        command_surface_delta_script_count = deltas["script_count"]
+    else:
+        command_surface_reason_codes.append("command_surface_delta_script_count_invalid")
+    if isinstance(deltas.get("shell_line_total"), int):
+        command_surface_delta_shell_line_total = deltas["shell_line_total"]
+    else:
+        command_surface_reason_codes.append("command_surface_delta_shell_line_total_invalid")
+else:
+    command_surface_reason_codes.append("command_surface_deltas_missing")
+
+if command_surface_thresholds:
+    command_surface_warn_delta_script_count_max = command_surface_thresholds[
+        "COMMAND_SURFACE_SCRIPT_COUNT_WARN_DELTA_MAX"
+    ]
+    command_surface_fail_delta_script_count_max = command_surface_thresholds[
+        "COMMAND_SURFACE_SCRIPT_COUNT_FAIL_DELTA_MAX"
+    ]
+    command_surface_warn_delta_shell_line_total_max = command_surface_thresholds[
+        "COMMAND_SURFACE_SHELL_LINE_TOTAL_WARN_DELTA_MAX"
+    ]
+    command_surface_fail_delta_shell_line_total_max = command_surface_thresholds[
+        "COMMAND_SURFACE_SHELL_LINE_TOTAL_FAIL_DELTA_MAX"
+    ]
+
+if command_surface_checker_exit_code != 0 or command_surface_status != "pass":
+    command_surface_reason_codes.append("command_surface_budget_status_fail")
+
+has_delta_parse_errors = (
+    "command_surface_delta_script_count_invalid" in command_surface_reason_codes
+    or "command_surface_delta_shell_line_total_invalid" in command_surface_reason_codes
+)
+if command_surface_thresholds and not has_delta_parse_errors:
+    if command_surface_delta_script_count > command_surface_fail_delta_script_count_max:
+        command_surface_reason_codes.append("command_surface_script_count_trend_fail_delta_exceeded")
+    elif command_surface_delta_script_count > command_surface_warn_delta_script_count_max:
+        command_surface_reason_codes.append("command_surface_script_count_trend_warn_delta_exceeded")
+
+    if command_surface_delta_shell_line_total > command_surface_fail_delta_shell_line_total_max:
+        command_surface_reason_codes.append("command_surface_shell_line_total_trend_fail_delta_exceeded")
+    elif command_surface_delta_shell_line_total > command_surface_warn_delta_shell_line_total_max:
+        command_surface_reason_codes.append("command_surface_shell_line_total_trend_warn_delta_exceeded")
+
+if (
+    "command_surface_script_count_trend_fail_delta_exceeded" in command_surface_reason_codes
+    or "command_surface_shell_line_total_trend_fail_delta_exceeded" in command_surface_reason_codes
+):
+    command_surface_trend_status = "fail"
+elif (
+    "command_surface_script_count_trend_warn_delta_exceeded" in command_surface_reason_codes
+    or "command_surface_shell_line_total_trend_warn_delta_exceeded" in command_surface_reason_codes
+):
+    command_surface_trend_status = "warn"
+elif not command_surface_thresholds:
+    command_surface_trend_status = "invalid"
+elif has_delta_parse_errors:
+    command_surface_trend_status = "invalid"
+else:
+    command_surface_trend_status = "within"
+
+if (
+    command_surface_checker_exit_code != 0
+    or command_surface_status == "fail"
+    or command_surface_trend_status in ("fail", "invalid")
+):
+    command_surface_policy_decision = "NO-GO"
+elif command_surface_trend_status == "warn":
+    command_surface_policy_decision = "WARN"
+else:
+    command_surface_policy_decision = "GO"
+
+def decision_rank(value: str) -> int:
+    if value == "NO-GO":
+        return 2
+    if value == "WARN":
+        return 1
+    return 0
+
+harness_policy_decision = policy.get("policy_decision")
+if not isinstance(harness_policy_decision, str):
+    harness_policy_decision = "NO-GO"
+
+if decision_rank(harness_policy_decision) >= decision_rank(command_surface_policy_decision):
+    combined_policy_decision = harness_policy_decision
+else:
+    combined_policy_decision = command_surface_policy_decision
+
+harness_reason_codes = policy.get("reason_codes", [])
+if not isinstance(harness_reason_codes, list):
+    harness_reason_codes = []
+
+combined_reason_codes: list[str] = []
+for code in [*harness_reason_codes, *command_surface_reason_codes]:
+    if isinstance(code, str) and code and code not in combined_reason_codes:
+        combined_reason_codes.append(code)
+
+combined_review_required = bool(policy.get("review_required")) or command_surface_policy_decision != "GO"
+output_status = "ok"
+if enforce_command_surface_fail and command_surface_policy_decision == "NO-GO":
+    output_status = "fail"
+
 summary = {
     "schema_version": "kamn.ci.kolme-test-harness-loc-trend-report.v1",
-    "status": "ok",
+    "status": output_status,
     "source_report_file": str(report_path.resolve()),
     "source_policy_file": str(policy_path.resolve()),
+    "source_command_surface_report_file": str(command_surface_report_path.resolve()),
+    "command_surface_checker_exit_code": command_surface_checker_exit_code,
+    "harness_trend_status": policy.get("trend_status"),
+    "harness_policy_decision": harness_policy_decision,
+    "harness_reason_codes": harness_reason_codes,
     "harness_script_count": report.get("harness_script_count"),
     "harness_shell_line_total": report.get("harness_shell_line_total"),
     "soft_budget_status": policy.get("soft_budget_status"),
     "trend_status": policy.get("trend_status"),
-    "policy_decision": policy.get("policy_decision"),
-    "review_required": policy.get("review_required"),
-    "reason_codes": policy.get("reason_codes", []),
+    "policy_decision": combined_policy_decision,
+    "review_required": combined_review_required,
+    "reason_codes": combined_reason_codes,
     "delta_harness_script_count": policy.get("delta_harness_script_count"),
     "delta_harness_shell_line_total": policy.get("delta_harness_shell_line_total"),
+    "command_surface_status": command_surface_status,
+    "command_surface_trend_status": command_surface_trend_status,
+    "command_surface_policy_decision": command_surface_policy_decision,
+    "command_surface_reason_codes": command_surface_reason_codes,
+    "command_surface_script_count": command_surface_script_count,
+    "command_surface_shell_line_total": command_surface_shell_line_total,
+    "command_surface_delta_script_count": command_surface_delta_script_count,
+    "command_surface_delta_shell_line_total": command_surface_delta_shell_line_total,
+    "command_surface_warn_delta_script_count_max": command_surface_warn_delta_script_count_max,
+    "command_surface_fail_delta_script_count_max": command_surface_fail_delta_script_count_max,
+    "command_surface_warn_delta_shell_line_total_max": command_surface_warn_delta_shell_line_total_max,
+    "command_surface_fail_delta_shell_line_total_max": command_surface_fail_delta_shell_line_total_max,
+    "enforce_command_surface_fail": enforce_command_surface_fail,
 }
 
 output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
@@ -91,23 +355,23 @@ print(policy.get("trend_status", ""))
 PY
 )"
 
-policy_decision="$(python3 - "$policy_file" <<'PY'
+policy_decision="$(python3 - "$output_json" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-policy = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(policy.get("policy_decision", ""))
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("policy_decision", ""))
 PY
 )"
 
-reason_codes="$(python3 - "$policy_file" <<'PY'
+reason_codes="$(python3 - "$output_json" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-policy = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-codes = policy.get("reason_codes", [])
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+codes = payload.get("reason_codes", [])
 if not codes:
     print("none")
 else:
@@ -115,8 +379,44 @@ else:
 PY
 )"
 
-echo "status=ok"
+command_surface_trend_status="$(python3 - "$output_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("command_surface_trend_status", ""))
+PY
+)"
+
+command_surface_policy_decision="$(python3 - "$output_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("command_surface_policy_decision", ""))
+PY
+)"
+
+status_value="$(python3 - "$output_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("status", ""))
+PY
+)"
+
+echo "status=$status_value"
 echo "trend_status=$trend_status"
 echo "policy_decision=$policy_decision"
+echo "command_surface_trend_status=$command_surface_trend_status"
+echo "command_surface_policy_decision=$command_surface_policy_decision"
 echo "reason_codes=$reason_codes"
 echo "report_file=$(realpath "$output_json")"
+
+if [ "$enforce_command_surface_fail" -eq 1 ] && [ "$command_surface_policy_decision" = "NO-GO" ]; then
+  exit 1
+fi

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -227,7 +227,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    fixtures/ci/kolme_wave10_wrapper_family_matrix.json|fixtures/ci/kolme_wave10_wrapper_family_baseline.json|fixtures/ci/kolme_wave10_wrapper_family_trend_thresholds.json|.ci/kolme-test-harness-loc-trend-thresholds.env|scripts/ci/check_kolme_wave10_wrapper_family_budget_trend.sh|scripts/ci/generate_kolme_test_harness_loc_report.sh|scripts/ci/check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/check_test_harness_loc_soft_budget.py|scripts/ci/generate_kolme_test_harness_loc_trend_report.sh|scripts/ci/test_check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh)
+    fixtures/ci/kolme_wave10_wrapper_family_matrix.json|fixtures/ci/kolme_wave10_wrapper_family_baseline.json|fixtures/ci/kolme_wave10_wrapper_family_trend_thresholds.json|.ci/kolme-test-harness-loc-trend-thresholds.env|.ci/kolme-command-surface-soft-budget.env|.ci/kolme-command-surface-baseline.env|.ci/kolme-command-surface-trend-thresholds.env|scripts/ci/check_kolme_wave10_wrapper_family_budget_trend.sh|scripts/ci/generate_kolme_test_harness_loc_report.sh|scripts/ci/check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/check_test_harness_loc_soft_budget.py|scripts/ci/generate_kolme_test_harness_loc_trend_report.sh|scripts/ci/test_check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh)
       CI_STRATEGY_DOC_CONTRACT_CHANGED=true
       ci_contract_scope_only_candidate=true
       classified=true

--- a/scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh
+++ b/scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh
@@ -35,14 +35,42 @@ cat >"$within_input" <<'EOF_REPORT'
 }
 EOF_REPORT
 
+command_surface_within_report="$TMP_DIR/kolme-command-surface-within-report.json"
+cat >"$command_surface_within_report" <<'EOF_REPORT'
+{
+  "schema_version": "kamn.ci.script-surface-budget-report.v1",
+  "status": "pass",
+  "metrics": {
+    "script_count": 56,
+    "shell_line_total": 12958,
+    "duplicate_basename": 0,
+    "duplicate_content": 0
+  },
+  "deltas": {
+    "script_count": 0,
+    "shell_line_total": 0,
+    "duplicate_basename": 0,
+    "duplicate_content": 0
+  }
+}
+EOF_REPORT
+
 within_report="$TMP_DIR/kolme-trend-within.json"
-within_output="$(bash "$SCRIPT" --report-file "$within_input" --output-json "$within_report")"
+within_output="$(bash "$SCRIPT" --report-file "$within_input" --command-surface-report-file "$command_surface_within_report" --output-json "$within_report")"
 if ! printf '%s\n' "$within_output" | grep -q '^trend_status=within$'; then
   echo "expected trend_status=within for deterministic within-threshold trend report path" >&2
   exit 1
 fi
 if ! printf '%s\n' "$within_output" | grep -q '^policy_decision=GO$'; then
   echo "expected policy_decision=GO for deterministic within-threshold trend report path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$within_output" | grep -q '^command_surface_trend_status=within$'; then
+  echo "expected command_surface_trend_status=within for deterministic within-threshold trend report path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$within_output" | grep -q '^command_surface_policy_decision=GO$'; then
+  echo "expected command_surface_policy_decision=GO for deterministic within-threshold trend report path" >&2
   exit 1
 fi
 
@@ -56,13 +84,106 @@ cat >"$fail_input" <<'EOF_REPORT'
 EOF_REPORT
 
 fail_report="$TMP_DIR/kolme-trend-fail.json"
-fail_output="$(bash "$SCRIPT" --report-file "$fail_input" --output-json "$fail_report")"
+fail_output="$(bash "$SCRIPT" --report-file "$fail_input" --command-surface-report-file "$command_surface_within_report" --output-json "$fail_report")"
 if ! printf '%s\n' "$fail_output" | grep -q '^trend_status=fail$'; then
   echo "expected trend_status=fail for deterministic fail-threshold trend report path" >&2
   exit 1
 fi
 if ! printf '%s\n' "$fail_output" | grep -q '^policy_decision=NO-GO$'; then
   echo "expected policy_decision=NO-GO for deterministic fail-threshold trend report path" >&2
+  exit 1
+fi
+
+command_surface_warn_report="$TMP_DIR/kolme-command-surface-warn-report.json"
+cat >"$command_surface_warn_report" <<'EOF_REPORT'
+{
+  "schema_version": "kamn.ci.script-surface-budget-report.v1",
+  "status": "pass",
+  "metrics": {
+    "script_count": 60,
+    "shell_line_total": 14458,
+    "duplicate_basename": 0,
+    "duplicate_content": 0
+  },
+  "deltas": {
+    "script_count": 4,
+    "shell_line_total": 1500,
+    "duplicate_basename": 0,
+    "duplicate_content": 0
+  }
+}
+EOF_REPORT
+
+command_surface_warn_output="$(
+  bash "$SCRIPT" \
+    --report-file "$within_input" \
+    --command-surface-report-file "$command_surface_warn_report" \
+    --output-json "$TMP_DIR/kolme-command-surface-warn-trend.json"
+)"
+if ! printf '%s\n' "$command_surface_warn_output" | grep -q '^command_surface_trend_status=warn$'; then
+  echo "expected command_surface_trend_status=warn for deterministic warn command-surface trend path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$command_surface_warn_output" | grep -q '^command_surface_policy_decision=WARN$'; then
+  echo "expected command_surface_policy_decision=WARN for deterministic warn command-surface trend path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$command_surface_warn_output" | grep -q '^policy_decision=WARN$'; then
+  echo "expected combined policy_decision=WARN for deterministic warn command-surface trend path" >&2
+  exit 1
+fi
+
+command_surface_fail_report="$TMP_DIR/kolme-command-surface-fail-report.json"
+cat >"$command_surface_fail_report" <<'EOF_REPORT'
+{
+  "schema_version": "kamn.ci.script-surface-budget-report.v1",
+  "status": "pass",
+  "metrics": {
+    "script_count": 66,
+    "shell_line_total": 15358,
+    "duplicate_basename": 0,
+    "duplicate_content": 0
+  },
+  "deltas": {
+    "script_count": 10,
+    "shell_line_total": 2400,
+    "duplicate_basename": 0,
+    "duplicate_content": 0
+  }
+}
+EOF_REPORT
+
+command_surface_fail_output="$(
+  bash "$SCRIPT" \
+    --report-file "$within_input" \
+    --command-surface-report-file "$command_surface_fail_report" \
+    --output-json "$TMP_DIR/kolme-command-surface-fail-trend.json"
+)"
+if ! printf '%s\n' "$command_surface_fail_output" | grep -q '^command_surface_trend_status=fail$'; then
+  echo "expected command_surface_trend_status=fail for deterministic fail command-surface trend path" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$command_surface_fail_output" | grep -q '^command_surface_policy_decision=NO-GO$'; then
+  echo "expected command_surface_policy_decision=NO-GO for deterministic fail command-surface trend path" >&2
+  exit 1
+fi
+
+set +e
+command_surface_enforced_fail_output="$(
+  bash "$SCRIPT" \
+    --report-file "$within_input" \
+    --command-surface-report-file "$command_surface_fail_report" \
+    --enforce-command-surface-fail \
+    --output-json "$TMP_DIR/kolme-command-surface-fail-enforced-trend.json" 2>&1
+)"
+command_surface_enforced_fail_code=$?
+set -e
+if [ "$command_surface_enforced_fail_code" -eq 0 ]; then
+  echo "expected enforce-command-surface-fail to return non-zero for command-surface fail trend status" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$command_surface_enforced_fail_output" | grep -q '^status=fail$'; then
+  echo "expected status=fail marker for enforce-command-surface-fail path" >&2
   exit 1
 fi
 
@@ -79,6 +200,10 @@ for path in sys.argv[1:]:
         raise SystemExit("missing trend_status in Kolme trend report")
     if "policy_decision" not in payload:
         raise SystemExit("missing policy_decision in Kolme trend report")
+    if "command_surface_trend_status" not in payload:
+        raise SystemExit("missing command_surface_trend_status in Kolme trend report")
+    if "command_surface_policy_decision" not in payload:
+        raise SystemExit("missing command_surface_policy_decision in Kolme trend report")
 PY
 
 echo "Kolme test harness trend report generator tests passed."


### PR DESCRIPTION
## Summary
- Extended Kolme harness trend reporting to include deterministic command-surface drift metrics, policy decisions, and reason codes.
- Added versioned Kolme command-surface budget/baseline/trend-threshold configuration under `.ci/`.
- Updated docs and CI selector routing so command-surface drift remains visible in fast, low-cost contract checks.

## Linked Issues
- Closes #2402

## Changes
- `.ci/kolme-command-surface-soft-budget.env`: command-surface soft budget thresholds.
- `.ci/kolme-command-surface-baseline.env`: versioned baseline snapshot for `scripts/kolme` non-test shell command surface.
- `.ci/kolme-command-surface-trend-thresholds.env`: warning/fail delta thresholds for command-surface drift.
- `scripts/ci/generate_kolme_test_harness_loc_trend_report.sh`: added command-surface report ingestion/generation, trend classification, combined policy decision, deterministic reason codes, and optional `--enforce-command-surface-fail` non-zero mode.
- `scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh`: added deterministic coverage for within/warn/fail command-surface drift and enforce mode.
- `scripts/ci/select_targets.sh`: routed new `.ci/kolme-command-surface-*.env` files into Kolme CI budget contract scope.
- `docs/ci/strategy.md` and `docs/ci/ci-cost-and-lane-framework.md`: documented command-surface budget files, trend markers, and fail-enforcement semantics.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `bash scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh`
- Failure (before implementation): `missing command_surface_trend_status in Kolme trend report`

### 🟢 Green Phase
- `bash scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh`
- `bash scripts/ci/test_check_kolme_test_harness_loc_soft_budget.sh`
- `bash scripts/ci/test_select_targets.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `bash scripts/ci/test_ci_tools_command_surface_contract.sh`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` (known unrelated baseline fail on existing missing-docs velocity guard)

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | deterministic command-surface delta classification in `scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh` | |
| Functional   | ✅ | trend report generator + harness budget checker contract tests | |
| Integration  | ✅ | CI selector routing (`scripts/ci/test_select_targets.sh`) + CI strategy contract docs checks | |
| Regression   | ✅ | command-surface warn/fail/enforce reason-code coverage (`Regression: #2388`) | |
| Performance  | ✅ | checks are local shell/Python budget contracts suitable for fast-gate cost bounds | |

## Risks & Rollback
- Risk: stricter command-surface trend visibility may create additional WARN/NO-GO markers when non-test Kolme scripts grow quickly.
- Mitigation: default path remains soft-trend visibility with optional enforce mode; deterministic reason codes make drift reviewable.
- Rollback plan: revert commit `7aba85d`.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/ci/ci-cost-and-lane-framework.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: CI target selection + CI budget contract scripts/docs surface.
Expected runtime delta: negligible; deterministic shell/Python checks only.
Expected runner-minute delta: near-zero expected change for fast-gate.
Rollback plan if CI cost/runtime regresses: revert commit `7aba85d` and remove `.ci/kolme-command-surface-*.env` routing additions from `scripts/ci/select_targets.sh`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Unit / Functional / Integration / Regression / Performance coverage documented
