### PR TITLE
feat(node): integrate managed-external signer backend command adapter

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1,5 +1,8 @@
 use std::env;
-use std::process::ExitCode;
+use std::io::Read;
+use std::process::{Command, ExitCode, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use k256::ecdsa::{RecoveryId, Signature, SigningKey, VerifyingKey};
 use kamn_core::{
@@ -32,6 +35,11 @@ const KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK_ENV: &str =
     "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK";
 const KOLME_LIVE_SIGNER_KEY_REF_ENV: &str = "KAMN_KOLME_LIVE_SIGNER_KEY_REF";
 const KOLME_LIVE_SIGNER_KEY_REF_SECONDARY_ENV: &str = "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY";
+const KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV: &str = "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND";
+const KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV: &str =
+    "KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS";
+const KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_DEFAULT: u64 = 5;
+const KOLME_LIVE_MANAGED_SIGNER_POLL_INTERVAL_MILLIS: u64 = 10;
 const KOLME_LIVE_NATIVE_CREATED_AT: &str = "2026-02-12T00:00:00Z";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -883,6 +891,222 @@ fn map_kolme_live_secure_signer_backend_error(error: SignerBackendError) -> Conf
     ))
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManagedExternalBackendSignature {
+    signature_hex: String,
+    recovery_id: u8,
+}
+
+fn resolve_optional_kolme_live_managed_signer_command() -> Result<Option<String>, ConfigError> {
+    match env::var(KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV) {
+        Ok(command) => {
+            let trimmed = command.trim();
+            if trimmed.is_empty() {
+                return Err(ConfigError::RuntimeKolmeLive(format!(
+                    "{KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV} must not be empty when present (managed_signer_backend_unavailable)"
+                )));
+            }
+            Ok(Some(trimmed.to_owned()))
+        }
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err(ConfigError::RuntimeKolmeLive(format!(
+            "{KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV} must be valid utf-8 when present (managed_signer_backend_unavailable)"
+        ))),
+    }
+}
+
+fn resolve_kolme_live_managed_signer_timeout_seconds() -> Result<u64, ConfigError> {
+    match env::var(KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV) {
+        Ok(raw_timeout) => {
+            let trimmed = raw_timeout.trim();
+            if trimmed.is_empty() {
+                return Err(ConfigError::RuntimeKolmeLive(format!(
+                    "{KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV} must not be empty when present (managed_signer_backend_timeout_invalid)"
+                )));
+            }
+            let timeout = trimmed.parse::<u64>().map_err(|_| {
+                ConfigError::RuntimeKolmeLive(format!(
+                    "{KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV} must be a positive integer, found '{trimmed}' (managed_signer_backend_timeout_invalid)"
+                ))
+            })?;
+            if timeout == 0 {
+                return Err(ConfigError::RuntimeKolmeLive(format!(
+                    "{KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV} must be greater than zero (managed_signer_backend_timeout_invalid)"
+                )));
+            }
+            Ok(timeout)
+        }
+        Err(env::VarError::NotPresent) => Ok(KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_DEFAULT),
+        Err(env::VarError::NotUnicode(_)) => Err(ConfigError::RuntimeKolmeLive(format!(
+            "{KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV} must be valid utf-8 when present (managed_signer_backend_timeout_invalid)"
+        ))),
+    }
+}
+
+fn parse_kolme_live_managed_signer_command_output(
+    stdout: &str,
+) -> Result<ManagedExternalBackendSignature, ConfigError> {
+    let mut signature_hex = None;
+    let mut recovery_id = None;
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let (key, value) = trimmed.split_once('=').ok_or_else(|| {
+            ConfigError::RuntimeKolmeLive(format!(
+                "managed-external signer backend response line must be key=value, found '{trimmed}' (managed_signer_backend_response_malformed)"
+            ))
+        })?;
+        match key.trim() {
+            "signature_hex" => {
+                let value = value.trim();
+                if value.is_empty() {
+                    return Err(ConfigError::RuntimeKolmeLive(
+                        "managed-external signer backend response missing signature_hex value (managed_signer_backend_response_malformed)".to_owned(),
+                    ));
+                }
+                signature_hex = Some(value.to_owned());
+            }
+            "recovery_id" => {
+                let value = value.trim();
+                if value.is_empty() {
+                    return Err(ConfigError::RuntimeKolmeLive(
+                        "managed-external signer backend response missing recovery_id value (managed_signer_backend_response_malformed)".to_owned(),
+                    ));
+                }
+                recovery_id = Some(value.parse::<u8>().map_err(|_| {
+                    ConfigError::RuntimeKolmeLive(format!(
+                        "managed-external signer backend response recovery_id must be an integer, found '{value}' (managed_signer_backend_response_malformed)"
+                    ))
+                })?);
+            }
+            _ => {}
+        }
+    }
+    let signature_hex = signature_hex.ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive(
+            "managed-external signer backend response missing signature_hex key (managed_signer_backend_response_malformed)"
+                .to_owned(),
+        )
+    })?;
+    let recovery_id = recovery_id.ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive(
+            "managed-external signer backend response missing recovery_id key (managed_signer_backend_response_malformed)"
+                .to_owned(),
+        )
+    })?;
+    let signature_bytes = decode_kolme_hex_bytes(
+        signature_hex.as_str(),
+        "managed_external_signer_backend_signature_hex",
+    )
+    .map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signature hex is invalid: {error} (managed_signer_backend_response_malformed)"
+        ))
+    })?;
+    if signature_bytes.len() != 64 {
+        return Err(ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signature hex must decode to 64 bytes, found {} (managed_signer_backend_response_malformed)",
+            signature_bytes.len()
+        )));
+    }
+    if RecoveryId::from_byte(recovery_id).is_none() {
+        return Err(ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response recovery_id must be within secp256k1 range [0,3], found {recovery_id} (managed_signer_backend_response_malformed)"
+        )));
+    }
+    Ok(ManagedExternalBackendSignature {
+        signature_hex,
+        recovery_id,
+    })
+}
+
+fn execute_kolme_live_managed_signer_backend_command(
+    command: &str,
+    timeout_seconds: u64,
+    key_reference: &str,
+    signing_request: &SigningRequest,
+    canonical_message: &str,
+) -> Result<ManagedExternalBackendSignature, ConfigError> {
+    let nonce = signing_request.nonce.to_string();
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .env("KAMN_MANAGED_SIGNER_KEY_REFERENCE", key_reference)
+        .env("KAMN_MANAGED_SIGNER_ACTOR_DID", signing_request.sender.as_str())
+        .env("KAMN_MANAGED_SIGNER_NONCE", nonce.as_str())
+        .env("KAMN_MANAGED_SIGNER_STATE_ROOT", signing_request.state_hash.as_str())
+        .env("KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE", canonical_message)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            ConfigError::RuntimeKolmeLive(format!(
+                "managed-external signer backend unavailable: failed to spawn command from {KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV}: {error} (managed_signer_backend_unavailable)"
+            ))
+        })?;
+    let mut stdout = child.stdout.take().ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive(
+            "managed-external signer backend unavailable: stdout pipe was not configured (managed_signer_backend_unavailable)"
+                .to_owned(),
+        )
+    })?;
+    let mut stderr = child.stderr.take().ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive(
+            "managed-external signer backend unavailable: stderr pipe was not configured (managed_signer_backend_unavailable)"
+                .to_owned(),
+        )
+    })?;
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(ConfigError::RuntimeKolmeLive(format!(
+                        "managed-external signer backend timed out after {timeout_seconds}s (managed_signer_backend_timeout)"
+                    )));
+                }
+                thread::sleep(Duration::from_millis(
+                    KOLME_LIVE_MANAGED_SIGNER_POLL_INTERVAL_MILLIS,
+                ));
+            }
+            Err(error) => {
+                return Err(ConfigError::RuntimeKolmeLive(format!(
+                    "managed-external signer backend unavailable while waiting for completion: {error} (managed_signer_backend_unavailable)"
+                )))
+            }
+        }
+    };
+    let mut stdout_text = String::new();
+    stdout.read_to_string(&mut stdout_text).map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend unavailable: failed to read stdout: {error} (managed_signer_backend_unavailable)"
+        ))
+    })?;
+    let mut stderr_text = String::new();
+    stderr.read_to_string(&mut stderr_text).map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend unavailable: failed to read stderr: {error} (managed_signer_backend_unavailable)"
+        ))
+    })?;
+    if !status.success() {
+        let stderr_trimmed = stderr_text.trim();
+        let stderr_summary = if stderr_trimmed.is_empty() {
+            "no stderr output"
+        } else {
+            stderr_trimmed
+        };
+        return Err(ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend unavailable: command exited with status {status} ({stderr_summary}) (managed_signer_backend_unavailable)"
+        )));
+    }
+    parse_kolme_live_managed_signer_command_output(stdout_text.as_str())
+}
+
 fn sign_kolme_live_managed_external_message(
     key_reference: &str,
     request: &KolmeRuntimeCommitRequest,
@@ -913,6 +1137,35 @@ fn sign_kolme_live_managed_external_message(
         .sign(&signing_request)
         .map_err(map_kolme_live_secure_signer_backend_error)?;
     let signing_key = build_kolme_live_managed_signing_key(key_reference)?;
+    if let Some(command) = resolve_optional_kolme_live_managed_signer_command()? {
+        let timeout_seconds = resolve_kolme_live_managed_signer_timeout_seconds()?;
+        let backend_signature = execute_kolme_live_managed_signer_backend_command(
+            command.as_str(),
+            timeout_seconds,
+            key_reference,
+            &signing_request,
+            canonical_message,
+        )?;
+        let verifier = KolmeForkSecp256k1SignerAdapter {
+            signing_key,
+            private_key_env: KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV,
+        };
+        verifier
+            .verify_message(
+                canonical_message,
+                backend_signature.signature_hex.as_str(),
+                backend_signature.recovery_id,
+            )
+            .map_err(|error| {
+                ConfigError::RuntimeKolmeLive(format!(
+                    "managed-external signer backend response failed secp256k1 verification: {error} (managed_signer_backend_response_malformed)"
+                ))
+            })?;
+        return Ok((
+            backend_signature.signature_hex,
+            backend_signature.recovery_id,
+        ));
+    }
     let (signature, recovery_id) = signing_key
         .sign_recoverable(canonical_message.as_bytes())
         .map_err(|error| {
@@ -1128,7 +1381,7 @@ fn read_kolme_live_signer_private_key_hex_with_provider<P: KolmeLiveSignerSecret
         let key_reference = read_required_kolme_live_key_reference_from_env(&selection)?;
         ensure_kolme_live_managed_external_private_key_env_unset(&selection)?;
         return Err(ConfigError::RuntimeKolmeLive(format!(
-            "managed-external signer key reference {key_reference} from {} requires secure signer backend execution path (managed_signer_backend_path_not_integrated)",
+            "managed-external signer key reference {key_reference} from {} cannot use private-key signer adapter path; route through managed signer backend execution (managed_signer_private_key_adapter_unsupported)",
             selection.key_reference_env
         )));
     }
@@ -3504,6 +3757,127 @@ mod tests {
         assert!(
             matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_provider_unavailable")),
             "managed-external provider unavailability must map to deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_kolme_live_managed_external_backend_timeout_maps_reason_code() {
+        // Regression: #2423
+        let _lock = signer_env_lock()
+            .lock()
+            .expect("signer env lock should guard test mutation");
+        let _backend_command_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND", Some("sleep 2"));
+        let _backend_timeout_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS", Some("1"));
+        let request = KolmeRuntimeCommitRequest::deterministic(
+            "op-node-live-2423-timeout",
+            "state:node-live-2423-timeout",
+            "kamn:did:agent:node-live-2423-timeout",
+            1,
+            "payload:node-live-2423-timeout",
+        )
+        .expect("request should build");
+        let error = sign_kolme_live_managed_external_message(
+            TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
+            &request,
+            1,
+            "payload:managed-signature",
+            SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        )
+        .expect_err("managed-external backend timeout must fail closed");
+        assert!(
+            matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_timeout")),
+            "managed-external backend timeout must map to deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_kolme_live_managed_external_backend_malformed_response_maps_reason_code() {
+        // Regression: #2423
+        let _lock = signer_env_lock()
+            .lock()
+            .expect("signer env lock should guard test mutation");
+        let _backend_command_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
+            Some("printf 'signature_hex=zzzz\\nrecovery_id=9\\n'"),
+        );
+        let _backend_timeout_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS", Some("5"));
+        let request = KolmeRuntimeCommitRequest::deterministic(
+            "op-node-live-2423-malformed",
+            "state:node-live-2423-malformed",
+            "kamn:did:agent:node-live-2423-malformed",
+            1,
+            "payload:node-live-2423-malformed",
+        )
+        .expect("request should build");
+        let error = sign_kolme_live_managed_external_message(
+            TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
+            &request,
+            1,
+            "payload:managed-signature",
+            SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        )
+        .expect_err("managed-external backend malformed response must fail closed");
+        assert!(
+            matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_response_malformed")),
+            "managed-external backend malformed response must map to deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_kolme_live_managed_external_backend_unavailable_maps_reason_code() {
+        // Regression: #2423
+        let _lock = signer_env_lock()
+            .lock()
+            .expect("signer env lock should guard test mutation");
+        let _backend_command_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
+            Some("this-command-should-not-exist-2423"),
+        );
+        let _backend_timeout_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS", Some("5"));
+        let request = KolmeRuntimeCommitRequest::deterministic(
+            "op-node-live-2423-unavailable",
+            "state:node-live-2423-unavailable",
+            "kamn:did:agent:node-live-2423-unavailable",
+            1,
+            "payload:node-live-2423-unavailable",
+        )
+        .expect("request should build");
+        let error = sign_kolme_live_managed_external_message(
+            TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
+            &request,
+            1,
+            "payload:managed-signature",
+            SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        )
+        .expect_err("managed-external backend unavailability must fail closed");
+        assert!(
+            matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_unavailable")),
+            "managed-external backend unavailability must map to deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_kolme_live_managed_external_adapter_retired_not_integrated_marker() {
+        // Regression: #2423
+        let _lock = signer_env_lock()
+            .lock()
+            .expect("signer env lock should guard test mutation");
+        let _profile_env_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+        let _key_ref_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
+            Some(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE),
+        );
+        let _primary_key_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX", None);
+        let error = build_kolme_live_signer_adapter(Some("ops-primary"), Some("managed-external"))
+            .expect_err("managed-external private-key adapter path must fail closed");
+        assert!(
+            matches!(error, ConfigError::RuntimeKolmeLive(message) if !message.contains("managed_signer_backend_path_not_integrated")),
+            "managed-external signer adapter path must retire not-integrated marker"
         );
     }
 

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -240,6 +240,12 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - signer profile selector contract: `KAMN_KOLME_LIVE_SIGNER_PROFILE` with supported values `ops-primary` (default) and `ops-secondary`; unsupported values fail closed.
     - private key source contracts: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX` for `ops-primary`, `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY` for `ops-secondary` (required for selected profile; no fallback private key path).
     - signer adapter contract: `KolmeForkSecp256k1SignerAdapter` owns secp256k1 key decode, recoverable signing, and sign-then-verify compatibility checks against the selected signer key.
+    - managed-external backend command contract:
+      - optional command env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`.
+      - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`.
+      - command output contract (stdout, key-value lines): `signature_hex=<128-hex>` and `recovery_id=<0..3>`.
+      - timeout override marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS` (default `5`).
+      - deterministic backend reason-code classes: `managed_signer_backend_timeout`, `managed_signer_backend_unavailable`, `managed_signer_backend_response_malformed`.
     - malformed signature bytes, invalid recovery id, or recovered-key mismatch are rejected fail-closed before runtime submit dispatch.
     - fallback private key marker contract: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` must remain unset; policy fails closed with `fallback_signer_secret_present_violation` when present.
     - synthetic fallback signature material (`signature=<idempotency_key>`) is rejected by runtime tests/policies.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -560,6 +560,12 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `fallback signer secret env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK)`
   - real-node profile managed-external boundary rejects raw signer secret env and prints remediation:
     - `managed-external signer raw private key env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF)`
+  - real-node profile managed-external backend adapter command contract:
+    - optional command env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`
+    - optional timeout env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS` (default `5`)
+    - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`
+    - command output markers: `signature_hex=<128-hex>` and `recovery_id=<0..3>`
+    - deterministic managed-external backend failure reason codes: `managed_signer_backend_timeout`, `managed_signer_backend_unavailable`, `managed_signer_backend_response_malformed`
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:
     - `runtime_commit_in_memory_provider_reference_detected`
     - `runtime_commit_policy_check_in_memory_provider_reference_detected`


### PR DESCRIPTION
## Summary
This adds a managed-external signer backend command adapter path for `kolme-live` runtime signing in `kamn-node` and wires deterministic fail-closed reason-code mapping for backend timeout, unavailable backend, and malformed backend response scenarios.
It also retires the stale `managed_signer_backend_path_not_integrated` marker in the private-key signer adapter path.

Closes #2423

## Changes
- `crates/kamn-node/src/main.rs`: added optional managed-external backend command execution contract (`KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`), bounded timeout control (`KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS`), deterministic response parser/validator, and new regression tests for timeout/unavailable/malformed mapping + stale marker retirement.
- `docs/foundation/kolme-runtime-commit-client.md`: documented managed-external backend command input/output env contract, timeout marker, and deterministic reason-code taxonomy.
- `docs/planning/kolme-devnet-ops.md`: documented operator-facing managed-external backend command contract and reason-code mapping markers.

## Risks & Compatibility
- No breaking CLI changes.
- Managed-external command adapter path is opt-in via env marker; default behavior remains deterministic in-process signing when command marker is not set.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated new managed-external backend regression tests and full `kamn-node` test suite; validated edited docs via `kamn-core` doc-contract tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | New/updated managed-external signer adapter tests in `kamn-node` |
| Functional  | ✅ | Runtime signer command contract + reason-code checks in `kamn-node` tests |
| Integration | ✅ | `cargo test -p kamn-node` + docs contract tests in `kamn-core` |
| Regression  | ✅ | Added `Regression: #2423` coverage for timeout/unavailable/malformed + marker retirement |
