### PR TITLE
feat(deploy): add staging soak runtime telemetry thresholds

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -29,6 +29,32 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
 
 `scripts/ci/check_fast_gate_budget_delta_threshold.sh` fails closed when positive variance exceeds configured limits without a valid waiver.
 
+## Staging Soak Telemetry Policy
+Staging soak/rehearsal evidence for rollout readiness is generated and checked with:
+
+- `scripts/deploy/generate_staging_rehearsal_bundle.sh`
+- `scripts/deploy/check_staging_rehearsal_policy.sh`
+- `scripts/deploy/run_staging_rehearsal_contract_lane.sh`
+- `scripts/deploy/run_staging_rehearsal_deep_lane.sh` (manual/deep validation path)
+
+Deterministic runtime telemetry threshold fields in `kamn.release.staging-rehearsal.v1`:
+
+- `runtime_submit_success_rate_bps` with threshold `min_runtime_submit_success_rate_bps`
+- `runtime_finality_timeout_count` with threshold `max_runtime_finality_timeout_count`
+- `signer_profile_drift_events` with threshold `max_signer_profile_drift_events`
+
+Fail-closed reason codes for threshold overruns:
+
+- `runtime_submit_success_rate_below_threshold`
+- `runtime_finality_timeout_threshold_exceeded`
+- `signer_profile_drift_threshold_exceeded`
+
+Escalation path when telemetry thresholds fail:
+
+1. Open/update a tracking issue with threshold overrun evidence and candidate mitigation.
+2. Re-run `run_staging_rehearsal_contract_lane.sh` after mitigation.
+3. Use `run_staging_rehearsal_deep_lane.sh` for manual drift rehearsal before rollout approval.
+
 ## Script-Surface Budget Policy
 `scripts/ci/check_script_duplication_budget.py` computes deterministic metrics over non-test shell command surface under `scripts/**/*.sh`:
 
@@ -87,6 +113,8 @@ bash scripts/ci/test_check_script_duplication_budget.sh
 bash scripts/ci/test_generate_fast_gate_budget_delta_report.sh
 bash scripts/ci/test_check_fast_gate_budget_delta_threshold.sh
 bash scripts/ci/test_ci_tools.sh
+bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
+bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
 ```
 
 Kolme harness + command-surface trend validation:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -739,6 +739,28 @@ JSON`
   - runtime/deployment shared signer-attestation schema + reason-code parity remains fail-closed (`Regression: #2326`).
   - replay/tamper/stale-signer attestation regression matrix remains fail-closed (`Regression: #2327`).
 
+## Staging Soak Telemetry Lane (Issue #2422)
+
+- Fast lane command:
+  - `bash scripts/deploy/run_staging_rehearsal_contract_lane.sh`
+- Deep/manual lane command:
+  - `bash scripts/deploy/run_staging_rehearsal_deep_lane.sh`
+- Direct bundle generation command (explicit telemetry thresholds):
+  - `bash scripts/deploy/generate_staging_rehearsal_bundle.sh --output-file /tmp/staging-rehearsal-soak.json --release-candidate v1.1.0-rc.soak --deploy-status PASS --rollback-status PASS --rollback-target-hash state-hash-stable --post-rollback-hash state-hash-stable --recovery-time-seconds 420 --max-allowed-recovery-time-seconds 900 --evidence-complete true --ci-fast-gate PASS --runtime-submit-success-rate-bps 9950 --min-runtime-submit-success-rate-bps 9900 --runtime-finality-timeout-count 0 --max-runtime-finality-timeout-count 1 --signer-profile-drift-events 0 --max-signer-profile-drift-events 0`
+- Policy checker command:
+  - `bash scripts/deploy/check_staging_rehearsal_policy.sh --bundle-file /tmp/staging-rehearsal-soak.json`
+- Telemetry threshold markers:
+  - `runtime_submit_success_rate_bps` vs `min_runtime_submit_success_rate_bps`
+  - `runtime_finality_timeout_count` vs `max_runtime_finality_timeout_count`
+  - `signer_profile_drift_events` vs `max_signer_profile_drift_events`
+- Deterministic threshold reason codes:
+  - `runtime_submit_success_rate_below_threshold`
+  - `runtime_finality_timeout_threshold_exceeded`
+  - `signer_profile_drift_threshold_exceeded`
+- Interpretation contract:
+  - `final_decision=GO`: rollout soak telemetry remains within configured thresholds.
+  - `final_decision=NO-GO`: at least one runtime telemetry threshold exceeded; capture `reason_codes` from policy output and block promotion until remediated.
+
 ## Live Provider Operator Runbook (Issue #2114)
 
 ### Prerequisites (Local)

--- a/scripts/deploy/staging_rehearsal_contract.py
+++ b/scripts/deploy/staging_rehearsal_contract.py
@@ -23,6 +23,7 @@ from framework.contract_framework import (  # noqa: E402
 SCHEMA_VERSION = "kamn.release.staging-rehearsal.v1"
 GO_DECISION = "GO"
 NO_GO_DECISION = "NO-GO"
+MAX_BPS = 10_000
 
 
 def _parse_pass_fail(field_name: str, raw_value: str) -> str:
@@ -56,12 +57,22 @@ def _parse_positive_int(field_name: str, raw_value: str) -> int:
     return parsed
 
 
+def _parse_bps(field_name: str, raw_value: str) -> int:
+    parsed = _parse_non_negative_int(field_name, raw_value)
+    if parsed > MAX_BPS:
+        fail(f"{field_name} must be <= {MAX_BPS}")
+    return parsed
+
+
 def _compute_decision_reasons(
     *,
     deploy_status: str,
     rollback_status: str,
     rollback_hash_match: bool,
     mttr_within_bound: bool,
+    runtime_submit_success_rate_within_bound: bool,
+    runtime_finality_timeouts_within_bound: bool,
+    signer_profile_drift_within_bound: bool,
     evidence_complete: bool,
     ci_fast_gate: str,
 ) -> list[str]:
@@ -74,6 +85,12 @@ def _compute_decision_reasons(
         decision_reasons.append("rollback target hash mismatch")
     if not mttr_within_bound:
         decision_reasons.append("mttr-threshold-exceeded")
+    if not runtime_submit_success_rate_within_bound:
+        decision_reasons.append("runtime_submit_success_rate_below_threshold")
+    if not runtime_finality_timeouts_within_bound:
+        decision_reasons.append("runtime_finality_timeout_threshold_exceeded")
+    if not signer_profile_drift_within_bound:
+        decision_reasons.append("signer_profile_drift_threshold_exceeded")
     if not evidence_complete:
         decision_reasons.append("incomplete evidence")
     if ci_fast_gate != "PASS":
@@ -106,15 +123,45 @@ def generate_bundle(args: argparse.Namespace) -> int:
     max_allowed_recovery_time_seconds = _parse_positive_int(
         "max-allowed-recovery-time-seconds", args.max_allowed_recovery_time_seconds
     )
+    runtime_submit_success_rate_bps = _parse_bps(
+        "runtime-submit-success-rate-bps", args.runtime_submit_success_rate_bps
+    )
+    min_runtime_submit_success_rate_bps = _parse_bps(
+        "min-runtime-submit-success-rate-bps", args.min_runtime_submit_success_rate_bps
+    )
+    runtime_finality_timeout_count = _parse_non_negative_int(
+        "runtime-finality-timeout-count", args.runtime_finality_timeout_count
+    )
+    max_runtime_finality_timeout_count = _parse_non_negative_int(
+        "max-runtime-finality-timeout-count", args.max_runtime_finality_timeout_count
+    )
+    signer_profile_drift_events = _parse_non_negative_int(
+        "signer-profile-drift-events", args.signer_profile_drift_events
+    )
+    max_signer_profile_drift_events = _parse_non_negative_int(
+        "max-signer-profile-drift-events", args.max_signer_profile_drift_events
+    )
     evidence_complete = _parse_bool("evidence-complete", args.evidence_complete)
     rollback_hash_match = args.rollback_target_hash == args.post_rollback_hash
     mttr_within_bound = recovery_time_seconds <= max_allowed_recovery_time_seconds
+    runtime_submit_success_rate_within_bound = (
+        runtime_submit_success_rate_bps >= min_runtime_submit_success_rate_bps
+    )
+    runtime_finality_timeouts_within_bound = (
+        runtime_finality_timeout_count <= max_runtime_finality_timeout_count
+    )
+    signer_profile_drift_within_bound = (
+        signer_profile_drift_events <= max_signer_profile_drift_events
+    )
 
     decision_reasons = _compute_decision_reasons(
         deploy_status=deploy_status,
         rollback_status=rollback_status,
         rollback_hash_match=rollback_hash_match,
         mttr_within_bound=mttr_within_bound,
+        runtime_submit_success_rate_within_bound=runtime_submit_success_rate_within_bound,
+        runtime_finality_timeouts_within_bound=runtime_finality_timeouts_within_bound,
+        signer_profile_drift_within_bound=signer_profile_drift_within_bound,
         evidence_complete=evidence_complete,
         ci_fast_gate=ci_fast_gate,
     )
@@ -136,6 +183,15 @@ def generate_bundle(args: argparse.Namespace) -> int:
             "recovery_time_seconds": recovery_time_seconds,
             "max_allowed_recovery_time_seconds": max_allowed_recovery_time_seconds,
             "mttr_within_bound": mttr_within_bound,
+            "runtime_submit_success_rate_bps": runtime_submit_success_rate_bps,
+            "min_runtime_submit_success_rate_bps": min_runtime_submit_success_rate_bps,
+            "runtime_submit_success_rate_within_bound": runtime_submit_success_rate_within_bound,
+            "runtime_finality_timeout_count": runtime_finality_timeout_count,
+            "max_runtime_finality_timeout_count": max_runtime_finality_timeout_count,
+            "runtime_finality_timeouts_within_bound": runtime_finality_timeouts_within_bound,
+            "signer_profile_drift_events": signer_profile_drift_events,
+            "max_signer_profile_drift_events": max_signer_profile_drift_events,
+            "signer_profile_drift_within_bound": signer_profile_drift_within_bound,
             "evidence_complete": evidence_complete,
             "ci_fast_gate": ci_fast_gate,
         },
@@ -224,6 +280,89 @@ def check_bundle(args: argparse.Namespace) -> int:
     if not isinstance(mttr_within_bound, bool):
         fail("rehearsal.mttr_within_bound must be a boolean")
 
+    runtime_submit_success_rate_bps = _require_rehearsal_field(
+        rehearsal, "runtime_submit_success_rate_bps"
+    )
+    if not isinstance(runtime_submit_success_rate_bps, int) or isinstance(
+        runtime_submit_success_rate_bps, bool
+    ):
+        fail("rehearsal.runtime_submit_success_rate_bps must be an integer")
+    if runtime_submit_success_rate_bps < 0 or runtime_submit_success_rate_bps > MAX_BPS:
+        fail(f"rehearsal.runtime_submit_success_rate_bps must be within [0,{MAX_BPS}]")
+
+    min_runtime_submit_success_rate_bps = _require_rehearsal_field(
+        rehearsal, "min_runtime_submit_success_rate_bps"
+    )
+    if not isinstance(min_runtime_submit_success_rate_bps, int) or isinstance(
+        min_runtime_submit_success_rate_bps, bool
+    ):
+        fail("rehearsal.min_runtime_submit_success_rate_bps must be an integer")
+    if (
+        min_runtime_submit_success_rate_bps < 0
+        or min_runtime_submit_success_rate_bps > MAX_BPS
+    ):
+        fail(
+            f"rehearsal.min_runtime_submit_success_rate_bps must be within [0,{MAX_BPS}]"
+        )
+
+    runtime_submit_success_rate_within_bound = _require_rehearsal_field(
+        rehearsal, "runtime_submit_success_rate_within_bound"
+    )
+    if not isinstance(runtime_submit_success_rate_within_bound, bool):
+        fail("rehearsal.runtime_submit_success_rate_within_bound must be a boolean")
+
+    runtime_finality_timeout_count = _require_rehearsal_field(
+        rehearsal, "runtime_finality_timeout_count"
+    )
+    if not isinstance(runtime_finality_timeout_count, int) or isinstance(
+        runtime_finality_timeout_count, bool
+    ):
+        fail("rehearsal.runtime_finality_timeout_count must be an integer")
+    if runtime_finality_timeout_count < 0:
+        fail("rehearsal.runtime_finality_timeout_count must be >= 0")
+
+    max_runtime_finality_timeout_count = _require_rehearsal_field(
+        rehearsal, "max_runtime_finality_timeout_count"
+    )
+    if not isinstance(max_runtime_finality_timeout_count, int) or isinstance(
+        max_runtime_finality_timeout_count, bool
+    ):
+        fail("rehearsal.max_runtime_finality_timeout_count must be an integer")
+    if max_runtime_finality_timeout_count < 0:
+        fail("rehearsal.max_runtime_finality_timeout_count must be >= 0")
+
+    runtime_finality_timeouts_within_bound = _require_rehearsal_field(
+        rehearsal, "runtime_finality_timeouts_within_bound"
+    )
+    if not isinstance(runtime_finality_timeouts_within_bound, bool):
+        fail("rehearsal.runtime_finality_timeouts_within_bound must be a boolean")
+
+    signer_profile_drift_events = _require_rehearsal_field(
+        rehearsal, "signer_profile_drift_events"
+    )
+    if not isinstance(signer_profile_drift_events, int) or isinstance(
+        signer_profile_drift_events, bool
+    ):
+        fail("rehearsal.signer_profile_drift_events must be an integer")
+    if signer_profile_drift_events < 0:
+        fail("rehearsal.signer_profile_drift_events must be >= 0")
+
+    max_signer_profile_drift_events = _require_rehearsal_field(
+        rehearsal, "max_signer_profile_drift_events"
+    )
+    if not isinstance(max_signer_profile_drift_events, int) or isinstance(
+        max_signer_profile_drift_events, bool
+    ):
+        fail("rehearsal.max_signer_profile_drift_events must be an integer")
+    if max_signer_profile_drift_events < 0:
+        fail("rehearsal.max_signer_profile_drift_events must be >= 0")
+
+    signer_profile_drift_within_bound = _require_rehearsal_field(
+        rehearsal, "signer_profile_drift_within_bound"
+    )
+    if not isinstance(signer_profile_drift_within_bound, bool):
+        fail("rehearsal.signer_profile_drift_within_bound must be a boolean")
+
     evidence_complete = _require_rehearsal_field(rehearsal, "evidence_complete")
     if not isinstance(evidence_complete, bool):
         fail("rehearsal.evidence_complete must be a boolean")
@@ -249,15 +388,74 @@ def check_bundle(args: argparse.Namespace) -> int:
             f"compare as {derived_mttr_within_bound}"
         )
 
+    derived_runtime_submit_success_rate_within_bound = (
+        runtime_submit_success_rate_bps >= min_runtime_submit_success_rate_bps
+    )
+    if (
+        runtime_submit_success_rate_within_bound
+        != derived_runtime_submit_success_rate_within_bound
+    ):
+        fail(
+            "runtime submit success-rate threshold mismatch: "
+            f"declared runtime_submit_success_rate_within_bound={runtime_submit_success_rate_within_bound} "
+            f"but runtime_submit_success_rate_bps={runtime_submit_success_rate_bps} "
+            f"and min_runtime_submit_success_rate_bps={min_runtime_submit_success_rate_bps} "
+            f"compare as {derived_runtime_submit_success_rate_within_bound}"
+        )
+
+    derived_runtime_finality_timeouts_within_bound = (
+        runtime_finality_timeout_count <= max_runtime_finality_timeout_count
+    )
+    if (
+        runtime_finality_timeouts_within_bound
+        != derived_runtime_finality_timeouts_within_bound
+    ):
+        fail(
+            "runtime finality timeout threshold mismatch: "
+            f"declared runtime_finality_timeouts_within_bound={runtime_finality_timeouts_within_bound} "
+            f"but runtime_finality_timeout_count={runtime_finality_timeout_count} "
+            f"and max_runtime_finality_timeout_count={max_runtime_finality_timeout_count} "
+            f"compare as {derived_runtime_finality_timeouts_within_bound}"
+        )
+
+    derived_signer_profile_drift_within_bound = (
+        signer_profile_drift_events <= max_signer_profile_drift_events
+    )
+    if signer_profile_drift_within_bound != derived_signer_profile_drift_within_bound:
+        fail(
+            "signer profile drift threshold mismatch: "
+            f"declared signer_profile_drift_within_bound={signer_profile_drift_within_bound} "
+            f"but signer_profile_drift_events={signer_profile_drift_events} "
+            f"and max_signer_profile_drift_events={max_signer_profile_drift_events} "
+            f"compare as {derived_signer_profile_drift_within_bound}"
+        )
+
     decision_reasons = _compute_decision_reasons(
         deploy_status=deploy_status,
         rollback_status=rollback_status,
         rollback_hash_match=rollback_hash_match,
         mttr_within_bound=mttr_within_bound,
+        runtime_submit_success_rate_within_bound=runtime_submit_success_rate_within_bound,
+        runtime_finality_timeouts_within_bound=runtime_finality_timeouts_within_bound,
+        signer_profile_drift_within_bound=signer_profile_drift_within_bound,
         evidence_complete=evidence_complete,
         ci_fast_gate=ci_fast_gate,
     )
     expected_decision = GO_DECISION if not decision_reasons else NO_GO_DECISION
+    expected_decision_reasons = (
+        decision_reasons if decision_reasons else ["all rehearsal gates satisfied"]
+    )
+
+    actual_decision_reasons = payload.get("decision_reasons")
+    if not isinstance(actual_decision_reasons, list) or not all(
+        isinstance(reason, str) for reason in actual_decision_reasons
+    ):
+        fail("decision_reasons must be a list of strings")
+    if actual_decision_reasons != expected_decision_reasons:
+        fail(
+            "decision_reasons mismatch: "
+            f"expected {expected_decision_reasons}, found {actual_decision_reasons}"
+        )
 
     actual_decision = payload.get("final_decision")
     if actual_decision not in {GO_DECISION, NO_GO_DECISION}:
@@ -276,6 +474,31 @@ def check_bundle(args: argparse.Namespace) -> int:
     print(f"recovery_time_seconds={recovery_time_seconds}")
     print(f"max_allowed_recovery_time_seconds={max_allowed_recovery_time_seconds}")
     print(f"mttr_within_bound={str(mttr_within_bound).lower()}")
+    print(f"runtime_submit_success_rate_bps={runtime_submit_success_rate_bps}")
+    print(
+        f"min_runtime_submit_success_rate_bps={min_runtime_submit_success_rate_bps}"
+    )
+    print(
+        "runtime_submit_success_rate_within_bound="
+        f"{str(runtime_submit_success_rate_within_bound).lower()}"
+    )
+    print(f"runtime_finality_timeout_count={runtime_finality_timeout_count}")
+    print(
+        f"max_runtime_finality_timeout_count={max_runtime_finality_timeout_count}"
+    )
+    print(
+        "runtime_finality_timeouts_within_bound="
+        f"{str(runtime_finality_timeouts_within_bound).lower()}"
+    )
+    print(f"signer_profile_drift_events={signer_profile_drift_events}")
+    print(
+        f"max_signer_profile_drift_events={max_signer_profile_drift_events}"
+    )
+    print(
+        "signer_profile_drift_within_bound="
+        f"{str(signer_profile_drift_within_bound).lower()}"
+    )
+    print(f"reason_codes={','.join(expected_decision_reasons)}")
     print(f"evidence_complete={str(evidence_complete).lower()}")
     return 0
 
@@ -297,6 +520,12 @@ def build_parser() -> argparse.ArgumentParser:
     generate.add_argument("--max-allowed-recovery-time-seconds")
     generate.add_argument("--evidence-complete")
     generate.add_argument("--ci-fast-gate")
+    generate.add_argument("--runtime-submit-success-rate-bps", default="10000")
+    generate.add_argument("--min-runtime-submit-success-rate-bps", default="9900")
+    generate.add_argument("--runtime-finality-timeout-count", default="0")
+    generate.add_argument("--max-runtime-finality-timeout-count", default="1")
+    generate.add_argument("--signer-profile-drift-events", default="0")
+    generate.add_argument("--max-signer-profile-drift-events", default="0")
     generate.set_defaults(handler=generate_bundle)
 
     check = subparsers.add_parser("check")

--- a/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
+++ b/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
@@ -45,7 +45,13 @@ go_generate_output="$(
     --recovery-time-seconds 420 \
     --max-allowed-recovery-time-seconds 900 \
     --evidence-complete true \
-    --ci-fast-gate PASS
+    --ci-fast-gate PASS \
+    --runtime-submit-success-rate-bps 10000 \
+    --min-runtime-submit-success-rate-bps 9900 \
+    --runtime-finality-timeout-count 0 \
+    --max-runtime-finality-timeout-count 1 \
+    --signer-profile-drift-events 0 \
+    --max-signer-profile-drift-events 0
 )"
 
 assert_eq "$(extract_value "$go_generate_output" "status")" "generated" "expected GO rehearsal bundle generation to succeed"
@@ -98,6 +104,47 @@ mttr_no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$mttr_no_go_bu
 assert_eq "$(extract_value "$mttr_no_go_policy_output" "status")" "ok" "expected MTTR NO-GO rehearsal policy check to pass"
 assert_eq "$(extract_value "$mttr_no_go_policy_output" "final_decision")" "NO-GO" "expected MTTR NO-GO rehearsal policy check decision"
 assert_eq "$(extract_value "$mttr_no_go_policy_output" "mttr_within_bound")" "false" "expected MTTR NO-GO rehearsal policy check to report out-of-bound recovery time"
+
+telemetry_no_go_bundle="$TMP_DIR/rehearsal-no-go-telemetry.json"
+telemetry_no_go_generate_output="$(
+  bash "$GENERATOR" \
+    --output-file "$telemetry_no_go_bundle" \
+    --release-candidate "v1.1.0-rc.4" \
+    --deploy-status PASS \
+    --rollback-status PASS \
+    --rollback-target-hash "state-hash-stable" \
+    --post-rollback-hash "state-hash-stable" \
+    --recovery-time-seconds 420 \
+    --max-allowed-recovery-time-seconds 900 \
+    --evidence-complete true \
+    --ci-fast-gate PASS \
+    --runtime-submit-success-rate-bps 9200 \
+    --min-runtime-submit-success-rate-bps 9500 \
+    --runtime-finality-timeout-count 3 \
+    --max-runtime-finality-timeout-count 1 \
+    --signer-profile-drift-events 2 \
+    --max-signer-profile-drift-events 0
+)"
+
+assert_eq "$(extract_value "$telemetry_no_go_generate_output" "final_decision")" "NO-GO" "expected runtime telemetry threshold breach to force NO-GO"
+
+telemetry_no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$telemetry_no_go_bundle")"
+assert_eq "$(extract_value "$telemetry_no_go_policy_output" "status")" "ok" "expected telemetry NO-GO rehearsal policy check to pass"
+assert_eq "$(extract_value "$telemetry_no_go_policy_output" "final_decision")" "NO-GO" "expected telemetry NO-GO rehearsal policy check decision"
+
+telemetry_reason_codes="$(extract_value "$telemetry_no_go_policy_output" "reason_codes")"
+if ! printf '%s\n' "$telemetry_reason_codes" | grep -q "runtime_submit_success_rate_below_threshold"; then
+  echo "expected runtime submit success-rate threshold reason for telemetry NO-GO policy output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$telemetry_reason_codes" | grep -q "runtime_finality_timeout_threshold_exceeded"; then
+  echo "expected runtime finality-timeout threshold reason for telemetry NO-GO policy output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$telemetry_reason_codes" | grep -q "signer_profile_drift_threshold_exceeded"; then
+  echo "expected signer-profile drift threshold reason for telemetry NO-GO policy output" >&2
+  exit 1
+fi
 
 tampered_bundle="$TMP_DIR/rehearsal-tampered.json"
 cp "$no_go_bundle" "$tampered_bundle"


### PR DESCRIPTION
## Summary
This extends staging soak/rehearsal policy contracts with explicit live runtime telemetry thresholds for submit success rate, finality timeouts, and signer-profile drift.
It adds deterministic fail-closed reason-code mapping for telemetry overruns and updates the required CI-cost and Kolme devnet ops docs.

Closes #2425

## Changes
- `scripts/deploy/staging_rehearsal_contract.py`: added runtime telemetry threshold fields, derived bound checks, decision-reason mapping, decision-reason parity validation, and policy output reason codes.
- `scripts/deploy/test_generate_staging_rehearsal_bundle.sh`: added red/green regression coverage for telemetry threshold NO-GO scenarios and reason-code assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: added staging soak telemetry threshold policy + escalation path and local validation commands.
- `docs/planning/kolme-devnet-ops.md`: added staging soak telemetry lane invocation, threshold markers, reason codes, and interpretation contract.

## Risks & Compatibility
- Backward compatible: new staging rehearsal generator flags have deterministic defaults so existing command surfaces remain valid.
- Policy checker is stricter: malformed or drifted decision-reason/threshold markers fail closed by design.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (not applicable; no Rust source changed in this PR)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed staging rehearsal test lanes and docs contract test locally.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Threshold parsing and bound-derivation checks in `staging_rehearsal_contract.py` |
| Functional  | ✅ | `scripts/deploy/test_generate_staging_rehearsal_bundle.sh` GO/NO-GO telemetry scenarios |
| Integration | ✅ | `scripts/deploy/test_run_staging_rehearsal_contract_lane.sh` |
| Regression  | ✅ | Telemetry threshold reason-code assertions for submit/finality/signer-drift drift guards |
