### PR TITLE
feat(kolme): enforce runtime signer-quorum linkage contracts (#2433)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -405,6 +405,12 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_raw_private_key_present=false`
       - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
       - `runtime_signer_attestation_bundle`
+      - `runtime_signer_quorum_linkage_contract_version=v1`
+      - `runtime_signer_quorum_required_approvals`
+      - `runtime_signer_quorum_approved_signers_count`
+      - `runtime_signer_quorum_profile_linked`
+      - `runtime_signer_quorum_satisfied`
+      - `runtime_signer_quorum_linked`
     - strict secondary signer summary marker contracts:
       - `runtime_signer_profile=ops-secondary`
       - `runtime_signer_previous_profile=ops-secondary`
@@ -432,6 +438,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signer_attestation_approved_signers_not_unique`
       - `runtime_signer_attestation_quorum_shortfall`
       - `runtime_signer_attestation_schema_invalid`
+      - `runtime_signer_quorum_linkage_drift`
+      - `runtime_signer_quorum_linkage_violation`
       - `runtime_commit_non_synthetic_submit_probe_missing`
       - `runtime_commit_real_signing_profile_marker_missing`
       - `runtime_commit_simulated_signing_profile_detected`
@@ -529,6 +537,11 @@ JSON`
       - `contracts.runtime_signer_attestation_threshold_required=true`
       - `contracts.runtime_signer_attestation_profile_membership_required=true`
       - `contracts.runtime_signer_attestation_required_approvals=2`
+      - `contracts.runtime_signer_quorum_linkage_contract_version=v1`
+      - `contracts.runtime_signer_quorum_required_approvals=2`
+      - `contracts.runtime_signer_quorum_linked_required=true`
+      - `contracts.runtime_signer_quorum_threshold_required=true`
+      - `contracts.runtime_signer_quorum_profile_membership_required=true`
       - `contracts.custody_evidence_required=true`
       - `contracts.signer_provenance_required=true`
       - `contracts.signer_provenance_sha256_required=true`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -531,8 +531,17 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_raw_private_key_present=false`
     - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
     - `runtime_signer_attestation_bundle`
+    - `runtime_signer_quorum_linkage_contract_version=v1`
+    - `runtime_signer_quorum_required_approvals`
+    - `runtime_signer_quorum_approved_signers_count`
+    - `runtime_signer_quorum_profile_linked`
+    - `runtime_signer_quorum_satisfied`
+    - `runtime_signer_quorum_linked`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
+    - `contracts.runtime_signer_quorum_linked_required=true`
+    - `contracts.runtime_signer_quorum_threshold_required=true`
+    - `contracts.runtime_signer_quorum_profile_membership_required=true`
     - `contracts.runtime_signer_fallback_private_key_allowed=false`
     - `contracts.runtime_signer_managed_external_raw_private_key_allowed=false`
   - real-node profile accepts secondary signer summary/contracts markers for failover drills:
@@ -576,6 +585,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_attestation_approved_signers_not_unique`
     - `runtime_signer_attestation_quorum_shortfall`
     - `runtime_signer_attestation_schema_invalid`
+    - `runtime_signer_quorum_linkage_drift`
+    - `runtime_signer_quorum_linkage_violation`
   - integration summary emits `ci_fast_gate_eligible=false` with `contracts.ci_fast_gate_scope=local-only` for explicit PR-fast-gate exclusion enforcement.
   - explicit runtime-commit submit-profile probe over `PUT /broadcast` with fail-closed reason codes.
   - signed runtime-commit envelope translation enforces `signer_key_id` presence and canonical message/signature binding before broadcast normalization.

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -333,6 +333,90 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
                 if isinstance(entry, str) and entry.strip():
                     runtime_signer_attestation_approved_signers.append(entry.strip())
 
+    runtime_signer_quorum_linkage_contract_version = report.get(
+        "runtime_signer_quorum_linkage_contract_version"
+    )
+    if runtime_signer_quorum_linkage_contract_version is not None:
+        if (
+            not isinstance(runtime_signer_quorum_linkage_contract_version, str)
+            or not runtime_signer_quorum_linkage_contract_version.strip()
+        ):
+            reason_codes.append("runtime_signer_quorum_linkage_contract_version_invalid")
+        elif runtime_signer_quorum_linkage_contract_version != "v1":
+            reason_codes.append("runtime_signer_quorum_linkage_contract_version_mismatch")
+
+    runtime_signer_quorum_required_approvals = report.get(
+        "runtime_signer_quorum_required_approvals"
+    )
+    if runtime_signer_quorum_required_approvals is not None:
+        if (
+            not isinstance(runtime_signer_quorum_required_approvals, int)
+            or runtime_signer_quorum_required_approvals <= 0
+        ):
+            reason_codes.append("runtime_signer_quorum_required_approvals_invalid")
+        elif (
+            isinstance(runtime_signer_attestation_required_approvals, int)
+            and runtime_signer_quorum_required_approvals
+            != runtime_signer_attestation_required_approvals
+        ):
+            reason_codes.append("runtime_signer_quorum_required_approvals_mismatch")
+
+    expected_runtime_signer_quorum_profile_linked = (
+        isinstance(runtime_signer_profile, str)
+        and runtime_signer_profile.strip()
+        and runtime_signer_profile in runtime_signer_attestation_approved_signers
+    )
+    expected_runtime_signer_quorum_satisfied = (
+        isinstance(runtime_signer_attestation_required_approvals, int)
+        and len(runtime_signer_attestation_approved_signers)
+        >= runtime_signer_attestation_required_approvals
+    )
+    expected_runtime_signer_quorum_linked = (
+        expected_runtime_signer_quorum_profile_linked
+        and expected_runtime_signer_quorum_satisfied
+    )
+
+    runtime_signer_quorum_approved_signers_count = report.get(
+        "runtime_signer_quorum_approved_signers_count"
+    )
+    if runtime_signer_quorum_approved_signers_count is not None:
+        if (
+            not isinstance(runtime_signer_quorum_approved_signers_count, int)
+            or runtime_signer_quorum_approved_signers_count < 0
+        ):
+            reason_codes.append("runtime_signer_quorum_approved_signers_count_invalid")
+        elif runtime_signer_quorum_approved_signers_count != len(
+            runtime_signer_attestation_approved_signers
+        ):
+            reason_codes.append("runtime_signer_quorum_approved_signers_count_mismatch")
+
+    runtime_signer_quorum_profile_linked = report.get("runtime_signer_quorum_profile_linked")
+    if runtime_signer_quorum_profile_linked is not None:
+        if not isinstance(runtime_signer_quorum_profile_linked, bool):
+            reason_codes.append("runtime_signer_quorum_profile_linked_invalid")
+        elif runtime_signer_quorum_profile_linked != bool(
+            expected_runtime_signer_quorum_profile_linked
+        ):
+            reason_codes.append("runtime_signer_quorum_profile_linked_mismatch")
+
+    runtime_signer_quorum_satisfied = report.get("runtime_signer_quorum_satisfied")
+    if runtime_signer_quorum_satisfied is not None:
+        if not isinstance(runtime_signer_quorum_satisfied, bool):
+            reason_codes.append("runtime_signer_quorum_satisfied_invalid")
+        elif runtime_signer_quorum_satisfied != bool(expected_runtime_signer_quorum_satisfied):
+            reason_codes.append("runtime_signer_quorum_satisfied_mismatch")
+
+    runtime_signer_quorum_linked = report.get("runtime_signer_quorum_linked")
+    if runtime_signer_quorum_linked is None:
+        runtime_signer_quorum_linked = expected_runtime_signer_quorum_linked
+    elif not isinstance(runtime_signer_quorum_linked, bool):
+        reason_codes.append("runtime_signer_quorum_linked_invalid")
+    elif runtime_signer_quorum_linked != bool(expected_runtime_signer_quorum_linked):
+        reason_codes.append("runtime_signer_quorum_linkage_drift")
+
+    if runtime_signer_quorum_linked is False:
+        reason_codes.append("runtime_signer_quorum_linkage_violation")
+
     if isinstance(runtime_signer_failover_active, bool) and runtime_signer_failover_active:
         if (
             not isinstance(runtime_signer_attestation_required_approvals, int)
@@ -440,6 +524,34 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_attestation_threshold_required_contract_mismatch")
         if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
             reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_linkage_contract_version") not in (None, "v1"):
+            reason_codes.append("runtime_signer_quorum_linkage_contract_version_contract_mismatch")
+        expected_runtime_signer_quorum_required_approvals = (
+            runtime_signer_attestation_required_approvals
+            if isinstance(runtime_signer_attestation_required_approvals, int)
+            else 1
+        )
+        if contracts.get("runtime_signer_quorum_required_approvals") not in (
+            None,
+            expected_runtime_signer_quorum_required_approvals,
+        ):
+            reason_codes.append("runtime_signer_quorum_required_approvals_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_linked_required") not in (None, True):
+            reason_codes.append("runtime_signer_quorum_linked_required_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_threshold_required") not in (None, True):
+            reason_codes.append("runtime_signer_quorum_threshold_required_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_profile_membership_required") not in (
+            None,
+            True,
+        ):
+            reason_codes.append(
+                "runtime_signer_quorum_profile_membership_required_contract_mismatch"
+            )
+        if contracts.get("runtime_signer_quorum_linked") not in (
+            None,
+            bool(expected_runtime_signer_quorum_linked),
+        ):
+            reason_codes.append("runtime_signer_quorum_linked_contract_mismatch")
         expected_runtime_signer_attestation_required_approvals = (
             RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
             if runtime_signer_failover_active is True

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -298,6 +298,90 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
                 if isinstance(entry, str) and entry.strip():
                     runtime_signer_attestation_approved_signers.append(entry.strip())
 
+    runtime_signer_quorum_linkage_contract_version = report.get(
+        "runtime_signer_quorum_linkage_contract_version"
+    )
+    if runtime_signer_quorum_linkage_contract_version is not None:
+        if (
+            not isinstance(runtime_signer_quorum_linkage_contract_version, str)
+            or not runtime_signer_quorum_linkage_contract_version.strip()
+        ):
+            reason_codes.append("runtime_signer_quorum_linkage_contract_version_invalid")
+        elif runtime_signer_quorum_linkage_contract_version != "v1":
+            reason_codes.append("runtime_signer_quorum_linkage_contract_version_mismatch")
+
+    runtime_signer_quorum_required_approvals = report.get(
+        "runtime_signer_quorum_required_approvals"
+    )
+    if runtime_signer_quorum_required_approvals is not None:
+        if (
+            not isinstance(runtime_signer_quorum_required_approvals, int)
+            or runtime_signer_quorum_required_approvals <= 0
+        ):
+            reason_codes.append("runtime_signer_quorum_required_approvals_invalid")
+        elif (
+            isinstance(runtime_signer_attestation_required_approvals, int)
+            and runtime_signer_quorum_required_approvals
+            != runtime_signer_attestation_required_approvals
+        ):
+            reason_codes.append("runtime_signer_quorum_required_approvals_mismatch")
+
+    expected_runtime_signer_quorum_profile_linked = (
+        isinstance(runtime_signer_profile, str)
+        and runtime_signer_profile.strip()
+        and runtime_signer_profile in runtime_signer_attestation_approved_signers
+    )
+    expected_runtime_signer_quorum_satisfied = (
+        isinstance(runtime_signer_attestation_required_approvals, int)
+        and len(runtime_signer_attestation_approved_signers)
+        >= runtime_signer_attestation_required_approvals
+    )
+    expected_runtime_signer_quorum_linked = (
+        expected_runtime_signer_quorum_profile_linked
+        and expected_runtime_signer_quorum_satisfied
+    )
+
+    runtime_signer_quorum_approved_signers_count = report.get(
+        "runtime_signer_quorum_approved_signers_count"
+    )
+    if runtime_signer_quorum_approved_signers_count is not None:
+        if (
+            not isinstance(runtime_signer_quorum_approved_signers_count, int)
+            or runtime_signer_quorum_approved_signers_count < 0
+        ):
+            reason_codes.append("runtime_signer_quorum_approved_signers_count_invalid")
+        elif runtime_signer_quorum_approved_signers_count != len(
+            runtime_signer_attestation_approved_signers
+        ):
+            reason_codes.append("runtime_signer_quorum_approved_signers_count_mismatch")
+
+    runtime_signer_quorum_profile_linked = report.get("runtime_signer_quorum_profile_linked")
+    if runtime_signer_quorum_profile_linked is not None:
+        if not isinstance(runtime_signer_quorum_profile_linked, bool):
+            reason_codes.append("runtime_signer_quorum_profile_linked_invalid")
+        elif runtime_signer_quorum_profile_linked != bool(
+            expected_runtime_signer_quorum_profile_linked
+        ):
+            reason_codes.append("runtime_signer_quorum_profile_linked_mismatch")
+
+    runtime_signer_quorum_satisfied = report.get("runtime_signer_quorum_satisfied")
+    if runtime_signer_quorum_satisfied is not None:
+        if not isinstance(runtime_signer_quorum_satisfied, bool):
+            reason_codes.append("runtime_signer_quorum_satisfied_invalid")
+        elif runtime_signer_quorum_satisfied != bool(expected_runtime_signer_quorum_satisfied):
+            reason_codes.append("runtime_signer_quorum_satisfied_mismatch")
+
+    runtime_signer_quorum_linked = report.get("runtime_signer_quorum_linked")
+    if runtime_signer_quorum_linked is None:
+        runtime_signer_quorum_linked = expected_runtime_signer_quorum_linked
+    elif not isinstance(runtime_signer_quorum_linked, bool):
+        reason_codes.append("runtime_signer_quorum_linked_invalid")
+    elif runtime_signer_quorum_linked != bool(expected_runtime_signer_quorum_linked):
+        reason_codes.append("runtime_signer_quorum_linkage_drift")
+
+    if runtime_signer_quorum_linked is False:
+        reason_codes.append("runtime_signer_quorum_linkage_violation")
+
     if isinstance(runtime_signer_failover_active, bool) and runtime_signer_failover_active:
         if (
             not isinstance(runtime_signer_attestation_required_approvals, int)
@@ -494,6 +578,34 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_attestation_threshold_required_contract_mismatch")
         if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
             reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_linkage_contract_version") not in (None, "v1"):
+            reason_codes.append("runtime_signer_quorum_linkage_contract_version_contract_mismatch")
+        expected_runtime_signer_quorum_required_approvals = (
+            runtime_signer_attestation_required_approvals
+            if isinstance(runtime_signer_attestation_required_approvals, int)
+            else 1
+        )
+        if contracts.get("runtime_signer_quorum_required_approvals") not in (
+            None,
+            expected_runtime_signer_quorum_required_approvals,
+        ):
+            reason_codes.append("runtime_signer_quorum_required_approvals_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_linked_required") not in (None, True):
+            reason_codes.append("runtime_signer_quorum_linked_required_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_threshold_required") not in (None, True):
+            reason_codes.append("runtime_signer_quorum_threshold_required_contract_mismatch")
+        if contracts.get("runtime_signer_quorum_profile_membership_required") not in (
+            None,
+            True,
+        ):
+            reason_codes.append(
+                "runtime_signer_quorum_profile_membership_required_contract_mismatch"
+            )
+        if contracts.get("runtime_signer_quorum_linked") not in (
+            None,
+            bool(expected_runtime_signer_quorum_linked),
+        ):
+            reason_codes.append("runtime_signer_quorum_linked_contract_mismatch")
         expected_runtime_signer_attestation_required_approvals = (
             RUNTIME_SIGNER_FAILOVER_ATTESTATION_MIN_REQUIRED_APPROVALS
             if runtime_signer_failover_active is True

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -203,6 +203,24 @@ def main() -> int:
         if runtime_signer_attestation_bundle.get("approved_signers") != ["ops-primary"]:
             print("expected runtime signer attestation approved signers marker in dry-run summary", file=sys.stderr)
             return 1
+        if summary_payload.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+            print("expected runtime signer quorum linkage contract version marker in dry-run summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_signer_quorum_required_approvals") != 1:
+            print("expected runtime signer quorum required approvals marker in dry-run summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_signer_quorum_approved_signers_count") != 1:
+            print("expected runtime signer quorum approved signers count marker in dry-run summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_signer_quorum_profile_linked") is not True:
+            print("expected runtime signer quorum profile linked marker true in dry-run summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_signer_quorum_satisfied") is not True:
+            print("expected runtime signer quorum satisfied marker true in dry-run summary", file=sys.stderr)
+            return 1
+        if summary_payload.get("runtime_signer_quorum_linked") is not True:
+            print("expected runtime signer quorum linked marker true in dry-run summary", file=sys.stderr)
+            return 1
         contracts_payload = summary_payload.get("contracts")
         if not isinstance(contracts_payload, dict):
             print("expected contracts object in dry-run summary", file=sys.stderr)
@@ -239,6 +257,24 @@ def main() -> int:
             return 1
         if contracts_payload.get("runtime_signer_attestation_required_approvals") != 1:
             print("expected contracts runtime signer attestation required approvals marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+            print("expected contracts runtime signer quorum linkage contract version marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_quorum_required_approvals") != 1:
+            print("expected contracts runtime signer quorum required approvals marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_quorum_linked_required") is not True:
+            print("expected contracts runtime signer quorum linked-required marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_quorum_threshold_required") is not True:
+            print("expected contracts runtime signer quorum threshold-required marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_quorum_profile_membership_required") is not True:
+            print("expected contracts runtime signer quorum profile-membership marker in summary", file=sys.stderr)
+            return 1
+        if contracts_payload.get("runtime_signer_quorum_linked") is not True:
+            print("expected contracts runtime signer quorum linked marker in summary", file=sys.stderr)
             return 1
         checks_payload = summary_payload.get("checks")
         if not isinstance(checks_payload, list):
@@ -653,6 +689,19 @@ def main() -> int:
         attestation_quorum_shortfall_payload["runtime_signer_attestation_bundle"] = (
             attestation_quorum_shortfall_bundle
         )
+        attestation_quorum_shortfall_payload["runtime_signer_quorum_required_approvals"] = 2
+        attestation_quorum_shortfall_payload["runtime_signer_quorum_approved_signers_count"] = 1
+        attestation_quorum_shortfall_payload["runtime_signer_quorum_profile_linked"] = True
+        attestation_quorum_shortfall_payload["runtime_signer_quorum_satisfied"] = False
+        attestation_quorum_shortfall_payload["runtime_signer_quorum_linked"] = False
+        attestation_quorum_shortfall_contracts = dict(
+            attestation_quorum_shortfall_payload.get("contracts", {})
+        )
+        attestation_quorum_shortfall_contracts["runtime_signer_quorum_required_approvals"] = 2
+        attestation_quorum_shortfall_contracts["runtime_signer_quorum_linked"] = False
+        attestation_quorum_shortfall_payload["contracts"] = (
+            attestation_quorum_shortfall_contracts
+        )
         attestation_quorum_shortfall_report = temp_path / "runtime_attestation_quorum_shortfall_summary.json"
         attestation_quorum_shortfall_report.write_text(
             json.dumps(attestation_quorum_shortfall_payload, sort_keys=True, indent=2) + "\n",
@@ -688,6 +737,12 @@ def main() -> int:
         if "runtime_signer_attestation_quorum_shortfall" not in attestation_quorum_shortfall_output:
             print(
                 "expected runtime signer attestation quorum shortfall reason for policy failure",
+                file=sys.stderr,
+            )
+            return 1
+        if "runtime_signer_quorum_linkage_violation" not in attestation_quorum_shortfall_output:
+            print(
+                "expected runtime signer quorum linkage violation reason for policy failure",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -318,6 +318,24 @@ def main() -> int:
     if runtime_signer_attestation_bundle.get("approved_signers") != expected_attestation_signers:
         print("expected runtime signer attestation approved signers marker in contract-lane summary", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+        print("expected runtime signer quorum linkage contract version marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_quorum_required_approvals") != 1:
+        print("expected runtime signer quorum required approvals marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_quorum_approved_signers_count") != 1:
+        print("expected runtime signer quorum approved signers count marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_quorum_profile_linked") is not True:
+        print("expected runtime signer quorum profile linked marker true in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_quorum_satisfied") is not True:
+        print("expected runtime signer quorum satisfied marker true in contract-lane summary", file=sys.stderr)
+        return 1
+    if summary.get("runtime_signer_quorum_linked") is not True:
+        print("expected runtime signer quorum linked marker true in contract-lane summary", file=sys.stderr)
+        return 1
     checks = summary.get("checks")
     if not isinstance(checks, list):
         print("expected checks list in real-node profile contract-lane summary", file=sys.stderr)
@@ -403,6 +421,24 @@ def main() -> int:
     if contracts.get("runtime_signer_attestation_required_approvals") != 1:
         print("expected contracts runtime signer attestation required approvals marker in contract-lane summary", file=sys.stderr)
         return 1
+    if contracts.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+        print("expected contracts runtime signer quorum linkage contract version marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_quorum_required_approvals") != 1:
+        print("expected contracts runtime signer quorum required approvals marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_quorum_linked_required") is not True:
+        print("expected contracts runtime signer quorum linked-required marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_quorum_threshold_required") is not True:
+        print("expected contracts runtime signer quorum threshold-required marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_quorum_profile_membership_required") is not True:
+        print("expected contracts runtime signer quorum profile-membership marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_quorum_linked") is not True:
+        print("expected contracts runtime signer quorum linked marker in contract-lane summary", file=sys.stderr)
+        return 1
     if contracts.get("runtime_signer_failover_attestation_min_required_approvals") != 2:
         print(
             "expected contracts runtime signer failover attestation minimum approvals marker in contract-lane summary",
@@ -486,6 +522,11 @@ def main() -> int:
         forced_failover_go_summary["runtime_signer_attestation_bundle"] = (
             forced_failover_go_attestation_bundle
         )
+        forced_failover_go_summary["runtime_signer_quorum_required_approvals"] = 2
+        forced_failover_go_summary["runtime_signer_quorum_approved_signers_count"] = 2
+        forced_failover_go_summary["runtime_signer_quorum_profile_linked"] = True
+        forced_failover_go_summary["runtime_signer_quorum_satisfied"] = True
+        forced_failover_go_summary["runtime_signer_quorum_linked"] = True
         forced_failover_go_contracts = dict(summary.get("contracts", {}))
         forced_failover_go_contracts["runtime_signer_profile"] = alternate_signer_profile
         forced_failover_go_contracts["runtime_signer_private_key_env"] = (
@@ -495,6 +536,8 @@ def main() -> int:
             SIGNER_KEY_REF_ENV_BY_PROFILE[alternate_signer_profile]
         )
         forced_failover_go_contracts["runtime_signer_attestation_required_approvals"] = 2
+        forced_failover_go_contracts["runtime_signer_quorum_required_approvals"] = 2
+        forced_failover_go_contracts["runtime_signer_quorum_linked"] = True
         forced_failover_go_summary["contracts"] = forced_failover_go_contracts
         forced_failover_go_summary_file.write_text(
             json.dumps(forced_failover_go_summary, sort_keys=True, indent=2) + "\n",
@@ -994,6 +1037,19 @@ def main() -> int:
         attestation_quorum_shortfall_summary["runtime_signer_attestation_bundle"] = (
             attestation_quorum_shortfall_bundle
         )
+        attestation_quorum_shortfall_summary["runtime_signer_quorum_required_approvals"] = 2
+        attestation_quorum_shortfall_summary["runtime_signer_quorum_approved_signers_count"] = 1
+        attestation_quorum_shortfall_summary["runtime_signer_quorum_profile_linked"] = True
+        attestation_quorum_shortfall_summary["runtime_signer_quorum_satisfied"] = False
+        attestation_quorum_shortfall_summary["runtime_signer_quorum_linked"] = False
+        attestation_quorum_shortfall_contracts = dict(
+            attestation_quorum_shortfall_summary.get("contracts", {})
+        )
+        attestation_quorum_shortfall_contracts["runtime_signer_quorum_required_approvals"] = 2
+        attestation_quorum_shortfall_contracts["runtime_signer_quorum_linked"] = False
+        attestation_quorum_shortfall_summary["contracts"] = (
+            attestation_quorum_shortfall_contracts
+        )
         attestation_quorum_shortfall_summary_file.write_text(
             json.dumps(attestation_quorum_shortfall_summary, sort_keys=True, indent=2) + "\n",
             encoding="utf-8",
@@ -1022,6 +1078,12 @@ def main() -> int:
         if "runtime_signer_attestation_quorum_shortfall" not in attestation_quorum_shortfall_reason_codes:
             print(
                 "expected runtime_signer_attestation_quorum_shortfall in attestation quorum shortfall policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if "runtime_signer_quorum_linkage_violation" not in attestation_quorum_shortfall_reason_codes:
+            print(
+                "expected runtime_signer_quorum_linkage_violation in attestation quorum shortfall policy output",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
@@ -1005,6 +1005,19 @@ runtime_signer_attestation_bundle = {
     "signer_profile": runtime_signer_profile,
     "signer_key_source": runtime_signer_key_source,
 }
+runtime_signer_quorum_linkage_contract_version = "v1"
+runtime_signer_quorum_approved_signers_count = len(runtime_signer_attestation_approved_signers)
+runtime_signer_quorum_profile_linked = (
+    isinstance(runtime_signer_profile, str)
+    and runtime_signer_profile.strip()
+    and runtime_signer_profile in runtime_signer_attestation_approved_signers
+)
+runtime_signer_quorum_satisfied = (
+    runtime_signer_quorum_approved_signers_count >= runtime_signer_attestation_required_approvals
+)
+runtime_signer_quorum_linked = (
+    runtime_signer_quorum_profile_linked and runtime_signer_quorum_satisfied
+)
 
 summary = {
     "schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
@@ -1043,6 +1056,12 @@ summary = {
     "runtime_signer_raw_private_key_present": runtime_signer_raw_private_key_present,
     "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
     "runtime_signer_attestation_bundle": runtime_signer_attestation_bundle,
+    "runtime_signer_quorum_linkage_contract_version": runtime_signer_quorum_linkage_contract_version,
+    "runtime_signer_quorum_required_approvals": runtime_signer_attestation_required_approvals,
+    "runtime_signer_quorum_approved_signers_count": runtime_signer_quorum_approved_signers_count,
+    "runtime_signer_quorum_profile_linked": runtime_signer_quorum_profile_linked,
+    "runtime_signer_quorum_satisfied": runtime_signer_quorum_satisfied,
+    "runtime_signer_quorum_linked": runtime_signer_quorum_linked,
     "runtime_commit_live_policy_report": runtime_commit_live_policy_report,
     "runtime_commit_finality_command": runtime_commit_finality_command if runtime_commit_finality_command else "",
     "runtime_commit_finality_output_file": runtime_commit_finality_output_file if runtime_commit_finality_command else "",
@@ -1081,6 +1100,12 @@ summary = {
         "runtime_signer_attestation_threshold_required": True,
         "runtime_signer_attestation_profile_membership_required": True,
         "runtime_signer_attestation_required_approvals": runtime_signer_attestation_required_approvals,
+        "runtime_signer_quorum_linkage_contract_version": runtime_signer_quorum_linkage_contract_version,
+        "runtime_signer_quorum_required_approvals": runtime_signer_attestation_required_approvals,
+        "runtime_signer_quorum_linked_required": True,
+        "runtime_signer_quorum_threshold_required": True,
+        "runtime_signer_quorum_profile_membership_required": True,
+        "runtime_signer_quorum_linked": runtime_signer_quorum_linked,
         "runtime_commit_endpoint": "/broadcast/runtime-commit",
         "runtime_commit_method": "POST",
         "runtime_commit_finality_primary_endpoint": "/notifications",

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -20,6 +20,7 @@ TMP_REPORT_SPLIT_BRAIN="$TMP_DIR/split-brain-report.json"
 TMP_REPORT_FAILOVER_ATTESTATION_QUORUM_INSUFFICIENT="$TMP_DIR/failover-attestation-quorum-insufficient-report.json"
 TMP_REPORT_ATTESTATION_DUPLICATE="$TMP_DIR/attestation-duplicate-report.json"
 TMP_REPORT_ATTESTATION_QUORUM_SHORTFALL="$TMP_DIR/attestation-quorum-shortfall-report.json"
+TMP_REPORT_QUORUM_LINKAGE_DRIFT="$TMP_DIR/quorum-linkage-drift-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_REPORT_SYNTHETIC="$TMP_DIR/synthetic-report.json"
 TMP_REPORT_SIMULATED="$TMP_DIR/simulated-signing-profile-report.json"
@@ -97,6 +98,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "signer_profile": "ops-primary",
     "signer_key_source": "env-local"
   },
+  "runtime_signer_quorum_linkage_contract_version": "v1",
+  "runtime_signer_quorum_required_approvals": 1,
+  "runtime_signer_quorum_approved_signers_count": 1,
+  "runtime_signer_quorum_profile_linked": true,
+  "runtime_signer_quorum_satisfied": true,
+  "runtime_signer_quorum_linked": true,
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_command_profile_version": "v1",
@@ -135,6 +142,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_attestation_threshold_required": true,
     "runtime_signer_attestation_profile_membership_required": true,
     "runtime_signer_attestation_required_approvals": 1,
+    "runtime_signer_quorum_linkage_contract_version": "v1",
+    "runtime_signer_quorum_required_approvals": 1,
+    "runtime_signer_quorum_linked_required": true,
+    "runtime_signer_quorum_threshold_required": true,
+    "runtime_signer_quorum_profile_membership_required": true,
+    "runtime_signer_quorum_linked": true,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
     "runtime_commit_method": "POST",
     "runtime_commit_finality_primary_endpoint": "/notifications",
@@ -640,6 +653,39 @@ fi
 
 if ! grep -q "runtime_signer_attestation_quorum_shortfall" "$TMP_ERR"; then
   echo "expected attestation quorum shortfall reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_QUORUM_LINKAGE_DRIFT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_quorum_linked"] = False
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_QUORUM_LINKAGE_DRIFT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+quorum_linkage_drift_exit_code=$?
+set -e
+
+if [ "$quorum_linkage_drift_exit_code" -eq 0 ]; then
+  echo "expected signer quorum linkage drift proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_quorum_linkage_drift" "$TMP_ERR"; then
+  echo "expected signer quorum linkage drift reason for policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -412,6 +412,30 @@ if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is n
     raise SystemExit(
         "expected contracts managed-external raw private key allowed=false marker in contract-lane summary"
     )
+if summary.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+    raise SystemExit("expected runtime signer quorum linkage contract version marker in contract-lane summary")
+if summary.get("runtime_signer_quorum_required_approvals") != 1:
+    raise SystemExit("expected runtime signer quorum required approvals marker in contract-lane summary")
+if summary.get("runtime_signer_quorum_approved_signers_count") != 1:
+    raise SystemExit("expected runtime signer quorum approved signers count marker in contract-lane summary")
+if summary.get("runtime_signer_quorum_profile_linked") is not True:
+    raise SystemExit("expected runtime signer quorum profile-linked marker true in contract-lane summary")
+if summary.get("runtime_signer_quorum_satisfied") is not True:
+    raise SystemExit("expected runtime signer quorum satisfied marker true in contract-lane summary")
+if summary.get("runtime_signer_quorum_linked") is not True:
+    raise SystemExit("expected runtime signer quorum linked marker true in contract-lane summary")
+if contracts.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+    raise SystemExit("expected contracts runtime signer quorum linkage contract version marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_required_approvals") != 1:
+    raise SystemExit("expected contracts runtime signer quorum required approvals marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_linked_required") is not True:
+    raise SystemExit("expected contracts runtime signer quorum linked-required marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_threshold_required") is not True:
+    raise SystemExit("expected contracts runtime signer quorum threshold-required marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_profile_membership_required") is not True:
+    raise SystemExit("expected contracts runtime signer quorum profile-membership marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_linked") is not True:
+    raise SystemExit("expected contracts runtime signer quorum linked marker in contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("unexpected local KAMN live runtime integration contract-lane policy schema")
 if policy.get("final_decision") != "GO":

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -347,6 +347,18 @@ if attestation_bundle.get("required_approvals") != 1:
     raise SystemExit("expected runtime signer attestation required approvals marker in real-node profile contract-lane summary")
 if attestation_bundle.get("approved_signers") != ["ops-primary"]:
     raise SystemExit("expected runtime signer attestation approved signer marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+    raise SystemExit("expected runtime signer quorum linkage contract version marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_quorum_required_approvals") != 1:
+    raise SystemExit("expected runtime signer quorum required approvals marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_quorum_approved_signers_count") != 1:
+    raise SystemExit("expected runtime signer quorum approved signers count marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_quorum_profile_linked") is not True:
+    raise SystemExit("expected runtime signer quorum profile-linked marker true in real-node profile contract-lane summary")
+if summary.get("runtime_signer_quorum_satisfied") is not True:
+    raise SystemExit("expected runtime signer quorum satisfied marker true in real-node profile contract-lane summary")
+if summary.get("runtime_signer_quorum_linked") is not True:
+    raise SystemExit("expected runtime signer quorum linked marker true in real-node profile contract-lane summary")
 checks = summary.get("checks", [])
 if not any(
     isinstance(check, dict)
@@ -392,6 +404,18 @@ if contracts.get("runtime_signer_attestation_signer_uniqueness_required") is not
     raise SystemExit("expected contracts runtime signer attestation signer-uniqueness requirement marker")
 if contracts.get("runtime_signer_attestation_threshold_required") is not True:
     raise SystemExit("expected contracts runtime signer attestation threshold requirement marker")
+if contracts.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+    raise SystemExit("expected contracts runtime signer quorum linkage contract version marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_quorum_required_approvals") != 1:
+    raise SystemExit("expected contracts runtime signer quorum required approvals marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_quorum_linked_required") is not True:
+    raise SystemExit("expected contracts runtime signer quorum linked-required marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_quorum_threshold_required") is not True:
+    raise SystemExit("expected contracts runtime signer quorum threshold-required marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_quorum_profile_membership_required") is not True:
+    raise SystemExit("expected contracts runtime signer quorum profile-membership marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_quorum_linked") is not True:
+    raise SystemExit("expected contracts runtime signer quorum linked marker in real-node profile contract-lane summary")
 if policy.get("schema_version") != "kamn.kolme.local-kamn-live-runtime-real-node-policy-report.v1":
     raise SystemExit("unexpected real-node profile contract-lane policy schema")
 if policy.get("final_decision") != "GO":
@@ -437,6 +461,18 @@ if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected secondary signer fallback private key presence marker false in contract-lane summary")
 if summary.get("runtime_signer_raw_private_key_present") is not False:
     raise SystemExit("expected secondary signer raw private key presence marker false in contract-lane summary")
+if summary.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+    raise SystemExit("expected secondary signer quorum linkage contract version marker in contract-lane summary")
+if summary.get("runtime_signer_quorum_required_approvals") != 1:
+    raise SystemExit("expected secondary signer quorum required approvals marker in contract-lane summary")
+if summary.get("runtime_signer_quorum_approved_signers_count") != 1:
+    raise SystemExit("expected secondary signer quorum approved signers count marker in contract-lane summary")
+if summary.get("runtime_signer_quorum_profile_linked") is not True:
+    raise SystemExit("expected secondary signer quorum profile-linked marker true in contract-lane summary")
+if summary.get("runtime_signer_quorum_satisfied") is not True:
+    raise SystemExit("expected secondary signer quorum satisfied marker true in contract-lane summary")
+if summary.get("runtime_signer_quorum_linked") is not True:
+    raise SystemExit("expected secondary signer quorum linked marker true in contract-lane summary")
 contracts = summary.get("contracts", {})
 if contracts.get("runtime_signer_profile") != "ops-secondary":
     raise SystemExit("expected contracts secondary signer profile marker in contract-lane summary")
@@ -460,6 +496,18 @@ if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") i
     )
 if contracts.get("runtime_signer_managed_external_raw_private_key_allowed") is not False:
     raise SystemExit("expected contracts secondary signer managed-external raw private key allowed=false marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_linkage_contract_version") != "v1":
+    raise SystemExit("expected contracts secondary signer quorum linkage contract version marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_required_approvals") != 1:
+    raise SystemExit("expected contracts secondary signer quorum required approvals marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_linked_required") is not True:
+    raise SystemExit("expected contracts secondary signer quorum linked-required marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_threshold_required") is not True:
+    raise SystemExit("expected contracts secondary signer quorum threshold-required marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_profile_membership_required") is not True:
+    raise SystemExit("expected contracts secondary signer quorum profile-membership marker in contract-lane summary")
+if contracts.get("runtime_signer_quorum_linked") is not True:
+    raise SystemExit("expected contracts secondary signer quorum linked marker in contract-lane summary")
 if policy.get("final_decision") != "GO":
     raise SystemExit("expected secondary signer policy final_decision GO")
 if policy.get("reason_codes") != []:


### PR DESCRIPTION
## Summary
This change adds deterministic runtime signer-quorum linkage markers to local KAMN live runtime integration summaries and enforces fail-closed quorum linkage validation in both integration and real-node profile policy checkers. It closes the runtime evidence gap where signer attestation data existed but explicit signer-quorum linkage contracts were not first-class, versioned policy inputs.

Closes #2433
Closes #2439
Closes #2440

## Changes
- scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh: added runtime signer-quorum linkage summary/contracts markers.
- scripts/kolme/check_local_kamn_live_runtime_integration_policy.py: added signer-quorum linkage validation and drift/violation reason-code checks.
- scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py: added signer-quorum linkage validation and drift/violation reason-code checks.
- scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py: added quorum marker assertions and quorum-shortfall violation regression checks.
- scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py: added quorum marker assertions, forced-failover matrix alignment updates, and quorum-shortfall violation checks.
- scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh: added quorum-linkage fixture coverage and drift negative proof.
- scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh: added summary/contracts quorum marker assertions.
- scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh: added primary/secondary summary/contracts quorum marker assertions.
- docs/planning/kolme-devnet-ops.md and docs/ci/strategy.md: documented new quorum linkage marker/reason-code contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands (pre-fix failure states observed):
- `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/realnode-summary.json --policy-output-json /tmp/realnode-policy.json`
  - failure: `expected forced failover GO scenario matrix proof to pass`
- `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/realnode-summary.json --policy-output-json /tmp/realnode-policy.json`
  - failure: `expected runtime_signer_quorum_linkage_violation in attestation quorum shortfall policy output`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/realnode-summary.json --policy-output-json /tmp/realnode-policy.json`
- `bash scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh --output-json /tmp/integration-summary.json --policy-output-json /tmp/integration-policy.json`

Observed:
- both contract lanes pass with quorum linkage markers and fail-closed drift behavior.

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_integration_policy.py scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`
- `bash -n scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`

Observed:
- all checks pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | checker-level quorum marker parsing/validation paths | |
| Functional   | ✅     | summary/contracts marker assertions in contract lane tests | |
| Integration  | ✅     | integration + real-node contract lane GO/NO-GO coverage | |
| Regression   | ✅     | quorum linkage drift/shortfall negative proofs | |
| Performance  | N/A    | metadata/policy checks only; no runtime throughput path changes | offline lane checks |

## Risks & Rollback
- Risk: stricter quorum linkage validation can surface additional NO-GO outcomes on previously under-specified summaries.
- Rollback: revert commit `7c68e57`.

## Documentation Updates
- docs/planning/kolme-devnet-ops.md
- docs/ci/strategy.md

## Validation Checklist
- [x] `cargo fmt --check` — clean (not applicable; no Rust changes)
- [x] `cargo clippy -- -D warnings` — clean (not applicable; no Rust changes)
- [x] TDD Red/Green evidence included above
