### PR TITLE
feat(kolme): add deployment drift telemetry admission bundle checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,8 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # quorum_evidence_rotation_metadata_valid
 # runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1
 # runtime_signer_attestation_bundle
+# runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1
+# runtime_signer_drift_telemetry
 # contracts.ci_fast_gate_scope=ci-fast-gate
 # contracts.required_runtime_mode=kolme-live
 # contracts.fallback_private_key_path_allowed=false
@@ -779,6 +781,12 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.runtime_signer_attestation_threshold_required=true
 # contracts.runtime_signer_attestation_profile_membership_required=true
 # contracts.runtime_signer_attestation_required_approvals=2
+# contracts.runtime_signer_drift_telemetry_required=true
+# contracts.runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1
+# contracts.runtime_signer_drift_telemetry_rotation_delta_match_required=true
+# contracts.runtime_signer_drift_telemetry_stale_flag_match_required=true
+# contracts.runtime_signer_drift_telemetry_quorum_flag_match_required=true
+# contracts.runtime_signer_drift_telemetry_approval_counts_match_required=true
 # contracts.custody_evidence_required=true
 # contracts.signer_provenance_required=true
 # contracts.signer_provenance_sha256_required=true
@@ -819,6 +827,9 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # runtime_signer_attestation_approved_signers_not_unique
 # runtime_signer_attestation_quorum_shortfall
 # runtime_signer_attestation_schema_invalid
+# runtime_signer_drift_telemetry_missing
+# runtime_signer_drift_telemetry_schema_version_mismatch
+# runtime_signer_drift_telemetry_rotation_delta_invalid
 # custody_evidence_missing
 # custody_evidence_sha256_invalid
 # signer_key_source_contract_version_mismatch

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -55,6 +55,27 @@ Escalation path when telemetry thresholds fail:
 2. Re-run `run_staging_rehearsal_contract_lane.sh` after mitigation.
 3. Use `run_staging_rehearsal_deep_lane.sh` for manual drift rehearsal before rollout approval.
 
+## Deployment Preflight Runtime-Signer Drift Telemetry Policy
+Kolme deployment admission preflight emits deterministic runtime signer drift telemetry in
+`kamn.kolme.local-live-deployment-preflight-summary.v1`:
+
+- `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
+- `runtime_signer_drift_telemetry` bundle with rotation and quorum drift fields
+- `contracts.runtime_signer_drift_telemetry_required=true`
+
+Fail-closed reason codes for missing/malformed telemetry:
+
+- `runtime_signer_drift_telemetry_missing`
+- `runtime_signer_drift_telemetry_schema_version_mismatch`
+- `runtime_signer_drift_telemetry_rotation_delta_invalid`
+
+Coverage split for cost control:
+
+- fast lane: `run_local_kolme_live_deployment_preflight_lane.sh` +
+  `check_local_kolme_live_deployment_preflight_policy.py` (ci-fast-gate eligible)
+- contract lane: `run_local_kolme_live_deployment_preflight_contract_lane.sh` for docs/policy parity
+- local-heavy/deep integration remains outside fast gate and opt-in only
+
 ## Script-Surface Budget Policy
 `scripts/ci/check_script_duplication_budget.py` computes deterministic metrics over non-test shell command surface under `scripts/**/*.sh`:
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -517,6 +517,8 @@ JSON`
       - `quorum_evidence_rotation_metadata_valid`
       - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
       - `runtime_signer_attestation_bundle`
+      - `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
+      - `runtime_signer_drift_telemetry`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
       - `contracts.required_runtime_mode=kolme-live`
       - `contracts.fallback_private_key_path_allowed=false`
@@ -537,6 +539,12 @@ JSON`
       - `contracts.runtime_signer_attestation_threshold_required=true`
       - `contracts.runtime_signer_attestation_profile_membership_required=true`
       - `contracts.runtime_signer_attestation_required_approvals=2`
+      - `contracts.runtime_signer_drift_telemetry_required=true`
+      - `contracts.runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
+      - `contracts.runtime_signer_drift_telemetry_rotation_delta_match_required=true`
+      - `contracts.runtime_signer_drift_telemetry_stale_flag_match_required=true`
+      - `contracts.runtime_signer_drift_telemetry_quorum_flag_match_required=true`
+      - `contracts.runtime_signer_drift_telemetry_approval_counts_match_required=true`
       - `contracts.runtime_signer_quorum_linkage_contract_version=v1`
       - `contracts.runtime_signer_quorum_required_approvals=2`
       - `contracts.runtime_signer_quorum_linked_required=true`
@@ -581,6 +589,9 @@ JSON`
       - `runtime_signer_attestation_approved_signers_not_unique`
       - `runtime_signer_attestation_quorum_shortfall`
       - `runtime_signer_attestation_schema_invalid`
+      - `runtime_signer_drift_telemetry_missing`
+      - `runtime_signer_drift_telemetry_schema_version_mismatch`
+      - `runtime_signer_drift_telemetry_rotation_delta_invalid`
       - `custody_evidence_missing`
       - `custody_evidence_sha256_invalid`
       - `signer_key_source_contract_version_mismatch`

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -23,7 +23,10 @@ For semantic versioning policy and compatibility rules, see `docs/foundation/ver
 - Required signer-custody markers:
   - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
   - `fallback_signer_secret_present=false`
+  - `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
+  - `runtime_signer_drift_telemetry`
   - `contracts.fallback_private_key_path_allowed=false`
+  - `contracts.runtime_signer_drift_telemetry_required=true`
   - `required_approvals=2`
   - `received_approvals=2`
   - `contracts.approval_quorum_required=2`
@@ -33,6 +36,9 @@ For semantic versioning policy and compatibility rules, see `docs/foundation/ver
   - `signer_quorum_shortfall`
   - `custody_evidence_missing`
   - `custody_evidence_sha256_invalid`
+  - `runtime_signer_drift_telemetry_missing`
+  - `runtime_signer_drift_telemetry_schema_version_mismatch`
+  - `runtime_signer_drift_telemetry_rotation_delta_invalid`
 
 ## Deterministic Dry-Run Workflow
 1. Create release candidate tag.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -672,6 +672,8 @@ JSON`
     - `quorum_evidence_rotation_metadata_valid`
     - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
     - `runtime_signer_attestation_bundle`
+    - `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
+    - `runtime_signer_drift_telemetry`
     - `custody_evidence_file`
     - `custody_evidence_present`
     - `custody_evidence_sha256_valid`
@@ -699,6 +701,12 @@ JSON`
     - `contracts.runtime_signer_attestation_threshold_required=true`
     - `contracts.runtime_signer_attestation_profile_membership_required=true`
     - `contracts.runtime_signer_attestation_required_approvals=2`
+    - `contracts.runtime_signer_drift_telemetry_required=true`
+    - `contracts.runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
+    - `contracts.runtime_signer_drift_telemetry_rotation_delta_match_required=true`
+    - `contracts.runtime_signer_drift_telemetry_stale_flag_match_required=true`
+    - `contracts.runtime_signer_drift_telemetry_quorum_flag_match_required=true`
+    - `contracts.runtime_signer_drift_telemetry_approval_counts_match_required=true`
     - `contracts.custody_evidence_required=true`
     - `contracts.custody_evidence_sha256_required=true`
     - `contracts.signer_provenance_required=true`
@@ -734,6 +742,9 @@ JSON`
   - `runtime_signer_attestation_approved_signers_not_unique`
   - `runtime_signer_attestation_quorum_shortfall`
   - `runtime_signer_attestation_schema_invalid`
+  - `runtime_signer_drift_telemetry_missing`
+  - `runtime_signer_drift_telemetry_schema_version_mismatch`
+  - `runtime_signer_drift_telemetry_rotation_delta_invalid`
   - `custody_evidence_missing`
   - `custody_evidence_sha256_invalid`
   - `signer_key_source_contract_version_mismatch`

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -15,6 +15,7 @@ FALLBACK_SIGNER_SECRET_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 REQUIRED_SECRET_HEX_LENGTH = 64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION = "kamn.kolme.runtime-signer-attestation.v1"
+RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION = "kamn.kolme.runtime-signer-drift-telemetry.v1"
 QUORUM_EVIDENCE_SCHEMA_VERSION = RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION
 ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
@@ -58,6 +59,126 @@ def evaluate_runtime_signer_attestation_bundle(
             and runtime_signer_profile not in normalized_signers
         ):
             reason_codes.append("runtime_signer_attestation_profile_not_approved")
+
+    return reason_codes
+
+
+def evaluate_runtime_signer_drift_telemetry(
+    telemetry_bundle: object,
+    expected_required_approvals: object,
+    expected_received_approvals: object,
+    expected_rotation_delta_epochs: object,
+    expected_rotation_freshness_max_delta: object,
+) -> list[str]:
+    reason_codes: list[str] = []
+    if not isinstance(telemetry_bundle, dict):
+        return ["runtime_signer_drift_telemetry_missing"]
+
+    if telemetry_bundle.get("schema_version") != RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_drift_telemetry_schema_invalid")
+
+    signer_rotation_epoch = telemetry_bundle.get("signer_rotation_epoch")
+    if not isinstance(signer_rotation_epoch, int) or signer_rotation_epoch <= 0:
+        reason_codes.append("runtime_signer_drift_telemetry_rotation_epoch_invalid")
+
+    signer_previous_rotation_epoch = telemetry_bundle.get("signer_previous_rotation_epoch")
+    if not isinstance(signer_previous_rotation_epoch, int) or signer_previous_rotation_epoch <= 0:
+        reason_codes.append("runtime_signer_drift_telemetry_previous_rotation_epoch_invalid")
+
+    signer_rotation_delta_epochs = telemetry_bundle.get("signer_rotation_delta_epochs")
+    if not isinstance(signer_rotation_delta_epochs, int) or signer_rotation_delta_epochs < 0:
+        reason_codes.append("runtime_signer_drift_telemetry_rotation_delta_invalid")
+
+    signer_rotation_freshness_max_delta = telemetry_bundle.get("signer_rotation_freshness_max_delta")
+    if (
+        not isinstance(signer_rotation_freshness_max_delta, int)
+        or signer_rotation_freshness_max_delta < 0
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_freshness_delta_invalid")
+
+    signer_rotation_stale = telemetry_bundle.get("signer_rotation_stale")
+    if not isinstance(signer_rotation_stale, bool):
+        reason_codes.append("runtime_signer_drift_telemetry_stale_flag_invalid")
+
+    required_approvals = telemetry_bundle.get("required_approvals")
+    if not isinstance(required_approvals, int) or required_approvals <= 0:
+        reason_codes.append("runtime_signer_drift_telemetry_required_approvals_invalid")
+
+    received_approvals = telemetry_bundle.get("received_approvals")
+    if not isinstance(received_approvals, int) or received_approvals < 0:
+        reason_codes.append("runtime_signer_drift_telemetry_received_approvals_invalid")
+
+    quorum_shortfall = telemetry_bundle.get("quorum_shortfall")
+    if not isinstance(quorum_shortfall, bool):
+        reason_codes.append("runtime_signer_drift_telemetry_quorum_shortfall_flag_invalid")
+
+    if (
+        isinstance(signer_rotation_epoch, int)
+        and signer_rotation_epoch > 0
+        and isinstance(signer_previous_rotation_epoch, int)
+        and signer_previous_rotation_epoch > 0
+        and isinstance(signer_rotation_delta_epochs, int)
+        and signer_rotation_delta_epochs >= 0
+        and signer_rotation_delta_epochs != signer_rotation_epoch - signer_previous_rotation_epoch
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_rotation_delta_mismatch")
+
+    if (
+        isinstance(signer_rotation_delta_epochs, int)
+        and signer_rotation_delta_epochs >= 0
+        and isinstance(signer_rotation_freshness_max_delta, int)
+        and signer_rotation_freshness_max_delta >= 0
+        and isinstance(signer_rotation_stale, bool)
+        and signer_rotation_stale
+        != (signer_rotation_delta_epochs > signer_rotation_freshness_max_delta)
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_stale_flag_mismatch")
+
+    if (
+        isinstance(expected_required_approvals, int)
+        and expected_required_approvals > 0
+        and isinstance(required_approvals, int)
+        and required_approvals > 0
+        and required_approvals != expected_required_approvals
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_required_approvals_mismatch")
+
+    if (
+        isinstance(expected_received_approvals, int)
+        and expected_received_approvals >= 0
+        and isinstance(received_approvals, int)
+        and received_approvals >= 0
+        and received_approvals != expected_received_approvals
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_received_approvals_mismatch")
+
+    if (
+        isinstance(required_approvals, int)
+        and required_approvals > 0
+        and isinstance(received_approvals, int)
+        and received_approvals >= 0
+        and isinstance(quorum_shortfall, bool)
+        and quorum_shortfall != (received_approvals < required_approvals)
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_quorum_shortfall_flag_mismatch")
+
+    if (
+        isinstance(expected_rotation_delta_epochs, int)
+        and expected_rotation_delta_epochs >= 0
+        and isinstance(signer_rotation_delta_epochs, int)
+        and signer_rotation_delta_epochs >= 0
+        and signer_rotation_delta_epochs != expected_rotation_delta_epochs
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_rotation_delta_contract_mismatch")
+
+    if (
+        isinstance(expected_rotation_freshness_max_delta, int)
+        and expected_rotation_freshness_max_delta >= 0
+        and isinstance(signer_rotation_freshness_max_delta, int)
+        and signer_rotation_freshness_max_delta >= 0
+        and signer_rotation_freshness_max_delta != expected_rotation_freshness_max_delta
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_freshness_delta_contract_mismatch")
 
     return reason_codes
 
@@ -340,6 +461,27 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif "runtime_signer_attestation_profile_not_approved" in reason_codes and runtime_signer_attestation_profile_approved:
         reason_codes.append("runtime_signer_attestation_profile_approved_contract_mismatch")
 
+    runtime_signer_drift_telemetry_schema_version = report.get(
+        "runtime_signer_drift_telemetry_schema_version"
+    )
+    if (
+        not isinstance(runtime_signer_drift_telemetry_schema_version, str)
+        or not runtime_signer_drift_telemetry_schema_version.strip()
+    ):
+        reason_codes.append("runtime_signer_drift_telemetry_schema_version_missing")
+    elif runtime_signer_drift_telemetry_schema_version != RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_drift_telemetry_schema_version_mismatch")
+
+    reason_codes.extend(
+        evaluate_runtime_signer_drift_telemetry(
+            report.get("runtime_signer_drift_telemetry"),
+            required_approvals,
+            received_approvals,
+            signer_rotation_delta_epochs,
+            signer_rotation_freshness_max_delta,
+        )
+    )
+
     custody_evidence_file = report.get("custody_evidence_file")
     if not isinstance(custody_evidence_file, str):
         reason_codes.append("custody_evidence_file_invalid")
@@ -429,6 +571,21 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_attestation_profile_membership_required_contract_mismatch")
         if contracts.get("runtime_signer_attestation_required_approvals") != required_approvals:
             reason_codes.append("runtime_signer_attestation_required_approvals_contract_mismatch")
+        if contracts.get("runtime_signer_drift_telemetry_required") is not True:
+            reason_codes.append("runtime_signer_drift_telemetry_required_contract_mismatch")
+        if (
+            contracts.get("runtime_signer_drift_telemetry_schema_version")
+            != RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION
+        ):
+            reason_codes.append("runtime_signer_drift_telemetry_schema_version_contract_mismatch")
+        if contracts.get("runtime_signer_drift_telemetry_rotation_delta_match_required") is not True:
+            reason_codes.append("runtime_signer_drift_telemetry_rotation_delta_match_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_telemetry_stale_flag_match_required") is not True:
+            reason_codes.append("runtime_signer_drift_telemetry_stale_flag_match_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_telemetry_quorum_flag_match_required") is not True:
+            reason_codes.append("runtime_signer_drift_telemetry_quorum_flag_match_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_telemetry_approval_counts_match_required") is not True:
+            reason_codes.append("runtime_signer_drift_telemetry_approval_counts_match_required_contract_mismatch")
         if contracts.get("custody_evidence_required") is not True:
             reason_codes.append("custody_evidence_required_contract_mismatch")
         if contracts.get("custody_evidence_sha256_required") is not True:

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -234,6 +234,25 @@ def main() -> int:
     if runtime_signer_attestation_bundle.get("approved_signers") != ["ops-primary", "ops-secondary"]:
         print("expected deployment preflight summary runtime signer attestation approved signers marker", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_drift_telemetry_schema_version") != "kamn.kolme.runtime-signer-drift-telemetry.v1":
+        print("expected deployment preflight summary runtime signer drift telemetry schema marker", file=sys.stderr)
+        return 1
+    runtime_signer_drift_telemetry = summary.get("runtime_signer_drift_telemetry")
+    if not isinstance(runtime_signer_drift_telemetry, dict):
+        print("expected deployment preflight summary runtime signer drift telemetry bundle", file=sys.stderr)
+        return 1
+    if runtime_signer_drift_telemetry.get("schema_version") != "kamn.kolme.runtime-signer-drift-telemetry.v1":
+        print("expected deployment preflight summary runtime signer drift telemetry bundle schema marker", file=sys.stderr)
+        return 1
+    if runtime_signer_drift_telemetry.get("signer_rotation_delta_epochs") != summary.get("signer_rotation_delta_epochs"):
+        print("expected deployment preflight summary runtime signer drift telemetry rotation delta marker", file=sys.stderr)
+        return 1
+    if runtime_signer_drift_telemetry.get("required_approvals") != summary.get("required_approvals"):
+        print("expected deployment preflight summary runtime signer drift telemetry required approvals marker", file=sys.stderr)
+        return 1
+    if runtime_signer_drift_telemetry.get("received_approvals") != summary.get("received_approvals"):
+        print("expected deployment preflight summary runtime signer drift telemetry received approvals marker", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in deployment preflight summary", file=sys.stderr)
@@ -306,6 +325,24 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_attestation_required_approvals") != 2:
         print("expected deployment preflight contracts runtime signer attestation required approvals marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_telemetry_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift telemetry requirement marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_telemetry_schema_version") != "kamn.kolme.runtime-signer-drift-telemetry.v1":
+        print("expected deployment preflight contracts runtime signer drift telemetry schema marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_telemetry_rotation_delta_match_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift telemetry rotation delta match marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_telemetry_stale_flag_match_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift telemetry stale flag match marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_telemetry_quorum_flag_match_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift telemetry quorum flag match marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_telemetry_approval_counts_match_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift telemetry approval count match marker", file=sys.stderr)
         return 1
     if contracts.get("custody_evidence_required") is not True:
         print("expected deployment preflight contracts custody_evidence_required=true", file=sys.stderr)
@@ -709,6 +746,67 @@ def main() -> int:
             print("expected schema-invalid signer attestation policy final_decision NO-GO", file=sys.stderr)
             return 1
 
+        drift_telemetry_negative_report = temp_path / "runtime_signer_drift_telemetry_negative_summary.json"
+        drift_telemetry_negative_policy = temp_path / "runtime_signer_drift_telemetry_negative_policy.json"
+        drift_telemetry_negative_summary = dict(summary)
+        drift_telemetry_negative_summary["mode"] = "run"
+        drift_telemetry_negative_summary["status"] = "fail"
+        drift_telemetry_negative_summary["reason_code"] = "checkpoint_failed_signer_rotation_freshness_contract"
+        drift_telemetry_negative_summary["signer_secret_present"] = True
+        drift_telemetry_negative_summary["signer_secret_hex_valid"] = True
+        drift_telemetry_negative_summary["required_approvals"] = 2
+        drift_telemetry_negative_summary["received_approvals"] = 1
+        drift_telemetry_negative_summary["runtime_signer_drift_telemetry_schema_version"] = (
+            "kamn.kolme.runtime-signer-drift-telemetry.v0"
+        )
+        drift_telemetry_negative_summary["runtime_signer_drift_telemetry"] = {
+            "schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v0",
+            "signer_rotation_epoch": 3,
+            "signer_previous_rotation_epoch": 1,
+            "signer_rotation_delta_epochs": "bad",
+            "signer_rotation_freshness_max_delta": -1,
+            "signer_rotation_stale": "bad",
+            "required_approvals": 2,
+            "received_approvals": 1,
+            "quorum_shortfall": "bad",
+        }
+        drift_telemetry_negative_report.write_text(
+            json.dumps(drift_telemetry_negative_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        drift_telemetry_no_go_result = run_policy_check(
+            report_file=drift_telemetry_negative_report,
+            output_json=drift_telemetry_negative_policy,
+            expected_final_decision="NO-GO",
+            required_reason_code="checkpoint_failed_signer_rotation_freshness_contract",
+        )
+        if drift_telemetry_no_go_result.returncode == 0:
+            print("expected runtime signer drift telemetry negative proof to fail closed", file=sys.stderr)
+            return 1
+        drift_telemetry_no_go_policy = json.loads(
+            drift_telemetry_negative_policy.read_text(encoding="utf-8")
+        )
+        drift_telemetry_no_go_reason_codes = drift_telemetry_no_go_policy.get("reason_codes")
+        if not isinstance(drift_telemetry_no_go_reason_codes, list):
+            print("expected reason_codes list in runtime signer drift telemetry negative policy output", file=sys.stderr)
+            return 1
+        if "runtime_signer_drift_telemetry_schema_version_mismatch" not in drift_telemetry_no_go_reason_codes:
+            print(
+                "expected runtime_signer_drift_telemetry_schema_version_mismatch in runtime signer drift telemetry negative policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if "runtime_signer_drift_telemetry_rotation_delta_invalid" not in drift_telemetry_no_go_reason_codes:
+            print(
+                "expected runtime_signer_drift_telemetry_rotation_delta_invalid in runtime signer drift telemetry negative policy output",
+                file=sys.stderr,
+            )
+            return 1
+        if drift_telemetry_no_go_policy.get("final_decision") != "NO-GO":
+            print("expected runtime signer drift telemetry negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
         provenance_negative_report = temp_path / "signer_provenance_negative_summary.json"
         provenance_negative_policy = temp_path / "signer_provenance_negative_policy.json"
         provenance_negative_summary = dict(summary)
@@ -854,6 +952,12 @@ def main() -> int:
         "runtime_signer_attestation_schema_invalid",
         "runtime_signer_attestation_approved_signers_not_unique",
         "runtime_signer_attestation_quorum_shortfall",
+        "runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1",
+        "runtime_signer_drift_telemetry",
+        "runtime_signer_drift_telemetry_missing",
+        "runtime_signer_drift_telemetry_schema_version_mismatch",
+        "runtime_signer_drift_telemetry_rotation_delta_invalid",
+        "contracts.runtime_signer_drift_telemetry_required=true",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -904,6 +1008,12 @@ def main() -> int:
         "runtime_signer_attestation_schema_invalid",
         "runtime_signer_attestation_approved_signers_not_unique",
         "runtime_signer_attestation_quorum_shortfall",
+        "runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1",
+        "runtime_signer_drift_telemetry",
+        "runtime_signer_drift_telemetry_missing",
+        "runtime_signer_drift_telemetry_schema_version_mismatch",
+        "runtime_signer_drift_telemetry_rotation_delta_invalid",
+        "contracts.runtime_signer_drift_telemetry_required=true",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -954,6 +1064,12 @@ def main() -> int:
         "runtime_signer_attestation_schema_invalid",
         "runtime_signer_attestation_approved_signers_not_unique",
         "runtime_signer_attestation_quorum_shortfall",
+        "runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1",
+        "runtime_signer_drift_telemetry",
+        "runtime_signer_drift_telemetry_missing",
+        "runtime_signer_drift_telemetry_schema_version_mismatch",
+        "runtime_signer_drift_telemetry_rotation_delta_invalid",
+        "contracts.runtime_signer_drift_telemetry_required=true",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -29,6 +29,7 @@ FALLBACK_SIGNER_SECRET_REMEDIATION="unset ${FALLBACK_SIGNER_SECRET_ENV}"
 REQUIRED_SECRET_HEX_LENGTH=64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED="v1"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION="kamn.kolme.runtime-signer-attestation.v1"
+RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION="kamn.kolme.runtime-signer-drift-telemetry.v1"
 QUORUM_EVIDENCE_SCHEMA_VERSION="$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION"
 
 while [ "$#" -gt 0 ]; do
@@ -782,7 +783,7 @@ PY
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$quorum_evidence_signer_roles_present" "$quorum_evidence_signer_roles_valid" "$quorum_evidence_rotation_metadata_present" "$quorum_evidence_rotation_metadata_valid" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$runtime_signer_attestation_approved_signers_csv" "$runtime_signer_attestation_profile_approved" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$quorum_evidence_signer_roles_present" "$quorum_evidence_signer_roles_valid" "$quorum_evidence_rotation_metadata_present" "$quorum_evidence_rotation_metadata_valid" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$runtime_signer_attestation_approved_signers_csv" "$runtime_signer_attestation_profile_approved" "$RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION" <<'PY'
 from __future__ import annotations
 
 import json
@@ -846,6 +847,7 @@ signer_rotation_fresh = sys.argv[54] == "true"
 runtime_signer_attestation_schema_version = sys.argv[55]
 runtime_signer_attestation_approved_signers_csv = sys.argv[56]
 runtime_signer_attestation_profile_approved = sys.argv[57] == "true"
+runtime_signer_drift_telemetry_schema_version = sys.argv[58]
 
 runtime_signer_attestation_approved_signers: list[str] = [
     entry.strip()
@@ -867,6 +869,17 @@ runtime_signer_attestation_bundle = {
     "approved_signers": runtime_signer_attestation_approved_signers,
     "signer_profile": signer_profile,
     "signer_key_source": signer_key_source,
+}
+runtime_signer_drift_telemetry = {
+    "schema_version": runtime_signer_drift_telemetry_schema_version,
+    "signer_rotation_epoch": signer_rotation_epoch,
+    "signer_previous_rotation_epoch": signer_previous_rotation_epoch,
+    "signer_rotation_delta_epochs": signer_rotation_delta_epochs,
+    "signer_rotation_freshness_max_delta": signer_rotation_freshness_max_delta,
+    "signer_rotation_stale": signer_rotation_delta_epochs > signer_rotation_freshness_max_delta,
+    "required_approvals": required_approvals,
+    "received_approvals": received_approvals,
+    "quorum_shortfall": received_approvals < required_approvals,
 }
 
 checks = []
@@ -924,6 +937,8 @@ summary = {
     "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
     "runtime_signer_attestation_bundle": runtime_signer_attestation_bundle,
     "runtime_signer_attestation_profile_approved": runtime_signer_attestation_profile_approved,
+    "runtime_signer_drift_telemetry_schema_version": runtime_signer_drift_telemetry_schema_version,
+    "runtime_signer_drift_telemetry": runtime_signer_drift_telemetry,
     "custody_evidence_file": custody_evidence_file,
     "custody_evidence_present": custody_evidence_present,
     "custody_evidence_sha256": custody_evidence_sha256,
@@ -973,6 +988,12 @@ summary = {
         "runtime_signer_attestation_threshold_required": True,
         "runtime_signer_attestation_profile_membership_required": True,
         "runtime_signer_attestation_required_approvals": required_approvals,
+        "runtime_signer_drift_telemetry_required": True,
+        "runtime_signer_drift_telemetry_schema_version": runtime_signer_drift_telemetry_schema_version,
+        "runtime_signer_drift_telemetry_rotation_delta_match_required": True,
+        "runtime_signer_drift_telemetry_stale_flag_match_required": True,
+        "runtime_signer_drift_telemetry_quorum_flag_match_required": True,
+        "runtime_signer_drift_telemetry_approval_counts_match_required": True,
         "custody_evidence_required": True,
         "custody_evidence_sha256_required": True,
         "signer_provenance_required": True,

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -10,6 +10,7 @@ README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_QUORUM_MINIMUM="$TMP_DIR/quorum-minimum-report.json"
+TMP_REPORT_DRIFT_MALFORMED="$TMP_DIR/drift-malformed-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
 TMP_SUMMARY="$TMP_DIR/summary.json"
@@ -84,6 +85,18 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "signer_key_source": "env-local"
   },
   "runtime_signer_attestation_profile_approved": true,
+  "runtime_signer_drift_telemetry_schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v1",
+  "runtime_signer_drift_telemetry": {
+    "schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v1",
+    "signer_rotation_epoch": 1,
+    "signer_previous_rotation_epoch": 1,
+    "signer_rotation_delta_epochs": 0,
+    "signer_rotation_freshness_max_delta": 2,
+    "signer_rotation_stale": false,
+    "required_approvals": 2,
+    "received_approvals": 0,
+    "quorum_shortfall": true
+  },
   "custody_evidence_file": "",
   "custody_evidence_present": false,
   "custody_evidence_sha256": "",
@@ -142,6 +155,12 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_attestation_threshold_required": true,
     "runtime_signer_attestation_profile_membership_required": true,
     "runtime_signer_attestation_required_approvals": 2,
+    "runtime_signer_drift_telemetry_required": true,
+    "runtime_signer_drift_telemetry_schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v1",
+    "runtime_signer_drift_telemetry_rotation_delta_match_required": true,
+    "runtime_signer_drift_telemetry_stale_flag_match_required": true,
+    "runtime_signer_drift_telemetry_quorum_flag_match_required": true,
+    "runtime_signer_drift_telemetry_approval_counts_match_required": true,
     "custody_evidence_required": true,
     "custody_evidence_sha256_required": true,
     "signer_provenance_required": true,
@@ -276,6 +295,54 @@ fi
 
 if ! grep -q "signer_quorum_minimum_not_met" "$TMP_ERR"; then
   echo "expected signer_quorum_minimum_not_met reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_DRIFT_MALFORMED" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_drift_telemetry_schema_version"] = "kamn.kolme.runtime-signer-drift-telemetry.v0"
+report["runtime_signer_drift_telemetry"] = {
+    "schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v0",
+    "signer_rotation_epoch": 1,
+    "signer_previous_rotation_epoch": 1,
+    "signer_rotation_delta_epochs": "bad",
+    "signer_rotation_freshness_max_delta": -1,
+    "signer_rotation_stale": "bad",
+    "required_approvals": 2,
+    "received_approvals": 0,
+    "quorum_shortfall": "bad",
+}
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_DRIFT_MALFORMED" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+drift_malformed_exit_code=$?
+set -e
+
+if [ "$drift_malformed_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight policy checker to fail on malformed runtime signer drift telemetry" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_drift_telemetry_schema_version_mismatch" "$TMP_ERR"; then
+  echo "expected runtime signer drift telemetry schema version mismatch reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_drift_telemetry_rotation_delta_invalid" "$TMP_ERR"; then
+  echo "expected runtime signer drift telemetry rotation delta invalid reason for deployment preflight policy failure" >&2
   exit 1
 fi
 
@@ -537,6 +604,11 @@ fi
 
 if ! grep -q "runtime_signer_attestation_profile_not_approved" "$TMP_ERR"; then
   echo "expected runtime signer attestation profile membership reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_drift_telemetry_missing" "$TMP_ERR"; then
+  echo "expected runtime signer drift telemetry missing reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
@@ -101,6 +101,12 @@ required_coverage_markers=(
   "runtime_signer_attestation_approved_signers_not_unique"
   "runtime_signer_attestation_quorum_shortfall"
   "runtime_signer_attestation_schema_invalid"
+  "runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1"
+  "runtime_signer_drift_telemetry"
+  "runtime_signer_drift_telemetry_missing"
+  "runtime_signer_drift_telemetry_schema_version_mismatch"
+  "runtime_signer_drift_telemetry_rotation_delta_invalid"
+  "contracts.runtime_signer_drift_telemetry_required=true"
   "Regression: #2226"
   "Regression: #2337"
   "Regression: #2300"
@@ -142,6 +148,30 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "runtime_signer_attestation_quorum_shortfall" "$docs_file"; then
     echo "expected docs parity to include runtime signer attestation quorum shortfall reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift telemetry schema marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_telemetry" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift telemetry bundle marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_telemetry_missing" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift telemetry missing reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_telemetry_schema_version_mismatch" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift telemetry schema-version mismatch reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_telemetry_rotation_delta_invalid" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift telemetry rotation-delta invalid reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.runtime_signer_drift_telemetry_required=true" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift telemetry contract requirement marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "quorum_evidence_signer_roles_missing" "$docs_file"; then
@@ -262,6 +292,19 @@ if attestation_bundle.get("required_approvals") != summary.get("required_approva
     raise SystemExit("expected deployment preflight summary attestation required approvals to mirror quorum threshold")
 if attestation_bundle.get("approved_signers") != ["ops-primary", "ops-secondary"]:
     raise SystemExit("expected deployment preflight summary attestation approved signers marker")
+if summary.get("runtime_signer_drift_telemetry_schema_version") != "kamn.kolme.runtime-signer-drift-telemetry.v1":
+    raise SystemExit("expected deployment preflight summary runtime signer drift telemetry schema marker")
+runtime_signer_drift_telemetry = summary.get("runtime_signer_drift_telemetry")
+if not isinstance(runtime_signer_drift_telemetry, dict):
+    raise SystemExit("expected deployment preflight summary runtime signer drift telemetry bundle")
+if runtime_signer_drift_telemetry.get("schema_version") != "kamn.kolme.runtime-signer-drift-telemetry.v1":
+    raise SystemExit("expected deployment preflight summary runtime signer drift telemetry schema marker in bundle")
+if runtime_signer_drift_telemetry.get("signer_rotation_delta_epochs") != summary.get("signer_rotation_delta_epochs"):
+    raise SystemExit("expected deployment preflight summary runtime signer drift telemetry rotation delta marker")
+if runtime_signer_drift_telemetry.get("required_approvals") != summary.get("required_approvals"):
+    raise SystemExit("expected deployment preflight summary runtime signer drift telemetry required approvals marker")
+if runtime_signer_drift_telemetry.get("received_approvals") != summary.get("received_approvals"):
+    raise SystemExit("expected deployment preflight summary runtime signer drift telemetry received approvals marker")
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "ci-fast-gate":
     raise SystemExit("expected deployment preflight contracts ci_fast_gate_scope=ci-fast-gate")
@@ -273,6 +316,18 @@ if contracts.get("runtime_signer_attestation_threshold_required") is not True:
     raise SystemExit("expected deployment preflight contracts runtime signer attestation threshold marker")
 if contracts.get("runtime_signer_attestation_profile_membership_required") is not True:
     raise SystemExit("expected deployment preflight contracts runtime signer attestation profile membership marker")
+if contracts.get("runtime_signer_drift_telemetry_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry requirement marker")
+if contracts.get("runtime_signer_drift_telemetry_schema_version") != "kamn.kolme.runtime-signer-drift-telemetry.v1":
+    raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry schema marker")
+if contracts.get("runtime_signer_drift_telemetry_rotation_delta_match_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry rotation delta match marker")
+if contracts.get("runtime_signer_drift_telemetry_stale_flag_match_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry stale flag match marker")
+if contracts.get("runtime_signer_drift_telemetry_quorum_flag_match_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry quorum flag match marker")
+if contracts.get("runtime_signer_drift_telemetry_approval_counts_match_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry approval count match marker")
 if policy.get("schema_version") != "kamn.kolme.local-live-deployment-preflight-policy-report.v1":
     raise SystemExit("unexpected deployment preflight contract-lane policy schema")
 if policy.get("final_decision") != "GO":


### PR DESCRIPTION
Closes #2434

## Summary
Add deterministic runtime signer drift telemetry fields to the local Kolme deployment preflight summary and enforce them in fail-closed policy/contract lanes so deployment admission consumes explicit drift evidence.

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`: emit `runtime_signer_drift_telemetry_schema_version`, `runtime_signer_drift_telemetry`, and matching `contracts.*` requirement markers.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`: validate runtime signer drift telemetry schema/shape/cross-field invariants with deterministic NO-GO reason codes.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`: assert new summary/contracts markers and add malformed telemetry negative proof.
- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`: red/green coverage for missing and malformed runtime signer drift telemetry.
- `scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`: coverage + docs parity assertions for drift telemetry markers/reasons.
- Docs updated with required marker/reason contracts: `README.md`, `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `docs/foundation/release-gonogo-checklist.md`, `docs/ci/ci-cost-and-lane-framework.md`.

## Risks & Compatibility
- None

## Validation
- [x] `bash -n scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
- [x] `python3 -m py_compile scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`
- [x] `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
- [x] `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy -- -D warnings`
- [ ] Unit tests pass (full workspace)
- [ ] Integration tests pass (full workspace)
- [x] Manual verification: validated deterministic summary markers, contract markers, and fail-closed reason-code surface for missing/malformed runtime signer drift telemetry in local deployment preflight policy/contract lanes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | policy checker telemetry validation + malformed fixture assertions |
| Functional  | ✅ | summary generation emits telemetry schema/bundle + contracts markers |
| Integration | ✅ | deployment preflight contract lane GO + negative telemetry proof |
| Regression  | ✅ | docs parity + reason-code drift checks updated and passing |