### PR TITLE
feat(kolme): enforce runtime signer drift admission matrix policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,8 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # runtime_signer_attestation_bundle
 # runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1
 # runtime_signer_drift_telemetry
+# runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1
+# runtime_signer_drift_thresholds_bundle
 # contracts.ci_fast_gate_scope=ci-fast-gate
 # contracts.required_runtime_mode=kolme-live
 # contracts.fallback_private_key_path_allowed=false
@@ -787,6 +789,12 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.runtime_signer_drift_telemetry_stale_flag_match_required=true
 # contracts.runtime_signer_drift_telemetry_quorum_flag_match_required=true
 # contracts.runtime_signer_drift_telemetry_approval_counts_match_required=true
+# contracts.runtime_signer_drift_thresholds_required=true
+# contracts.runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1
+# contracts.runtime_signer_drift_thresholds_rotation_warn_lte_fail_required=true
+# contracts.runtime_signer_drift_thresholds_quorum_warn_lte_fail_required=true
+# contracts.runtime_signer_drift_admission_matrix_required=true
+# contracts.runtime_signer_drift_admission_matrix_decision_values=GO,WARN,NO-GO
 # contracts.custody_evidence_required=true
 # contracts.signer_provenance_required=true
 # contracts.signer_provenance_sha256_required=true
@@ -830,6 +838,10 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # runtime_signer_drift_telemetry_missing
 # runtime_signer_drift_telemetry_schema_version_mismatch
 # runtime_signer_drift_telemetry_rotation_delta_invalid
+# runtime_signer_drift_admission_matrix_decision
+# runtime_signer_drift_admission_matrix_class
+# runtime_signer_drift_rotation_warning_threshold_reached
+# runtime_signer_drift_quorum_fail_threshold_exceeded
 # custody_evidence_missing
 # custody_evidence_sha256_invalid
 # signer_key_source_contract_version_mismatch

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -62,12 +62,18 @@ Kolme deployment admission preflight emits deterministic runtime signer drift te
 - `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
 - `runtime_signer_drift_telemetry` bundle with rotation and quorum drift fields
 - `contracts.runtime_signer_drift_telemetry_required=true`
+- `runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+- `runtime_signer_drift_thresholds_bundle`
+- `runtime_signer_drift_admission_matrix_decision=GO|WARN|NO-GO`
+- `runtime_signer_drift_admission_matrix_class=healthy|warning-edge|hard-fail`
 
 Fail-closed reason codes for missing/malformed telemetry:
 
 - `runtime_signer_drift_telemetry_missing`
 - `runtime_signer_drift_telemetry_schema_version_mismatch`
 - `runtime_signer_drift_telemetry_rotation_delta_invalid`
+- `runtime_signer_drift_quorum_fail_threshold_exceeded`
+- `runtime_signer_drift_rotation_fail_threshold_exceeded`
 
 Coverage split for cost control:
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -519,6 +519,8 @@ JSON`
       - `runtime_signer_attestation_bundle`
       - `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
       - `runtime_signer_drift_telemetry`
+      - `runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+      - `runtime_signer_drift_thresholds_bundle`
       - `contracts.ci_fast_gate_scope=ci-fast-gate`
       - `contracts.required_runtime_mode=kolme-live`
       - `contracts.fallback_private_key_path_allowed=false`
@@ -545,6 +547,12 @@ JSON`
       - `contracts.runtime_signer_drift_telemetry_stale_flag_match_required=true`
       - `contracts.runtime_signer_drift_telemetry_quorum_flag_match_required=true`
       - `contracts.runtime_signer_drift_telemetry_approval_counts_match_required=true`
+      - `contracts.runtime_signer_drift_thresholds_required=true`
+      - `contracts.runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+      - `contracts.runtime_signer_drift_thresholds_rotation_warn_lte_fail_required=true`
+      - `contracts.runtime_signer_drift_thresholds_quorum_warn_lte_fail_required=true`
+      - `contracts.runtime_signer_drift_admission_matrix_required=true`
+      - `contracts.runtime_signer_drift_admission_matrix_decision_values=GO,WARN,NO-GO`
       - `contracts.runtime_signer_quorum_linkage_contract_version=v1`
       - `contracts.runtime_signer_quorum_required_approvals=2`
       - `contracts.runtime_signer_quorum_linked_required=true`
@@ -592,6 +600,10 @@ JSON`
       - `runtime_signer_drift_telemetry_missing`
       - `runtime_signer_drift_telemetry_schema_version_mismatch`
       - `runtime_signer_drift_telemetry_rotation_delta_invalid`
+      - `runtime_signer_drift_admission_matrix_decision`
+      - `runtime_signer_drift_admission_matrix_class`
+      - `runtime_signer_drift_rotation_warning_threshold_reached`
+      - `runtime_signer_drift_quorum_fail_threshold_exceeded`
       - `custody_evidence_missing`
       - `custody_evidence_sha256_invalid`
       - `signer_key_source_contract_version_mismatch`

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -39,6 +39,14 @@ For semantic versioning policy and compatibility rules, see `docs/foundation/ver
   - `runtime_signer_drift_telemetry_missing`
   - `runtime_signer_drift_telemetry_schema_version_mismatch`
   - `runtime_signer_drift_telemetry_rotation_delta_invalid`
+  - `runtime_signer_drift_quorum_fail_threshold_exceeded`
+  - `runtime_signer_drift_rotation_fail_threshold_exceeded`
+- Admission policy decision matrix markers:
+  - `runtime_signer_drift_admission_matrix_decision=GO|WARN|NO-GO`
+  - `runtime_signer_drift_admission_matrix_class=healthy|warning-edge|hard-fail`
+  - `runtime_signer_drift_admission_matrix_reason_codes`
+  - `runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+  - `runtime_signer_drift_thresholds_bundle`
 
 ## Deterministic Dry-Run Workflow
 1. Create release candidate tag.

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -123,6 +123,11 @@ JSON`
   - `kamn.kolme.runtime-signer-attestation.v1`
   - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
   - `runtime_signer_attestation_bundle`
+  - `runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+  - `runtime_signer_drift_thresholds_bundle`
+  - `runtime_signer_drift_admission_matrix_decision=GO|WARN|NO-GO`
+  - `runtime_signer_drift_admission_matrix_class=healthy|warning-edge|hard-fail`
+  - `runtime_signer_drift_admission_matrix_reason_codes`
   - `checkpoint_failed_signer_quorum_contract`
   - `checkpoint_failed_quorum_evidence_contract`
   - `checkpoint_failed_custody_evidence_contract`
@@ -130,6 +135,11 @@ JSON`
   - `quorum_evidence_custody_sha256_mismatch`
   - `runtime_signer_attestation_approved_signers_not_unique`
   - `runtime_signer_attestation_quorum_shortfall`
+  - `runtime_signer_drift_quorum_fail_threshold_exceeded`
+  - `runtime_signer_drift_rotation_fail_threshold_exceeded`
+- Drift-breach response:
+  - If matrix class is `warning-edge`, freeze promotion, rotate signer evidence within threshold, and rerun preflight lane/policy before continuing.
+  - If matrix class is `hard-fail` or decision is `NO-GO`, block rollout, execute signer incident rollback flow, and require fresh custody/quorum/provenance artifacts before unfreezing.
 - Regression policy:
   - signer quorum/custody/provenance drift, quorum evidence schema drift, or contract-lane/docs parity drift force `NO-GO` (`Regression: #2301`).
   - runtime/deployment signer-attestation schema and reason-code drift force `NO-GO` (`Regression: #2326`).

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -674,6 +674,8 @@ JSON`
     - `runtime_signer_attestation_bundle`
     - `runtime_signer_drift_telemetry_schema_version=kamn.kolme.runtime-signer-drift-telemetry.v1`
     - `runtime_signer_drift_telemetry`
+    - `runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+    - `runtime_signer_drift_thresholds_bundle`
     - `custody_evidence_file`
     - `custody_evidence_present`
     - `custody_evidence_sha256_valid`
@@ -707,6 +709,12 @@ JSON`
     - `contracts.runtime_signer_drift_telemetry_stale_flag_match_required=true`
     - `contracts.runtime_signer_drift_telemetry_quorum_flag_match_required=true`
     - `contracts.runtime_signer_drift_telemetry_approval_counts_match_required=true`
+    - `contracts.runtime_signer_drift_thresholds_required=true`
+    - `contracts.runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1`
+    - `contracts.runtime_signer_drift_thresholds_rotation_warn_lte_fail_required=true`
+    - `contracts.runtime_signer_drift_thresholds_quorum_warn_lte_fail_required=true`
+    - `contracts.runtime_signer_drift_admission_matrix_required=true`
+    - `contracts.runtime_signer_drift_admission_matrix_decision_values=GO,WARN,NO-GO`
     - `contracts.custody_evidence_required=true`
     - `contracts.custody_evidence_sha256_required=true`
     - `contracts.signer_provenance_required=true`
@@ -745,6 +753,10 @@ JSON`
   - `runtime_signer_drift_telemetry_missing`
   - `runtime_signer_drift_telemetry_schema_version_mismatch`
   - `runtime_signer_drift_telemetry_rotation_delta_invalid`
+  - `runtime_signer_drift_admission_matrix_decision`
+  - `runtime_signer_drift_admission_matrix_class`
+  - `runtime_signer_drift_rotation_warning_threshold_reached`
+  - `runtime_signer_drift_quorum_fail_threshold_exceeded`
   - `custody_evidence_missing`
   - `custody_evidence_sha256_invalid`
   - `signer_key_source_contract_version_mismatch`

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -16,6 +16,7 @@ REQUIRED_SECRET_HEX_LENGTH = 64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION = "kamn.kolme.runtime-signer-attestation.v1"
 RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION = "kamn.kolme.runtime-signer-drift-telemetry.v1"
+RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION = "kamn.kolme.runtime-signer-drift-thresholds.v1"
 QUORUM_EVIDENCE_SCHEMA_VERSION = RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION
 ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
@@ -183,6 +184,142 @@ def evaluate_runtime_signer_drift_telemetry(
     return reason_codes
 
 
+def evaluate_runtime_signer_drift_thresholds_bundle(
+    thresholds_bundle: object,
+) -> tuple[list[str], dict[str, int] | None]:
+    reason_codes: list[str] = []
+    if not isinstance(thresholds_bundle, dict):
+        return ["runtime_signer_drift_thresholds_bundle_missing"], None
+
+    if thresholds_bundle.get("schema_version") != RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_drift_thresholds_schema_invalid")
+
+    rotation_warn_delta_epochs = thresholds_bundle.get("rotation_warn_delta_epochs")
+    if not isinstance(rotation_warn_delta_epochs, int) or rotation_warn_delta_epochs < 0:
+        reason_codes.append("runtime_signer_drift_thresholds_rotation_warn_invalid")
+
+    rotation_fail_delta_epochs = thresholds_bundle.get("rotation_fail_delta_epochs")
+    if not isinstance(rotation_fail_delta_epochs, int) or rotation_fail_delta_epochs < 0:
+        reason_codes.append("runtime_signer_drift_thresholds_rotation_fail_invalid")
+
+    quorum_warn_shortfall_events = thresholds_bundle.get("quorum_warn_shortfall_events")
+    if not isinstance(quorum_warn_shortfall_events, int) or quorum_warn_shortfall_events < 0:
+        reason_codes.append("runtime_signer_drift_thresholds_quorum_warn_invalid")
+
+    quorum_fail_shortfall_events = thresholds_bundle.get("quorum_fail_shortfall_events")
+    if not isinstance(quorum_fail_shortfall_events, int) or quorum_fail_shortfall_events < 0:
+        reason_codes.append("runtime_signer_drift_thresholds_quorum_fail_invalid")
+
+    if (
+        isinstance(rotation_warn_delta_epochs, int)
+        and rotation_warn_delta_epochs >= 0
+        and isinstance(rotation_fail_delta_epochs, int)
+        and rotation_fail_delta_epochs >= 0
+        and rotation_warn_delta_epochs > rotation_fail_delta_epochs
+    ):
+        reason_codes.append("runtime_signer_drift_thresholds_rotation_warn_gt_fail")
+
+    if (
+        isinstance(quorum_warn_shortfall_events, int)
+        and quorum_warn_shortfall_events >= 0
+        and isinstance(quorum_fail_shortfall_events, int)
+        and quorum_fail_shortfall_events >= 0
+        and quorum_warn_shortfall_events > quorum_fail_shortfall_events
+    ):
+        reason_codes.append("runtime_signer_drift_thresholds_quorum_warn_gt_fail")
+
+    if reason_codes:
+        return reason_codes, None
+
+    return (
+        reason_codes,
+        {
+            "rotation_warn_delta_epochs": int(rotation_warn_delta_epochs),
+            "rotation_fail_delta_epochs": int(rotation_fail_delta_epochs),
+            "quorum_warn_shortfall_events": int(quorum_warn_shortfall_events),
+            "quorum_fail_shortfall_events": int(quorum_fail_shortfall_events),
+        },
+    )
+
+
+def evaluate_runtime_signer_drift_admission_matrix(
+    mode: object,
+    thresholds: dict[str, int] | None,
+    required_approvals: object,
+    received_approvals: object,
+    signer_rotation_delta_epochs: object,
+) -> dict[str, object]:
+    # Dry-run is informational; admission matrix hard-gating applies to run mode.
+    if mode != "run":
+        return {
+            "decision": "GO",
+            "class": "healthy",
+            "reason_codes": [],
+            "observed_rotation_delta_epochs": signer_rotation_delta_epochs if isinstance(signer_rotation_delta_epochs, int) else 0,
+            "observed_quorum_shortfall_events": 0,
+        }
+
+    if (
+        thresholds is None
+        or not isinstance(required_approvals, int)
+        or required_approvals <= 0
+        or not isinstance(received_approvals, int)
+        or received_approvals < 0
+        or not isinstance(signer_rotation_delta_epochs, int)
+        or signer_rotation_delta_epochs < 0
+    ):
+        return {
+            "decision": "NO-GO",
+            "class": "hard-fail",
+            "reason_codes": ["runtime_signer_drift_matrix_inputs_invalid"],
+            "observed_rotation_delta_epochs": signer_rotation_delta_epochs if isinstance(signer_rotation_delta_epochs, int) else 0,
+            "observed_quorum_shortfall_events": 0,
+        }
+
+    observed_quorum_shortfall_events = max(required_approvals - received_approvals, 0)
+    fail_reason_codes: list[str] = []
+    warning_reason_codes: list[str] = []
+
+    if observed_quorum_shortfall_events > thresholds["quorum_fail_shortfall_events"]:
+        fail_reason_codes.append("runtime_signer_drift_quorum_fail_threshold_exceeded")
+    elif observed_quorum_shortfall_events > thresholds["quorum_warn_shortfall_events"]:
+        warning_reason_codes.append("runtime_signer_drift_quorum_warning_threshold_exceeded")
+
+    if signer_rotation_delta_epochs > thresholds["rotation_fail_delta_epochs"]:
+        fail_reason_codes.append("runtime_signer_drift_rotation_fail_threshold_exceeded")
+    elif (
+        thresholds["rotation_warn_delta_epochs"] > 0
+        and signer_rotation_delta_epochs >= thresholds["rotation_warn_delta_epochs"]
+    ):
+        warning_reason_codes.append("runtime_signer_drift_rotation_warning_threshold_reached")
+
+    if fail_reason_codes:
+        return {
+            "decision": "NO-GO",
+            "class": "hard-fail",
+            "reason_codes": fail_reason_codes + warning_reason_codes,
+            "observed_rotation_delta_epochs": signer_rotation_delta_epochs,
+            "observed_quorum_shortfall_events": observed_quorum_shortfall_events,
+        }
+
+    if warning_reason_codes:
+        return {
+            "decision": "WARN",
+            "class": "warning-edge",
+            "reason_codes": warning_reason_codes,
+            "observed_rotation_delta_epochs": signer_rotation_delta_epochs,
+            "observed_quorum_shortfall_events": observed_quorum_shortfall_events,
+        }
+
+    return {
+        "decision": "GO",
+        "class": "healthy",
+        "reason_codes": [],
+        "observed_rotation_delta_epochs": signer_rotation_delta_epochs,
+        "observed_quorum_shortfall_events": observed_quorum_shortfall_events,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Validate local Kolme live deployment preflight summary policy."
@@ -195,7 +332,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, list[str]]:
+def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, list[str], dict[str, object]]:
     reason_codes: list[str] = []
 
     if report.get("schema_version") != "kamn.kolme.local-live-deployment-preflight-summary.v1":
@@ -482,6 +619,22 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         )
     )
 
+    runtime_signer_drift_thresholds_schema_version = report.get(
+        "runtime_signer_drift_thresholds_schema_version"
+    )
+    if (
+        not isinstance(runtime_signer_drift_thresholds_schema_version, str)
+        or not runtime_signer_drift_thresholds_schema_version.strip()
+    ):
+        reason_codes.append("runtime_signer_drift_thresholds_schema_version_missing")
+    elif runtime_signer_drift_thresholds_schema_version != RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION:
+        reason_codes.append("runtime_signer_drift_thresholds_schema_version_mismatch")
+
+    threshold_reason_codes, parsed_runtime_signer_drift_thresholds = evaluate_runtime_signer_drift_thresholds_bundle(
+        report.get("runtime_signer_drift_thresholds_bundle")
+    )
+    reason_codes.extend(threshold_reason_codes)
+
     custody_evidence_file = report.get("custody_evidence_file")
     if not isinstance(custody_evidence_file, str):
         reason_codes.append("custody_evidence_file_invalid")
@@ -586,6 +739,21 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_drift_telemetry_quorum_flag_match_required_contract_mismatch")
         if contracts.get("runtime_signer_drift_telemetry_approval_counts_match_required") is not True:
             reason_codes.append("runtime_signer_drift_telemetry_approval_counts_match_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_thresholds_required") is not True:
+            reason_codes.append("runtime_signer_drift_thresholds_required_contract_mismatch")
+        if (
+            contracts.get("runtime_signer_drift_thresholds_schema_version")
+            != RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION
+        ):
+            reason_codes.append("runtime_signer_drift_thresholds_schema_version_contract_mismatch")
+        if contracts.get("runtime_signer_drift_thresholds_rotation_warn_lte_fail_required") is not True:
+            reason_codes.append("runtime_signer_drift_thresholds_rotation_warn_lte_fail_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_thresholds_quorum_warn_lte_fail_required") is not True:
+            reason_codes.append("runtime_signer_drift_thresholds_quorum_warn_lte_fail_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_admission_matrix_required") is not True:
+            reason_codes.append("runtime_signer_drift_admission_matrix_required_contract_mismatch")
+        if contracts.get("runtime_signer_drift_admission_matrix_decision_values") != ["GO", "WARN", "NO-GO"]:
+            reason_codes.append("runtime_signer_drift_admission_matrix_decision_values_contract_mismatch")
         if contracts.get("custody_evidence_required") is not True:
             reason_codes.append("custody_evidence_required_contract_mismatch")
         if contracts.get("custody_evidence_sha256_required") is not True:
@@ -722,6 +890,23 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         if signer_rotation_fresh is not True:
             reason_codes.append("signer_rotation_fresh_violation")
 
+    runtime_signer_drift_admission_matrix = evaluate_runtime_signer_drift_admission_matrix(
+        mode=mode,
+        thresholds=parsed_runtime_signer_drift_thresholds,
+        required_approvals=required_approvals,
+        received_approvals=received_approvals,
+        signer_rotation_delta_epochs=signer_rotation_delta_epochs,
+    )
+    matrix_reason_codes = runtime_signer_drift_admission_matrix.get("reason_codes")
+    if isinstance(matrix_reason_codes, list):
+        for matrix_reason_code in matrix_reason_codes:
+            if matrix_reason_code in (
+                "runtime_signer_drift_matrix_inputs_invalid",
+                "runtime_signer_drift_quorum_fail_threshold_exceeded",
+                "runtime_signer_drift_rotation_fail_threshold_exceeded",
+            ):
+                reason_codes.append(matrix_reason_code)
+
     for required_reason_code in args.require_reason_code:
         if reason_code != required_reason_code:
             reason_codes.append(f"required_reason_code_missing:{required_reason_code}")
@@ -730,7 +915,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("observed_final_decision_mismatch")
 
     final_decision = "GO" if not reason_codes else "NO-GO"
-    return final_decision, reason_codes
+    return final_decision, reason_codes, runtime_signer_drift_admission_matrix
 
 
 def main() -> int:
@@ -745,7 +930,7 @@ def main() -> int:
     elif observed_status == "fail":
         observed_final_decision = "NO-GO"
 
-    final_decision, reason_codes = evaluate(report, args)
+    final_decision, reason_codes, runtime_signer_drift_admission_matrix = evaluate(report, args)
     output = {
         "schema_version": "kamn.kolme.local-live-deployment-preflight-policy-report.v1",
         "report_file": str(report_path),
@@ -757,6 +942,15 @@ def main() -> int:
         "observed_reason_code": report.get("reason_code"),
         "reason_codes": reason_codes,
         "final_decision": final_decision,
+        "runtime_signer_drift_admission_matrix_decision": runtime_signer_drift_admission_matrix.get("decision"),
+        "runtime_signer_drift_admission_matrix_class": runtime_signer_drift_admission_matrix.get("class"),
+        "runtime_signer_drift_admission_matrix_reason_codes": runtime_signer_drift_admission_matrix.get("reason_codes"),
+        "runtime_signer_drift_admission_matrix_observed_rotation_delta_epochs": runtime_signer_drift_admission_matrix.get(
+            "observed_rotation_delta_epochs"
+        ),
+        "runtime_signer_drift_admission_matrix_observed_quorum_shortfall_events": runtime_signer_drift_admission_matrix.get(
+            "observed_quorum_shortfall_events"
+        ),
     }
 
     if args.output_json:

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -253,6 +253,16 @@ def main() -> int:
     if runtime_signer_drift_telemetry.get("received_approvals") != summary.get("received_approvals"):
         print("expected deployment preflight summary runtime signer drift telemetry received approvals marker", file=sys.stderr)
         return 1
+    if summary.get("runtime_signer_drift_thresholds_schema_version") != "kamn.kolme.runtime-signer-drift-thresholds.v1":
+        print("expected deployment preflight summary runtime signer drift thresholds schema marker", file=sys.stderr)
+        return 1
+    runtime_signer_drift_thresholds_bundle = summary.get("runtime_signer_drift_thresholds_bundle")
+    if not isinstance(runtime_signer_drift_thresholds_bundle, dict):
+        print("expected deployment preflight summary runtime signer drift thresholds bundle", file=sys.stderr)
+        return 1
+    if runtime_signer_drift_thresholds_bundle.get("schema_version") != "kamn.kolme.runtime-signer-drift-thresholds.v1":
+        print("expected deployment preflight summary runtime signer drift thresholds bundle schema marker", file=sys.stderr)
+        return 1
     contracts = summary.get("contracts", {})
     if not isinstance(contracts, dict):
         print("expected contracts object in deployment preflight summary", file=sys.stderr)
@@ -344,6 +354,24 @@ def main() -> int:
     if contracts.get("runtime_signer_drift_telemetry_approval_counts_match_required") is not True:
         print("expected deployment preflight contracts runtime signer drift telemetry approval count match marker", file=sys.stderr)
         return 1
+    if contracts.get("runtime_signer_drift_thresholds_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift thresholds requirement marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_thresholds_schema_version") != "kamn.kolme.runtime-signer-drift-thresholds.v1":
+        print("expected deployment preflight contracts runtime signer drift thresholds schema marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_thresholds_rotation_warn_lte_fail_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift thresholds warn<=fail marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_thresholds_quorum_warn_lte_fail_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift thresholds quorum warn<=fail marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_admission_matrix_required") is not True:
+        print("expected deployment preflight contracts runtime signer drift admission matrix requirement marker", file=sys.stderr)
+        return 1
+    if contracts.get("runtime_signer_drift_admission_matrix_decision_values") != ["GO", "WARN", "NO-GO"]:
+        print("expected deployment preflight contracts runtime signer drift admission matrix decision-value marker", file=sys.stderr)
+        return 1
     if contracts.get("custody_evidence_required") is not True:
         print("expected deployment preflight contracts custody_evidence_required=true", file=sys.stderr)
         return 1
@@ -370,6 +398,12 @@ def main() -> int:
         return 1
     if policy.get("final_decision") != "GO":
         print("expected deployment preflight contract-lane policy final_decision GO", file=sys.stderr)
+        return 1
+    if policy.get("runtime_signer_drift_admission_matrix_decision") != "GO":
+        print("expected deployment preflight contract-lane policy runtime signer drift matrix decision GO", file=sys.stderr)
+        return 1
+    if policy.get("runtime_signer_drift_admission_matrix_class") != "healthy":
+        print("expected deployment preflight contract-lane policy runtime signer drift matrix class healthy", file=sys.stderr)
         return 1
 
     with tempfile.TemporaryDirectory(prefix="kolme-deployment-preflight-negative-") as temp_dir:
@@ -411,6 +445,151 @@ def main() -> int:
             return 1
         if no_go_policy.get("final_decision") != "NO-GO":
             print("expected deployment preflight negative policy final_decision NO-GO", file=sys.stderr)
+            return 1
+
+        warning_edge_report = temp_path / "runtime_signer_drift_warning_edge_summary.json"
+        warning_edge_policy = temp_path / "runtime_signer_drift_warning_edge_policy.json"
+        warning_edge_summary = dict(summary)
+        warning_edge_summary["mode"] = "run"
+        warning_edge_summary["status"] = "ok"
+        warning_edge_summary["reason_code"] = "deployment_preflight_passed"
+        warning_edge_summary["signer_secret_present"] = True
+        warning_edge_summary["signer_secret_hex_valid"] = True
+        warning_edge_summary["required_approvals"] = 2
+        warning_edge_summary["received_approvals"] = 2
+        warning_edge_summary["quorum_evidence_file"] = "/tmp/quorum-evidence.json"
+        warning_edge_summary["quorum_evidence_present"] = True
+        warning_edge_summary["quorum_evidence_sha256"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        warning_edge_summary["quorum_evidence_sha256_valid"] = True
+        warning_edge_summary["quorum_evidence_schema_valid"] = True
+        warning_edge_summary["quorum_evidence_approval_count"] = 2
+        warning_edge_summary["quorum_evidence_signers_unique"] = True
+        warning_edge_summary["quorum_evidence_matches_threshold"] = True
+        warning_edge_summary["quorum_evidence_custody_sha256_match"] = True
+        warning_edge_summary["quorum_evidence_signer_roles_present"] = True
+        warning_edge_summary["quorum_evidence_signer_roles_valid"] = True
+        warning_edge_summary["quorum_evidence_rotation_metadata_present"] = True
+        warning_edge_summary["quorum_evidence_rotation_metadata_valid"] = True
+        warning_edge_summary["custody_evidence_file"] = "/tmp/custody-evidence.json"
+        warning_edge_summary["custody_evidence_present"] = True
+        warning_edge_summary["custody_evidence_sha256"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        warning_edge_summary["custody_evidence_sha256_valid"] = True
+        warning_edge_summary["signer_provenance_file"] = "/tmp/signer-provenance.json"
+        warning_edge_summary["signer_provenance_present"] = True
+        warning_edge_summary["signer_provenance_sha256"] = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        warning_edge_summary["signer_provenance_sha256_valid"] = True
+        warning_edge_summary["signer_rotation_epoch"] = 3
+        warning_edge_summary["signer_previous_rotation_epoch"] = 1
+        warning_edge_summary["signer_rotation_freshness_max_delta"] = 2
+        warning_edge_summary["signer_rotation_delta_epochs"] = 2
+        warning_edge_summary["signer_rotation_fresh"] = True
+        warning_edge_summary["runtime_signer_drift_telemetry"] = {
+            "schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v1",
+            "signer_rotation_epoch": 3,
+            "signer_previous_rotation_epoch": 1,
+            "signer_rotation_delta_epochs": 2,
+            "signer_rotation_freshness_max_delta": 2,
+            "signer_rotation_stale": False,
+            "required_approvals": 2,
+            "received_approvals": 2,
+            "quorum_shortfall": False,
+        }
+        warning_edge_summary["runtime_signer_drift_thresholds_bundle"] = {
+            "schema_version": "kamn.kolme.runtime-signer-drift-thresholds.v1",
+            "rotation_warn_delta_epochs": 1,
+            "rotation_fail_delta_epochs": 2,
+            "quorum_warn_shortfall_events": 0,
+            "quorum_fail_shortfall_events": 0,
+        }
+        warning_edge_summary["checks"] = [
+            {
+                "id": "runtime_mode_contract",
+                "command": "runtime-mode must equal kolme-live",
+                "status": "pass",
+                "reason_code": "runtime_mode_validated",
+            },
+            {
+                "id": "signer_profile_contract",
+                "command": "signer profile must be ops-primary or ops-secondary",
+                "status": "pass",
+                "reason_code": "signer_profile_validated",
+            },
+            {
+                "id": "signer_secret_contract",
+                "command": "selected signer secret env must exist and be 64-char hex",
+                "status": "pass",
+                "reason_code": "signer_secret_validated",
+            },
+            {
+                "id": "fallback_private_key_contract",
+                "command": "fallback signer secret env must remain unset",
+                "status": "pass",
+                "reason_code": "fallback_signer_secret_absent",
+            },
+            {
+                "id": "signer_quorum_contract",
+                "command": "received approvals must satisfy required approvals threshold",
+                "status": "pass",
+                "reason_code": "signer_quorum_validated",
+            },
+            {
+                "id": "quorum_evidence_contract",
+                "command": "quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match",
+                "status": "pass",
+                "reason_code": "quorum_evidence_validated",
+            },
+            {
+                "id": "custody_evidence_contract",
+                "command": "signer custody evidence file and sha256 marker must be present",
+                "status": "pass",
+                "reason_code": "custody_evidence_validated",
+            },
+            {
+                "id": "signer_provenance_contract",
+                "command": "signer provenance evidence file and sha256 marker must be present",
+                "status": "pass",
+                "reason_code": "signer_provenance_validated",
+            },
+            {
+                "id": "signer_rotation_freshness_contract",
+                "command": "signer rotation metadata must satisfy freshness threshold",
+                "status": "pass",
+                "reason_code": "signer_rotation_freshness_validated",
+            },
+        ]
+        warning_edge_report.write_text(
+            json.dumps(warning_edge_summary, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        warning_edge_result = run_policy_check(
+            report_file=warning_edge_report,
+            output_json=warning_edge_policy,
+            expected_final_decision="GO",
+            required_reason_code="deployment_preflight_passed",
+        )
+        if warning_edge_result.returncode != 0:
+            print("expected runtime signer drift warning-edge proof to pass with GO decision", file=sys.stderr)
+            stderr = warning_edge_result.stderr.strip()
+            if stderr:
+                print(stderr, file=sys.stderr)
+            return 1
+        warning_edge_policy_payload = json.loads(warning_edge_policy.read_text(encoding="utf-8"))
+        if warning_edge_policy_payload.get("runtime_signer_drift_admission_matrix_decision") != "WARN":
+            print("expected runtime signer drift warning-edge policy matrix decision WARN", file=sys.stderr)
+            return 1
+        if warning_edge_policy_payload.get("runtime_signer_drift_admission_matrix_class") != "warning-edge":
+            print("expected runtime signer drift warning-edge policy matrix class warning-edge", file=sys.stderr)
+            return 1
+        warning_edge_reason_codes = warning_edge_policy_payload.get("runtime_signer_drift_admission_matrix_reason_codes")
+        if not isinstance(warning_edge_reason_codes, list):
+            print("expected runtime signer drift warning-edge policy matrix reason-code list", file=sys.stderr)
+            return 1
+        if "runtime_signer_drift_rotation_warning_threshold_reached" not in warning_edge_reason_codes:
+            print("expected runtime signer drift warning-edge policy matrix warning reason marker", file=sys.stderr)
+            return 1
+        if warning_edge_policy_payload.get("final_decision") != "GO":
+            print("expected runtime signer drift warning-edge policy final_decision GO", file=sys.stderr)
             return 1
 
         quorum_negative_report = temp_path / "signer_quorum_negative_summary.json"
@@ -957,7 +1136,15 @@ def main() -> int:
         "runtime_signer_drift_telemetry_missing",
         "runtime_signer_drift_telemetry_schema_version_mismatch",
         "runtime_signer_drift_telemetry_rotation_delta_invalid",
+        "runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1",
+        "runtime_signer_drift_thresholds_bundle",
+        "runtime_signer_drift_admission_matrix_decision",
+        "runtime_signer_drift_admission_matrix_class",
+        "runtime_signer_drift_rotation_warning_threshold_reached",
+        "runtime_signer_drift_quorum_fail_threshold_exceeded",
         "contracts.runtime_signer_drift_telemetry_required=true",
+        "contracts.runtime_signer_drift_thresholds_required=true",
+        "contracts.runtime_signer_drift_admission_matrix_required=true",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -1013,7 +1200,15 @@ def main() -> int:
         "runtime_signer_drift_telemetry_missing",
         "runtime_signer_drift_telemetry_schema_version_mismatch",
         "runtime_signer_drift_telemetry_rotation_delta_invalid",
+        "runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1",
+        "runtime_signer_drift_thresholds_bundle",
+        "runtime_signer_drift_admission_matrix_decision",
+        "runtime_signer_drift_admission_matrix_class",
+        "runtime_signer_drift_rotation_warning_threshold_reached",
+        "runtime_signer_drift_quorum_fail_threshold_exceeded",
         "contracts.runtime_signer_drift_telemetry_required=true",
+        "contracts.runtime_signer_drift_thresholds_required=true",
+        "contracts.runtime_signer_drift_admission_matrix_required=true",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
@@ -1069,7 +1264,15 @@ def main() -> int:
         "runtime_signer_drift_telemetry_missing",
         "runtime_signer_drift_telemetry_schema_version_mismatch",
         "runtime_signer_drift_telemetry_rotation_delta_invalid",
+        "runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1",
+        "runtime_signer_drift_thresholds_bundle",
+        "runtime_signer_drift_admission_matrix_decision",
+        "runtime_signer_drift_admission_matrix_class",
+        "runtime_signer_drift_rotation_warning_threshold_reached",
+        "runtime_signer_drift_quorum_fail_threshold_exceeded",
         "contracts.runtime_signer_drift_telemetry_required=true",
+        "contracts.runtime_signer_drift_thresholds_required=true",
+        "contracts.runtime_signer_drift_admission_matrix_required=true",
         "custody_evidence_missing",
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -30,6 +30,7 @@ REQUIRED_SECRET_HEX_LENGTH=64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED="v1"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION="kamn.kolme.runtime-signer-attestation.v1"
 RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION="kamn.kolme.runtime-signer-drift-telemetry.v1"
+RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION="kamn.kolme.runtime-signer-drift-thresholds.v1"
 QUORUM_EVIDENCE_SCHEMA_VERSION="$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION"
 
 while [ "$#" -gt 0 ]; do
@@ -783,7 +784,7 @@ PY
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$quorum_evidence_signer_roles_present" "$quorum_evidence_signer_roles_valid" "$quorum_evidence_rotation_metadata_present" "$quorum_evidence_rotation_metadata_valid" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$runtime_signer_attestation_approved_signers_csv" "$runtime_signer_attestation_profile_approved" "$RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$RUNTIME_MODE" "$SIGNER_PROFILE_SELECTOR_ENV" "$SIGNER_PROFILE" "$selected_signer_secret_env" "$FALLBACK_SIGNER_SECRET_ENV" "$signer_secret_present" "$fallback_signer_secret_present" "$signer_secret_hex_valid" "$CHECK_FILE" "$REQUIRED_RUNTIME_MODE" "$PRIMARY_SIGNER_PROFILE" "$SECONDARY_SIGNER_PROFILE" "$PRIMARY_SIGNER_SECRET_ENV" "$SECONDARY_SIGNER_SECRET_ENV" "$REQUIRED_SECRET_HEX_LENGTH" "$REQUIRED_APPROVALS" "$RECEIVED_APPROVALS" "$QUORUM_EVIDENCE_FILE" "$quorum_evidence_present" "$quorum_evidence_sha256" "$quorum_evidence_sha256_valid" "$quorum_evidence_schema_valid" "$quorum_evidence_approval_count" "$quorum_evidence_signers_unique" "$quorum_evidence_matches_threshold" "$quorum_evidence_custody_sha256_match" "$quorum_evidence_signer_roles_present" "$quorum_evidence_signer_roles_valid" "$quorum_evidence_rotation_metadata_present" "$quorum_evidence_rotation_metadata_valid" "$QUORUM_EVIDENCE_SCHEMA_VERSION" "$CUSTODY_EVIDENCE_FILE" "$custody_evidence_present" "$custody_evidence_sha256" "$custody_evidence_sha256_valid" "$SIGNER_PROVENANCE_FILE" "$signer_provenance_present" "$signer_provenance_sha256" "$signer_provenance_sha256_valid" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$SIGNER_KEY_SOURCE" "$SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED" "$SIGNER_ROTATION_EPOCH" "$SIGNER_PREVIOUS_ROTATION_EPOCH" "$SIGNER_ROTATION_FRESHNESS_MAX_DELTA" "$signer_rotation_delta_epochs" "$signer_rotation_fresh" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$runtime_signer_attestation_approved_signers_csv" "$runtime_signer_attestation_profile_approved" "$RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION" "$RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION" <<'PY'
 from __future__ import annotations
 
 import json
@@ -848,6 +849,7 @@ runtime_signer_attestation_schema_version = sys.argv[55]
 runtime_signer_attestation_approved_signers_csv = sys.argv[56]
 runtime_signer_attestation_profile_approved = sys.argv[57] == "true"
 runtime_signer_drift_telemetry_schema_version = sys.argv[58]
+runtime_signer_drift_thresholds_schema_version = sys.argv[59]
 
 runtime_signer_attestation_approved_signers: list[str] = [
     entry.strip()
@@ -880,6 +882,13 @@ runtime_signer_drift_telemetry = {
     "required_approvals": required_approvals,
     "received_approvals": received_approvals,
     "quorum_shortfall": received_approvals < required_approvals,
+}
+runtime_signer_drift_thresholds_bundle = {
+    "schema_version": runtime_signer_drift_thresholds_schema_version,
+    "rotation_warn_delta_epochs": max(0, signer_rotation_freshness_max_delta - 1),
+    "rotation_fail_delta_epochs": signer_rotation_freshness_max_delta,
+    "quorum_warn_shortfall_events": 0,
+    "quorum_fail_shortfall_events": 0,
 }
 
 checks = []
@@ -939,6 +948,8 @@ summary = {
     "runtime_signer_attestation_profile_approved": runtime_signer_attestation_profile_approved,
     "runtime_signer_drift_telemetry_schema_version": runtime_signer_drift_telemetry_schema_version,
     "runtime_signer_drift_telemetry": runtime_signer_drift_telemetry,
+    "runtime_signer_drift_thresholds_schema_version": runtime_signer_drift_thresholds_schema_version,
+    "runtime_signer_drift_thresholds_bundle": runtime_signer_drift_thresholds_bundle,
     "custody_evidence_file": custody_evidence_file,
     "custody_evidence_present": custody_evidence_present,
     "custody_evidence_sha256": custody_evidence_sha256,
@@ -994,6 +1005,12 @@ summary = {
         "runtime_signer_drift_telemetry_stale_flag_match_required": True,
         "runtime_signer_drift_telemetry_quorum_flag_match_required": True,
         "runtime_signer_drift_telemetry_approval_counts_match_required": True,
+        "runtime_signer_drift_thresholds_required": True,
+        "runtime_signer_drift_thresholds_schema_version": runtime_signer_drift_thresholds_schema_version,
+        "runtime_signer_drift_thresholds_rotation_warn_lte_fail_required": True,
+        "runtime_signer_drift_thresholds_quorum_warn_lte_fail_required": True,
+        "runtime_signer_drift_admission_matrix_required": True,
+        "runtime_signer_drift_admission_matrix_decision_values": ["GO", "WARN", "NO-GO"],
         "custody_evidence_required": True,
         "custody_evidence_sha256_required": True,
         "signer_provenance_required": True,

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -11,6 +11,8 @@ TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_QUORUM_MINIMUM="$TMP_DIR/quorum-minimum-report.json"
 TMP_REPORT_DRIFT_MALFORMED="$TMP_DIR/drift-malformed-report.json"
+TMP_REPORT_MATRIX_WARN="$TMP_DIR/drift-matrix-warn-report.json"
+TMP_REPORT_MATRIX_FAIL="$TMP_DIR/drift-matrix-fail-report.json"
 TMP_REPORT_BAD="$TMP_DIR/bad-report.json"
 TMP_POLICY_OUT="$TMP_DIR/policy-report.json"
 TMP_SUMMARY="$TMP_DIR/summary.json"
@@ -97,6 +99,14 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "received_approvals": 0,
     "quorum_shortfall": true
   },
+  "runtime_signer_drift_thresholds_schema_version": "kamn.kolme.runtime-signer-drift-thresholds.v1",
+  "runtime_signer_drift_thresholds_bundle": {
+    "schema_version": "kamn.kolme.runtime-signer-drift-thresholds.v1",
+    "rotation_warn_delta_epochs": 1,
+    "rotation_fail_delta_epochs": 2,
+    "quorum_warn_shortfall_events": 0,
+    "quorum_fail_shortfall_events": 0
+  },
   "custody_evidence_file": "",
   "custody_evidence_present": false,
   "custody_evidence_sha256": "",
@@ -161,6 +171,16 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_drift_telemetry_stale_flag_match_required": true,
     "runtime_signer_drift_telemetry_quorum_flag_match_required": true,
     "runtime_signer_drift_telemetry_approval_counts_match_required": true,
+    "runtime_signer_drift_thresholds_required": true,
+    "runtime_signer_drift_thresholds_schema_version": "kamn.kolme.runtime-signer-drift-thresholds.v1",
+    "runtime_signer_drift_thresholds_rotation_warn_lte_fail_required": true,
+    "runtime_signer_drift_thresholds_quorum_warn_lte_fail_required": true,
+    "runtime_signer_drift_admission_matrix_required": true,
+    "runtime_signer_drift_admission_matrix_decision_values": [
+      "GO",
+      "WARN",
+      "NO-GO"
+    ],
     "custody_evidence_required": true,
     "custody_evidence_sha256_required": true,
     "signer_provenance_required": true,
@@ -256,7 +276,177 @@ if report.get("final_decision") != "GO":
     raise SystemExit("expected final_decision GO for valid deployment preflight report")
 if report.get("reason_codes") != []:
     raise SystemExit("expected no reason codes for valid deployment preflight report")
+if report.get("runtime_signer_drift_admission_matrix_decision") not in ("GO", "WARN", "NO-GO"):
+    raise SystemExit("expected runtime signer drift admission matrix decision marker in deployment preflight policy report")
+if report.get("runtime_signer_drift_admission_matrix_class") not in ("healthy", "warning-edge", "hard-fail"):
+    raise SystemExit("expected runtime signer drift admission matrix class marker in deployment preflight policy report")
+matrix_reason_codes = report.get("runtime_signer_drift_admission_matrix_reason_codes")
+if not isinstance(matrix_reason_codes, list):
+    raise SystemExit("expected runtime signer drift admission matrix reason-code list in deployment preflight policy report")
 PY
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_MATRIX_WARN" "$TMP_REPORT_MATRIX_FAIL" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+warn_report = dict(report)
+warn_report["mode"] = "run"
+warn_report["status"] = "ok"
+warn_report["reason_code"] = "deployment_preflight_passed"
+warn_report["signer_secret_present"] = True
+warn_report["signer_secret_hex_valid"] = True
+warn_report["required_approvals"] = 2
+warn_report["received_approvals"] = 2
+warn_report["quorum_evidence_file"] = "/tmp/quorum.json"
+warn_report["quorum_evidence_present"] = True
+warn_report["quorum_evidence_sha256"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+warn_report["quorum_evidence_sha256_valid"] = True
+warn_report["quorum_evidence_schema_valid"] = True
+warn_report["quorum_evidence_approval_count"] = 2
+warn_report["quorum_evidence_signers_unique"] = True
+warn_report["quorum_evidence_matches_threshold"] = True
+warn_report["quorum_evidence_custody_sha256_match"] = True
+warn_report["quorum_evidence_signer_roles_present"] = True
+warn_report["quorum_evidence_signer_roles_valid"] = True
+warn_report["quorum_evidence_rotation_metadata_present"] = True
+warn_report["quorum_evidence_rotation_metadata_valid"] = True
+warn_report["runtime_signer_attestation_bundle"] = {
+    "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+    "required_approvals": 2,
+    "approved_signers": ["ops-primary", "ops-secondary"],
+    "signer_profile": "ops-primary",
+    "signer_key_source": "env-local",
+}
+warn_report["runtime_signer_attestation_profile_approved"] = True
+warn_report["runtime_signer_drift_telemetry"] = {
+    "schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v1",
+    "signer_rotation_epoch": 3,
+    "signer_previous_rotation_epoch": 1,
+    "signer_rotation_delta_epochs": 2,
+    "signer_rotation_freshness_max_delta": 2,
+    "signer_rotation_stale": False,
+    "required_approvals": 2,
+    "received_approvals": 2,
+    "quorum_shortfall": False,
+}
+warn_report["custody_evidence_file"] = "/tmp/custody.json"
+warn_report["custody_evidence_present"] = True
+warn_report["custody_evidence_sha256"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+warn_report["custody_evidence_sha256_valid"] = True
+warn_report["signer_provenance_file"] = "/tmp/provenance.json"
+warn_report["signer_provenance_present"] = True
+warn_report["signer_provenance_sha256"] = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+warn_report["signer_provenance_sha256_valid"] = True
+warn_report["signer_rotation_epoch"] = 3
+warn_report["signer_previous_rotation_epoch"] = 1
+warn_report["signer_rotation_freshness_max_delta"] = 2
+warn_report["signer_rotation_delta_epochs"] = 2
+warn_report["signer_rotation_fresh"] = True
+warn_report["runtime_signer_drift_thresholds_bundle"] = {
+    "schema_version": "kamn.kolme.runtime-signer-drift-thresholds.v1",
+    "rotation_warn_delta_epochs": 1,
+    "rotation_fail_delta_epochs": 2,
+    "quorum_warn_shortfall_events": 0,
+    "quorum_fail_shortfall_events": 0,
+}
+warn_report["contracts"] = dict(warn_report.get("contracts", {}))
+warn_report["contracts"]["approval_quorum_required"] = 2
+warn_report["contracts"]["runtime_signer_attestation_required_approvals"] = 2
+warn_report["contracts"]["runtime_signer_drift_telemetry_required"] = True
+warn_report["contracts"]["runtime_signer_drift_telemetry_schema_version"] = "kamn.kolme.runtime-signer-drift-telemetry.v1"
+warn_report["contracts"]["runtime_signer_drift_telemetry_rotation_delta_match_required"] = True
+warn_report["contracts"]["runtime_signer_drift_telemetry_stale_flag_match_required"] = True
+warn_report["contracts"]["runtime_signer_drift_telemetry_quorum_flag_match_required"] = True
+warn_report["contracts"]["runtime_signer_drift_telemetry_approval_counts_match_required"] = True
+warn_report["contracts"]["runtime_signer_drift_thresholds_required"] = True
+warn_report["contracts"]["runtime_signer_drift_thresholds_schema_version"] = "kamn.kolme.runtime-signer-drift-thresholds.v1"
+warn_report["contracts"]["runtime_signer_drift_thresholds_rotation_warn_lte_fail_required"] = True
+warn_report["contracts"]["runtime_signer_drift_thresholds_quorum_warn_lte_fail_required"] = True
+warn_report["contracts"]["runtime_signer_drift_admission_matrix_required"] = True
+warn_report["contracts"]["runtime_signer_drift_admission_matrix_decision_values"] = ["GO", "WARN", "NO-GO"]
+warn_report["checks"] = [
+    {"id": "runtime_mode_contract", "command": "runtime-mode must equal kolme-live", "status": "pass", "reason_code": "runtime_mode_validated"},
+    {"id": "signer_profile_contract", "command": "signer profile must be ops-primary or ops-secondary", "status": "pass", "reason_code": "signer_profile_validated"},
+    {"id": "signer_secret_contract", "command": "selected signer secret env must exist and be 64-char hex", "status": "pass", "reason_code": "signer_secret_validated"},
+    {"id": "fallback_private_key_contract", "command": "fallback signer secret env must remain unset", "status": "pass", "reason_code": "fallback_signer_secret_absent"},
+    {"id": "signer_quorum_contract", "command": "received approvals must satisfy required approvals threshold", "status": "pass", "reason_code": "signer_quorum_validated"},
+    {"id": "quorum_evidence_contract", "command": "quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match", "status": "pass", "reason_code": "quorum_evidence_validated"},
+    {"id": "custody_evidence_contract", "command": "signer custody evidence file and sha256 marker must be present", "status": "pass", "reason_code": "custody_evidence_validated"},
+    {"id": "signer_provenance_contract", "command": "signer provenance evidence file and sha256 marker must be present", "status": "pass", "reason_code": "signer_provenance_validated"},
+    {"id": "signer_rotation_freshness_contract", "command": "signer rotation metadata must satisfy freshness threshold", "status": "pass", "reason_code": "signer_rotation_freshness_validated"},
+]
+
+fail_report = dict(warn_report)
+fail_report["status"] = "fail"
+fail_report["reason_code"] = "checkpoint_failed_signer_quorum_contract"
+fail_report["received_approvals"] = 1
+fail_report["quorum_evidence_approval_count"] = 1
+fail_report["quorum_evidence_matches_threshold"] = False
+fail_report["runtime_signer_drift_telemetry"] = dict(warn_report["runtime_signer_drift_telemetry"])
+fail_report["runtime_signer_drift_telemetry"]["received_approvals"] = 1
+fail_report["runtime_signer_drift_telemetry"]["quorum_shortfall"] = True
+fail_report["checks"] = [
+    {"id": "runtime_mode_contract", "command": "runtime-mode must equal kolme-live", "status": "pass", "reason_code": "runtime_mode_validated"},
+    {"id": "signer_profile_contract", "command": "signer profile must be ops-primary or ops-secondary", "status": "pass", "reason_code": "signer_profile_validated"},
+    {"id": "signer_secret_contract", "command": "selected signer secret env must exist and be 64-char hex", "status": "pass", "reason_code": "signer_secret_validated"},
+    {"id": "fallback_private_key_contract", "command": "fallback signer secret env must remain unset", "status": "pass", "reason_code": "fallback_signer_secret_absent"},
+    {"id": "signer_quorum_contract", "command": "received approvals must satisfy required approvals threshold", "status": "fail", "reason_code": "signer_quorum_shortfall"},
+    {"id": "quorum_evidence_contract", "command": "quorum evidence bundle must satisfy schema, signer uniqueness, threshold, and custody digest match", "status": "skipped", "reason_code": "signer_quorum_shortfall"},
+    {"id": "custody_evidence_contract", "command": "signer custody evidence file and sha256 marker must be present", "status": "skipped", "reason_code": "signer_quorum_shortfall"},
+    {"id": "signer_provenance_contract", "command": "signer provenance evidence file and sha256 marker must be present", "status": "skipped", "reason_code": "signer_quorum_shortfall"},
+    {"id": "signer_rotation_freshness_contract", "command": "signer rotation metadata must satisfy freshness threshold", "status": "skipped", "reason_code": "signer_quorum_shortfall"},
+]
+
+pathlib.Path(sys.argv[2]).write_text(json.dumps(warn_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+pathlib.Path(sys.argv[3]).write_text(json.dumps(fail_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_MATRIX_WARN" \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --require-reason-code deployment_preflight_passed \
+  --output-json "$TMP_POLICY_OUT" >/dev/null
+
+python3 - "$TMP_POLICY_OUT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("runtime_signer_drift_admission_matrix_decision") != "WARN":
+    raise SystemExit("expected runtime signer drift admission matrix decision WARN for warning-edge deployment report")
+if report.get("runtime_signer_drift_admission_matrix_class") != "warning-edge":
+    raise SystemExit("expected runtime signer drift admission matrix class warning-edge for warning deployment report")
+matrix_reason_codes = report.get("runtime_signer_drift_admission_matrix_reason_codes")
+if not isinstance(matrix_reason_codes, list):
+    raise SystemExit("expected runtime signer drift admission matrix reason-code list for warning deployment report")
+if "runtime_signer_drift_rotation_warning_threshold_reached" not in matrix_reason_codes:
+    raise SystemExit("expected runtime signer drift rotation warning-threshold reason code in warning deployment report")
+if report.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision GO for warning-edge deployment report")
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_MATRIX_FAIL" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+matrix_fail_exit_code=$?
+set -e
+
+if [ "$matrix_fail_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight policy checker to fail for hard-fail runtime signer drift matrix report" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_drift_quorum_fail_threshold_exceeded" "$TMP_ERR"; then
+  echo "expected runtime signer drift quorum fail-threshold reason for hard-fail deployment matrix report" >&2
+  exit 1
+fi
 
 python3 - "$TMP_REPORT_OK" "$TMP_REPORT_QUORUM_MINIMUM" <<'PY'
 import json

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh
@@ -106,7 +106,15 @@ required_coverage_markers=(
   "runtime_signer_drift_telemetry_missing"
   "runtime_signer_drift_telemetry_schema_version_mismatch"
   "runtime_signer_drift_telemetry_rotation_delta_invalid"
+  "runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1"
+  "runtime_signer_drift_thresholds_bundle"
+  "runtime_signer_drift_admission_matrix_decision"
+  "runtime_signer_drift_admission_matrix_class"
+  "runtime_signer_drift_rotation_warning_threshold_reached"
+  "runtime_signer_drift_quorum_fail_threshold_exceeded"
   "contracts.runtime_signer_drift_telemetry_required=true"
+  "contracts.runtime_signer_drift_thresholds_required=true"
+  "contracts.runtime_signer_drift_admission_matrix_required=true"
   "Regression: #2226"
   "Regression: #2337"
   "Regression: #2300"
@@ -172,6 +180,38 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
   fi
   if ! grep -q "contracts.runtime_signer_drift_telemetry_required=true" "$docs_file"; then
     echo "expected docs parity to include runtime signer drift telemetry contract requirement marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_thresholds_schema_version=kamn.kolme.runtime-signer-drift-thresholds.v1" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift thresholds schema marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_thresholds_bundle" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift thresholds bundle marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_admission_matrix_decision" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift admission matrix decision marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_admission_matrix_class" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift admission matrix class marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_rotation_warning_threshold_reached" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift warning-threshold reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_drift_quorum_fail_threshold_exceeded" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift quorum fail-threshold reason marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.runtime_signer_drift_thresholds_required=true" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift thresholds contract requirement marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "contracts.runtime_signer_drift_admission_matrix_required=true" "$docs_file"; then
+    echo "expected docs parity to include runtime signer drift admission matrix contract requirement marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "quorum_evidence_signer_roles_missing" "$docs_file"; then
@@ -305,6 +345,13 @@ if runtime_signer_drift_telemetry.get("required_approvals") != summary.get("requ
     raise SystemExit("expected deployment preflight summary runtime signer drift telemetry required approvals marker")
 if runtime_signer_drift_telemetry.get("received_approvals") != summary.get("received_approvals"):
     raise SystemExit("expected deployment preflight summary runtime signer drift telemetry received approvals marker")
+if summary.get("runtime_signer_drift_thresholds_schema_version") != "kamn.kolme.runtime-signer-drift-thresholds.v1":
+    raise SystemExit("expected deployment preflight summary runtime signer drift thresholds schema marker")
+runtime_signer_drift_thresholds_bundle = summary.get("runtime_signer_drift_thresholds_bundle")
+if not isinstance(runtime_signer_drift_thresholds_bundle, dict):
+    raise SystemExit("expected deployment preflight summary runtime signer drift thresholds bundle")
+if runtime_signer_drift_thresholds_bundle.get("schema_version") != "kamn.kolme.runtime-signer-drift-thresholds.v1":
+    raise SystemExit("expected deployment preflight summary runtime signer drift thresholds bundle schema marker")
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "ci-fast-gate":
     raise SystemExit("expected deployment preflight contracts ci_fast_gate_scope=ci-fast-gate")
@@ -328,10 +375,26 @@ if contracts.get("runtime_signer_drift_telemetry_quorum_flag_match_required") is
     raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry quorum flag match marker")
 if contracts.get("runtime_signer_drift_telemetry_approval_counts_match_required") is not True:
     raise SystemExit("expected deployment preflight contracts runtime signer drift telemetry approval count match marker")
+if contracts.get("runtime_signer_drift_thresholds_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift thresholds requirement marker")
+if contracts.get("runtime_signer_drift_thresholds_schema_version") != "kamn.kolme.runtime-signer-drift-thresholds.v1":
+    raise SystemExit("expected deployment preflight contracts runtime signer drift thresholds schema marker")
+if contracts.get("runtime_signer_drift_thresholds_rotation_warn_lte_fail_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift thresholds warn<=fail marker")
+if contracts.get("runtime_signer_drift_thresholds_quorum_warn_lte_fail_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift thresholds quorum warn<=fail marker")
+if contracts.get("runtime_signer_drift_admission_matrix_required") is not True:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift admission matrix requirement marker")
+if contracts.get("runtime_signer_drift_admission_matrix_decision_values") != ["GO", "WARN", "NO-GO"]:
+    raise SystemExit("expected deployment preflight contracts runtime signer drift admission matrix decision-value marker")
 if policy.get("schema_version") != "kamn.kolme.local-live-deployment-preflight-policy-report.v1":
     raise SystemExit("unexpected deployment preflight contract-lane policy schema")
 if policy.get("final_decision") != "GO":
     raise SystemExit("expected deployment preflight contract-lane policy final_decision GO")
+if policy.get("runtime_signer_drift_admission_matrix_decision") != "GO":
+    raise SystemExit("expected deployment preflight contract-lane policy runtime signer drift matrix decision GO")
+if policy.get("runtime_signer_drift_admission_matrix_class") != "healthy":
+    raise SystemExit("expected deployment preflight contract-lane policy runtime signer drift matrix class healthy")
 PY
 
 python3 - "$TMP_REPORT" "$TMP_NEGATIVE_REPORT" <<'PY'


### PR DESCRIPTION
Closes #2435

## Summary
Implement deterministic runtime signer drift threshold parsing and GO/WARN/NO-GO admission matrix output for deployment preflight policy, with stable reason-code mapping for threshold breach classes.

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`: emit runtime signer drift thresholds schema/bundle plus matrix contract markers.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`: validate drift-threshold bundle bounds, compute runtime signer drift admission matrix (`GO|WARN|NO-GO`, `healthy|warning-edge|hard-fail`), and enforce deterministic fail reason codes for hard breaches.
- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`: red/green matrix-output coverage and scenario checks for warning-edge and hard-fail classes.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`: assert matrix and thresholds markers and add warning-edge matrix integration proof.
- `scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`: enforce matrix/threshold docs parity markers and policy-output assertions.
- Docs updated for matrix contracts and breach response: `README.md`, `docs/planning/kolme-devnet-ops.md`, `docs/ci/strategy.md`, `docs/foundation/release-gonogo-checklist.md`, `docs/foundation/upgrade-rollback-runbook.md`, `docs/ci/ci-cost-and-lane-framework.md`.

## Risks & Compatibility
- None

## Validation
- [x] `bash -n scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
- [x] `python3 -m py_compile scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`
- [x] `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
- [x] `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy -- -D warnings`
- [ ] Unit tests pass (full workspace)
- [ ] Integration tests pass (full workspace)
- [x] Manual verification: checked matrix decision/class + reason-code outputs for healthy, warning-edge, and hard-fail runtime signer drift scenarios in deployment preflight policy outputs.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | threshold bundle parsing, bounds checks, matrix reason mapping |
| Functional  | ✅ | policy output matrix decision/class behavior across representative reports |
| Integration | ✅ | deployment preflight contract lane includes warning-edge + hard-fail matrix proofs |
| Regression  | ✅ | docs parity + deterministic matrix marker drift checks |