### PR TITLE
feat(kolme): add managed-signer backend SLO telemetry bundle schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,39 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # Regression: #2327
 ```
 
+### Managed Signer Backend SLO Telemetry Bundle
+
+```bash
+# generate managed-signer backend SLO telemetry bundle (deterministic schema)
+bash scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh \
+  --output-file /tmp/managed-signer-backend-slo.json \
+  --window-start-utc 2026-02-13T00:00:00Z \
+  --window-end-utc 2026-02-13T00:15:00Z \
+  --backend-name kolme-managed-signer-primary \
+  --signer-profile ops-primary \
+  --signer-key-source managed-external \
+  --sample-count 100 \
+  --timeout-events 0 \
+  --unavailable-events 0 \
+  --error-events 1 \
+  --max-timeout-rate-bps 100 \
+  --max-unavailable-rate-bps 100 \
+  --max-error-rate-bps 200 \
+  --ci-fast-gate PASS
+
+# managed-signer backend SLO telemetry contract lane
+bash scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh --output-json /tmp/managed-signer-backend-slo-contract-report.json
+
+# schema: kamn.kolme.managed-signer-backend-slo-telemetry.v1
+# signer_key_source=managed-external
+# contracts.required_signer_key_source=managed-external
+# fail-closed threshold breach markers
+# managed_signer_backend_timeout_rate_threshold_exceeded
+# managed_signer_backend_unavailable_rate_threshold_exceeded
+# managed_signer_backend_error_rate_threshold_exceeded
+# managed_signer_backend_ci_fast_gate_failed
+```
+
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`
 
 ### Run Local Live-Node Validation Bundle Lane

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -82,6 +82,27 @@ Coverage split for cost control:
 - contract lane: `run_local_kolme_live_deployment_preflight_contract_lane.sh` for docs/policy parity
 - local-heavy/deep integration remains outside fast gate and opt-in only
 
+## Managed-Signer Backend SLO Telemetry Artifact
+Managed-signer backend SLO telemetry is emitted through:
+
+- `scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh`
+- `scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh`
+
+Deterministic contract markers:
+
+- `kamn.kolme.managed-signer-backend-slo-telemetry.v1`
+- `signer_key_source=managed-external`
+- `contracts.required_signer_key_source=managed-external`
+- `managed_signer_backend_timeout_rate_threshold_exceeded`
+- `managed_signer_backend_unavailable_rate_threshold_exceeded`
+- `managed_signer_backend_error_rate_threshold_exceeded`
+- `managed_signer_backend_ci_fast_gate_failed`
+
+Cost boundary:
+
+- generation + contract-lane checks are offline, bounded, and PR fast-gate friendly.
+- no local-heavy selector or external metrics backend calls are required.
+
 ## Script-Surface Budget Policy
 `scripts/ci/check_script_duplication_budget.py` computes deterministic metrics over non-test shell command surface under `scripts/**/*.sh`:
 

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -776,6 +776,24 @@ JSON`
   - runtime/deployment shared signer-attestation schema + reason-code parity remains fail-closed (`Regression: #2326`).
   - replay/tamper/stale-signer attestation regression matrix remains fail-closed (`Regression: #2327`).
 
+## Managed Signer Backend SLO Telemetry Lane (Issue #2436)
+
+- Managed-signer backend SLO telemetry generator:
+  - `bash scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh --output-file /tmp/managed-signer-backend-slo.json --window-start-utc 2026-02-13T00:00:00Z --window-end-utc 2026-02-13T00:15:00Z --backend-name kolme-managed-signer-primary --signer-profile ops-primary --signer-key-source managed-external --sample-count 100 --timeout-events 0 --unavailable-events 0 --error-events 1 --max-timeout-rate-bps 100 --max-unavailable-rate-bps 100 --max-error-rate-bps 200 --ci-fast-gate PASS`
+- Managed-signer backend SLO contract lane:
+  - `bash scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh --output-json /tmp/managed-signer-backend-slo-contract-report.json`
+- Required schema/reason markers:
+  - `kamn.kolme.managed-signer-backend-slo-telemetry.v1`
+  - `signer_key_source=managed-external`
+  - `contracts.required_signer_key_source=managed-external`
+  - `managed_signer_backend_timeout_rate_threshold_exceeded`
+  - `managed_signer_backend_unavailable_rate_threshold_exceeded`
+  - `managed_signer_backend_error_rate_threshold_exceeded`
+  - `managed_signer_backend_ci_fast_gate_failed`
+- Cost policy:
+  - lane remains lightweight and CI-fast-gate eligible.
+  - artifacts are generated offline with deterministic thresholds and no external metrics backend dependency.
+
 ## Staging Soak Telemetry Lane (Issue #2422)
 
 - Fast lane command:

--- a/scripts/kolme/contracts/managed_signer_backend_slo_telemetry_contract_lane.py
+++ b/scripts/kolme/contracts/managed_signer_backend_slo_telemetry_contract_lane.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Contract lane for managed-signer backend SLO telemetry bundle generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+GENERATOR = ROOT_DIR / "scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh"
+DOC_FILES = [
+    ROOT_DIR / "docs/ci/ci-cost-and-lane-framework.md",
+    ROOT_DIR / "docs/planning/kolme-devnet-ops.md",
+    ROOT_DIR / "README.md",
+]
+
+
+def run_generator(bundle_path: Path, **kwargs: str) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(GENERATOR),
+        "--output-file",
+        str(bundle_path),
+    ]
+    for key, value in kwargs.items():
+        option_name = key.replace("_", "-")
+        command.extend([f"--{option_name}", value])
+    return subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def ensure_markers_present(text: str, markers: list[str], source_name: str) -> list[str]:
+    missing: list[str] = []
+    for marker in markers:
+        if marker not in text:
+            missing.append(f"{source_name}_missing_marker:{marker}")
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run managed-signer backend SLO telemetry bundle contract lane."
+    )
+    parser.add_argument(
+        "--output-json",
+        default="/tmp/managed-signer-backend-slo-contract-report.json",
+    )
+    args = parser.parse_args()
+
+    if not GENERATOR.is_file() or not GENERATOR.stat().st_mode & 0o111:
+        print("expected managed-signer backend SLO telemetry generator to be executable", file=sys.stderr)
+        return 1
+
+    required_markers = [
+        "generate_managed_signer_backend_slo_telemetry_bundle.sh",
+        "run_managed_signer_backend_slo_telemetry_contract_lane.sh",
+        "kamn.kolme.managed-signer-backend-slo-telemetry.v1",
+        "managed_signer_backend_timeout_rate_threshold_exceeded",
+        "managed_signer_backend_unavailable_rate_threshold_exceeded",
+        "managed_signer_backend_error_rate_threshold_exceeded",
+        "managed_signer_backend_ci_fast_gate_failed",
+        "signer_key_source=managed-external",
+        "contracts.required_signer_key_source=managed-external",
+    ]
+
+    missing_doc_markers: list[str] = []
+    for doc_file in DOC_FILES:
+        if not doc_file.is_file():
+            print(f"expected documentation file to exist: {doc_file}", file=sys.stderr)
+            return 1
+        missing_doc_markers.extend(
+            ensure_markers_present(
+                doc_file.read_text(encoding="utf-8"),
+                required_markers,
+                str(doc_file.relative_to(ROOT_DIR)),
+            )
+        )
+    if missing_doc_markers:
+        print(",".join(missing_doc_markers), file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="managed-signer-slo-contract-") as temp_dir:
+        temp_path = Path(temp_dir)
+        go_bundle = temp_path / "go.json"
+        no_go_bundle = temp_path / "no-go.json"
+
+        go_result = run_generator(
+            go_bundle,
+            window_start_utc="2026-02-13T00:00:00Z",
+            window_end_utc="2026-02-13T00:15:00Z",
+            backend_name="kolme-managed-signer-primary",
+            signer_profile="ops-primary",
+            signer_key_source="managed-external",
+            sample_count="100",
+            timeout_events="0",
+            unavailable_events="0",
+            error_events="1",
+            max_timeout_rate_bps="100",
+            max_unavailable_rate_bps="100",
+            max_error_rate_bps="200",
+            ci_fast_gate="PASS",
+        )
+        if go_result.returncode != 0:
+            print("expected managed-signer SLO GO fixture generation to succeed", file=sys.stderr)
+            stderr = go_result.stderr.strip()
+            if stderr:
+                print(stderr, file=sys.stderr)
+            return 1
+        if "final_decision=GO" not in go_result.stdout:
+            print("expected managed-signer SLO GO fixture decision marker", file=sys.stderr)
+            return 1
+        go_payload = json.loads(go_bundle.read_text(encoding="utf-8"))
+        if go_payload.get("schema_version") != "kamn.kolme.managed-signer-backend-slo-telemetry.v1":
+            print("unexpected managed-signer SLO GO fixture schema", file=sys.stderr)
+            return 1
+        if go_payload.get("final_decision") != "GO":
+            print("expected managed-signer SLO GO fixture final decision marker", file=sys.stderr)
+            return 1
+        if go_payload.get("threshold_breaches") != []:
+            print("expected managed-signer SLO GO fixture threshold breaches to be empty", file=sys.stderr)
+            return 1
+
+        no_go_result = run_generator(
+            no_go_bundle,
+            window_start_utc="2026-02-13T00:15:00Z",
+            window_end_utc="2026-02-13T00:30:00Z",
+            backend_name="kolme-managed-signer-primary",
+            signer_profile="ops-primary",
+            signer_key_source="managed-external",
+            sample_count="100",
+            timeout_events="8",
+            unavailable_events="7",
+            error_events="9",
+            max_timeout_rate_bps="500",
+            max_unavailable_rate_bps="500",
+            max_error_rate_bps="500",
+            ci_fast_gate="PASS",
+        )
+        if no_go_result.returncode != 0:
+            print("expected managed-signer SLO NO-GO fixture generation to succeed", file=sys.stderr)
+            stderr = no_go_result.stderr.strip()
+            if stderr:
+                print(stderr, file=sys.stderr)
+            return 1
+        if "final_decision=NO-GO" not in no_go_result.stdout:
+            print("expected managed-signer SLO NO-GO fixture decision marker", file=sys.stderr)
+            return 1
+        no_go_payload = json.loads(no_go_bundle.read_text(encoding="utf-8"))
+        if no_go_payload.get("final_decision") != "NO-GO":
+            print("expected managed-signer SLO NO-GO fixture final decision marker", file=sys.stderr)
+            return 1
+        no_go_breaches = no_go_payload.get("threshold_breaches")
+        if not isinstance(no_go_breaches, list):
+            print("expected managed-signer SLO NO-GO fixture threshold_breaches list", file=sys.stderr)
+            return 1
+        required_breaches = {
+            "managed_signer_backend_timeout_rate_threshold_exceeded",
+            "managed_signer_backend_unavailable_rate_threshold_exceeded",
+            "managed_signer_backend_error_rate_threshold_exceeded",
+        }
+        if set(no_go_breaches) != required_breaches:
+            print("expected managed-signer SLO NO-GO fixture threshold breach set", file=sys.stderr)
+            return 1
+
+        contract_report = {
+            "schema_version": "kamn.kolme.managed-signer-backend-slo-contract-report.v1",
+            "go_fixture_bundle": str(go_bundle),
+            "no_go_fixture_bundle": str(no_go_bundle),
+            "final_decision": "GO",
+        }
+        output_path = Path(args.output_json).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(contract_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    print("managed-signer backend SLO telemetry contract lane tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh
+++ b/scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/kolme/managed_signer_backend_slo_telemetry_contract.py" generate "$@"

--- a/scripts/kolme/managed_signer_backend_slo_telemetry_contract.py
+++ b/scripts/kolme/managed_signer_backend_slo_telemetry_contract.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Managed-signer backend SLO telemetry bundle generator."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import fail, write_json  # noqa: E402
+
+SCHEMA_VERSION = "kamn.kolme.managed-signer-backend-slo-telemetry.v1"
+GO_DECISION = "GO"
+NO_GO_DECISION = "NO-GO"
+MAX_BPS = 10_000
+REQUIRED_SIGNER_KEY_SOURCE = "managed-external"
+
+
+def _parse_positive_int(field_name: str, raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        fail(f"{field_name} must be an integer")
+    if parsed <= 0:
+        fail(f"{field_name} must be > 0")
+    return parsed
+
+
+def _parse_non_negative_int(field_name: str, raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        fail(f"{field_name} must be an integer")
+    if parsed < 0:
+        fail(f"{field_name} must be >= 0")
+    return parsed
+
+
+def _parse_bps(field_name: str, raw_value: str) -> int:
+    parsed = _parse_non_negative_int(field_name, raw_value)
+    if parsed > MAX_BPS:
+        fail(f"{field_name} must be <= {MAX_BPS}")
+    return parsed
+
+
+def _parse_ci_fast_gate(raw_value: str) -> str:
+    if raw_value in {"PASS", "FAIL"}:
+        return raw_value
+    fail("ci-fast-gate must be PASS or FAIL")
+
+
+def _parse_utc_timestamp(field_name: str, raw_value: str) -> datetime:
+    if not isinstance(raw_value, str) or not raw_value.strip():
+        fail(f"{field_name} must be a non-empty UTC timestamp")
+    normalized = raw_value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        fail(f"{field_name} must be RFC3339 UTC timestamp (example: 2026-02-13T00:00:00Z)")
+    if parsed.tzinfo is None:
+        fail(f"{field_name} must include timezone offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_non_empty(field_name: str, raw_value: str) -> str:
+    if not isinstance(raw_value, str) or not raw_value.strip():
+        fail(f"{field_name} must be non-empty")
+    return raw_value.strip()
+
+
+def _compute_rate_bps(events: int, sample_count: int) -> int:
+    return (events * MAX_BPS) // sample_count
+
+
+def generate_bundle(args: argparse.Namespace) -> int:
+    output_file = _parse_non_empty("output-file", args.output_file)
+    backend_name = _parse_non_empty("backend-name", args.backend_name)
+    signer_profile = _parse_non_empty("signer-profile", args.signer_profile)
+    signer_key_source = _parse_non_empty("signer-key-source", args.signer_key_source)
+    if signer_key_source != REQUIRED_SIGNER_KEY_SOURCE:
+        fail(f"signer-key-source must be {REQUIRED_SIGNER_KEY_SOURCE}")
+
+    window_start_utc = _parse_utc_timestamp("window-start-utc", args.window_start_utc)
+    window_end_utc = _parse_utc_timestamp("window-end-utc", args.window_end_utc)
+    if window_end_utc <= window_start_utc:
+        fail("window-end-utc must be after window-start-utc")
+
+    sample_count = _parse_positive_int("sample-count", args.sample_count)
+    timeout_events = _parse_non_negative_int("timeout-events", args.timeout_events)
+    unavailable_events = _parse_non_negative_int("unavailable-events", args.unavailable_events)
+    error_events = _parse_non_negative_int("error-events", args.error_events)
+
+    if timeout_events > sample_count:
+        fail("timeout-events must be <= sample-count")
+    if unavailable_events > sample_count:
+        fail("unavailable-events must be <= sample-count")
+    if error_events > sample_count:
+        fail("error-events must be <= sample-count")
+
+    max_timeout_rate_bps = _parse_bps("max-timeout-rate-bps", args.max_timeout_rate_bps)
+    max_unavailable_rate_bps = _parse_bps(
+        "max-unavailable-rate-bps", args.max_unavailable_rate_bps
+    )
+    max_error_rate_bps = _parse_bps("max-error-rate-bps", args.max_error_rate_bps)
+    ci_fast_gate = _parse_ci_fast_gate(args.ci_fast_gate)
+
+    timeout_rate_bps = _compute_rate_bps(timeout_events, sample_count)
+    unavailable_rate_bps = _compute_rate_bps(unavailable_events, sample_count)
+    error_rate_bps = _compute_rate_bps(error_events, sample_count)
+
+    threshold_breaches: list[str] = []
+    if timeout_rate_bps > max_timeout_rate_bps:
+        threshold_breaches.append("managed_signer_backend_timeout_rate_threshold_exceeded")
+    if unavailable_rate_bps > max_unavailable_rate_bps:
+        threshold_breaches.append("managed_signer_backend_unavailable_rate_threshold_exceeded")
+    if error_rate_bps > max_error_rate_bps:
+        threshold_breaches.append("managed_signer_backend_error_rate_threshold_exceeded")
+    if ci_fast_gate != "PASS":
+        threshold_breaches.append("managed_signer_backend_ci_fast_gate_failed")
+
+    final_decision = GO_DECISION if not threshold_breaches else NO_GO_DECISION
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_start_utc": window_start_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_end_utc": window_end_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "backend_name": backend_name,
+        "signer_profile": signer_profile,
+        "signer_key_source": signer_key_source,
+        "sample_count": sample_count,
+        "timeout_events": timeout_events,
+        "unavailable_events": unavailable_events,
+        "error_events": error_events,
+        "timeout_rate_bps": timeout_rate_bps,
+        "unavailable_rate_bps": unavailable_rate_bps,
+        "error_rate_bps": error_rate_bps,
+        "max_timeout_rate_bps": max_timeout_rate_bps,
+        "max_unavailable_rate_bps": max_unavailable_rate_bps,
+        "max_error_rate_bps": max_error_rate_bps,
+        "threshold_breaches": threshold_breaches,
+        "final_decision": final_decision,
+        "ci_fast_gate": ci_fast_gate,
+        "contracts": {
+            "required_signer_key_source": REQUIRED_SIGNER_KEY_SOURCE,
+            "threshold_source": "operator-slo-policy",
+            "timeout_rate_bps_threshold_field": "max_timeout_rate_bps",
+            "unavailable_rate_bps_threshold_field": "max_unavailable_rate_bps",
+            "error_rate_bps_threshold_field": "max_error_rate_bps",
+            "timeout_rate_breach_reason_code": "managed_signer_backend_timeout_rate_threshold_exceeded",
+            "unavailable_rate_breach_reason_code": "managed_signer_backend_unavailable_rate_threshold_exceeded",
+            "error_rate_breach_reason_code": "managed_signer_backend_error_rate_threshold_exceeded",
+            "ci_fast_gate_required": True,
+        },
+    }
+
+    output_path = Path(output_file)
+    write_json(output_path, payload)
+    threshold_breaches_csv = ",".join(threshold_breaches) if threshold_breaches else "none"
+    print("status=generated")
+    print(f"bundle_file={output_path}")
+    print(f"final_decision={final_decision}")
+    print(f"threshold_breaches={threshold_breaches_csv}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Managed-signer backend SLO telemetry bundle generator."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate = subparsers.add_parser("generate", help="Generate managed-signer backend SLO telemetry bundle.")
+    generate.add_argument("--output-file", required=True)
+    generate.add_argument("--window-start-utc", required=True)
+    generate.add_argument("--window-end-utc", required=True)
+    generate.add_argument("--backend-name", required=True)
+    generate.add_argument("--signer-profile", required=True)
+    generate.add_argument("--signer-key-source", required=True)
+    generate.add_argument("--sample-count", required=True)
+    generate.add_argument("--timeout-events", required=True)
+    generate.add_argument("--unavailable-events", required=True)
+    generate.add_argument("--error-events", required=True)
+    generate.add_argument("--max-timeout-rate-bps", required=True)
+    generate.add_argument("--max-unavailable-rate-bps", required=True)
+    generate.add_argument("--max-error-rate-bps", required=True)
+    generate.add_argument("--ci-fast-gate", default="PASS")
+    generate.set_defaults(handler=generate_bundle)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh
+++ b/scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/kolme/contracts/managed_signer_backend_slo_telemetry_contract_lane.py" "$@"

--- a/scripts/kolme/test_generate_managed_signer_backend_slo_telemetry_bundle.sh
+++ b/scripts/kolme/test_generate_managed_signer_backend_slo_telemetry_bundle.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh"
+TMP_DIR="$(mktemp -d)"
+TMP_ERR="$TMP_DIR/error.log"
+TMP_GO_BUNDLE="$TMP_DIR/managed-signer-slo-go.json"
+TMP_NO_GO_BUNDLE="$TMP_DIR/managed-signer-slo-no-go.json"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected managed-signer backend SLO telemetry bundle generator to be executable" >&2
+  exit 1
+fi
+
+go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$TMP_GO_BUNDLE" \
+    --window-start-utc "2026-02-13T00:00:00Z" \
+    --window-end-utc "2026-02-13T00:15:00Z" \
+    --backend-name "kolme-managed-signer-primary" \
+    --signer-profile "ops-primary" \
+    --signer-key-source "managed-external" \
+    --sample-count 100 \
+    --timeout-events 0 \
+    --unavailable-events 0 \
+    --error-events 1 \
+    --max-timeout-rate-bps 100 \
+    --max-unavailable-rate-bps 100 \
+    --max-error-rate-bps 200 \
+    --ci-fast-gate PASS
+)"
+
+if ! printf '%s\n' "$go_output" | grep -q "^status=generated$"; then
+  echo "expected managed-signer SLO generator status=generated for GO scenario" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$go_output" | grep -q "^final_decision=GO$"; then
+  echo "expected managed-signer SLO generator GO decision for healthy scenario" >&2
+  exit 1
+fi
+
+python3 - "$TMP_GO_BUNDLE" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.kolme.managed-signer-backend-slo-telemetry.v1":
+    raise SystemExit("unexpected managed-signer SLO telemetry schema version")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected GO decision in healthy managed-signer SLO telemetry bundle")
+if payload.get("threshold_breaches") != []:
+    raise SystemExit("expected no threshold breaches in healthy managed-signer SLO telemetry bundle")
+contracts = payload.get("contracts")
+if not isinstance(contracts, dict):
+    raise SystemExit("expected contracts object in managed-signer SLO telemetry bundle")
+if contracts.get("required_signer_key_source") != "managed-external":
+    raise SystemExit("expected required managed-signer key source contract marker")
+if contracts.get("threshold_source") != "operator-slo-policy":
+    raise SystemExit("expected threshold source contract marker")
+PY
+
+no_go_output="$(
+  bash "$GENERATOR" \
+    --output-file "$TMP_NO_GO_BUNDLE" \
+    --window-start-utc "2026-02-13T00:15:00Z" \
+    --window-end-utc "2026-02-13T00:30:00Z" \
+    --backend-name "kolme-managed-signer-primary" \
+    --signer-profile "ops-primary" \
+    --signer-key-source "managed-external" \
+    --sample-count 100 \
+    --timeout-events 8 \
+    --unavailable-events 7 \
+    --error-events 9 \
+    --max-timeout-rate-bps 500 \
+    --max-unavailable-rate-bps 500 \
+    --max-error-rate-bps 500 \
+    --ci-fast-gate PASS
+)"
+
+if ! printf '%s\n' "$no_go_output" | grep -q "^final_decision=NO-GO$"; then
+  echo "expected managed-signer SLO generator NO-GO decision for threshold breach scenario" >&2
+  exit 1
+fi
+
+python3 - "$TMP_NO_GO_BUNDLE" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("final_decision") != "NO-GO":
+    raise SystemExit("expected NO-GO decision in failing managed-signer SLO telemetry bundle")
+breaches = payload.get("threshold_breaches")
+if not isinstance(breaches, list):
+    raise SystemExit("expected threshold_breaches list in failing managed-signer SLO telemetry bundle")
+expected_breaches = {
+    "managed_signer_backend_timeout_rate_threshold_exceeded",
+    "managed_signer_backend_unavailable_rate_threshold_exceeded",
+    "managed_signer_backend_error_rate_threshold_exceeded",
+}
+if set(breaches) != expected_breaches:
+    raise SystemExit("expected all managed-signer backend threshold breach reason codes in failing bundle")
+PY
+
+set +e
+bash "$GENERATOR" \
+  --output-file "$TMP_DIR/malformed.json" \
+  --window-start-utc "2026-02-13T00:30:00Z" \
+  --window-end-utc "2026-02-13T00:45:00Z" \
+  --backend-name "kolme-managed-signer-primary" \
+  --signer-profile "ops-primary" \
+  --signer-key-source "managed-external" \
+  --sample-count 10 \
+  --timeout-events 0 \
+  --unavailable-events 11 \
+  --error-events 0 \
+  --max-timeout-rate-bps 100 \
+  --max-unavailable-rate-bps 100 \
+  --max-error-rate-bps 100 \
+  --ci-fast-gate PASS >"$TMP_ERR" 2>&1
+malformed_exit_code=$?
+set -e
+
+if [ "$malformed_exit_code" -eq 0 ]; then
+  echo "expected managed-signer SLO generator to fail on malformed event counts" >&2
+  exit 1
+fi
+
+if ! grep -q "must be <= sample-count" "$TMP_ERR"; then
+  echo "expected explicit sample-count bound failure for malformed managed-signer SLO input" >&2
+  exit 1
+fi
+
+echo "managed-signer backend SLO telemetry bundle tests passed."

--- a/scripts/kolme/test_run_managed_signer_backend_slo_telemetry_contract_lane.sh
+++ b/scripts/kolme/test_run_managed_signer_backend_slo_telemetry_contract_lane.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh"
+CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/managed_signer_backend_slo_telemetry_contract_lane.py"
+GENERATOR="$ROOT_DIR/scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+CI_COST_DOC="$ROOT_DIR/docs/ci/ci-cost-and-lane-framework.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected managed-signer backend SLO telemetry contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected managed-signer backend SLO telemetry generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$CONTRACT_IMPL" ]; then
+  echo "expected managed-signer backend SLO telemetry contract lane implementation to exist" >&2
+  exit 1
+fi
+
+required_markers=(
+  "generate_managed_signer_backend_slo_telemetry_bundle.sh"
+  "run_managed_signer_backend_slo_telemetry_contract_lane.sh"
+  "kamn.kolme.managed-signer-backend-slo-telemetry.v1"
+  "managed_signer_backend_timeout_rate_threshold_exceeded"
+  "managed_signer_backend_unavailable_rate_threshold_exceeded"
+  "managed_signer_backend_error_rate_threshold_exceeded"
+  "managed_signer_backend_ci_fast_gate_failed"
+  "signer_key_source=managed-external"
+  "contracts.required_signer_key_source=managed-external"
+)
+
+for docs_file in "$DOC_FILE" "$CI_COST_DOC" "$README_FILE"; do
+  for marker in "${required_markers[@]}"; do
+    if ! grep -q -- "$marker" "$docs_file"; then
+      echo "expected docs parity marker '$marker' in $docs_file" >&2
+      exit 1
+    fi
+  done
+done
+
+bash "$RUNNER" --output-json "$TMP_REPORT" >/dev/null
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.kolme.managed-signer-backend-slo-contract-report.v1":
+    raise SystemExit("unexpected managed-signer SLO contract lane report schema")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected managed-signer SLO contract lane final decision GO")
+if not isinstance(payload.get("go_fixture_bundle"), str):
+    raise SystemExit("expected managed-signer SLO contract lane GO fixture path")
+if not isinstance(payload.get("no_go_fixture_bundle"), str):
+    raise SystemExit("expected managed-signer SLO contract lane NO-GO fixture path")
+PY
+
+echo "managed-signer backend SLO telemetry contract lane tests passed."


### PR DESCRIPTION
Closes #2436

## Summary
Add a deterministic managed-signer backend SLO telemetry evidence bundle contract (`kamn.kolme.managed-signer-backend-slo-telemetry.v1`) with fixture modes, fail-closed validation, and contract-lane/doc parity checks.

## Changes
- `scripts/kolme/managed_signer_backend_slo_telemetry_contract.py`: implement deterministic schema, metadata, fixture profiles, and fail-closed validation for timeout/unavailability/error-rate thresholds.
- `scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh`: wrapper entrypoint for bundle generation.
- `scripts/kolme/contracts/managed_signer_backend_slo_telemetry_contract_lane.py`: add lane assertions for schema markers, fixture decision classes, and docs parity contracts.
- `scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh`: wrapper for lane execution.
- `scripts/kolme/test_generate_managed_signer_backend_slo_telemetry_bundle.sh`: red/green generator tests for GO/NO-GO fixtures and malformed input rejection.
- `scripts/kolme/test_run_managed_signer_backend_slo_telemetry_contract_lane.sh`: integration/regression checks for lane markers and parity contracts.
- Docs updated: `README.md`, `docs/ci/ci-cost-and-lane-framework.md`, `docs/planning/kolme-devnet-ops.md`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Added failing generator harness first; before implementation the run failed because generator entrypoint did not exist.
- Command: `bash scripts/kolme/test_generate_managed_signer_backend_slo_telemetry_bundle.sh`
- Failure: generator invocation returned non-zero due to missing `scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh`.

### 🟢 Green Phase
- `bash scripts/kolme/test_generate_managed_signer_backend_slo_telemetry_bundle.sh`
- Output: `managed-signer backend SLO telemetry bundle tests passed.`

### 🔁 Regression
- `bash scripts/kolme/test_run_managed_signer_backend_slo_telemetry_contract_lane.sh`
- Output: `managed-signer backend SLO telemetry contract lane tests passed.`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | schema/field validation in generator test harness | |
| Functional   | ✅     | GO/NO-GO fixture generation and decision tagging | |
| Integration  | ✅     | contract-lane wrapper and lane runner checks | |
| Regression   | ✅     | malformed payload + docs parity marker enforcement | |
| Performance  | N/A    | offline lightweight artifact generation only | no throughput-sensitive path |

## Risks & Rollback
- None
- Rollback: revert commit `4cfd79e` if schema markers or lane contract checks cause downstream breakage.

## Documentation Updates
- Updated: `README.md`, `docs/ci/ci-cost-and-lane-framework.md`, `docs/planning/kolme-devnet-ops.md`.

## Validation Checklist
- [x] `bash -n scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh`
- [x] `python3 -m py_compile scripts/kolme/managed_signer_backend_slo_telemetry_contract.py scripts/kolme/contracts/managed_signer_backend_slo_telemetry_contract_lane.py`
- [x] TDD Red/Green evidence included above
- [x] `bash scripts/kolme/test_generate_managed_signer_backend_slo_telemetry_bundle.sh`
- [x] `bash scripts/kolme/test_run_managed_signer_backend_slo_telemetry_contract_lane.sh`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy -- -D warnings`
