### PR TITLE
feat(kolme): add managed-signer slo policy checker and lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,14 +885,30 @@ bash scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh \
 # managed-signer backend SLO telemetry contract lane
 bash scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh --output-json /tmp/managed-signer-backend-slo-contract-report.json
 
+# managed-signer backend SLO policy checker
+python3 scripts/kolme/check_managed_signer_backend_slo_policy.py \
+  --telemetry-bundle /tmp/managed-signer-backend-slo.json \
+  --output-json /tmp/managed-signer-backend-slo-policy-report.json || true
+
+# managed-signer backend SLO policy contract lane
+bash scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh --output-json /tmp/managed-signer-backend-slo-policy-contract-report.json
+
 # schema: kamn.kolme.managed-signer-backend-slo-telemetry.v1
+# policy schema: kamn.kolme.managed-signer-backend-slo-policy-report.v1
+# contract schema: kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1
 # signer_key_source=managed-external
 # contracts.required_signer_key_source=managed-external
+# managed_signer_backend_slo_within_threshold
+# managed_signer_backend_no_action_required
 # fail-closed threshold breach markers
 # managed_signer_backend_timeout_rate_threshold_exceeded
 # managed_signer_backend_unavailable_rate_threshold_exceeded
 # managed_signer_backend_error_rate_threshold_exceeded
 # managed_signer_backend_ci_fast_gate_failed
+# managed_signer_backend_reduce_timeout_burst
+# managed_signer_backend_failover_endpoint
+# managed_signer_backend_enable_circuit_breaker
+# managed_signer_backend_replay_ci_fast_gate
 ```
 
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -87,20 +87,30 @@ Managed-signer backend SLO telemetry is emitted through:
 
 - `scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh`
 - `scripts/kolme/run_managed_signer_backend_slo_telemetry_contract_lane.sh`
+- `scripts/kolme/check_managed_signer_backend_slo_policy.py`
+- `scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh`
 
 Deterministic contract markers:
 
 - `kamn.kolme.managed-signer-backend-slo-telemetry.v1`
+- `kamn.kolme.managed-signer-backend-slo-policy-report.v1`
+- `kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1`
 - `signer_key_source=managed-external`
 - `contracts.required_signer_key_source=managed-external`
+- `managed_signer_backend_slo_within_threshold`
+- `managed_signer_backend_no_action_required`
 - `managed_signer_backend_timeout_rate_threshold_exceeded`
 - `managed_signer_backend_unavailable_rate_threshold_exceeded`
 - `managed_signer_backend_error_rate_threshold_exceeded`
 - `managed_signer_backend_ci_fast_gate_failed`
+- `managed_signer_backend_reduce_timeout_burst`
+- `managed_signer_backend_failover_endpoint`
+- `managed_signer_backend_enable_circuit_breaker`
+- `managed_signer_backend_replay_ci_fast_gate`
 
 Cost boundary:
 
-- generation + contract-lane checks are offline, bounded, and PR fast-gate friendly.
+- generation + policy + contract-lane checks are offline, bounded, and PR fast-gate friendly.
 - no local-heavy selector or external metrics backend calls are required.
 
 ## Script-Surface Budget Policy

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -794,6 +794,34 @@ JSON`
   - lane remains lightweight and CI-fast-gate eligible.
   - artifacts are generated offline with deterministic thresholds and no external metrics backend dependency.
 
+## Managed Signer Backend SLO Policy Lane (Issue #2437)
+
+- Managed-signer backend SLO policy checker:
+  - `python3 scripts/kolme/check_managed_signer_backend_slo_policy.py --telemetry-bundle /tmp/managed-signer-backend-slo.json --output-json /tmp/managed-signer-backend-slo-policy-report.json`
+- Managed-signer backend SLO policy contract lane:
+  - `bash scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh --output-json /tmp/managed-signer-backend-slo-policy-contract-report.json`
+- Required schema/reason/remediation markers:
+  - `kamn.kolme.managed-signer-backend-slo-policy-report.v1`
+  - `kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1`
+  - `managed_signer_backend_slo_within_threshold`
+  - `managed_signer_backend_no_action_required`
+  - `managed_signer_backend_timeout_rate_threshold_exceeded`
+  - `managed_signer_backend_unavailable_rate_threshold_exceeded`
+  - `managed_signer_backend_error_rate_threshold_exceeded`
+  - `managed_signer_backend_ci_fast_gate_failed`
+  - `managed_signer_backend_reduce_timeout_burst`
+  - `managed_signer_backend_failover_endpoint`
+  - `managed_signer_backend_enable_circuit_breaker`
+  - `managed_signer_backend_replay_ci_fast_gate`
+- Operator remediation guidance:
+  - timeout bursts: gate promotion and reduce submit burst rate before rerun.
+  - unavailable drift: fail over endpoint/profile before rerun.
+  - error-rate drift: enable circuit breaker and hold promotion.
+  - ci-fast-gate failure: rerun lane only after fast-gate blockers are resolved.
+- Cost policy:
+  - checker and contract lane remain local-fast and bounded.
+  - no local-heavy selector or external metrics backend call is required.
+
 ## Staging Soak Telemetry Lane (Issue #2422)
 
 - Fast lane command:

--- a/scripts/kolme/check_managed_signer_backend_slo_policy.py
+++ b/scripts/kolme/check_managed_signer_backend_slo_policy.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Fail-closed policy checker for managed-signer backend SLO telemetry bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+POLICY_SCHEMA_VERSION = "kamn.kolme.managed-signer-backend-slo-policy-report.v1"
+TELEMETRY_SCHEMA_VERSION = "kamn.kolme.managed-signer-backend-slo-telemetry.v1"
+GO_DECISION = "GO"
+NO_GO_DECISION = "NO-GO"
+GO_REASON_CODE = "managed_signer_backend_slo_within_threshold"
+GO_REMEDIATION_MARKER = "managed_signer_backend_no_action_required"
+MAX_BPS = 10_000
+
+TIMEOUT_BREACH_REASON = "managed_signer_backend_timeout_rate_threshold_exceeded"
+UNAVAILABLE_BREACH_REASON = "managed_signer_backend_unavailable_rate_threshold_exceeded"
+ERROR_BREACH_REASON = "managed_signer_backend_error_rate_threshold_exceeded"
+CI_FAST_GATE_BREACH_REASON = "managed_signer_backend_ci_fast_gate_failed"
+
+BREACH_TO_REMEDIATION = {
+    TIMEOUT_BREACH_REASON: "managed_signer_backend_reduce_timeout_burst",
+    UNAVAILABLE_BREACH_REASON: "managed_signer_backend_failover_endpoint",
+    ERROR_BREACH_REASON: "managed_signer_backend_enable_circuit_breaker",
+    CI_FAST_GATE_BREACH_REASON: "managed_signer_backend_replay_ci_fast_gate",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate managed-signer backend SLO telemetry policy checks."
+    )
+    parser.add_argument("--telemetry-bundle", required=True)
+    parser.add_argument("--expected-final-decision", choices=[GO_DECISION, NO_GO_DECISION], default="")
+    parser.add_argument("--require-reason-code", action="append", default=[])
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def _append_unique(sequence: list[str], value: str) -> None:
+    if value not in sequence:
+        sequence.append(value)
+
+
+def _read_bundle(bundle_path: Path) -> tuple[dict[str, Any], list[str]]:
+    reason_codes: list[str] = []
+    if not bundle_path.is_file():
+        reason_codes.append("telemetry_bundle_missing")
+        return {}, reason_codes
+    try:
+        payload = json.loads(bundle_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        reason_codes.append("telemetry_bundle_invalid_json")
+        return {}, reason_codes
+    if not isinstance(payload, dict):
+        reason_codes.append("telemetry_bundle_invalid_type")
+        return {}, reason_codes
+    return payload, reason_codes
+
+
+def _read_non_empty_string(payload: dict[str, Any], key: str, reason_codes: list[str]) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        reason_codes.append(f"{key}_missing")
+        return ""
+    return value.strip()
+
+
+def _read_non_negative_int(
+    payload: dict[str, Any],
+    key: str,
+    reason_codes: list[str],
+    *,
+    max_value: int | None = None,
+) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int):
+        reason_codes.append(f"{key}_invalid")
+        return 0
+    if value < 0:
+        reason_codes.append(f"{key}_invalid")
+        return 0
+    if max_value is not None and value > max_value:
+        reason_codes.append(f"{key}_invalid")
+        return 0
+    return value
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    ordered: list[str] = []
+    for value in values:
+        _append_unique(ordered, value)
+    return ordered
+
+
+def evaluate(bundle: dict[str, Any], args: argparse.Namespace, base_reason_codes: list[str]) -> tuple[str, list[str], list[str]]:
+    reason_codes: list[str] = list(base_reason_codes)
+
+    telemetry_schema_version = bundle.get("schema_version")
+    if telemetry_schema_version != TELEMETRY_SCHEMA_VERSION:
+        reason_codes.append("telemetry_schema_version_mismatch")
+
+    backend_name = _read_non_empty_string(bundle, "backend_name", reason_codes)
+    signer_profile = _read_non_empty_string(bundle, "signer_profile", reason_codes)
+    signer_key_source = _read_non_empty_string(bundle, "signer_key_source", reason_codes)
+    if signer_key_source and signer_key_source != "managed-external":
+        reason_codes.append("signer_key_source_invalid")
+
+    ci_fast_gate = _read_non_empty_string(bundle, "ci_fast_gate", reason_codes)
+    if ci_fast_gate and ci_fast_gate not in {"PASS", "FAIL"}:
+        reason_codes.append("ci_fast_gate_invalid")
+
+    sample_count = _read_non_negative_int(bundle, "sample_count", reason_codes)
+    if sample_count <= 0:
+        reason_codes.append("sample_count_invalid")
+
+    timeout_events = _read_non_negative_int(bundle, "timeout_events", reason_codes)
+    unavailable_events = _read_non_negative_int(bundle, "unavailable_events", reason_codes)
+    error_events = _read_non_negative_int(bundle, "error_events", reason_codes)
+
+    if sample_count > 0:
+        if timeout_events > sample_count:
+            reason_codes.append("timeout_events_exceeds_sample_count")
+        if unavailable_events > sample_count:
+            reason_codes.append("unavailable_events_exceeds_sample_count")
+        if error_events > sample_count:
+            reason_codes.append("error_events_exceeds_sample_count")
+
+    timeout_rate_bps = _read_non_negative_int(bundle, "timeout_rate_bps", reason_codes, max_value=MAX_BPS)
+    unavailable_rate_bps = _read_non_negative_int(bundle, "unavailable_rate_bps", reason_codes, max_value=MAX_BPS)
+    error_rate_bps = _read_non_negative_int(bundle, "error_rate_bps", reason_codes, max_value=MAX_BPS)
+
+    max_timeout_rate_bps = _read_non_negative_int(
+        bundle, "max_timeout_rate_bps", reason_codes, max_value=MAX_BPS
+    )
+    max_unavailable_rate_bps = _read_non_negative_int(
+        bundle, "max_unavailable_rate_bps", reason_codes, max_value=MAX_BPS
+    )
+    max_error_rate_bps = _read_non_negative_int(
+        bundle, "max_error_rate_bps", reason_codes, max_value=MAX_BPS
+    )
+
+    if sample_count > 0:
+        expected_timeout_rate_bps = (timeout_events * MAX_BPS) // sample_count
+        expected_unavailable_rate_bps = (unavailable_events * MAX_BPS) // sample_count
+        expected_error_rate_bps = (error_events * MAX_BPS) // sample_count
+        if timeout_rate_bps != expected_timeout_rate_bps:
+            reason_codes.append("timeout_rate_bps_mismatch")
+        if unavailable_rate_bps != expected_unavailable_rate_bps:
+            reason_codes.append("unavailable_rate_bps_mismatch")
+        if error_rate_bps != expected_error_rate_bps:
+            reason_codes.append("error_rate_bps_mismatch")
+
+    threshold_reasons: list[str] = []
+    if timeout_rate_bps > max_timeout_rate_bps:
+        threshold_reasons.append(TIMEOUT_BREACH_REASON)
+    if unavailable_rate_bps > max_unavailable_rate_bps:
+        threshold_reasons.append(UNAVAILABLE_BREACH_REASON)
+    if error_rate_bps > max_error_rate_bps:
+        threshold_reasons.append(ERROR_BREACH_REASON)
+    if ci_fast_gate == "FAIL":
+        threshold_reasons.append(CI_FAST_GATE_BREACH_REASON)
+
+    reason_codes.extend(threshold_reasons)
+
+    threshold_breaches = bundle.get("threshold_breaches")
+    if not isinstance(threshold_breaches, list) or not all(
+        isinstance(reason, str) and reason.strip() for reason in threshold_breaches
+    ):
+        reason_codes.append("threshold_breaches_invalid")
+    else:
+        telemetry_threshold_reasons = set(threshold_breaches)
+        policy_threshold_reasons = set(threshold_reasons)
+        if telemetry_threshold_reasons != policy_threshold_reasons:
+            reason_codes.append("threshold_breaches_mismatch")
+
+    bundle_final_decision = bundle.get("final_decision")
+    if bundle_final_decision not in {GO_DECISION, NO_GO_DECISION}:
+        reason_codes.append("telemetry_final_decision_invalid")
+
+    reason_codes = _ordered_unique(reason_codes)
+    derived_final_decision = GO_DECISION if not reason_codes else NO_GO_DECISION
+
+    if bundle_final_decision in {GO_DECISION, NO_GO_DECISION} and bundle_final_decision != derived_final_decision:
+        reason_codes.append("telemetry_final_decision_mismatch")
+        derived_final_decision = NO_GO_DECISION
+
+    if args.expected_final_decision and derived_final_decision != args.expected_final_decision:
+        reason_codes.append("observed_final_decision_mismatch")
+        derived_final_decision = NO_GO_DECISION
+
+    if derived_final_decision == GO_DECISION:
+        output_reason_codes = [GO_REASON_CODE]
+    else:
+        output_reason_codes = _ordered_unique(reason_codes)
+
+    for required_reason_code in args.require_reason_code:
+        if required_reason_code not in output_reason_codes:
+            output_reason_codes.append(f"required_reason_code_missing:{required_reason_code}")
+            derived_final_decision = NO_GO_DECISION
+
+    if derived_final_decision == GO_DECISION:
+        remediation_markers = [GO_REMEDIATION_MARKER]
+    else:
+        remediation_markers: list[str] = []
+        for reason_code in output_reason_codes:
+            marker = BREACH_TO_REMEDIATION.get(reason_code)
+            if marker:
+                _append_unique(remediation_markers, marker)
+        if not remediation_markers:
+            remediation_markers = ["managed_signer_backend_rebuild_telemetry_bundle"]
+
+    # Keep these fields validated to prevent accidental regressions where metadata is dropped.
+    if not backend_name:
+        _append_unique(output_reason_codes, "backend_name_missing")
+    if not signer_profile:
+        _append_unique(output_reason_codes, "signer_profile_missing")
+    if not signer_key_source:
+        _append_unique(output_reason_codes, "signer_key_source_missing")
+    if derived_final_decision == GO_DECISION and output_reason_codes != [GO_REASON_CODE]:
+        derived_final_decision = NO_GO_DECISION
+
+    return derived_final_decision, output_reason_codes, remediation_markers
+
+
+def main() -> int:
+    args = parse_args()
+    bundle_path = Path(args.telemetry_bundle).resolve()
+    bundle, base_reason_codes = _read_bundle(bundle_path)
+    final_decision, reason_codes, remediation_markers = evaluate(bundle, args, base_reason_codes)
+
+    report = {
+        "schema_version": POLICY_SCHEMA_VERSION,
+        "telemetry_bundle": str(bundle_path),
+        "telemetry_schema_version": bundle.get("schema_version"),
+        "backend_name": bundle.get("backend_name"),
+        "signer_profile": bundle.get("signer_profile"),
+        "signer_key_source": bundle.get("signer_key_source"),
+        "sample_count": bundle.get("sample_count"),
+        "timeout_rate_bps": bundle.get("timeout_rate_bps"),
+        "unavailable_rate_bps": bundle.get("unavailable_rate_bps"),
+        "error_rate_bps": bundle.get("error_rate_bps"),
+        "max_timeout_rate_bps": bundle.get("max_timeout_rate_bps"),
+        "max_unavailable_rate_bps": bundle.get("max_unavailable_rate_bps"),
+        "max_error_rate_bps": bundle.get("max_error_rate_bps"),
+        "ci_fast_gate": bundle.get("ci_fast_gate"),
+        "required_reason_codes": args.require_reason_code,
+        "reason_codes": reason_codes,
+        "remediation_markers": remediation_markers,
+        "final_decision": final_decision,
+        "contracts": {
+            "telemetry_schema_version": TELEMETRY_SCHEMA_VERSION,
+            "go_reason_code": GO_REASON_CODE,
+            "go_remediation_marker": GO_REMEDIATION_MARKER,
+            "timeout_rate_breach_reason_code": TIMEOUT_BREACH_REASON,
+            "unavailable_rate_breach_reason_code": UNAVAILABLE_BREACH_REASON,
+            "error_rate_breach_reason_code": ERROR_BREACH_REASON,
+            "ci_fast_gate_breach_reason_code": CI_FAST_GATE_BREACH_REASON,
+        },
+    }
+
+    if args.output_json:
+        output_file = Path(args.output_json).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    status = "ok" if final_decision == GO_DECISION else "fail"
+    reason_codes_csv = ",".join(reason_codes) if reason_codes else "none"
+    remediation_csv = ",".join(remediation_markers) if remediation_markers else "none"
+    print(f"status={status}")
+    print(f"final_decision={final_decision}")
+    print(f"reason_codes={reason_codes_csv}")
+    print(f"remediation_markers={remediation_csv}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+
+    return 0 if final_decision == GO_DECISION else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/contracts/managed_signer_backend_slo_policy_contract_lane.py
+++ b/scripts/kolme/contracts/managed_signer_backend_slo_policy_contract_lane.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Contract lane for managed-signer backend SLO policy checker behavior."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+GENERATOR = ROOT_DIR / "scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh"
+POLICY_CHECKER = ROOT_DIR / "scripts/kolme/check_managed_signer_backend_slo_policy.py"
+DOC_FILES = [
+    ROOT_DIR / "docs/ci/ci-cost-and-lane-framework.md",
+    ROOT_DIR / "docs/planning/kolme-devnet-ops.md",
+    ROOT_DIR / "README.md",
+]
+
+DOC_MARKERS = [
+    "check_managed_signer_backend_slo_policy.py",
+    "run_managed_signer_backend_slo_policy_contract_lane.sh",
+    "kamn.kolme.managed-signer-backend-slo-policy-report.v1",
+    "kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1",
+    "managed_signer_backend_slo_within_threshold",
+    "managed_signer_backend_no_action_required",
+    "managed_signer_backend_timeout_rate_threshold_exceeded",
+    "managed_signer_backend_unavailable_rate_threshold_exceeded",
+    "managed_signer_backend_error_rate_threshold_exceeded",
+    "managed_signer_backend_ci_fast_gate_failed",
+    "managed_signer_backend_reduce_timeout_burst",
+    "managed_signer_backend_failover_endpoint",
+    "managed_signer_backend_enable_circuit_breaker",
+    "managed_signer_backend_replay_ci_fast_gate",
+]
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def ensure_markers_present(text: str, markers: list[str], source_name: str) -> list[str]:
+    missing: list[str] = []
+    for marker in markers:
+        if marker not in text:
+            missing.append(f"{source_name}_missing_marker:{marker}")
+    return missing
+
+
+def run_generator(bundle_path: Path, **kwargs: str) -> subprocess.CompletedProcess[str]:
+    command = [
+        "bash",
+        str(GENERATOR),
+        "--output-file",
+        str(bundle_path),
+    ]
+    for key, value in kwargs.items():
+        command.extend([f"--{key.replace('_', '-')}", value])
+    return run_command(command)
+
+
+def run_checker(bundle_path: Path, report_path: Path) -> subprocess.CompletedProcess[str]:
+    command = [
+        "python3",
+        str(POLICY_CHECKER),
+        "--telemetry-bundle",
+        str(bundle_path),
+        "--output-json",
+        str(report_path),
+    ]
+    return run_command(command)
+
+
+def _require_output_marker(output: str, marker: str, message: str) -> None:
+    if marker not in output:
+        raise RuntimeError(message)
+
+
+def _read_json(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected JSON object in {path}")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run managed-signer backend SLO policy contract lane."
+    )
+    parser.add_argument(
+        "--output-json",
+        default="/tmp/managed-signer-backend-slo-policy-contract-report.json",
+    )
+    args = parser.parse_args()
+
+    if not GENERATOR.is_file() or not GENERATOR.stat().st_mode & 0o111:
+        print("expected managed-signer backend SLO telemetry generator to be executable", file=sys.stderr)
+        return 1
+    if not POLICY_CHECKER.is_file() or not POLICY_CHECKER.stat().st_mode & 0o111:
+        print("expected managed-signer backend SLO policy checker to be executable", file=sys.stderr)
+        return 1
+
+    missing_doc_markers: list[str] = []
+    for doc_file in DOC_FILES:
+        if not doc_file.is_file():
+            print(f"expected documentation file to exist: {doc_file}", file=sys.stderr)
+            return 1
+        missing_doc_markers.extend(
+            ensure_markers_present(
+                doc_file.read_text(encoding="utf-8"),
+                DOC_MARKERS,
+                str(doc_file.relative_to(ROOT_DIR)),
+            )
+        )
+    if missing_doc_markers:
+        print(",".join(missing_doc_markers), file=sys.stderr)
+        return 1
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="managed-signer-slo-policy-contract-") as temp_dir:
+            temp_path = Path(temp_dir)
+            go_bundle = temp_path / "go-bundle.json"
+            no_go_bundle = temp_path / "no-go-bundle.json"
+            ci_bundle = temp_path / "ci-bundle.json"
+            go_report = temp_path / "go-policy-report.json"
+            no_go_report = temp_path / "no-go-policy-report.json"
+            ci_report = temp_path / "ci-policy-report.json"
+
+            go_bundle_result = run_generator(
+                go_bundle,
+                window_start_utc="2026-02-13T00:00:00Z",
+                window_end_utc="2026-02-13T00:15:00Z",
+                backend_name="kolme-managed-signer-primary",
+                signer_profile="ops-primary",
+                signer_key_source="managed-external",
+                sample_count="100",
+                timeout_events="0",
+                unavailable_events="0",
+                error_events="1",
+                max_timeout_rate_bps="100",
+                max_unavailable_rate_bps="100",
+                max_error_rate_bps="200",
+                ci_fast_gate="PASS",
+            )
+            if go_bundle_result.returncode != 0:
+                raise RuntimeError(
+                    f"expected GO fixture generation to succeed: {go_bundle_result.stderr.strip()}"
+                )
+
+            go_policy_result = run_checker(go_bundle, go_report)
+            if go_policy_result.returncode != 0:
+                raise RuntimeError(
+                    f"expected GO policy case to pass: {go_policy_result.stdout}{go_policy_result.stderr}"
+                )
+            _require_output_marker(
+                go_policy_result.stdout,
+                "final_decision=GO",
+                "expected GO policy output final_decision=GO",
+            )
+            _require_output_marker(
+                go_policy_result.stdout,
+                "reason_codes=managed_signer_backend_slo_within_threshold",
+                "expected deterministic GO reason code",
+            )
+
+            no_go_bundle_result = run_generator(
+                no_go_bundle,
+                window_start_utc="2026-02-13T00:15:00Z",
+                window_end_utc="2026-02-13T00:30:00Z",
+                backend_name="kolme-managed-signer-primary",
+                signer_profile="ops-primary",
+                signer_key_source="managed-external",
+                sample_count="100",
+                timeout_events="9",
+                unavailable_events="8",
+                error_events="9",
+                max_timeout_rate_bps="500",
+                max_unavailable_rate_bps="500",
+                max_error_rate_bps="500",
+                ci_fast_gate="PASS",
+            )
+            if no_go_bundle_result.returncode != 0:
+                raise RuntimeError(
+                    f"expected NO-GO threshold fixture generation to succeed: {no_go_bundle_result.stderr.strip()}"
+                )
+
+            no_go_policy_result = run_checker(no_go_bundle, no_go_report)
+            if no_go_policy_result.returncode == 0:
+                raise RuntimeError("expected threshold-breach policy case to fail closed")
+            _require_output_marker(
+                no_go_policy_result.stdout,
+                "final_decision=NO-GO",
+                "expected threshold-breach policy output final_decision=NO-GO",
+            )
+            for marker in [
+                "managed_signer_backend_timeout_rate_threshold_exceeded",
+                "managed_signer_backend_unavailable_rate_threshold_exceeded",
+                "managed_signer_backend_error_rate_threshold_exceeded",
+            ]:
+                _require_output_marker(
+                    no_go_policy_result.stdout,
+                    marker,
+                    f"expected deterministic threshold reason code marker: {marker}",
+                )
+
+            ci_bundle_result = run_generator(
+                ci_bundle,
+                window_start_utc="2026-02-13T00:30:00Z",
+                window_end_utc="2026-02-13T00:45:00Z",
+                backend_name="kolme-managed-signer-primary",
+                signer_profile="ops-primary",
+                signer_key_source="managed-external",
+                sample_count="100",
+                timeout_events="0",
+                unavailable_events="0",
+                error_events="0",
+                max_timeout_rate_bps="100",
+                max_unavailable_rate_bps="100",
+                max_error_rate_bps="100",
+                ci_fast_gate="FAIL",
+            )
+            if ci_bundle_result.returncode != 0:
+                raise RuntimeError(
+                    f"expected ci-fast-gate NO-GO fixture generation to succeed: {ci_bundle_result.stderr.strip()}"
+                )
+
+            ci_policy_result = run_checker(ci_bundle, ci_report)
+            if ci_policy_result.returncode == 0:
+                raise RuntimeError("expected ci-fast-gate policy case to fail closed")
+            _require_output_marker(
+                ci_policy_result.stdout,
+                "managed_signer_backend_ci_fast_gate_failed",
+                "expected ci-fast-gate NO-GO reason code marker",
+            )
+            _require_output_marker(
+                ci_policy_result.stdout,
+                "managed_signer_backend_replay_ci_fast_gate",
+                "expected ci-fast-gate remediation marker",
+            )
+
+            go_payload = _read_json(go_report)
+            no_go_payload = _read_json(no_go_report)
+            ci_payload = _read_json(ci_report)
+
+            if go_payload.get("schema_version") != "kamn.kolme.managed-signer-backend-slo-policy-report.v1":
+                raise RuntimeError("unexpected GO policy report schema")
+            if go_payload.get("final_decision") != "GO":
+                raise RuntimeError("expected GO policy report final decision")
+            if go_payload.get("reason_codes") != ["managed_signer_backend_slo_within_threshold"]:
+                raise RuntimeError("expected deterministic GO policy reason code list")
+
+            if no_go_payload.get("final_decision") != "NO-GO":
+                raise RuntimeError("expected NO-GO threshold policy report final decision")
+            no_go_reasons = set(no_go_payload.get("reason_codes", []))
+            for marker in [
+                "managed_signer_backend_timeout_rate_threshold_exceeded",
+                "managed_signer_backend_unavailable_rate_threshold_exceeded",
+                "managed_signer_backend_error_rate_threshold_exceeded",
+            ]:
+                if marker not in no_go_reasons:
+                    raise RuntimeError(f"expected threshold-breach report marker: {marker}")
+            no_go_remediation = set(no_go_payload.get("remediation_markers", []))
+            for marker in [
+                "managed_signer_backend_reduce_timeout_burst",
+                "managed_signer_backend_failover_endpoint",
+                "managed_signer_backend_enable_circuit_breaker",
+            ]:
+                if marker not in no_go_remediation:
+                    raise RuntimeError(f"expected threshold remediation marker: {marker}")
+
+            if ci_payload.get("final_decision") != "NO-GO":
+                raise RuntimeError("expected ci-fast-gate policy report final decision")
+            if "managed_signer_backend_ci_fast_gate_failed" not in set(ci_payload.get("reason_codes", [])):
+                raise RuntimeError("expected ci-fast-gate reason code in report")
+            if "managed_signer_backend_replay_ci_fast_gate" not in set(ci_payload.get("remediation_markers", [])):
+                raise RuntimeError("expected ci-fast-gate remediation marker in report")
+
+            contract_report = {
+                "schema_version": "kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1",
+                "go_policy_report": str(go_report),
+                "no_go_policy_report": str(no_go_report),
+                "ci_fast_gate_no_go_policy_report": str(ci_report),
+                "final_decision": "GO",
+            }
+            output_path = Path(args.output_json).resolve()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(contract_report, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print("managed-signer backend SLO policy contract lane tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh
+++ b/scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 "$ROOT_DIR/scripts/kolme/contracts/managed_signer_backend_slo_policy_contract_lane.py" "$@"

--- a/scripts/kolme/test_check_managed_signer_backend_slo_policy.sh
+++ b/scripts/kolme/test_check_managed_signer_backend_slo_policy.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/kolme/check_managed_signer_backend_slo_policy.py"
+GENERATOR="$ROOT_DIR/scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh"
+TMP_DIR="$(mktemp -d)"
+GO_BUNDLE="$TMP_DIR/go-bundle.json"
+NO_GO_BUNDLE="$TMP_DIR/no-go-bundle.json"
+GO_REPORT="$TMP_DIR/go-policy-report.json"
+NO_GO_REPORT="$TMP_DIR/no-go-policy-report.json"
+MALFORMED_BUNDLE="$TMP_DIR/malformed-bundle.json"
+MALFORMED_REPORT="$TMP_DIR/malformed-policy-report.json"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+extract_value() {
+  local output="$1"
+  local key="$2"
+  printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key { sub($1 "=",""); print; exit }'
+}
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected managed-signer backend SLO policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected managed-signer backend SLO telemetry generator to be executable" >&2
+  exit 1
+fi
+
+bash "$GENERATOR" \
+  --output-file "$GO_BUNDLE" \
+  --window-start-utc "2026-02-13T00:00:00Z" \
+  --window-end-utc "2026-02-13T00:15:00Z" \
+  --backend-name "kolme-managed-signer-primary" \
+  --signer-profile "ops-primary" \
+  --signer-key-source "managed-external" \
+  --sample-count 100 \
+  --timeout-events 0 \
+  --unavailable-events 0 \
+  --error-events 1 \
+  --max-timeout-rate-bps 100 \
+  --max-unavailable-rate-bps 100 \
+  --max-error-rate-bps 200 \
+  --ci-fast-gate PASS >/dev/null
+
+go_output="$(
+  python3 "$CHECKER" \
+    --telemetry-bundle "$GO_BUNDLE" \
+    --output-json "$GO_REPORT"
+)"
+
+if [ "$(extract_value "$go_output" "status")" != "ok" ]; then
+  echo "expected GO policy status to be ok" >&2
+  exit 1
+fi
+if [ "$(extract_value "$go_output" "final_decision")" != "GO" ]; then
+  echo "expected GO policy final_decision=GO" >&2
+  exit 1
+fi
+if [ "$(extract_value "$go_output" "reason_codes")" != "managed_signer_backend_slo_within_threshold" ]; then
+  echo "expected deterministic GO policy reason code" >&2
+  exit 1
+fi
+if [ "$(extract_value "$go_output" "remediation_markers")" != "managed_signer_backend_no_action_required" ]; then
+  echo "expected deterministic GO remediation marker" >&2
+  exit 1
+fi
+
+bash "$GENERATOR" \
+  --output-file "$NO_GO_BUNDLE" \
+  --window-start-utc "2026-02-13T00:15:00Z" \
+  --window-end-utc "2026-02-13T00:30:00Z" \
+  --backend-name "kolme-managed-signer-primary" \
+  --signer-profile "ops-primary" \
+  --signer-key-source "managed-external" \
+  --sample-count 100 \
+  --timeout-events 10 \
+  --unavailable-events 0 \
+  --error-events 8 \
+  --max-timeout-rate-bps 500 \
+  --max-unavailable-rate-bps 500 \
+  --max-error-rate-bps 500 \
+  --ci-fast-gate FAIL >/dev/null
+
+set +e
+no_go_output="$(
+  python3 "$CHECKER" \
+    --telemetry-bundle "$NO_GO_BUNDLE" \
+    --output-json "$NO_GO_REPORT" 2>&1
+)"
+no_go_code=$?
+set -e
+
+if [ "$no_go_code" -eq 0 ]; then
+  echo "expected NO-GO policy case to fail closed" >&2
+  exit 1
+fi
+if [ "$(extract_value "$no_go_output" "status")" != "fail" ]; then
+  echo "expected NO-GO policy status to be fail" >&2
+  exit 1
+fi
+if [ "$(extract_value "$no_go_output" "final_decision")" != "NO-GO" ]; then
+  echo "expected NO-GO policy final_decision=NO-GO" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$no_go_output" | grep -q "managed_signer_backend_timeout_rate_threshold_exceeded"; then
+  echo "expected timeout-rate threshold reason code in NO-GO policy output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$no_go_output" | grep -q "managed_signer_backend_error_rate_threshold_exceeded"; then
+  echo "expected error-rate threshold reason code in NO-GO policy output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$no_go_output" | grep -q "managed_signer_backend_ci_fast_gate_failed"; then
+  echo "expected ci-fast-gate reason code in NO-GO policy output" >&2
+  exit 1
+fi
+
+python3 - "$GO_REPORT" "$NO_GO_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+go_payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if go_payload.get("schema_version") != "kamn.kolme.managed-signer-backend-slo-policy-report.v1":
+    raise SystemExit("unexpected policy report schema in GO report")
+if go_payload.get("final_decision") != "GO":
+    raise SystemExit("expected GO final_decision in GO report")
+if go_payload.get("reason_codes") != ["managed_signer_backend_slo_within_threshold"]:
+    raise SystemExit("expected deterministic GO reason_codes list")
+if go_payload.get("remediation_markers") != ["managed_signer_backend_no_action_required"]:
+    raise SystemExit("expected deterministic GO remediation marker list")
+
+no_go_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if no_go_payload.get("final_decision") != "NO-GO":
+    raise SystemExit("expected NO-GO final_decision in NO-GO report")
+reasons = set(no_go_payload.get("reason_codes", []))
+required_reasons = {
+    "managed_signer_backend_timeout_rate_threshold_exceeded",
+    "managed_signer_backend_error_rate_threshold_exceeded",
+    "managed_signer_backend_ci_fast_gate_failed",
+}
+if not required_reasons.issubset(reasons):
+    raise SystemExit("missing deterministic NO-GO threshold reason codes in report")
+markers = set(no_go_payload.get("remediation_markers", []))
+required_markers = {
+    "managed_signer_backend_reduce_timeout_burst",
+    "managed_signer_backend_enable_circuit_breaker",
+    "managed_signer_backend_replay_ci_fast_gate",
+}
+if not required_markers.issubset(markers):
+    raise SystemExit("missing deterministic NO-GO remediation markers in report")
+PY
+
+python3 - "$GO_BUNDLE" "$MALFORMED_BUNDLE" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+payload["signer_key_source"] = "raw-private-key"
+pathlib.Path(sys.argv[2]).write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+malformed_output="$(
+  python3 "$CHECKER" \
+    --telemetry-bundle "$MALFORMED_BUNDLE" \
+    --output-json "$MALFORMED_REPORT" 2>&1
+)"
+malformed_code=$?
+set -e
+
+if [ "$malformed_code" -eq 0 ]; then
+  echo "expected malformed managed-signer telemetry bundle to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$malformed_output" | grep -q "signer_key_source_invalid"; then
+  echo "expected signer_key_source_invalid reason code in malformed policy output" >&2
+  exit 1
+fi
+
+echo "managed-signer backend SLO policy checker tests passed."

--- a/scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh
+++ b/scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh"
+CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/managed_signer_backend_slo_policy_contract_lane.py"
+GENERATOR="$ROOT_DIR/scripts/kolme/generate_managed_signer_backend_slo_telemetry_bundle.sh"
+CHECKER="$ROOT_DIR/scripts/kolme/check_managed_signer_backend_slo_policy.py"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+CI_COST_DOC="$ROOT_DIR/docs/ci/ci-cost-and-lane-framework.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected managed-signer backend SLO policy contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$GENERATOR" ]; then
+  echo "expected managed-signer backend SLO telemetry generator to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected managed-signer backend SLO policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$CONTRACT_IMPL" ]; then
+  echo "expected managed-signer backend SLO policy contract lane implementation to exist" >&2
+  exit 1
+fi
+
+required_markers=(
+  "check_managed_signer_backend_slo_policy.py"
+  "run_managed_signer_backend_slo_policy_contract_lane.sh"
+  "kamn.kolme.managed-signer-backend-slo-policy-report.v1"
+  "kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1"
+  "managed_signer_backend_slo_within_threshold"
+  "managed_signer_backend_no_action_required"
+  "managed_signer_backend_timeout_rate_threshold_exceeded"
+  "managed_signer_backend_unavailable_rate_threshold_exceeded"
+  "managed_signer_backend_error_rate_threshold_exceeded"
+  "managed_signer_backend_ci_fast_gate_failed"
+  "managed_signer_backend_reduce_timeout_burst"
+  "managed_signer_backend_failover_endpoint"
+  "managed_signer_backend_enable_circuit_breaker"
+  "managed_signer_backend_replay_ci_fast_gate"
+)
+
+for docs_file in "$DOC_FILE" "$CI_COST_DOC" "$README_FILE"; do
+  for marker in "${required_markers[@]}"; do
+    if ! grep -q -- "$marker" "$docs_file"; then
+      echo "expected docs parity marker '$marker' in $docs_file" >&2
+      exit 1
+    fi
+  done
+done
+
+bash "$RUNNER" --output-json "$TMP_REPORT" >/dev/null
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.kolme.managed-signer-backend-slo-policy-contract-report.v1":
+    raise SystemExit("unexpected managed-signer SLO policy contract lane report schema")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected managed-signer SLO policy contract lane final decision GO")
+if not isinstance(payload.get("go_policy_report"), str):
+    raise SystemExit("expected managed-signer SLO policy GO report path")
+if not isinstance(payload.get("no_go_policy_report"), str):
+    raise SystemExit("expected managed-signer SLO policy NO-GO report path")
+if not isinstance(payload.get("ci_fast_gate_no_go_policy_report"), str):
+    raise SystemExit("expected managed-signer SLO policy CI-fast-gate NO-GO report path")
+PY
+
+echo "managed-signer backend SLO policy contract lane tests passed."


### PR DESCRIPTION
Closes #2437

## Summary
Add a fail-closed managed-signer backend SLO policy checker and bounded policy contract lane with deterministic GO/NO-GO reason codes, remediation markers, and docs parity contracts.

## Changes
- `scripts/kolme/check_managed_signer_backend_slo_policy.py`: evaluate telemetry bundle shape/rates/thresholds and emit deterministic policy report `kamn.kolme.managed-signer-backend-slo-policy-report.v1`.
- `scripts/kolme/test_check_managed_signer_backend_slo_policy.sh`: red/green checker coverage for GO, threshold NO-GO, ci-fast-gate NO-GO, and malformed bundle fail-closed behavior.
- `scripts/kolme/contracts/managed_signer_backend_slo_policy_contract_lane.py`: integration lane validating generator+checker composition plus docs parity markers.
- `scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh`: lane wrapper entrypoint.
- `scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh`: contract lane regression checks.
- Docs parity updates: `README.md`, `docs/ci/ci-cost-and-lane-framework.md`, `docs/planning/kolme-devnet-ops.md`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Added checker test harness first.
- Command: `bash scripts/kolme/test_check_managed_signer_backend_slo_policy.sh`
- Failure (pre-implementation): `expected managed-signer backend SLO policy checker to be executable`

### 🟢 Green Phase
- `bash scripts/kolme/test_check_managed_signer_backend_slo_policy.sh`
- Output: `managed-signer backend SLO policy checker tests passed.`

### 🔁 Regression
- `bash scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh`
- Output: `managed-signer backend SLO policy contract lane tests passed.`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | checker field/rate validation and reason-code mapping assertions | |
| Functional   | ✅     | GO vs NO-GO policy decisions with deterministic reason/remediation markers | |
| Integration  | ✅     | contract lane composes telemetry generator + policy checker | |
| Regression   | ✅     | docs marker parity + malformed bundle fail-closed checks | |
| Performance  | N/A    | local-fast bounded scripts only | no throughput-sensitive runtime path |

## Risks & Rollback
- None
- Rollback: revert commit `4a137f2` if policy marker parity or report schema causes downstream breakage.

## Documentation Updates
- Updated: `README.md`, `docs/ci/ci-cost-and-lane-framework.md`, `docs/planning/kolme-devnet-ops.md`.

## Validation Checklist
- [x] `bash -n scripts/kolme/test_check_managed_signer_backend_slo_policy.sh scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh`
- [x] `python3 -m py_compile scripts/kolme/check_managed_signer_backend_slo_policy.py scripts/kolme/contracts/managed_signer_backend_slo_policy_contract_lane.py`
- [x] TDD Red/Green evidence included above
- [x] `bash scripts/kolme/test_check_managed_signer_backend_slo_policy.sh`
- [x] `bash scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy -- -D warnings`
