### PR TITLE
feat(kolme): add bounded localhost live-provider integration lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,12 @@ python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --repor
 
 # bounded contract lane (dry-run + run-mode evidence + policy checks)
 bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json /tmp/kolme-local-runtime-commit-live-summary.json --policy-output-json /tmp/kolme-local-runtime-commit-live-policy.json
+
+# bounded localhost live-provider runtime integration proof lane
+bash scripts/kolme/run_local_live_provider_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-live-provider-runtime-integration-contract-report.json
+# provider mismatch fail-closed reason: provider_client_contract_mismatch
+# in-memory provider drift fail-closed reason: provider_in_memory_reference_detected
+# unavailable-node deterministic reasons: live_preflight_failed, live_preflight_timeout
 # live-provider marker contracts: provider_contract_enforcement_mode, provider_live_contract_marker, provider_live_contract_marker_present, provider_in_memory_reference_detected
 # summary markers: submit_evidence_marker_present, finality_evidence_marker_present
 # request/finality linkage markers: request_payload_evidence_marker_present, request_payload_evidence_artifact_path, submit_evidence_artifact_path, finality_evidence_artifact_path, request_finality_evidence_contract_version, request_finality_evidence_linked

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1193,6 +1193,8 @@ Operator checkpoints:
   - `python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/kolme-local-runtime-commit-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-non-synthetic-run-evidence --output-json /tmp/kolme-local-runtime-commit-live-policy.json`
 - Finality evidence contract lane command:
   - `bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json /tmp/kolme-local-runtime-commit-live-summary.json --policy-output-json /tmp/kolme-local-runtime-commit-live-policy.json`
+- Bounded localhost live-provider integration proof lane:
+  - `bash scripts/kolme/run_local_live_provider_runtime_integration_contract_lane.sh --output-json /tmp/kolme-local-live-provider-runtime-integration-contract-report.json`
 - Default live-provider smoke command executed by run mode:
   - `KAMN_KOLME_LIVE_BASE_URL=http://127.0.0.1:3000 KAMN_KOLME_LIVE_PROVIDER_HINT=kolme-fork-local KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 cargo test -p kamn-core --test kolme_runtime_commit_http_transport -- --ignored --exact integration_kolme_fork_live_node_submit_reaches_endpoint`
 - Summary schema:
@@ -1210,6 +1212,8 @@ Operator checkpoints:
   - request/finality linkage markers (`request_payload_evidence_marker_present`, `request_payload_evidence_artifact_path`, `submit_evidence_artifact_path`, `finality_evidence_artifact_path`, `request_finality_evidence_contract_version`, `request_finality_evidence_linked`) remain fail-closed in policy checks
   - finality retry evidence markers (`finality_retry_contract_version`, `finality_retry_max_attempts`, `finality_retry_backoff_seconds`, `finality_retry_attempts_used`, `finality_retry_exhausted`, `finality_retry_failure_class`) remain fail-closed in policy checks
   - live-provider marker contracts (`provider_contract_enforcement_mode`, `provider_live_contract_marker`, `provider_live_contract_marker_present`, `provider_in_memory_reference_detected`) remain fail-closed in policy checks
+  - provider mismatch remains fail-closed with deterministic reason `provider_client_contract_mismatch`.
+  - bounded localhost integration proof lane validates deterministic NO-GO on node-unavailable preflight reasons `live_preflight_failed` or `live_preflight_timeout`.
   - native payload evidence marker fields (`native_payload_pubkey_marker_present`, `native_payload_nonce_marker_present`, `native_payload_messages_marker_present`) remain fail-closed in strict real-node policy checks
   - summary includes `live_command_synthetic`, `finality_command_synthetic`, and `synthetic_evidence_classification_version=v1` for deterministic synthetic-command detection.
   - `--require-non-synthetic-run-evidence` enforces NO-GO on synthetic run-mode command paths (`synthetic_live_command_detected`, `synthetic_finality_command_detected`).

--- a/scripts/framework/manifests/kolme_local_live_provider_runtime_integration_contract_lane.json
+++ b/scripts/framework/manifests/kolme_local_live_provider_runtime_integration_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "kolme.local_live_provider_runtime_integration.contract",
+  "evidence_key": "kolme_local_live_provider_runtime_integration_contract_lane:v1",
+  "reason_key": "kolme_local_live_provider_runtime_integration_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py"
+    ]
+  }
+}

--- a/scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Bounded localhost integration contract lane for live-provider runtime checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+RUNNER = ROOT_DIR / "scripts/kolme/run_local_runtime_commit_live_lane.sh"
+CHECKER = ROOT_DIR / "scripts/kolme/check_local_runtime_commit_live_evidence_policy.py"
+DOC_FILES = [
+    ROOT_DIR / "docs/planning/kolme-devnet-ops.md",
+    ROOT_DIR / "README.md",
+]
+
+DOC_MARKERS = [
+    "run_local_live_provider_runtime_integration_contract_lane.sh",
+    "run_local_runtime_commit_live_lane.sh",
+    "check_local_runtime_commit_live_evidence_policy.py",
+    "provider_client_contract=KolmeRuntimeCommitLiveProvider",
+    "provider_client_contract_mismatch",
+    "provider_in_memory_reference_detected",
+    "live_preflight_failed",
+    "live_preflight_timeout",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run bounded localhost live-provider runtime integration contract lane."
+    )
+    parser.add_argument(
+        "--output-json",
+        default="/tmp/kolme-local-live-provider-runtime-integration-contract-report.json",
+    )
+    parser.add_argument("--max-seconds", default="90")
+    return parser.parse_args()
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_healthz(base_url: str, timeout_seconds: int = 10) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(f"{base_url}/healthz", timeout=1) as response:
+                if response.status == 200:
+                    return True
+        except URLError:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+def _run(command: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _ensure_docs_markers() -> None:
+    missing: list[str] = []
+    for doc_file in DOC_FILES:
+        if not doc_file.is_file():
+            raise RuntimeError(f"expected documentation file to exist: {doc_file}")
+        doc_text = doc_file.read_text(encoding="utf-8")
+        for marker in DOC_MARKERS:
+            if marker not in doc_text:
+                missing.append(f"{doc_file.relative_to(ROOT_DIR)}_missing_marker:{marker}")
+    if missing:
+        raise RuntimeError(",".join(missing))
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.max_seconds.isdigit() or int(args.max_seconds) <= 0:
+        print("max-seconds must be a positive integer", file=sys.stderr)
+        return 1
+
+    if not RUNNER.is_file() or not os.access(RUNNER, os.X_OK):
+        print("expected local runtime-commit live lane runner to be executable", file=sys.stderr)
+        return 1
+    if not CHECKER.is_file() or not os.access(CHECKER, os.X_OK):
+        print("expected local runtime-commit live evidence policy checker to be executable", file=sys.stderr)
+        return 1
+
+    try:
+        _ensure_docs_markers()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    start_epoch = time.monotonic()
+
+    with tempfile.TemporaryDirectory(prefix="live-provider-runtime-integration-contract-") as temp_dir:
+        temp_path = Path(temp_dir)
+        mock_server_file = temp_path / "mock_kolme_api.py"
+        mock_server_log = temp_path / "mock_kolme_api.log"
+        go_summary_file = temp_path / "go_summary.json"
+        go_policy_file = temp_path / "go_policy.json"
+        provider_mismatch_summary_file = temp_path / "provider_mismatch_summary.json"
+        provider_mismatch_policy_file = temp_path / "provider_mismatch_policy.json"
+        unavailable_summary_file = temp_path / "unavailable_summary.json"
+        unavailable_policy_file = temp_path / "unavailable_policy.json"
+        go_live_output = temp_path / "go_live_output.txt"
+        go_finality_output = temp_path / "go_finality_output.txt"
+        unavailable_live_output = temp_path / "unavailable_live_output.txt"
+        unavailable_finality_output = temp_path / "unavailable_finality_output.txt"
+
+        mock_server_file.write_text(
+            """#!/usr/bin/env python3
+from __future__ import annotations
+
+import http.server
+import json
+import socketserver
+import sys
+from urllib.parse import parse_qs, urlparse
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def _send(self, status: int, body: str, content_type: str = "text/plain") -> None:
+        encoded = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/healthz":
+            self._send(200, "ok")
+            return
+        if parsed.path == "/fork-info":
+            params = parse_qs(parsed.query)
+            chain_version = params.get("chain_version", [""])[0]
+            payload = {"chain_version": chain_version or "v0.15.2", "first_block": 1, "last_block": 1}
+            self._send(200, json.dumps(payload, sort_keys=True), "application/json")
+            return
+        self._send(404, "not found")
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+
+def main() -> int:
+    port = int(sys.argv[1])
+    with socketserver.TCPServer(("127.0.0.1", port), Handler) as server:
+        server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+""",
+            encoding="utf-8",
+        )
+        mock_server_file.chmod(0o755)
+
+        port = _pick_free_port()
+        base_url = f"http://127.0.0.1:{port}"
+        server_process = subprocess.Popen(
+            ["python3", str(mock_server_file), str(port)],
+            cwd=ROOT_DIR,
+            stdout=mock_server_log.open("w", encoding="utf-8"),
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        try:
+            if not _wait_for_healthz(base_url):
+                raise RuntimeError("mock Kolme API server failed readiness probe")
+
+            go_live_command = (
+                "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 "
+                f"curl --silent --show-error --fail {base_url}/healthz >/dev/null && "
+                "printf 'status=submitted\\nintegration_kolme_fork_live_node_submit_reaches_endpoint\\n"
+                "{\"pubkey\":\"proof\",\"nonce\":1,\"messages\":[]}\\n'"
+            )
+            go_result = _run(
+                [
+                    "bash",
+                    str(RUNNER),
+                    "--mode",
+                    "run",
+                    "--base-url",
+                    base_url,
+                    "--provider-hint",
+                    "kolme-fork-local",
+                    "--max-seconds",
+                    "30",
+                    "--preflight-max-seconds",
+                    "5",
+                    "--live-command",
+                    go_live_command,
+                    "--finality-command",
+                    f"curl --silent --show-error --fail {base_url}/healthz >/dev/null && printf 'finality=final\\n'",
+                    "--finality-max-seconds",
+                    "5",
+                    "--finality-retry-max-attempts",
+                    "2",
+                    "--finality-retry-backoff-seconds",
+                    "0",
+                    "--output-json",
+                    str(go_summary_file),
+                    "--live-output-file",
+                    str(go_live_output),
+                    "--finality-output-file",
+                    str(go_finality_output),
+                ],
+                env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
+            )
+            if go_result.returncode != 0:
+                raise RuntimeError(
+                    "expected GO live-provider integration run to succeed: "
+                    f"{go_result.stdout}{go_result.stderr}"
+                )
+
+            go_policy_result = _run(
+                [
+                    "python3",
+                    str(CHECKER),
+                    "--report-file",
+                    str(go_summary_file),
+                    "--expected-final-decision",
+                    "GO",
+                    "--ci-fast-gate",
+                    "PASS",
+                    "--expected-provider-client-contract",
+                    "KolmeRuntimeCommitLiveProvider",
+                    "--require-non-synthetic-run-evidence",
+                    "--require-native-payload-evidence",
+                    "--output-json",
+                    str(go_policy_file),
+                ]
+            )
+            if go_policy_result.returncode != 0:
+                raise RuntimeError(
+                    "expected GO live-provider integration policy check to pass: "
+                    f"{go_policy_result.stdout}{go_policy_result.stderr}"
+                )
+
+            go_summary = json.loads(go_summary_file.read_text(encoding="utf-8"))
+            if go_summary.get("provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+                raise RuntimeError("expected provider_client_contract=KolmeRuntimeCommitLiveProvider in GO summary")
+            if go_summary.get("provider_in_memory_reference_detected") is not False:
+                raise RuntimeError("expected provider_in_memory_reference_detected=false in GO summary")
+
+            provider_mismatch_summary = dict(go_summary)
+            provider_mismatch_summary["provider_client_contract"] = "InMemoryKolmeRuntimeCommitClient"
+            provider_mismatch_summary["provider_in_memory_reference_detected"] = True
+            provider_mismatch_summary["provider_live_contract_marker"] = (
+                "provider_client_contract=InMemoryKolmeRuntimeCommitClient"
+            )
+            provider_mismatch_summary["provider_live_contract_marker_present"] = False
+            provider_mismatch_summary_file.write_text(
+                json.dumps(provider_mismatch_summary, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            provider_mismatch_result = _run(
+                [
+                    "python3",
+                    str(CHECKER),
+                    "--report-file",
+                    str(provider_mismatch_summary_file),
+                    "--expected-final-decision",
+                    "NO-GO",
+                    "--ci-fast-gate",
+                    "PASS",
+                    "--expected-provider-client-contract",
+                    "KolmeRuntimeCommitLiveProvider",
+                    "--output-json",
+                    str(provider_mismatch_policy_file),
+                ]
+            )
+            if provider_mismatch_result.returncode == 0:
+                raise RuntimeError("expected provider mismatch policy check to fail closed")
+            provider_mismatch_policy = json.loads(
+                provider_mismatch_policy_file.read_text(encoding="utf-8")
+            )
+            provider_mismatch_reasons = provider_mismatch_policy.get("reason_codes")
+            if not isinstance(provider_mismatch_reasons, list):
+                raise RuntimeError("expected reason_codes list in provider mismatch policy output")
+            required_provider_reasons = {
+                "provider_client_contract_mismatch",
+                "provider_in_memory_reference_detected",
+            }
+            if not required_provider_reasons.issubset(set(provider_mismatch_reasons)):
+                raise RuntimeError("missing required provider mismatch fail-closed reason markers")
+
+            unavailable_base_url = f"http://127.0.0.1:{port + 17}"
+            unavailable_result = _run(
+                [
+                    "bash",
+                    str(RUNNER),
+                    "--mode",
+                    "run",
+                    "--base-url",
+                    unavailable_base_url,
+                    "--provider-hint",
+                    "kolme-fork-local",
+                    "--max-seconds",
+                    "20",
+                    "--preflight-max-seconds",
+                    "2",
+                    "--live-command",
+                    go_live_command,
+                    "--output-json",
+                    str(unavailable_summary_file),
+                    "--live-output-file",
+                    str(unavailable_live_output),
+                    "--finality-output-file",
+                    str(unavailable_finality_output),
+                ],
+                env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
+            )
+            if unavailable_result.returncode == 0:
+                raise RuntimeError("expected unavailable-node integration run to fail closed")
+            unavailable_summary = json.loads(unavailable_summary_file.read_text(encoding="utf-8"))
+            unavailable_reason_code = unavailable_summary.get("reason_code")
+            if unavailable_reason_code not in {"live_preflight_failed", "live_preflight_timeout"}:
+                raise RuntimeError("expected deterministic preflight failure reason for unavailable-node path")
+
+            unavailable_policy_result = _run(
+                [
+                    "python3",
+                    str(CHECKER),
+                    "--report-file",
+                    str(unavailable_summary_file),
+                    "--expected-final-decision",
+                    "NO-GO",
+                    "--ci-fast-gate",
+                    "PASS",
+                    "--expected-provider-client-contract",
+                    "KolmeRuntimeCommitLiveProvider",
+                    "--require-reason-code",
+                    str(unavailable_reason_code),
+                    "--output-json",
+                    str(unavailable_policy_file),
+                ]
+            )
+            if unavailable_policy_result.returncode != 0:
+                raise RuntimeError(
+                    "expected unavailable-node NO-GO policy check to pass with deterministic reason: "
+                    f"{unavailable_policy_result.stdout}{unavailable_policy_result.stderr}"
+                )
+
+            contract_report = {
+                "schema_version": "kamn.kolme.local-live-provider-runtime-integration-contract-report.v1",
+                "go_summary_file": str(go_summary_file),
+                "go_policy_file": str(go_policy_file),
+                "provider_mismatch_summary_file": str(provider_mismatch_summary_file),
+                "provider_mismatch_policy_file": str(provider_mismatch_policy_file),
+                "unavailable_summary_file": str(unavailable_summary_file),
+                "unavailable_policy_file": str(unavailable_policy_file),
+                "final_decision": "GO",
+            }
+            output_path = Path(args.output_json).resolve()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(contract_report, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        finally:
+            server_process.terminate()
+            try:
+                server_process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                server_process.kill()
+                server_process.wait(timeout=3)
+
+    elapsed_seconds = int(time.monotonic() - start_epoch)
+    if elapsed_seconds > int(args.max_seconds):
+        print(
+            f"live-provider runtime integration contract lane exceeded runtime budget: {elapsed_seconds}s",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("local live-provider runtime integration contract lane tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_contract_lane_dispatch.sh
+++ b/scripts/kolme/run_contract_lane_dispatch.sh
@@ -60,6 +60,7 @@ resolve_manifest_name() {
     run_local_heavy_validation_matrix_contract_lane.sh) echo "kolme_local_heavy_validation_matrix_contract_lane.json" ;;
     run_local_kamn_live_runtime_integration_contract_lane.sh) echo "kolme_local_kamn_live_runtime_integration_contract_lane.json" ;;
     run_local_kamn_live_runtime_real_node_profile_contract_lane.sh) echo "kolme_local_kamn_live_runtime_real_node_profile_contract_lane.json" ;;
+    run_local_live_provider_runtime_integration_contract_lane.sh) echo "kolme_local_live_provider_runtime_integration_contract_lane.json" ;;
     run_local_kolme_live_deployment_preflight_contract_lane.sh) echo "kolme_local_kolme_live_deployment_preflight_contract_lane.json" ;;
     run_local_live_node_validation_bundle_contract_lane.sh) echo "kolme_local_live_node_validation_bundle_contract_lane.json" ;;
     run_local_kolme_fork_bootstrap_readiness_contract_lane.sh) echo "kolme_local_kolme_fork_bootstrap_readiness_contract_lane.json" ;;

--- a/scripts/kolme/run_local_live_provider_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/run_local_live_provider_runtime_integration_contract_lane.sh
@@ -1,0 +1,1 @@
+run_contract_lane_dispatch.sh

--- a/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
+++ b/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
@@ -17,6 +17,7 @@ lane_wrappers=(
   "run_local_heavy_validation_matrix_contract_lane.sh"
   "run_local_kamn_live_runtime_integration_contract_lane.sh"
   "run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"
+  "run_local_live_provider_runtime_integration_contract_lane.sh"
   "run_local_kolme_live_deployment_preflight_contract_lane.sh"
   "run_local_live_node_validation_bundle_contract_lane.sh"
   "run_local_kolme_fork_bootstrap_readiness_contract_lane.sh"

--- a/scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_local_live_provider_runtime_integration_contract_lane.sh"
+CHECKER="$ROOT_DIR/scripts/kolme/check_local_runtime_commit_live_evidence_policy.py"
+CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py"
+DISPATCHER="$ROOT_DIR/scripts/kolme/run_contract_lane_dispatch.sh"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/kolme_local_live_provider_runtime_integration_contract_lane.json"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected local live-provider runtime integration contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -L "$RUNNER" ]; then
+  echo "expected local live-provider runtime integration contract lane runner to be a symlink dispatcher wrapper" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected local runtime commit live evidence policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$CONTRACT_IMPL" ]; then
+  echo "expected local live-provider runtime integration contract lane implementation to exist" >&2
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected local live-provider runtime integration contract lane manifest to exist" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$RUNNER")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST" ]; then
+  echo "expected live-provider runtime integration wrapper to resolve deterministic manifest" >&2
+  exit 1
+fi
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest_path = pathlib.Path(sys.argv[1])
+payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+contract_command = payload.get("phases", {}).get("contract")
+if contract_command != [
+    "python3",
+    "scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py",
+]:
+    raise SystemExit("expected local live-provider runtime integration manifest contract command")
+PY
+
+required_doc_markers=(
+  "run_local_live_provider_runtime_integration_contract_lane.sh"
+  "run_local_runtime_commit_live_lane.sh"
+  "check_local_runtime_commit_live_evidence_policy.py"
+  "provider_client_contract=KolmeRuntimeCommitLiveProvider"
+  "provider_client_contract_mismatch"
+  "provider_in_memory_reference_detected"
+  "live_preflight_failed"
+  "live_preflight_timeout"
+)
+
+for docs_file in "$DOC_FILE" "$README_FILE"; do
+  for marker in "${required_doc_markers[@]}"; do
+    if ! grep -q -- "$marker" "$docs_file"; then
+      echo "expected docs parity marker '$marker' in $docs_file" >&2
+      exit 1
+    fi
+  done
+done
+
+bash "$RUNNER" --output-json "$TMP_REPORT" >/dev/null
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.kolme.local-live-provider-runtime-integration-contract-report.v1":
+    raise SystemExit("unexpected live-provider runtime integration contract report schema")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected live-provider runtime integration contract report final_decision GO")
+required_paths = (
+    "go_summary_file",
+    "go_policy_file",
+    "provider_mismatch_summary_file",
+    "provider_mismatch_policy_file",
+    "unavailable_summary_file",
+    "unavailable_policy_file",
+)
+for key in required_paths:
+    if not isinstance(payload.get(key), str):
+        raise SystemExit(f"expected string path for {key} in contract report")
+PY
+
+echo "local live-provider runtime integration contract lane tests passed."


### PR DESCRIPTION
Closes #2451

## Summary
Add a bounded localhost live-provider runtime integration contract lane that validates GO behavior against a running local mock Kolme node and deterministic NO-GO paths for provider mismatch and node-unavailable preflight failures.

## Changes
- `scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py`: new contract lane implementation that:
  - boots a local mock Kolme API server (`/healthz`, `/fork-info`),
  - runs `run_local_runtime_commit_live_lane.sh` in run mode with live-provider markers,
  - validates GO policy path,
  - enforces NO-GO provider mismatch (`provider_client_contract_mismatch`, `provider_in_memory_reference_detected`),
  - enforces deterministic node-unavailable NO-GO reasons (`live_preflight_failed|live_preflight_timeout`).
- `scripts/framework/manifests/kolme_local_live_provider_runtime_integration_contract_lane.json`: manifest for the new contract lane.
- `scripts/kolme/run_local_live_provider_runtime_integration_contract_lane.sh`: symlink wrapper via shared dispatcher.
- `scripts/kolme/run_contract_lane_dispatch.sh`: added wrapper→manifest mapping.
- `scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh`: lane + docs parity test harness.
- `scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`: include new wrapper in dispatcher matrix test.
- Docs updated: `README.md`, `docs/planning/kolme-devnet-ops.md`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Initial lane validation failures before fixes:
  - `live-command must set KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`
  - `synthetic_finality_command_detected`

### 🟢 Green Phase
- `bash scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh`
- Output: `local live-provider runtime integration contract lane tests passed.`

### 🔁 Regression
- `bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`
- `bash scripts/kolme/test_check_local_runtime_commit_live_evidence_policy.sh`
- `bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | policy reason-code checks for provider mismatch/unavailable preflight | |
| Functional   | ✅     | GO vs NO-GO lane behavior across live-provider and provider drift paths | |
| Integration  | ✅     | local mock node integration run-mode proof lane | |
| Regression   | ✅     | dispatcher wrapper matrix + existing runtime policy/finality tests | |
| Performance  | N/A    | bounded local lane only; no new CI-heavy runtime class | |

## Risks & Rollback
- None
- Rollback: revert commit `255b741` if new lane contracts need to be rolled back quickly.

## Documentation Updates
- Updated: `README.md`, `docs/planning/kolme-devnet-ops.md`.

## Validation Checklist
- [x] `bash -n scripts/kolme/run_contract_lane_dispatch.sh scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh`
- [x] `python3 -m py_compile scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py`
- [x] TDD Red/Green evidence included above
- [x] `bash scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh`
- [x] `bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`
- [x] `bash scripts/kolme/test_check_local_runtime_commit_live_evidence_policy.sh`
- [x] `bash scripts/kolme/test_run_local_runtime_commit_live_finality_evidence_contract_lane.sh`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy -- -D warnings`
