### PR TITLE
fix(kolme): enforce signer custody remediation contracts

### DIFF
--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -160,11 +160,15 @@ Fallback private-key surfaces are forbidden in deployment preflight and runtime 
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
 - Required schema/reason markers:
   - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
   - `runtime_signer_fallback_private_key_present=false`
   - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
   - `runtime_signer_raw_private_key_present=false`
   - `runtime_signer_fallback_private_key_present_violation`
   - `runtime_signer_managed_external_raw_private_key_present_violation`
+  - `contracts.runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `contracts.runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
   - `contracts.runtime_signer_fallback_private_key_allowed=false`
   - `contracts.runtime_signer_managed_external_raw_private_key_allowed=false`
 - Incident response and remediation:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -455,6 +455,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `runtime_signer_fallback_private_key_present=false`
     - `runtime_signer_raw_private_key_present=false`
   - GO proof also supports deterministic secondary signer markers:
@@ -542,12 +544,16 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `contracts.runtime_signer_quorum_linked_required=true`
     - `contracts.runtime_signer_quorum_threshold_required=true`
     - `contracts.runtime_signer_quorum_profile_membership_required=true`
+    - `contracts.runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `contracts.runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `contracts.runtime_signer_fallback_private_key_allowed=false`
     - `contracts.runtime_signer_managed_external_raw_private_key_allowed=false`
   - real-node profile accepts secondary signer summary/contracts markers for failover drills:
     - `runtime_signer_profile=ops-secondary`
     - `runtime_signer_previous_profile=ops-secondary`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
+    - `runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY`
+    - `contracts.runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY`
     - `contracts.runtime_signer_failover_requires_profile_change=true`
     - `contracts.runtime_signer_rotation_epoch_must_increase_on_failover=true`
   - forced failover scenario matrix markers:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -23,6 +23,9 @@ REAL_SIGNER_PRIVATE_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_
 REAL_SIGNER_KEY_REF_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_KEY_REF"
 REAL_SIGNER_KEY_REF_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
 REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+REAL_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION = (
+    f"unset {REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV}"
+)
 REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
 ALLOWED_SIGNER_PROFILES = (
     REAL_SIGNER_PROFILE_PRIMARY,
@@ -255,6 +258,38 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("runtime_signer_fallback_private_key_env_missing")
     elif runtime_signer_fallback_private_key_env != REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
         reason_codes.append("runtime_signer_fallback_private_key_env_mismatch")
+
+    runtime_signer_fallback_private_key_remediation = report.get(
+        "runtime_signer_fallback_private_key_remediation"
+    )
+    if (
+        not isinstance(runtime_signer_fallback_private_key_remediation, str)
+        or not runtime_signer_fallback_private_key_remediation.strip()
+    ):
+        reason_codes.append("runtime_signer_fallback_private_key_remediation_missing")
+    elif runtime_signer_fallback_private_key_remediation != REAL_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION:
+        reason_codes.append("runtime_signer_fallback_private_key_remediation_mismatch")
+
+    expected_managed_external_raw_private_key_remediation = ""
+    if expected_signer_private_key_env and expected_signer_key_reference_env:
+        expected_managed_external_raw_private_key_remediation = (
+            f"unset {expected_signer_private_key_env}; set {expected_signer_key_reference_env}"
+        )
+
+    runtime_signer_managed_external_raw_private_key_remediation = report.get(
+        "runtime_signer_managed_external_raw_private_key_remediation"
+    )
+    if (
+        not isinstance(runtime_signer_managed_external_raw_private_key_remediation, str)
+        or not runtime_signer_managed_external_raw_private_key_remediation.strip()
+    ):
+        reason_codes.append("runtime_signer_managed_external_raw_private_key_remediation_missing")
+    elif (
+        expected_managed_external_raw_private_key_remediation
+        and runtime_signer_managed_external_raw_private_key_remediation
+        != expected_managed_external_raw_private_key_remediation
+    ):
+        reason_codes.append("runtime_signer_managed_external_raw_private_key_remediation_mismatch")
 
     runtime_signer_fallback_private_key_present = report.get("runtime_signer_fallback_private_key_present")
     if not isinstance(runtime_signer_fallback_private_key_present, bool):
@@ -564,6 +599,19 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_key_reference_env_contract_mismatch")
         if contracts.get("runtime_signer_fallback_private_key_env") != REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
             reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
+        if (
+            contracts.get("runtime_signer_fallback_private_key_remediation")
+            != REAL_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION
+        ):
+            reason_codes.append("runtime_signer_fallback_private_key_remediation_contract_mismatch")
+        if (
+            expected_managed_external_raw_private_key_remediation
+            and contracts.get("runtime_signer_managed_external_raw_private_key_remediation")
+            != expected_managed_external_raw_private_key_remediation
+        ):
+            reason_codes.append(
+                "runtime_signer_managed_external_raw_private_key_remediation_contract_mismatch"
+            )
         if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -105,6 +105,12 @@ def main() -> int:
     expected_signer_key_source = "env-local"
     expected_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[expected_signer_profile]
     expected_signer_key_reference_env = SIGNER_KEY_REF_ENV_BY_PROFILE[expected_signer_profile]
+    expected_fallback_signer_private_key_remediation = (
+        f"unset {FALLBACK_SIGNER_PRIVATE_KEY_ENV}"
+    )
+    expected_managed_external_raw_private_key_remediation = (
+        f"unset {expected_signer_private_key_env}; set {expected_signer_key_reference_env}"
+    )
     alternate_signer_profile = "ops-secondary" if expected_signer_profile == "ops-primary" else "ops-primary"
     alternate_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[alternate_signer_profile]
 
@@ -295,6 +301,24 @@ def main() -> int:
     if summary.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
         print("expected fallback signer private key env marker in contract-lane summary", file=sys.stderr)
         return 1
+    if (
+        summary.get("runtime_signer_fallback_private_key_remediation")
+        != expected_fallback_signer_private_key_remediation
+    ):
+        print(
+            "expected fallback signer private key remediation marker in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
+    if (
+        summary.get("runtime_signer_managed_external_raw_private_key_remediation")
+        != expected_managed_external_raw_private_key_remediation
+    ):
+        print(
+            "expected managed-external signer raw private key remediation marker in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
     if summary.get("runtime_signer_fallback_private_key_present") is not False:
         print("expected fallback signer private key presence marker false in contract-lane summary", file=sys.stderr)
         return 1
@@ -393,6 +417,24 @@ def main() -> int:
         return 1
     if contracts.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
         print("expected contracts fallback signer private key env marker in contract-lane summary", file=sys.stderr)
+        return 1
+    if (
+        contracts.get("runtime_signer_fallback_private_key_remediation")
+        != expected_fallback_signer_private_key_remediation
+    ):
+        print(
+            "expected contracts fallback signer private key remediation marker in contract-lane summary",
+            file=sys.stderr,
+        )
+        return 1
+    if (
+        contracts.get("runtime_signer_managed_external_raw_private_key_remediation")
+        != expected_managed_external_raw_private_key_remediation
+    ):
+        print(
+            "expected contracts managed-external signer raw private key remediation marker in contract-lane summary",
+            file=sys.stderr,
+        )
         return 1
     if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
         print("expected contracts fallback signer private key allowed=false marker in contract-lane summary", file=sys.stderr)
@@ -507,6 +549,12 @@ def main() -> int:
         forced_failover_go_summary["runtime_signer_key_reference_env"] = SIGNER_KEY_REF_ENV_BY_PROFILE[
             alternate_signer_profile
         ]
+        forced_failover_go_summary["runtime_signer_managed_external_raw_private_key_remediation"] = (
+            "unset "
+            f"{SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[alternate_signer_profile]}; "
+            "set "
+            f"{SIGNER_KEY_REF_ENV_BY_PROFILE[alternate_signer_profile]}"
+        )
         forced_failover_go_summary["runtime_commit_command"] = runtime_commit_command.replace(
             expected_signer_command_marker,
             f"KAMN_KOLME_LIVE_SIGNER_PROFILE={alternate_signer_profile}",
@@ -534,6 +582,12 @@ def main() -> int:
         )
         forced_failover_go_contracts["runtime_signer_key_reference_env"] = (
             SIGNER_KEY_REF_ENV_BY_PROFILE[alternate_signer_profile]
+        )
+        forced_failover_go_contracts["runtime_signer_managed_external_raw_private_key_remediation"] = (
+            "unset "
+            f"{SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[alternate_signer_profile]}; "
+            "set "
+            f"{SIGNER_KEY_REF_ENV_BY_PROFILE[alternate_signer_profile]}"
         )
         forced_failover_go_contracts["runtime_signer_attestation_required_approvals"] = 2
         forced_failover_go_contracts["runtime_signer_quorum_required_approvals"] = 2

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
@@ -41,6 +41,8 @@ RUNTIME_SIGNER_KEY_SOURCE=""
 RUNTIME_SIGNER_PRIVATE_KEY_ENV=""
 RUNTIME_SIGNER_KEY_REF_ENV=""
 RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION="unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+RUNTIME_SIGNER_MANAGED_EXTERNAL_RAW_PRIVATE_KEY_REMEDIATION=""
 RUNTIME_SIGNER_PROFILE_OVERRIDE=""
 RUNTIME_SIGNER_KEY_SOURCE_OVERRIDE=""
 
@@ -444,6 +446,7 @@ if [ "$RUNTIME_PROFILE" = "real-node" ]; then
     echo "runtime-signer-key-source managed-external is not allowed for runtime-signer-profile=ops-secondary" >&2
     exit 1
   fi
+  RUNTIME_SIGNER_MANAGED_EXTERNAL_RAW_PRIVATE_KEY_REMEDIATION="unset ${RUNTIME_SIGNER_PRIVATE_KEY_ENV}; set ${RUNTIME_SIGNER_KEY_REF_ENV}"
   RUNTIME_SIGNER_PREVIOUS_PROFILE="$RUNTIME_SIGNER_PROFILE"
 fi
 
@@ -802,7 +805,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$RUNTIME_SIGNING_PROFILE" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$RUNTIME_SIGNING_PROFILE" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION" "$RUNTIME_SIGNER_MANAGED_EXTERNAL_RAW_PRIVATE_KEY_REMEDIATION" <<'PY'
 from __future__ import annotations
 
 import json
@@ -857,6 +860,8 @@ runtime_signer_fallback_private_key_present = sys.argv[45] == "true"
 runtime_signer_raw_private_key_present = sys.argv[46] == "true"
 runtime_signer_attestation_schema_version = sys.argv[47]
 runtime_signing_profile = sys.argv[48]
+runtime_signer_fallback_private_key_remediation = sys.argv[49]
+runtime_signer_managed_external_raw_private_key_remediation = sys.argv[50]
 
 checks = []
 for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
@@ -1052,6 +1057,8 @@ summary = {
     "runtime_signer_private_key_env": runtime_signer_private_key_env,
     "runtime_signer_key_reference_env": runtime_signer_key_reference_env,
     "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
+    "runtime_signer_fallback_private_key_remediation": runtime_signer_fallback_private_key_remediation,
+    "runtime_signer_managed_external_raw_private_key_remediation": runtime_signer_managed_external_raw_private_key_remediation,
     "runtime_signer_fallback_private_key_present": runtime_signer_fallback_private_key_present,
     "runtime_signer_raw_private_key_present": runtime_signer_raw_private_key_present,
     "runtime_signer_attestation_schema_version": runtime_signer_attestation_schema_version,
@@ -1092,6 +1099,8 @@ summary = {
         "runtime_signer_private_key_env": runtime_signer_private_key_env,
         "runtime_signer_key_reference_env": runtime_signer_key_reference_env,
         "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
+        "runtime_signer_fallback_private_key_remediation": runtime_signer_fallback_private_key_remediation,
+        "runtime_signer_managed_external_raw_private_key_remediation": runtime_signer_managed_external_raw_private_key_remediation,
         "runtime_signer_fallback_private_key_allowed": False,
         "runtime_signer_fallback_private_key_command_marker_allowed": False,
         "runtime_signer_managed_external_raw_private_key_allowed": False,

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -13,8 +13,10 @@ TMP_REPORT_OK_SECONDARY="$TMP_DIR/ok-report-secondary.json"
 TMP_REPORT_OK_MANAGED="$TMP_DIR/ok-report-managed.json"
 TMP_REPORT_KEY_SOURCE_MARKER_MISSING="$TMP_DIR/key-source-marker-missing-report.json"
 TMP_REPORT_FALLBACK_COMMAND_MARKER="$TMP_DIR/fallback-command-marker-report.json"
+TMP_REPORT_FALLBACK_REMEDIATION_DRIFT="$TMP_DIR/fallback-remediation-drift-report.json"
 TMP_REPORT_MANAGED_KEY_REF_MISSING="$TMP_DIR/managed-key-ref-missing-report.json"
 TMP_REPORT_MANAGED_PRIVATE_KEY_COMMAND="$TMP_DIR/managed-private-key-command-report.json"
+TMP_REPORT_MANAGED_REMEDIATION_DRIFT="$TMP_DIR/managed-remediation-drift-report.json"
 TMP_REPORT_KEY_SOURCE_PAIR_BAD="$TMP_DIR/key-source-pair-bad-report.json"
 TMP_REPORT_SPLIT_BRAIN="$TMP_DIR/split-brain-report.json"
 TMP_REPORT_FAILOVER_ATTESTATION_QUORUM_INSUFFICIENT="$TMP_DIR/failover-attestation-quorum-insufficient-report.json"
@@ -86,6 +88,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_signer_key_reference_env": "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
   "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_managed_external_raw_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF",
   "runtime_signer_fallback_private_key_present": false,
   "runtime_signer_raw_private_key_present": false,
   "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
@@ -134,6 +138,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_signer_key_reference_env": "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
     "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_managed_external_raw_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF",
     "runtime_signer_fallback_private_key_allowed": false,
     "runtime_signer_fallback_private_key_command_marker_allowed": false,
     "runtime_signer_managed_external_raw_private_key_allowed": false,
@@ -247,6 +253,10 @@ report["runtime_signer_profile"] = "ops-secondary"
 report["runtime_signer_previous_profile"] = "ops-secondary"
 report["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
 report["runtime_signer_key_reference_env"] = "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+report["runtime_signer_managed_external_raw_private_key_remediation"] = (
+    "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; "
+    "set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+)
 report["runtime_commit_command"] = str(report["runtime_commit_command"]).replace(
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary",
     "KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary",
@@ -260,6 +270,10 @@ if isinstance(contracts, dict):
     contracts["runtime_signer_profile"] = "ops-secondary"
     contracts["runtime_signer_private_key_env"] = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"
     contracts["runtime_signer_key_reference_env"] = "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+    contracts["runtime_signer_managed_external_raw_private_key_remediation"] = (
+        "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; "
+        "set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+    )
 pathlib.Path(sys.argv[2]).write_text(
     json.dumps(report, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
@@ -305,6 +319,13 @@ report["runtime_commit_command"] = runtime_commit_command
 contracts = report.get("contracts", {})
 if isinstance(contracts, dict):
     contracts["runtime_signer_key_source"] = "managed-external"
+report["runtime_signer_managed_external_raw_private_key_remediation"] = (
+    "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF"
+)
+if isinstance(contracts, dict):
+    contracts["runtime_signer_managed_external_raw_private_key_remediation"] = (
+        "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF"
+    )
 pathlib.Path(sys.argv[2]).write_text(
     json.dumps(report, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
@@ -390,6 +411,92 @@ fi
 
 if ! grep -q "runtime_commit_fallback_private_key_command_marker_detected" "$TMP_ERR"; then
   echo "expected fallback signer private key command marker detected reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_FALLBACK_REMEDIATION_DRIFT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_fallback_private_key_remediation"] = "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+contracts = report.get("contracts", {})
+if isinstance(contracts, dict):
+    contracts["runtime_signer_fallback_private_key_remediation"] = "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_FALLBACK_REMEDIATION_DRIFT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+fallback_remediation_drift_exit_code=$?
+set -e
+
+if [ "$fallback_remediation_drift_exit_code" -eq 0 ]; then
+  echo "expected fallback signer remediation marker drift proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_remediation_mismatch" "$TMP_ERR"; then
+  echo "expected fallback signer remediation marker mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_private_key_remediation_contract_mismatch" "$TMP_ERR"; then
+  echo "expected fallback signer remediation contract marker mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_MANAGED_REMEDIATION_DRIFT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["runtime_signer_managed_external_raw_private_key_remediation"] = (
+    "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+)
+contracts = report.get("contracts", {})
+if isinstance(contracts, dict):
+    contracts["runtime_signer_managed_external_raw_private_key_remediation"] = (
+        "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
+    )
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_MANAGED_REMEDIATION_DRIFT" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --require-non-synthetic-run-evidence \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+managed_remediation_drift_exit_code=$?
+set -e
+
+if [ "$managed_remediation_drift_exit_code" -eq 0 ]; then
+  echo "expected managed-external signer remediation marker drift proof to fail closed" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_managed_external_raw_private_key_remediation_mismatch" "$TMP_ERR"; then
+  echo "expected managed-external signer remediation marker mismatch reason for policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_managed_external_raw_private_key_remediation_contract_mismatch" "$TMP_ERR"; then
+  echo "expected managed-external signer remediation contract marker mismatch reason for policy failure" >&2
   exit 1
 fi
 
@@ -1186,6 +1293,10 @@ if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIV
     raise SystemExit("expected signer private key env marker in runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
     raise SystemExit("expected fallback signer private key env marker in runner-generated summary")
+if summary.get("runtime_signer_fallback_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key remediation marker in runner-generated summary")
+if summary.get("runtime_signer_managed_external_raw_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF":
+    raise SystemExit("expected managed-external signer raw private key remediation marker in runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected fallback signer private key presence marker false in runner-generated summary")
 checks = summary.get("checks")
@@ -1250,10 +1361,18 @@ if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PR
     raise SystemExit("expected contracts secondary signer private key env marker in secondary runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
     raise SystemExit("expected fallback signer private key env marker in secondary runner-generated summary")
+if summary.get("runtime_signer_fallback_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected fallback signer private key remediation marker in secondary runner-generated summary")
+if summary.get("runtime_signer_managed_external_raw_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
+    raise SystemExit("expected managed-external signer raw private key remediation marker in secondary runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected fallback signer private key presence marker false in secondary runner-generated summary")
 if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
     raise SystemExit("expected contracts fallback signer private key env marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_fallback_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
+    raise SystemExit("expected contracts fallback signer private key remediation marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_managed_external_raw_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
+    raise SystemExit("expected contracts managed-external signer raw private key remediation marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:


### PR DESCRIPTION
## Summary
This hardens real-node Kolme runtime signer custody contracts by making remediation guidance deterministic and policy-enforced. The runtime integration lane now emits explicit remediation markers for fallback/private-key violations, and the real-node policy/contract lanes fail closed on remediation marker drift.

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh`: emit deterministic signer-custody remediation markers in summary/contracts.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: enforce fallback + managed-external remediation marker contracts with fail-closed reason codes.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: assert remediation markers in positive contract checks and keep failover GO matrix aligned for the new marker contracts.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: add red/green regression coverage for remediation marker drift and runner-emitted marker assertions.
- `docs/planning/kolme-devnet-ops.md`: document required remediation markers in real-node runtime summary/contracts.
- `docs/foundation/upgrade-rollback-runbook.md`: document deterministic remediation markers and contract expectations for runtime signer-custody violations.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
```
Output:
```text
expected fallback signer remediation marker mismatch reason for policy failure
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
```
Outputs:
```text
local KAMN live runtime real-node profile policy checker tests passed.
local KAMN live runtime real-node profile contract lane tests passed.
local KAMN live runtime integration contract lane tests passed.
```

### 🔁 Regression
Commands:
```bash
python3 -m py_compile scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
bash -n scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` fixture-level reason-code assertions | |
| Functional   | ✅     | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` GO/NO-GO policy outcomes | |
| Integration  | ✅     | `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh` | |
| Regression   | ✅     | remediation-marker drift proofs in `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` and contract-lane checks | |
| Performance  | N/A    | | Bounded local policy/lane checks only; no new throughput path |

## Risks & Rollback
- Breaking change risk: low-medium. Real-node summaries that omit remediation markers now fail closed.
- Rollback plan: revert commit `9ba8884` to restore previous non-enforced remediation marker behavior.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `docs/foundation/upgrade-rollback-runbook.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean (not applicable to these script/docs-only changes)
- [ ] `cargo clippy -- -D warnings` — clean (not applicable to these script/docs-only changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant local Kolme policy/contract suites)
- [x] Docs updated (or justified why not)

Closes #2453
