### PR TITLE
docs(kolme): harden modularization parity doc contracts

### DIFF
--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -8,6 +8,8 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("KolmeRuntimeCommitProviderReceipt"));
     assert!(DOC.contains("KolmeRuntimeCommitProviderError"));
     assert!(DOC.contains("KolmeRuntimeCommitForkFinalityResolver"));
+    assert!(DOC.contains("## Module Ownership Map"));
+    assert!(DOC.contains("crates/kamn-kolme/src/runtime_transport_contracts.rs"));
     assert!(DOC.contains("runtime_lifecycle_policy"));
     assert!(DOC.contains("commit_finality_from_receipt_finality"));
     assert!(DOC.contains("parse_commit_receipt_finality"));
@@ -39,6 +41,10 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains(
         "cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact"
     ));
+    assert!(
+        DOC.contains("cargo test -p kamn-kolme --test runtime_commit_module_boundary_contracts")
+    );
+    assert!(DOC.contains("cargo test -p kamn-core --test kolme_runtime_commit_import_boundary"));
     assert!(DOC.contains("check_local_runtime_commit_live_evidence_policy.py"));
     assert!(DOC.contains("run_local_runtime_commit_live_finality_evidence_contract_lane.sh"));
     assert!(DOC.contains("submit_evidence_marker_present"));
@@ -56,6 +62,8 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("test_check_runtime_commit_decomposition_parity_matrix.sh"));
     assert!(DOC.contains("submit_http_round_trip"));
     assert!(DOC.contains("finality_block_fallback_resolution"));
+    assert!(DOC.contains("receipt_provider_mismatch"));
+    assert!(DOC.contains("receipt_not_final"));
 }
 
 #[test]

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -149,6 +149,11 @@ fn checklist_contains_kolme_version_compatibility_replay_evidence_contract() {
     assert!(CHECKLIST.contains("check_runtime_commit_replay_policy.py"));
     assert!(CHECKLIST.contains("run_runtime_commit_replay_tamper_matrix.py"));
     assert!(CHECKLIST.contains("run_runtime_commit_adapter_contract_lane.sh"));
+    assert!(CHECKLIST
+        .contains("cargo test -p kamn-kolme --test runtime_commit_module_boundary_contracts"));
+    assert!(
+        CHECKLIST.contains("cargo test -p kamn-core --test kolme_runtime_commit_import_boundary")
+    );
     assert!(CHECKLIST.contains("receipt_provider_mismatch"));
     assert!(CHECKLIST.contains("receipt_not_final"));
     assert!(CHECKLIST.contains("run_version_compatibility_contract_lane.sh"));

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -183,6 +183,9 @@ handling.
   - mapped to `KolmeRuntimeCommitError::ProviderMismatch`
 - Non-final provider receipt:
   - mapped to `KolmeRuntimeCommitError::NonFinalReceipt`
+- Adapter reason-code parity markers:
+  - `receipt_provider_mismatch`
+  - `receipt_not_final`
 
 ## Decomposition Parity Matrix (Task #2124)
 
@@ -232,6 +235,8 @@ cargo test -p kamn-core --test kolme_runtime_commit_http_transport integration_h
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_http_transport_submit_broadcast_request_rejects_malformed_txhash_response -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact
 cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact
+cargo test -p kamn-kolme --test runtime_commit_module_boundary_contracts
+cargo test -p kamn-core --test kolme_runtime_commit_import_boundary
 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode dry-run --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt
 python3 scripts/kolme/check_local_runtime_commit_live_evidence_policy.py --report-file /tmp/kolme-local-runtime-commit-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-runtime-commit-live-policy.json
 KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_runtime_commit_live_lane.sh --mode run --base-url http://127.0.0.1:3000 --provider-hint kolme-fork-local --max-seconds 90 --preflight-max-seconds 10 --output-json /tmp/kolme-local-runtime-commit-live-summary.json --live-output-file /tmp/kolme-local-runtime-commit-live-output.txt

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -274,6 +274,8 @@ Kolme upgrade approvals require deterministic KAMN/Kolme version compatibility v
   - `python3 scripts/kolme/run_runtime_commit_replay_tamper_matrix.py --fixture fixtures/kolme_commit/runtime_commit_replay_tamper_cases.json --output-json /tmp/kolme-runtime-commit-replay-report.json`
 - Runtime commit adapter replay/finality fast lane:
   - `bash scripts/kolme/run_runtime_commit_adapter_contract_lane.sh`
+  - `cargo test -p kamn-kolme --test runtime_commit_module_boundary_contracts`
+  - `cargo test -p kamn-core --test kolme_runtime_commit_import_boundary`
   - adapter reason-code checks include:
     - `receipt_provider_mismatch`
     - `receipt_not_final`


### PR DESCRIPTION
## Summary
Harden runtime-commit modularization parity/docs contracts by adding explicit command markers and reason-code parity markers to foundation/release docs, and updating docs contract tests to fail closed on drift.

## Changes
- `docs/foundation/kolme-runtime-commit-client.md`:
  - added adapter reason-code parity markers (`receipt_provider_mismatch`, `receipt_not_final`).
  - added modularization parity validation command references:
    - `cargo test -p kamn-kolme --test runtime_commit_module_boundary_contracts`
    - `cargo test -p kamn-core --test kolme_runtime_commit_import_boundary`
- `docs/foundation/release-gonogo-checklist.md`:
  - added the same boundary/parity command references under runtime commit adapter replay/finality fast lane.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`:
  - added docs contract assertions for new ownership/parity markers.
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`:
  - added checklist docs contract assertions for new parity command references.

## TDD Evidence (Mandatory)
### Red Phase
Command:
```bash
git show origin/main:docs/foundation/release-gonogo-checklist.md | rg -n "runtime_commit_module_boundary_contracts|kolme_runtime_commit_import_boundary"
```
Output:
```text
(no matches)
```

Command:
```bash
git show origin/main:docs/foundation/kolme-runtime-commit-client.md | rg -n "Adapter reason-code parity markers|kolme_runtime_commit_import_boundary"
```
Output:
```text
(no matches)
```

### Green Phase
Command:
```bash
rg -n "runtime_commit_module_boundary_contracts|kolme_runtime_commit_import_boundary" docs/foundation/release-gonogo-checklist.md docs/foundation/kolme-runtime-commit-client.md crates/kamn-core/tests/release_gonogo_checklist_docs.rs crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
```
Result:
```text
present in docs and docs-contract tests
```

Command:
```bash
rg -n "Adapter reason-code parity markers|receipt_provider_mismatch|receipt_not_final" docs/foundation/kolme-runtime-commit-client.md
```
Result:
```text
present in runtime-commit foundation docs
```

### Regression
Command:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core --test kolme_runtime_commit_client_docs --test release_gonogo_checklist_docs
cargo test -p kamn-kolme --test runtime_commit_module_boundary_contracts
cargo test -p kamn-core --test kolme_runtime_commit_import_boundary
```
Result:
```text
pass: fmt clean, clippy clean, docs contracts clean (2 + 58 passed), and boundary suites clean (2 + 2 passed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing docs contract tests extended for new parity markers | |
| Functional   | ✅     | Existing docs contract behavior validated through command/marker assertions | |
| Integration  | ✅     | Cross-doc contract suites and boundary suites validated together | |
| Regression   | ✅     | New assertions fail closed on marker/command drift | |
| Performance  | N/A    | Docs/test hardening only | No runtime-path changes |

## Risks & Rollback
- Risk: low; docs and docs contract assertions only.
- Rollback: revert commit `8068563`.

## Documentation Updates
- Updated runtime-commit foundation docs and release go/no-go checklist with modularization parity references.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`kamn-core` targeted)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (targeted docs/boundary suites)
- [x] Docs updated (or justified why not)

Closes #2467
Refs #2463
Refs #2462
