### PR TITLE
fix: enforce managed-external signer source in deployment preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-
 # sample signer custody evidence marker for run mode
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json
 # sample signer provenance evidence marker for run mode
-printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json
+printf '%s\n' "signer-provenance=ops-primary:source-managed-external:epoch-1" > /tmp/kolme-live-signer-provenance.json
 # sample signer quorum evidence bundle for run mode
 custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
 {
@@ -731,10 +731,10 @@ JSON
 
 # deployment preflight run mode (fast-gate eligible, no local-heavy gate required)
 KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 \
-bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
+bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source managed-external --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
 
 # deployment preflight policy checker contract
-python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json
+python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code deployment_preflight_passed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json
 
 # deployment preflight contract lane (dry-run summary + policy + docs parity)
 bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json
@@ -744,7 +744,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
 # fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
 # signer_key_source_contract_version=v1
-# signer_key_source=env-local
+# signer_key_source=managed-external
 # signer_provenance_file
 # signer_provenance_present
 # signer_provenance_sha256_valid
@@ -809,7 +809,9 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # contracts.signer_provenance_required=true
 # contracts.signer_provenance_sha256_required=true
 # contracts.signer_key_source_contract_version=v1
-# contracts.signer_key_source=env-local
+# contracts.signer_key_source=managed-external
+# contracts.required_signer_key_source_for_production=managed-external
+# contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required
 # contracts.signer_rotation_freshness_max_delta=2
 # contracts.signer_rotation_stale_rejected=true
 
@@ -856,7 +858,7 @@ bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --
 # custody_evidence_sha256_invalid
 # signer_key_source_contract_version_mismatch
 # signer_key_source_invalid
-# signer_key_source_profile_pair_disallowed
+# signer_key_source_production_managed_external_required
 # signer_provenance_missing
 # signer_provenance_sha256_invalid
 # signer_rotation_epoch_stale

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -475,7 +475,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   - deployment preflight signer/runtime checks remain fast and ci-fast-gate eligible.
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
     - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
-    - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+    - `printf '%s\n' "signer-provenance=ops-primary:source-managed-external:epoch-1" > /tmp/kolme-live-signer-provenance.json`
     - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
 {
   "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
@@ -487,15 +487,15 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   "custody_evidence_sha256": "$custody_sha"
 }
 JSON`
-    - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
-    - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+    - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source managed-external --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+    - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code deployment_preflight_passed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
     - deterministic marker contracts:
       - `signer_profile_selector_env=KAMN_KOLME_LIVE_SIGNER_PROFILE`
       - `fallback_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
       - `fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
       - `signer_key_source_contract_version=v1`
-      - `signer_key_source=env-local`
+      - `signer_key_source=managed-external`
       - `signer_provenance_file`
       - `signer_provenance_present`
       - `signer_provenance_sha256_valid`
@@ -565,7 +565,9 @@ JSON`
       - `contracts.signer_provenance_required=true`
       - `contracts.signer_provenance_sha256_required=true`
       - `contracts.signer_key_source_contract_version=v1`
-      - `contracts.signer_key_source=env-local`
+      - `contracts.signer_key_source=managed-external`
+      - `contracts.required_signer_key_source_for_production=managed-external`
+      - `contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required`
       - `contracts.signer_rotation_freshness_max_delta=2`
       - `contracts.signer_rotation_stale_rejected=true`
     - fail-closed drift reasons:
@@ -611,7 +613,7 @@ JSON`
       - `custody_evidence_sha256_invalid`
       - `signer_key_source_contract_version_mismatch`
       - `signer_key_source_invalid`
-      - `signer_key_source_profile_pair_disallowed`
+      - `signer_key_source_production_managed_external_required`
       - `signer_provenance_missing`
       - `signer_provenance_sha256_invalid`
       - `signer_rotation_epoch_stale`

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -101,7 +101,7 @@ Local Kolme deployment gates require deterministic multi-signer quorum and custo
   - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Quorum/custody/provenance evidence preparation:
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
-  - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+  - `printf '%s\n' "signer-provenance=ops-primary:source-managed-external:epoch-1" > /tmp/kolme-live-signer-provenance.json`
   - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
 {
   "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
@@ -112,14 +112,15 @@ Local Kolme deployment gates require deterministic multi-signer quorum and custo
 }
 JSON`
 - Deployment preflight run mode:
-  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --custody-evidence-file /tmp/kolme-live-signer-custody.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source managed-external --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Deployment preflight policy checker:
-  - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+  - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code deployment_preflight_passed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
 - Deployment preflight contract lane:
   - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
 - Required schema/reason markers:
   - `kamn.kolme.local-live-deployment-preflight-summary.v1`
   - `kamn.kolme.local-live-deployment-preflight-policy-report.v1`
+  - `kamn.kolme.signer-quorum-evidence.v1`
   - `kamn.kolme.runtime-signer-attestation.v1`
   - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
   - `runtime_signer_attestation_bundle`
@@ -148,7 +149,7 @@ JSON`
 Fallback private-key surfaces are forbidden in deployment preflight and runtime launch paths; checks fail closed with deterministic remediation guidance.
 
 - Deployment preflight fallback guard:
-  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source managed-external --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Runtime integration fallback guard:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode run --runtime-profile real-node --checkout-path /tmp/kolme_fork --expected-remote-url https://github.com/njfio/kolme_fork.git --expected-ref refs/heads/main --base-url http://127.0.0.1:3000 --fork-chain-version v0.15.2 --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --runtime-commit-live-summary /tmp/kolme-local-runtime-commit-live-summary.json --runtime-commit-live-policy-report /tmp/kolme-local-runtime-commit-live-policy.json --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json`
 - Runtime integration managed-external raw-key guard:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -614,7 +614,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Deployment preflight run mode:
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
-  - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+  - `printf '%s\n' "signer-provenance=ops-primary:source-managed-external:epoch-1" > /tmp/kolme-live-signer-provenance.json`
   - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
 {
   "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
@@ -626,9 +626,9 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   "custody_evidence_sha256": "$custody_sha"
 }
 JSON`
-  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source env-local --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
+  - `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source managed-external --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json`
 - Deployment preflight policy checker command:
-  - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+  - `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code deployment_preflight_passed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
 - Deployment preflight contract lane command:
   - `bash scripts/kolme/run_local_kolme_live_deployment_preflight_contract_lane.sh --output-json /tmp/kolme-local-live-deployment-preflight-summary.json --policy-output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
 - Summary/policy schemas:
@@ -653,7 +653,7 @@ JSON`
     - `fallback_signer_secret_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
     - `fallback_signer_secret_present=false`
     - `signer_key_source_contract_version=v1`
-    - `signer_key_source=env-local`
+    - `signer_key_source=managed-external`
     - `signer_provenance_file`
     - `signer_provenance_present`
     - `signer_provenance_sha256_valid`
@@ -726,7 +726,9 @@ JSON`
     - `contracts.signer_provenance_required=true`
     - `contracts.signer_provenance_sha256_required=true`
     - `contracts.signer_key_source_contract_version=v1`
-    - `contracts.signer_key_source=env-local`
+    - `contracts.signer_key_source=managed-external`
+    - `contracts.required_signer_key_source_for_production=managed-external`
+    - `contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required`
     - `contracts.signer_rotation_freshness_max_delta=2`
     - `contracts.signer_rotation_stale_rejected=true`
 - Fail-closed reasons include:
@@ -767,7 +769,7 @@ JSON`
   - `custody_evidence_sha256_invalid`
   - `signer_key_source_contract_version_mismatch`
   - `signer_key_source_invalid`
-  - `signer_key_source_profile_pair_disallowed`
+  - `signer_key_source_production_managed_external_required`
   - `signer_provenance_missing`
   - `signer_provenance_sha256_invalid`
   - `signer_rotation_epoch_stale`
@@ -867,7 +869,7 @@ JSON`
   - `export KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=<64-hex-private-key>`
   - `unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
   - `printf '%s\n' "custody-attestation=ops-primary:epoch-1" > /tmp/kolme-live-signer-custody.json`
-  - `printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" > /tmp/kolme-live-signer-provenance.json`
+  - `printf '%s\n' "signer-provenance=ops-primary:source-managed-external:epoch-1" > /tmp/kolme-live-signer-provenance.json`
   - `custody_sha="$(sha256sum /tmp/kolme-live-signer-custody.json | awk '{print $1}')"; cat > /tmp/kolme-live-signer-quorum.json <<JSON
 {
   "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
@@ -933,7 +935,7 @@ Operator checkpoints:
 - `reason_code=checkpoint_failed_custody_evidence_contract`:
   - verify `--custody-evidence-file` exists and its sha256 can be emitted in summary markers.
 - `reason_code=checkpoint_failed_signer_provenance_contract`:
-  - verify `--signer-provenance-file` exists and signer key-source markers remain `--signer-key-source env-local --signer-key-source-contract-version v1`.
+  - verify `--signer-provenance-file` exists and signer key-source markers remain `--signer-key-source managed-external --signer-key-source-contract-version v1`.
 - `reason_code=checkpoint_failed_signer_rotation_freshness_contract`:
   - verify `--signer-rotation-epoch`, `--signer-previous-rotation-epoch`, and `--signer-rotation-freshness-max-delta` satisfy the freshness delta contract.
 - `ci_fast_gate_eligibility_violation` or `ci_fast_gate_scope_mismatch` from policy checker:

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -21,8 +21,9 @@ QUORUM_EVIDENCE_SCHEMA_VERSION = RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION
 ALLOWED_SIGNER_KEY_SOURCES = ("env-local", "managed-external")
 ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE = {
     PRIMARY_SIGNER_PROFILE: ("env-local", "managed-external"),
-    SECONDARY_SIGNER_PROFILE: ("env-local",),
+    SECONDARY_SIGNER_PROFILE: ("env-local", "managed-external"),
 }
+REQUIRED_PRODUCTION_SIGNER_KEY_SOURCE = "managed-external"
 MIN_PRODUCTION_REQUIRED_APPROVALS = 2
 
 
@@ -430,6 +431,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         and signer_key_source not in ALLOWED_SIGNER_KEY_SOURCES_BY_PROFILE[signer_profile]
     ):
         reason_codes.append("signer_key_source_profile_pair_disallowed")
+    elif signer_profile_class == "production" and signer_key_source != REQUIRED_PRODUCTION_SIGNER_KEY_SOURCE:
+        reason_codes.append("signer_key_source_production_managed_external_required")
 
     signer_provenance_file = report.get("signer_provenance_file")
     if not isinstance(signer_provenance_file, str):
@@ -766,9 +769,16 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("signer_key_source_contract_version_contract_mismatch")
         if isinstance(signer_key_source, str) and signer_key_source and contracts.get("signer_key_source") != signer_key_source:
             reason_codes.append("signer_key_source_contract_mismatch")
-        if contracts.get("signer_key_source_allowed_for_ops_primary") != ["env-local", "managed-external"]:
+        if contracts.get("required_signer_key_source_for_production") != REQUIRED_PRODUCTION_SIGNER_KEY_SOURCE:
+            reason_codes.append("required_signer_key_source_for_production_contract_mismatch")
+        if (
+            contracts.get("signer_key_source_production_requirement_reason_code")
+            != "signer_key_source_production_managed_external_required"
+        ):
+            reason_codes.append("signer_key_source_production_requirement_reason_code_contract_mismatch")
+        if contracts.get("signer_key_source_allowed_for_ops_primary") != ["managed-external"]:
             reason_codes.append("signer_key_source_allowed_for_ops_primary_contract_mismatch")
-        if contracts.get("signer_key_source_allowed_for_ops_secondary") != ["env-local"]:
+        if contracts.get("signer_key_source_allowed_for_ops_secondary") != ["managed-external"]:
             reason_codes.append("signer_key_source_allowed_for_ops_secondary_contract_mismatch")
         if (
             isinstance(signer_rotation_freshness_max_delta, int)

--- a/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py
@@ -182,8 +182,8 @@ def main() -> int:
     if summary.get("signer_key_source_contract_version") != "v1":
         print("expected deployment preflight summary signer key-source contract version marker", file=sys.stderr)
         return 1
-    if summary.get("signer_key_source") != "env-local":
-        print("expected deployment preflight summary signer key-source marker", file=sys.stderr)
+    if summary.get("signer_key_source") != "managed-external":
+        print("expected deployment preflight summary signer key-source marker managed-external", file=sys.stderr)
         return 1
     if summary.get("signer_rotation_epoch") != 1:
         print("expected deployment preflight summary signer rotation epoch marker", file=sys.stderr)
@@ -384,8 +384,35 @@ def main() -> int:
     if contracts.get("signer_key_source_contract_version") != "v1":
         print("expected deployment preflight contracts signer_key_source_contract_version=v1", file=sys.stderr)
         return 1
-    if contracts.get("signer_key_source") != "env-local":
-        print("expected deployment preflight contracts signer_key_source=env-local", file=sys.stderr)
+    if contracts.get("signer_key_source") != "managed-external":
+        print("expected deployment preflight contracts signer_key_source=managed-external", file=sys.stderr)
+        return 1
+    if contracts.get("required_signer_key_source_for_production") != "managed-external":
+        print(
+            "expected deployment preflight contracts required_signer_key_source_for_production=managed-external",
+            file=sys.stderr,
+        )
+        return 1
+    if (
+        contracts.get("signer_key_source_production_requirement_reason_code")
+        != "signer_key_source_production_managed_external_required"
+    ):
+        print(
+            "expected deployment preflight contracts signer_key_source_production_requirement_reason_code marker",
+            file=sys.stderr,
+        )
+        return 1
+    if contracts.get("signer_key_source_allowed_for_ops_primary") != ["managed-external"]:
+        print(
+            "expected deployment preflight contracts signer_key_source_allowed_for_ops_primary managed-external allowlist",
+            file=sys.stderr,
+        )
+        return 1
+    if contracts.get("signer_key_source_allowed_for_ops_secondary") != ["managed-external"]:
+        print(
+            "expected deployment preflight contracts signer_key_source_allowed_for_ops_secondary managed-external allowlist",
+            file=sys.stderr,
+        )
         return 1
     if contracts.get("signer_rotation_freshness_max_delta") != 2:
         print("expected deployment preflight contracts signer_rotation_freshness_max_delta=2", file=sys.stderr)
@@ -704,7 +731,7 @@ def main() -> int:
             "required_approvals": 2,
             "approved_signers": ["ops-primary"],
             "signer_profile": "ops-primary",
-            "signer_key_source": "env-local",
+            "signer_key_source": "managed-external",
         }
         quorum_evidence_negative_summary["runtime_signer_attestation_profile_approved"] = True
         quorum_evidence_negative_report.write_text(
@@ -827,7 +854,7 @@ def main() -> int:
             "required_approvals": 2,
             "approved_signers": ["ops-primary", "ops-primary"],
             "signer_profile": "ops-primary",
-            "signer_key_source": "env-local",
+            "signer_key_source": "managed-external",
         }
         attestation_duplicate_summary["runtime_signer_attestation_profile_approved"] = True
         attestation_duplicate_report.write_text(
@@ -891,7 +918,7 @@ def main() -> int:
             "required_approvals": 2,
             "approved_signers": ["ops-primary", "ops-secondary"],
             "signer_profile": "ops-primary",
-            "signer_key_source": "env-local",
+            "signer_key_source": "managed-external",
         }
         attestation_schema_invalid_summary["runtime_signer_attestation_profile_approved"] = True
         attestation_schema_invalid_report.write_text(
@@ -1059,7 +1086,7 @@ def main() -> int:
         rotation_negative_summary["signer_provenance_sha256"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         rotation_negative_summary["signer_provenance_sha256_valid"] = True
         rotation_negative_summary["signer_key_source_contract_version"] = "v1"
-        rotation_negative_summary["signer_key_source"] = "env-local"
+        rotation_negative_summary["signer_key_source"] = "managed-external"
         rotation_negative_summary["signer_rotation_epoch"] = 8
         rotation_negative_summary["signer_previous_rotation_epoch"] = 3
         rotation_negative_summary["signer_rotation_freshness_max_delta"] = 2
@@ -1149,6 +1176,9 @@ def main() -> int:
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
         "signer_key_source",
+        "signer_key_source_production_managed_external_required",
+        "contracts.required_signer_key_source_for_production=managed-external",
+        "contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required",
         "signer_provenance_file",
         "signer_rotation_epoch_stale",
         "Regression: #2226",
@@ -1213,6 +1243,9 @@ def main() -> int:
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
         "signer_key_source",
+        "signer_key_source_production_managed_external_required",
+        "contracts.required_signer_key_source_for_production=managed-external",
+        "contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required",
         "signer_provenance_file",
         "signer_rotation_epoch_stale",
         "Regression: #2226",
@@ -1277,6 +1310,9 @@ def main() -> int:
         "custody_evidence_sha256_invalid",
         "signer_key_source_contract_version",
         "signer_key_source",
+        "signer_key_source_production_managed_external_required",
+        "contracts.required_signer_key_source_for_production=managed-external",
+        "contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required",
         "signer_provenance_file",
         "signer_rotation_epoch_stale",
         "Regression: #2226",

--- a/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh
@@ -12,7 +12,7 @@ QUORUM_EVIDENCE_FILE=""
 CUSTODY_EVIDENCE_FILE=""
 SIGNER_PROVENANCE_FILE=""
 SIGNER_KEY_SOURCE_CONTRACT_VERSION="v1"
-SIGNER_KEY_SOURCE="env-local"
+SIGNER_KEY_SOURCE="managed-external"
 SIGNER_ROTATION_EPOCH=1
 SIGNER_PREVIOUS_ROTATION_EPOCH=1
 SIGNER_ROTATION_FRESHNESS_MAX_DELTA=2
@@ -28,6 +28,7 @@ FALLBACK_SIGNER_SECRET_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
 FALLBACK_SIGNER_SECRET_REMEDIATION="unset ${FALLBACK_SIGNER_SECRET_ENV}"
 REQUIRED_SECRET_HEX_LENGTH=64
 SIGNER_KEY_SOURCE_CONTRACT_VERSION_SUPPORTED="v1"
+REQUIRED_PRODUCTION_SIGNER_KEY_SOURCE="managed-external"
 RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION="kamn.kolme.runtime-signer-attestation.v1"
 RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION="kamn.kolme.runtime-signer-drift-telemetry.v1"
 RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION="kamn.kolme.runtime-signer-drift-thresholds.v1"
@@ -712,10 +713,15 @@ PY
                 elif [ "$SIGNER_KEY_SOURCE" != "env-local" ] && [ "$SIGNER_KEY_SOURCE" != "managed-external" ]; then
                   signer_provenance_reason="signer_key_source_invalid"
                   signer_provenance_message="signer key source is unsupported: $SIGNER_KEY_SOURCE"
-                elif [ "$SIGNER_PROFILE" = "$SECONDARY_SIGNER_PROFILE" ] && [ "$SIGNER_KEY_SOURCE" != "env-local" ]; then
-                  signer_provenance_reason="signer_key_source_profile_pair_disallowed"
-                  signer_provenance_message="signer key source/profile pair is not allowed: profile=$SIGNER_PROFILE source=$SIGNER_KEY_SOURCE"
-                else
+                elif (
+                  [ "$SIGNER_PROFILE" = "$PRIMARY_SIGNER_PROFILE" ] ||
+                  [ "$SIGNER_PROFILE" = "$SECONDARY_SIGNER_PROFILE" ]
+                ) && [ "$SIGNER_KEY_SOURCE" != "$REQUIRED_PRODUCTION_SIGNER_KEY_SOURCE" ]; then
+                  signer_provenance_reason="signer_key_source_production_managed_external_required"
+                  signer_provenance_message="production signer profiles require signer key source $REQUIRED_PRODUCTION_SIGNER_KEY_SOURCE: profile=$SIGNER_PROFILE source=$SIGNER_KEY_SOURCE"
+                fi
+
+                if [ -z "$signer_provenance_reason" ]; then
                   if [ -n "$SIGNER_PROVENANCE_FILE" ] && [ -f "$SIGNER_PROVENANCE_FILE" ]; then
                     signer_provenance_present="true"
                     signer_provenance_sha256="$(sha256sum "$SIGNER_PROVENANCE_FILE" | awk '{print $1}')"
@@ -1017,8 +1023,10 @@ summary = {
         "signer_provenance_sha256_required": True,
         "signer_key_source_contract_version": signer_key_source_contract_version_supported,
         "signer_key_source": signer_key_source,
-        "signer_key_source_allowed_for_ops_primary": ["env-local", "managed-external"],
-        "signer_key_source_allowed_for_ops_secondary": ["env-local"],
+        "required_signer_key_source_for_production": "managed-external",
+        "signer_key_source_production_requirement_reason_code": "signer_key_source_production_managed_external_required",
+        "signer_key_source_allowed_for_ops_primary": ["managed-external"],
+        "signer_key_source_allowed_for_ops_secondary": ["managed-external"],
         "signer_rotation_freshness_max_delta": signer_rotation_freshness_max_delta,
         "signer_rotation_stale_rejected": True,
     },

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -10,6 +10,7 @@ README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
 TMP_REPORT_QUORUM_MINIMUM="$TMP_DIR/quorum-minimum-report.json"
+TMP_REPORT_PRODUCTION_KEY_SOURCE="$TMP_DIR/production-key-source-report.json"
 TMP_REPORT_DRIFT_MALFORMED="$TMP_DIR/drift-malformed-report.json"
 TMP_REPORT_MATRIX_WARN="$TMP_DIR/drift-matrix-warn-report.json"
 TMP_REPORT_MATRIX_FAIL="$TMP_DIR/drift-matrix-fail-report.json"
@@ -84,7 +85,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
       "ops-secondary"
     ],
     "signer_profile": "ops-primary",
-    "signer_key_source": "env-local"
+    "signer_key_source": "managed-external"
   },
   "runtime_signer_attestation_profile_approved": true,
   "runtime_signer_drift_telemetry_schema_version": "kamn.kolme.runtime-signer-drift-telemetry.v1",
@@ -116,7 +117,7 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "signer_provenance_sha256": "",
   "signer_provenance_sha256_valid": false,
   "signer_key_source_contract_version": "v1",
-  "signer_key_source": "env-local",
+  "signer_key_source": "managed-external",
   "signer_rotation_epoch": 1,
   "signer_previous_rotation_epoch": 1,
   "signer_rotation_freshness_max_delta": 2,
@@ -186,13 +187,14 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "signer_provenance_required": true,
     "signer_provenance_sha256_required": true,
     "signer_key_source_contract_version": "v1",
-    "signer_key_source": "env-local",
+    "signer_key_source": "managed-external",
+    "required_signer_key_source_for_production": "managed-external",
+    "signer_key_source_production_requirement_reason_code": "signer_key_source_production_managed_external_required",
     "signer_key_source_allowed_for_ops_primary": [
-      "env-local",
       "managed-external"
     ],
     "signer_key_source_allowed_for_ops_secondary": [
-      "env-local"
+      "managed-external"
     ],
     "signer_rotation_freshness_max_delta": 2,
     "signer_rotation_stale_rejected": true
@@ -317,7 +319,7 @@ warn_report["runtime_signer_attestation_bundle"] = {
     "required_approvals": 2,
     "approved_signers": ["ops-primary", "ops-secondary"],
     "signer_profile": "ops-primary",
-    "signer_key_source": "env-local",
+    "signer_key_source": "managed-external",
 }
 warn_report["runtime_signer_attestation_profile_approved"] = True
 warn_report["runtime_signer_drift_telemetry"] = {
@@ -485,6 +487,44 @@ fi
 
 if ! grep -q "signer_quorum_minimum_not_met" "$TMP_ERR"; then
   echo "expected signer_quorum_minimum_not_met reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT_OK" "$TMP_REPORT_PRODUCTION_KEY_SOURCE" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+report["signer_key_source"] = "env-local"
+bundle = dict(report.get("runtime_signer_attestation_bundle", {}))
+bundle["signer_key_source"] = "env-local"
+report["runtime_signer_attestation_bundle"] = bundle
+contracts = dict(report.get("contracts", {}))
+contracts["signer_key_source"] = "env-local"
+report["contracts"] = contracts
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(report, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REPORT_PRODUCTION_KEY_SOURCE" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUT" >"$TMP_ERR" 2>&1
+production_key_source_exit_code=$?
+set -e
+
+if [ "$production_key_source_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight policy checker to fail when production signer key-source is not managed-external" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_key_source_production_managed_external_required" "$TMP_ERR"; then
+  echo "expected signer_key_source_production_managed_external_required reason for deployment preflight policy failure" >&2
   exit 1
 fi
 

--- a/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh
@@ -15,7 +15,7 @@ TMP_QUORUM_SINGLE="$(mktemp)"
 trap 'rm -f "$TMP_SUMMARY" "$TMP_ERR" "$TMP_CUSTODY" "$TMP_PROVENANCE" "$TMP_QUORUM" "$TMP_QUORUM_SINGLE"' EXIT
 
 printf '%s\n' "custody-attestation=ops-primary:epoch-1" >"$TMP_CUSTODY"
-printf '%s\n' "signer-provenance=ops-primary:source-env-local:epoch-1" >"$TMP_PROVENANCE"
+printf '%s\n' "signer-provenance=ops-primary:source-managed-external:epoch-1" >"$TMP_PROVENANCE"
 TMP_CUSTODY_SHA="$(sha256sum "$TMP_CUSTODY" | awk '{print $1}')"
 cat >"$TMP_QUORUM" <<JSON
 {
@@ -168,7 +168,7 @@ if summary.get("signer_provenance_present") is not False:
     raise SystemExit("expected deployment preflight summary signer provenance marker to be false in dry-run")
 if summary.get("signer_key_source_contract_version") != "v1":
     raise SystemExit("expected deployment preflight summary signer key-source contract version marker")
-if summary.get("signer_key_source") != "env-local":
+if summary.get("signer_key_source") != "managed-external":
     raise SystemExit("expected deployment preflight summary signer key-source marker")
 if summary.get("signer_rotation_epoch") != 1:
     raise SystemExit("expected deployment preflight summary signer rotation epoch marker")
@@ -221,8 +221,16 @@ if contracts.get("signer_provenance_sha256_required") is not True:
     raise SystemExit("expected deployment preflight contracts to require signer provenance sha256 evidence")
 if contracts.get("signer_key_source_contract_version") != "v1":
     raise SystemExit("expected deployment preflight contracts signer key-source contract version marker")
-if contracts.get("signer_key_source") != "env-local":
+if contracts.get("signer_key_source") != "managed-external":
     raise SystemExit("expected deployment preflight contracts signer key-source marker")
+if contracts.get("required_signer_key_source_for_production") != "managed-external":
+    raise SystemExit("expected deployment preflight contracts required production signer key-source marker")
+if contracts.get("signer_key_source_production_requirement_reason_code") != "signer_key_source_production_managed_external_required":
+    raise SystemExit("expected deployment preflight contracts production signer key-source reason-code marker")
+if contracts.get("signer_key_source_allowed_for_ops_primary") != ["managed-external"]:
+    raise SystemExit("expected deployment preflight contracts ops-primary signer key-source allowlist marker")
+if contracts.get("signer_key_source_allowed_for_ops_secondary") != ["managed-external"]:
+    raise SystemExit("expected deployment preflight contracts ops-secondary signer key-source allowlist marker")
 if contracts.get("signer_rotation_freshness_max_delta") != 2:
     raise SystemExit("expected deployment preflight contracts signer rotation freshness max delta marker")
 if contracts.get("signer_rotation_stale_rejected") is not True:
@@ -374,6 +382,30 @@ fi
 
 if ! grep -q "signer provenance evidence file is required for selected profile" "$TMP_ERR"; then
   echo "expected deterministic missing signer provenance evidence message from deployment preflight lane" >&2
+  exit 1
+fi
+
+set +e
+KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX="1111111111111111111111111111111111111111111111111111111111111111" \
+bash "$RUNNER" \
+  --mode run \
+  --required-approvals 2 \
+  --received-approvals 2 \
+  --custody-evidence-file "$TMP_CUSTODY" \
+  --quorum-evidence-file "$TMP_QUORUM" \
+  --signer-provenance-file "$TMP_PROVENANCE" \
+  --signer-key-source env-local \
+  --output-json "$TMP_SUMMARY" >"$TMP_ERR" 2>&1
+production_key_source_exit_code=$?
+set -e
+
+if [ "$production_key_source_exit_code" -eq 0 ]; then
+  echo "expected deployment preflight run mode to fail closed when production signer key-source is not managed-external" >&2
+  exit 1
+fi
+
+if ! grep -q "production signer profiles require signer key source managed-external" "$TMP_ERR"; then
+  echo "expected deterministic production signer key-source requirement message from deployment preflight lane" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #2468

## Summary
This change hardens the local Kolme deployment preflight lane so production signer profiles fail closed unless signer source is `managed-external`. It also synchronizes policy checker contracts, lane tests, and deployment-preflight documentation markers.

## Changes
- `scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh`: default signer source to `managed-external`, enforce production managed-source requirement, add deterministic reason code `signer_key_source_production_managed_external_required`, and publish new contract markers.
- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`: enforce production managed-source requirement and validate new contract fields:
  - `required_signer_key_source_for_production`
  - `signer_key_source_production_requirement_reason_code`
  - managed-only profile allowlists.
- `scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`: update baseline expectations and add regression for production `env-local` rejection.
- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`: update fixture baseline to managed-external and add policy NO-GO regression for non-managed production source.
- `scripts/kolme/contracts/local_kolme_live_deployment_preflight_contract_lane.py`: update managed-source assertions and docs marker contracts.
- `README.md`: update deployment-preflight commands and markers to managed-external.
- `docs/ci/strategy.md`: update deployment-preflight CI command markers and fail-closed reasons.
- `docs/planning/kolme-devnet-ops.md`: update deployment-preflight commands/markers/reasons and troubleshooting guidance.
- `docs/foundation/upgrade-rollback-runbook.md`: update runbook preflight commands and restore missing schema marker `kamn.kolme.signer-quorum-evidence.v1`.

## Risks & Compatibility
- No API compatibility break in Rust crates.
- Behavioral hardening: production deployment preflight now rejects `env-local` signer-source markers.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: updated deployment-preflight run/docs marker consistency and reran lane/checker/contract-lane scripts locally.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅  | `cargo test -p kamn-core --test upgrade_rollback_runbook_docs`; `cargo test -p kamn-core --test ci_strategy_docs` |
| Functional  | ✅  | `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` |
| Integration | ✅  | `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh`; `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh` |
| Regression  | ✅  | Added/validated production non-managed signer-source rejection path (`signer_key_source_production_managed_external_required`) |
