### PR TITLE
docs: add quorum/rotation telemetry response matrix contracts

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -67,6 +67,9 @@ Kolme deployment admission preflight emits deterministic runtime signer drift te
 - `runtime_signer_drift_thresholds_bundle`
 - `runtime_signer_drift_admission_matrix_decision=GO|WARN|NO-GO`
 - `runtime_signer_drift_admission_matrix_class=healthy|warning-edge|hard-fail`
+- `signer_key_source=managed-external`
+- `contracts.required_signer_key_source_for_production=managed-external`
+- `contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required`
 
 Fail-closed reason codes for missing/malformed telemetry:
 
@@ -75,6 +78,13 @@ Fail-closed reason codes for missing/malformed telemetry:
 - `runtime_signer_drift_telemetry_rotation_delta_invalid`
 - `runtime_signer_drift_quorum_fail_threshold_exceeded`
 - `runtime_signer_drift_rotation_fail_threshold_exceeded`
+- `signer_key_source_production_managed_external_required`
+
+Deterministic response matrix:
+
+1. `GO` + `healthy`: continue promotion with standard artifact archival.
+2. `WARN` + `warning-edge`: freeze promotion, rotate signer evidence within threshold, rerun preflight lane + policy checker, then resume only on `GO`.
+3. `NO-GO` + `hard-fail`: block rollout, execute signer rollback runbook, refresh quorum/custody/provenance evidence, and require a clean rerun before unfreeze.
 
 Coverage split for cost control:
 

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -6,6 +6,7 @@ CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_live_deployment_preflight_pol
 RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 CI_DOC_FILE="$ROOT_DIR/docs/ci/strategy.md"
+COST_DOC_FILE="$ROOT_DIR/docs/ci/ci-cost-and-lane-framework.md"
 README_FILE="$ROOT_DIR/README.md"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT_OK="$TMP_DIR/ok-report.json"
@@ -32,6 +33,26 @@ fi
 
 if ! grep -q "check_local_kolme_live_deployment_preflight_policy.py" "$CI_DOC_FILE"; then
   echo "expected CI strategy docs to reference deployment preflight policy checker command" >&2
+  exit 1
+fi
+
+if ! grep -q "run_local_kolme_live_deployment_preflight_contract_lane.sh" "$COST_DOC_FILE"; then
+  echo "expected CI cost/lane framework docs to reference deployment preflight contract lane placement" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_drift_admission_matrix_decision=GO|WARN|NO-GO" "$COST_DOC_FILE"; then
+  echo "expected CI cost/lane framework docs to include runtime signer drift admission matrix decision marker" >&2
+  exit 1
+fi
+
+if ! grep -q "signer_key_source_production_managed_external_required" "$COST_DOC_FILE"; then
+  echo "expected CI cost/lane framework docs to include production managed-external signer-source fail-closed reason marker" >&2
+  exit 1
+fi
+
+if ! grep -q "Deterministic response matrix" "$COST_DOC_FILE"; then
+  echo "expected CI cost/lane framework docs to include deterministic response matrix guidance" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #2469

## Summary
This change makes the quorum/rotation telemetry policy documentation auditable in CI by adding an explicit GO/WARN/NO-GO response matrix and managed-source fail-closed markers to the CI cost/lane framework doc. It also binds these markers to the deployment-preflight policy checker contract test.

## Changes
- `docs/ci/ci-cost-and-lane-framework.md`: added deployment preflight telemetry markers for managed-source enforcement and deterministic response guidance for `GO`, `WARN`, and `NO-GO` decision classes.
- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`: added CI-cost framework doc parity checks for:
  - deployment preflight contract lane placement marker
  - admission matrix decision marker
  - managed-source fail-closed reason marker
  - deterministic response matrix section marker.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: reviewed updated CI cost-framework section for actionable GO/WARN/NO-GO operator guidance.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅  | `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings` |
| Functional  | ✅  | `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` |
| Integration | ✅  | `bash scripts/kolme/test_run_local_kolme_live_deployment_preflight_contract_lane.sh` |
| Regression  | ✅  | New doc-contract checks enforce telemetry decision matrix + managed-source reason markers |
