### PR TITLE
refactor(kamn-node): extract bootstrap report builder module

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -10,10 +10,12 @@ use kamn_core::{
 use std::env;
 use std::process::ExitCode;
 
+mod report_builder;
 mod report_render;
 mod signer;
 mod wire_payload;
 
+use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
 use signer::build_kolme_live_direct_signed_wire_payload;
 #[cfg(test)]
@@ -1073,123 +1075,6 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
     );
 
     Ok(report)
-}
-
-fn build_bootstrap_report(
-    plan: &BootstrapPlan,
-    profile: Option<LocalProfile>,
-    diagnostics_mode: DiagnosticsMode,
-    runtime_mode: RuntimeMode,
-    runtime_execution: RuntimeExecutionBundle,
-) -> NodeBootstrapReport {
-    let RuntimeExecutionBundle {
-        planning,
-        recovery,
-        daemon,
-        kolme_live,
-    } = runtime_execution;
-    let operational_profile = plan.config.operational_profile();
-    let components = plan
-        .wiring
-        .all_components()
-        .into_iter()
-        .map(str::to_owned)
-        .collect::<Vec<String>>();
-    let planning_expected_state_hash = planning
-        .as_ref()
-        .map(|planning| planning.expected_state_hash.clone());
-    let planning_candidate_count = planning.as_ref().map(|planning| planning.candidate_count);
-    let planning_scheduled_candidate_ids = planning
-        .as_ref()
-        .map(|planning| planning.scheduled_candidate_ids.clone());
-    let recovery_expected_state_version = recovery
-        .as_ref()
-        .map(|recovery| recovery.expected_state_version);
-    let recovery_expected_state_hash = recovery
-        .as_ref()
-        .map(|recovery| recovery.expected_state_hash.clone());
-    let recovery_attempt_count = recovery.as_ref().map(|recovery| recovery.attempt_count);
-    let recovery_decisions = recovery.as_ref().map(|recovery| recovery.decisions.clone());
-    let daemon_max_ticks = daemon.as_ref().map(|daemon| daemon.max_ticks);
-    let daemon_tick_interval_ms = daemon.as_ref().map(|daemon| daemon.tick_interval_ms);
-    let daemon_executed_ticks = daemon.as_ref().map(|daemon| daemon.executed_ticks);
-    let daemon_completion_reason = daemon
-        .as_ref()
-        .map(|daemon| daemon.completion_reason.clone());
-    let daemon_peer_id = daemon.as_ref().and_then(|daemon| daemon.peer_id.clone());
-    let daemon_peer_lifecycle_final_state = daemon
-        .as_ref()
-        .and_then(|daemon| daemon.peer_lifecycle_final_state.clone());
-    let daemon_peer_lifecycle_applied_events = daemon
-        .as_ref()
-        .and_then(|daemon| daemon.peer_lifecycle_applied_events.clone());
-    let kolme_live_provider_client_contract = kolme_live
-        .as_ref()
-        .map(|execution| execution.provider_client_contract.clone());
-    let kolme_live_base_url = kolme_live
-        .as_ref()
-        .map(|execution| execution.base_url.clone());
-    let kolme_live_provider_hint = kolme_live
-        .as_ref()
-        .map(|execution| execution.provider_hint.clone());
-    let kolme_live_signing_profile = kolme_live
-        .as_ref()
-        .map(|execution| execution.signing_profile.clone());
-    let kolme_live_signer_profile_selector_env = kolme_live
-        .as_ref()
-        .map(|execution| execution.signer_profile_selector_env.clone());
-    let kolme_live_signer_profile = kolme_live
-        .as_ref()
-        .map(|execution| execution.signer_profile.clone());
-    let kolme_live_signer_key_source = kolme_live
-        .as_ref()
-        .map(|execution| execution.signer_key_source.clone());
-    let kolme_live_signer_private_key_env = kolme_live
-        .as_ref()
-        .map(|execution| execution.signer_private_key_env.clone());
-    let kolme_live_execution_status = kolme_live
-        .as_ref()
-        .map(|execution| execution.execution_status.clone());
-    NodeBootstrapReport {
-        runtime_mode: runtime_mode.as_str().to_owned(),
-        diagnostics_mode: diagnostics_mode.as_str().to_owned(),
-        component_count: components.len(),
-        planning_expected_state_hash,
-        planning_candidate_count,
-        planning_scheduled_candidate_ids,
-        recovery_expected_state_version,
-        recovery_expected_state_hash,
-        recovery_attempt_count,
-        recovery_decisions,
-        daemon_max_ticks,
-        daemon_tick_interval_ms,
-        daemon_executed_ticks,
-        daemon_completion_reason,
-        daemon_peer_id,
-        daemon_peer_lifecycle_final_state,
-        daemon_peer_lifecycle_applied_events,
-        kolme_live_provider_client_contract,
-        kolme_live_base_url,
-        kolme_live_provider_hint,
-        kolme_live_signing_profile,
-        kolme_live_signer_profile_selector_env,
-        kolme_live_signer_profile,
-        kolme_live_signer_key_source,
-        kolme_live_signer_private_key_env,
-        kolme_live_execution_status,
-        profile: profile.map(LocalProfile::as_str).map(str::to_owned),
-        role: plan.config.role.as_str().to_owned(),
-        chain_id: plan.config.chain_id.clone(),
-        chain_version: plan.config.chain_version.clone(),
-        storage_dir: plan.config.storage_dir.clone(),
-        gossip_enabled: plan.config.enable_gossip,
-        sync_mode: plan.config.sync_mode.as_str().to_owned(),
-        sync_startup: format!("{:?}", operational_profile.startup_strategy),
-        sync_recovery: format!("{:?}", operational_profile.recovery_strategy),
-        state_version: plan.state_schema.version.0,
-        pending_migrations: plan.migration_plan.steps.len(),
-        components,
-    }
 }
 
 fn main() -> ExitCode {

--- a/crates/kamn-node/src/report_builder.rs
+++ b/crates/kamn-node/src/report_builder.rs
@@ -1,0 +1,121 @@
+use crate::{
+    DiagnosticsMode, LocalProfile, NodeBootstrapReport, RuntimeExecutionBundle, RuntimeMode,
+};
+use kamn_core::BootstrapPlan;
+
+pub(crate) fn build_bootstrap_report(
+    plan: &BootstrapPlan,
+    profile: Option<LocalProfile>,
+    diagnostics_mode: DiagnosticsMode,
+    runtime_mode: RuntimeMode,
+    runtime_execution: RuntimeExecutionBundle,
+) -> NodeBootstrapReport {
+    let RuntimeExecutionBundle {
+        planning,
+        recovery,
+        daemon,
+        kolme_live,
+    } = runtime_execution;
+    let operational_profile = plan.config.operational_profile();
+    let components = plan
+        .wiring
+        .all_components()
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<String>>();
+    let planning_expected_state_hash = planning
+        .as_ref()
+        .map(|planning| planning.expected_state_hash.clone());
+    let planning_candidate_count = planning.as_ref().map(|planning| planning.candidate_count);
+    let planning_scheduled_candidate_ids = planning
+        .as_ref()
+        .map(|planning| planning.scheduled_candidate_ids.clone());
+    let recovery_expected_state_version = recovery
+        .as_ref()
+        .map(|recovery| recovery.expected_state_version);
+    let recovery_expected_state_hash = recovery
+        .as_ref()
+        .map(|recovery| recovery.expected_state_hash.clone());
+    let recovery_attempt_count = recovery.as_ref().map(|recovery| recovery.attempt_count);
+    let recovery_decisions = recovery.as_ref().map(|recovery| recovery.decisions.clone());
+    let daemon_max_ticks = daemon.as_ref().map(|daemon| daemon.max_ticks);
+    let daemon_tick_interval_ms = daemon.as_ref().map(|daemon| daemon.tick_interval_ms);
+    let daemon_executed_ticks = daemon.as_ref().map(|daemon| daemon.executed_ticks);
+    let daemon_completion_reason = daemon
+        .as_ref()
+        .map(|daemon| daemon.completion_reason.clone());
+    let daemon_peer_id = daemon.as_ref().and_then(|daemon| daemon.peer_id.clone());
+    let daemon_peer_lifecycle_final_state = daemon
+        .as_ref()
+        .and_then(|daemon| daemon.peer_lifecycle_final_state.clone());
+    let daemon_peer_lifecycle_applied_events = daemon
+        .as_ref()
+        .and_then(|daemon| daemon.peer_lifecycle_applied_events.clone());
+    let kolme_live_provider_client_contract = kolme_live
+        .as_ref()
+        .map(|execution| execution.provider_client_contract.clone());
+    let kolme_live_base_url = kolme_live
+        .as_ref()
+        .map(|execution| execution.base_url.clone());
+    let kolme_live_provider_hint = kolme_live
+        .as_ref()
+        .map(|execution| execution.provider_hint.clone());
+    let kolme_live_signing_profile = kolme_live
+        .as_ref()
+        .map(|execution| execution.signing_profile.clone());
+    let kolme_live_signer_profile_selector_env = kolme_live
+        .as_ref()
+        .map(|execution| execution.signer_profile_selector_env.clone());
+    let kolme_live_signer_profile = kolme_live
+        .as_ref()
+        .map(|execution| execution.signer_profile.clone());
+    let kolme_live_signer_key_source = kolme_live
+        .as_ref()
+        .map(|execution| execution.signer_key_source.clone());
+    let kolme_live_signer_private_key_env = kolme_live
+        .as_ref()
+        .map(|execution| execution.signer_private_key_env.clone());
+    let kolme_live_execution_status = kolme_live
+        .as_ref()
+        .map(|execution| execution.execution_status.clone());
+    NodeBootstrapReport {
+        runtime_mode: runtime_mode.as_str().to_owned(),
+        diagnostics_mode: diagnostics_mode.as_str().to_owned(),
+        component_count: components.len(),
+        planning_expected_state_hash,
+        planning_candidate_count,
+        planning_scheduled_candidate_ids,
+        recovery_expected_state_version,
+        recovery_expected_state_hash,
+        recovery_attempt_count,
+        recovery_decisions,
+        daemon_max_ticks,
+        daemon_tick_interval_ms,
+        daemon_executed_ticks,
+        daemon_completion_reason,
+        daemon_peer_id,
+        daemon_peer_lifecycle_final_state,
+        daemon_peer_lifecycle_applied_events,
+        kolme_live_provider_client_contract,
+        kolme_live_base_url,
+        kolme_live_provider_hint,
+        kolme_live_signing_profile,
+        kolme_live_signer_profile_selector_env,
+        kolme_live_signer_profile,
+        kolme_live_signer_key_source,
+        kolme_live_signer_private_key_env,
+        kolme_live_execution_status,
+        profile: profile.map(LocalProfile::as_str).map(str::to_owned),
+        role: plan.config.role.as_str().to_owned(),
+        chain_id: plan.config.chain_id.clone(),
+        chain_version: plan.config.chain_version.clone(),
+        storage_dir: plan.config.storage_dir.clone(),
+        gossip_enabled: plan.config.enable_gossip,
+        sync_mode: plan.config.sync_mode.as_str().to_owned(),
+        sync_startup: format!("{:?}", operational_profile.startup_strategy),
+        sync_recovery: format!("{:?}", operational_profile.recovery_strategy),
+        state_version: plan.state_schema.version.0,
+        pending_migrations: plan.migration_plan.steps.len(),
+        components,
+    }
+}

--- a/crates/kamn-node/tests/main_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/main_module_extraction_contract.rs
@@ -24,6 +24,10 @@ fn main_module_extraction_contract_declares_signer_and_wire_modules() {
         "main.rs should declare report_render module"
     );
     assert!(
+        main_rs.contains("mod report_builder;"),
+        "main.rs should declare report_builder module"
+    );
+    assert!(
         main_rs.contains("mod main_tests;"),
         "main.rs should declare sidecar test module for maintainability"
     );
@@ -52,6 +56,10 @@ fn main_module_extraction_contract_removes_inline_report_rendering_impls() {
         !main_rs.contains("fn json_escape("),
         "main.rs should not keep inline json escape helper"
     );
+    assert!(
+        !main_rs.contains("fn build_bootstrap_report("),
+        "main.rs should not keep inline bootstrap report assembly"
+    );
 }
 
 #[test]
@@ -74,6 +82,7 @@ fn main_module_extraction_contract_removes_inline_signer_payload_impls() {
 #[test]
 fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     let signer_rs = read_repo_file("src/signer.rs");
+    let report_builder_rs = read_repo_file("src/report_builder.rs");
     let report_render_rs = read_repo_file("src/report_render.rs");
     let wire_payload_rs = read_repo_file("src/wire_payload.rs");
     assert!(
@@ -91,5 +100,9 @@ fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     assert!(
         report_render_rs.contains("pub(crate) fn render_bootstrap_report("),
         "report_render module should own bootstrap report rendering"
+    );
+    assert!(
+        report_builder_rs.contains("pub(crate) fn build_bootstrap_report("),
+        "report_builder module should own bootstrap report assembly"
     );
 }


### PR DESCRIPTION
## Summary
Extracts bootstrap report assembly from `crates/kamn-node/src/main.rs` into a dedicated `report_builder` module, continuing production-path decoupling under #2485. Behavior remains unchanged and extraction boundaries are enforced by contract tests.

Closes #2490
Refs #2485

## Changes
- `crates/kamn-node/src/main.rs`
  - declares `mod report_builder;`
  - delegates via `use report_builder::build_bootstrap_report;`
  - removes inline `build_bootstrap_report` implementation.
- `crates/kamn-node/src/report_builder.rs`
  - new module containing extracted bootstrap report assembly logic.
- `crates/kamn-node/tests/main_module_extraction_contract.rs`
  - adds extraction guards for `report_builder` module declaration and ownership of `build_bootstrap_report`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-node --test main_module_extraction_contract`
  - failed with:
    - missing `mod report_builder;` in `main.rs`
    - missing `src/report_builder.rs`
    - inline `fn build_bootstrap_report(` still present in `main.rs`

### 🟢 Green Phase
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node --test main_module_extraction_contract`
- `cargo test -p kamn-node`

### 🔁 Regression
- `cargo test -p kamn-node`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | extraction contract assertions for `report_builder` ownership | |
| Functional   | ✅     | package runtime behavior via `cargo test -p kamn-node` | |
| Integration  | ✅     | node docs/runtime contracts in full package test run | |
| Regression   | ✅     | full package regression after extraction | |
| Performance  | N/A    | None                 | refactor-only, no runtime algorithm changes |

## Risks & Rollback
- Risk: low; module-boundary refactor with unchanged output contracts.
- Rollback plan: revert commit `83a9966` if report assembly drift is observed.

## Documentation Updates
- None required; command/API/report schema unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated or justified
