### PR TITLE
refactor(kamn-node): extract runtime_kolme_live helper module

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1,22 +1,25 @@
 use kamn_core::{
-    bootstrap, BootstrapPlan, ConfigError, DeterministicProposalPlanner,
-    KolmeCommitReceiptFinality, KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitHttpTransport,
+    bootstrap, ConfigError, DeterministicProposalPlanner, KolmeCommitReceiptFinality,
+    KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitHttpTransport,
     KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
-    KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderReceipt,
-    KolmeRuntimeCommitRequest, NodeConfig, NodeRole, PeerLifecycle, PeerLifecycleEvent,
-    PeerLifecycleState, ProposalCandidate, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
-    SyncMode,
+    NodeConfig, NodeRole, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate,
+    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, SyncMode,
 };
 use std::env;
 use std::process::ExitCode;
 
 mod report_builder;
 mod report_render;
+mod runtime_kolme_live;
 mod signer;
 mod wire_payload;
 
 use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
+use runtime_kolme_live::{
+    build_kolme_live_request, ensure_kolme_live_provider_marker, kolme_live_finality_label,
+    map_kolme_live_submit_outcome,
+};
 use signer::build_kolme_live_direct_signed_wire_payload;
 #[cfg(test)]
 use signer::{
@@ -775,58 +778,6 @@ fn run() -> Result<(), ConfigError> {
     println!("{}", render_bootstrap_report(&report, output_mode));
 
     Ok(())
-}
-
-fn build_kolme_live_request(
-    plan: &BootstrapPlan,
-) -> Result<KolmeRuntimeCommitRequest, ConfigError> {
-    let role_label = plan.config.role.as_str();
-    let operation_id = format!("runtime-commit:{}:{role_label}", plan.config.chain_id);
-    let state_root = format!(
-        "state:{}:{}",
-        plan.config.chain_version, plan.state_schema.version.0
-    );
-    let actor_did = format!("kamn:did:agent:node-runtime-{role_label}");
-    let payload_hash = format!("payload:{}:{role_label}", plan.config.chain_version);
-    KolmeRuntimeCommitRequest::deterministic(
-        operation_id.as_str(),
-        state_root.as_str(),
-        actor_did.as_str(),
-        1,
-        payload_hash.as_str(),
-    )
-    .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))
-}
-
-fn ensure_kolme_live_provider_marker(expected: &str, observed: &str) -> Result<(), ConfigError> {
-    if expected == observed {
-        return Ok(());
-    }
-    Err(ConfigError::RuntimeKolmeLive(format!(
-        "provider marker drift: expected '{expected}', observed '{observed}'"
-    )))
-}
-
-fn kolme_live_finality_label(finality: KolmeCommitReceiptFinality) -> &'static str {
-    match finality {
-        KolmeCommitReceiptFinality::Pending => "pending",
-        KolmeCommitReceiptFinality::Final => "final",
-        KolmeCommitReceiptFinality::Failed => "failed",
-    }
-}
-
-fn map_kolme_live_submit_outcome(
-    outcome: KolmeRuntimeCommitProviderOutcome,
-) -> Result<(&'static str, KolmeRuntimeCommitProviderReceipt), ConfigError> {
-    match outcome {
-        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => Ok(("submitted", receipt)),
-        KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => Ok(("duplicate", receipt)),
-        KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
-            Err(ConfigError::RuntimeKolmeLive(format!(
-                "provider rejected runtime commit submission: {reason}"
-            )))
-        }
-    }
 }
 
 fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -1,0 +1,59 @@
+use kamn_core::{
+    BootstrapPlan, ConfigError, KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderOutcome,
+    KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitRequest,
+};
+
+pub(crate) fn build_kolme_live_request(
+    plan: &BootstrapPlan,
+) -> Result<KolmeRuntimeCommitRequest, ConfigError> {
+    let role_label = plan.config.role.as_str();
+    let operation_id = format!("runtime-commit:{}:{role_label}", plan.config.chain_id);
+    let state_root = format!(
+        "state:{}:{}",
+        plan.config.chain_version, plan.state_schema.version.0
+    );
+    let actor_did = format!("kamn:did:agent:node-runtime-{role_label}");
+    let payload_hash = format!("payload:{}:{role_label}", plan.config.chain_version);
+    KolmeRuntimeCommitRequest::deterministic(
+        operation_id.as_str(),
+        state_root.as_str(),
+        actor_did.as_str(),
+        1,
+        payload_hash.as_str(),
+    )
+    .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))
+}
+
+pub(crate) fn ensure_kolme_live_provider_marker(
+    expected: &str,
+    observed: &str,
+) -> Result<(), ConfigError> {
+    if expected == observed {
+        return Ok(());
+    }
+    Err(ConfigError::RuntimeKolmeLive(format!(
+        "provider marker drift: expected '{expected}', observed '{observed}'"
+    )))
+}
+
+pub(crate) fn kolme_live_finality_label(finality: KolmeCommitReceiptFinality) -> &'static str {
+    match finality {
+        KolmeCommitReceiptFinality::Pending => "pending",
+        KolmeCommitReceiptFinality::Final => "final",
+        KolmeCommitReceiptFinality::Failed => "failed",
+    }
+}
+
+pub(crate) fn map_kolme_live_submit_outcome(
+    outcome: KolmeRuntimeCommitProviderOutcome,
+) -> Result<(&'static str, KolmeRuntimeCommitProviderReceipt), ConfigError> {
+    match outcome {
+        KolmeRuntimeCommitProviderOutcome::Submitted(receipt) => Ok(("submitted", receipt)),
+        KolmeRuntimeCommitProviderOutcome::Duplicate(receipt) => Ok(("duplicate", receipt)),
+        KolmeRuntimeCommitProviderOutcome::Rejected { reason } => {
+            Err(ConfigError::RuntimeKolmeLive(format!(
+                "provider rejected runtime commit submission: {reason}"
+            )))
+        }
+    }
+}

--- a/crates/kamn-node/tests/main_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/main_module_extraction_contract.rs
@@ -28,6 +28,10 @@ fn main_module_extraction_contract_declares_signer_and_wire_modules() {
         "main.rs should declare report_builder module"
     );
     assert!(
+        main_rs.contains("mod runtime_kolme_live;"),
+        "main.rs should declare runtime_kolme_live module"
+    );
+    assert!(
         main_rs.contains("mod main_tests;"),
         "main.rs should declare sidecar test module for maintainability"
     );
@@ -60,6 +64,22 @@ fn main_module_extraction_contract_removes_inline_report_rendering_impls() {
         !main_rs.contains("fn build_bootstrap_report("),
         "main.rs should not keep inline bootstrap report assembly"
     );
+    assert!(
+        !main_rs.contains("fn build_kolme_live_request("),
+        "main.rs should not keep inline Kolme live request builder"
+    );
+    assert!(
+        !main_rs.contains("fn ensure_kolme_live_provider_marker("),
+        "main.rs should not keep inline Kolme provider marker guard"
+    );
+    assert!(
+        !main_rs.contains("fn map_kolme_live_submit_outcome("),
+        "main.rs should not keep inline Kolme submit outcome mapper"
+    );
+    assert!(
+        !main_rs.contains("fn kolme_live_finality_label("),
+        "main.rs should not keep inline Kolme finality label helper"
+    );
 }
 
 #[test]
@@ -84,6 +104,7 @@ fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     let signer_rs = read_repo_file("src/signer.rs");
     let report_builder_rs = read_repo_file("src/report_builder.rs");
     let report_render_rs = read_repo_file("src/report_render.rs");
+    let runtime_kolme_live_rs = read_repo_file("src/runtime_kolme_live.rs");
     let wire_payload_rs = read_repo_file("src/wire_payload.rs");
     assert!(
         signer_rs.contains("pub(crate) fn build_kolme_live_direct_signed_wire_payload("),
@@ -104,5 +125,17 @@ fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     assert!(
         report_builder_rs.contains("pub(crate) fn build_bootstrap_report("),
         "report_builder module should own bootstrap report assembly"
+    );
+    assert!(
+        runtime_kolme_live_rs.contains("pub(crate) fn build_kolme_live_request("),
+        "runtime_kolme_live module should own request builder"
+    );
+    assert!(
+        runtime_kolme_live_rs.contains("pub(crate) fn ensure_kolme_live_provider_marker("),
+        "runtime_kolme_live module should own provider marker guard"
+    );
+    assert!(
+        runtime_kolme_live_rs.contains("pub(crate) fn map_kolme_live_submit_outcome("),
+        "runtime_kolme_live module should own submit outcome mapper"
     );
 }


### PR DESCRIPTION
## Summary
Extracted Kolme live runtime helper orchestration from `kamn-node` `main.rs` into a dedicated `runtime_kolme_live` module. This keeps runtime behavior unchanged while reducing `main.rs` ownership scope and enforcing module boundaries with extraction contracts.

## Changes
- `crates/kamn-node/src/main.rs`: declare `mod runtime_kolme_live;`, delegate helper calls, remove inline helper implementations.
- `crates/kamn-node/src/runtime_kolme_live.rs`: add extracted helper functions for request building, provider marker guard, submit outcome mapping, and finality labeling.
- `crates/kamn-node/tests/main_module_extraction_contract.rs`: add boundary assertions for new module declaration, no-inline helper contracts, and ownership checks.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node --test main_module_extraction_contract`

Failing signals captured before implementation:
- `main.rs should declare runtime_kolme_live module`
- `main.rs should not keep inline Kolme live request builder`
- `failed to read src/runtime_kolme_live.rs: No such file or directory`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node --test main_module_extraction_contract`

Result:
- all commands pass
- extraction contract: `4 passed; 0 failed`

### 🔁 Regression
Command:
`cargo test -p kamn-node`

Result:
- `85 passed; 0 failed; 1 ignored` (unit/functional/integration coverage in `src/main_tests.rs`)
- extraction contract suite: `4 passed; 0 failed`
- docs contract suites: all passing

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `main_module_extraction_contract` module ownership assertions | |
| Functional   | ✅     | `cargo test -p kamn-node` (`main_tests::*`) | |
| Integration  | ✅     | `cargo test -p kamn-node` includes integration tests for runtime modes | |
| Regression   | ✅     | boundary regression checks in extraction contract | |
| Performance  | N/A    | None | refactor-only extraction; no runtime algorithm/path changes |

## Risks & Rollback
- None expected; helper implementations are moved verbatim.
- Rollback: revert this PR to restore inline helper implementations in `main.rs`.

## Documentation Updates
- None required. Existing runtime docs remain accurate (no flag/behavior change).

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)

Closes #2492
Refs #2485
Refs #2484
Refs #2462
