### PR TITLE
refactor(kamn-node): extract kolme-live runtime execution branch

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1,9 +1,7 @@
 use kamn_core::{
-    bootstrap, ConfigError, DeterministicProposalPlanner, KolmeCommitReceiptFinality,
-    KolmeRuntimeCommitFinalityChecker, KolmeRuntimeCommitHttpTransport,
-    KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitProvider, KolmeRuntimeCommitProviderError,
-    NodeConfig, NodeRole, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate,
-    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, SyncMode,
+    bootstrap, ConfigError, DeterministicProposalPlanner, NodeConfig, NodeRole, PeerLifecycle,
+    PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, RecoveryRejoinGuard, RecoveryStatus,
+    RejoinAttempt, SyncMode,
 };
 use std::env;
 use std::process::ExitCode;
@@ -16,14 +14,13 @@ mod wire_payload;
 
 use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
-use runtime_kolme_live::{
-    build_kolme_live_request, ensure_kolme_live_provider_marker, kolme_live_finality_label,
-    map_kolme_live_submit_outcome,
-};
-use signer::build_kolme_live_direct_signed_wire_payload;
+#[cfg(test)]
+use runtime_kolme_live::build_kolme_live_request;
+use runtime_kolme_live::execute_kolme_live_runtime;
 #[cfg(test)]
 use signer::{
-    build_kolme_live_managed_signing_key, build_kolme_live_signer_adapter, encode_kolme_hex_lower,
+    build_kolme_live_direct_signed_wire_payload, build_kolme_live_managed_signing_key,
+    build_kolme_live_signer_adapter, encode_kolme_hex_lower,
     resolve_kolme_live_managed_signer_required_marker, resolve_kolme_live_nonce,
     resolve_kolme_live_signer_private_key_env_name, sign_kolme_live_managed_external_message,
     KolmeForkSecp256k1SignerAdapter,
@@ -918,12 +915,6 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             let signing_profile = kolme_live_signing_profile.ok_or(
                 ConfigError::MissingArgumentValue("--kolme-live-signing-profile"),
             )?;
-            if provider_hint.contains(KOLME_IN_MEMORY_PROVIDER_MARKER) {
-                return Err(ConfigError::InvalidKolmeLiveProviderHint(provider_hint));
-            }
-            if signing_profile != KOLME_LIVE_SIGNING_PROFILE {
-                return Err(ConfigError::InvalidKolmeLiveSigningProfile(signing_profile));
-            }
             let strict_signer_profile = if kolme_live_strict_signer_contracts {
                 Some(normalize_kolme_live_signer_profile_selector(
                     kolme_live_signer_profile.as_deref().ok_or(
@@ -942,77 +933,16 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             } else {
                 None
             };
-            let mut transport =
-                KolmeRuntimeCommitHttpTransport::new(KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS)
-                    .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-            let request = build_kolme_live_request(&plan)?;
-            let (signed_wire_payload, signer_selection) =
-                build_kolme_live_direct_signed_wire_payload(
-                    base_url.as_str(),
-                    &mut transport,
-                    &request,
-                    strict_signer_profile,
-                    strict_signer_key_source,
-                )?;
-            let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
-                base_url.as_str(),
-                provider_hint.as_str(),
-                transport.clone(),
-            )
-            .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-            let submit_outcome = provider
-                .submit_runtime_commit(signed_wire_payload.as_str(), request.idempotency_key())
-                .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-            let (submit_status, mut receipt) = map_kolme_live_submit_outcome(submit_outcome)?;
-            ensure_kolme_live_provider_marker(provider_hint.as_str(), receipt.provider.as_str())?;
-            let mut resolution = "submit-receipt".to_owned();
-            if matches!(receipt.finality, KolmeCommitReceiptFinality::Pending) {
-                let mut checker = KolmeRuntimeCommitFinalityChecker::new(
-                    base_url.as_str(),
-                    KOLME_LIVE_FINALITY_STATUS_PATH,
-                    transport,
-                )
-                .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-                match checker
-                    .poll_finality(receipt.commit_id.as_str(), KOLME_LIVE_FINALITY_MAX_ATTEMPTS)
-                {
-                    Ok(polled_receipt) => {
-                        ensure_kolme_live_provider_marker(
-                            provider_hint.as_str(),
-                            polled_receipt.provider.as_str(),
-                        )?;
-                        receipt = polled_receipt;
-                        resolution = "finality-polled".to_owned();
-                    }
-                    Err(KolmeRuntimeCommitProviderError::Timeout) => {
-                        resolution = "finality-timeout".to_owned();
-                    }
-                    Err(KolmeRuntimeCommitProviderError::Unavailable { .. }) => {
-                        resolution = "finality-unavailable".to_owned();
-                    }
-                    Err(KolmeRuntimeCommitProviderError::MalformedResponse { reason }) => {
-                        return Err(ConfigError::RuntimeKolmeLive(format!(
-                            "finality response malformed: {reason}"
-                        )));
-                    }
-                }
-            }
-            let finality = kolme_live_finality_label(receipt.finality);
+            let kolme_live_execution = execute_kolme_live_runtime(
+                &plan,
+                base_url,
+                provider_hint,
+                signing_profile,
+                strict_signer_profile,
+                strict_signer_key_source,
+            )?;
             RuntimeExecutionBundle {
-                kolme_live: Some(KolmeLiveExecution {
-                    provider_client_contract: KOLME_LIVE_PROVIDER_CONTRACT.to_owned(),
-                    base_url,
-                    provider_hint,
-                    signing_profile,
-                    signer_profile_selector_env: KOLME_LIVE_SIGNER_PROFILE_ENV.to_owned(),
-                    signer_profile: signer_selection.profile.to_owned(),
-                    signer_key_source: signer_selection.key_source.to_owned(),
-                    signer_private_key_env: signer_selection.private_key_env.to_owned(),
-                    execution_status: format!(
-                        "{submit_status};commit_id={};finality={finality};resolution={resolution}",
-                        receipt.commit_id
-                    ),
-                }),
+                kolme_live: Some(kolme_live_execution),
                 ..RuntimeExecutionBundle::default()
             }
         }

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -1,5 +1,13 @@
+use super::signer::build_kolme_live_direct_signed_wire_payload;
+use super::{
+    KolmeLiveExecution, KOLME_IN_MEMORY_PROVIDER_MARKER, KOLME_LIVE_FINALITY_MAX_ATTEMPTS,
+    KOLME_LIVE_FINALITY_STATUS_PATH, KOLME_LIVE_PROVIDER_CONTRACT, KOLME_LIVE_SIGNER_PROFILE_ENV,
+    KOLME_LIVE_SIGNING_PROFILE, KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS,
+};
 use kamn_core::{
-    BootstrapPlan, ConfigError, KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderOutcome,
+    BootstrapPlan, ConfigError, KolmeCommitReceiptFinality, KolmeRuntimeCommitFinalityChecker,
+    KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitLiveProvider, KolmeRuntimeCommitProvider,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
     KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitRequest,
 };
 
@@ -56,4 +64,89 @@ pub(crate) fn map_kolme_live_submit_outcome(
             )))
         }
     }
+}
+
+pub(crate) fn execute_kolme_live_runtime(
+    plan: &BootstrapPlan,
+    base_url: String,
+    provider_hint: String,
+    signing_profile: String,
+    strict_signer_profile: Option<&'static str>,
+    strict_signer_key_source: Option<&'static str>,
+) -> Result<KolmeLiveExecution, ConfigError> {
+    if provider_hint.contains(KOLME_IN_MEMORY_PROVIDER_MARKER) {
+        return Err(ConfigError::InvalidKolmeLiveProviderHint(provider_hint));
+    }
+    if signing_profile != KOLME_LIVE_SIGNING_PROFILE {
+        return Err(ConfigError::InvalidKolmeLiveSigningProfile(signing_profile));
+    }
+
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS)
+        .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+    let request = build_kolme_live_request(plan)?;
+    let (signed_wire_payload, signer_selection) = build_kolme_live_direct_signed_wire_payload(
+        base_url.as_str(),
+        &mut transport,
+        &request,
+        strict_signer_profile,
+        strict_signer_key_source,
+    )?;
+    let mut provider = KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile(
+        base_url.as_str(),
+        provider_hint.as_str(),
+        transport.clone(),
+    )
+    .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+    let submit_outcome = provider
+        .submit_runtime_commit(signed_wire_payload.as_str(), request.idempotency_key())
+        .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+    let (submit_status, mut receipt) = map_kolme_live_submit_outcome(submit_outcome)?;
+    ensure_kolme_live_provider_marker(provider_hint.as_str(), receipt.provider.as_str())?;
+    let mut resolution = "submit-receipt".to_owned();
+
+    if matches!(receipt.finality, KolmeCommitReceiptFinality::Pending) {
+        let mut checker = KolmeRuntimeCommitFinalityChecker::new(
+            base_url.as_str(),
+            KOLME_LIVE_FINALITY_STATUS_PATH,
+            transport,
+        )
+        .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+        match checker.poll_finality(receipt.commit_id.as_str(), KOLME_LIVE_FINALITY_MAX_ATTEMPTS) {
+            Ok(polled_receipt) => {
+                ensure_kolme_live_provider_marker(
+                    provider_hint.as_str(),
+                    polled_receipt.provider.as_str(),
+                )?;
+                receipt = polled_receipt;
+                resolution = "finality-polled".to_owned();
+            }
+            Err(KolmeRuntimeCommitProviderError::Timeout) => {
+                resolution = "finality-timeout".to_owned();
+            }
+            Err(KolmeRuntimeCommitProviderError::Unavailable { .. }) => {
+                resolution = "finality-unavailable".to_owned();
+            }
+            Err(KolmeRuntimeCommitProviderError::MalformedResponse { reason }) => {
+                return Err(ConfigError::RuntimeKolmeLive(format!(
+                    "finality response malformed: {reason}"
+                )));
+            }
+        }
+    }
+
+    let finality = kolme_live_finality_label(receipt.finality);
+    Ok(KolmeLiveExecution {
+        provider_client_contract: KOLME_LIVE_PROVIDER_CONTRACT.to_owned(),
+        base_url,
+        provider_hint,
+        signing_profile,
+        signer_profile_selector_env: KOLME_LIVE_SIGNER_PROFILE_ENV.to_owned(),
+        signer_profile: signer_selection.profile.to_owned(),
+        signer_key_source: signer_selection.key_source.to_owned(),
+        signer_private_key_env: signer_selection.private_key_env.to_owned(),
+        execution_status: format!(
+            "{submit_status};commit_id={};finality={finality};resolution={resolution}",
+            receipt.commit_id
+        ),
+    })
 }

--- a/crates/kamn-node/tests/main_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/main_module_extraction_contract.rs
@@ -100,6 +100,29 @@ fn main_module_extraction_contract_removes_inline_signer_payload_impls() {
 }
 
 #[test]
+fn main_module_extraction_contract_removes_inline_kolme_live_branch_execution_impls() {
+    let main_rs = read_repo_file("src/main.rs");
+    assert!(
+        !main_rs.contains("KolmeRuntimeCommitLiveProvider::new_kolme_fork_broadcast_profile("),
+        "main.rs should not keep inline Kolme live provider constructor path"
+    );
+    assert!(
+        !main_rs.contains(
+            "submit_runtime_commit(signed_wire_payload.as_str(), request.idempotency_key())"
+        ),
+        "main.rs should not keep inline Kolme live submit invocation"
+    );
+    assert!(
+        !main_rs.contains("KolmeRuntimeCommitFinalityChecker::new("),
+        "main.rs should not keep inline Kolme live finality checker orchestration"
+    );
+    assert!(
+        main_rs.contains("execute_kolme_live_runtime("),
+        "main.rs should delegate Kolme live runtime branch to extracted module function"
+    );
+}
+
+#[test]
 fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     let signer_rs = read_repo_file("src/signer.rs");
     let report_builder_rs = read_repo_file("src/report_builder.rs");
@@ -137,5 +160,9 @@ fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     assert!(
         runtime_kolme_live_rs.contains("pub(crate) fn map_kolme_live_submit_outcome("),
         "runtime_kolme_live module should own submit outcome mapper"
+    );
+    assert!(
+        runtime_kolme_live_rs.contains("pub(crate) fn execute_kolme_live_runtime("),
+        "runtime_kolme_live module should own Kolme live runtime branch execution"
     );
 }


### PR DESCRIPTION
## Summary
Extracted the inline `RuntimeModeKind::KolmeLive` execution orchestration from `crates/kamn-node/src/main.rs` into `crates/kamn-node/src/runtime_kolme_live.rs` as `execute_kolme_live_runtime`. This preserves runtime behavior while reducing `main.rs` coupling and strengthening extraction contracts.

## Changes
- `crates/kamn-node/src/runtime_kolme_live.rs`: added `execute_kolme_live_runtime` owning provider construction, submit outcome mapping, provider marker drift checks, and finality polling orchestration.
- `crates/kamn-node/src/main.rs`: removed inline Kolme live runtime branch internals; delegates to `execute_kolme_live_runtime`.
- `crates/kamn-node/tests/main_module_extraction_contract.rs`: added red/green contract assertions for extracted branch ownership and no-inline provider/finality orchestration in `main.rs`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node --test main_module_extraction_contract`

Failing signals captured before implementation:
- `main.rs should not keep inline Kolme live provider constructor path`
- `runtime_kolme_live module should own Kolme live runtime branch execution`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node --test main_module_extraction_contract`

Result:
- all commands pass
- extraction contract: `5 passed; 0 failed`

### 🔁 Regression
Command:
`cargo test -p kamn-node`

Result:
- `85 passed; 0 failed; 1 ignored` (main test suite)
- extraction contracts: `5 passed; 0 failed`
- docs contract suites: all passing

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | extraction assertions for Kolme live branch delegation in `main_module_extraction_contract` | |
| Functional   | ✅     | `cargo test -p kamn-node` (`main_tests::*`) | |
| Integration  | ✅     | `cargo test -p kamn-node` integration runtime tests remain green | |
| Regression   | ✅     | no-inline branch orchestration regression checks in extraction contract | |
| Performance  | N/A    | None | refactor-only; no algorithm/protocol changes |

## Risks & Rollback
- None expected; implementation moves existing orchestration logic into a module with behavior parity.
- Rollback: revert this PR to restore inline branch execution in `main.rs`.

## Documentation Updates
- None required; no CLI contract or behavior changes.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)

Closes #2494
Refs #2485
Refs #2484
Refs #2462
