### PR TITLE
refactor(kamn-node): deduplicate signer normalization helpers

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -25,6 +25,9 @@ use signer::{
     resolve_kolme_live_signer_private_key_env_name, sign_kolme_live_managed_external_message,
     KolmeForkSecp256k1SignerAdapter,
 };
+use signer::{
+    normalize_kolme_live_signer_key_source, normalize_kolme_live_signer_profile_selector,
+};
 #[cfg(test)]
 use wire_payload::render_kolme_live_native_direct_message;
 
@@ -656,40 +659,6 @@ where
         output_mode,
         diagnostics_mode,
     })
-}
-
-fn normalize_kolme_live_signer_profile_selector(value: &str) -> Result<&'static str, ConfigError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(ConfigError::RuntimeKolmeLive(
-            "--kolme-live-signer-profile must not be empty".to_owned(),
-        ));
-    }
-    match trimmed {
-        KOLME_LIVE_SIGNER_PROFILE_PRIMARY => Ok(KOLME_LIVE_SIGNER_PROFILE_PRIMARY),
-        KOLME_LIVE_SIGNER_PROFILE_SECONDARY => Ok(KOLME_LIVE_SIGNER_PROFILE_SECONDARY),
-        _ => Err(ConfigError::RuntimeKolmeLive(format!(
-            "--kolme-live-signer-profile has unsupported profile: {trimmed}"
-        ))),
-    }
-}
-
-fn normalize_kolme_live_signer_key_source(value: &str) -> Result<&'static str, ConfigError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(ConfigError::RuntimeKolmeLive(
-            "--kolme-live-signer-key-source must not be empty".to_owned(),
-        ));
-    }
-    match trimmed {
-        KOLME_LIVE_SIGNER_KEY_SOURCE_ENV_LOCAL => Ok(KOLME_LIVE_SIGNER_KEY_SOURCE_ENV_LOCAL),
-        KOLME_LIVE_SIGNER_KEY_SOURCE_MANAGED_EXTERNAL => {
-            Ok(KOLME_LIVE_SIGNER_KEY_SOURCE_MANAGED_EXTERNAL)
-        }
-        _ => Err(ConfigError::RuntimeKolmeLive(format!(
-            "--kolme-live-signer-key-source has unsupported key source: {trimmed}"
-        ))),
-    }
 }
 
 fn parse_state_version_arg(value: &str) -> Result<u64, ConfigError> {

--- a/crates/kamn-node/tests/main_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/main_module_extraction_contract.rs
@@ -97,6 +97,14 @@ fn main_module_extraction_contract_removes_inline_signer_payload_impls() {
         !main_rs.contains("fn render_kolme_live_native_direct_message("),
         "main.rs should not keep inline native direct message renderer"
     );
+    assert!(
+        !main_rs.contains("fn normalize_kolme_live_signer_profile_selector("),
+        "main.rs should not keep inline signer profile normalization helper"
+    );
+    assert!(
+        !main_rs.contains("fn normalize_kolme_live_signer_key_source("),
+        "main.rs should not keep inline signer key-source normalization helper"
+    );
 }
 
 #[test]
@@ -136,6 +144,14 @@ fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     assert!(
         signer_rs.contains("pub(crate) fn resolve_kolme_live_nonce("),
         "signer module should own nonce resolver"
+    );
+    assert!(
+        signer_rs.contains("pub(crate) fn normalize_kolme_live_signer_profile_selector("),
+        "signer module should own signer profile normalization helper"
+    );
+    assert!(
+        signer_rs.contains("pub(crate) fn normalize_kolme_live_signer_key_source("),
+        "signer module should own signer key-source normalization helper"
     );
     assert!(
         wire_payload_rs.contains("pub(crate) fn render_kolme_live_native_direct_message("),


### PR DESCRIPTION
## Summary
Removed duplicated Kolme signer normalization helpers from `crates/kamn-node/src/main.rs` and delegated to shared implementations in `crates/kamn-node/src/signer.rs`. This reduces drift risk and keeps strict signer contract behavior centralized.

## Changes
- `crates/kamn-node/src/main.rs`: removed local `normalize_kolme_live_signer_profile_selector` and `normalize_kolme_live_signer_key_source`; imported signer module helpers.
- `crates/kamn-node/tests/main_module_extraction_contract.rs`: added boundary assertions that normalization helpers must not be inline in `main.rs` and must remain owned by `signer.rs`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node --test main_module_extraction_contract`

Failing signal before implementation:
- `main.rs should not keep inline signer profile normalization helper`

### 🟢 Green Phase
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node --test main_module_extraction_contract`

Result:
- all commands pass
- extraction contract: `5 passed; 0 failed`

### 🔁 Regression
Command:
`cargo test -p kamn-node`

Result:
- `85 passed; 0 failed; 1 ignored`
- extraction contracts/docs contracts all passing

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | extraction assertions for normalization helper ownership | |
| Functional   | ✅     | `cargo test -p kamn-node` functional runtime/CLI behavior tests | |
| Integration  | ✅     | `cargo test -p kamn-node` integration tests remain green | |
| Regression   | ✅     | no-inline helper regression checks in extraction contract | |
| Performance  | N/A    | None | refactor-only |

## Risks & Rollback
- None expected; accepted value set and errors are preserved via shared helpers.
- Rollback: revert this PR to restore local helper definitions in `main.rs`.

## Documentation Updates
- None required; behavior and CLI contract unchanged.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)

Closes #2500
Refs #2485
Refs #2484
Refs #2462
