### PR TITLE
fix(ci): guard ci-tools fast mode from local-heavy leakage

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -96,6 +96,8 @@ Coverage split for cost control:
     - `steps.scope.outputs.run_kolme_local_heavy_contract_tests == 'true'`
     - `steps.scope.outputs.kolme_local_heavy_selector_opt_in == 'true'`
   - fail-closed policy reason for missing dual gate: `local_heavy_lane_not_opt_in_selector_gated`
+  - fail-closed policy reason when local-heavy commands leak into ci-tools fast mode:
+    - `local_heavy_lane_commands_in_ci_tools_fast_mode`
 
 ## Managed-Signer Backend SLO Telemetry Artifact
 Managed-signer backend SLO telemetry is emitted through:

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -108,6 +108,9 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - local-heavy lane execution is dual-gated in workflow policy:
       - `if: steps.scope.outputs.run_kolme_local_heavy_contract_tests == 'true' && steps.scope.outputs.kolme_local_heavy_selector_opt_in == 'true'`
       - fail-closed reason code for missing dual gate: `local_heavy_lane_not_opt_in_selector_gated`
+    - workflow/local-heavy policy checker also validates `scripts/ci/test_ci_tools.sh` fast-mode surface:
+      - local-heavy commands must not appear under `KAMN_CI_TOOLS_FAST_MODE=true`
+      - fail-closed reason code for leakage: `local_heavy_lane_commands_in_ci_tools_fast_mode`
   - default selector outputs:
     - `run_kolme_local_heavy_contract_tests=false`
     - `kolme_local_heavy_selector_opt_in=false`

--- a/scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py
+++ b/scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py
@@ -40,6 +40,11 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="Path to selector script for heavy-lane parity validation.",
     )
+    parser.add_argument(
+        "--ci-tools-file",
+        type=Path,
+        help="Path to ci-tools regression script for fast-mode local-heavy leakage checks.",
+    )
     parser.add_argument("--output-json", type=Path)
     return parser.parse_args()
 
@@ -52,6 +57,17 @@ def extract_step_block(text: str, step_name: str) -> str:
     if not step_match:
         return ""
     return step_match.group("body")
+
+
+def extract_ci_tools_fast_mode_block(text: str) -> str:
+    fast_mode_match = re.search(
+        r'if \[ "\$\{KAMN_CI_TOOLS_FAST_MODE:-false\}" = "true" \]; then(?P<body>.*?)\n\s*exit 0\nfi',
+        text,
+        flags=re.DOTALL,
+    )
+    if not fast_mode_match:
+        return ""
+    return fast_mode_match.group("body")
 
 
 def unique_preserving_order(values: List[str]) -> List[str]:
@@ -153,6 +169,24 @@ def main() -> int:
             if missing_selector_commands:
                 failed_checks.append("selector_local_heavy_commands_missing")
 
+    ci_tools_file = args.ci_tools_file
+    if ci_tools_file:
+        if not ci_tools_file.exists():
+            failed_checks.append("ci_tools_file_missing")
+        else:
+            ci_tools_text = ci_tools_file.read_text(encoding="utf-8")
+            ci_tools_fast_mode_block = extract_ci_tools_fast_mode_block(ci_tools_text)
+            if not ci_tools_fast_mode_block:
+                failed_checks.append("ci_tools_fast_mode_block_missing")
+            else:
+                leaked_ci_tools_local_heavy_commands = []
+                for command in LOCAL_HEAVY_LANE_COMMANDS:
+                    command_path = command.replace("bash ", "", 1)
+                    if command_path in ci_tools_fast_mode_block:
+                        leaked_ci_tools_local_heavy_commands.append(command_path)
+                if leaked_ci_tools_local_heavy_commands:
+                    failed_checks.append("local_heavy_lane_commands_in_ci_tools_fast_mode")
+
     if failed_checks:
         status = "fail"
         final_decision = "NO-GO"
@@ -166,6 +200,7 @@ def main() -> int:
         "schema_version": "kamn.ci.workflow-kolme-heavy-exclusion-policy-report.v1",
         "workflow_file": str(args.workflow_file),
         "selector_file": str(selector_file) if selector_file else None,
+        "ci_tools_file": str(ci_tools_file) if ci_tools_file else None,
         "status": status,
         "final_decision": final_decision,
         "failed_checks": failed_checks,

--- a/scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh
+++ b/scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECKER="$ROOT_DIR/scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py"
 FAST_WORKFLOW="$ROOT_DIR/.github/workflows/ci-fast-gate.yml"
 SELECTOR_FILE="$ROOT_DIR/scripts/ci/select_targets.sh"
+CI_TOOLS_SCRIPT="$ROOT_DIR/scripts/ci/test_ci_tools.sh"
 SAFE_FIXTURE="$ROOT_DIR/fixtures/ci/workflow_kolme_heavy_policy_safe.yml"
 UNSAFE_MISSING_INPUT_FIXTURE="$ROOT_DIR/fixtures/ci/workflow_kolme_heavy_policy_unsafe_missing_input.yml"
 UNSAFE_FORCED_TRUE_FIXTURE="$ROOT_DIR/fixtures/ci/workflow_kolme_heavy_policy_unsafe_forced_true.yml"
@@ -20,7 +21,7 @@ fi
 
 safe_report="$(mktemp)"
 safe_log="$(mktemp)"
-if ! python3 "$CHECKER" --workflow-file "$SAFE_FIXTURE" --selector-file "$SELECTOR_FILE" --output-json "$safe_report" >"$safe_log" 2>&1; then
+if ! python3 "$CHECKER" --workflow-file "$SAFE_FIXTURE" --selector-file "$SELECTOR_FILE" --ci-tools-file "$CI_TOOLS_SCRIPT" --output-json "$safe_report" >"$safe_log" 2>&1; then
   cat "$safe_log" >&2
   echo "expected safe workflow fixture to pass policy checker" >&2
   exit 1
@@ -43,7 +44,7 @@ fi
 
 real_report="$(mktemp)"
 real_log="$(mktemp)"
-if ! python3 "$CHECKER" --workflow-file "$FAST_WORKFLOW" --selector-file "$SELECTOR_FILE" --output-json "$real_report" >"$real_log" 2>&1; then
+if ! python3 "$CHECKER" --workflow-file "$FAST_WORKFLOW" --selector-file "$SELECTOR_FILE" --ci-tools-file "$CI_TOOLS_SCRIPT" --output-json "$real_report" >"$real_log" 2>&1; then
   cat "$real_log" >&2
   echo "expected ci-fast-gate workflow to satisfy local-heavy exclusion policy" >&2
   exit 1
@@ -123,7 +124,7 @@ rm -f "$safe_report" "$safe_log" "$real_report" "$real_log" "$missing_input_log"
 
 selector_missing_local_heavy_command_log="$(mktemp)"
 # Regression: #2388
-if python3 "$CHECKER" --workflow-file "$SAFE_FIXTURE" --selector-file "$UNSAFE_SELECTOR_MISSING_LOCAL_HEAVY_COMMAND_FIXTURE" >"$selector_missing_local_heavy_command_log" 2>&1; then
+if python3 "$CHECKER" --workflow-file "$SAFE_FIXTURE" --selector-file "$UNSAFE_SELECTOR_MISSING_LOCAL_HEAVY_COMMAND_FIXTURE" --ci-tools-file "$CI_TOOLS_SCRIPT" >"$selector_missing_local_heavy_command_log" 2>&1; then
   cat "$selector_missing_local_heavy_command_log" >&2
   echo "expected selector fixture missing local-heavy command to fail policy checker" >&2
   exit 1
@@ -140,4 +141,35 @@ if ! grep -Fq "reason_codes=selector_local_heavy_commands_missing" "$selector_mi
 fi
 
 rm -f "$selector_missing_local_heavy_command_log"
+
+unsafe_ci_tools_file="$(mktemp)"
+awk '
+  BEGIN { inserted = 0 }
+  {
+    if (!inserted && $0 ~ /echo "Fast-mode CI tool regression tests passed\."/ ) {
+      print "  bash \"$ROOT_DIR/scripts/kolme/test_run_local_heavy_validation_matrix.sh\""
+      inserted = 1
+    }
+    print $0
+  }
+' "$CI_TOOLS_SCRIPT" >"$unsafe_ci_tools_file"
+
+ci_tools_local_heavy_log="$(mktemp)"
+if python3 "$CHECKER" --workflow-file "$SAFE_FIXTURE" --selector-file "$SELECTOR_FILE" --ci-tools-file "$unsafe_ci_tools_file" >"$ci_tools_local_heavy_log" 2>&1; then
+  cat "$ci_tools_local_heavy_log" >&2
+  echo "expected ci-tools fast-mode local-heavy leak fixture to fail policy checker" >&2
+  exit 1
+fi
+if ! grep -Fq "local_heavy_lane_commands_in_ci_tools_fast_mode" "$ci_tools_local_heavy_log"; then
+  cat "$ci_tools_local_heavy_log" >&2
+  echo "expected ci-tools local-heavy leak fixture to report local_heavy_lane_commands_in_ci_tools_fast_mode" >&2
+  exit 1
+fi
+if ! grep -Fq "reason_codes=local_heavy_lane_commands_in_ci_tools_fast_mode" "$ci_tools_local_heavy_log"; then
+  cat "$ci_tools_local_heavy_log" >&2
+  echo "expected ci-tools local-heavy leak fixture to emit deterministic reason code marker" >&2
+  exit 1
+fi
+
+rm -f "$unsafe_ci_tools_file" "$ci_tools_local_heavy_log"
 echo "workflow Kolme local-heavy exclusion policy checker tests passed."


### PR DESCRIPTION
## Summary
Added a fail-closed CI policy guard that prevents Kolme local-heavy command leakage into `scripts/ci/test_ci_tools.sh` fast mode. The existing workflow/selector heavy-exclusion checker now also validates the ci-tools fast-mode command surface.

## Changes
- `scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py`: added `--ci-tools-file` validation path and new reason code `local_heavy_lane_commands_in_ci_tools_fast_mode`.
- `scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`: added red/green coverage for ci-tools fast-mode leakage using a deterministic injected unsafe fixture.
- `docs/ci/strategy.md`: documented the new ci-tools fast-mode leakage guard.
- `docs/ci/ci-cost-and-lane-framework.md`: documented leakage reason code in cost-control policy section.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`

Failing signal before implementation:
- checker rejected new argument: `error: unrecognized arguments: --ci-tools-file ...`

### 🟢 Green Phase
Commands:
- `bash scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`

Result:
- all commands pass
- heavy-exclusion checker emits deterministic failure reason for injected ci-tools leak fixture

### 🔁 Regression
Commands:
- `bash scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`

Result:
- all regression checks pass

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | checker branch logic in `check_workflow_kolme_heavy_exclusion_policy.py` covered via targeted script tests | |
| Functional   | ✅     | policy checker validates real workflow + selector + ci-tools fast-mode surface | |
| Integration  | ✅     | workflow policy + selector + ci-tools command surface validated together in contract test | |
| Regression   | ✅     | injected unsafe ci-tools fixture asserts fail-closed reason code stability | |
| Performance  | N/A    | none | policy/doc update only; no runtime workload changes |

## Risks & Rollback
- Risk is low; change is checker/doc only and adds stricter guardrails.
- Rollback: revert this PR to remove ci-tools fast-mode leakage check.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/ci/ci-cost-and-lane-framework.md`

## Validation Checklist
- [x] Targeted policy tests pass
- [x] TDD Red/Green evidence included above
- [x] Regression checks pass for touched policy/docs contracts
- [x] Docs updated

Closes #2499
Refs #2497
Refs #2496
Refs #2462
