### PR TITLE
fix(kolme): enforce local-heavy matrix mode parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,9 @@ JSON
 KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX=1111111111111111111111111111111111111111111111111111111111111111 \
 bash scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh --mode run --runtime-mode kolme-live --signer-profile ops-primary --required-approvals 2 --received-approvals 2 --custody-evidence-file /tmp/kolme-live-signer-custody.json --quorum-evidence-file /tmp/kolme-live-signer-quorum.json --signer-provenance-file /tmp/kolme-live-signer-provenance.json --signer-key-source managed-external --signer-key-source-contract-version v1 --signer-rotation-epoch 3 --signer-previous-rotation-epoch 1 --signer-rotation-freshness-max-delta 2 --max-seconds 12 --output-json /tmp/kolme-local-live-deployment-preflight-summary.json
 
+# deployment preflight policy checker contract (dry-run summary path)
+python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json
+
 # deployment preflight policy checker contract
 python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code deployment_preflight_passed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json
 
@@ -1018,6 +1021,9 @@ bash scripts/kolme/run_local_heavy_validation_matrix.sh --mode run --output-json
 
 # policy checker contract
 python3 scripts/kolme/check_local_heavy_validation_matrix_policy.py --report-file /tmp/kolme-local-heavy-validation-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-heavy-validation-policy.json
+
+# run-mode policy checker contract (after explicit local-only heavy execution)
+python3 scripts/kolme/check_local_heavy_validation_matrix_policy.py --report-file /tmp/kolme-local-heavy-validation-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code local_heavy_validation_passed --output-json /tmp/kolme-local-heavy-validation-policy.json
 
 # bounded contract lane (dry-run + policy)
 bash scripts/kolme/run_local_heavy_validation_matrix_contract_lane.sh --output-json /tmp/kolme-local-heavy-validation-summary.json --policy-output-json /tmp/kolme-local-heavy-validation-policy.json

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1345,6 +1345,8 @@ Operator checkpoints:
   - `KAMN_KOLME_LOCAL_HEAVY=1 bash scripts/kolme/run_local_heavy_validation_matrix.sh --mode run --output-json /tmp/kolme-local-heavy-validation-summary.json`
 - Policy checker contract:
   - `python3 scripts/kolme/check_local_heavy_validation_matrix_policy.py --report-file /tmp/kolme-local-heavy-validation-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-heavy-validation-policy.json`
+- Run-mode policy checker contract (after explicit opt-in execution):
+  - `python3 scripts/kolme/check_local_heavy_validation_matrix_policy.py --report-file /tmp/kolme-local-heavy-validation-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code local_heavy_validation_passed --output-json /tmp/kolme-local-heavy-validation-policy.json`
 - Bounded contract lane (dry-run + policy):
   - `bash scripts/kolme/run_local_heavy_validation_matrix_contract_lane.sh --output-json /tmp/kolme-local-heavy-validation-summary.json --policy-output-json /tmp/kolme-local-heavy-validation-policy.json`
 - Summary schema:

--- a/scripts/kolme/run_local_heavy_validation_matrix.sh
+++ b/scripts/kolme/run_local_heavy_validation_matrix.sh
@@ -67,6 +67,11 @@ if [ "$MODE" = "run" ]; then
   reason_code="local_heavy_validation_passed"
 fi
 
+REAL_NODE_POLICY_REQUIRED_REASON_CODE="dry_run_no_commands_executed"
+if [ "$MODE" = "run" ]; then
+  REAL_NODE_POLICY_REQUIRED_REASON_CODE="live_runtime_integration_passed"
+fi
+
 BOOTSTRAP_REPORT="/tmp/kolme-local-bootstrap-summary.json"
 DEEP_REPORT="/tmp/kolme-version-compatibility-report.json"
 FORK_RUST_MATRIX_REPORT="/tmp/kolme-local-fork-rust-test-matrix-summary.json"
@@ -94,8 +99,8 @@ declare -a COMMANDS=(
   "bash scripts/kolme/run_local_kolme_live_api_conformance_contract_lane.sh --output-json $LIVE_API_CONFORMANCE_REPORT --policy-output-json $LIVE_API_CONFORMANCE_POLICY_REPORT"
   "bash scripts/kolme/run_local_runtime_commit_live_finality_evidence_contract_lane.sh --output-json $RUNTIME_COMMIT_LIVE_SUMMARY_REPORT --policy-output-json $RUNTIME_COMMIT_LIVE_POLICY_REPORT --max-seconds $RUNTIME_COMMIT_FINALITY_LANE_MAX_SECONDS --finality-max-seconds $RUNTIME_COMMIT_FINALITY_CHECK_MAX_SECONDS --require-non-synthetic-run-evidence --require-native-payload-evidence"
   "bash scripts/kolme/run_local_native_api_parity_live_proof_contract_lane.sh --output-json $NATIVE_API_PARITY_SUMMARY_REPORT --policy-output-json $NATIVE_API_PARITY_POLICY_REPORT --max-seconds $NATIVE_API_PARITY_MAX_SECONDS"
-  "bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode dry-run --runtime-profile real-node --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds $REAL_NODE_INTEGRATION_MAX_SECONDS --runtime-commit-max-seconds $REAL_NODE_RUNTIME_COMMIT_MAX_SECONDS --runtime-commit-finality-max-seconds $REAL_NODE_RUNTIME_COMMIT_FINALITY_MAX_SECONDS --runtime-commit-live-summary $RUNTIME_COMMIT_LIVE_SUMMARY_REPORT --runtime-commit-live-policy-report $RUNTIME_COMMIT_LIVE_POLICY_REPORT --output-json $REAL_NODE_RUNTIME_INTEGRATION_REPORT"
-  "python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py --report-file $REAL_NODE_RUNTIME_INTEGRATION_REPORT --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --require-non-synthetic-run-evidence --output-json $REAL_NODE_RUNTIME_INTEGRATION_POLICY_REPORT"
+  "bash scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh --mode $MODE --runtime-profile real-node --runtime-provider-client-contract KolmeRuntimeCommitLiveProvider --max-seconds $REAL_NODE_INTEGRATION_MAX_SECONDS --runtime-commit-max-seconds $REAL_NODE_RUNTIME_COMMIT_MAX_SECONDS --runtime-commit-finality-max-seconds $REAL_NODE_RUNTIME_COMMIT_FINALITY_MAX_SECONDS --runtime-commit-live-summary $RUNTIME_COMMIT_LIVE_SUMMARY_REPORT --runtime-commit-live-policy-report $RUNTIME_COMMIT_LIVE_POLICY_REPORT --output-json $REAL_NODE_RUNTIME_INTEGRATION_REPORT"
+  "python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py --report-file $REAL_NODE_RUNTIME_INTEGRATION_REPORT --expected-final-decision GO --ci-fast-gate PASS --require-reason-code $REAL_NODE_POLICY_REQUIRED_REASON_CODE --require-non-synthetic-run-evidence --output-json $REAL_NODE_RUNTIME_INTEGRATION_POLICY_REPORT"
 )
 
 declare -a ARTIFACTS=(

--- a/scripts/kolme/test_run_local_heavy_validation_matrix.sh
+++ b/scripts/kolme/test_run_local_heavy_validation_matrix.sh
@@ -57,6 +57,16 @@ if ! grep -q "scripts/framework/assert_local_heavy_opt_in.sh" "$MATRIX_RUNNER"; 
   exit 1
 fi
 
+if ! grep -q -- "--mode \$MODE --runtime-profile real-node" "$MATRIX_RUNNER"; then
+  echo "expected real-node integration command to track selected matrix mode" >&2
+  exit 1
+fi
+
+if ! grep -q "REAL_NODE_POLICY_REQUIRED_REASON_CODE" "$MATRIX_RUNNER"; then
+  echo "expected matrix runner to declare dynamic real-node policy reason-code marker" >&2
+  exit 1
+fi
+
 dry_run_output="$(
   bash "$MATRIX_RUNNER" \
     --mode dry-run \


### PR DESCRIPTION
## Summary
Fixed local-heavy validation matrix mode parity so real-node runtime integration command composition follows the selected matrix mode. The matrix no longer hardcodes `--mode dry-run` for the real-node integration command, and policy reason-code requirements now switch deterministically between dry-run and run expectations.

## Changes
- `scripts/kolme/run_local_heavy_validation_matrix.sh`
  - Added dynamic `REAL_NODE_POLICY_REQUIRED_REASON_CODE` (`dry_run_no_commands_executed` vs `live_runtime_integration_passed`).
  - Updated nested real-node integration command to pass `--mode $MODE`.
  - Updated nested real-node policy check command to use dynamic required reason code.
- `scripts/kolme/test_run_local_heavy_validation_matrix.sh`
  - Added regression assertions to fail closed if matrix runner hardcodes dry-run mode or omits dynamic reason-code marker variable.
- `docs/planning/kolme-devnet-ops.md`
  - Added run-mode policy checker command with `--require-reason-code local_heavy_validation_passed`.
- `README.md`
  - Added run-mode policy checker command for local-heavy matrix.
  - Added dry-run deployment-preflight policy checker command marker required by README contract tests.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_run_local_heavy_validation_matrix.sh`

Failing signal before implementation:
- `expected real-node integration command to track selected matrix mode`

### 🟢 Green Phase
Commands:
- `bash scripts/kolme/test_run_local_heavy_validation_matrix.sh`
- `bash scripts/kolme/test_run_local_heavy_validation_matrix_contract_lane.sh`
- `bash scripts/kolme/test_check_local_heavy_validation_matrix_policy.sh`
- `bash scripts/ci/test_readme_contract.sh`

Result:
- all commands pass

### 🔁 Regression
Commands:
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`

Result:
- all commands pass

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `test_run_local_heavy_validation_matrix.sh` mode-parity and dynamic reason-code marker assertions | |
| Functional   | ✅     | matrix runner + matrix policy checker tests | |
| Integration  | ✅     | real-node runtime integration + contract lane tests | |
| Regression   | ✅     | fail-closed assertions for hardcoded mode/marker drift + policy checker regression suite | |
| Performance  | ✅     | bounded runtime markers remain enforced (`--max-seconds`, `--runtime-commit-max-seconds`, `--runtime-commit-finality-max-seconds`) in matrix command contracts | |

## Risks & Rollback
- Low risk; changes are deterministic command composition and policy expectation wiring.
- Rollback: revert this PR to restore previous matrix command composition.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `README.md`

## Validation Checklist
- [x] TDD Red/Green evidence included
- [x] Local regression checks passed for touched matrix + policy + real-node profile contracts
- [x] Docs updated

Closes #2498
Refs #2497
Refs #2496
Refs #2462
