### PR TITLE
fix(kolme): require backend command for managed-external signing

### DIFF
--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -1433,6 +1433,49 @@ fn regression_kolme_live_managed_external_required_marker_forces_backend_command
 }
 
 #[test]
+fn regression_kolme_live_managed_external_requires_backend_command_without_required_marker() {
+    // Regression: #2505
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _key_ref_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
+        Some(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE),
+    );
+    let _primary_key_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX", None);
+    let _fallback_key_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK", None);
+    let _backend_command_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND", None);
+    let _required_marker_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED", None);
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-node-live-2505-command-required",
+        "state:node-live-2505-command-required",
+        "kamn:did:agent:node-live-2505-command-required",
+        1,
+        "payload:node-live-2505-command-required",
+    )
+    .expect("request should build");
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![MockHttpReply::ok(
+        r#"{"next_nonce":44,"account_id":"acct-2505-required"}"#,
+    )]);
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let error = build_kolme_live_direct_signed_wire_payload(
+        base_url.as_str(),
+        &mut transport,
+        &request,
+        None,
+        Some("managed-external"),
+    )
+    .expect_err("managed-external signer mode must require backend command marker");
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_required_missing")),
+        "managed-external signer mode without backend command must fail closed"
+    );
+}
+
+#[test]
 fn integration_kolme_live_managed_external_builds_direct_signed_wire_payload() {
     // Regression: #2323
     let _lock = signer_env_lock()
@@ -1525,7 +1568,6 @@ fn regression_kolme_live_managed_external_maps_provider_unavailable_reason_code(
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(false),
-        false,
     )
     .expect_err("managed-external provider unavailability must fail closed");
     assert!(
@@ -1558,7 +1600,6 @@ fn regression_kolme_live_managed_external_backend_timeout_maps_reason_code() {
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(true),
-        false,
     )
     .expect_err("managed-external backend timeout must fail closed");
     assert!(
@@ -1593,7 +1634,6 @@ fn regression_kolme_live_managed_external_backend_malformed_response_maps_reason
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(true),
-        false,
     )
     .expect_err("managed-external backend malformed response must fail closed");
     assert!(
@@ -1628,7 +1668,6 @@ fn regression_kolme_live_managed_external_backend_unavailable_maps_reason_code()
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(true),
-        false,
     )
     .expect_err("managed-external backend unavailability must fail closed");
     assert!(

--- a/crates/kamn-node/src/signer.rs
+++ b/crates/kamn-node/src/signer.rs
@@ -416,7 +416,6 @@ pub(crate) fn sign_kolme_live_managed_external_message(
     nonce: u64,
     canonical_message: &str,
     provider_handshake_matrix: SignerProviderHandshakeMatrix,
-    backend_command_required: bool,
 ) -> Result<(String, u8), ConfigError> {
     let _provider = SecureSignerProvider::from_key_id(key_reference).map_err(|error| {
         ConfigError::RuntimeKolmeLive(format!(
@@ -441,51 +440,37 @@ pub(crate) fn sign_kolme_live_managed_external_message(
         .sign(&signing_request)
         .map_err(map_kolme_live_secure_signer_backend_error)?;
     let signing_key = build_kolme_live_managed_signing_key(key_reference)?;
-    let managed_signer_command = resolve_optional_kolme_live_managed_signer_command()?;
-    if backend_command_required && managed_signer_command.is_none() {
-        return Err(ConfigError::RuntimeKolmeLive(format!(
-            "{KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV} must be set when managed-external signing is required by strict signer contracts or {KOLME_LIVE_MANAGED_SIGNER_REQUIRED_ENV}=true (managed_signer_backend_required_missing)"
-        )));
-    }
-    if let Some(command) = managed_signer_command {
-        let timeout_seconds = resolve_kolme_live_managed_signer_timeout_seconds()?;
-        let backend_signature = execute_kolme_live_managed_signer_backend_command(
-            command.as_str(),
-            timeout_seconds,
-            key_reference,
-            &signing_request,
+    let command = resolve_optional_kolme_live_managed_signer_command()?.ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "{KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV} must be set when managed-external signing is selected (managed_signer_backend_required_missing)"
+        ))
+    })?;
+    let timeout_seconds = resolve_kolme_live_managed_signer_timeout_seconds()?;
+    let backend_signature = execute_kolme_live_managed_signer_backend_command(
+        command.as_str(),
+        timeout_seconds,
+        key_reference,
+        &signing_request,
+        canonical_message,
+    )?;
+    let verifier = KolmeForkSecp256k1SignerAdapter {
+        signing_key,
+        private_key_env: KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV,
+    };
+    verifier
+        .verify_message(
             canonical_message,
-        )?;
-        let verifier = KolmeForkSecp256k1SignerAdapter {
-            signing_key,
-            private_key_env: KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV,
-        };
-        verifier
-            .verify_message(
-                canonical_message,
-                backend_signature.signature_hex.as_str(),
-                backend_signature.recovery_id,
-            )
-            .map_err(|error| {
-                ConfigError::RuntimeKolmeLive(format!(
-                    "managed-external signer backend response failed secp256k1 verification: {error} (managed_signer_backend_response_malformed)"
-                ))
-            })?;
-        return Ok((
-            backend_signature.signature_hex,
+            backend_signature.signature_hex.as_str(),
             backend_signature.recovery_id,
-        ));
-    }
-    let (signature, recovery_id) = signing_key
-        .sign_recoverable(canonical_message.as_bytes())
+        )
         .map_err(|error| {
             ConfigError::RuntimeKolmeLive(format!(
-                "managed-external signer failed to produce secp256k1 payload signature: {error} (managed_signer_signature_failed)"
+                "managed-external signer backend response failed secp256k1 verification: {error} (managed_signer_backend_response_malformed)"
             ))
         })?;
     Ok((
-        encode_kolme_hex_lower(signature.to_bytes().as_ref()),
-        recovery_id.to_byte(),
+        backend_signature.signature_hex,
+        backend_signature.recovery_id,
     ))
 }
 
@@ -637,18 +622,6 @@ fn resolve_kolme_live_signer_selection(
         private_key_env,
         key_reference_env,
     })
-}
-
-fn is_kolme_live_managed_signer_backend_required(
-    strict_signer_profile: Option<&str>,
-    signer_selection: &KolmeLiveSignerSelection,
-) -> Result<bool, ConfigError> {
-    if signer_selection.key_source != KOLME_LIVE_SIGNER_KEY_SOURCE_MANAGED_EXTERNAL {
-        return Ok(false);
-    }
-    let marker_required = resolve_kolme_live_managed_signer_required_marker()?;
-    let strict_required = strict_signer_profile.is_some();
-    Ok(marker_required || strict_required)
 }
 
 trait KolmeLiveSignerSecretProvider {
@@ -867,65 +840,64 @@ pub(crate) fn build_kolme_live_direct_signed_wire_payload(
 ) -> Result<(String, KolmeLiveSignerSelection), ConfigError> {
     let signer_selection =
         resolve_kolme_live_signer_selection(strict_signer_profile, strict_signer_key_source)?;
-    let managed_signer_backend_required =
-        is_kolme_live_managed_signer_backend_required(strict_signer_profile, &signer_selection)?;
-    let (canonical_message, signature_hex, recovery_id) =
-        if signer_selection.key_source == KOLME_LIVE_SIGNER_KEY_SOURCE_MANAGED_EXTERNAL {
-            let provider = EnvKolmeLiveSignerSecretProvider;
-            provider.ensure_no_fallback_private_key_path()?;
-            ensure_kolme_live_managed_external_private_key_env_unset(&signer_selection)?;
-            let key_reference = read_required_kolme_live_key_reference_from_env(&signer_selection)?;
-            let managed_signing_key = build_kolme_live_managed_signing_key(key_reference.as_str())?;
-            let pubkey = encode_kolme_hex_lower(
-                managed_signing_key
-                    .verifying_key()
-                    .to_encoded_point(true)
-                    .as_bytes(),
-            );
-            let nonce = resolve_kolme_live_nonce(base_url, transport, pubkey.as_str())?;
-            let canonical_message =
-                render_kolme_live_native_direct_message(request, pubkey.as_str(), nonce)?;
-            let (signature_hex, recovery_id) = sign_kolme_live_managed_external_message(
-                key_reference.as_str(),
-                request,
-                nonce,
-                canonical_message.as_str(),
-                SignerProviderHandshakeMatrix::with_uniform_availability(true),
-                managed_signer_backend_required,
-            )?;
-            let verifier = KolmeForkSecp256k1SignerAdapter {
-                signing_key: managed_signing_key,
-                private_key_env: signer_selection.key_reference_env,
-            };
-            verifier.verify_message(
-                canonical_message.as_str(),
-                signature_hex.as_str(),
-                recovery_id,
-            )?;
-            (canonical_message, signature_hex, recovery_id)
-        } else {
-            let (signer_adapter, signer_selection_from_adapter) =
-                build_kolme_live_signer_adapter(strict_signer_profile, strict_signer_key_source)?;
-            let pubkey = signer_adapter.public_key_compressed_hex();
-            let nonce = resolve_kolme_live_nonce(base_url, transport, pubkey.as_str())?;
-            let canonical_message =
-                render_kolme_live_native_direct_message(request, pubkey.as_str(), nonce)?;
-            let (signature_hex, recovery_id) =
-                signer_adapter.sign_message(canonical_message.as_str())?;
-            debug_assert_eq!(
-                signer_selection.profile,
-                signer_selection_from_adapter.profile
-            );
-            debug_assert_eq!(
-                signer_selection.key_source,
-                signer_selection_from_adapter.key_source
-            );
-            debug_assert_eq!(
-                signer_selection.private_key_env,
-                signer_selection_from_adapter.private_key_env
-            );
-            (canonical_message, signature_hex, recovery_id)
+    let (canonical_message, signature_hex, recovery_id) = if signer_selection.key_source
+        == KOLME_LIVE_SIGNER_KEY_SOURCE_MANAGED_EXTERNAL
+    {
+        let provider = EnvKolmeLiveSignerSecretProvider;
+        provider.ensure_no_fallback_private_key_path()?;
+        ensure_kolme_live_managed_external_private_key_env_unset(&signer_selection)?;
+        let _managed_signer_required_marker = resolve_kolme_live_managed_signer_required_marker()?;
+        let key_reference = read_required_kolme_live_key_reference_from_env(&signer_selection)?;
+        let managed_signing_key = build_kolme_live_managed_signing_key(key_reference.as_str())?;
+        let pubkey = encode_kolme_hex_lower(
+            managed_signing_key
+                .verifying_key()
+                .to_encoded_point(true)
+                .as_bytes(),
+        );
+        let nonce = resolve_kolme_live_nonce(base_url, transport, pubkey.as_str())?;
+        let canonical_message =
+            render_kolme_live_native_direct_message(request, pubkey.as_str(), nonce)?;
+        let (signature_hex, recovery_id) = sign_kolme_live_managed_external_message(
+            key_reference.as_str(),
+            request,
+            nonce,
+            canonical_message.as_str(),
+            SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        )?;
+        let verifier = KolmeForkSecp256k1SignerAdapter {
+            signing_key: managed_signing_key,
+            private_key_env: signer_selection.key_reference_env,
         };
+        verifier.verify_message(
+            canonical_message.as_str(),
+            signature_hex.as_str(),
+            recovery_id,
+        )?;
+        (canonical_message, signature_hex, recovery_id)
+    } else {
+        let (signer_adapter, signer_selection_from_adapter) =
+            build_kolme_live_signer_adapter(strict_signer_profile, strict_signer_key_source)?;
+        let pubkey = signer_adapter.public_key_compressed_hex();
+        let nonce = resolve_kolme_live_nonce(base_url, transport, pubkey.as_str())?;
+        let canonical_message =
+            render_kolme_live_native_direct_message(request, pubkey.as_str(), nonce)?;
+        let (signature_hex, recovery_id) =
+            signer_adapter.sign_message(canonical_message.as_str())?;
+        debug_assert_eq!(
+            signer_selection.profile,
+            signer_selection_from_adapter.profile
+        );
+        debug_assert_eq!(
+            signer_selection.key_source,
+            signer_selection_from_adapter.key_source
+        );
+        debug_assert_eq!(
+            signer_selection.private_key_env,
+            signer_selection_from_adapter.private_key_env
+        );
+        (canonical_message, signature_hex, recovery_id)
+    };
     let request = KolmeApiBroadcastRequest::new(
         canonical_message.as_str(),
         signature_hex.as_str(),

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -263,10 +263,9 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
     - signer adapter contract: `KolmeForkSecp256k1SignerAdapter` owns secp256k1 key decode, recoverable signing, and sign-then-verify compatibility checks against the selected signer key.
     - managed-external backend command contract:
       - command env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`.
-      - strict managed-external signer contracts require the command marker; missing marker fails closed with `managed_signer_backend_required_missing`.
-      - optional requirement override marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false`:
-        - `true`: require backend command execution even when strict signer CLI contracts are not enabled.
-        - invalid/empty values fail closed with `managed_signer_backend_required_invalid`.
+      - managed-external signer mode always requires the command marker; missing marker fails closed with `managed_signer_backend_required_missing`.
+      - compatibility marker `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false` is parsed when present; invalid/empty values fail closed with `managed_signer_backend_required_invalid`.
+      - marker presence does not relax mandatory managed-external backend command execution.
       - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`.
       - command output contract (stdout, key-value lines): `signature_hex=<128-hex>` and `recovery_id=<0..3>`.
       - timeout override marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS` (default `5`).

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -218,11 +218,11 @@ This document captures node-runtime productionization slices for machine-readabl
     - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY`
   - managed-external mode rejects raw private-key env markers for the selected profile with deterministic reason code `managed_signer_raw_private_key_forbidden`
-  - managed-external strict signer contracts require `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`; if absent, runtime fails closed with `managed_signer_backend_required_missing`
-  - managed-external backend requirement marker:
+  - managed-external signer mode requires `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`; if absent, runtime fails closed with `managed_signer_backend_required_missing`
+  - managed-external compatibility marker parsing:
     - `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false`
     - invalid/empty values fail closed with `managed_signer_backend_required_invalid`
-    - when set to `true`, managed-external signing requires backend command execution even outside strict-signer CLI mode
+    - marker presence does not relax mandatory backend command execution for managed-external signing
   - fail-closed error semantics:
     - empty profile/source declarations are rejected
     - unsupported profile/source declarations are rejected
@@ -234,7 +234,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - pending submit receipts poll finality via `/runtime-commit/status` with max-attempt budget `2`
   - malformed finality responses fail closed
   - finality transport timeout/unavailable keeps execution in pending status without falling back to in-memory adapters
-  - managed-external strict signer mode enforces secure-provider handshake routing before payload signing and maps provider failures to deterministic reason codes such as:
+  - managed-external signer mode enforces secure-provider handshake routing before payload signing and maps provider failures to deterministic reason codes such as:
     - `managed_signer_provider_unavailable`
     - `managed_signer_provider_handshake_rejected`
     - `managed_signer_backend_error`


### PR DESCRIPTION
## Summary
Require explicit managed signer backend command routing for managed-external runtime signing in `kamn-node`, and remove runtime fallback signature emission when the command marker is missing.
This closes an operational custody gap where managed-external mode could still sign via a local derived fallback path.

Closes #2505

## Changes
- `crates/kamn-node/src/signer.rs`: removed managed-external local fallback signing branch; `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND` is now mandatory for managed-external signing execution.
- `crates/kamn-node/src/main_tests.rs`: added regression test for non-strict managed-external mode without backend command marker; updated direct managed-external signer function call sites.
- `docs/foundation/node-runtime-cli.md`: updated managed-external command requirement semantics.
- `docs/foundation/kolme-runtime-commit-client.md`: updated managed-external backend command contract text.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_requires_backend_command_without_required_marker -- --exact
```
Result before fix: failed because runtime returned a signed payload instead of fail-closed `managed_signer_backend_required_missing`.

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_requires_backend_command_without_required_marker -- --exact
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_required_marker_forces_backend_command -- --exact
cargo test -p kamn-node main_tests::integration_kolme_live_managed_external_builds_direct_signed_wire_payload -- --exact
```
Result: all passed.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node
```
Result: all passed.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified                                                                                                  | Justification if N/A |
|--------------|--------|------------------------------------------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | `main_tests::regression_kolme_live_managed_external_requires_backend_command_without_required_marker`                 |                      |
| Functional   | ✅     | managed-external runtime signing path assertions in `main_tests`                                                      |                      |
| Integration  | ✅     | `main_tests::integration_kolme_live_managed_external_builds_direct_signed_wire_payload`                              |                      |
| Regression   | ✅     | new #2505 regression + existing managed-external reason-code regression tests                                         |                      |
| Performance  | N/A    | No new heavy lanes; existing checks remain within `kamn-node` fast validation set                                     | No performance-path changes |

## Risks & Rollback
- Behavior change: managed-external signing now requires backend command marker in all managed-external runtime paths.
- Rollback plan: revert commit `4d121e7` to restore prior managed-external fallback behavior.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/foundation/kolme-runtime-commit-client.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)
