### PR TITLE
fix(kolme): enforce managed signer provenance markers

### DIFF
--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -25,6 +25,8 @@ const TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY: &str =
     "838c3528422eb527b4c108b8f6d1e5f629543c304ea49cf608c67794424291c4";
 const TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE: &str =
     "secure:aws-kms:role-operator/key-live-ops-primary";
+const TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE_SECONDARY: &str =
+    "secure:aws-kms:role-operator/key-live-ops-secondary";
 
 fn signer_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -1100,9 +1102,10 @@ fn integration_runtime_kolme_live_renders_managed_external_signer_selection_mark
         .sign_recoverable(canonical_message.as_bytes())
         .expect("managed signing key should sign canonical message");
     let backend_command = format!(
-        "printf 'signature_hex={}\\nrecovery_id={}\\n'",
+        "printf 'signature_hex={}\\nrecovery_id={}\\nsigner_public_key_hex={}\\n'",
         encode_kolme_hex_lower(backend_signature.to_bytes().as_ref()),
-        backend_recovery_id.to_byte()
+        backend_recovery_id.to_byte(),
+        managed_pubkey,
     );
     let _backend_command_guard = EnvVarGuard::set(
         "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
@@ -1513,9 +1516,10 @@ fn integration_kolme_live_managed_external_builds_direct_signed_wire_payload() {
         .sign_recoverable(canonical_message.as_bytes())
         .expect("managed signing key should sign canonical message");
     let backend_command = format!(
-        "printf 'signature_hex={}\\nrecovery_id={}\\n'",
+        "printf 'signature_hex={}\\nrecovery_id={}\\nsigner_public_key_hex={}\\n'",
         encode_kolme_hex_lower(backend_signature.to_bytes().as_ref()),
-        backend_recovery_id.to_byte()
+        backend_recovery_id.to_byte(),
+        managed_pubkey,
     );
     let _backend_command_guard = EnvVarGuard::set(
         "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
@@ -1552,6 +1556,144 @@ fn integration_kolme_live_managed_external_builds_direct_signed_wire_payload() {
 }
 
 #[test]
+fn regression_kolme_live_managed_external_backend_response_requires_signer_public_key_marker() {
+    // Regression: #2509
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _key_ref_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
+        Some(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE),
+    );
+    let _primary_key_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX", None);
+    let _fallback_key_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK", None);
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-node-live-2509-provenance-required",
+        "state:node-live-2509-provenance-required",
+        "kamn:did:agent:node-live-2509-provenance-required",
+        1,
+        "payload:node-live-2509-provenance-required",
+    )
+    .expect("request should build");
+    let signing_key = build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE)
+        .expect("managed signing key should derive");
+    let managed_pubkey = encode_kolme_hex_lower(
+        signing_key
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
+    let canonical_message =
+        render_kolme_live_native_direct_message(&request, managed_pubkey.as_str(), 45)
+            .expect("canonical message should render");
+    let (backend_signature, backend_recovery_id) = signing_key
+        .sign_recoverable(canonical_message.as_bytes())
+        .expect("managed signing key should sign canonical message");
+    let backend_command = format!(
+        "printf 'signature_hex={}\\nrecovery_id={}\\n'",
+        encode_kolme_hex_lower(backend_signature.to_bytes().as_ref()),
+        backend_recovery_id.to_byte()
+    );
+    let _backend_command_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
+        Some(backend_command.as_str()),
+    );
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![MockHttpReply::ok(
+        r#"{"next_nonce":45,"account_id":"acct-2509-provenance-required"}"#,
+    )]);
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let error = build_kolme_live_direct_signed_wire_payload(
+        base_url.as_str(),
+        &mut transport,
+        &request,
+        None,
+        Some("managed-external"),
+    )
+    .expect_err("managed-external backend response must include signer public key marker");
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_response_provenance_missing")),
+        "missing managed-external signer provenance marker must fail closed"
+    );
+}
+
+#[test]
+fn regression_kolme_live_managed_external_backend_response_rejects_signer_public_key_mismatch() {
+    // Regression: #2509
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _key_ref_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
+        Some(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE),
+    );
+    let _primary_key_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX", None);
+    let _fallback_key_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK", None);
+    let request = KolmeRuntimeCommitRequest::deterministic(
+        "op-node-live-2509-provenance-mismatch",
+        "state:node-live-2509-provenance-mismatch",
+        "kamn:did:agent:node-live-2509-provenance-mismatch",
+        1,
+        "payload:node-live-2509-provenance-mismatch",
+    )
+    .expect("request should build");
+    let signing_key = build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE)
+        .expect("managed signing key should derive");
+    let managed_pubkey = encode_kolme_hex_lower(
+        signing_key
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
+    let canonical_message =
+        render_kolme_live_native_direct_message(&request, managed_pubkey.as_str(), 46)
+            .expect("canonical message should render");
+    let (backend_signature, backend_recovery_id) = signing_key
+        .sign_recoverable(canonical_message.as_bytes())
+        .expect("managed signing key should sign canonical message");
+    let secondary_key =
+        build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE_SECONDARY)
+            .expect("secondary managed signing key should derive");
+    let secondary_pubkey = encode_kolme_hex_lower(
+        secondary_key
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
+    let backend_command = format!(
+        "printf 'signature_hex={}\\nrecovery_id={}\\nsigner_public_key_hex={}\\n'",
+        encode_kolme_hex_lower(backend_signature.to_bytes().as_ref()),
+        backend_recovery_id.to_byte(),
+        secondary_pubkey,
+    );
+    let _backend_command_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
+        Some(backend_command.as_str()),
+    );
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![MockHttpReply::ok(
+        r#"{"next_nonce":46,"account_id":"acct-2509-provenance-mismatch"}"#,
+    )]);
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let error = build_kolme_live_direct_signed_wire_payload(
+        base_url.as_str(),
+        &mut transport,
+        &request,
+        None,
+        Some("managed-external"),
+    )
+    .expect_err("managed-external backend response must reject signer public key mismatch");
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_response_provenance_mismatch")),
+        "managed-external signer provenance mismatch must fail closed"
+    );
+}
+
+#[test]
 fn regression_kolme_live_managed_external_maps_provider_unavailable_reason_code() {
     // Regression: #2323
     let request = KolmeRuntimeCommitRequest::deterministic(
@@ -1562,12 +1704,20 @@ fn regression_kolme_live_managed_external_maps_provider_unavailable_reason_code(
         "payload:node-live-2323-provider",
     )
     .expect("request should build");
+    let expected_signer_public_key_hex = encode_kolme_hex_lower(
+        build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE)
+            .expect("managed signing key should derive")
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
     let error = sign_kolme_live_managed_external_message(
         TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
         &request,
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(false),
+        expected_signer_public_key_hex.as_str(),
     )
     .expect_err("managed-external provider unavailability must fail closed");
     assert!(
@@ -1594,12 +1744,20 @@ fn regression_kolme_live_managed_external_backend_timeout_maps_reason_code() {
         "payload:node-live-2423-timeout",
     )
     .expect("request should build");
+    let expected_signer_public_key_hex = encode_kolme_hex_lower(
+        build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE)
+            .expect("managed signing key should derive")
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
     let error = sign_kolme_live_managed_external_message(
         TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
         &request,
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        expected_signer_public_key_hex.as_str(),
     )
     .expect_err("managed-external backend timeout must fail closed");
     assert!(
@@ -1616,7 +1774,7 @@ fn regression_kolme_live_managed_external_backend_malformed_response_maps_reason
         .expect("signer env lock should guard test mutation");
     let _backend_command_guard = EnvVarGuard::set(
         "KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND",
-        Some("printf 'signature_hex=zzzz\\nrecovery_id=9\\n'"),
+        Some("printf 'signature_hex=zzzz\\nrecovery_id=9\\nsigner_public_key_hex=03af446f76cf36092a4e45864210a1dbf03e872756eec21de61910859f8a607dd2\\n'"),
     );
     let _backend_timeout_guard =
         EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS", Some("5"));
@@ -1628,12 +1786,20 @@ fn regression_kolme_live_managed_external_backend_malformed_response_maps_reason
         "payload:node-live-2423-malformed",
     )
     .expect("request should build");
+    let expected_signer_public_key_hex = encode_kolme_hex_lower(
+        build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE)
+            .expect("managed signing key should derive")
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
     let error = sign_kolme_live_managed_external_message(
         TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
         &request,
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        expected_signer_public_key_hex.as_str(),
     )
     .expect_err("managed-external backend malformed response must fail closed");
     assert!(
@@ -1662,12 +1828,20 @@ fn regression_kolme_live_managed_external_backend_unavailable_maps_reason_code()
         "payload:node-live-2423-unavailable",
     )
     .expect("request should build");
+    let expected_signer_public_key_hex = encode_kolme_hex_lower(
+        build_kolme_live_managed_signing_key(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE)
+            .expect("managed signing key should derive")
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes(),
+    );
     let error = sign_kolme_live_managed_external_message(
         TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE,
         &request,
         1,
         "payload:managed-signature",
         SignerProviderHandshakeMatrix::with_uniform_availability(true),
+        expected_signer_public_key_hex.as_str(),
     )
     .expect_err("managed-external backend unavailability must fail closed");
     assert!(

--- a/crates/kamn-node/src/signer.rs
+++ b/crates/kamn-node/src/signer.rs
@@ -174,6 +174,7 @@ fn map_kolme_live_secure_signer_backend_error(error: SignerBackendError) -> Conf
 struct ManagedExternalBackendSignature {
     signature_hex: String,
     recovery_id: u8,
+    signer_public_key_hex: String,
 }
 
 fn resolve_optional_kolme_live_managed_signer_command() -> Result<Option<String>, ConfigError> {
@@ -251,6 +252,7 @@ fn parse_kolme_live_managed_signer_command_output(
 ) -> Result<ManagedExternalBackendSignature, ConfigError> {
     let mut signature_hex = None;
     let mut recovery_id = None;
+    let mut signer_public_key_hex = None;
     for line in stdout.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -283,6 +285,15 @@ fn parse_kolme_live_managed_signer_command_output(
                         "managed-external signer backend response recovery_id must be an integer, found '{value}' (managed_signer_backend_response_malformed)"
                     ))
                 })?);
+            }
+            "signer_public_key_hex" => {
+                let value = value.trim();
+                if value.is_empty() {
+                    return Err(ConfigError::RuntimeKolmeLive(
+                        "managed-external signer backend response missing signer_public_key_hex value (managed_signer_backend_response_provenance_missing)".to_owned(),
+                    ));
+                }
+                signer_public_key_hex = Some(value.to_owned());
             }
             _ => {}
         }
@@ -319,10 +330,116 @@ fn parse_kolme_live_managed_signer_command_output(
             "managed-external signer backend response recovery_id must be within secp256k1 range [0,3], found {recovery_id} (managed_signer_backend_response_malformed)"
         )));
     }
+    let signer_public_key_hex = signer_public_key_hex.ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive(
+            "managed-external signer backend response missing signer_public_key_hex key (managed_signer_backend_response_provenance_missing)"
+                .to_owned(),
+        )
+    })?;
+    let signer_public_key_bytes = decode_kolme_hex_bytes(
+        signer_public_key_hex.as_str(),
+        "managed_external_signer_backend_signer_public_key_hex",
+    )
+    .map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signer_public_key_hex is invalid: {error} (managed_signer_backend_response_provenance_malformed)"
+        ))
+    })?;
+    if signer_public_key_bytes.len() != 33 {
+        return Err(ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signer_public_key_hex must decode to 33 bytes compressed secp256k1 key material, found {} (managed_signer_backend_response_provenance_malformed)",
+            signer_public_key_bytes.len()
+        )));
+    }
+    let signer_verifying_key =
+        VerifyingKey::from_sec1_bytes(signer_public_key_bytes.as_slice()).map_err(|error| {
+            ConfigError::RuntimeKolmeLive(format!(
+                "managed-external signer backend response signer_public_key_hex is not valid secp256k1 key material: {error} (managed_signer_backend_response_provenance_malformed)"
+            ))
+        })?;
     Ok(ManagedExternalBackendSignature {
         signature_hex,
         recovery_id,
+        signer_public_key_hex: encode_kolme_hex_lower(
+            signer_verifying_key.to_encoded_point(true).as_bytes(),
+        ),
     })
+}
+
+fn verify_kolme_live_managed_signer_backend_signature_provenance(
+    canonical_message: &str,
+    expected_signer_public_key_hex: &str,
+    backend_signature: &ManagedExternalBackendSignature,
+) -> Result<(), ConfigError> {
+    let expected_signer_public_key_hex = expected_signer_public_key_hex.trim();
+    if expected_signer_public_key_hex.is_empty() {
+        return Err(ConfigError::RuntimeKolmeLive(
+            "expected managed-external signer public key must not be empty (managed_signer_backend_response_provenance_mismatch)"
+                .to_owned(),
+        ));
+    }
+    if !backend_signature
+        .signer_public_key_hex
+        .eq_ignore_ascii_case(expected_signer_public_key_hex)
+    {
+        return Err(ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signer_public_key_hex does not match expected runtime signer key material (expected={}, found={}) (managed_signer_backend_response_provenance_mismatch)",
+            expected_signer_public_key_hex,
+            backend_signature.signer_public_key_hex,
+        )));
+    }
+
+    let signature_bytes = decode_kolme_hex_bytes(
+        backend_signature.signature_hex.as_str(),
+        "managed_external_signer_backend_signature_hex",
+    )
+    .map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signature hex is invalid: {error} (managed_signer_backend_response_malformed)"
+        ))
+    })?;
+    let signature = Signature::from_slice(signature_bytes.as_slice()).map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signature bytes are invalid secp256k1 material: {error} (managed_signer_backend_response_malformed)"
+        ))
+    })?;
+    let recovery =
+        RecoveryId::from_byte(backend_signature.recovery_id).ok_or_else(|| {
+            ConfigError::RuntimeKolmeLive(format!(
+                "managed-external signer backend response recovery_id must be within secp256k1 range [0,3], found {} (managed_signer_backend_response_malformed)",
+                backend_signature.recovery_id
+            ))
+        })?;
+    let recovered = VerifyingKey::recover_from_msg(canonical_message.as_bytes(), &signature, recovery)
+        .map_err(|error| {
+            ConfigError::RuntimeKolmeLive(format!(
+                "failed to recover secp256k1 public key from managed-external signer backend response: {error} (managed_signer_backend_response_malformed)"
+            ))
+        })?;
+    let expected = VerifyingKey::from_sec1_bytes(
+        decode_kolme_hex_bytes(
+            backend_signature.signer_public_key_hex.as_str(),
+            "managed_external_signer_backend_signer_public_key_hex",
+        )
+        .map_err(|error| {
+            ConfigError::RuntimeKolmeLive(format!(
+                "managed-external signer backend response signer_public_key_hex is invalid: {error} (managed_signer_backend_response_provenance_malformed)"
+            ))
+        })?
+        .as_slice(),
+    )
+    .map_err(|error| {
+        ConfigError::RuntimeKolmeLive(format!(
+            "managed-external signer backend response signer_public_key_hex is not valid secp256k1 key material: {error} (managed_signer_backend_response_provenance_malformed)"
+        ))
+    })?;
+    if recovered != expected {
+        return Err(ConfigError::RuntimeKolmeLive(
+            "managed-external signer backend response signature does not match signer_public_key_hex (managed_signer_backend_response_provenance_mismatch)"
+                .to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 fn execute_kolme_live_managed_signer_backend_command(
@@ -416,6 +533,7 @@ pub(crate) fn sign_kolme_live_managed_external_message(
     nonce: u64,
     canonical_message: &str,
     provider_handshake_matrix: SignerProviderHandshakeMatrix,
+    expected_signer_public_key_hex: &str,
 ) -> Result<(String, u8), ConfigError> {
     let _provider = SecureSignerProvider::from_key_id(key_reference).map_err(|error| {
         ConfigError::RuntimeKolmeLive(format!(
@@ -439,7 +557,6 @@ pub(crate) fn sign_kolme_live_managed_external_message(
     let _backend_signature = secure_backend
         .sign(&signing_request)
         .map_err(map_kolme_live_secure_signer_backend_error)?;
-    let signing_key = build_kolme_live_managed_signing_key(key_reference)?;
     let command = resolve_optional_kolme_live_managed_signer_command()?.ok_or_else(|| {
         ConfigError::RuntimeKolmeLive(format!(
             "{KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV} must be set when managed-external signing is selected (managed_signer_backend_required_missing)"
@@ -453,21 +570,11 @@ pub(crate) fn sign_kolme_live_managed_external_message(
         &signing_request,
         canonical_message,
     )?;
-    let verifier = KolmeForkSecp256k1SignerAdapter {
-        signing_key,
-        private_key_env: KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV,
-    };
-    verifier
-        .verify_message(
-            canonical_message,
-            backend_signature.signature_hex.as_str(),
-            backend_signature.recovery_id,
-        )
-        .map_err(|error| {
-            ConfigError::RuntimeKolmeLive(format!(
-                "managed-external signer backend response failed secp256k1 verification: {error} (managed_signer_backend_response_malformed)"
-            ))
-        })?;
+    verify_kolme_live_managed_signer_backend_signature_provenance(
+        canonical_message,
+        expected_signer_public_key_hex,
+        &backend_signature,
+    )?;
     Ok((
         backend_signature.signature_hex,
         backend_signature.recovery_id,
@@ -864,15 +971,7 @@ pub(crate) fn build_kolme_live_direct_signed_wire_payload(
             nonce,
             canonical_message.as_str(),
             SignerProviderHandshakeMatrix::with_uniform_availability(true),
-        )?;
-        let verifier = KolmeForkSecp256k1SignerAdapter {
-            signing_key: managed_signing_key,
-            private_key_env: signer_selection.key_reference_env,
-        };
-        verifier.verify_message(
-            canonical_message.as_str(),
-            signature_hex.as_str(),
-            recovery_id,
+            pubkey.as_str(),
         )?;
         (canonical_message, signature_hex, recovery_id)
     } else {

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -267,7 +267,10 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
       - compatibility marker `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false` is parsed when present; invalid/empty values fail closed with `managed_signer_backend_required_invalid`.
       - marker presence does not relax mandatory managed-external backend command execution.
       - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`.
-      - command output contract (stdout, key-value lines): `signature_hex=<128-hex>` and `recovery_id=<0..3>`.
+      - command output contract (stdout, key-value lines): `signature_hex=<128-hex>`, `recovery_id=<0..3>`, and `signer_public_key_hex=<33-byte-compressed-secp256k1-hex>`.
+      - missing signer provenance marker fails closed with `managed_signer_backend_response_provenance_missing`.
+      - malformed signer provenance marker fails closed with `managed_signer_backend_response_provenance_malformed`.
+      - signer provenance mismatch fails closed with `managed_signer_backend_response_provenance_mismatch`.
       - timeout override marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS` (default `5`).
       - deterministic backend reason-code classes: `managed_signer_backend_timeout`, `managed_signer_backend_unavailable`, `managed_signer_backend_response_malformed`.
     - malformed signature bytes, invalid recovery id, or recovered-key mismatch are rejected fail-closed before runtime submit dispatch.

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -223,6 +223,13 @@ This document captures node-runtime productionization slices for machine-readabl
     - `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false`
     - invalid/empty values fail closed with `managed_signer_backend_required_invalid`
     - marker presence does not relax mandatory backend command execution for managed-external signing
+  - managed-external backend command output contract:
+    - `signature_hex=<128-hex>`
+    - `recovery_id=<0..3>`
+    - `signer_public_key_hex=<33-byte-compressed-secp256k1-hex>`
+    - missing signer provenance marker fails closed with `managed_signer_backend_response_provenance_missing`
+    - malformed signer provenance marker fails closed with `managed_signer_backend_response_provenance_malformed`
+    - signer provenance mismatch fails closed with `managed_signer_backend_response_provenance_mismatch`
   - fail-closed error semantics:
     - empty profile/source declarations are rejected
     - unsupported profile/source declarations are rejected

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -577,12 +577,15 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `managed-external signer raw private key env must not be set: KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX (remediation: unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF)`
   - real-node profile managed-external backend adapter command contract:
     - command env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`
-    - strict managed-external signer contracts require command marker presence; missing marker fails closed with `managed_signer_backend_required_missing`
+    - managed-external signer mode requires command marker presence; missing marker fails closed with `managed_signer_backend_required_missing`
     - optional requirement override marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false`
     - invalid/empty requirement marker values fail closed with `managed_signer_backend_required_invalid`
     - optional timeout env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS` (default `5`)
     - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`
-    - command output markers: `signature_hex=<128-hex>` and `recovery_id=<0..3>`
+    - command output markers: `signature_hex=<128-hex>`, `recovery_id=<0..3>`, and `signer_public_key_hex=<33-byte-compressed-secp256k1-hex>`
+    - missing provenance marker fails closed with `managed_signer_backend_response_provenance_missing`
+    - malformed provenance marker fails closed with `managed_signer_backend_response_provenance_malformed`
+    - signer provenance mismatch fails closed with `managed_signer_backend_response_provenance_mismatch`
     - deterministic managed-external backend failure reason codes: `managed_signer_backend_timeout`, `managed_signer_backend_unavailable`, `managed_signer_backend_response_malformed`
   - real-node profile checker fails closed on in-memory provider references in command/policy surfaces:
     - `runtime_commit_in_memory_provider_reference_detected`


### PR DESCRIPTION
## Summary
Enforced managed-external signer provenance contracts in `kamn-node` runtime signing by requiring backend command output to include `signer_public_key_hex` and failing closed on missing/malformed/mismatched provenance evidence.
This removes key-reference-derived verification as the managed-external signature verification authority.

Closes #2509

## Changes
- `crates/kamn-node/src/signer.rs`
  - Added backend response provenance field parsing for `signer_public_key_hex`.
  - Added fail-closed reason codes:
    - `managed_signer_backend_response_provenance_missing`
    - `managed_signer_backend_response_provenance_malformed`
    - `managed_signer_backend_response_provenance_mismatch`
  - Managed-external signature verification now validates recovered signature key against backend-provided signer provenance evidence.
- `crates/kamn-node/src/main_tests.rs`
  - Added Red/Green regressions for missing provenance marker and signer-public-key mismatch.
  - Updated managed-external backend command fixtures to emit `signer_public_key_hex`.
- `docs/foundation/node-runtime-cli.md`
  - Added managed-external backend output provenance marker rules and fail-closed reason codes.
- `docs/foundation/kolme-runtime-commit-client.md`
  - Added backend output provenance contract and new reason-code taxonomy.
- `docs/planning/kolme-devnet-ops.md`
  - Updated runbook contract markers for managed-external backend provenance requirements.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_backend_response_requires_signer_public_key_marker -- --exact
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_backend_response_rejects_signer_public_key_mismatch -- --exact
```
Result before fix: both failed because runtime accepted managed-external backend responses without enforced signer provenance output markers.

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_backend_response_requires_signer_public_key_marker -- --exact
cargo test -p kamn-node main_tests::regression_kolme_live_managed_external_backend_response_rejects_signer_public_key_mismatch -- --exact
cargo test -p kamn-node main_tests::integration_runtime_kolme_live_renders_managed_external_signer_selection_markers -- --exact
cargo test -p kamn-node main_tests::integration_kolme_live_managed_external_builds_direct_signed_wire_payload -- --exact
```
Result: all passed.

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node
cargo test -p kamn-core --test kolme_runtime_commit_client_docs
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Result: all passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified                                                                                                                   | Justification if N/A |
|--------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | managed-external backend response provenance parser/verification paths in `main_tests` and `signer.rs`                               |                      |
| Functional   | ✅     | managed-external runtime signing path with provenance marker acceptance/rejection                                                       |                      |
| Integration  | ✅     | live runtime managed-external direct-signed flow tests with backend command fixture output                                             |                      |
| Regression   | ✅     | new #2509 regressions for missing provenance marker and signer public key mismatch; existing managed-external reason-code regressions |                      |
| Performance  | N/A    | no new heavy lane; changes remain in fast local test surface                                                                           | no performance-path change |

## Risks & Rollback
- Behavior change: managed-external backend responses must now emit `signer_public_key_hex` and match expected runtime signer key material.
- Rollback plan: revert commit `20ff62a`.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
