### PR TITLE
docs(kolme): publish managed-external runtime signer pubkey marker contracts (#2514)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -91,6 +91,10 @@ fn plan_contains_local_kamn_live_runtime_integration_lane() {
     assert!(PLAN.contains("run_local_kamn_live_runtime_integration_contract_lane.sh"));
     assert!(PLAN.contains("run_local_runtime_commit_live_finality_evidence_contract_lane.sh"));
     assert!(PLAN.contains("--runtime-commit-live-policy-report"));
+    assert!(PLAN.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX"));
+    assert!(PLAN.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY"));
+    assert!(PLAN.contains("managed_signer_public_key_marker_missing"));
+    assert!(PLAN.contains("managed_signer_public_key_marker_invalid"));
     assert!(PLAN.contains("run_localhost_signed_integration_contract_lane.sh"));
     assert!(PLAN.contains("kamn.kolme.local-kamn-live-runtime-integration-summary.v1"));
     assert!(PLAN.contains(

--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -49,6 +49,10 @@ fn doc_contains_adapter_types_and_validation_commands() {
     assert!(DOC.contains("run_local_runtime_commit_live_finality_evidence_contract_lane.sh"));
     assert!(DOC.contains("submit_evidence_marker_present"));
     assert!(DOC.contains("finality_evidence_marker_present"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY"));
+    assert!(DOC.contains("managed_signer_public_key_marker_missing"));
+    assert!(DOC.contains("managed_signer_public_key_marker_invalid"));
     assert!(DOC.contains("scripts/kolme/run_runtime_commit_contract_lane.sh"));
     assert!(DOC.contains("run_local_kamn_live_runtime_integration_lane.sh --mode run"));
     assert!(DOC.contains("--runtime-commit-finality-command"));

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -122,11 +122,15 @@ fn doc_contains_runtime_kolme_live_rules() {
     assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PROFILE"));
     assert!(DOC.contains("KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND"));
     assert!(DOC.contains("KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY"));
     assert!(DOC.contains("ops-primary"));
     assert!(DOC.contains("ops-secondary"));
     assert!(DOC.contains("env-local"));
     assert!(DOC.contains("managed_signer_backend_required_missing"));
     assert!(DOC.contains("managed_signer_backend_required_invalid"));
+    assert!(DOC.contains("managed_signer_public_key_marker_missing"));
+    assert!(DOC.contains("managed_signer_public_key_marker_invalid"));
     assert!(DOC.contains("/runtime-commit/status"));
     assert!(DOC.contains("max-attempt budget `2`"));
     assert!(DOC.contains("finality-polled"));

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -266,6 +266,12 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
       - managed-external signer mode always requires the command marker; missing marker fails closed with `managed_signer_backend_required_missing`.
       - compatibility marker `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false` is parsed when present; invalid/empty values fail closed with `managed_signer_backend_required_invalid`.
       - marker presence does not relax mandatory managed-external backend command execution.
+      - runtime signer public-key env marker contracts:
+        - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`
+        - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY`
+        - runtime nonce lookup and canonical payload rendering consume these markers directly.
+        - missing marker fails closed with `managed_signer_public_key_marker_missing`.
+        - invalid/empty/non-secp256k1 marker fails closed with `managed_signer_public_key_marker_invalid`.
       - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`.
       - command output contract (stdout, key-value lines): `signature_hex=<128-hex>`, `recovery_id=<0..3>`, and `signer_public_key_hex=<33-byte-compressed-secp256k1-hex>`.
       - missing signer provenance marker fails closed with `managed_signer_backend_response_provenance_missing`.

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -179,7 +179,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - `kamn-node --role processor --runtime-mode kolme-live`
   - `kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1`
   - `kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1 --kolme-live-strict-signer-contracts --kolme-live-signer-profile ops-primary --kolme-live-signer-key-source env-local`
-  - `KAMN_KOLME_LIVE_SIGNER_KEY_REF=secure:aws-kms:role-operator/key-live-ops-primary KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND='sh /opt/kamn/signer-backend.sh' kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1 --kolme-live-strict-signer-contracts --kolme-live-signer-profile ops-primary --kolme-live-signer-key-source managed-external`
+  - `KAMN_KOLME_LIVE_SIGNER_KEY_REF=secure:aws-kms:role-operator/key-live-ops-primary KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX=03af446f76cf36092a4e45864210a1dbf03e872756eec21de61910859f8a607dd2 KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND='sh /opt/kamn/signer-backend.sh' kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1 --kolme-live-strict-signer-contracts --kolme-live-signer-profile ops-primary --kolme-live-signer-key-source managed-external`
 
 ## Daemon Runtime Rules
 - Supported runtime modes:
@@ -217,6 +217,11 @@ This document captures node-runtime productionization slices for machine-readabl
   - managed-external key-reference env markers:
     - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY`
+  - managed-external signer public-key env markers:
+    - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`
+    - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY`
+    - missing marker fails closed with `managed_signer_public_key_marker_missing`
+    - invalid/empty/non-secp256k1 marker fails closed with `managed_signer_public_key_marker_invalid`
   - managed-external mode rejects raw private-key env markers for the selected profile with deterministic reason code `managed_signer_raw_private_key_forbidden`
   - managed-external signer mode requires `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`; if absent, runtime fails closed with `managed_signer_backend_required_missing`
   - managed-external compatibility marker parsing:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -567,6 +567,11 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1`; checker fails closed with `runtime_commit_real_signing_profile_marker_missing` when omitted.
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-primary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
   - real-node profile requires runtime command surfaces to include `KAMN_KOLME_LIVE_SIGNER_PROFILE=ops-secondary` when `runtime_signer_profile=ops-secondary`; checker fails closed with `runtime_commit_signer_profile_marker_missing` when omitted.
+  - real-node profile requires managed-external runtime signer public-key command markers:
+    - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX=<33-byte-compressed-secp256k1-hex>`
+    - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY=<33-byte-compressed-secp256k1-hex>`
+    - missing marker fails closed with `managed_signer_public_key_marker_missing`
+    - invalid/empty/non-secp256k1 marker fails closed with `managed_signer_public_key_marker_invalid`
   - real-node profile command composition rejects in-memory fallback references at runner boundary:
     - `runtime-commit-command must not reference InMemoryKolmeRuntimeCommitClient when runtime-profile=real-node`
   - real-node profile command composition rejects fallback signer private-key command markers at runner boundary:
@@ -580,6 +585,11 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - managed-external signer mode requires command marker presence; missing marker fails closed with `managed_signer_backend_required_missing`
     - optional requirement override marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false`
     - invalid/empty requirement marker values fail closed with `managed_signer_backend_required_invalid`
+    - runtime signer public-key env marker contracts:
+      - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`
+      - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY`
+      - missing marker fails closed with `managed_signer_public_key_marker_missing`
+      - invalid/empty/non-secp256k1 marker fails closed with `managed_signer_public_key_marker_invalid`
     - optional timeout env marker: `KAMN_KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS` (default `5`)
     - command input env markers: `KAMN_MANAGED_SIGNER_KEY_REFERENCE`, `KAMN_MANAGED_SIGNER_ACTOR_DID`, `KAMN_MANAGED_SIGNER_NONCE`, `KAMN_MANAGED_SIGNER_STATE_ROOT`, `KAMN_MANAGED_SIGNER_CANONICAL_MESSAGE`
     - command output markers: `signature_hex=<128-hex>`, `recovery_id=<0..3>`, and `signer_public_key_hex=<33-byte-compressed-secp256k1-hex>`


### PR DESCRIPTION
## Summary
Publishes the managed-external runtime signer public-key marker contracts introduced by `#2512` across the three required docs and locks them with doc-contract tests. This keeps operator guidance and policy evidence aligned with merged runtime fail-closed behavior.

Closes #2514

## Changes
- `docs/foundation/node-runtime-cli.md`: documented profile-aware runtime marker env contracts (`KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`, `..._SECONDARY`) and fail-closed reason codes; updated managed-external command example.
- `docs/foundation/kolme-runtime-commit-client.md`: documented that runtime nonce/canonical composition consumes explicit marker input and fails closed on missing/invalid marker.
- `docs/planning/kolme-devnet-ops.md`: added managed-external marker requirements to real-node command/runbook contract sections.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added doc-contract assertions for marker env names and reason codes.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: added doc-contract assertions for marker env names and reason codes.
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`: added doc-contract assertions for marker env names and reason codes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_runtime_kolme_live_rules -- --exact` ❌
  - failed on missing `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs doc_contains_adapter_types_and_validation_commands -- --exact` ❌
  - failed on missing `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs plan_contains_local_kamn_live_runtime_integration_lane -- --exact` ❌
  - failed on missing `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX`

### 🟢 Green Phase
- `cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_runtime_kolme_live_rules -- --exact` ✅
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs doc_contains_adapter_types_and_validation_commands -- --exact` ✅
- `cargo test -p kamn-core --test kolme_devnet_ops_docs plan_contains_local_kamn_live_runtime_integration_lane -- --exact` ✅

### 🔁 Regression
- `cargo fmt --check` ✅
- `cargo clippy -p kamn-node -p kamn-core -- -D warnings` ✅
- `cargo test -p kamn-node --test node_runtime_cli_docs` ✅
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs` ✅
- `cargo test -p kamn-core --test kolme_devnet_ops_docs` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | doc-contract assertions for marker env/reason-code strings | |
| Functional   | ✅     | docs test suites validating published runtime contract text | |
| Integration  | N/A    | documentation-only task | No runtime/module integration behavior changed |
| Regression   | ✅     | red/green drift checks for marker contract strings | |
| Performance  | N/A    | docs-only; no runtime hot path change | Existing fast docs lanes retained |

## Risks & Rollback
- Risk: minimal; documentation/test-only change.
- Rollback: revert this PR commit to restore prior docs/tests state.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/foundation/kolme-runtime-commit-client.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-node` and `kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite executed
