### PR TITLE
docs(architecture): publish KAMN-Kolme runtime flow diagram and ownership map (#2517)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ bash scripts/kolme/test_check_runtime_commit_decomposition_parity_matrix.sh
 
 Architecture/module-boundary ownership and parity scenario details are documented
 in `docs/foundation/kolme-runtime-commit-client.md`.
+Canonical runtime integration flow and module ownership mapping are documented in
+`docs/foundation/kolme-runtime-architecture.md#runtime-flow-diagram` and
+`docs/foundation/kolme-runtime-architecture.md#ownership-map`.
 
 ### Fast Make Lanes
 

--- a/crates/kamn-core/tests/kolme_runtime_architecture_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_architecture_docs.rs
@@ -1,0 +1,32 @@
+const DOC: &str = include_str!("../../../docs/foundation/kolme-runtime-architecture.md");
+const README: &str = include_str!("../../../README.md");
+
+#[test]
+fn architecture_doc_contains_runtime_flow_and_signer_boundaries() {
+    assert!(DOC.contains("## Runtime Flow Diagram"));
+    assert!(DOC.contains("```mermaid"));
+    assert!(DOC.contains("graph TD"));
+    assert!(DOC.contains("kamn-node"));
+    assert!(DOC.contains("kamn-core"));
+    assert!(DOC.contains("kamn-kolme"));
+    assert!(DOC.contains("KolmeRuntimeCommitLiveProvider"));
+    assert!(DOC.contains("managed-external signer backend"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY"));
+}
+
+#[test]
+fn architecture_doc_contains_module_ownership_map() {
+    assert!(DOC.contains("## Ownership Map"));
+    assert!(DOC.contains("crates/kamn-node/src/runtime_kolme_live.rs"));
+    assert!(DOC.contains("crates/kamn-node/src/signer.rs"));
+    assert!(DOC.contains("crates/kamn-core/src/kolme_runtime_commit.rs"));
+    assert!(DOC.contains("crates/kamn-kolme/src/live_provider_pipeline.rs"));
+}
+
+#[test]
+fn readme_references_architecture_doc() {
+    assert!(README.contains("docs/foundation/kolme-runtime-architecture.md"));
+    assert!(README.contains("docs/foundation/kolme-runtime-architecture.md#runtime-flow-diagram"));
+    assert!(README.contains("docs/foundation/kolme-runtime-architecture.md#ownership-map"));
+}

--- a/docs/foundation/kolme-runtime-architecture.md
+++ b/docs/foundation/kolme-runtime-architecture.md
@@ -1,0 +1,56 @@
+# KAMN-Kolme Runtime Architecture
+
+This document provides a canonical, contributor-facing map of the runtime commit
+execution boundary between `kamn-node`, `kamn-core`, and `kamn-kolme`.
+
+## Runtime Flow Diagram
+
+```mermaid
+graph TD
+    A[kamn-node CLI<br/>runtime-mode=kolme-live] --> B[kamn-node<br/>runtime_kolme_live.rs]
+    B --> C[kamn-node<br/>signer.rs]
+    C --> D[kamn-core<br/>KolmeRuntimeCommitHttpTransport]
+    C --> E[kamn-node<br/>wire_payload.rs]
+    C --> F[managed-external signer backend]
+    F --> G[signer_public_key_hex]
+    C --> H[KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX]
+    C --> I[KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY]
+    B --> J[kamn-core<br/>KolmeRuntimeCommitLiveProvider]
+    J --> K[kamn-kolme<br/>live_provider_pipeline.rs]
+    K --> L[Kolme runtime endpoint<br/>/broadcast]
+    B --> M[kamn-core<br/>KolmeRuntimeCommitFinalityChecker]
+    M --> N[Kolme finality endpoint<br/>/runtime-commit/status]
+```
+
+## Flow Notes
+
+- `kamn-node` composes deterministic runtime requests in
+  `crates/kamn-node/src/runtime_kolme_live.rs` and routes signer selection
+  through `crates/kamn-node/src/signer.rs`.
+- Managed-external mode requires explicit runtime signer public-key markers:
+  `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX` (primary) and
+  `KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY` (secondary).
+- `kamn-core` exposes the compatibility/runtime provider boundary through
+  `KolmeRuntimeCommitLiveProvider` and transport/finality contracts in
+  `crates/kamn-core/src/kolme_runtime_commit.rs`.
+- `kamn-kolme` owns the canonical live submit pipeline in
+  `crates/kamn-kolme/src/live_provider_pipeline.rs`.
+- Backend signer provenance remains fail-closed: runtime marker input and
+  backend `signer_public_key_hex` output must agree.
+
+## Ownership Map
+
+- CLI/runtime orchestration: `crates/kamn-node/src/runtime_kolme_live.rs`
+- Signer profile/key-source + managed-external contracts:
+  `crates/kamn-node/src/signer.rs`
+- Native direct message rendering: `crates/kamn-node/src/wire_payload.rs`
+- Runtime provider compatibility facade:
+  `crates/kamn-core/src/kolme_runtime_commit.rs`
+- Live-provider config/pipeline ownership:
+  `crates/kamn-kolme/src/live_provider_pipeline.rs`
+
+## Related References
+
+- Runtime client contracts: `docs/foundation/kolme-runtime-commit-client.md`
+- Node runtime CLI contracts: `docs/foundation/node-runtime-cli.md`
+- Local runbook contracts: `docs/planning/kolme-devnet-ops.md`


### PR DESCRIPTION
## Summary
Publishes a canonical KAMN↔Kolme runtime architecture artifact and adds deterministic docs-contract tests to prevent drift. README now links directly to the runtime-flow and ownership-map anchors for contributor entry.

Closes #2517

## Changes
- `docs/foundation/kolme-runtime-architecture.md`: new architecture doc with Mermaid runtime flow diagram, signer boundary contracts, and module ownership map.
- `crates/kamn-core/tests/kolme_runtime_architecture_docs.rs`: new docs-contract test suite for required architecture markers and README anchors.
- `README.md`: added explicit links to runtime-flow and ownership-map anchors.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-core --test kolme_runtime_architecture_docs` ❌
- Failure (pre-implementation):
  - `couldn't read .../docs/foundation/kolme-runtime-architecture.md: No such file or directory`

### 🟢 Green Phase
- `cargo test -p kamn-core --test kolme_runtime_architecture_docs` ✅ (`3 passed`)

### 🔁 Regression
- `bash scripts/ci/test_readme_contract.sh` ✅
- `cargo fmt --check` ✅
- `cargo clippy -p kamn-core -- -D warnings` ✅
- `cargo test -p kamn-core --test engineering_hardening_wave_docs` ✅
- `cargo test -p kamn-core --test live_network_wave_docs` ✅

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `kolme_runtime_architecture_docs` marker assertions | |
| Functional   | ✅     | architecture doc flow/ownership contract assertions | |
| Integration  | N/A    | docs-only task | No runtime behavior changed |
| Regression   | ✅     | README/docs drift contract checks | |
| Performance  | N/A    | docs/test-only change | No runtime or CI lane expansion |

## Risks & Rollback
- Risk: low; documentation/test-only change.
- Rollback: revert this PR commit.

## Documentation Updates
- `docs/foundation/kolme-runtime-architecture.md` (new)
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite executed
