### PR TITLE
feat: add fallback signer marker retirement matrix contracts

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -8,6 +8,16 @@ fn plan_contains_triadic_smoke_contract_commands() {
 }
 
 #[test]
+fn plan_contains_fallback_marker_retirement_matrix_contract() {
+    assert!(PLAN.contains("## Fallback Marker Retirement Matrix (Issue #2526)"));
+    assert!(PLAN.contains("fixtures/kolme_compatibility/fallback_signer_marker_matrix.json"));
+    assert!(PLAN.contains("kamn.kolme.fallback-signer-marker-matrix.v1"));
+    assert!(PLAN.contains("check_fallback_signer_marker_matrix_policy.py"));
+    assert!(PLAN.contains("bash scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh"));
+    assert!(PLAN.contains("remove-target"));
+}
+
+#[test]
 fn plan_contains_failover_sync_drill_lane_policy() {
     assert!(PLAN.contains("## Failover + Sync Drill Lane Policy"));
     assert!(PLAN.contains("select_failover_sync_drill_lane.sh"));

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -33,6 +33,21 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - `kolme.local.kamn.live_runtime_integration`
   - `kolme.local.heavy.validation_matrix`
 
+## Fallback Marker Retirement Matrix (Issue #2526)
+
+- Canonical fallback marker classification fixture:
+  - `fixtures/kolme_compatibility/fallback_signer_marker_matrix.json`
+- Matrix schema version:
+  - `kamn.kolme.fallback-signer-marker-matrix.v1`
+- Fail-closed matrix policy checker:
+  - `python3 scripts/kolme/check_fallback_signer_marker_matrix_policy.py --matrix-file fixtures/kolme_compatibility/fallback_signer_marker_matrix.json`
+- Matrix contract test:
+  - `bash scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh`
+- Classification contract:
+  - `keep` markers remain active fail-closed controls.
+  - `deprecate` markers remain compatibility-visible while retirement sequencing is active.
+  - `remove-target` markers track surfaces scheduled for removal in later tranches.
+
 ## Shared Wrapper Dispatcher Tranche (Issue #1827)
 
 - Shared Kolme contract-lane dispatcher:

--- a/fixtures/kolme_compatibility/fallback_signer_marker_matrix.json
+++ b/fixtures/kolme_compatibility/fallback_signer_marker_matrix.json
@@ -1,0 +1,85 @@
+{
+  "markers": [
+    {
+      "classification": "keep",
+      "marker_id": "fallback_signer_secret_present_violation",
+      "marker_value": "fallback_signer_secret_present_violation",
+      "owner": "security",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
+      "surface": "runner_guard",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "keep",
+      "marker_id": "runtime_commit_fallback_private_key_command_marker_detected",
+      "marker_value": "runtime_commit_fallback_private_key_command_marker_detected",
+      "owner": "backend",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py",
+      "surface": "policy_reason_code",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "keep",
+      "marker_id": "runtime_signer_fallback_private_key_present_violation",
+      "marker_value": "runtime_signer_fallback_private_key_present_violation",
+      "owner": "devops",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
+      "surface": "summary_field",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "deprecate",
+      "marker_id": "runtime_signer_fallback_private_key_allowed",
+      "marker_value": "runtime_signer_fallback_private_key_allowed",
+      "owner": "backend",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py",
+      "surface": "contracts_field",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "deprecate",
+      "marker_id": "runtime_signer_fallback_private_key_env",
+      "marker_value": "runtime_signer_fallback_private_key_env",
+      "owner": "devops",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
+      "surface": "summary_field",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "deprecate",
+      "marker_id": "runtime_signer_fallback_private_key_remediation",
+      "marker_value": "runtime_signer_fallback_private_key_remediation",
+      "owner": "devops",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
+      "surface": "summary_field",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "remove-target",
+      "marker_id": "fallback_env_literal",
+      "marker_value": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+      "owner": "security",
+      "parent_issue": "#2524",
+      "source_entry": "docs/planning/kolme-devnet-ops.md",
+      "surface": "docs_marker",
+      "target_issue": "#2526"
+    },
+    {
+      "classification": "remove-target",
+      "marker_id": "runtime_signer_fallback_private_key_command_marker_allowed",
+      "marker_value": "runtime_signer_fallback_private_key_command_marker_allowed",
+      "owner": "backend",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py",
+      "surface": "contracts_field",
+      "target_issue": "#2526"
+    }
+  ],
+  "schema_version": "kamn.kolme.fallback-signer-marker-matrix.v1"
+}

--- a/scripts/kolme/check_fallback_signer_marker_matrix_policy.py
+++ b/scripts/kolme/check_fallback_signer_marker_matrix_policy.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate fallback signer marker retirement matrix policy contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "kamn.kolme.fallback-signer-marker-matrix.v1"
+ALLOWED_CLASSIFICATIONS = {"keep", "deprecate", "remove-target"}
+CLASSIFICATION_RANK = {"keep": 0, "deprecate": 1, "remove-target": 2}
+ALLOWED_SURFACES = {
+    "runner_guard",
+    "policy_reason_code",
+    "summary_field",
+    "contracts_field",
+    "docs_marker",
+}
+ISSUE_PATTERN = re.compile(r"^#\d+$")
+REQUIRED_MARKER_IDS = {
+    "runtime_commit_fallback_private_key_command_marker_detected",
+    "runtime_signer_fallback_private_key_present_violation",
+    "fallback_signer_secret_present_violation",
+}
+REQUIRED_FIELDS = {
+    "marker_id",
+    "marker_value",
+    "surface",
+    "classification",
+    "owner",
+    "source_entry",
+    "parent_issue",
+    "target_issue",
+}
+
+
+def require_non_empty_string(payload: dict[str, Any], key: str, index: int) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"marker[{index}] {key} must be a non-empty string")
+    return value.strip()
+
+
+def validate_marker_record(marker: dict[str, Any], index: int) -> str:
+    unknown_fields = sorted(set(marker.keys()) - REQUIRED_FIELDS)
+    if unknown_fields:
+        raise ValueError(
+            f"marker[{index}] contains unknown fields: {', '.join(unknown_fields)}"
+        )
+    missing_fields = sorted(REQUIRED_FIELDS - set(marker.keys()))
+    if missing_fields:
+        raise ValueError(
+            f"marker[{index}] missing required fields: {', '.join(missing_fields)}"
+        )
+
+    marker_id = require_non_empty_string(marker, "marker_id", index)
+    marker_value = require_non_empty_string(marker, "marker_value", index)
+    surface = require_non_empty_string(marker, "surface", index)
+    classification = require_non_empty_string(marker, "classification", index)
+    owner = require_non_empty_string(marker, "owner", index)
+    source_entry = require_non_empty_string(marker, "source_entry", index)
+    parent_issue = require_non_empty_string(marker, "parent_issue", index)
+    target_issue = require_non_empty_string(marker, "target_issue", index)
+
+    if surface not in ALLOWED_SURFACES:
+        raise ValueError(
+            f"marker[{index}] surface must be one of {sorted(ALLOWED_SURFACES)}"
+        )
+    if classification not in ALLOWED_CLASSIFICATIONS:
+        raise ValueError(
+            f"marker[{index}] classification must be one of {sorted(ALLOWED_CLASSIFICATIONS)}"
+        )
+    if not owner.islower():
+        raise ValueError(f"marker[{index}] owner must use lowercase handle")
+    if "/" not in source_entry:
+        raise ValueError(
+            f"marker[{index}] source_entry must include a script/doc path segment"
+        )
+    if not ISSUE_PATTERN.match(parent_issue):
+        raise ValueError(f"marker[{index}] parent_issue must match #<id>")
+    if not ISSUE_PATTERN.match(target_issue):
+        raise ValueError(f"marker[{index}] target_issue must match #<id>")
+    if " " in marker_id:
+        raise ValueError(f"marker[{index}] marker_id must not contain spaces")
+    if not marker_value:
+        raise ValueError(f"marker[{index}] marker_value must not be empty")
+
+    return marker_id
+
+
+def validate_matrix(path: Path) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("matrix payload must be a JSON object")
+
+    schema_version = payload.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+
+    markers = payload.get("markers")
+    if not isinstance(markers, list) or not markers:
+        raise ValueError("markers must be a non-empty array")
+
+    seen: set[str] = set()
+    for index, marker in enumerate(markers):
+        if not isinstance(marker, dict):
+            raise ValueError(f"marker[{index}] must be an object")
+        marker_id = validate_marker_record(marker, index)
+        if marker_id in seen:
+            raise ValueError(f"marker_id must be unique: {marker_id}")
+        seen.add(marker_id)
+
+    missing_required = sorted(REQUIRED_MARKER_IDS - seen)
+    if missing_required:
+        raise ValueError(
+            f"required marker ids missing: {', '.join(missing_required)}"
+        )
+
+    classifications = {marker["classification"] for marker in markers}
+    if "keep" not in classifications:
+        raise ValueError("at least one keep marker classification is required")
+    if "remove-target" not in classifications:
+        raise ValueError("at least one remove-target marker classification is required")
+
+    expected_order = sorted(
+        markers,
+        key=lambda marker: (
+            CLASSIFICATION_RANK[marker["classification"]],
+            marker["marker_id"],
+        ),
+    )
+    if markers != expected_order:
+        raise ValueError(
+            "markers must be sorted by classification (keep->deprecate->remove-target) and then marker_id"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate fallback signer marker retirement matrix policy."
+    )
+    parser.add_argument(
+        "--matrix-file",
+        required=True,
+        help="Path to fallback signer marker matrix JSON fixture.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    matrix_path = Path(args.matrix_file)
+    if not matrix_path.is_file():
+        print(
+            f"fallback signer marker matrix policy failed: matrix file not found: {matrix_path}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        validate_matrix(matrix_path)
+    except ValueError as error:
+        print(f"fallback signer marker matrix policy failed: {error}", file=sys.stderr)
+        return 1
+
+    print("fallback signer marker matrix policy passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh
+++ b/scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/kolme/check_fallback_signer_marker_matrix_policy.py"
+MATRIX_FIXTURE="$ROOT_DIR/fixtures/kolme_compatibility/fallback_signer_marker_matrix.json"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "expected fallback signer marker matrix policy checker to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$MATRIX_FIXTURE" ]; then
+  echo "expected fallback signer marker matrix fixture to exist" >&2
+  exit 1
+fi
+
+if ! grep -q "check_fallback_signer_marker_matrix_policy.py" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops docs to reference fallback signer marker matrix policy checker" >&2
+  exit 1
+fi
+
+if ! grep -q "fallback_signer_marker_matrix.json" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops docs to reference fallback signer marker matrix fixture" >&2
+  exit 1
+fi
+
+python3 "$SCRIPT" \
+  --matrix-file "$MATRIX_FIXTURE"
+
+INVALID_CLASSIFICATION_MATRIX="$TMP_DIR/invalid-classification.json"
+cp "$MATRIX_FIXTURE" "$INVALID_CLASSIFICATION_MATRIX"
+python3 - "$INVALID_CLASSIFICATION_MATRIX" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["markers"][0]["classification"] = "legacy"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 "$SCRIPT" --matrix-file "$INVALID_CLASSIFICATION_MATRIX" >"$TMP_DIR/invalid-classification.out" 2>"$TMP_DIR/invalid-classification.err"; then
+  echo "expected fallback signer marker matrix policy checker to fail for invalid classification" >&2
+  cat "$TMP_DIR/invalid-classification.out" >&2 || true
+  cat "$TMP_DIR/invalid-classification.err" >&2 || true
+  exit 1
+fi
+
+MISSING_REQUIRED_MARKER_MATRIX="$TMP_DIR/missing-required-marker.json"
+cp "$MATRIX_FIXTURE" "$MISSING_REQUIRED_MARKER_MATRIX"
+python3 - "$MISSING_REQUIRED_MARKER_MATRIX" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["markers"] = [
+    marker
+    for marker in payload.get("markers", [])
+    if marker.get("marker_id") != "runtime_commit_fallback_private_key_command_marker_detected"
+]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 "$SCRIPT" --matrix-file "$MISSING_REQUIRED_MARKER_MATRIX" >"$TMP_DIR/missing-required.out" 2>"$TMP_DIR/missing-required.err"; then
+  echo "expected fallback signer marker matrix policy checker to fail when required marker is missing" >&2
+  cat "$TMP_DIR/missing-required.out" >&2 || true
+  cat "$TMP_DIR/missing-required.err" >&2 || true
+  exit 1
+fi
+
+echo "fallback signer marker matrix policy checker tests passed."


### PR DESCRIPTION
## Summary
Adds a deterministic fallback signer marker retirement matrix contract for Kolme real-node lanes. This introduces a canonical fixture, a fail-closed checker, and a contract test so fallback marker retirement sequencing is auditable and policy-enforced.

## Changes
- `fixtures/kolme_compatibility/fallback_signer_marker_matrix.json`: new canonical marker classification fixture (`keep`, `deprecate`, `remove-target`) with issue linkage.
- `scripts/kolme/check_fallback_signer_marker_matrix_policy.py`: new fail-closed policy checker for matrix schema/order/classification/required markers.
- `scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh`: new contract test covering valid matrix, invalid classification, and required-marker removal failures.
- `docs/planning/kolme-devnet-ops.md`: new fallback marker retirement matrix section with fixture/checker/test commands.
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`: new docs contract assertion for fallback matrix section markers.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: checker fails closed for invalid classifications and missing required fallback marker IDs.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test kolme_devnet_ops_docs` |
| Functional  | ✅     | `bash scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh` |
| Integration | ✅     | `bash scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh` (fixture/checker contract path) |
| Regression  | ✅     | invalid-classification + missing-required-marker fail-closed checks in script contract test |

Closes #2526
