### PR TITLE
refactor(kolme): migrate fallback summary markers to guard contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,8 @@ python3 scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py 
 # runtime_signing_profile=kolme-fork-secp256k1-v1
 # runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX
 # runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF
-# runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK
+# runtime_signer_fallback_guard_contract_version=v2
+# runtime_signer_fallback_guard_mode=reject_if_present
 # runtime_signer_fallback_private_key_present=false
 # runtime_signer_raw_private_key_present=false
 # runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -406,7 +406,8 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `runtime_signing_profile=kolme-fork-secp256k1-v1`
       - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
       - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
-      - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+      - `runtime_signer_fallback_guard_contract_version=v2`
+      - `runtime_signer_fallback_guard_mode=reject_if_present`
       - `runtime_signer_fallback_private_key_present=false`
       - `runtime_signer_raw_private_key_present=false`
       - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -160,15 +160,16 @@ Fallback private-key surfaces are forbidden in deployment preflight and runtime 
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
 - Required schema/reason markers:
-  - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
-  - `runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `runtime_signer_fallback_guard_contract_version=v2`
+  - `runtime_signer_fallback_guard_mode=reject_if_present`
   - `runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
   - `runtime_signer_fallback_private_key_present=false`
   - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
   - `runtime_signer_raw_private_key_present=false`
   - `runtime_signer_fallback_private_key_present_violation`
   - `runtime_signer_managed_external_raw_private_key_present_violation`
-  - `contracts.runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+  - `contracts.runtime_signer_fallback_guard_contract_version=v2`
+  - `contracts.runtime_signer_fallback_guard_mode=reject_if_present`
   - `contracts.runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
   - `contracts.runtime_signer_fallback_private_key_allowed=false`
   - `contracts.runtime_signer_managed_external_raw_private_key_allowed=false`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -469,8 +469,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signing_profile=kolme-fork-secp256k1-v1`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
-    - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
-    - `runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `runtime_signer_fallback_guard_contract_version=v2`
+    - `runtime_signer_fallback_guard_mode=reject_if_present`
     - `runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `runtime_signer_fallback_private_key_present=false`
     - `runtime_signer_raw_private_key_present=false`
@@ -529,7 +529,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_key_source`
     - `runtime_signer_private_key_env`
     - `runtime_signer_key_reference_env`
-    - `runtime_signer_fallback_private_key_env`
+    - `runtime_signer_fallback_guard_contract_version`
+    - `runtime_signer_fallback_guard_mode`
     - `runtime_signer_fallback_private_key_present`
     - `runtime_signer_raw_private_key_present`
   - real-node profile requires `runtime_commit_command_profile=real-node-non-synthetic-v1`, `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`, and `runtime_commit_command_profile_version=v1`; real-node checker fails closed on marker drift.
@@ -544,7 +545,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `runtime_signer_key_source=env-local`
     - `runtime_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX`
     - `runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF`
-    - `runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `runtime_signer_fallback_guard_contract_version=v2`
+    - `runtime_signer_fallback_guard_mode=reject_if_present`
     - `runtime_signer_fallback_private_key_present=false`
     - `runtime_signer_raw_private_key_present=false`
     - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
@@ -560,7 +562,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - `contracts.runtime_signer_quorum_linked_required=true`
     - `contracts.runtime_signer_quorum_threshold_required=true`
     - `contracts.runtime_signer_quorum_profile_membership_required=true`
-    - `contracts.runtime_signer_fallback_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK`
+    - `contracts.runtime_signer_fallback_guard_contract_version=v2`
+    - `contracts.runtime_signer_fallback_guard_mode=reject_if_present`
     - `contracts.runtime_signer_managed_external_raw_private_key_remediation=unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `contracts.runtime_signer_fallback_private_key_allowed=false`
     - `contracts.runtime_signer_managed_external_raw_private_key_allowed=false`

--- a/fixtures/kolme_compatibility/fallback_signer_marker_matrix.json
+++ b/fixtures/kolme_compatibility/fallback_signer_marker_matrix.json
@@ -8,7 +8,7 @@
       "parent_issue": "#2524",
       "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
       "surface": "runner_guard",
-      "target_issue": "#2526"
+      "target_issue": "#2530"
     },
     {
       "classification": "keep",
@@ -18,7 +18,27 @@
       "parent_issue": "#2524",
       "source_entry": "scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py",
       "surface": "policy_reason_code",
-      "target_issue": "#2526"
+      "target_issue": "#2530"
+    },
+    {
+      "classification": "keep",
+      "marker_id": "runtime_signer_fallback_guard_contract_version",
+      "marker_value": "runtime_signer_fallback_guard_contract_version",
+      "owner": "devops",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
+      "surface": "contracts_field",
+      "target_issue": "#2530"
+    },
+    {
+      "classification": "keep",
+      "marker_id": "runtime_signer_fallback_guard_mode",
+      "marker_value": "runtime_signer_fallback_guard_mode",
+      "owner": "devops",
+      "parent_issue": "#2524",
+      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
+      "surface": "summary_field",
+      "target_issue": "#2530"
     },
     {
       "classification": "keep",
@@ -28,7 +48,7 @@
       "parent_issue": "#2524",
       "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
       "surface": "summary_field",
-      "target_issue": "#2526"
+      "target_issue": "#2530"
     },
     {
       "classification": "deprecate",
@@ -38,27 +58,7 @@
       "parent_issue": "#2524",
       "source_entry": "scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py",
       "surface": "contracts_field",
-      "target_issue": "#2526"
-    },
-    {
-      "classification": "deprecate",
-      "marker_id": "runtime_signer_fallback_private_key_env",
-      "marker_value": "runtime_signer_fallback_private_key_env",
-      "owner": "devops",
-      "parent_issue": "#2524",
-      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
-      "surface": "summary_field",
-      "target_issue": "#2526"
-    },
-    {
-      "classification": "deprecate",
-      "marker_id": "runtime_signer_fallback_private_key_remediation",
-      "marker_value": "runtime_signer_fallback_private_key_remediation",
-      "owner": "devops",
-      "parent_issue": "#2524",
-      "source_entry": "scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh",
-      "surface": "summary_field",
-      "target_issue": "#2526"
+      "target_issue": "#2530"
     },
     {
       "classification": "remove-target",
@@ -68,7 +68,7 @@
       "parent_issue": "#2524",
       "source_entry": "docs/planning/kolme-devnet-ops.md",
       "surface": "docs_marker",
-      "target_issue": "#2526"
+      "target_issue": "#2530"
     },
     {
       "classification": "remove-target",
@@ -78,7 +78,7 @@
       "parent_issue": "#2524",
       "source_entry": "scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py",
       "surface": "contracts_field",
-      "target_issue": "#2526"
+      "target_issue": "#2530"
     }
   ],
   "schema_version": "kamn.kolme.fallback-signer-marker-matrix.v1"

--- a/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_integration_policy.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 
 RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+RUNTIME_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION = "v2"
+RUNTIME_SIGNER_FALLBACK_GUARD_MODE = "reject_if_present"
 RUNTIME_SIGNER_PROFILE_PRIMARY = "ops-primary"
 RUNTIME_SIGNER_PROFILE_SECONDARY = "ops-secondary"
 ALLOWED_RUNTIME_SIGNER_PROFILES = (
@@ -461,11 +463,28 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(runtime_commit_failure_diagnostic_hint, str) or not runtime_commit_failure_diagnostic_hint.strip():
         reason_codes.append("runtime_commit_failure_diagnostic_hint_missing")
 
-    runtime_signer_fallback_private_key_env = report.get("runtime_signer_fallback_private_key_env")
-    if not isinstance(runtime_signer_fallback_private_key_env, str) or not runtime_signer_fallback_private_key_env.strip():
-        reason_codes.append("runtime_signer_fallback_private_key_env_missing")
-    elif runtime_signer_fallback_private_key_env != RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
-        reason_codes.append("runtime_signer_fallback_private_key_env_mismatch")
+    runtime_signer_fallback_guard_contract_version = report.get(
+        "runtime_signer_fallback_guard_contract_version"
+    )
+    if (
+        not isinstance(runtime_signer_fallback_guard_contract_version, str)
+        or not runtime_signer_fallback_guard_contract_version.strip()
+    ):
+        reason_codes.append("runtime_signer_fallback_guard_contract_version_missing")
+    elif (
+        runtime_signer_fallback_guard_contract_version
+        != RUNTIME_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION
+    ):
+        reason_codes.append("runtime_signer_fallback_guard_contract_version_mismatch")
+
+    runtime_signer_fallback_guard_mode = report.get("runtime_signer_fallback_guard_mode")
+    if (
+        not isinstance(runtime_signer_fallback_guard_mode, str)
+        or not runtime_signer_fallback_guard_mode.strip()
+    ):
+        reason_codes.append("runtime_signer_fallback_guard_mode_missing")
+    elif runtime_signer_fallback_guard_mode != RUNTIME_SIGNER_FALLBACK_GUARD_MODE:
+        reason_codes.append("runtime_signer_fallback_guard_mode_mismatch")
 
     runtime_signer_fallback_private_key_present = report.get("runtime_signer_fallback_private_key_present")
     if not isinstance(runtime_signer_fallback_private_key_present, bool):
@@ -508,8 +527,15 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_commit_finality_fallback_endpoint_mismatch")
         if contracts.get("runtime_commit_failure_taxonomy_version") != "v1":
             reason_codes.append("runtime_commit_failure_taxonomy_contract_version_mismatch")
-        if contracts.get("runtime_signer_fallback_private_key_env") != RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
-            reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
+        if (
+            contracts.get("runtime_signer_fallback_guard_contract_version")
+            != RUNTIME_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION
+        ):
+            reason_codes.append(
+                "runtime_signer_fallback_guard_contract_version_contract_mismatch"
+            )
+        if contracts.get("runtime_signer_fallback_guard_mode") != RUNTIME_SIGNER_FALLBACK_GUARD_MODE:
+            reason_codes.append("runtime_signer_fallback_guard_mode_contract_mismatch")
         if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
             reason_codes.append("runtime_signer_fallback_private_key_allowed_contract_mismatch")
         if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:

--- a/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
+++ b/scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py
@@ -25,9 +25,8 @@ REAL_SIGNER_KEY_REF_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY"
 REAL_SIGNER_PUBLIC_KEY_ENV_PRIMARY = "KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX"
 REAL_SIGNER_PUBLIC_KEY_ENV_SECONDARY = "KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY"
 REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
-REAL_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION = (
-    f"unset {REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV}"
-)
+REAL_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION = "v2"
+REAL_SIGNER_FALLBACK_GUARD_MODE = "reject_if_present"
 REAL_SIGNER_KEY_SOURCE_CONTRACT_VERSION = "v1"
 ALLOWED_SIGNER_PROFILES = (
     REAL_SIGNER_PROFILE_PRIMARY,
@@ -261,22 +260,30 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     elif expected_signer_key_reference_env and runtime_signer_key_reference_env != expected_signer_key_reference_env:
         reason_codes.append("runtime_signer_key_reference_env_mismatch")
 
-    runtime_signer_fallback_private_key_env = report.get("runtime_signer_fallback_private_key_env")
-    if not isinstance(runtime_signer_fallback_private_key_env, str) or not runtime_signer_fallback_private_key_env.strip():
-        reason_codes.append("runtime_signer_fallback_private_key_env_missing")
-    elif runtime_signer_fallback_private_key_env != REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
-        reason_codes.append("runtime_signer_fallback_private_key_env_mismatch")
-
-    runtime_signer_fallback_private_key_remediation = report.get(
-        "runtime_signer_fallback_private_key_remediation"
+    runtime_signer_fallback_guard_contract_version = report.get(
+        "runtime_signer_fallback_guard_contract_version"
     )
     if (
-        not isinstance(runtime_signer_fallback_private_key_remediation, str)
-        or not runtime_signer_fallback_private_key_remediation.strip()
+        not isinstance(runtime_signer_fallback_guard_contract_version, str)
+        or not runtime_signer_fallback_guard_contract_version.strip()
     ):
-        reason_codes.append("runtime_signer_fallback_private_key_remediation_missing")
-    elif runtime_signer_fallback_private_key_remediation != REAL_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION:
-        reason_codes.append("runtime_signer_fallback_private_key_remediation_mismatch")
+        reason_codes.append("runtime_signer_fallback_guard_contract_version_missing")
+    elif (
+        runtime_signer_fallback_guard_contract_version
+        != REAL_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION
+    ):
+        reason_codes.append("runtime_signer_fallback_guard_contract_version_mismatch")
+
+    runtime_signer_fallback_guard_mode = report.get(
+        "runtime_signer_fallback_guard_mode"
+    )
+    if (
+        not isinstance(runtime_signer_fallback_guard_mode, str)
+        or not runtime_signer_fallback_guard_mode.strip()
+    ):
+        reason_codes.append("runtime_signer_fallback_guard_mode_missing")
+    elif runtime_signer_fallback_guard_mode != REAL_SIGNER_FALLBACK_GUARD_MODE:
+        reason_codes.append("runtime_signer_fallback_guard_mode_mismatch")
 
     expected_managed_external_raw_private_key_remediation = ""
     if expected_signer_private_key_env and expected_signer_key_reference_env:
@@ -614,13 +621,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             reason_codes.append("runtime_signer_private_key_env_contract_mismatch")
         if expected_signer_key_reference_env and contracts.get("runtime_signer_key_reference_env") != expected_signer_key_reference_env:
             reason_codes.append("runtime_signer_key_reference_env_contract_mismatch")
-        if contracts.get("runtime_signer_fallback_private_key_env") != REAL_SIGNER_FALLBACK_PRIVATE_KEY_ENV:
-            reason_codes.append("runtime_signer_fallback_private_key_env_contract_mismatch")
         if (
-            contracts.get("runtime_signer_fallback_private_key_remediation")
-            != REAL_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION
+            contracts.get("runtime_signer_fallback_guard_contract_version")
+            != REAL_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION
         ):
-            reason_codes.append("runtime_signer_fallback_private_key_remediation_contract_mismatch")
+            reason_codes.append(
+                "runtime_signer_fallback_guard_contract_version_contract_mismatch"
+            )
+        if (
+            contracts.get("runtime_signer_fallback_guard_mode")
+            != REAL_SIGNER_FALLBACK_GUARD_MODE
+        ):
+            reason_codes.append("runtime_signer_fallback_guard_mode_contract_mismatch")
         if (
             expected_managed_external_raw_private_key_remediation
             and contracts.get("runtime_signer_managed_external_raw_private_key_remediation")

--- a/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py
@@ -16,7 +16,8 @@ RUNNER = ROOT_DIR / "scripts/kolme/run_local_kamn_live_runtime_integration_lane.
 CHECKER = ROOT_DIR / "scripts/kolme/check_local_kamn_live_runtime_integration_policy.py"
 DOC_FILE = ROOT_DIR / "docs/planning/kolme-devnet-ops.md"
 README_FILE = ROOT_DIR / "README.md"
-FALLBACK_SIGNER_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+FALLBACK_SIGNER_GUARD_CONTRACT_VERSION = "v2"
+FALLBACK_SIGNER_GUARD_MODE = "reject_if_present"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -175,8 +176,17 @@ def main() -> int:
         if not isinstance(diagnostic_hint, str) or not diagnostic_hint.strip():
             print("expected runtime commit failure diagnostic hint marker in summary", file=sys.stderr)
             return 1
-        if summary_payload.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
-            print("expected fallback signer private key env marker in summary", file=sys.stderr)
+        if (
+            summary_payload.get("runtime_signer_fallback_guard_contract_version")
+            != FALLBACK_SIGNER_GUARD_CONTRACT_VERSION
+        ):
+            print(
+                "expected fallback signer guard contract version marker in summary",
+                file=sys.stderr,
+            )
+            return 1
+        if summary_payload.get("runtime_signer_fallback_guard_mode") != FALLBACK_SIGNER_GUARD_MODE:
+            print("expected fallback signer guard mode marker in summary", file=sys.stderr)
             return 1
         if summary_payload.get("runtime_signer_fallback_private_key_present") is not False:
             print("expected fallback signer private key presence marker false in dry-run summary", file=sys.stderr)
@@ -225,8 +235,17 @@ def main() -> int:
         if not isinstance(contracts_payload, dict):
             print("expected contracts object in dry-run summary", file=sys.stderr)
             return 1
-        if contracts_payload.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
-            print("expected contracts fallback signer private key env marker in summary", file=sys.stderr)
+        if (
+            contracts_payload.get("runtime_signer_fallback_guard_contract_version")
+            != FALLBACK_SIGNER_GUARD_CONTRACT_VERSION
+        ):
+            print(
+                "expected contracts fallback signer guard contract version marker in summary",
+                file=sys.stderr,
+            )
+            return 1
+        if contracts_payload.get("runtime_signer_fallback_guard_mode") != FALLBACK_SIGNER_GUARD_MODE:
+            print("expected contracts fallback signer guard mode marker in summary", file=sys.stderr)
             return 1
         if contracts_payload.get("runtime_signer_fallback_private_key_allowed") is not False:
             print("expected contracts fallback signer private key allowed=false marker in summary", file=sys.stderr)
@@ -809,8 +828,14 @@ def main() -> int:
         print("expected Kolme devnet ops doc to include runtime finality contract composition regression marker", file=sys.stderr)
         return 1
     # Regression: #2302
-    if "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" not in doc_text:
-        print("expected Kolme devnet ops doc to include fallback signer private key env marker", file=sys.stderr)
+    if "runtime_signer_fallback_guard_contract_version=v2" not in doc_text:
+        print(
+            "expected Kolme devnet ops doc to include fallback signer guard contract version marker",
+            file=sys.stderr,
+        )
+        return 1
+    if "runtime_signer_fallback_guard_mode=reject_if_present" not in doc_text:
+        print("expected Kolme devnet ops doc to include fallback signer guard mode marker", file=sys.stderr)
         return 1
     if "runtime_signer_fallback_private_key_present=false" not in doc_text:
         print("expected Kolme devnet ops doc to include fallback signer private key presence marker", file=sys.stderr)
@@ -884,8 +909,11 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    if "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" not in readme_text:
-        print("expected README to include fallback signer private key env marker", file=sys.stderr)
+    if "runtime_signer_fallback_guard_contract_version=v2" not in readme_text:
+        print("expected README to include fallback signer guard contract version marker", file=sys.stderr)
+        return 1
+    if "runtime_signer_fallback_guard_mode=reject_if_present" not in readme_text:
+        print("expected README to include fallback signer guard mode marker", file=sys.stderr)
         return 1
     if "runtime_signer_fallback_private_key_present=false" not in readme_text:
         print("expected README to include fallback signer private key presence marker", file=sys.stderr)

--- a/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
+++ b/scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py
@@ -25,7 +25,8 @@ SIGNER_KEY_REF_ENV_BY_PROFILE = {
     "ops-primary": "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
     "ops-secondary": "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY",
 }
-FALLBACK_SIGNER_PRIVATE_KEY_ENV = "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+FALLBACK_SIGNER_GUARD_CONTRACT_VERSION = "v2"
+FALLBACK_SIGNER_GUARD_MODE = "reject_if_present"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -105,9 +106,6 @@ def main() -> int:
     expected_signer_key_source = "env-local"
     expected_signer_private_key_env = SIGNER_PRIVATE_KEY_ENV_BY_PROFILE[expected_signer_profile]
     expected_signer_key_reference_env = SIGNER_KEY_REF_ENV_BY_PROFILE[expected_signer_profile]
-    expected_fallback_signer_private_key_remediation = (
-        f"unset {FALLBACK_SIGNER_PRIVATE_KEY_ENV}"
-    )
     expected_managed_external_raw_private_key_remediation = (
         f"unset {expected_signer_private_key_env}; set {expected_signer_key_reference_env}"
     )
@@ -298,17 +296,17 @@ def main() -> int:
     if summary.get("runtime_signer_key_reference_env") != expected_signer_key_reference_env:
         print("expected signer key reference env marker in contract-lane summary", file=sys.stderr)
         return 1
-    if summary.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
-        print("expected fallback signer private key env marker in contract-lane summary", file=sys.stderr)
-        return 1
     if (
-        summary.get("runtime_signer_fallback_private_key_remediation")
-        != expected_fallback_signer_private_key_remediation
+        summary.get("runtime_signer_fallback_guard_contract_version")
+        != FALLBACK_SIGNER_GUARD_CONTRACT_VERSION
     ):
         print(
-            "expected fallback signer private key remediation marker in contract-lane summary",
+            "expected fallback signer guard contract version marker in contract-lane summary",
             file=sys.stderr,
         )
+        return 1
+    if summary.get("runtime_signer_fallback_guard_mode") != FALLBACK_SIGNER_GUARD_MODE:
+        print("expected fallback signer guard mode marker in contract-lane summary", file=sys.stderr)
         return 1
     if (
         summary.get("runtime_signer_managed_external_raw_private_key_remediation")
@@ -415,17 +413,17 @@ def main() -> int:
     if contracts.get("runtime_signer_key_reference_env") != expected_signer_key_reference_env:
         print("expected contracts signer key reference env marker in contract-lane summary", file=sys.stderr)
         return 1
-    if contracts.get("runtime_signer_fallback_private_key_env") != FALLBACK_SIGNER_PRIVATE_KEY_ENV:
-        print("expected contracts fallback signer private key env marker in contract-lane summary", file=sys.stderr)
-        return 1
     if (
-        contracts.get("runtime_signer_fallback_private_key_remediation")
-        != expected_fallback_signer_private_key_remediation
+        contracts.get("runtime_signer_fallback_guard_contract_version")
+        != FALLBACK_SIGNER_GUARD_CONTRACT_VERSION
     ):
         print(
-            "expected contracts fallback signer private key remediation marker in contract-lane summary",
+            "expected contracts fallback signer guard contract version marker in contract-lane summary",
             file=sys.stderr,
         )
+        return 1
+    if contracts.get("runtime_signer_fallback_guard_mode") != FALLBACK_SIGNER_GUARD_MODE:
+        print("expected contracts fallback signer guard mode marker in contract-lane summary", file=sys.stderr)
         return 1
     if (
         contracts.get("runtime_signer_managed_external_raw_private_key_remediation")
@@ -1543,7 +1541,8 @@ def main() -> int:
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
-        "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "runtime_signer_fallback_guard_contract_version=v2",
+        "runtime_signer_fallback_guard_mode=reject_if_present",
         "runtime_signer_fallback_private_key_present=false",
         "runtime_signer_raw_private_key_present=false",
         "runtime_signer_fallback_private_key_present_violation",
@@ -1585,7 +1584,8 @@ def main() -> int:
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
-        "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "runtime_signer_fallback_guard_contract_version=v2",
+        "runtime_signer_fallback_guard_mode=reject_if_present",
         "runtime_signer_fallback_private_key_present=false",
         "runtime_signer_raw_private_key_present=false",
         "runtime_signer_fallback_private_key_present_violation",
@@ -1627,7 +1627,8 @@ def main() -> int:
         "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1",
         "runtime_signer_attestation_bundle",
         "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF",
-        "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        "runtime_signer_fallback_guard_contract_version=v2",
+        "runtime_signer_fallback_guard_mode=reject_if_present",
         "runtime_signer_fallback_private_key_present=false",
         "runtime_signer_raw_private_key_present=false",
         "runtime_signer_fallback_private_key_present_violation",

--- a/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
+++ b/scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh
@@ -42,7 +42,8 @@ RUNTIME_SIGNER_PRIVATE_KEY_ENV=""
 RUNTIME_SIGNER_KEY_REF_ENV=""
 RUNTIME_SIGNER_PUBLIC_KEY_ENV=""
 RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV="KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
-RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION="unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+RUNTIME_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION="v2"
+RUNTIME_SIGNER_FALLBACK_GUARD_MODE="reject_if_present"
 RUNTIME_SIGNER_MANAGED_EXTERNAL_RAW_PRIVATE_KEY_REMEDIATION=""
 RUNTIME_SIGNER_PROFILE_OVERRIDE=""
 RUNTIME_SIGNER_KEY_SOURCE_OVERRIDE=""
@@ -819,7 +820,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_ENV" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$RUNTIME_SIGNING_PROFILE" "$RUNTIME_SIGNER_FALLBACK_PRIVATE_KEY_REMEDIATION" "$RUNTIME_SIGNER_MANAGED_EXTERNAL_RAW_PRIVATE_KEY_REMEDIATION" <<'PY'
+python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$BASE_URL" "$FORK_CHAIN_VERSION" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$runtime_commit_command" "$RUNTIME_COMMIT_OUTPUT_FILE" "$RUNTIME_COMMIT_LIVE_SUMMARY" "$RUNTIME_COMMIT_LIVE_POLICY_REPORT" "$RUNTIME_COMMIT_FINALITY_COMMAND" "$RUNTIME_COMMIT_FINALITY_OUTPUT_FILE" "$RUNTIME_COMMIT_FINALITY_MAX_SECONDS" "$BOOTSTRAP_REPORT" "$LOCALHOST_SIGNED_REPORT" "$CONFORMANCE_REPORT" "$bootstrap_reason_code" "$localhost_signed_reason_code" "$conformance_reason_code" "$runtime_commit_reason_code" "$runtime_commit_policy_reason_code" "$RUNTIME_PROFILE" "$CHECK_FILE" "$RUNTIME_PROVIDER_CLIENT_CONTRACT" "$runtime_commit_command_profile" "$runtime_commit_policy_command_profile" "$runtime_commit_command_profile_version" "$RUNTIME_SIGNER_PROFILE_SELECTOR_ENV" "$RUNTIME_SIGNER_PROFILE" "$RUNTIME_SIGNER_PREVIOUS_PROFILE" "$RUNTIME_SIGNER_FAILOVER_ACTIVE" "$RUNTIME_SIGNER_ROTATION_EPOCH" "$RUNTIME_SIGNER_PREVIOUS_ROTATION_EPOCH" "$RUNTIME_SIGNER_KEY_SOURCE_CONTRACT_VERSION" "$RUNTIME_SIGNER_KEY_SOURCE" "$RUNTIME_SIGNER_PRIVATE_KEY_ENV" "$RUNTIME_SIGNER_KEY_REF_ENV" "$RUNTIME_SIGNER_FALLBACK_GUARD_CONTRACT_VERSION" "$runtime_signer_fallback_private_key_present" "$runtime_signer_raw_private_key_present" "$RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION" "$RUNTIME_SIGNING_PROFILE" "$RUNTIME_SIGNER_FALLBACK_GUARD_MODE" "$RUNTIME_SIGNER_MANAGED_EXTERNAL_RAW_PRIVATE_KEY_REMEDIATION" <<'PY'
 from __future__ import annotations
 
 import json
@@ -869,12 +870,12 @@ runtime_signer_key_source_contract_version = sys.argv[40]
 runtime_signer_key_source = sys.argv[41]
 runtime_signer_private_key_env = sys.argv[42]
 runtime_signer_key_reference_env = sys.argv[43]
-runtime_signer_fallback_private_key_env = sys.argv[44]
+runtime_signer_fallback_guard_contract_version = sys.argv[44]
 runtime_signer_fallback_private_key_present = sys.argv[45] == "true"
 runtime_signer_raw_private_key_present = sys.argv[46] == "true"
 runtime_signer_attestation_schema_version = sys.argv[47]
 runtime_signing_profile = sys.argv[48]
-runtime_signer_fallback_private_key_remediation = sys.argv[49]
+runtime_signer_fallback_guard_mode = sys.argv[49]
 runtime_signer_managed_external_raw_private_key_remediation = sys.argv[50]
 
 checks = []
@@ -1070,8 +1071,8 @@ summary = {
     "runtime_signer_key_source": runtime_signer_key_source,
     "runtime_signer_private_key_env": runtime_signer_private_key_env,
     "runtime_signer_key_reference_env": runtime_signer_key_reference_env,
-    "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
-    "runtime_signer_fallback_private_key_remediation": runtime_signer_fallback_private_key_remediation,
+    "runtime_signer_fallback_guard_contract_version": runtime_signer_fallback_guard_contract_version,
+    "runtime_signer_fallback_guard_mode": runtime_signer_fallback_guard_mode,
     "runtime_signer_managed_external_raw_private_key_remediation": runtime_signer_managed_external_raw_private_key_remediation,
     "runtime_signer_fallback_private_key_present": runtime_signer_fallback_private_key_present,
     "runtime_signer_raw_private_key_present": runtime_signer_raw_private_key_present,
@@ -1112,8 +1113,8 @@ summary = {
         "runtime_signer_key_source": runtime_signer_key_source,
         "runtime_signer_private_key_env": runtime_signer_private_key_env,
         "runtime_signer_key_reference_env": runtime_signer_key_reference_env,
-        "runtime_signer_fallback_private_key_env": runtime_signer_fallback_private_key_env,
-        "runtime_signer_fallback_private_key_remediation": runtime_signer_fallback_private_key_remediation,
+        "runtime_signer_fallback_guard_contract_version": runtime_signer_fallback_guard_contract_version,
+        "runtime_signer_fallback_guard_mode": runtime_signer_fallback_guard_mode,
         "runtime_signer_managed_external_raw_private_key_remediation": runtime_signer_managed_external_raw_private_key_remediation,
         "runtime_signer_fallback_private_key_allowed": False,
         "runtime_signer_fallback_private_key_command_marker_allowed": False,

--- a/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
+++ b/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh
@@ -90,8 +90,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
   "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
   "runtime_signer_key_reference_env": "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
-  "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
-  "runtime_signer_fallback_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_guard_contract_version": "v2",
+  "runtime_signer_fallback_guard_mode": "reject_if_present",
   "runtime_signer_managed_external_raw_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF",
   "runtime_signer_fallback_private_key_present": false,
   "runtime_signer_raw_private_key_present": false,
@@ -140,8 +140,8 @@ cat >"$TMP_REPORT_OK" <<'JSON'
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
     "runtime_signer_key_reference_env": "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
-    "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
-    "runtime_signer_fallback_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_guard_contract_version": "v2",
+    "runtime_signer_fallback_guard_mode": "reject_if_present",
     "runtime_signer_managed_external_raw_private_key_remediation": "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF",
     "runtime_signer_fallback_private_key_allowed": false,
     "runtime_signer_fallback_private_key_command_marker_allowed": false,
@@ -423,10 +423,10 @@ import pathlib
 import sys
 
 report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-report["runtime_signer_fallback_private_key_remediation"] = "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+report["runtime_signer_fallback_guard_mode"] = "allow_if_present"
 contracts = report.get("contracts", {})
 if isinstance(contracts, dict):
-    contracts["runtime_signer_fallback_private_key_remediation"] = "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"
+    contracts["runtime_signer_fallback_guard_mode"] = "allow_if_present"
 pathlib.Path(sys.argv[2]).write_text(
     json.dumps(report, sort_keys=True, indent=2) + "\n",
     encoding="utf-8",
@@ -444,17 +444,17 @@ fallback_remediation_drift_exit_code=$?
 set -e
 
 if [ "$fallback_remediation_drift_exit_code" -eq 0 ]; then
-  echo "expected fallback signer remediation marker drift proof to fail closed" >&2
+  echo "expected fallback signer guard-mode marker drift proof to fail closed" >&2
   exit 1
 fi
 
-if ! grep -q "runtime_signer_fallback_private_key_remediation_mismatch" "$TMP_ERR"; then
-  echo "expected fallback signer remediation marker mismatch reason for policy failure" >&2
+if ! grep -q "runtime_signer_fallback_guard_mode_mismatch" "$TMP_ERR"; then
+  echo "expected fallback signer guard-mode marker mismatch reason for policy failure" >&2
   exit 1
 fi
 
-if ! grep -q "runtime_signer_fallback_private_key_remediation_contract_mismatch" "$TMP_ERR"; then
-  echo "expected fallback signer remediation contract marker mismatch reason for policy failure" >&2
+if ! grep -q "runtime_signer_fallback_guard_mode_contract_mismatch" "$TMP_ERR"; then
+  echo "expected fallback signer guard-mode contract marker mismatch reason for policy failure" >&2
   exit 1
 fi
 
@@ -1020,7 +1020,8 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
   "runtime_signer_key_source_contract_version": "v1",
   "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
-  "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_guard_contract_version": "v2",
+  "runtime_signer_fallback_guard_mode": "reject_if_present",
   "runtime_signer_fallback_private_key_present": false,
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
@@ -1045,7 +1046,8 @@ cat >"$TMP_REPORT_SYNTHETIC" <<'JSON'
     "runtime_signer_key_source_contract_version": "v1",
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
-    "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_guard_contract_version": "v2",
+    "runtime_signer_fallback_guard_mode": "reject_if_present",
     "runtime_signer_fallback_private_key_allowed": false,
     "runtime_signer_fallback_private_key_command_marker_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
@@ -1186,7 +1188,8 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
   "runtime_signer_key_source_contract_version": "v1",
   "runtime_signer_key_source": "env-local",
   "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
-  "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+  "runtime_signer_fallback_guard_contract_version": "v2",
+  "runtime_signer_fallback_guard_mode": "reject_if_present",
   "runtime_signer_fallback_private_key_present": false,
   "runtime_commit_command_profile": "real-node-non-synthetic-v1",
   "runtime_commit_policy_command_profile": "real-node-non-synthetic-v1",
@@ -1211,7 +1214,8 @@ cat >"$TMP_REPORT_INMEMORY" <<'JSON'
     "runtime_signer_key_source_contract_version": "v1",
     "runtime_signer_key_source": "env-local",
     "runtime_signer_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
-    "runtime_signer_fallback_private_key_env": "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+    "runtime_signer_fallback_guard_contract_version": "v2",
+    "runtime_signer_fallback_guard_mode": "reject_if_present",
     "runtime_signer_fallback_private_key_allowed": false,
     "runtime_signer_fallback_private_key_command_marker_allowed": false,
     "runtime_commit_endpoint": "/broadcast/runtime-commit",
@@ -1395,10 +1399,10 @@ if summary.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
     raise SystemExit("expected runtime signing profile marker in runner-generated summary")
 if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX":
     raise SystemExit("expected signer private key env marker in runner-generated summary")
-if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key env marker in runner-generated summary")
-if summary.get("runtime_signer_fallback_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key remediation marker in runner-generated summary")
+if summary.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected fallback signer guard contract version marker in runner-generated summary")
+if summary.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected fallback signer guard mode marker in runner-generated summary")
 if summary.get("runtime_signer_managed_external_raw_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX; set KAMN_KOLME_LIVE_SIGNER_KEY_REF":
     raise SystemExit("expected managed-external signer raw private key remediation marker in runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
@@ -1463,18 +1467,18 @@ if contracts.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
     raise SystemExit("expected contracts runtime signing profile marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY":
     raise SystemExit("expected contracts secondary signer private key env marker in secondary runner-generated summary")
-if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key env marker in secondary runner-generated summary")
-if summary.get("runtime_signer_fallback_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key remediation marker in secondary runner-generated summary")
+if summary.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected fallback signer guard contract version marker in secondary runner-generated summary")
+if summary.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected fallback signer guard mode marker in secondary runner-generated summary")
 if summary.get("runtime_signer_managed_external_raw_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
     raise SystemExit("expected managed-external signer raw private key remediation marker in secondary runner-generated summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected fallback signer private key presence marker false in secondary runner-generated summary")
-if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected contracts fallback signer private key env marker in secondary runner-generated summary")
-if contracts.get("runtime_signer_fallback_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected contracts fallback signer private key remediation marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected contracts fallback signer guard contract version marker in secondary runner-generated summary")
+if contracts.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected contracts fallback signer guard mode marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_managed_external_raw_private_key_remediation") != "unset KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY; set KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
     raise SystemExit("expected contracts managed-external signer raw private key remediation marker in secondary runner-generated summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh
@@ -149,7 +149,8 @@ required_coverage_markers=(
   "runtime_signer_raw_private_key_present=false"
   "runtime_commit_failure_taxonomy_mismatch:finality.timeout"
   "runtime_profile_run_mode_mismatch"
-  "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+  "runtime_signer_fallback_guard_contract_version=v2"
+  "runtime_signer_fallback_guard_mode=reject_if_present"
   "runtime_signer_fallback_private_key_present=false"
   "Regression: #1489"
   "Regression: #1971"
@@ -213,8 +214,13 @@ if ! grep -q "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" 
   exit 1
 fi
 
-if ! grep -q "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$DOC_FILE"; then
-  echo "expected Kolme devnet ops doc to include fallback signer private key env marker" >&2
+if ! grep -q "runtime_signer_fallback_guard_contract_version=v2" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fallback signer guard contract version marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_guard_mode=reject_if_present" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to include fallback signer guard mode marker" >&2
   exit 1
 fi
 
@@ -288,8 +294,13 @@ if ! grep -q "run_local_runtime_commit_live_finality_evidence_contract_lane.sh" 
   exit 1
 fi
 
-if ! grep -q "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$README_FILE"; then
-  echo "expected README to include fallback signer private key env marker" >&2
+if ! grep -q "runtime_signer_fallback_guard_contract_version=v2" "$README_FILE"; then
+  echo "expected README to include fallback signer guard contract version marker" >&2
+  exit 1
+fi
+
+if ! grep -q "runtime_signer_fallback_guard_mode=reject_if_present" "$README_FILE"; then
+  echo "expected README to include fallback signer guard mode marker" >&2
   exit 1
 fi
 
@@ -351,8 +362,10 @@ if summary.get("reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected dry_run_no_commands_executed reason code in contract-lane summary")
 if summary.get("runtime_profile") != "real-node":
     raise SystemExit("expected runtime_profile=real-node in contract-lane summary")
-if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key env marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected fallback signer guard contract version marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected fallback signer guard mode marker in contract-lane summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected fallback signer private key presence marker false in contract-lane summary")
 if summary.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
@@ -398,8 +411,10 @@ if summary.get("ci_fast_gate_eligible") is not False:
 contracts = summary.get("contracts", {})
 if contracts.get("ci_fast_gate_scope") != "local-only":
     raise SystemExit("expected local-only fast-gate scope contract marker in contract-lane summary")
-if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected contracts fallback signer private key env marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected contracts fallback signer guard contract version marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected contracts fallback signer guard mode marker in contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:

--- a/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh
@@ -263,8 +263,10 @@ import sys
 summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 if summary.get("reason_code") != "runtime_signer_fallback_private_key_present_violation":
     raise SystemExit("expected fallback signer private key violation reason code in real-node profile run summary")
-if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key env marker in real-node profile run summary")
+if summary.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected fallback signer guard contract version marker in real-node profile run summary")
+if summary.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected fallback signer guard mode marker in real-node profile run summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not True:
     raise SystemExit("expected fallback signer private key presence marker true in real-node profile run summary")
 checks = summary.get("checks")

--- a/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh
@@ -84,7 +84,8 @@ required_coverage_markers=(
   "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
   "runtime_signer_attestation_bundle"
   "runtime_signer_key_reference_env=KAMN_KOLME_LIVE_SIGNER_KEY_REF"
-  "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK"
+  "runtime_signer_fallback_guard_contract_version=v2"
+  "runtime_signer_fallback_guard_mode=reject_if_present"
   "runtime_signer_fallback_private_key_present=false"
   "runtime_signer_raw_private_key_present=false"
   "runtime_signer_fallback_private_key_present_violation"
@@ -177,8 +178,12 @@ for docs_file in "$DOC_FILE" "$CI_DOC_FILE" "$README_FILE"; do
     echo "expected docs parity to include signer key reference env marker in $docs_file" >&2
     exit 1
   fi
-  if ! grep -q "runtime_signer_fallback_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK" "$docs_file"; then
-    echo "expected docs parity to include fallback signer private key env marker in $docs_file" >&2
+  if ! grep -q "runtime_signer_fallback_guard_contract_version=v2" "$docs_file"; then
+    echo "expected docs parity to include fallback signer guard contract version marker in $docs_file" >&2
+    exit 1
+  fi
+  if ! grep -q "runtime_signer_fallback_guard_mode=reject_if_present" "$docs_file"; then
+    echo "expected docs parity to include fallback signer guard mode marker in $docs_file" >&2
     exit 1
   fi
   if ! grep -q "runtime_signer_fallback_private_key_present=false" "$docs_file"; then
@@ -330,8 +335,10 @@ if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIV
     raise SystemExit("expected signer private key env marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
     raise SystemExit("expected signer key reference env marker in real-node profile contract-lane summary")
-if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected fallback signer private key env marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected fallback signer guard contract version marker in real-node profile contract-lane summary")
+if summary.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected fallback signer guard mode marker in real-node profile contract-lane summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected fallback signer private key presence marker false in real-node profile contract-lane summary")
 if summary.get("runtime_signer_raw_private_key_present") is not False:
@@ -388,8 +395,10 @@ if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PR
     raise SystemExit("expected contracts signer private key env marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF":
     raise SystemExit("expected contracts signer key reference env marker in real-node profile contract-lane summary")
-if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected contracts fallback signer private key env marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected contracts fallback signer guard contract version marker in real-node profile contract-lane summary")
+if contracts.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected contracts fallback signer guard mode marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts fallback signer private key allowed=false marker in real-node profile contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:
@@ -455,8 +464,10 @@ if summary.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIV
     raise SystemExit("expected secondary signer private key env marker in contract-lane summary")
 if summary.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
     raise SystemExit("expected secondary signer key reference env marker in contract-lane summary")
-if summary.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected secondary signer fallback private key env marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected secondary signer fallback guard contract version marker in contract-lane summary")
+if summary.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected secondary signer fallback guard mode marker in contract-lane summary")
 if summary.get("runtime_signer_fallback_private_key_present") is not False:
     raise SystemExit("expected secondary signer fallback private key presence marker false in contract-lane summary")
 if summary.get("runtime_signer_raw_private_key_present") is not False:
@@ -486,8 +497,10 @@ if contracts.get("runtime_signer_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PR
     raise SystemExit("expected contracts secondary signer private key env marker in contract-lane summary")
 if contracts.get("runtime_signer_key_reference_env") != "KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY":
     raise SystemExit("expected contracts secondary signer key reference env marker in contract-lane summary")
-if contracts.get("runtime_signer_fallback_private_key_env") != "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK":
-    raise SystemExit("expected contracts secondary signer fallback private key env marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_guard_contract_version") != "v2":
+    raise SystemExit("expected contracts secondary signer fallback guard contract version marker in contract-lane summary")
+if contracts.get("runtime_signer_fallback_guard_mode") != "reject_if_present":
+    raise SystemExit("expected contracts secondary signer fallback guard mode marker in contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_allowed") is not False:
     raise SystemExit("expected contracts secondary signer fallback private key allowed=false marker in contract-lane summary")
 if contracts.get("runtime_signer_fallback_private_key_command_marker_allowed") is not False:


### PR DESCRIPTION
## Summary
Migrates deprecated fallback summary marker requirements to compact guard markers for local KAMN live runtime integration policy surfaces. This keeps fallback handling fail-closed while shrinking summary/contracts marker surface area.

Closes #2530
Refs #2529
Refs #2528

## Changes
- `scripts/kolme/run_local_kamn_live_runtime_integration_lane_impl.sh`: replaced `runtime_signer_fallback_private_key_env`/`runtime_signer_fallback_private_key_remediation` summary+contracts fields with `runtime_signer_fallback_guard_contract_version` and `runtime_signer_fallback_guard_mode`.
- `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`: migrated required summary/contracts checks and reason codes to guard markers.
- `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`: migrated required summary/contracts checks and reason codes to guard markers.
- `scripts/kolme/contracts/local_kamn_live_runtime_integration_contract_lane.py`: updated summary/contracts assertions and docs parity checks for guard markers.
- `scripts/kolme/contracts/local_kamn_live_runtime_real_node_profile_contract_lane.py`: updated summary/contracts assertions and docs parity checks for guard markers.
- `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`: updated fixtures/assertions to the new guard marker schema and maintained fail-closed drift proof.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`: updated coverage/doc/summary/contracts marker checks.
- `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`: updated coverage/doc/summary/contracts marker checks.
- `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`: updated run-mode fallback guard summary checks.
- `fixtures/kolme_compatibility/fallback_signer_marker_matrix.json`: migrated matrix entries to guard markers and retargeted tranche work to `#2530`.
- `docs/planning/kolme-devnet-ops.md`, `docs/foundation/upgrade-rollback-runbook.md`, `docs/ci/strategy.md`, `README.md`: replaced deprecated fallback summary markers with guard markers in documented contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`

Failing output:
`expected fallback signer guard-mode marker mismatch reason for policy failure`

### 🟢 Green Phase
Commands and pass output:
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
  - `local KAMN live runtime real-node profile policy checker tests passed.`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
  - `local KAMN live runtime integration contract lane tests passed.`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
  - `local KAMN live runtime real-node profile contract lane tests passed.`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
  - `local KAMN live runtime integration real-node profile tests passed.`
- `bash scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh`
  - `fallback signer marker matrix policy passed.`
  - `fallback signer marker matrix policy checker tests passed.`

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo test -p kamn-core --test upgrade_rollback_runbook_docs`

Result: pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh` fixture/assertion updates for guard marker validation | |
| Functional   | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh` run-mode fallback guard summary checks | |
| Integration  | ✅ | `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`, `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh` | |
| Regression   | ✅ | docs parity and reason-code drift checks + matrix policy checker regression cases | |
| Performance  | N/A | None | Marker/schema migration only; no throughput/runtime algorithm change |

## Risks & Rollback
- Risk: downstream consumers expecting deprecated summary fields could fail if not migrated.
- Rollback: revert commit `31bbcd2` to restore previous fallback summary marker schema.

## Documentation Updates
- Updated:
  - `README.md`
  - `docs/ci/strategy.md`
  - `docs/foundation/upgrade-rollback-runbook.md`
  - `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
