### PR TITLE
test(ci): add workspace cargo license policy guard

### DIFF
--- a/scripts/ci/check_workspace_license_policy.py
+++ b/scripts/ci/check_workspace_license_policy.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Fail-closed workspace Cargo license policy checker."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+DEFAULT_LICENSE = "Apache-2.0"
+DEFAULT_MANIFEST_GLOBS = ("crates/*/Cargo.toml",)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate Cargo manifest license fields against workspace policy."
+    )
+    parser.add_argument(
+        "--workspace-root",
+        default=".",
+        help="Workspace root used to discover Cargo manifests when --manifest is omitted.",
+    )
+    parser.add_argument(
+        "--expected-license",
+        default=DEFAULT_LICENSE,
+        help="Expected SPDX license identifier.",
+    )
+    parser.add_argument(
+        "--manifest",
+        action="append",
+        default=[],
+        help="Explicit Cargo.toml path(s) to check. May be repeated.",
+    )
+    return parser
+
+
+def discover_manifests(workspace_root: Path) -> list[Path]:
+    manifests: set[Path] = set()
+    for pattern in DEFAULT_MANIFEST_GLOBS:
+        for manifest in workspace_root.glob(pattern):
+            if manifest.is_file():
+                manifests.add(manifest.resolve())
+    return sorted(manifests)
+
+
+def resolve_manifests(args: argparse.Namespace) -> list[Path]:
+    if args.manifest:
+        manifests = [Path(path).resolve() for path in args.manifest]
+        return sorted(manifests)
+    return discover_manifests(Path(args.workspace_root).resolve())
+
+
+def check_manifest(manifest_path: Path, expected_license: str) -> list[str]:
+    errors: list[str] = []
+    if not manifest_path.is_file():
+        return [f"manifest_not_found:{manifest_path}"]
+
+    try:
+        payload = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        return [f"manifest_invalid_toml:{manifest_path}"]
+
+    package = payload.get("package")
+    if not isinstance(package, dict):
+        return [f"package_section_missing:{manifest_path}"]
+
+    observed_license = package.get("license")
+    if not isinstance(observed_license, str) or not observed_license.strip():
+        return [f"license_missing:{manifest_path}"]
+
+    normalized_license = observed_license.strip()
+    if normalized_license != expected_license:
+        return [
+            "license_mismatch:"
+            f"{manifest_path}:expected={expected_license}:observed={normalized_license}"
+        ]
+
+    return errors
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    expected_license = args.expected_license.strip()
+    if not expected_license:
+        print("workspace license policy check failed: expected license must be non-empty", file=sys.stderr)
+        return 1
+
+    manifests = resolve_manifests(args)
+    if not manifests:
+        print("workspace license policy check failed: no crate Cargo manifests found", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for manifest in manifests:
+        failures.extend(check_manifest(manifest, expected_license))
+
+    if failures:
+        print("workspace license policy check failed:", file=sys.stderr)
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    print("workspace license policy check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_check_workspace_license_policy.sh
+++ b/scripts/ci/test_check_workspace_license_policy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/ci/check_workspace_license_policy.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected workspace license policy checker to be executable" >&2
+  exit 1
+fi
+
+python3 "$CHECKER" --workspace-root "$ROOT_DIR" --expected-license "Apache-2.0" >/dev/null
+
+MISMATCH_MANIFEST="$TMP_DIR/mismatch.Cargo.toml"
+cp "$ROOT_DIR/crates/kamn-core/Cargo.toml" "$MISMATCH_MANIFEST"
+python3 - "$MISMATCH_MANIFEST" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = re.sub(r'^license\s*=\s*".*"$', 'license = "MIT"', text, flags=re.MULTILINE)
+path.write_text(text, encoding="utf-8")
+PY
+
+if python3 "$CHECKER" --manifest "$MISMATCH_MANIFEST" --expected-license "Apache-2.0" >"$TMP_DIR/mismatch.out" 2>"$TMP_DIR/mismatch.err"; then
+  echo "expected workspace license policy checker to fail on mismatched license field" >&2
+  cat "$TMP_DIR/mismatch.out" >&2 || true
+  cat "$TMP_DIR/mismatch.err" >&2 || true
+  exit 1
+fi
+
+if ! grep -q "license_mismatch" "$TMP_DIR/mismatch.err"; then
+  echo "expected license_mismatch reason in checker stderr output" >&2
+  cat "$TMP_DIR/mismatch.err" >&2 || true
+  exit 1
+fi
+
+MISSING_MANIFEST="$TMP_DIR/missing.Cargo.toml"
+cp "$ROOT_DIR/crates/kamn-core/Cargo.toml" "$MISSING_MANIFEST"
+python3 - "$MISSING_MANIFEST" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = re.sub(r'^license\s*=\s*".*"$\n?', '', text, flags=re.MULTILINE)
+path.write_text(text, encoding="utf-8")
+PY
+
+if python3 "$CHECKER" --manifest "$MISSING_MANIFEST" --expected-license "Apache-2.0" >"$TMP_DIR/missing.out" 2>"$TMP_DIR/missing.err"; then
+  echo "expected workspace license policy checker to fail on missing license field" >&2
+  cat "$TMP_DIR/missing.out" >&2 || true
+  cat "$TMP_DIR/missing.err" >&2 || true
+  exit 1
+fi
+
+if ! grep -q "license_missing" "$TMP_DIR/missing.err"; then
+  echo "expected license_missing reason in checker stderr output" >&2
+  cat "$TMP_DIR/missing.err" >&2 || true
+  exit 1
+fi
+
+echo "workspace license policy checker tests passed."


### PR DESCRIPTION
## Summary
Adds a deterministic workspace Cargo license policy checker and test harness to prevent future license metadata drift. Current manifests already match Apache-2.0, so this PR focuses on fail-closed regression protection.

Closes #2534
Refs #2533
Refs #2532

## Changes
- `scripts/ci/check_workspace_license_policy.py`: new checker validating crate `Cargo.toml` `package.license` fields against `Apache-2.0`.
- `scripts/ci/test_check_workspace_license_policy.sh`: new test harness covering pass path + mismatch + missing license fail-closed behavior.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/ci/test_check_workspace_license_policy.sh`

Failing output:
`bash: scripts/ci/test_check_workspace_license_policy.sh: No such file or directory`

### 🟢 Green Phase
Commands and pass output:
- `bash scripts/ci/test_check_workspace_license_policy.sh`
  - `workspace license policy checker tests passed.`

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`

Result: pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | mismatch/missing license branches in `scripts/ci/test_check_workspace_license_policy.sh` | |
| Functional   | ✅ | checker pass-path invocation in `scripts/ci/test_check_workspace_license_policy.sh` | |
| Integration  | ✅ | workspace-wide crate manifest scan in `scripts/ci/check_workspace_license_policy.py` | |
| Regression   | ✅ | fail-closed mismatch and missing-field proofs in `scripts/ci/test_check_workspace_license_policy.sh` | |
| Performance  | N/A | None | static manifest parsing only; no hot-path runtime change |

## Risks & Rollback
- Risk: minimal; checker-only addition.
- Rollback: revert commit `b166e2d`.

## Documentation Updates
- None required.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
