### PR TITLE
fix(ci): terminal GO for fully graduated missing-docs allowlist

### DIFF
--- a/.ci/kolme-command-surface-asymmetry-policy.json
+++ b/.ci/kolme-command-surface-asymmetry-policy.json
@@ -10,6 +10,7 @@
     "scripts/kolme/test_validate_version_compatibility.sh"
   ],
   "ci_tools_only": [
+    "scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh",
     "scripts/kolme/test_check_lane_migration_matrix_policy.sh",
     "scripts/kolme/test_check_local_bootstrap_health_policy.sh",
     "scripts/kolme/test_check_local_e2e_integration_policy.sh",

--- a/docs/planning/issues/missing-docs-velocity-cadence.md
+++ b/docs/planning/issues/missing-docs-velocity-cadence.md
@@ -15,6 +15,10 @@ and the reporting cadence for issue `#2127`.
   `graduated_module_delta == 0`
 - `window_target_met`:
   `observed_window_modules_per_100_commits >= min_modules_per_100_commits`
+- `allowlist_exhausted`: `report.allowlisted_module_count == 0`
+  - terminal behavior: when true, policy returns
+    `reason_key=allowlist_fully_graduated` with `final_decision=GO`
+    and skips stagnation/velocity-window threshold checks.
 
 ## Reporting Cadence
 

--- a/scripts/ci/missing_docs_velocity_guard.py
+++ b/scripts/ci/missing_docs_velocity_guard.py
@@ -196,6 +196,7 @@ def evaluate_velocity_policy(
     allowlisted_module_delta = (
         report["allowlisted_module_count"] - baseline["allowlisted_module_count"]
     )
+    allowlist_exhausted = report["allowlisted_module_count"] == 0
 
     if commit_delta == 0:
         observed_window_modules_per_100_commits = 0.0
@@ -204,49 +205,59 @@ def evaluate_velocity_policy(
             (graduated_module_delta * 100.0) / float(commit_delta), 4
         )
 
-    stagnation_window_exceeded = (
-        commit_delta >= thresholds["max_commits_without_graduation"]
-        and graduated_module_delta == 0
-    )
-    window_target_applicable = commit_delta >= thresholds["velocity_window_commits"]
-    window_target_met = (
-        observed_window_modules_per_100_commits >= thresholds["min_modules_per_100_commits"]
-    )
-
-    violations: list[str] = []
-    if stagnation_window_exceeded:
-        violations.append(
-            "stagnation window exceeded: "
-            f"commit_delta={commit_delta} "
-            f"max_commits_without_graduation={thresholds['max_commits_without_graduation']}"
-        )
-    if (
-        thresholds["enforce_window_target"]
-        and window_target_applicable
-        and not window_target_met
-    ):
-        violations.append(
-            "velocity window target under threshold: "
-            f"observed_modules_per_100_commits={observed_window_modules_per_100_commits} "
-            f"min_modules_per_100_commits={thresholds['min_modules_per_100_commits']}"
-        )
-
-    status = "pass" if not violations else "fail"
-    final_decision = "GO" if status == "pass" else "HOLD"
-
-    if status == "pass":
-        if commit_delta == 0:
-            reason_key = "baseline_window_not_elapsed"
-        elif not window_target_applicable:
-            reason_key = "window_not_elapsed"
-        else:
-            reason_key = "velocity_target_met"
-    elif len(violations) == 1 and violations[0].startswith("stagnation window exceeded"):
-        reason_key = "stagnation_window_exceeded"
-    elif len(violations) == 1:
-        reason_key = "velocity_window_under_threshold"
+    if allowlist_exhausted:
+        stagnation_window_exceeded = False
+        window_target_applicable = False
+        window_target_met = True
+        violations: list[str] = []
+        status = "pass"
+        final_decision = "GO"
+        reason_key = "allowlist_fully_graduated"
     else:
-        reason_key = "multiple_policy_violations"
+        stagnation_window_exceeded = (
+            commit_delta >= thresholds["max_commits_without_graduation"]
+            and graduated_module_delta == 0
+        )
+        window_target_applicable = commit_delta >= thresholds["velocity_window_commits"]
+        window_target_met = (
+            observed_window_modules_per_100_commits
+            >= thresholds["min_modules_per_100_commits"]
+        )
+
+        violations = []
+        if stagnation_window_exceeded:
+            violations.append(
+                "stagnation window exceeded: "
+                f"commit_delta={commit_delta} "
+                f"max_commits_without_graduation={thresholds['max_commits_without_graduation']}"
+            )
+        if (
+            thresholds["enforce_window_target"]
+            and window_target_applicable
+            and not window_target_met
+        ):
+            violations.append(
+                "velocity window target under threshold: "
+                f"observed_modules_per_100_commits={observed_window_modules_per_100_commits} "
+                f"min_modules_per_100_commits={thresholds['min_modules_per_100_commits']}"
+            )
+
+        status = "pass" if not violations else "fail"
+        final_decision = "GO" if status == "pass" else "HOLD"
+
+        if status == "pass":
+            if commit_delta == 0:
+                reason_key = "baseline_window_not_elapsed"
+            elif not window_target_applicable:
+                reason_key = "window_not_elapsed"
+            else:
+                reason_key = "velocity_target_met"
+        elif len(violations) == 1 and violations[0].startswith("stagnation window exceeded"):
+            reason_key = "stagnation_window_exceeded"
+        elif len(violations) == 1:
+            reason_key = "velocity_window_under_threshold"
+        else:
+            reason_key = "multiple_policy_violations"
 
     policy = {
         "schema_version": VELOCITY_POLICY_SCHEMA_VERSION,
@@ -266,6 +277,7 @@ def evaluate_velocity_policy(
         "report_allowlisted_module_count": report["allowlisted_module_count"],
         "baseline_allowlisted_module_count": baseline["allowlisted_module_count"],
         "allowlisted_module_delta": allowlisted_module_delta,
+        "allowlist_exhausted": allowlist_exhausted,
         "report_target_modules_per_100_commits": report["target_modules_per_100_commits"],
         "report_observed_modules_per_100_commits": report["observed_modules_per_100_commits"],
         "velocity_window_commits": thresholds["velocity_window_commits"],

--- a/scripts/ci/test_check_kamn_core_missing_docs_policy.sh
+++ b/scripts/ci/test_check_kamn_core_missing_docs_policy.sh
@@ -106,6 +106,9 @@ sed -i '/batch_id: first-three-modules-v1/d' "$GRADUATION_BATCH_REPORT_FIXTURE"
 expect_failure "graduation batch report marker drift should fail"
 
 reset_fixtures
+printf '\nbootstrap\n' >>"$ALLOWLIST_FIXTURE"
+sed -i 's/^pub mod bootstrap;/#[allow(missing_docs)]\npub mod bootstrap;/' "$CORE_LIB_FIXTURE"
+sed -i '/^bootstrap$/d' "$GRADUATED_MODULES_FIXTURE"
 python3 - "$VELOCITY_BASELINE_FIXTURE" <<'PY'
 import json
 import sys
@@ -114,6 +117,8 @@ from pathlib import Path
 path = Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
 payload["commit_count"] = 1
+payload["graduated_module_count"] = 61
+payload["allowlisted_module_count"] = 1
 path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
 expect_failure "velocity guard stagnation policy drift should fail"

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -131,6 +131,7 @@ bash "$ROOT_DIR/scripts/kolme/test_run_local_kolme_fork_bootstrap_readiness_cont
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh"
 bash "$ROOT_DIR/scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh"
+bash "$ROOT_DIR/scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_run_local_kolme_live_deployment_preflight_lane.sh"
 bash "$ROOT_DIR/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh"

--- a/scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
+++ b/scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh
@@ -68,6 +68,7 @@ patterns = (
     re.compile(r"^\s*(Compiling|Checking|Documenting)\s+.+$"),
     re.compile(r"^\s*Finished `.* target\(s\) in .*s$"),
     re.compile(r"^\s*Running tests/.+\(target/.+\)$"),
+    re.compile(r"^\s*Blocking waiting for file lock on .+$"),
 )
 for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
     line = raw.rstrip()

--- a/scripts/ci/test_missing_docs_velocity_guard_contract.sh
+++ b/scripts/ci/test_missing_docs_velocity_guard_contract.sh
@@ -44,25 +44,50 @@ python3 "$VELOCITY_GUARD_SCRIPT" check \
 
 grep -q '^status=pass$' "$TMP_DIR/pass.out"
 grep -q '^final_decision=GO$' "$TMP_DIR/pass.out"
+grep -q '^reason_key=allowlist_fully_graduated$' "$TMP_DIR/pass.out"
 grep -Eq '^commit_delta=[0-9]+$' "$TMP_DIR/pass.out"
 grep -q '"schema_version": "kamn.ci.kamn-core-missing-docs-velocity-policy.v1"' "$POLICY_PATH"
-
-MUTATED_BASELINE="$TMP_DIR/mutated-baseline.json"
-cp "$BASELINE_FILE" "$MUTATED_BASELINE"
-python3 - "$MUTATED_BASELINE" <<'PY'
+python3 - "$POLICY_PATH" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-path = Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["commit_count"] = 1
-payload["graduated_module_count"] = payload["graduated_module_count"]
-path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("allowlist_exhausted") is not True:
+    raise SystemExit("expected allowlist_exhausted=true for fully graduated baseline")
+if payload.get("reason_key") != "allowlist_fully_graduated":
+    raise SystemExit("expected terminal allowlist reason key")
+PY
+
+MUTATED_BASELINE="$TMP_DIR/mutated-baseline.json"
+cp "$BASELINE_FILE" "$MUTATED_BASELINE"
+MUTATED_REPORT="$TMP_DIR/mutated-report.json"
+cp "$REPORT_PATH" "$MUTATED_REPORT"
+python3 - "$MUTATED_BASELINE" "$MUTATED_REPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline_path = Path(sys.argv[1])
+report_path = Path(sys.argv[2])
+
+baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+baseline["commit_count"] = 1
+baseline_path.write_text(
+    json.dumps(baseline, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+
+report = json.loads(report_path.read_text(encoding="utf-8"))
+report["allowlisted_module_count"] = 1
+report_path.write_text(
+    json.dumps(report, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
 PY
 
 if python3 "$VELOCITY_GUARD_SCRIPT" check \
-  --report-file "$REPORT_PATH" \
+  --report-file "$MUTATED_REPORT" \
   --baseline-file "$MUTATED_BASELINE" \
   --threshold-file "$THRESHOLD_FILE" \
   --output-json "$TMP_DIR/fail-policy.json" >"$TMP_DIR/fail.out" 2>&1; then


### PR DESCRIPTION
## Summary
Fixes missing-docs velocity policy behavior when the allowlist is fully exhausted, and stabilizes Kolme tranche-1 wrapper/direct parity normalization against transient Cargo lock messages. This removes a persistent false HOLD decision and restores deterministic CI tool regressions.

## Changes
- `scripts/ci/missing_docs_velocity_guard.py`: add terminal policy branch for `allowlisted_module_count == 0`, returning `status=pass`, `final_decision=GO`, `reason_key=allowlist_fully_graduated`, and `allowlist_exhausted=true`.
- `scripts/ci/test_missing_docs_velocity_guard_contract.sh`: assert terminal fully-graduated behavior and preserve non-terminal stagnation failure coverage via mutated report fixtures.
- `scripts/ci/test_check_kamn_core_missing_docs_policy.sh`: force non-terminal fixture state for stagnation drift checks.
- `scripts/ci/test_ci_tools.sh`: include missing `scripts/kolme/test_check_fallback_signer_marker_matrix_policy.sh` lane.
- `.ci/kolme-command-surface-asymmetry-policy.json`: add missing Kolme lane to `ci_tools_only` inventory.
- `scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh`: normalize away transient `Blocking waiting for file lock on ...` Cargo lines.
- `docs/planning/issues/missing-docs-velocity-cadence.md`: document terminal allowlist semantics.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/ci/test_ci_tools.sh`

Failing signal before fix:
- `scripts/ci/test_check_kamn_core_missing_docs_policy.sh` failed
- `status=fail`
- `final_decision=HOLD`
- `reason_key=multiple_policy_violations`
- `commit_delta=212`
- `graduated_module_delta=0`

Additional deterministic diff failure before normalization fix:
- `expected wrapper/direct normalized outputs to match for lane: kolme.notifications.consumer.contract`
- wrapper-only transient line: `Blocking waiting for file lock on build directory`

### 🟢 Green Phase
Commands:
- `bash scripts/ci/test_missing_docs_velocity_guard_contract.sh`
- `bash scripts/ci/test_check_kamn_core_missing_docs_policy.sh`
- `bash scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh`

Result:
- all three pass

### 🔁 Regression
Command:
- `bash scripts/ci/test_ci_tools.sh`

Result:
- pass (`All CI tool regression tests passed.`)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Script/policy lane changes only |
| Functional   | ✅     | `scripts/ci/test_missing_docs_velocity_guard_contract.sh`, `scripts/ci/test_check_kamn_core_missing_docs_policy.sh` | |
| Integration  | ✅     | `scripts/ci/test_kolme_tranche1_dispatch_execution_parity_contract.sh`, `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | `scripts/ci/test_ci_tools.sh` full suite | |
| Performance  | N/A    | None                 | No runtime hot-path/product throughput changes |

## Risks & Rollback
- Risk: Low. Changes are isolated to CI policy and test harness normalization.
- Rollback plan: Revert commit `780f7ce` to restore prior behavior.

## Documentation Updates
- Updated `docs/planning/issues/missing-docs-velocity-cadence.md` with terminal policy semantics.

## Validation Checklist
- [ ] `cargo fmt --check` — clean (N/A: no Rust source changes)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2553
Refs #2552
Refs #2551
