### PR TITLE
fix(ci): route generic harness trend thresholds via selector contract map

### DIFF
--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -227,7 +227,7 @@ for file in "${CHANGED_FILES[@]}"; do
   esac
 
   case "$file" in
-    fixtures/ci/kolme_wave10_wrapper_family_matrix.json|fixtures/ci/kolme_wave10_wrapper_family_baseline.json|fixtures/ci/kolme_wave10_wrapper_family_trend_thresholds.json|.ci/kolme-test-harness-loc-trend-thresholds.env|.ci/kolme-command-surface-soft-budget.env|.ci/kolme-command-surface-baseline.env|.ci/kolme-command-surface-trend-thresholds.env|scripts/ci/check_kolme_wave10_wrapper_family_budget_trend.sh|scripts/ci/generate_kolme_test_harness_loc_report.sh|scripts/ci/check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/check_test_harness_loc_soft_budget.py|scripts/ci/generate_kolme_test_harness_loc_trend_report.sh|scripts/ci/test_check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh)
+    fixtures/ci/kolme_wave10_wrapper_family_matrix.json|fixtures/ci/kolme_wave10_wrapper_family_baseline.json|fixtures/ci/kolme_wave10_wrapper_family_trend_thresholds.json|.ci/kolme-test-harness-loc-trend-thresholds.env|.ci/test-harness-loc-trend-thresholds.env|.ci/kolme-command-surface-soft-budget.env|.ci/kolme-command-surface-baseline.env|.ci/kolme-command-surface-trend-thresholds.env|scripts/ci/check_kolme_wave10_wrapper_family_budget_trend.sh|scripts/ci/generate_kolme_test_harness_loc_report.sh|scripts/ci/check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/check_test_harness_loc_soft_budget.py|scripts/ci/generate_kolme_test_harness_loc_trend_report.sh|scripts/ci/test_check_kolme_test_harness_loc_soft_budget.sh|scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh)
       CI_STRATEGY_DOC_CONTRACT_CHANGED=true
       ci_contract_scope_only_candidate=true
       classified=true

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -133,6 +133,12 @@ assert_eq "$(extract_output "$kolme_harness_trend_threshold_output" "run_ci_tool
 assert_eq "$(extract_output "$kolme_harness_trend_threshold_output" "unknown_risk_changed")" "false" "Kolme harness trend-threshold config changes should be classified"
 assert_eq "$(extract_output "$kolme_harness_trend_threshold_output" "test_scope")" "ci-doc-contract" "Kolme harness trend-threshold config changes should use ci-doc-contract scope"
 
+generic_harness_trend_threshold_output="$(run_selector $'.ci/test-harness-loc-trend-thresholds.env')"
+assert_eq "$(extract_output "$generic_harness_trend_threshold_output" "run_rust")" "false" "generic harness trend-threshold config changes should avoid rust full fallback"
+assert_eq "$(extract_output "$generic_harness_trend_threshold_output" "run_ci_tool_checks")" "true" "generic harness trend-threshold config changes must run CI tool checks"
+assert_eq "$(extract_output "$generic_harness_trend_threshold_output" "unknown_risk_changed")" "false" "generic harness trend-threshold config changes should be classified"
+assert_eq "$(extract_output "$generic_harness_trend_threshold_output" "test_scope")" "ci-doc-contract" "generic harness trend-threshold config changes should use ci-doc-contract scope"
+
 kolme_harness_trend_report_script_output="$(run_selector $'scripts/ci/generate_kolme_test_harness_loc_trend_report.sh')"
 assert_eq "$(extract_output "$kolme_harness_trend_report_script_output" "run_rust")" "false" "Kolme harness trend-report script changes should avoid rust full fallback"
 assert_eq "$(extract_output "$kolme_harness_trend_report_script_output" "run_ci_tool_checks")" "true" "Kolme harness trend-report script changes must run CI tool checks"


### PR DESCRIPTION
## Summary
This change makes CI selector routing deterministic for generic test-harness trend-threshold config updates. It prevents unknown-risk fallback for `.ci/test-harness-loc-trend-thresholds.env` and keeps the change scoped to the existing ci-doc-contract lane behavior.

## Changes
- `scripts/ci/select_targets.sh`: added explicit classification for `.ci/test-harness-loc-trend-thresholds.env` in the ci-doc-contract mapping set.
- `scripts/ci/test_select_targets.sh`: added regression assertions for selector outputs when `.ci/test-harness-loc-trend-thresholds.env` changes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Output:
```text
generic harness trend-threshold config changes should avoid rust full fallback: expected 'false', got 'true'
```

### 🟢 Green Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Output:
```text
select_targets matrix regression tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_ci_strategy_contract.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
cargo fmt --check
cargo clippy -- -D warnings
```
Output summary:
```text
CI strategy contract tests passed.
Fast-mode CI tool regression tests passed.
cargo fmt --check passed.
cargo clippy -- -D warnings passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Selector/routing shell contract task |
| Functional   | ✅     | `scripts/ci/test_select_targets.sh` | |
| Integration  | ✅     | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | File-specific route assertion for `.ci/test-harness-loc-trend-thresholds.env` | |
| Performance  | N/A    | None                 | No runtime algorithm change; constant-time pattern add |

## Risks & Rollback
- None.
- Rollback: revert commit `a6c5dd9` to restore previous selector mapping.

## Documentation Updates
- None required. Behavior aligns with existing ci-doc-contract selector governance language in `docs/ci/strategy.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2618
