### PR TITLE
fix(node): fail closed when live signer key source is not declared

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -275,6 +275,13 @@ where
                 signing_profile.to_owned(),
             ));
         }
+        let key_source =
+            kolme_live_signer_key_source
+                .as_deref()
+                .ok_or(ConfigError::MissingArgumentValue(
+                    "--kolme-live-signer-key-source",
+                ))?;
+        normalize_kolme_live_signer_key_source(key_source)?;
         if kolme_live_strict_signer_contracts {
             let signer_profile =
                 kolme_live_signer_profile
@@ -283,10 +290,6 @@ where
                         "--kolme-live-signer-profile",
                     ))?;
             normalize_kolme_live_signer_profile_selector(signer_profile)?;
-            let key_source = kolme_live_signer_key_source.as_deref().ok_or(
-                ConfigError::MissingArgumentValue("--kolme-live-signer-key-source"),
-            )?;
-            normalize_kolme_live_signer_key_source(key_source)?;
         }
     }
 

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -372,6 +372,8 @@ fn parses_runtime_mode_kolme_live_with_required_flags() {
         "kolme-fork-local".to_owned(),
         "--kolme-live-signing-profile".to_owned(),
         "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
     ];
 
     let parsed = parse_args(args).expect("kolme-live args should parse");
@@ -390,7 +392,10 @@ fn parses_runtime_mode_kolme_live_with_required_flags() {
     );
     assert!(!parsed.kolme_live_strict_signer_contracts);
     assert_eq!(parsed.kolme_live_signer_profile, None);
-    assert_eq!(parsed.kolme_live_signer_key_source, None);
+    assert_eq!(
+        parsed.kolme_live_signer_key_source,
+        Some("env-local".to_owned())
+    );
 }
 
 #[test]
@@ -718,6 +723,8 @@ fn integration_runtime_kolme_live_renders_provider_contract_markers() {
         "kolme-fork-local".to_owned(),
         "--kolme-live-signing-profile".to_owned(),
         "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
         "--output".to_owned(),
         "json".to_owned(),
     ];
@@ -1057,6 +1064,8 @@ fn integration_runtime_kolme_live_renders_secondary_signer_selection_markers() {
         "kolme-fork-local".to_owned(),
         "--kolme-live-signing-profile".to_owned(),
         "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
         "--output".to_owned(),
         "json".to_owned(),
     ];
@@ -2076,6 +2085,8 @@ fn regression_runtime_kolme_live_rejects_provider_marker_drift() {
         "kolme-fork-local".to_owned(),
         "--kolme-live-signing-profile".to_owned(),
         "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
         "--output".to_owned(),
         "json".to_owned(),
     ];
@@ -2120,6 +2131,8 @@ fn regression_runtime_kolme_live_rejects_missing_signer_private_key_env() {
         "kolme-fork-local".to_owned(),
         "--kolme-live-signing-profile".to_owned(),
         "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
         "--output".to_owned(),
         "json".to_owned(),
     ];
@@ -2329,6 +2342,30 @@ fn rejects_kolme_live_without_signing_profile() {
         parse_args(args),
         Err(ConfigError::MissingArgumentValue(
             "--kolme-live-signing-profile"
+        ))
+    );
+}
+
+#[test]
+fn rejects_kolme_live_without_signer_key_source() {
+    // Regression: #2626
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        "http://127.0.0.1:3000".to_owned(),
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue(
+            "--kolme-live-signer-key-source"
         ))
     );
 }


### PR DESCRIPTION
## Summary
This change makes live Kolme runtime signer-source selection fail closed by requiring `--kolme-live-signer-key-source` for all `--runtime-mode kolme-live` invocations. It removes implicit key-source defaulting from CLI parsing and updates live-runtime tests to pass explicit signer-source markers.

## Changes
- `crates/kamn-node/src/cli.rs`: require and validate `--kolme-live-signer-key-source` for all `kolme-live` runs (not only strict contracts mode).
- `crates/kamn-node/src/main_tests.rs`: added regression test for missing key-source rejection and updated existing `kolme-live` argument fixtures to include explicit `env-local` signer-source markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node rejects_kolme_live_without_signer_key_source
```
Output excerpt:
```text
assertion `left == right` failed
left: Ok(NodeCli { ... kolme_live_signer_key_source: None, ... })
right: Err(MissingArgumentValue("--kolme-live-signer-key-source"))
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-node rejects_kolme_live_without_signer_key_source
```
Output summary:
```text
test main_tests::rejects_kolme_live_without_signer_key_source ... ok
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-node
cargo fmt --check
cargo clippy -- -D warnings
```
Output summary:
```text
kamn-node suite: 92 passed, 0 failed, 1 ignored
cargo fmt --check passed
cargo clippy -- -D warnings passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `main_tests::rejects_kolme_live_without_signer_key_source` | |
| Functional   | ✅     | `main_tests::parses_runtime_mode_kolme_live_with_required_flags` fixture updated for explicit signer source | |
| Integration  | ✅     | `cargo test -p kamn-node` (live-runtime integration tests in `main_tests`) | |
| Regression   | ✅     | New missing-key-source fail-closed regression test | |
| Performance  | N/A    | None | CLI validation-only change; no runtime hot-path impact |

## Risks & Rollback
- Risk: callers invoking `kolme-live` without `--kolme-live-signer-key-source` now fail fast at parse time.
- Rollback: revert commit `b138976`.

## Documentation Updates
- None required. Existing CLI docs already include `--kolme-live-signer-key-source` and pass contract tests.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #2626
