### PR TITLE
feat(node): add structured runtime logging baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ bash scripts/escrow/generate_settlement_reconciliation_evidence_bundle.sh --outp
 bash scripts/escrow/check_settlement_reconciliation_evidence_policy.sh --bundle-file /tmp/settlement-evidence.json
 ```
 
+### Node Structured Logging
+
+`kamn-node` emits structured runtime logs to stderr. Configure logging without code changes using:
+
+- `KAMN_NODE_LOG_LEVEL`: `error`, `warn`, `info`, `debug`, `trace` (default `info`)
+- `KAMN_NODE_LOG_FORMAT`: `text`, `json` (default `text`)
+
+Example:
+
+```bash
+KAMN_NODE_LOG_LEVEL=debug \
+KAMN_NODE_LOG_FORMAT=json \
+cargo run -p kamn-node -- --role processor --runtime-mode bootstrap
+```
+
 ### Kolme Native Parity Command Matrix (Fast Gate vs Local-Only Heavy)
 
 ```bash

--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -201,6 +201,8 @@ pub enum ConfigError {
     InvalidNodeProfile(String),
     /// Unknown or invalid diagnostics mode string.
     InvalidDiagnosticsMode(String),
+    /// Unknown or invalid node log configuration.
+    InvalidLogConfig(String),
     /// Unknown or invalid runtime mode string.
     InvalidRuntimeMode(String),
     /// Invalid expected state version argument.
@@ -246,6 +248,7 @@ impl fmt::Display for ConfigError {
             Self::InvalidDiagnosticsMode(value) => {
                 write!(f, "invalid diagnostics mode: {value}")
             }
+            Self::InvalidLogConfig(value) => write!(f, "invalid log config: {value}"),
             Self::InvalidRuntimeMode(value) => write!(f, "invalid runtime mode: {value}"),
             Self::InvalidExpectedStateVersion(value) => {
                 write!(f, "invalid expected state version: {value}")

--- a/crates/kamn-node/src/logging.rs
+++ b/crates/kamn-node/src/logging.rs
@@ -1,0 +1,272 @@
+use kamn_core::ConfigError;
+use std::env;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) const KAMN_NODE_LOG_LEVEL_ENV: &str = "KAMN_NODE_LOG_LEVEL";
+pub(crate) const KAMN_NODE_LOG_FORMAT_ENV: &str = "KAMN_NODE_LOG_FORMAT";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum NodeLogLevel {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
+
+impl NodeLogLevel {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "ERROR",
+            Self::Warn => "WARN",
+            Self::Info => "INFO",
+            Self::Debug => "DEBUG",
+            Self::Trace => "TRACE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NodeLogFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NodeLogConfig {
+    pub(crate) level: NodeLogLevel,
+    pub(crate) format: NodeLogFormat,
+}
+
+impl NodeLogConfig {
+    pub(crate) fn default_config() -> Self {
+        Self {
+            level: NodeLogLevel::Info,
+            format: NodeLogFormat::Text,
+        }
+    }
+
+    fn allows(self, event_level: NodeLogLevel) -> bool {
+        event_level <= self.level
+    }
+}
+
+pub(crate) fn resolve_log_config_from_env() -> Result<NodeLogConfig, ConfigError> {
+    let level_value = read_env_var(KAMN_NODE_LOG_LEVEL_ENV)?;
+    let format_value = read_env_var(KAMN_NODE_LOG_FORMAT_ENV)?;
+    resolve_log_config_from_inputs(level_value.as_deref(), format_value.as_deref())
+}
+
+pub(crate) fn resolve_log_config_from_inputs(
+    level: Option<&str>,
+    format: Option<&str>,
+) -> Result<NodeLogConfig, ConfigError> {
+    let base = NodeLogConfig::default_config();
+    let resolved_level = match level {
+        Some(raw) => parse_node_log_level(raw.trim())?,
+        None => base.level,
+    };
+    let resolved_format = match format {
+        Some(raw) => parse_node_log_format(raw.trim())?,
+        None => base.format,
+    };
+    Ok(NodeLogConfig {
+        level: resolved_level,
+        format: resolved_format,
+    })
+}
+
+pub(crate) fn log_info(event: &str, fields: &[(&str, &str)]) -> Result<(), ConfigError> {
+    emit_log_event(NodeLogLevel::Info, event, fields)
+}
+
+pub(crate) fn log_warn(event: &str, fields: &[(&str, &str)]) -> Result<(), ConfigError> {
+    emit_log_event(NodeLogLevel::Warn, event, fields)
+}
+
+pub(crate) fn log_error(event: &str, fields: &[(&str, &str)]) -> Result<(), ConfigError> {
+    emit_log_event(NodeLogLevel::Error, event, fields)
+}
+
+pub(crate) fn emit_log_event(
+    level: NodeLogLevel,
+    event: &str,
+    fields: &[(&str, &str)],
+) -> Result<(), ConfigError> {
+    let config = resolve_log_config_from_env()?;
+    if !config.allows(level) {
+        return Ok(());
+    }
+    let line = render_log_event_line(config, level, event, fields);
+    record_test_log_line(line.as_str());
+    eprintln!("{line}");
+    Ok(())
+}
+
+pub(crate) fn render_log_event_line(
+    config: NodeLogConfig,
+    level: NodeLogLevel,
+    event: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    let timestamp_ms = current_unix_timestamp_ms();
+    match config.format {
+        NodeLogFormat::Text => render_text_log_event_line(timestamp_ms, level, event, fields),
+        NodeLogFormat::Json => render_json_log_event_line(timestamp_ms, level, event, fields),
+    }
+}
+
+fn read_env_var(name: &'static str) -> Result<Option<String>, ConfigError> {
+    match env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err(ConfigError::InvalidLogConfig(format!(
+            "{name} must be valid UTF-8"
+        ))),
+    }
+}
+
+fn parse_node_log_level(value: &str) -> Result<NodeLogLevel, ConfigError> {
+    match value.to_ascii_lowercase().as_str() {
+        "error" => Ok(NodeLogLevel::Error),
+        "warn" => Ok(NodeLogLevel::Warn),
+        "info" => Ok(NodeLogLevel::Info),
+        "debug" => Ok(NodeLogLevel::Debug),
+        "trace" => Ok(NodeLogLevel::Trace),
+        _ => Err(ConfigError::InvalidLogConfig(format!(
+            "{KAMN_NODE_LOG_LEVEL_ENV} must be one of: error,warn,info,debug,trace"
+        ))),
+    }
+}
+
+fn parse_node_log_format(value: &str) -> Result<NodeLogFormat, ConfigError> {
+    match value.to_ascii_lowercase().as_str() {
+        "text" => Ok(NodeLogFormat::Text),
+        "json" => Ok(NodeLogFormat::Json),
+        _ => Err(ConfigError::InvalidLogConfig(format!(
+            "{KAMN_NODE_LOG_FORMAT_ENV} must be one of: text,json"
+        ))),
+    }
+}
+
+fn current_unix_timestamp_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+fn render_text_log_event_line(
+    timestamp_ms: u128,
+    level: NodeLogLevel,
+    event: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    let mut line = format!(
+        "ts_unix_ms={timestamp_ms} level={} event={}",
+        level.as_str(),
+        render_text_field_value(event)
+    );
+    for (key, value) in fields {
+        line.push(' ');
+        line.push_str(key);
+        line.push('=');
+        line.push_str(render_text_field_value(value).as_str());
+    }
+    line
+}
+
+fn render_json_log_event_line(
+    timestamp_ms: u128,
+    level: NodeLogLevel,
+    event: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    let mut line = format!(
+        "{{\"ts_unix_ms\":{timestamp_ms},\"level\":\"{}\",\"event\":\"{}\"",
+        level.as_str(),
+        escape_json_string(event)
+    );
+    if fields.is_empty() {
+        line.push('}');
+        return line;
+    }
+    line.push_str(",\"fields\":{");
+    for (index, (key, value)) in fields.iter().enumerate() {
+        if index > 0 {
+            line.push(',');
+        }
+        line.push('"');
+        line.push_str(escape_json_string(key).as_str());
+        line.push_str("\":\"");
+        line.push_str(escape_json_string(value).as_str());
+        line.push('"');
+    }
+    line.push_str("}}");
+    line
+}
+
+fn render_text_field_value(value: &str) -> String {
+    if value.is_empty() {
+        return "\"\"".to_owned();
+    }
+    if value
+        .bytes()
+        .all(|byte| matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'.' | b':' | b'/' ))
+    {
+        return value.to_owned();
+    }
+    format!("\"{}\"", escape_text_string(value))
+}
+
+fn escape_text_string(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn escape_json_string(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LOG_CAPTURE: std::cell::RefCell<Option<Vec<String>>> = const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn capture_test_logs<T, F>(operation: F) -> (T, Vec<String>)
+where
+    F: FnOnce() -> T + std::panic::UnwindSafe,
+{
+    TEST_LOG_CAPTURE.with(|capture| {
+        *capture.borrow_mut() = Some(Vec::new());
+    });
+    let outcome = std::panic::catch_unwind(operation);
+    let logs = TEST_LOG_CAPTURE.with(|capture| capture.borrow_mut().take().unwrap_or_default());
+    match outcome {
+        Ok(result) => (result, logs),
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[cfg(test)]
+fn record_test_log_line(line: &str) {
+    TEST_LOG_CAPTURE.with(|capture| {
+        if let Some(lines) = capture.borrow_mut().as_mut() {
+            lines.push(line.to_owned());
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn record_test_log_line(_line: &str) {}

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::process::ExitCode;
 
 mod cli;
+mod logging;
 mod report_builder;
 mod report_render;
 mod runtime_kolme_live;
@@ -14,6 +15,12 @@ mod signer;
 mod wire_payload;
 
 use cli::parse_args;
+#[cfg(test)]
+use logging::{
+    capture_test_logs, render_log_event_line, resolve_log_config_from_inputs, NodeLogConfig,
+    NodeLogFormat, NodeLogLevel,
+};
+use logging::{log_error, log_info};
 use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
 #[cfg(test)]
@@ -375,8 +382,20 @@ fn peer_lifecycle_state_as_str(state: PeerLifecycleState) -> &'static str {
 
 fn run() -> Result<(), ConfigError> {
     let cli = parse_args(env::args())?;
+    let runtime_mode = cli.runtime_mode.as_str();
+    log_info(
+        "node.runtime.execute.start",
+        &[("runtime_mode", runtime_mode)],
+    )?;
     let output_mode = cli.output_mode;
     let report = execute(cli)?;
+    log_info(
+        "node.runtime.execute.complete",
+        &[
+            ("runtime_mode", report.runtime_mode.as_str()),
+            ("role", report.role.as_str()),
+        ],
+    )?;
     println!("{}", render_bootstrap_report(&report, output_mode));
 
     Ok(())
@@ -419,8 +438,21 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
     };
 
     let plan = bootstrap(config)?;
+    log_info(
+        "node.runtime.mode.dispatch",
+        &[("runtime_mode", runtime_mode.as_str())],
+    )?;
     let runtime_execution = match runtime_mode.kind {
-        RuntimeModeKind::Bootstrap => RuntimeExecutionBundle::default(),
+        RuntimeModeKind::Bootstrap => {
+            log_info(
+                "node.runtime.bootstrap.plan.ready",
+                &[
+                    ("chain_id", plan.config.chain_id.as_str()),
+                    ("role", plan.config.role.as_str()),
+                ],
+            )?;
+            RuntimeExecutionBundle::default()
+        }
         RuntimeModeKind::Planning => {
             let expected_state_hash = expected_state_hash
                 .ok_or(ConfigError::MissingArgumentValue("--expected-state-hash"))?;
@@ -567,6 +599,11 @@ fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
+            let error_message = error.to_string();
+            let _ = log_error(
+                "node.runtime.execute.failed",
+                &[("error", error_message.as_str())],
+            );
             eprintln!("{error}");
             ExitCode::FAILURE
         }

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -1,12 +1,13 @@
 use super::{
     build_bootstrap_report, build_kolme_live_direct_signed_wire_payload,
     build_kolme_live_managed_signing_key, build_kolme_live_request,
-    build_kolme_live_signer_adapter, encode_kolme_hex_lower, execute, parse_args,
-    render_bootstrap_report, render_kolme_live_native_direct_message,
-    resolve_kolme_live_managed_signer_required_marker, resolve_kolme_live_nonce,
-    resolve_kolme_live_signer_private_key_env_name, sign_kolme_live_managed_external_message,
-    DiagnosticsMode, LocalProfile, NodeBootstrapReport, OutputMode, RuntimeExecutionBundle,
-    RuntimeMode,
+    build_kolme_live_signer_adapter, capture_test_logs, encode_kolme_hex_lower, execute,
+    parse_args, render_bootstrap_report, render_kolme_live_native_direct_message,
+    render_log_event_line, resolve_kolme_live_managed_signer_required_marker,
+    resolve_kolme_live_nonce, resolve_kolme_live_signer_private_key_env_name,
+    resolve_log_config_from_inputs, sign_kolme_live_managed_external_message, DiagnosticsMode,
+    LocalProfile, NodeBootstrapReport, NodeLogConfig, NodeLogFormat, NodeLogLevel, OutputMode,
+    RuntimeExecutionBundle, RuntimeMode,
 };
 use kamn_core::{
     bootstrap, ConfigError, KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitRequest, NodeConfig,
@@ -29,6 +30,11 @@ const TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE_SECONDARY: &str =
     "secure:aws-kms:role-operator/key-live-ops-secondary";
 
 fn signer_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn log_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
@@ -283,6 +289,184 @@ fn parses_diagnostics_snapshot_flag() {
 
     let parsed = parse_args(args).expect("diagnostics args should parse");
     assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::snapshot());
+}
+
+#[test]
+fn unit_log_config_parses_level_and_format_inputs() {
+    let config = resolve_log_config_from_inputs(Some("debug"), Some("json"))
+        .expect("log config inputs should parse");
+    assert_eq!(
+        config,
+        NodeLogConfig {
+            level: NodeLogLevel::Debug,
+            format: NodeLogFormat::Json,
+        }
+    );
+}
+
+#[test]
+fn unit_log_renderer_renders_json_event_fields() {
+    let line = render_log_event_line(
+        NodeLogConfig {
+            level: NodeLogLevel::Info,
+            format: NodeLogFormat::Json,
+        },
+        NodeLogLevel::Info,
+        "kolme.live.submit.start",
+        &[
+            ("correlation_id", "runtime-commit:abc"),
+            ("provider_hint", "local"),
+        ],
+    );
+    assert!(line.contains("\"level\":\"INFO\""));
+    assert!(line.contains("\"event\":\"kolme.live.submit.start\""));
+    assert!(line.contains("\"correlation_id\":\"runtime-commit:abc\""));
+    assert!(line.contains("\"provider_hint\":\"local\""));
+}
+
+#[test]
+fn integration_bootstrap_runtime_emits_structured_marker() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+    ])
+    .expect("args should parse");
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("bootstrap execution should succeed");
+    assert_eq!(report.runtime_mode, "bootstrap");
+    assert!(
+        captured_logs
+            .iter()
+            .any(|line| line.contains("\"event\":\"node.runtime.bootstrap.plan.ready\"")),
+        "bootstrap runtime should emit structured bootstrap marker"
+    );
+}
+
+#[test]
+fn functional_kolme_live_submit_and_finality_logs_keep_correlation_id() {
+    let _signer_lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _log_lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"pending"}"#,
+        ),
+        MockHttpReply::ok(
+            r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"final"}"#,
+        ),
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("kolme-live execution should succeed");
+    assert_eq!(report.runtime_mode, "kolme-live");
+
+    let required_events = [
+        "kolme.live.submit.start",
+        "kolme.live.submit.outcome",
+        "kolme.live.finality.poll.start",
+        "kolme.live.finality.poll.outcome",
+        "kolme.live.execution.complete",
+    ];
+
+    let mut correlation_id = None;
+    for event_name in required_events {
+        let matching_line = captured_logs
+            .iter()
+            .find(|line| line.contains(format!("\"event\":\"{event_name}\"").as_str()))
+            .expect("required structured event should be present");
+        let observed = extract_json_string_field(matching_line, "correlation_id")
+            .expect("structured event should include correlation id");
+        if let Some(expected) = correlation_id.as_deref() {
+            assert_eq!(observed, expected);
+        } else {
+            assert!(!observed.is_empty(), "correlation id must not be empty");
+            correlation_id = Some(observed);
+        }
+    }
+}
+
+#[test]
+fn regression_invalid_log_level_config_fails_closed() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("invalid-level"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+    ])
+    .expect("args should parse");
+    let error = execute(parsed).expect_err("invalid log level should fail closed");
+    assert!(
+        matches!(error, ConfigError::InvalidLogConfig(message) if message.contains("KAMN_NODE_LOG_LEVEL")),
+        "invalid log level should produce InvalidLogConfig"
+    );
+}
+
+#[test]
+fn performance_structured_logging_rendering_stays_bounded() {
+    let started = Instant::now();
+    for _ in 0..5_000 {
+        let line = render_log_event_line(
+            NodeLogConfig {
+                level: NodeLogLevel::Info,
+                format: NodeLogFormat::Json,
+            },
+            NodeLogLevel::Info,
+            "kolme.live.submit.outcome",
+            &[
+                ("correlation_id", "runtime-commit:benchmark"),
+                ("commit_id", "kolme-commit:benchmark"),
+                ("finality", "pending"),
+            ],
+        );
+        assert!(
+            line.contains("\"event\":\"kolme.live.submit.outcome\""),
+            "rendered line should contain expected event marker"
+        );
+    }
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "structured log rendering baseline exceeded 1s bound for 5k iterations"
+    );
 }
 
 #[test]

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -1,5 +1,6 @@
 use super::signer::build_kolme_live_direct_signed_wire_payload;
 use super::{
+    logging::{log_info, log_warn},
     KolmeLiveExecution, KOLME_IN_MEMORY_PROVIDER_MARKER, KOLME_LIVE_FINALITY_MAX_ATTEMPTS,
     KOLME_LIVE_FINALITY_STATUS_PATH, KOLME_LIVE_PROVIDER_CONTRACT, KOLME_LIVE_SIGNER_PROFILE_ENV,
     KOLME_LIVE_SIGNING_PROFILE, KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS,
@@ -84,6 +85,15 @@ pub(crate) fn execute_kolme_live_runtime(
     let mut transport = KolmeRuntimeCommitHttpTransport::new(KOLME_LIVE_TRANSPORT_TIMEOUT_SECONDS)
         .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
     let request = build_kolme_live_request(plan)?;
+    let correlation_id = request.idempotency_key().to_owned();
+    log_info(
+        "kolme.live.submit.start",
+        &[
+            ("correlation_id", correlation_id.as_str()),
+            ("provider_hint", provider_hint.as_str()),
+            ("base_url", base_url.as_str()),
+        ],
+    )?;
     let (signed_wire_payload, signer_selection) = build_kolme_live_direct_signed_wire_payload(
         base_url.as_str(),
         &mut transport,
@@ -102,9 +112,25 @@ pub(crate) fn execute_kolme_live_runtime(
         .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
     let (submit_status, mut receipt) = map_kolme_live_submit_outcome(submit_outcome)?;
     ensure_kolme_live_provider_marker(provider_hint.as_str(), receipt.provider.as_str())?;
+    log_info(
+        "kolme.live.submit.outcome",
+        &[
+            ("correlation_id", correlation_id.as_str()),
+            ("submit_status", submit_status),
+            ("commit_id", receipt.commit_id.as_str()),
+            ("finality", kolme_live_finality_label(receipt.finality)),
+        ],
+    )?;
     let mut resolution = "submit-receipt".to_owned();
 
     if matches!(receipt.finality, KolmeCommitReceiptFinality::Pending) {
+        log_info(
+            "kolme.live.finality.poll.start",
+            &[
+                ("correlation_id", correlation_id.as_str()),
+                ("commit_id", receipt.commit_id.as_str()),
+            ],
+        )?;
         let mut checker = KolmeRuntimeCommitFinalityChecker::new(
             base_url.as_str(),
             KOLME_LIVE_FINALITY_STATUS_PATH,
@@ -119,12 +145,37 @@ pub(crate) fn execute_kolme_live_runtime(
                 )?;
                 receipt = polled_receipt;
                 resolution = "finality-polled".to_owned();
+                log_info(
+                    "kolme.live.finality.poll.outcome",
+                    &[
+                        ("correlation_id", correlation_id.as_str()),
+                        ("commit_id", receipt.commit_id.as_str()),
+                        ("resolution", resolution.as_str()),
+                        ("finality", kolme_live_finality_label(receipt.finality)),
+                    ],
+                )?;
             }
             Err(KolmeRuntimeCommitProviderError::Timeout) => {
                 resolution = "finality-timeout".to_owned();
+                log_warn(
+                    "kolme.live.finality.poll.outcome",
+                    &[
+                        ("correlation_id", correlation_id.as_str()),
+                        ("commit_id", receipt.commit_id.as_str()),
+                        ("resolution", resolution.as_str()),
+                    ],
+                )?;
             }
             Err(KolmeRuntimeCommitProviderError::Unavailable { .. }) => {
                 resolution = "finality-unavailable".to_owned();
+                log_warn(
+                    "kolme.live.finality.poll.outcome",
+                    &[
+                        ("correlation_id", correlation_id.as_str()),
+                        ("commit_id", receipt.commit_id.as_str()),
+                        ("resolution", resolution.as_str()),
+                    ],
+                )?;
             }
             Err(KolmeRuntimeCommitProviderError::MalformedResponse { reason }) => {
                 return Err(ConfigError::RuntimeKolmeLive(format!(
@@ -135,6 +186,16 @@ pub(crate) fn execute_kolme_live_runtime(
     }
 
     let finality = kolme_live_finality_label(receipt.finality);
+    log_info(
+        "kolme.live.execution.complete",
+        &[
+            ("correlation_id", correlation_id.as_str()),
+            ("submit_status", submit_status),
+            ("commit_id", receipt.commit_id.as_str()),
+            ("finality", finality),
+            ("resolution", resolution.as_str()),
+        ],
+    )?;
     Ok(KolmeLiveExecution {
         provider_client_contract: KOLME_LIVE_PROVIDER_CONTRACT.to_owned(),
         base_url,


### PR DESCRIPTION
## Summary
Added a baseline structured logging facade for `kamn-node` and wired runtime/kolme-live execution paths to emit structured events with correlation-id continuity. This closes the operational visibility gap for bootstrap and live commit operations while keeping configuration runtime-only via environment variables.

Closes #2670

## Changes
- `crates/kamn-node/src/logging.rs`: added env-configurable structured logger (`text`/`json`, level filtering, event rendering, test capture hooks).
- `crates/kamn-core/src/config.rs`: added `ConfigError::InvalidLogConfig` fail-closed error surface.
- `crates/kamn-node/src/main.rs`: emits startup/dispatch/bootstrap/failure structured events.
- `crates/kamn-node/src/runtime_kolme_live.rs`: emits submit/finality/complete events with stable `correlation_id` across the sequence.
- `crates/kamn-node/src/main_tests.rs`: added unit/functional/integration/regression/performance tests for logging behavior.
- `README.md`: documented `KAMN_NODE_LOG_LEVEL` and `KAMN_NODE_LOG_FORMAT` configuration.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Added new logging tests first (unit/integration/functional/regression/performance) in `crates/kamn-node/src/main_tests.rs`.
- Initial code path had no logging facade and no `InvalidLogConfig` error variant, so the new assertions were unsatisfied until implementation wiring was added.

### 🟢 Green Phase
```bash
cargo test -p kamn-node
# result: 98 passed; 0 failed; 1 ignored (main tests)
```

### 🔁 Regression
```bash
cargo fmt --all --check
cargo clippy -p kamn-core -p kamn-node -- -D warnings
cargo test -p kamn-core config
# result: all commands passed
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `unit_log_config_parses_level_and_format_inputs`, `unit_log_renderer_renders_json_event_fields` | |
| Functional   | ✅ | `functional_kolme_live_submit_and_finality_logs_keep_correlation_id` | |
| Integration  | ✅ | `integration_bootstrap_runtime_emits_structured_marker` | |
| Regression   | ✅ | `regression_invalid_log_level_config_fails_closed` | |
| Performance  | ✅ | `performance_structured_logging_rendering_stays_bounded` | |

## Risks & Rollback
- Risk: log volume increase on info-level runtime paths may increase stderr output size in noisy environments.
- Rollback: revert this PR commit to restore previous stdout/stderr-only behavior.

## Documentation Updates
- Updated `README.md` with structured logging configuration and runtime usage example.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to touched crates: `kamn-core`, `kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
