### PR TITLE
feat(node): add deterministic runtime commit retry backoff

### DIFF
--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -744,6 +744,10 @@ fn integration_runtime_kolme_live_renders_provider_contract_markers() {
         "\"kolme_live_signer_private_key_env\":\"KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX\""
     ));
     assert!(rendered.contains("\"kolme_live_execution_status\":\"submitted;"));
+    assert!(rendered.contains("submit_attempts=1"));
+    assert!(rendered.contains("submit_retry_reason=none"));
+    assert!(rendered.contains("finality_retry_attempts=1"));
+    assert!(rendered.contains("finality_retry_reason=none"));
 
     let recorded_requests = requests.lock().expect("request mutex should lock");
     assert_eq!(
@@ -768,6 +772,168 @@ fn integration_runtime_kolme_live_renders_provider_contract_markers() {
     );
     assert!(recorded_requests[2]
         .contains("GET /runtime-commit/status?commit_id=kolme-commit%3Aab12cd34 HTTP/1.1"));
+}
+
+#[test]
+fn functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailable_errors() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"submit unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"pending"}"#,
+        ),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"finality unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(
+            r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"final"}"#,
+        ),
+    ]);
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("kolme-live args should parse");
+    let report = execute(parsed).expect("runtime should recover from transient provider failures");
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("submit_attempts=2"));
+    assert!(rendered.contains("submit_retry_reason=unavailable"));
+    assert!(rendered.contains("finality_retry_attempts=2"));
+    assert!(rendered.contains("finality_retry_reason=unavailable"));
+    assert!(rendered.contains("resolution=finality-polled"));
+
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        5,
+        "retry path should issue one extra submit and one extra finality request"
+    );
+}
+
+#[test]
+fn regression_runtime_kolme_live_submit_malformed_response_fails_fast_without_retry() {
+    // Regression: #2673
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply::ok(r#"{"provider":"kolme-fork-local"}"#),
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+    let error = execute(parsed).expect_err("malformed submit response must fail closed");
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("malformed")),
+        "malformed submit responses should stay fail-fast and non-retriable"
+    );
+
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        2,
+        "malformed submit response should fail without retrying submit requests"
+    );
+}
+
+#[test]
+fn performance_runtime_kolme_live_retry_recovery_stays_within_budget() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"submit unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"pending"}"#,
+        ),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"finality unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(
+            r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"final"}"#,
+        ),
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+    let started = Instant::now();
+    let report = execute(parsed).expect("retry flow should recover within bounded runtime budget");
+    assert_eq!(report.runtime_mode, "kolme-live");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "retry flow exceeded 1s budget for one submit and one finality retry"
+    );
 }
 
 #[test]

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -10,6 +10,13 @@ use kamn_core::{
     KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
     KolmeRuntimeCommitProviderReceipt, KolmeRuntimeCommitRequest,
 };
+use std::thread;
+use std::time::Duration;
+
+const KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS: u32 = 3;
+const KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS: u32 = 3;
+const KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS: u64 = 10;
+const KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS: u64 = 40;
 
 pub(crate) fn build_kolme_live_request(
     plan: &BootstrapPlan,
@@ -66,6 +73,25 @@ pub(crate) fn map_kolme_live_submit_outcome(
     }
 }
 
+fn classify_retry_category(error: &KolmeRuntimeCommitProviderError) -> Option<&'static str> {
+    match error {
+        KolmeRuntimeCommitProviderError::Timeout => Some("timeout"),
+        KolmeRuntimeCommitProviderError::Unavailable { .. } => Some("unavailable"),
+        KolmeRuntimeCommitProviderError::MalformedResponse { .. } => None,
+    }
+}
+
+fn deterministic_retry_backoff_millis(retry_attempt: u32) -> u64 {
+    let exponent = retry_attempt.saturating_sub(1).min(4);
+    let multiplier = 1_u64 << exponent;
+    (KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS * multiplier).min(KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS)
+}
+
+fn maybe_sleep_retry_backoff(retry_attempt: u32) {
+    let backoff = deterministic_retry_backoff_millis(retry_attempt);
+    thread::sleep(Duration::from_millis(backoff));
+}
+
 pub(crate) fn execute_kolme_live_runtime(
     plan: &BootstrapPlan,
     base_url: String,
@@ -97,12 +123,34 @@ pub(crate) fn execute_kolme_live_runtime(
         transport.clone(),
     )
     .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-    let submit_outcome = provider
-        .submit_runtime_commit(signed_wire_payload.as_str(), request.idempotency_key())
-        .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
+    let mut submit_attempts = 0_u32;
+    let mut submit_retry_reason = "none";
+    let submit_outcome = loop {
+        submit_attempts += 1;
+        match provider
+            .submit_runtime_commit(signed_wire_payload.as_str(), request.idempotency_key())
+        {
+            Ok(outcome) => break outcome,
+            Err(error) => {
+                if let Some(reason_code) = classify_retry_category(&error) {
+                    if submit_attempts < KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS {
+                        submit_retry_reason = reason_code;
+                        maybe_sleep_retry_backoff(submit_attempts);
+                        continue;
+                    }
+                    return Err(ConfigError::RuntimeKolmeLive(format!(
+                        "submit retries exhausted after {submit_attempts} attempts ({reason_code}): {error}"
+                    )));
+                }
+                return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
+            }
+        }
+    };
     let (submit_status, mut receipt) = map_kolme_live_submit_outcome(submit_outcome)?;
     ensure_kolme_live_provider_marker(provider_hint.as_str(), receipt.provider.as_str())?;
     let mut resolution = "submit-receipt".to_owned();
+    let mut finality_retry_attempts = 0_u32;
+    let mut finality_retry_reason = "none";
 
     if matches!(receipt.finality, KolmeCommitReceiptFinality::Pending) {
         let mut checker = KolmeRuntimeCommitFinalityChecker::new(
@@ -111,25 +159,40 @@ pub(crate) fn execute_kolme_live_runtime(
             transport,
         )
         .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-        match checker.poll_finality(receipt.commit_id.as_str(), KOLME_LIVE_FINALITY_MAX_ATTEMPTS) {
-            Ok(polled_receipt) => {
-                ensure_kolme_live_provider_marker(
-                    provider_hint.as_str(),
-                    polled_receipt.provider.as_str(),
-                )?;
-                receipt = polled_receipt;
-                resolution = "finality-polled".to_owned();
-            }
-            Err(KolmeRuntimeCommitProviderError::Timeout) => {
-                resolution = "finality-timeout".to_owned();
-            }
-            Err(KolmeRuntimeCommitProviderError::Unavailable { .. }) => {
-                resolution = "finality-unavailable".to_owned();
-            }
-            Err(KolmeRuntimeCommitProviderError::MalformedResponse { reason }) => {
-                return Err(ConfigError::RuntimeKolmeLive(format!(
-                    "finality response malformed: {reason}"
-                )));
+        loop {
+            finality_retry_attempts += 1;
+            match checker
+                .poll_finality(receipt.commit_id.as_str(), KOLME_LIVE_FINALITY_MAX_ATTEMPTS)
+            {
+                Ok(polled_receipt) => {
+                    ensure_kolme_live_provider_marker(
+                        provider_hint.as_str(),
+                        polled_receipt.provider.as_str(),
+                    )?;
+                    receipt = polled_receipt;
+                    resolution = "finality-polled".to_owned();
+                    break;
+                }
+                Err(error) => {
+                    if let Some(reason_code) = classify_retry_category(&error) {
+                        if finality_retry_attempts < KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS {
+                            finality_retry_reason = reason_code;
+                            maybe_sleep_retry_backoff(finality_retry_attempts);
+                            continue;
+                        }
+                        resolution = if reason_code == "timeout" {
+                            "finality-timeout".to_owned()
+                        } else {
+                            "finality-unavailable".to_owned()
+                        };
+                        break;
+                    }
+                    if let KolmeRuntimeCommitProviderError::MalformedResponse { reason } = error {
+                        return Err(ConfigError::RuntimeKolmeLive(format!(
+                            "finality response malformed: {reason}"
+                        )));
+                    }
+                }
             }
         }
     }
@@ -145,8 +208,61 @@ pub(crate) fn execute_kolme_live_runtime(
         signer_key_source: signer_selection.key_source.to_owned(),
         signer_private_key_env: signer_selection.private_key_env.to_owned(),
         execution_status: format!(
-            "{submit_status};commit_id={};finality={finality};resolution={resolution}",
-            receipt.commit_id
+            "{submit_status};commit_id={};finality={finality};resolution={resolution};submit_attempts={submit_attempts};submit_retry_reason={submit_retry_reason};finality_retry_attempts={finality_retry_attempts};finality_retry_reason={finality_retry_reason}",
+            receipt.commit_id,
         ),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        classify_retry_category, deterministic_retry_backoff_millis, ConfigError,
+        KolmeRuntimeCommitProviderError,
+    };
+
+    #[test]
+    fn unit_retry_classifier_marks_transient_provider_errors() {
+        assert_eq!(
+            classify_retry_category(&KolmeRuntimeCommitProviderError::Timeout),
+            Some("timeout")
+        );
+        assert_eq!(
+            classify_retry_category(&KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "network unavailable".to_owned(),
+            }),
+            Some("unavailable")
+        );
+        assert_eq!(
+            classify_retry_category(&KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "payload malformed".to_owned(),
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn unit_retry_backoff_policy_is_deterministic_and_bounded() {
+        assert_eq!(deterministic_retry_backoff_millis(1), 10);
+        assert_eq!(deterministic_retry_backoff_millis(2), 20);
+        assert_eq!(deterministic_retry_backoff_millis(3), 40);
+        assert_eq!(deterministic_retry_backoff_millis(8), 40);
+    }
+
+    #[test]
+    fn regression_retry_classifier_keeps_malformed_fail_fast() {
+        // Regression: #2673
+        assert_eq!(
+            classify_retry_category(&KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "status field missing".to_owned(),
+            }),
+            None
+        );
+        let message =
+            ConfigError::RuntimeKolmeLive("finality response malformed: x".to_owned()).to_string();
+        assert!(
+            message.contains("runtime kolme live validation failed"),
+            "runtime malformed response errors should remain explicit and fail-fast"
+        );
+    }
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -37,6 +37,18 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - harness accept windows are bounded to 2 seconds to avoid hanging PR runners
 - Heavy local Kolme node tests stay outside `ci-fast-gate` in local/manual lanes.
 
+## Kolme Live Retry Coverage
+- Runtime commit submit/finality retry behavior must remain deterministic and bounded.
+- Fast-gate coverage commands:
+  - `cargo test -p kamn-node main_tests::functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailable_errors -- --exact`
+  - `cargo test -p kamn-node main_tests::regression_runtime_kolme_live_submit_malformed_response_fails_fast_without_retry -- --exact`
+  - `cargo test -p kamn-node main_tests::performance_runtime_kolme_live_retry_recovery_stays_within_budget -- --exact`
+  - `cargo test -p kamn-node runtime_kolme_live::tests::unit_retry_classifier_marks_transient_provider_errors -- --exact`
+- Retry scope contracts:
+  - transient categories (`timeout`, `unavailable`) retry with bounded backoff.
+  - malformed/config categories fail fast without retry.
+  - execution status includes submit/finality retry metadata markers.
+
 ## kamn-core Missing-Docs Velocity Guard
 - Fast-gate missing-docs velocity regression command:
   - `bash scripts/ci/test_missing_docs_velocity_guard_contract.sh`


### PR DESCRIPTION
## Summary
Added deterministic retry/backoff policy for runtime commit submit and finality checks in `kamn-node` live runtime execution. Transient transport failures now retry with bounded backoff, malformed responses remain fail-fast, and execution status now exposes retry metadata for observability and contract checks.

Closes #2673

## Changes
- `crates/kamn-node/src/runtime_kolme_live.rs`:
  - added retry classifier (`timeout` / `unavailable` retriable, malformed fail-fast).
  - added deterministic bounded backoff policy.
  - added bounded submit retry loop and bounded finality retry loop.
  - appended retry metadata to `kolme_live_execution_status` (`submit_attempts`, `submit_retry_reason`, `finality_retry_attempts`, `finality_retry_reason`).
  - added unit tests for retry classifier/backoff and malformed fail-fast contract.
- `crates/kamn-node/src/main_tests.rs`:
  - updated existing runtime-kolme-live integration assertions for new retry metadata markers.
  - added functional transient-recovery test for submit + finality retry paths.
  - added regression fail-fast test for malformed submit responses.
  - added performance budget test for retry runtime path.
- `docs/ci/strategy.md`:
  - documented retry lane coverage commands and deterministic retry contract scope.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-node main_tests::functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailable_errors -- --exact
# before retry/backoff implementation: transient submit/finality failures did not recover and retry metadata markers were absent
```

### 🟢 Green Phase
```bash
cargo test -p kamn-node
# result: 98 passed; 0 failed; 1 ignored
```

### 🔁 Regression
```bash
cargo fmt --all --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node
cargo test -p kamn-core --test ci_strategy_docs
# result: all commands passed
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `runtime_kolme_live::tests::unit_retry_classifier_marks_transient_provider_errors`, `runtime_kolme_live::tests::unit_retry_backoff_policy_is_deterministic_and_bounded` | |
| Functional   | ✅ | `main_tests::functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailable_errors` | |
| Integration  | ✅ | `main_tests::integration_runtime_kolme_live_renders_provider_contract_markers` (retry metadata assertions) | |
| Regression   | ✅ | `main_tests::regression_runtime_kolme_live_submit_malformed_response_fails_fast_without_retry`, `runtime_kolme_live::tests::regression_retry_classifier_keeps_malformed_fail_fast` | |
| Performance  | ✅ | `main_tests::performance_runtime_kolme_live_retry_recovery_stays_within_budget` | |

## Risks & Rollback
- Risk: retry metadata expansion changes `kolme_live_execution_status` shape; downstream parsers expecting prior minimal status string may need to treat appended markers as optional fields.
- Rollback: revert this PR commit to restore single-attempt submit/finality behavior.

## Documentation Updates
- Updated `docs/ci/strategy.md` with retry contract coverage and selector-oriented fast-gate commands.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to touched crate: `kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
