### PR TITLE
feat(node): add deterministic daemon graceful shutdown contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,28 @@ bash scripts/ci/test_makefile_execution_contract.sh
 Deep/scheduled lanes remain opt-in via scripts in `scripts/sdk/` and `scripts/ci/`.
 CI fast gate provisions Node.js 22 for frontend and TypeScript contract lanes.
 
+### Daemon Graceful Shutdown Contract
+
+```bash
+cargo run -p kamn-node -- \
+  --role processor \
+  --runtime-mode daemon \
+  --daemon-max-ticks 10 \
+  --daemon-tick-interval-ms 25 \
+  --daemon-shutdown-signal-tick 3 \
+  --daemon-shutdown-drain-ticks 2 \
+  --daemon-shutdown-timeout-ticks 4 \
+  --output json
+```
+
+Daemon completion reasons are deterministic:
+- `tick-budget-exhausted` when no valid shutdown signal is observed.
+- `graceful-shutdown:...` when drain completes within the configured timeout budget.
+- `graceful-shutdown-timeout:...` when drain exceeds timeout or remaining tick budget (fail closed).
+
+`--daemon-shutdown-signal-tick` can be repeated; only the first valid signal is applied and
+remaining replay/late signals are counted in `ignored_signals`.
+
 ### Run A Focused Core Slice
 
 ```bash

--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -23,6 +23,9 @@ where
     let mut rejoin_attempts: Vec<RejoinAttempt> = Vec::new();
     let mut daemon_max_ticks: Option<u64> = None;
     let mut daemon_tick_interval_ms: Option<u64> = None;
+    let mut daemon_shutdown_signal_ticks: Vec<u64> = Vec::new();
+    let mut daemon_shutdown_drain_ticks: Option<u64> = None;
+    let mut daemon_shutdown_timeout_ticks: Option<u64> = None;
     let mut daemon_peer_id: Option<String> = None;
     let mut daemon_lifecycle_events: Vec<PeerLifecycleEvent> = Vec::new();
     let mut kolme_live_base_url: Option<String> = None;
@@ -128,6 +131,24 @@ where
                     "--daemon-tick-interval-ms",
                 ))?;
                 daemon_tick_interval_ms = Some(parse_daemon_control_arg(&value)?);
+            }
+            "--daemon-shutdown-signal-tick" => {
+                let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
+                    "--daemon-shutdown-signal-tick",
+                ))?;
+                daemon_shutdown_signal_ticks.push(parse_daemon_control_arg(&value)?);
+            }
+            "--daemon-shutdown-drain-ticks" => {
+                let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
+                    "--daemon-shutdown-drain-ticks",
+                ))?;
+                daemon_shutdown_drain_ticks = Some(parse_daemon_control_arg(&value)?);
+            }
+            "--daemon-shutdown-timeout-ticks" => {
+                let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
+                    "--daemon-shutdown-timeout-ticks",
+                ))?;
+                daemon_shutdown_timeout_ticks = Some(parse_daemon_control_arg(&value)?);
             }
             "--daemon-peer-id" => {
                 daemon_peer_id = Some(
@@ -244,6 +265,22 @@ where
         if !daemon_lifecycle_events.is_empty() && daemon_peer_id.is_none() {
             return Err(ConfigError::MissingArgumentValue("--daemon-peer-id"));
         }
+        if !daemon_shutdown_signal_ticks.is_empty() {
+            if daemon_shutdown_drain_ticks.is_none() {
+                return Err(ConfigError::MissingArgumentValue(
+                    "--daemon-shutdown-drain-ticks",
+                ));
+            }
+            if daemon_shutdown_timeout_ticks.is_none() {
+                return Err(ConfigError::MissingArgumentValue(
+                    "--daemon-shutdown-timeout-ticks",
+                ));
+            }
+        } else if daemon_shutdown_drain_ticks.is_some() || daemon_shutdown_timeout_ticks.is_some() {
+            return Err(ConfigError::MissingArgumentValue(
+                "--daemon-shutdown-signal-tick",
+            ));
+        }
     }
     if runtime_mode.kind == RuntimeModeKind::KolmeLive {
         if kolme_live_base_url.is_none() {
@@ -308,6 +345,9 @@ where
         rejoin_attempts,
         daemon_max_ticks,
         daemon_tick_interval_ms,
+        daemon_shutdown_signal_ticks,
+        daemon_shutdown_drain_ticks,
+        daemon_shutdown_timeout_ticks,
         daemon_peer_id,
         daemon_lifecycle_events,
         kolme_live_base_url,

--- a/crates/kamn-node/src/cli_tests.rs
+++ b/crates/kamn-node/src/cli_tests.rs
@@ -17,6 +17,9 @@ fn cli_module_parses_required_role_and_defaults() {
     assert!(parsed.enable_gossip);
     assert_eq!(parsed.sync_mode, SyncMode::Fast);
     assert_eq!(parsed.runtime_mode, RuntimeMode::bootstrap());
+    assert!(parsed.daemon_shutdown_signal_ticks.is_empty());
+    assert_eq!(parsed.daemon_shutdown_drain_ticks, None);
+    assert_eq!(parsed.daemon_shutdown_timeout_ticks, None);
     assert_eq!(parsed.output_mode, OutputMode::text());
     assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::basic());
 }

--- a/crates/kamn-node/src/daemon_shutdown.rs
+++ b/crates/kamn-node/src/daemon_shutdown.rs
@@ -1,0 +1,110 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DaemonCompletion {
+    pub(super) executed_ticks: u64,
+    pub(super) completion_reason: String,
+}
+
+pub(super) fn evaluate_daemon_completion(
+    max_ticks: u64,
+    shutdown_signal_ticks: &[u64],
+    drain_ticks: Option<u64>,
+    timeout_ticks: Option<u64>,
+) -> DaemonCompletion {
+    if shutdown_signal_ticks.is_empty() {
+        return DaemonCompletion {
+            executed_ticks: max_ticks,
+            completion_reason: "tick-budget-exhausted".to_owned(),
+        };
+    }
+
+    let first_valid_signal_tick = shutdown_signal_ticks
+        .iter()
+        .copied()
+        .filter(|tick| *tick <= max_ticks)
+        .min();
+    let ignored_signals = match first_valid_signal_tick {
+        Some(_) => shutdown_signal_ticks.len().saturating_sub(1),
+        None => shutdown_signal_ticks.len(),
+    };
+
+    let Some(signal_tick) = first_valid_signal_tick else {
+        return DaemonCompletion {
+            executed_ticks: max_ticks,
+            completion_reason: format!("tick-budget-exhausted;ignored_signals={ignored_signals}"),
+        };
+    };
+
+    let drain_ticks = drain_ticks.unwrap_or(1);
+    let timeout_ticks = timeout_ticks.unwrap_or(1);
+    let target_drain_tick = signal_tick.saturating_add(drain_ticks);
+    let timeout_deadline_tick = signal_tick.saturating_add(timeout_ticks).min(max_ticks);
+
+    if target_drain_tick <= timeout_deadline_tick && target_drain_tick <= max_ticks {
+        return DaemonCompletion {
+            executed_ticks: target_drain_tick,
+            completion_reason: format!(
+                "graceful-shutdown:signal@{signal_tick};drain_ticks={drain_ticks};timeout_ticks={timeout_ticks};ignored_signals={ignored_signals}"
+            ),
+        };
+    }
+
+    DaemonCompletion {
+        executed_ticks: timeout_deadline_tick,
+        completion_reason: format!(
+            "graceful-shutdown-timeout:signal@{signal_tick};drain_ticks={drain_ticks};timeout_ticks={timeout_ticks};ignored_signals={ignored_signals}"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::evaluate_daemon_completion;
+
+    #[test]
+    fn unit_daemon_completion_defaults_to_tick_budget_without_shutdown_signal() {
+        let completion = evaluate_daemon_completion(6, &[], None, None);
+        assert_eq!(completion.executed_ticks, 6);
+        assert_eq!(completion.completion_reason, "tick-budget-exhausted");
+    }
+
+    #[test]
+    fn unit_daemon_completion_applies_first_valid_shutdown_signal() {
+        let completion = evaluate_daemon_completion(10, &[8, 3, 7], Some(2), Some(4));
+        assert_eq!(completion.executed_ticks, 5);
+        assert_eq!(
+            completion.completion_reason,
+            "graceful-shutdown:signal@3;drain_ticks=2;timeout_ticks=4;ignored_signals=2"
+        );
+    }
+
+    #[test]
+    fn regression_daemon_completion_marks_late_shutdown_signals_as_ignored() {
+        // Regression: #2674
+        let completion = evaluate_daemon_completion(4, &[7, 8], Some(1), Some(1));
+        assert_eq!(completion.executed_ticks, 4);
+        assert_eq!(
+            completion.completion_reason,
+            "tick-budget-exhausted;ignored_signals=2"
+        );
+    }
+
+    #[test]
+    fn regression_daemon_completion_fails_closed_when_drain_exceeds_timeout() {
+        // Regression: #2674
+        let completion = evaluate_daemon_completion(9, &[7], Some(3), Some(1));
+        assert_eq!(completion.executed_ticks, 8);
+        assert_eq!(
+            completion.completion_reason,
+            "graceful-shutdown-timeout:signal@7;drain_ticks=3;timeout_ticks=1;ignored_signals=0"
+        );
+    }
+
+    #[test]
+    fn performance_daemon_completion_bounds_execution_by_timeout_deadline() {
+        let completion = evaluate_daemon_completion(9, &[8], Some(50), Some(1));
+        assert!(
+            completion.executed_ticks <= 9,
+            "timeout-bound completion must not exceed max tick budget"
+        );
+    }
+}

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::process::ExitCode;
 
 mod cli;
+mod daemon_shutdown;
 mod report_builder;
 mod report_render;
 mod runtime_kolme_live;
@@ -14,6 +15,7 @@ mod signer;
 mod wire_payload;
 
 use cli::parse_args;
+use daemon_shutdown::evaluate_daemon_completion;
 use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
 #[cfg(test)]
@@ -252,6 +254,9 @@ struct NodeCli {
     rejoin_attempts: Vec<RejoinAttempt>,
     daemon_max_ticks: Option<u64>,
     daemon_tick_interval_ms: Option<u64>,
+    daemon_shutdown_signal_ticks: Vec<u64>,
+    daemon_shutdown_drain_ticks: Option<u64>,
+    daemon_shutdown_timeout_ticks: Option<u64>,
     daemon_peer_id: Option<String>,
     daemon_lifecycle_events: Vec<PeerLifecycleEvent>,
     kolme_live_base_url: Option<String>,
@@ -398,6 +403,9 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         rejoin_attempts,
         daemon_max_ticks,
         daemon_tick_interval_ms,
+        daemon_shutdown_signal_ticks,
+        daemon_shutdown_drain_ticks,
+        daemon_shutdown_timeout_ticks,
         daemon_peer_id,
         daemon_lifecycle_events,
         kolme_live_base_url,
@@ -498,12 +506,18 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                     }
                     None => (None, None, None),
                 };
+            let daemon_completion = evaluate_daemon_completion(
+                max_ticks,
+                daemon_shutdown_signal_ticks.as_slice(),
+                daemon_shutdown_drain_ticks,
+                daemon_shutdown_timeout_ticks,
+            );
             RuntimeExecutionBundle {
                 daemon: Some(DaemonExecution {
                     max_ticks,
                     tick_interval_ms,
-                    executed_ticks: max_ticks,
-                    completion_reason: "tick-budget-exhausted".to_owned(),
+                    executed_ticks: daemon_completion.executed_ticks,
+                    completion_reason: daemon_completion.completion_reason,
                     peer_id,
                     peer_lifecycle_final_state,
                     peer_lifecycle_applied_events,

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -219,6 +219,9 @@ fn parses_required_role_and_defaults() {
     assert!(parsed.rejoin_attempts.is_empty());
     assert_eq!(parsed.daemon_max_ticks, None);
     assert_eq!(parsed.daemon_tick_interval_ms, None);
+    assert!(parsed.daemon_shutdown_signal_ticks.is_empty());
+    assert_eq!(parsed.daemon_shutdown_drain_ticks, None);
+    assert_eq!(parsed.daemon_shutdown_timeout_ticks, None);
     assert_eq!(parsed.daemon_peer_id, None);
     assert!(parsed.daemon_lifecycle_events.is_empty());
     assert_eq!(parsed.kolme_live_base_url, None);
@@ -356,6 +359,32 @@ fn parses_runtime_mode_daemon_with_bounded_controls() {
     assert_eq!(parsed.daemon_tick_interval_ms, Some(25));
     assert_eq!(parsed.daemon_peer_id, Some("peer-alpha".to_owned()));
     assert_eq!(parsed.daemon_lifecycle_events.len(), 2);
+}
+
+#[test]
+fn parses_runtime_mode_daemon_with_shutdown_controls() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "8".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "3".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "4".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("daemon args with shutdown controls should parse");
+    assert_eq!(parsed.daemon_shutdown_signal_ticks, vec![3]);
+    assert_eq!(parsed.daemon_shutdown_drain_ticks, Some(2));
+    assert_eq!(parsed.daemon_shutdown_timeout_ticks, Some(4));
 }
 
 #[test]
@@ -689,6 +718,68 @@ fn integration_runtime_daemon_renders_bounded_completion_output() {
             "\"daemon_peer_lifecycle_applied_events\":[\"start-connect\",\"handshake-succeeded\",\"heartbeat-missed\",\"heartbeat-restored\"]"
         )
     );
+}
+
+#[test]
+fn functional_runtime_daemon_applies_graceful_shutdown_signal() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "10".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "3".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "4".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("daemon shutdown args should parse");
+    let report = execute(parsed).expect("daemon graceful shutdown execution should succeed");
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("\"daemon_executed_ticks\":5"));
+    assert!(rendered.contains(
+        "\"daemon_completion_reason\":\"graceful-shutdown:signal@3;drain_ticks=2;timeout_ticks=4;ignored_signals=0\""
+    ));
+}
+
+#[test]
+fn integration_runtime_daemon_shutdown_timeout_is_fail_closed() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "10".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "7".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "4".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "2".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("daemon timeout args should parse");
+    let report = execute(parsed).expect("daemon timeout execution should succeed");
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("\"daemon_executed_ticks\":9"));
+    assert!(rendered.contains(
+        "\"daemon_completion_reason\":\"graceful-shutdown-timeout:signal@7;drain_ticks=4;timeout_ticks=2;ignored_signals=0\""
+    ));
 }
 
 #[test]
@@ -2298,6 +2389,81 @@ fn rejects_daemon_without_tick_interval() {
 }
 
 #[test]
+fn rejects_daemon_shutdown_signal_without_drain_ticks() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "8".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "3".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "2".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue(
+            "--daemon-shutdown-drain-ticks"
+        ))
+    );
+}
+
+#[test]
+fn rejects_daemon_shutdown_signal_without_timeout_ticks() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "8".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "3".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue(
+            "--daemon-shutdown-timeout-ticks"
+        ))
+    );
+}
+
+#[test]
+fn rejects_daemon_shutdown_controls_without_signal_tick() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "8".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "4".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue(
+            "--daemon-shutdown-signal-tick"
+        ))
+    );
+}
+
+#[test]
 fn rejects_kolme_live_without_base_url() {
     let args = vec![
         "kamn-node".to_owned(),
@@ -3023,5 +3189,74 @@ fn regression_runtime_daemon_rejects_invalid_lifecycle_transition() {
         Err(ConfigError::RuntimeDaemonLifecycle(
             "invalid peer lifecycle transition from Disconnected via HandshakeSucceeded".to_owned()
         ))
+    );
+}
+
+#[test]
+fn regression_runtime_daemon_ignores_replayed_and_late_shutdown_signals() {
+    // Regression: #2674
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "8".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "3".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "7".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "11".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "4".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ];
+    let parsed = parse_args(args).expect("daemon replay args should parse");
+    let report = execute(parsed).expect("daemon replay execution should succeed");
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("\"daemon_executed_ticks\":5"));
+    assert!(rendered.contains(
+        "\"daemon_completion_reason\":\"graceful-shutdown:signal@3;drain_ticks=2;timeout_ticks=4;ignored_signals=2\""
+    ));
+}
+
+#[test]
+fn performance_runtime_daemon_shutdown_drain_stays_bounded_by_timeout_budget() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "9".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "8".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "5".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "1".to_owned(),
+    ];
+    let parsed = parse_args(args).expect("daemon bounded shutdown args should parse");
+    let report = execute(parsed).expect("daemon bounded shutdown should succeed");
+    let executed_ticks = report
+        .daemon_executed_ticks
+        .expect("daemon execution must report executed ticks");
+    assert!(
+        executed_ticks <= 9,
+        "shutdown drain execution must remain within max tick budget"
+    );
+    assert_eq!(
+        report.daemon_completion_reason.as_deref(),
+        Some("graceful-shutdown-timeout:signal@8;drain_ticks=5;timeout_ticks=1;ignored_signals=0")
     );
 }

--- a/crates/kamn-node/tests/node_module_map_docs.rs
+++ b/crates/kamn-node/tests/node_module_map_docs.rs
@@ -5,6 +5,7 @@ fn doc_contains_module_ownership_boundaries() {
     assert!(DOC.contains("# KAMN Node Module Map"));
     assert!(DOC.contains("src/main.rs"));
     assert!(DOC.contains("src/cli.rs"));
+    assert!(DOC.contains("src/daemon_shutdown.rs"));
     assert!(DOC.contains("src/runtime_kolme_live.rs"));
     assert!(DOC.contains("src/signer.rs"));
     assert!(DOC.contains("src/wire_payload.rs"));

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -102,11 +102,17 @@ fn doc_contains_runtime_daemon_rules() {
     assert!(DOC.contains("## Daemon Runtime Rules"));
     assert!(DOC.contains("--daemon-max-ticks"));
     assert!(DOC.contains("--daemon-tick-interval-ms"));
+    assert!(DOC.contains("--daemon-shutdown-signal-tick"));
+    assert!(DOC.contains("--daemon-shutdown-drain-ticks"));
+    assert!(DOC.contains("--daemon-shutdown-timeout-ticks"));
     assert!(DOC.contains("--daemon-lifecycle-event"));
     assert!(DOC.contains("active construct-lock lease owner"));
     assert!(DOC.contains("execute_processor_daemon_tick"));
     assert!(DOC.contains("typed construct-lock errors"));
     assert!(DOC.contains("tick-budget-exhausted"));
+    assert!(DOC.contains("graceful-shutdown:"));
+    assert!(DOC.contains("graceful-shutdown-timeout:"));
+    assert!(DOC.contains("ignored_signals"));
 }
 
 #[test]
@@ -172,6 +178,12 @@ fn doc_contains_daemon_focused_fast_lane_commands() {
     ));
     assert!(DOC.contains(
         "cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node functional_runtime_daemon_applies_graceful_shutdown_signal"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node integration_runtime_daemon_shutdown_timeout_is_fail_closed"
     ));
     assert!(DOC.contains(
         "cargo test -p kamn-node regression_runtime_kolme_live_rejects_provider_marker_drift"

--- a/docs/architecture/kamn-node-module-map.md
+++ b/docs/architecture/kamn-node-module-map.md
@@ -25,6 +25,15 @@ refactors stay modular and auditable.
     validation.
   - Produces deterministic `NodeCli` parsing outcomes consumed by orchestration.
 
+### Daemon Shutdown Evaluation Surface
+
+- File:
+  - `crates/kamn-node/src/daemon_shutdown.rs`
+- Ownership boundary:
+  - Owns deterministic daemon shutdown signal, drain, and timeout evaluation.
+  - Emits bounded completion reason contracts for graceful and fail-closed
+    shutdown outcomes.
+
 ### Kolme Live Runtime Surface
 
 - File:

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -37,6 +37,15 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - harness accept windows are bounded to 2 seconds to avoid hanging PR runners
 - Heavy local Kolme node tests stay outside `ci-fast-gate` in local/manual lanes.
 
+## Node Runtime Daemon Shutdown Fast Lane
+- For `kamn-node` daemon-shutdown contract changes, keep PR validation on bounded deterministic tests:
+  - `cargo test -p kamn-node graceful_shutdown`
+  - `cargo test -p kamn-node runtime_daemon`
+- This lane is cost-effective:
+  - no external processes or signal orchestration harnesses required
+  - deterministic tick-budget simulation with bounded loop-free assertions
+  - timeout behavior validated through direct state transitions instead of wall-clock waits
+
 ## kamn-core Missing-Docs Velocity Guard
 - Fast-gate missing-docs velocity regression command:
   - `bash scripts/ci/test_missing_docs_velocity_guard_contract.sh`

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -35,6 +35,9 @@ This document captures node-runtime productionization slices for machine-readabl
 - Added daemon bounded-loop controls:
   - `--daemon-max-ticks <positive-integer>`
   - `--daemon-tick-interval-ms <positive-integer>`
+  - `--daemon-shutdown-signal-tick <positive-integer>` (repeatable, optional)
+  - `--daemon-shutdown-drain-ticks <positive-integer>` (required when shutdown signal tick is configured)
+  - `--daemon-shutdown-timeout-ticks <positive-integer>` (required when shutdown signal tick is configured)
   - `--daemon-peer-id <peer-id>` (optional)
   - `--daemon-lifecycle-event <start-connect|handshake-succeeded|heartbeat-missed|heartbeat-restored|disconnect|rejoin>` (repeatable)
 - Added Kolme live runtime controls:
@@ -175,6 +178,7 @@ This document captures node-runtime productionization slices for machine-readabl
 - Daemon mode:
   - `kamn-node --role processor --runtime-mode daemon`
   - `kamn-node --role processor --runtime-mode daemon --daemon-max-ticks 3 --daemon-tick-interval-ms 25`
+  - `kamn-node --role processor --runtime-mode daemon --daemon-max-ticks 10 --daemon-tick-interval-ms 25 --daemon-shutdown-signal-tick 3 --daemon-shutdown-drain-ticks 2 --daemon-shutdown-timeout-ticks 4`
 - Kolme-live mode:
   - `kamn-node --role processor --runtime-mode kolme-live`
   - `kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1`
@@ -188,6 +192,10 @@ This document captures node-runtime productionization slices for machine-readabl
 - Daemon mode requires:
   - `--daemon-max-ticks`
   - `--daemon-tick-interval-ms`
+- Shutdown contract controls:
+  - `--daemon-shutdown-signal-tick` may be supplied multiple times to inject deterministic shutdown signals.
+  - when any shutdown signal tick is supplied, both `--daemon-shutdown-drain-ticks` and `--daemon-shutdown-timeout-ticks` are mandatory.
+  - drain/timeout controls without a shutdown signal tick are rejected.
 - Daemon loop controls must be positive integers.
 - Optional daemon lifecycle inputs:
   - `--daemon-peer-id`
@@ -198,9 +206,11 @@ This document captures node-runtime productionization slices for machine-readabl
 - Processor daemon tick execution requires an active construct-lock lease owner and matching fencing token.
 - Daemon lease checks align with `execute_processor_daemon_tick` validation in `kamn-core`.
 - Missing or invalid daemon lease execution is rejected with typed construct-lock errors.
-- Daemon execution is deterministic and bounded by tick budget:
-  - `daemon_executed_ticks` equals configured `daemon_max_ticks`
-  - `daemon_completion_reason` emits `tick-budget-exhausted`
+- Daemon execution is deterministic and bounded:
+  - no valid shutdown signal => `daemon_executed_ticks` equals configured `daemon_max_ticks` and `daemon_completion_reason` emits `tick-budget-exhausted`
+  - graceful completion => `daemon_completion_reason` emits `graceful-shutdown:...`
+  - timeout/fail-closed completion => `daemon_completion_reason` emits `graceful-shutdown-timeout:...`
+  - repeated/late shutdown signals are counted as `ignored_signals` in completion metadata.
 
 ## Kolme Live Runtime Rules
 - Supported runtime modes:
@@ -314,6 +324,8 @@ cargo test -p kamn-core
 ```bash
 cargo test -p kamn-node integration_runtime_daemon_renders_bounded_completion_output
 cargo test -p kamn-node regression_runtime_daemon_rejects_invalid_lifecycle_transition
+cargo test -p kamn-node functional_runtime_daemon_applies_graceful_shutdown_signal
+cargo test -p kamn-node integration_runtime_daemon_shutdown_timeout_is_fail_closed
 cargo test -p kamn-node integration_runtime_kolme_live_renders_provider_contract_markers
 cargo test -p kamn-node regression_runtime_kolme_live_rejects_provider_marker_drift
 ```


### PR DESCRIPTION
## Summary
Adds deterministic daemon graceful-shutdown semantics to `kamn-node` with explicit shutdown signal entry points, bounded drain behavior, and fail-closed timeout completion reporting. This closes the gap between tick-budget-only daemon completion and signal-driven termination contracts.

Closes #2674

## Changes
- `crates/kamn-node/src/daemon_shutdown.rs`: new deterministic shutdown evaluator for signal/drain/timeout outcomes with unit/regression/performance tests.
- `crates/kamn-node/src/cli.rs`: adds `--daemon-shutdown-signal-tick`, `--daemon-shutdown-drain-ticks`, `--daemon-shutdown-timeout-ticks` parsing and validation contracts.
- `crates/kamn-node/src/main.rs`: routes daemon runtime completion through shutdown evaluator instead of fixed tick-budget completion.
- `crates/kamn-node/src/main_tests.rs`: adds functional/integration/regression/performance tests for graceful shutdown, timeout fail-closed, and replay/late signal handling.
- `README.md`, `docs/foundation/node-runtime-cli.md`, `docs/architecture/kamn-node-module-map.md`, `docs/ci/strategy.md`: documents shutdown semantics, module ownership, and fast-lane validation commands.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node graceful_shutdown -- --nocapture`

Failing output excerpt:
```text
error[E0609]: no field `daemon_shutdown_signal_ticks` on type `NodeCli`
error[E0609]: no field `daemon_shutdown_drain_ticks` on type `NodeCli`
error[E0609]: no field `daemon_shutdown_timeout_ticks` on type `NodeCli`
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node graceful_shutdown -- --nocapture`
- `cargo test -p kamn-node runtime_daemon -- --nocapture`
- `cargo test -p kamn-node rejects_daemon_shutdown -- --nocapture`
- `cargo test -p kamn-node performance_runtime_daemon_shutdown_drain_stays_bounded_by_timeout_budget -- --nocapture`

Passing summary:
- New graceful-shutdown functional/integration/regression/performance tests pass.
- Existing daemon and runtime-kolme-live coverage remains green.

### 🔁 Regression
Commands:
- `cargo fmt --all --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node`
- `cargo test -p kamn-core --test ci_strategy_docs`

Passing summary:
- `kamn-node`: 105 passed, 0 failed, 1 ignored.
- `ci_strategy_docs`: 2 passed, 0 failed.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `daemon_shutdown::tests::unit_daemon_completion_defaults_to_tick_budget_without_shutdown_signal`; `daemon_shutdown::tests::unit_daemon_completion_applies_first_valid_shutdown_signal`; parser defaults in `cli_tests` | |
| Functional   | ✅     | `main_tests::functional_runtime_daemon_applies_graceful_shutdown_signal` | |
| Integration  | ✅     | `main_tests::integration_runtime_daemon_shutdown_timeout_is_fail_closed`; `main_tests::integration_runtime_daemon_renders_bounded_completion_output`; docs contract tests | |
| Regression   | ✅     | `main_tests::regression_runtime_daemon_ignores_replayed_and_late_shutdown_signals`; `daemon_shutdown::tests::regression_daemon_completion_fails_closed_when_drain_exceeds_timeout`; `daemon_shutdown::tests::regression_daemon_completion_marks_late_shutdown_signals_as_ignored` | |
| Performance  | ✅     | `main_tests::performance_runtime_daemon_shutdown_drain_stays_bounded_by_timeout_budget`; `daemon_shutdown::tests::performance_daemon_completion_bounds_execution_by_timeout_deadline` | |

## Risks & Rollback
- Behavior change: daemon completion reason now reflects graceful-shutdown and timeout outcomes when shutdown signal controls are configured.
- Rollback: revert commit `c9ae06b` to restore prior tick-budget-only daemon completion semantics.

## Documentation Updates
- `README.md`
- `docs/foundation/node-runtime-cli.md`
- `docs/architecture/kamn-node-module-map.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant changed scope)
- [x] Docs updated (or justified why not)
