### PR TITLE
fix(core): migrate runtime commit HTTPS transport to native TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +209,9 @@ version = "0.1.0"
 dependencies = [
  "k256",
  "kamn-kolme",
+ "rustls",
+ "rustls-pemfile",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -253,6 +272,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +352,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
@@ -310,6 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +408,88 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zeroize"

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -9,6 +9,9 @@ path = "src/lib.rs"
 
 [dependencies]
 kamn-kolme = { path = "../kamn-kolme" }
+rustls = { version = "0.23.36", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pemfile = "2.2.0"
+webpki-roots = "1.0.3"
 
 [dev-dependencies]
 k256 = { version = "0.13.4", features = ["ecdsa"] }

--- a/crates/kamn-core/src/kolme_runtime_commit/http_transport.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/http_transport.rs
@@ -21,11 +21,14 @@ use kamn_kolme::{
     KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitFinalityTransport,
     KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderTransport,
 };
-use std::io::{Read, Write};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use std::fs;
+use std::io::{Cursor, Read, Write};
+use std::net::IpAddr;
 use std::net::TcpStream;
-use std::process::{Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::Duration;
 
 type ParsedHttpEndpoint = KamnKolmeParsedHttpEndpoint;
 
@@ -197,20 +200,60 @@ impl KolmeRuntimeCommitHttpTransport {
         endpoint: ParsedHttpEndpoint,
         request: &[u8],
     ) -> Result<Vec<u8>, KolmeRuntimeCommitProviderError> {
-        let connect_target = format!("{}:{}", endpoint.host, endpoint.port);
-        let mut command = Command::new("openssl");
-        command
-            .arg("s_client")
-            .arg("-quiet")
-            .arg("-verify_return_error")
-            .arg("-servername")
-            .arg(endpoint.host.as_str())
-            .arg("-connect")
-            .arg(connect_target.as_str())
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        let stream =
+            TcpStream::connect((endpoint.host.as_str(), endpoint.port)).map_err(|error| {
+                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+            })?;
+        let timeout = Duration::from_secs(self.timeout_seconds);
+        stream.set_read_timeout(Some(timeout)).map_err(|error| {
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+        })?;
+        stream.set_write_timeout(Some(timeout)).map_err(|error| {
+            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
+        })?;
 
+        let tls_config = self.resolve_tls_client_config()?;
+        let server_name = Self::resolve_tls_server_name(endpoint.host.as_str())?;
+        let connection = ClientConnection::new(tls_config, server_name).map_err(|error| {
+            KolmeRuntimeCommitProviderError::Unavailable {
+                reason: Self::classify_rustls_handshake_error(&error),
+            }
+        })?;
+        let mut tls_stream = StreamOwned::new(connection, stream);
+        tls_stream
+            .write_all(request)
+            .map_err(|error| Self::map_tls_io_error(&error))?;
+        tls_stream
+            .flush()
+            .map_err(|error| Self::map_tls_io_error(&error))?;
+
+        let mut response_bytes = Vec::new();
+        let mut read_buffer = [0_u8; 4096];
+        loop {
+            match tls_stream.read(&mut read_buffer) {
+                Ok(0) => break,
+                Ok(read_count) => response_bytes.extend_from_slice(&read_buffer[..read_count]),
+                Err(error) => {
+                    if matches!(error.kind(), std::io::ErrorKind::UnexpectedEof)
+                        && !response_bytes.is_empty()
+                    {
+                        break;
+                    }
+                    return Err(Self::map_tls_io_error(&error));
+                }
+            }
+        }
+        if !is_kolme_valid_http_response_bytes_input_contract(response_bytes.as_slice()) {
+            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "tls response body is empty".to_owned(),
+            });
+        }
+        Ok(response_bytes)
+    }
+
+    fn resolve_tls_client_config(
+        &self,
+    ) -> Result<Arc<ClientConfig>, KolmeRuntimeCommitProviderError> {
         let configured_ca_file =
             resolve_kolme_tls_ca_file_env_result_contract(std::env::var("KAMN_KOLME_TLS_CA_FILE"))
                 .map_err(|error| match error {
@@ -218,68 +261,82 @@ impl KolmeRuntimeCommitHttpTransport {
                         KolmeRuntimeCommitProviderError::Unavailable { reason }
                     }
                 })?;
-        if let Some(ca_file) = configured_ca_file {
-            command.arg("-CAfile").arg(ca_file);
-        }
-
-        let mut child =
-            command
-                .spawn()
-                .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
-                    reason: format!("tls command spawn failed: {error}"),
-                })?;
-        {
-            let mut stdin =
-                child
-                    .stdin
-                    .take()
-                    .ok_or_else(|| KolmeRuntimeCommitProviderError::Unavailable {
-                        reason: "tls command stdin unavailable".to_owned(),
-                    })?;
-            stdin.write_all(request).map_err(|error| {
-                KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-            })?;
-        }
-
-        let timeout = Duration::from_secs(self.timeout_seconds);
-        let started = Instant::now();
-        loop {
-            match child.try_wait() {
-                Ok(Some(_)) => break,
-                Ok(None) => {
-                    if started.elapsed() >= timeout {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        return Err(KolmeRuntimeCommitProviderError::Timeout);
+        let mut root_store = RootCertStore::empty();
+        match configured_ca_file {
+            Some(ca_file) => {
+                let cert_bytes = fs::read(ca_file.as_str()).map_err(|error| {
+                    KolmeRuntimeCommitProviderError::Unavailable {
+                        reason: format!("tls ca file read failed: {error}"),
                     }
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Err(error) => {
+                })?;
+                let mut cert_reader = Cursor::new(cert_bytes.as_slice());
+                let certs = rustls_pemfile::certs(&mut cert_reader)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|error| KolmeRuntimeCommitProviderError::Unavailable {
+                        reason: format!("tls ca file parse failed: {error}"),
+                    })?;
+                let (added, _) = root_store.add_parsable_certificates(certs);
+                if added == 0 {
                     return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                        reason: format!("tls command wait failed: {error}"),
+                        reason: "tls ca file does not contain valid certificates".to_owned(),
                     });
                 }
             }
+            None => {
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            }
         }
+        let config = ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        Ok(Arc::new(config))
+    }
 
-        let output = child.wait_with_output().map_err(|error| {
-            KolmeRuntimeCommitProviderError::from(classify_kolme_transport_io_error(&error))
-        })?;
-        let looks_like_http_response = output.stdout.starts_with(b"HTTP/1.")
-            && output.stdout.windows(4).any(|window| window == b"\r\n\r\n");
-        if !output.status.success() && !looks_like_http_response {
-            return Err(KolmeRuntimeCommitProviderError::Unavailable {
-                reason: classify_kolme_tls_failure_reason(
-                    String::from_utf8_lossy(&output.stderr).as_ref(),
-                ),
-            });
+    fn resolve_tls_server_name(
+        host: &str,
+    ) -> Result<ServerName<'static>, KolmeRuntimeCommitProviderError> {
+        if let Ok(ip_addr) = host.parse::<IpAddr>() {
+            return Ok(ServerName::IpAddress(ip_addr.into()));
         }
-        if !is_kolme_valid_http_response_bytes_input_contract(output.stdout.as_slice()) {
-            return Err(KolmeRuntimeCommitProviderError::MalformedResponse {
-                reason: "tls response body is empty".to_owned(),
-            });
+        ServerName::try_from(host.to_owned()).map_err(|_| {
+            KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "tls handshake failed".to_owned(),
+            }
+        })
+    }
+
+    fn map_tls_io_error(error: &std::io::Error) -> KolmeRuntimeCommitProviderError {
+        if let Some(rustls_error) = error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<rustls::Error>())
+        {
+            return KolmeRuntimeCommitProviderError::Unavailable {
+                reason: Self::classify_rustls_handshake_error(rustls_error),
+            };
         }
-        Ok(output.stdout)
+        match classify_kolme_transport_io_error(error) {
+            kamn_kolme::KolmeTransportIoClassification::Timeout => {
+                KolmeRuntimeCommitProviderError::Timeout
+            }
+            kamn_kolme::KolmeTransportIoClassification::Unavailable { reason } => {
+                let classified = classify_kolme_tls_failure_reason(error.to_string().as_str());
+                if classified == "tls certificate verification failed"
+                    || classified == "tls handshake failed"
+                {
+                    return KolmeRuntimeCommitProviderError::Unavailable { reason: classified };
+                }
+                KolmeRuntimeCommitProviderError::Unavailable { reason }
+            }
+        }
+    }
+
+    fn classify_rustls_handshake_error(error: &rustls::Error) -> String {
+        match error {
+            rustls::Error::InvalidCertificate(_) => {
+                "tls certificate verification failed".to_owned()
+            }
+            _ => "tls handshake failed".to_owned(),
+        }
     }
 }
 

--- a/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs
@@ -53,7 +53,7 @@ impl Drop for EnvVarGuard {
 
 struct HttpsSingleRequestServer {
     base_url: String,
-    cert_path: PathBuf,
+    ca_cert_path: PathBuf,
     child: Child,
     temp_dir: PathBuf,
 }
@@ -162,36 +162,95 @@ fn kolme_fork_sign_message(message: &str) -> (String, u8) {
     )
 }
 
-fn generate_self_signed_certificate(temp_dir: &Path) -> (PathBuf, PathBuf) {
-    let cert_path = temp_dir.join("cert.pem");
-    let key_path = temp_dir.join("key.pem");
+fn generate_test_ca_signed_certificate_chain(temp_dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let ca_cert_path = temp_dir.join("ca-cert.pem");
+    let ca_key_path = temp_dir.join("ca-key.pem");
+    let server_key_path = temp_dir.join("server-key.pem");
+    let server_csr_path = temp_dir.join("server.csr");
+    let server_cert_path = temp_dir.join("server-cert.pem");
+    let server_extensions_path = temp_dir.join("server-ext.cnf");
 
-    let status = Command::new("openssl")
+    let ca_status = Command::new("openssl")
         .arg("req")
         .arg("-x509")
         .arg("-newkey")
         .arg("rsa:2048")
         .arg("-keyout")
-        .arg(key_path.as_os_str())
+        .arg(ca_key_path.as_os_str())
         .arg("-out")
-        .arg(cert_path.as_os_str())
+        .arg(ca_cert_path.as_os_str())
         .arg("-days")
         .arg("1")
         .arg("-nodes")
         .arg("-subj")
-        .arg("/CN=127.0.0.1")
+        .arg("/CN=kamn-test-ca")
         .arg("-addext")
-        .arg("subjectAltName = DNS:localhost,IP:127.0.0.1")
+        .arg("basicConstraints = critical,CA:TRUE")
+        .arg("-addext")
+        .arg("keyUsage = critical,keyCertSign,cRLSign")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .expect("openssl should run");
+        .expect("openssl should run for CA certificate generation");
     assert!(
-        status.success(),
-        "openssl self-signed certificate generation should succeed"
+        ca_status.success(),
+        "openssl CA certificate generation should succeed"
     );
 
-    (cert_path, key_path)
+    let csr_status = Command::new("openssl")
+        .arg("req")
+        .arg("-new")
+        .arg("-newkey")
+        .arg("rsa:2048")
+        .arg("-keyout")
+        .arg(server_key_path.as_os_str())
+        .arg("-out")
+        .arg(server_csr_path.as_os_str())
+        .arg("-nodes")
+        .arg("-subj")
+        .arg("/CN=127.0.0.1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("openssl should run for server csr generation");
+    assert!(
+        csr_status.success(),
+        "openssl server csr generation should succeed"
+    );
+
+    fs::write(
+        server_extensions_path.as_path(),
+        "subjectAltName = DNS:localhost,IP:127.0.0.1\nbasicConstraints = critical,CA:FALSE\nkeyUsage = critical,digitalSignature,keyEncipherment\nextendedKeyUsage = serverAuth\n",
+    )
+    .expect("server extension file should be written");
+
+    let sign_status = Command::new("openssl")
+        .arg("x509")
+        .arg("-req")
+        .arg("-in")
+        .arg(server_csr_path.as_os_str())
+        .arg("-CA")
+        .arg(ca_cert_path.as_os_str())
+        .arg("-CAkey")
+        .arg(ca_key_path.as_os_str())
+        .arg("-CAcreateserial")
+        .arg("-out")
+        .arg(server_cert_path.as_os_str())
+        .arg("-days")
+        .arg("1")
+        .arg("-sha256")
+        .arg("-extfile")
+        .arg(server_extensions_path.as_os_str())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("openssl should run for server certificate signing");
+    assert!(
+        sign_status.success(),
+        "openssl server certificate signing should succeed"
+    );
+
+    (ca_cert_path, server_cert_path, server_key_path)
 }
 
 fn spawn_https_single_request_server(
@@ -199,7 +258,8 @@ fn spawn_https_single_request_server(
     response_body: &str,
 ) -> HttpsSingleRequestServer {
     let temp_dir = unique_temp_dir("kolme-https-server");
-    let (cert_path, key_path) = generate_self_signed_certificate(temp_dir.as_path());
+    let (ca_cert_path, server_cert_path, server_key_path) =
+        generate_test_ca_signed_certificate_chain(temp_dir.as_path());
     let server_script = r#"
 import http.server
 import ssl
@@ -243,8 +303,8 @@ httpd.handle_request()
         .arg("-c")
         .arg(server_script)
         .arg("0")
-        .arg(cert_path.as_os_str())
-        .arg(key_path.as_os_str())
+        .arg(server_cert_path.as_os_str())
+        .arg(server_key_path.as_os_str())
         .arg(status_code.to_string())
         .arg(response_body)
         .stdout(Stdio::piped())
@@ -269,7 +329,7 @@ httpd.handle_request()
         .expect("python https test server should emit a valid port");
     HttpsSingleRequestServer {
         base_url: format!("https://127.0.0.1:{port}"),
-        cert_path,
+        ca_cert_path,
         child,
         temp_dir,
     }
@@ -794,12 +854,12 @@ fn functional_https_transport_submit_with_trusted_ca_succeeds() {
         200,
         "status=submitted\nprovider=kolme-local\ncommit_id=kolme-commit:https\nfinality=final\n",
     );
-    let cert_path = server
-        .cert_path
+    let ca_cert_path = server
+        .ca_cert_path
         .to_str()
         .expect("temporary cert path should be valid utf-8")
         .to_owned();
-    let _env_guard = EnvVarGuard::set(TLS_CA_FILE_ENV, Some(cert_path.as_str()));
+    let _env_guard = EnvVarGuard::set(TLS_CA_FILE_ENV, Some(ca_cert_path.as_str()));
 
     let transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
     let mut provider = KolmeRuntimeCommitLiveProvider::new(
@@ -881,6 +941,59 @@ fn regression_https_transport_maps_tls_handshake_failures_to_unavailable() {
         Err(KolmeRuntimeCommitProviderError::Unavailable {
             reason: "tls handshake failed".to_owned(),
         })
+    );
+}
+
+#[test]
+fn performance_https_transport_timeout_budget_is_bounded() {
+    let _guard = tls_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _env_guard = EnvVarGuard::set(TLS_CA_FILE_ENV, None);
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    thread::spawn(move || {
+        let (_stream, _) = listener.accept().expect("connection should be accepted");
+        thread::sleep(Duration::from_secs(3));
+    });
+
+    let transport = KolmeRuntimeCommitHttpTransport::new(1).expect("transport should build");
+    let mut provider = KolmeRuntimeCommitLiveProvider::new(
+        format!("https://{addr}").as_str(),
+        "/broadcast/runtime-commit",
+        transport,
+    )
+    .expect("provider should build");
+
+    let started = Instant::now();
+    let result = provider.submit_runtime_commit("operation_id=op-https\n", "idempotency-key-https");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed <= Duration::from_secs(2),
+        "native HTTPS timeout handling exceeded 2s fast-gate budget window: {elapsed:?}"
+    );
+    assert!(
+        matches!(
+            result,
+            Err(KolmeRuntimeCommitProviderError::Timeout)
+                | Err(KolmeRuntimeCommitProviderError::Unavailable { .. })
+        ),
+        "slow TLS endpoint should fail closed within timeout budget"
+    );
+}
+
+#[test]
+fn regression_https_transport_does_not_use_openssl_subprocess() {
+    // Regression: #2671
+    const TRANSPORT_SOURCE: &str = include_str!("../src/kolme_runtime_commit/http_transport.rs");
+    assert!(
+        !TRANSPORT_SOURCE.contains("Command::new(\"openssl\")"),
+        "HTTPS transport must not spawn openssl subprocesses"
+    );
+    assert!(
+        !TRANSPORT_SOURCE.contains(".arg(\"s_client\")"),
+        "HTTPS transport must not depend on openssl s_client subprocess path"
     );
 }
 

--- a/crates/kamn-kolme/src/tls_policy.rs
+++ b/crates/kamn-kolme/src/tls_policy.rs
@@ -66,6 +66,10 @@ pub fn classify_tls_failure_reason(stderr: &str) -> String {
         || normalized.contains("wrong version number")
         || normalized.contains("tlsv")
         || normalized.contains("ssl routines")
+        || normalized.contains("received corrupt message")
+        || normalized.contains("invalidcontenttype")
+        || normalized.contains("invalidmessage")
+        || normalized.contains("peer sent")
     {
         return "tls handshake failed".to_owned();
     }
@@ -105,6 +109,10 @@ mod tests {
     fn functional_classify_tls_failure_reason_detects_handshake_pattern() {
         assert_eq!(
             classify_tls_failure_reason("ssl routines:ssl3_get_record:wrong version number"),
+            "tls handshake failed"
+        );
+        assert_eq!(
+            classify_tls_failure_reason("received corrupt message of type InvalidContentType"),
             "tls handshake failed"
         );
     }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -48,6 +48,17 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - deterministic tick-budget simulation with bounded loop-free assertions
   - timeout behavior and observability telemetry validated through direct state transitions instead of wall-clock waits
 
+## Kolme HTTPS Native Transport Contract
+- Runtime-commit HTTPS transport uses an in-process native TLS client path.
+- `openssl s_client` subprocess execution is prohibited in transport code paths (`Regression: #2671`).
+- Fast-gate regression command:
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_does_not_use_openssl_subprocess -- --exact`
+- HTTPS parity command coverage:
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact`
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact`
+  - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_tls_handshake_failures_to_unavailable -- --exact`
+- Certificate/handshake/timeout reason-code mapping remains deterministic and fail-closed for runtime commit submit/finality/block fallback flows.
+
 ## kamn-core Missing-Docs Velocity Guard
 - Fast-gate missing-docs velocity regression command:
   - `bash scripts/ci/test_missing_docs_velocity_guard_contract.sh`


### PR DESCRIPTION
## Summary
Rebases native HTTPS runtime-commit transport migration onto current `main` and preserves all later node/runtime changes. This keeps runtime commit HTTPS on native rustls transport and maintains deterministic fail-closed TLS error mapping.

Closes #2671
Supersedes #2676

## Changes
- `crates/kamn-core/src/kolme_runtime_commit/http_transport.rs`: native rustls HTTPS path (no subprocess TLS execution).
- `crates/kamn-core/Cargo.toml` + `Cargo.lock`: adds rustls/webpki root dependencies.
- `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`: HTTPS success and TLS failure mapping coverage.
- `crates/kamn-kolme/src/tls_policy.rs`: deterministic TLS failure classification updates.
- `docs/ci/strategy.md`: explicit native HTTPS transport contract lane commands.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Original red phase for #2671 was captured in prior task history; this PR is the rebased refresh against current `main`.

### 🟢 Green Phase
Commands:
- `cargo fmt --all --check`
- `cargo clippy -p kamn-core -p kamn-kolme -- -D warnings`
- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport`
- `cargo test -p kamn-kolme tls_policy`

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test ci_strategy_docs`

Passing summary:
- `kolme_runtime_commit_http_transport`: 32 passed, 0 failed, 1 ignored.
- `kamn-kolme tls_policy`: 5 passed, 0 failed.
- `ci_strategy_docs`: 2 passed, 0 failed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | TLS classification unit tests in `kamn-kolme` | |
| Functional   | ✅     | HTTPS transport success path with trusted CA | |
| Integration  | ✅     | runtime-commit HTTPS submit/finality transport contracts | |
| Regression   | ✅     | explicit guard forbidding subprocess TLS transport | |
| Performance  | ✅     | HTTPS timeout budget contract test | |

## Risks & Rollback
- Rollback by reverting this commit if TLS path regressions are detected.

## Documentation Updates
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped crates)
- [x] TDD evidence captured
- [x] Full relevant regression suite passing
- [x] Docs updated
