### PR TITLE
feat(core): add deterministic snapshot+journal replay for critical stores

### DIFF
--- a/crates/kamn-core/src/channel_models.rs
+++ b/crates/kamn-core/src/channel_models.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Supported channel categories in the KAMN messaging model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -766,6 +766,7 @@ impl ChannelSnapshotStore for InMemoryChannelSnapshotStore {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileChannelSnapshotStore {
     path: PathBuf,
+    journal_path: PathBuf,
 }
 
 /// Result of file-store recovery attempt.
@@ -775,6 +776,15 @@ pub struct ChannelRecoveryResult {
     pub latest: Option<ChannelSnapshot>,
     /// Whether an invalid payload was repaired via truncation.
     pub repaired: bool,
+    /// Deterministic recovery reason code.
+    pub reason_code: &'static str,
+}
+
+impl ChannelRecoveryResult {
+    /// Returns the deterministic recovery reason code.
+    pub fn reason_code(&self) -> &'static str {
+        self.reason_code
+    }
 }
 
 impl FileChannelSnapshotStore {
@@ -785,17 +795,19 @@ impl FileChannelSnapshotStore {
                 "snapshot file path cannot be empty".to_owned(),
             ));
         }
-        Ok(Self { path })
+        let journal_path = channel_snapshot_journal_path(&path);
+        Ok(Self { path, journal_path })
     }
 
     /// Attempt to read latest snapshot and repair invalid persisted payloads.
     pub fn recover_latest_and_repair(
         &mut self,
     ) -> Result<ChannelRecoveryResult, ChannelSnapshotStoreError> {
-        if !self.path.exists() {
+        if !self.path.exists() && !self.journal_path.exists() {
             return Ok(ChannelRecoveryResult {
                 latest: None,
                 repaired: false,
+                reason_code: "channel_snapshot_recovery_empty",
             });
         }
 
@@ -803,14 +815,23 @@ impl FileChannelSnapshotStore {
             Ok(snapshot) => Ok(ChannelRecoveryResult {
                 latest: snapshot,
                 repaired: false,
+                reason_code: "channel_snapshot_recovery_clean",
             }),
+            Err(ChannelSnapshotStoreError::InvalidPayload(value))
+                if value.starts_with(CHANNEL_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX) =>
+            {
+                Err(ChannelSnapshotStoreError::InvalidPayload(value))
+            }
             Err(ChannelSnapshotStoreError::InvalidPayload(_))
             | Err(ChannelSnapshotStoreError::Snapshot(_)) => {
                 fs::write(&self.path, "")
                     .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
+                fs::write(&self.journal_path, "")
+                    .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
                 Ok(ChannelRecoveryResult {
                     latest: None,
                     repaired: true,
+                    reason_code: "channel_snapshot_recovery_repaired_corrupt_payload",
                 })
             }
             Err(error) => Err(error),
@@ -832,25 +853,151 @@ impl ChannelSnapshotStore for FileChannelSnapshotStore {
             .open(&self.path)
             .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
         file.write_all(payload.as_bytes())
-            .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))
+            .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
+        append_channel_snapshot_journal_record(&self.journal_path, &payload)
     }
 
     fn read_latest(&self) -> Result<Option<ChannelSnapshot>, ChannelSnapshotStoreError> {
-        if !self.path.exists() {
-            return Ok(None);
+        let snapshot_payload = read_channel_snapshot_file(&self.path)?;
+        let journal_snapshot = replay_channel_snapshot_journal(&self.journal_path)?;
+        Ok(journal_snapshot.or(snapshot_payload))
+    }
+}
+
+const CHANNEL_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX: &str = "channel_snapshot_journal_corrupt_tail";
+
+fn channel_snapshot_journal_path(path: &Path) -> PathBuf {
+    let mut journal = path.as_os_str().to_os_string();
+    journal.push(".journal");
+    PathBuf::from(journal)
+}
+
+fn read_channel_snapshot_file(
+    path: &Path,
+) -> Result<Option<ChannelSnapshot>, ChannelSnapshotStoreError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(path)
+        .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
+    if payload.trim().is_empty() {
+        return Ok(None);
+    }
+    let snapshot = parse_channel_snapshot_payload(&payload)?;
+    let mut verifier = ChannelStore::new();
+    verifier
+        .restore_snapshot(snapshot.clone())
+        .map_err(ChannelSnapshotStoreError::Snapshot)?;
+    Ok(Some(snapshot))
+}
+
+fn append_channel_snapshot_journal_record(
+    journal_path: &Path,
+    payload: &str,
+) -> Result<(), ChannelSnapshotStoreError> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(journal_path)
+        .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
+    let record = format!("entry|1|{}\n", encode_journal_hex(payload.as_bytes()));
+    file.write_all(record.as_bytes())
+        .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))
+}
+
+fn replay_channel_snapshot_journal(
+    journal_path: &Path,
+) -> Result<Option<ChannelSnapshot>, ChannelSnapshotStoreError> {
+    if !journal_path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(journal_path)
+        .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
+    let mut latest = None;
+
+    for (index, line) in payload.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
         }
 
-        let payload = fs::read_to_string(&self.path)
-            .map_err(|error| ChannelSnapshotStoreError::Io(error.to_string()))?;
-        if payload.trim().is_empty() {
-            return Ok(None);
-        }
-        let snapshot = parse_channel_snapshot_payload(&payload)?;
+        let payload_hex = parse_channel_snapshot_journal_record(trimmed, index + 1)?;
+        let payload_bytes = decode_journal_hex(payload_hex)
+            .ok_or_else(|| channel_snapshot_journal_corrupt_tail(index + 1))?;
+        let payload = String::from_utf8(payload_bytes)
+            .map_err(|_| channel_snapshot_journal_corrupt_tail(index + 1))?;
+        let snapshot = parse_channel_snapshot_payload(&payload)
+            .map_err(|_| channel_snapshot_journal_corrupt_tail(index + 1))?;
         let mut verifier = ChannelStore::new();
         verifier
             .restore_snapshot(snapshot.clone())
-            .map_err(ChannelSnapshotStoreError::Snapshot)?;
-        Ok(Some(snapshot))
+            .map_err(|_| channel_snapshot_journal_corrupt_tail(index + 1))?;
+        latest = Some(snapshot);
+    }
+
+    Ok(latest)
+}
+
+fn parse_channel_snapshot_journal_record(
+    line: &str,
+    index: usize,
+) -> Result<&str, ChannelSnapshotStoreError> {
+    let mut parts = line.split('|');
+    let Some(prefix) = parts.next() else {
+        return Err(channel_snapshot_journal_corrupt_tail(index));
+    };
+    let Some(version) = parts.next() else {
+        return Err(channel_snapshot_journal_corrupt_tail(index));
+    };
+    let Some(payload_hex) = parts.next() else {
+        return Err(channel_snapshot_journal_corrupt_tail(index));
+    };
+    if prefix != "entry" || version != "1" || payload_hex.is_empty() || parts.next().is_some() {
+        return Err(channel_snapshot_journal_corrupt_tail(index));
+    }
+    Ok(payload_hex)
+}
+
+fn channel_snapshot_journal_corrupt_tail(index: usize) -> ChannelSnapshotStoreError {
+    ChannelSnapshotStoreError::InvalidPayload(format!(
+        "{CHANNEL_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX}:{index}"
+    ))
+}
+
+fn encode_journal_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn decode_journal_hex(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let high = decode_journal_nibble(bytes[index])?;
+        let low = decode_journal_nibble(bytes[index + 1])?;
+        decoded.push((high << 4) | low);
+        index += 2;
+    }
+    Some(decoded)
+}
+
+fn decode_journal_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -1178,11 +1325,13 @@ fn parse_channel_snapshot_payload(
 #[cfg(test)]
 mod tests {
     use super::{
-        ChannelMetadata, ChannelModelError, ChannelRecordSnapshot, ChannelSnapshot,
-        ChannelSnapshotError, ChannelSnapshotStore, ChannelSnapshotStoreError, ChannelStore,
-        ChannelType, FileChannelSnapshotStore,
+        serialize_channel_snapshot, ChannelMetadata, ChannelModelError, ChannelRecordSnapshot,
+        ChannelSnapshot, ChannelSnapshotError, ChannelSnapshotStore, ChannelSnapshotStoreError,
+        ChannelStore, ChannelType, FileChannelSnapshotStore,
     };
     use std::fs;
+    use std::fs::OpenOptions;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -1373,7 +1522,9 @@ mod tests {
     #[test]
     fn integration_file_channel_snapshot_store_roundtrips_snapshot() {
         let path = temp_channel_snapshot_path("roundtrip");
+        let journal_path = temp_channel_snapshot_journal_path(&path);
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
 
         let mut store = ChannelStore::new();
         store
@@ -1399,6 +1550,57 @@ mod tests {
         );
 
         let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn integration_file_channel_snapshot_store_replays_journal_when_snapshot_is_stale() {
+        let path = temp_channel_snapshot_path("journal-replay");
+        let journal_path = temp_channel_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut store = ChannelStore::new();
+        store
+            .create_group(
+                "channel:group:journal-1",
+                "kamn:did:agent:owner",
+                vec![
+                    "kamn:did:agent:owner".to_owned(),
+                    "kamn:did:agent:member-1".to_owned(),
+                ],
+                vec!["kamn:did:agent:owner".to_owned()],
+            )
+            .expect("group should be created");
+        let first_snapshot = store.export_snapshot();
+
+        let mut file_store = FileChannelSnapshotStore::new(path.clone()).expect("store");
+        file_store
+            .write(first_snapshot.clone())
+            .expect("write should succeed");
+
+        store
+            .invite_member(
+                "channel:group:journal-1",
+                "kamn:did:agent:owner",
+                "kamn:did:agent:member-2",
+            )
+            .expect("invite should succeed");
+        let second_snapshot = store.export_snapshot();
+        file_store
+            .write(second_snapshot.clone())
+            .expect("second write should succeed");
+
+        let stale_payload =
+            serialize_channel_snapshot(&first_snapshot).expect("first snapshot should serialize");
+        assert!(fs::write(&path, stale_payload).is_ok());
+        assert_eq!(
+            file_store.read_latest().expect("journal replay should win"),
+            Some(second_snapshot)
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
     }
 
     #[test]
@@ -1422,7 +1624,9 @@ mod tests {
     #[test]
     fn functional_file_channel_snapshot_store_recovery_repairs_corrupt_payload() {
         let path = temp_channel_snapshot_path("recover");
+        let journal_path = temp_channel_snapshot_journal_path(&path);
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
         assert!(fs::write(&path, "schema|1\nrecord|broken\n").is_ok());
 
         let mut file_store = FileChannelSnapshotStore::new(path.clone()).expect("store");
@@ -1437,6 +1641,47 @@ mod tests {
         );
 
         let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn regression_file_channel_snapshot_store_rejects_corrupt_journal_tail() {
+        // Regression: #2690
+        let path = temp_channel_snapshot_path("corrupt-journal-tail");
+        let journal_path = temp_channel_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut store = ChannelStore::new();
+        store
+            .create_group(
+                "channel:group:journal-tail",
+                "kamn:did:agent:owner",
+                vec![
+                    "kamn:did:agent:owner".to_owned(),
+                    "kamn:did:agent:member-1".to_owned(),
+                ],
+                vec!["kamn:did:agent:owner".to_owned()],
+            )
+            .expect("group should be created");
+        let snapshot = store.export_snapshot();
+        let mut file_store = FileChannelSnapshotStore::new(path.clone()).expect("store");
+        file_store.write(snapshot).expect("write should succeed");
+
+        let mut journal = OpenOptions::new()
+            .append(true)
+            .open(&journal_path)
+            .expect("journal should exist");
+        assert!(journal.write_all(b"entry|1|deadbeefz\n").is_ok());
+        assert_eq!(
+            file_store.recover_latest_and_repair(),
+            Err(ChannelSnapshotStoreError::InvalidPayload(
+                "channel_snapshot_journal_corrupt_tail:2".to_owned()
+            ))
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
     }
 
     #[test]
@@ -1500,5 +1745,11 @@ mod tests {
             .expect("clock should be monotonic")
             .as_nanos();
         std::env::temp_dir().join(format!("kamn-channel-snapshot-{tag}-{nonce}.log"))
+    }
+
+    fn temp_channel_snapshot_journal_path(path: &std::path::Path) -> PathBuf {
+        let mut journal = path.as_os_str().to_os_string();
+        journal.push(".journal");
+        PathBuf::from(journal)
     }
 }

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// Canonical lifecycle state for a message tracked by [`MessageLifecycleStore`].
@@ -657,6 +657,7 @@ impl MessageLifecycleSnapshotStore for InMemoryMessageLifecycleSnapshotStore {
 /// File-backed snapshot store for lifecycle state recovery.
 pub struct FileMessageLifecycleSnapshotStore {
     path: PathBuf,
+    journal_path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -666,6 +667,15 @@ pub struct MessageLifecycleRecoveryResult {
     pub latest: Option<MessageLifecycleSnapshot>,
     /// Whether recovery repaired a malformed on-disk payload.
     pub repaired: bool,
+    /// Deterministic recovery reason code.
+    pub reason_code: &'static str,
+}
+
+impl MessageLifecycleRecoveryResult {
+    /// Returns the deterministic recovery reason code.
+    pub fn reason_code(&self) -> &'static str {
+        self.reason_code
+    }
 }
 
 impl FileMessageLifecycleSnapshotStore {
@@ -676,17 +686,19 @@ impl FileMessageLifecycleSnapshotStore {
                 "snapshot file path cannot be empty".to_owned(),
             ));
         }
-        Ok(Self { path })
+        let journal_path = message_lifecycle_snapshot_journal_path(&path);
+        Ok(Self { path, journal_path })
     }
 
     /// Loads the latest snapshot and repairs malformed payloads by truncating the file.
     pub fn recover_latest_and_repair(
         &mut self,
     ) -> Result<MessageLifecycleRecoveryResult, MessageLifecycleSnapshotStoreError> {
-        if !self.path.exists() {
+        if !self.path.exists() && !self.journal_path.exists() {
             return Ok(MessageLifecycleRecoveryResult {
                 latest: None,
                 repaired: false,
+                reason_code: "message_lifecycle_snapshot_recovery_empty",
             });
         }
 
@@ -694,14 +706,23 @@ impl FileMessageLifecycleSnapshotStore {
             Ok(snapshot) => Ok(MessageLifecycleRecoveryResult {
                 latest: snapshot,
                 repaired: false,
+                reason_code: "message_lifecycle_snapshot_recovery_clean",
             }),
+            Err(MessageLifecycleSnapshotStoreError::InvalidPayload(value))
+                if value.starts_with(MESSAGE_LIFECYCLE_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX) =>
+            {
+                Err(MessageLifecycleSnapshotStoreError::InvalidPayload(value))
+            }
             Err(MessageLifecycleSnapshotStoreError::InvalidPayload(_))
             | Err(MessageLifecycleSnapshotStoreError::Snapshot(_)) => {
                 fs::write(&self.path, "")
                     .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
+                fs::write(&self.journal_path, "")
+                    .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
                 Ok(MessageLifecycleRecoveryResult {
                     latest: None,
                     repaired: true,
+                    reason_code: "message_lifecycle_snapshot_recovery_repaired_corrupt_payload",
                 })
             }
             Err(error) => Err(error),
@@ -726,27 +747,156 @@ impl MessageLifecycleSnapshotStore for FileMessageLifecycleSnapshotStore {
             .open(&self.path)
             .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
         file.write_all(payload.as_bytes())
-            .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))
+            .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
+        append_message_lifecycle_snapshot_journal_record(&self.journal_path, &payload)
     }
 
     fn read_latest(
         &self,
     ) -> Result<Option<MessageLifecycleSnapshot>, MessageLifecycleSnapshotStoreError> {
-        if !self.path.exists() {
-            return Ok(None);
+        let snapshot_payload = read_message_lifecycle_snapshot_file(&self.path)?;
+        let journal_snapshot = replay_message_lifecycle_snapshot_journal(&self.journal_path)?;
+        Ok(journal_snapshot.or(snapshot_payload))
+    }
+}
+
+const MESSAGE_LIFECYCLE_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX: &str =
+    "message_lifecycle_snapshot_journal_corrupt_tail";
+
+fn message_lifecycle_snapshot_journal_path(path: &Path) -> PathBuf {
+    let mut journal = path.as_os_str().to_os_string();
+    journal.push(".journal");
+    PathBuf::from(journal)
+}
+
+fn read_message_lifecycle_snapshot_file(
+    path: &Path,
+) -> Result<Option<MessageLifecycleSnapshot>, MessageLifecycleSnapshotStoreError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(path)
+        .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
+    if payload.trim().is_empty() {
+        return Ok(None);
+    }
+    let snapshot = parse_message_lifecycle_snapshot_payload(&payload)?;
+    let mut verifier = MessageLifecycleStore::new();
+    verifier
+        .restore_snapshot(snapshot.clone())
+        .map_err(MessageLifecycleSnapshotStoreError::Snapshot)?;
+    Ok(Some(snapshot))
+}
+
+fn append_message_lifecycle_snapshot_journal_record(
+    journal_path: &Path,
+    payload: &str,
+) -> Result<(), MessageLifecycleSnapshotStoreError> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(journal_path)
+        .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
+    let record = format!("entry|1|{}\n", encode_journal_hex(payload.as_bytes()));
+    file.write_all(record.as_bytes())
+        .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))
+}
+
+fn replay_message_lifecycle_snapshot_journal(
+    journal_path: &Path,
+) -> Result<Option<MessageLifecycleSnapshot>, MessageLifecycleSnapshotStoreError> {
+    if !journal_path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(journal_path)
+        .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
+    let mut latest = None;
+
+    for (index, line) in payload.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
         }
 
-        let payload = fs::read_to_string(&self.path)
-            .map_err(|error| MessageLifecycleSnapshotStoreError::Io(error.to_string()))?;
-        if payload.trim().is_empty() {
-            return Ok(None);
-        }
-        let snapshot = parse_message_lifecycle_snapshot_payload(&payload)?;
+        let payload_hex = parse_message_lifecycle_snapshot_journal_record(trimmed, index + 1)?;
+        let payload_bytes = decode_journal_hex(payload_hex)
+            .ok_or_else(|| message_lifecycle_snapshot_journal_corrupt_tail(index + 1))?;
+        let payload = String::from_utf8(payload_bytes)
+            .map_err(|_| message_lifecycle_snapshot_journal_corrupt_tail(index + 1))?;
+        let snapshot = parse_message_lifecycle_snapshot_payload(&payload)
+            .map_err(|_| message_lifecycle_snapshot_journal_corrupt_tail(index + 1))?;
         let mut verifier = MessageLifecycleStore::new();
         verifier
             .restore_snapshot(snapshot.clone())
-            .map_err(MessageLifecycleSnapshotStoreError::Snapshot)?;
-        Ok(Some(snapshot))
+            .map_err(|_| message_lifecycle_snapshot_journal_corrupt_tail(index + 1))?;
+        latest = Some(snapshot);
+    }
+
+    Ok(latest)
+}
+
+fn parse_message_lifecycle_snapshot_journal_record(
+    line: &str,
+    index: usize,
+) -> Result<&str, MessageLifecycleSnapshotStoreError> {
+    let mut parts = line.split('|');
+    let Some(prefix) = parts.next() else {
+        return Err(message_lifecycle_snapshot_journal_corrupt_tail(index));
+    };
+    let Some(version) = parts.next() else {
+        return Err(message_lifecycle_snapshot_journal_corrupt_tail(index));
+    };
+    let Some(payload_hex) = parts.next() else {
+        return Err(message_lifecycle_snapshot_journal_corrupt_tail(index));
+    };
+    if prefix != "entry" || version != "1" || payload_hex.is_empty() || parts.next().is_some() {
+        return Err(message_lifecycle_snapshot_journal_corrupt_tail(index));
+    }
+    Ok(payload_hex)
+}
+
+fn message_lifecycle_snapshot_journal_corrupt_tail(
+    index: usize,
+) -> MessageLifecycleSnapshotStoreError {
+    MessageLifecycleSnapshotStoreError::InvalidPayload(format!(
+        "{MESSAGE_LIFECYCLE_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX}:{index}"
+    ))
+}
+
+fn encode_journal_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn decode_journal_hex(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let high = decode_journal_nibble(bytes[index])?;
+        let low = decode_journal_nibble(bytes[index + 1])?;
+        decoded.push((high << 4) | low);
+        index += 2;
+    }
+    Some(decoded)
+}
+
+fn decode_journal_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -1008,13 +1158,15 @@ fn parse_message_lifecycle_snapshot_payload(
 #[cfg(test)]
 mod tests {
     use super::{
-        FileMessageLifecycleSnapshotStore, MessageLifecycleError, MessageLifecycleSnapshot,
-        MessageLifecycleSnapshotError, MessageLifecycleSnapshotStore,
-        MessageLifecycleSnapshotStoreError, MessageLifecycleStore, MessageProofAdmissionError,
-        MessageStatus,
+        serialize_message_lifecycle_snapshot, FileMessageLifecycleSnapshotStore,
+        MessageLifecycleError, MessageLifecycleSnapshot, MessageLifecycleSnapshotError,
+        MessageLifecycleSnapshotStore, MessageLifecycleSnapshotStoreError, MessageLifecycleStore,
+        MessageProofAdmissionError, MessageStatus,
     };
     use crate::{ProcessorProofAdmissionEvaluator, ProcessorProofArtifact, ZkDesignError};
     use std::fs;
+    use std::fs::OpenOptions;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -1323,7 +1475,9 @@ mod tests {
     #[test]
     fn integration_file_message_lifecycle_snapshot_store_roundtrips_snapshot() {
         let path = temp_message_lifecycle_snapshot_path("roundtrip");
+        let journal_path = temp_message_lifecycle_snapshot_journal_path(&path);
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
 
         let mut store = MessageLifecycleStore::new();
         store
@@ -1346,6 +1500,56 @@ mod tests {
         );
 
         let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn integration_file_message_lifecycle_snapshot_store_replays_journal_when_snapshot_is_stale() {
+        let path = temp_message_lifecycle_snapshot_path("journal-replay");
+        let journal_path = temp_message_lifecycle_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg-journal-1",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+        let first_snapshot = store.export_snapshot();
+        let mut file_store = FileMessageLifecycleSnapshotStore::new(path.clone()).expect("store");
+        file_store
+            .write(first_snapshot.clone())
+            .expect("write should pass");
+
+        store
+            .register(
+                "urn:uuid:msg-journal-2",
+                "kamn:did:agent:sender-2",
+                vec!["kamn:did:agent:recipient-2".to_owned()],
+                "2026-02-07T21:15:30.123Z",
+                "2026-02-07T21:45:30.123Z",
+            )
+            .expect("second register should succeed");
+        let second_snapshot = store.export_snapshot();
+        file_store
+            .write(second_snapshot.clone())
+            .expect("second write should pass");
+
+        let stale_payload = serialize_message_lifecycle_snapshot(&first_snapshot)
+            .expect("first snapshot should serialize");
+        assert!(fs::write(&path, stale_payload).is_ok());
+        assert_eq!(
+            file_store.read_latest().expect("journal replay should win"),
+            Some(second_snapshot)
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
     }
 
     #[test]
@@ -1369,7 +1573,9 @@ mod tests {
     #[test]
     fn functional_file_message_lifecycle_snapshot_store_recovery_repairs_corrupt_payload() {
         let path = temp_message_lifecycle_snapshot_path("recover");
+        let journal_path = temp_message_lifecycle_snapshot_journal_path(&path);
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
         assert!(fs::write(&path, "schema|1\nrecord|broken\n").is_ok());
 
         let mut file_store = FileMessageLifecycleSnapshotStore::new(path.clone()).expect("store");
@@ -1384,6 +1590,45 @@ mod tests {
         );
 
         let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn regression_file_message_lifecycle_snapshot_store_rejects_corrupt_journal_tail() {
+        // Regression: #2690
+        let path = temp_message_lifecycle_snapshot_path("corrupt-journal-tail");
+        let journal_path = temp_message_lifecycle_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg-tail",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+        let snapshot = store.export_snapshot();
+        let mut file_store = FileMessageLifecycleSnapshotStore::new(path.clone()).expect("store");
+        file_store.write(snapshot).expect("write should pass");
+
+        let mut journal = OpenOptions::new()
+            .append(true)
+            .open(&journal_path)
+            .expect("journal should exist");
+        assert!(journal.write_all(b"entry|1|deadbeefz\n").is_ok());
+        assert_eq!(
+            file_store.recover_latest_and_repair(),
+            Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "message_lifecycle_snapshot_journal_corrupt_tail:2".to_owned()
+            ))
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
     }
 
     #[test]
@@ -1442,5 +1687,11 @@ mod tests {
             .expect("clock should be monotonic")
             .as_nanos();
         std::env::temp_dir().join(format!("kamn-message-lifecycle-snapshot-{tag}-{nonce}.log"))
+    }
+
+    fn temp_message_lifecycle_snapshot_journal_path(path: &std::path::Path) -> PathBuf {
+        let mut journal = path.as_os_str().to_os_string();
+        journal.push(".journal");
+        PathBuf::from(journal)
     }
 }

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Notice kinds emitted for task operation lifecycle activity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -768,6 +768,7 @@ impl TaskOperationSnapshotStore for InMemoryTaskOperationSnapshotStore {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileTaskOperationSnapshotStore {
     path: PathBuf,
+    journal_path: PathBuf,
 }
 
 /// Recovery outcome for filesystem snapshot repair flow.
@@ -777,6 +778,15 @@ pub struct TaskOperationRecoveryResult {
     pub latest: Option<TaskOperationSnapshot>,
     /// Whether recovery rewrote corrupted payload to repaired baseline.
     pub repaired: bool,
+    /// Deterministic recovery reason code.
+    pub reason_code: &'static str,
+}
+
+impl TaskOperationRecoveryResult {
+    /// Returns the deterministic recovery reason code.
+    pub fn reason_code(&self) -> &'static str {
+        self.reason_code
+    }
 }
 
 impl FileTaskOperationSnapshotStore {
@@ -787,17 +797,19 @@ impl FileTaskOperationSnapshotStore {
                 "snapshot file path cannot be empty".to_owned(),
             ));
         }
-        Ok(Self { path })
+        let journal_path = task_operation_snapshot_journal_path(&path);
+        Ok(Self { path, journal_path })
     }
 
     /// Attempt to read latest snapshot; if corrupt, repair file and return empty state.
     pub fn recover_latest_and_repair(
         &mut self,
     ) -> Result<TaskOperationRecoveryResult, TaskOperationSnapshotStoreError> {
-        if !self.path.exists() {
+        if !self.path.exists() && !self.journal_path.exists() {
             return Ok(TaskOperationRecoveryResult {
                 latest: None,
                 repaired: false,
+                reason_code: "task_operation_snapshot_recovery_empty",
             });
         }
 
@@ -805,14 +817,23 @@ impl FileTaskOperationSnapshotStore {
             Ok(snapshot) => Ok(TaskOperationRecoveryResult {
                 latest: snapshot,
                 repaired: false,
+                reason_code: "task_operation_snapshot_recovery_clean",
             }),
+            Err(TaskOperationSnapshotStoreError::InvalidPayload(value))
+                if value.starts_with(TASK_OPERATION_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX) =>
+            {
+                Err(TaskOperationSnapshotStoreError::InvalidPayload(value))
+            }
             Err(TaskOperationSnapshotStoreError::InvalidPayload(_))
             | Err(TaskOperationSnapshotStoreError::Snapshot(_)) => {
                 fs::write(&self.path, "")
                     .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
+                fs::write(&self.journal_path, "")
+                    .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
                 Ok(TaskOperationRecoveryResult {
                     latest: None,
                     repaired: true,
+                    reason_code: "task_operation_snapshot_recovery_repaired_corrupt_payload",
                 })
             }
             Err(error) => Err(error),
@@ -837,27 +858,154 @@ impl TaskOperationSnapshotStore for FileTaskOperationSnapshotStore {
             .open(&self.path)
             .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
         file.write_all(payload.as_bytes())
-            .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))
+            .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
+        append_task_operation_snapshot_journal_record(&self.journal_path, &payload)
     }
 
     fn read_latest(
         &self,
     ) -> Result<Option<TaskOperationSnapshot>, TaskOperationSnapshotStoreError> {
-        if !self.path.exists() {
-            return Ok(None);
+        let snapshot_payload = read_task_operation_snapshot_file(&self.path)?;
+        let journal_snapshot = replay_task_operation_snapshot_journal(&self.journal_path)?;
+        Ok(journal_snapshot.or(snapshot_payload))
+    }
+}
+
+const TASK_OPERATION_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX: &str =
+    "task_operation_snapshot_journal_corrupt_tail";
+
+fn task_operation_snapshot_journal_path(path: &Path) -> PathBuf {
+    let mut journal = path.as_os_str().to_os_string();
+    journal.push(".journal");
+    PathBuf::from(journal)
+}
+
+fn read_task_operation_snapshot_file(
+    path: &Path,
+) -> Result<Option<TaskOperationSnapshot>, TaskOperationSnapshotStoreError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(path)
+        .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
+    if payload.trim().is_empty() {
+        return Ok(None);
+    }
+    let snapshot = parse_task_operation_snapshot_payload(&payload)?;
+    let mut verifier = TaskOperationEngine::new();
+    verifier
+        .restore_snapshot(snapshot.clone())
+        .map_err(TaskOperationSnapshotStoreError::Snapshot)?;
+    Ok(Some(snapshot))
+}
+
+fn append_task_operation_snapshot_journal_record(
+    journal_path: &Path,
+    payload: &str,
+) -> Result<(), TaskOperationSnapshotStoreError> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(journal_path)
+        .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
+    let record = format!("entry|1|{}\n", encode_journal_hex(payload.as_bytes()));
+    file.write_all(record.as_bytes())
+        .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))
+}
+
+fn replay_task_operation_snapshot_journal(
+    journal_path: &Path,
+) -> Result<Option<TaskOperationSnapshot>, TaskOperationSnapshotStoreError> {
+    if !journal_path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(journal_path)
+        .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
+    let mut latest = None;
+
+    for (index, line) in payload.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
         }
 
-        let payload = fs::read_to_string(&self.path)
-            .map_err(|error| TaskOperationSnapshotStoreError::Io(error.to_string()))?;
-        if payload.trim().is_empty() {
-            return Ok(None);
-        }
-        let snapshot = parse_task_operation_snapshot_payload(&payload)?;
+        let payload_hex = parse_task_operation_snapshot_journal_record(trimmed, index + 1)?;
+        let payload_bytes = decode_journal_hex(payload_hex)
+            .ok_or_else(|| task_operation_snapshot_journal_corrupt_tail(index + 1))?;
+        let payload = String::from_utf8(payload_bytes)
+            .map_err(|_| task_operation_snapshot_journal_corrupt_tail(index + 1))?;
+        let snapshot = parse_task_operation_snapshot_payload(&payload)
+            .map_err(|_| task_operation_snapshot_journal_corrupt_tail(index + 1))?;
         let mut verifier = TaskOperationEngine::new();
         verifier
             .restore_snapshot(snapshot.clone())
-            .map_err(TaskOperationSnapshotStoreError::Snapshot)?;
-        Ok(Some(snapshot))
+            .map_err(|_| task_operation_snapshot_journal_corrupt_tail(index + 1))?;
+        latest = Some(snapshot);
+    }
+
+    Ok(latest)
+}
+
+fn parse_task_operation_snapshot_journal_record(
+    line: &str,
+    index: usize,
+) -> Result<&str, TaskOperationSnapshotStoreError> {
+    let mut parts = line.split('|');
+    let Some(prefix) = parts.next() else {
+        return Err(task_operation_snapshot_journal_corrupt_tail(index));
+    };
+    let Some(version) = parts.next() else {
+        return Err(task_operation_snapshot_journal_corrupt_tail(index));
+    };
+    let Some(payload_hex) = parts.next() else {
+        return Err(task_operation_snapshot_journal_corrupt_tail(index));
+    };
+    if prefix != "entry" || version != "1" || payload_hex.is_empty() || parts.next().is_some() {
+        return Err(task_operation_snapshot_journal_corrupt_tail(index));
+    }
+    Ok(payload_hex)
+}
+
+fn task_operation_snapshot_journal_corrupt_tail(index: usize) -> TaskOperationSnapshotStoreError {
+    TaskOperationSnapshotStoreError::InvalidPayload(format!(
+        "{TASK_OPERATION_SNAPSHOT_JOURNAL_CORRUPT_TAIL_PREFIX}:{index}"
+    ))
+}
+
+fn encode_journal_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn decode_journal_hex(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let high = decode_journal_nibble(bytes[index])?;
+        let low = decode_journal_nibble(bytes[index + 1])?;
+        decoded.push((high << 4) | low);
+        index += 2;
+    }
+    Some(decoded)
+}
+
+fn decode_journal_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -1182,11 +1330,14 @@ fn parse_task_operation_snapshot_payload(
 #[cfg(test)]
 mod tests {
     use super::{
-        FileTaskOperationSnapshotStore, SwarmTaskDraft, TaskOperationEngine, TaskOperationError,
-        TaskOperationSnapshotStore, TaskOperationSnapshotStoreError,
+        serialize_task_operation_snapshot, FileTaskOperationSnapshotStore, SwarmTaskDraft,
+        TaskOperationEngine, TaskOperationError, TaskOperationSnapshotStore,
+        TaskOperationSnapshotStoreError,
     };
     use crate::TaskState;
     use std::fs;
+    use std::fs::OpenOptions;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1277,7 +1428,9 @@ mod tests {
     #[test]
     fn integration_file_task_operation_snapshot_store_roundtrips_snapshot() {
         let path = temp_task_operation_snapshot_path("roundtrip");
+        let journal_path = temp_task_operation_snapshot_journal_path(&path);
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
 
         let mut engine = TaskOperationEngine::new();
         engine
@@ -1302,6 +1455,53 @@ mod tests {
         );
 
         let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn integration_file_task_operation_snapshot_store_replays_journal_when_snapshot_is_stale() {
+        let path = temp_task_operation_snapshot_path("journal-replay");
+        let journal_path = temp_task_operation_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut engine = TaskOperationEngine::new();
+        engine
+            .submit(
+                "task-journal-1",
+                "kamn:did:agent:requester-1",
+                "first snapshot",
+            )
+            .expect("first submit should pass");
+        let first_snapshot = engine.export_snapshot();
+
+        let mut file_store = FileTaskOperationSnapshotStore::new(path.clone()).expect("store");
+        file_store
+            .write(first_snapshot.clone())
+            .expect("first write should pass");
+
+        engine
+            .submit(
+                "task-journal-2",
+                "kamn:did:agent:requester-1",
+                "second snapshot",
+            )
+            .expect("second submit should pass");
+        let second_snapshot = engine.export_snapshot();
+        file_store
+            .write(second_snapshot.clone())
+            .expect("second write should pass");
+
+        let stale_payload =
+            serialize_task_operation_snapshot(&first_snapshot).expect("serialize should pass");
+        assert!(fs::write(&path, stale_payload).is_ok());
+        assert_eq!(
+            file_store.read_latest().expect("journal replay should win"),
+            Some(second_snapshot)
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
     }
 
     #[test]
@@ -1325,7 +1525,9 @@ mod tests {
     #[test]
     fn functional_file_task_operation_snapshot_store_recovery_repairs_corrupt_payload() {
         let path = temp_task_operation_snapshot_path("recover");
+        let journal_path = temp_task_operation_snapshot_journal_path(&path);
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
         assert!(fs::write(&path, "schema|1\ntask|broken\n").is_ok());
 
         let mut file_store = FileTaskOperationSnapshotStore::new(path.clone()).expect("store");
@@ -1340,6 +1542,40 @@ mod tests {
         );
 
         let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn regression_file_task_operation_snapshot_store_rejects_corrupt_journal_tail() {
+        // Regression: #2690
+        let path = temp_task_operation_snapshot_path("corrupt-journal-tail");
+        let journal_path = temp_task_operation_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut engine = TaskOperationEngine::new();
+        engine
+            .submit("task-tail", "kamn:did:agent:requester-1", "tail payload")
+            .expect("submit should pass");
+        let snapshot = engine.export_snapshot();
+
+        let mut file_store = FileTaskOperationSnapshotStore::new(path.clone()).expect("store");
+        file_store.write(snapshot).expect("write should pass");
+
+        let mut journal = OpenOptions::new()
+            .append(true)
+            .open(&journal_path)
+            .expect("journal should exist");
+        assert!(journal.write_all(b"entry|1|deadbeefz\n").is_ok());
+        assert_eq!(
+            file_store.recover_latest_and_repair(),
+            Err(TaskOperationSnapshotStoreError::InvalidPayload(
+                "task_operation_snapshot_journal_corrupt_tail:2".to_owned()
+            ))
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
     }
 
     #[test]
@@ -1399,5 +1635,11 @@ mod tests {
             .expect("clock should be monotonic")
             .as_nanos();
         std::env::temp_dir().join(format!("kamn-task-operation-snapshot-{tag}-{nonce}.log"))
+    }
+
+    fn temp_task_operation_snapshot_journal_path(path: &std::path::Path) -> PathBuf {
+        let mut journal = path.as_os_str().to_os_string();
+        journal.push(".journal");
+        PathBuf::from(journal)
     }
 }

--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -9,6 +9,12 @@ fn doc_contains_make_and_demo_scope_contract_rules() {
     assert!(DOC.contains("scripts/ci/check_test_layering_policy.py"));
     assert!(DOC.contains("scripts/ci/test_check_test_layering_policy.sh"));
     assert!(DOC.contains("docs/planning/test_layering_policy.md"));
+    assert!(DOC.contains("## Snapshot + Journal Durability Replay Contract"));
+    assert!(DOC.contains("docs/planning/persistence_durability_model.md"));
+    assert!(DOC.contains("cargo test -p kamn-core --lib journal"));
+    assert!(DOC.contains("channel_snapshot_journal_corrupt_tail:<line>"));
+    assert!(DOC.contains("message_lifecycle_snapshot_journal_corrupt_tail:<line>"));
+    assert!(DOC.contains("task_operation_snapshot_journal_corrupt_tail:<line>"));
     assert!(DOC.contains("layering_marker_missing"));
     assert!(DOC.contains("run_localhost_signed_integration_contract_lane_tests"));
     assert!(DOC.contains("sdk-live-localhost-integration"));
@@ -156,6 +162,7 @@ fn regression_requires_make_and_selector_demo_contract_marker() {
     assert!(DOC.contains("Regression: #1466"));
     assert!(DOC.contains("Regression: #1497"));
     assert!(DOC.contains("Regression: #2694"));
+    assert!(DOC.contains("Regression: #2690"));
     assert!(DOC.contains("Regression: #2093"));
     assert!(DOC.contains("Regression: #2095"));
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -37,6 +37,20 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - `strategy_snippet_missing`
 - Regression: #2694
 
+## Snapshot + Journal Durability Replay Contract
+- Snapshot+journal durability policy is tracked in `docs/planning/persistence_durability_model.md`.
+- Fast-gate replay contract command:
+  - `cargo test -p kamn-core --lib journal`
+- Module-level bounded durability commands:
+  - `cargo test -p kamn-core --lib channel_models::tests::`
+  - `cargo test -p kamn-core --lib message_lifecycle::tests::`
+  - `cargo test -p kamn-core --lib task_operations::tests::`
+- Journal tail corruption remains fail-closed with deterministic reason codes:
+  - `channel_snapshot_journal_corrupt_tail:<line>`
+  - `message_lifecycle_snapshot_journal_corrupt_tail:<line>`
+  - `task_operation_snapshot_journal_corrupt_tail:<line>`
+- Regression: #2690
+
 ## Node Runtime Kolme-Live Fast Lane
 - For `kamn-node` live-runtime wiring/doc changes, keep PR validation on deterministic local harness tests:
   - `cargo test -p kamn-node runtime_kolme_live`

--- a/docs/planning/persistence_durability_model.md
+++ b/docs/planning/persistence_durability_model.md
@@ -1,0 +1,75 @@
+# Persistence Durability Model
+
+This document defines the deterministic crash-recovery contract for file-backed snapshot stores that persist runtime-adjacent state in `kamn-core`.
+
+## Scope
+
+Applies to:
+
+- `FileChannelSnapshotStore`
+- `FileMessageLifecycleSnapshotStore`
+- `FileTaskOperationSnapshotStore`
+
+## Contract Markers
+
+- `durability_schema_version=kamn.persistence.snapshot-journal.v1`
+- `write_path=latest_snapshot_plus_append_only_journal`
+- `replay_path=snapshot_base_plus_journal_tail`
+- `journal_tail_corruption=fail_closed`
+- `recovery_reason_codes=stable`
+
+## Write Path
+
+On each successful state write:
+
+1. Validate snapshot semantics with the in-memory verifier for that domain.
+2. Persist the latest snapshot payload to the snapshot file (truncate+replace).
+3. Append a deterministic journal record to the companion journal file.
+
+Journal entries are deterministic single-line records:
+
+- `entry|1|<hex-encoded-snapshot-payload>`
+
+## Replay Path
+
+Startup replay resolves state in this order:
+
+1. Parse and validate snapshot file payload as the base state (if present).
+2. Parse and replay all journal records in order.
+3. Return the latest valid replayed snapshot when journal entries exist.
+4. Fall back to snapshot-only state when journal is absent/empty.
+
+## Fail-Closed Rules
+
+Corrupt or truncated journal tails do not auto-repair. Replay fails closed with deterministic reason text:
+
+- `channel_snapshot_journal_corrupt_tail:<line>`
+- `message_lifecycle_snapshot_journal_corrupt_tail:<line>`
+- `task_operation_snapshot_journal_corrupt_tail:<line>`
+
+Recovery result objects also publish deterministic reason codes:
+
+- empty store: `*_snapshot_recovery_empty`
+- clean recovery: `*_snapshot_recovery_clean`
+- repaired corrupt snapshot payload: `*_snapshot_recovery_repaired_corrupt_payload`
+
+## Startup Budget
+
+Bounded performance checks for snapshot persistence/replay stay in fast CI:
+
+- channel snapshot roundtrip budget: `< 300ms`
+- message lifecycle snapshot roundtrip budget: `< 250ms`
+- task operation snapshot roundtrip budget: `< 250ms`
+
+## Evidence
+
+- Journal replay regression lane:
+  - `cargo test -p kamn-core --lib journal`
+- Module-level durability lanes:
+  - `cargo test -p kamn-core --lib channel_models::tests::`
+  - `cargo test -p kamn-core --lib message_lifecycle::tests::`
+  - `cargo test -p kamn-core --lib task_operations::tests::`
+
+## Regression
+
+- Regression: #2690


### PR DESCRIPTION
## Summary
Implements deterministic snapshot+journal durability for critical file-backed runtime stores (channel, message lifecycle, task operations). Recovery now replays append-only journal records over snapshot base state and fails closed on corrupt journal tails with stable reason codes.

Closes #2690

## Changes
- crates/kamn-core/src/channel_models.rs: added snapshot+journal write+replay flow, deterministic corrupt-tail reason codes, recovery reason-code metadata, and replay regression coverage.
- crates/kamn-core/src/message_lifecycle.rs: added snapshot+journal durability flow and fail-closed replay semantics matching channel/task stores.
- crates/kamn-core/src/task_operations.rs: added snapshot+journal durability flow and deterministic replay/corruption handling.
- docs/planning/persistence_durability_model.md: documented snapshot+journal recovery model, fail-closed rules, reason-code contract, and local evidence commands.
- docs/ci/strategy.md: added durability replay contract lane commands and fail-closed reason-code policy markers.
- crates/kamn-core/tests/ci_strategy_docs.rs: added doc-contract assertions to fail closed on durability policy drift.

## Risks & Compatibility
- None

## Validation
- [x] cargo fmt --all --check — clean
- [x] cargo clippy -p kamn-core -- -D warnings — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: executed targeted replay/corruption tests and module durability suites

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | journal replay/corrupt-tail tests for channel/message/task stores |
| Functional  | ✅     | recover_latest_and_repair behavior validated across updated store modules |
| Integration | ✅     | stale snapshot + newer journal replay tests validate restart composition |
| Regression  | ✅     | stable fail-closed corrupt-tail reason text asserts for all 3 stores |
