### PR TITLE
fix(node): emit daemon and retry runtime markers

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -40,6 +40,16 @@ fn doc_contains_make_and_demo_scope_contract_rules() {
     assert!(DOC.contains("run_input_mutation_coverage_guided_deep_lane.sh"));
     assert!(DOC.contains("runtime_input_mutation_coverage_guided_deep=skipped_local_only"));
     assert!(DOC.contains("KAMN_RUNTIME_INPUT_MUTATION_COVERAGE_GUIDED_DEEP_LOCAL_ONLY=true"));
+    assert!(DOC.contains(
+        "main_tests::functional_kolme_live_retry_emits_structured_retry_markers -- --exact"
+    ));
+    assert!(DOC.contains(
+        "main_tests::functional_runtime_daemon_emits_structured_transition_markers -- --exact"
+    ));
+    assert!(DOC.contains("kolme.live.submit.retry"));
+    assert!(DOC.contains("kolme.live.finality.retry"));
+    assert!(DOC.contains("node.runtime.daemon.execute.start"));
+    assert!(DOC.contains("node.runtime.daemon.execute.complete"));
     assert!(DOC.contains("layering_marker_missing"));
     assert!(DOC.contains("run_localhost_signed_integration_contract_lane_tests"));
     assert!(DOC.contains("sdk-live-localhost-integration"));

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -548,6 +548,16 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             let tick_interval_ms = daemon_tick_interval_ms.ok_or(
                 ConfigError::MissingArgumentValue("--daemon-tick-interval-ms"),
             )?;
+            let max_ticks_label = max_ticks.to_string();
+            let tick_interval_ms_label = tick_interval_ms.to_string();
+            log_info(
+                "node.runtime.daemon.execute.start",
+                &[
+                    ("runtime_mode", runtime_mode.as_str()),
+                    ("max_ticks", max_ticks_label.as_str()),
+                    ("tick_interval_ms", tick_interval_ms_label.as_str()),
+                ],
+            )?;
             let (peer_id, peer_lifecycle_final_state, peer_lifecycle_applied_events) =
                 match daemon_peer_id {
                     Some(peer_id) => {
@@ -580,6 +590,18 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 daemon_completion.completion_reason.as_str(),
             )
             .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+            let executed_ticks_label = daemon_completion.executed_ticks.to_string();
+            log_info(
+                "node.runtime.daemon.execute.complete",
+                &[
+                    ("runtime_mode", runtime_mode.as_str()),
+                    ("executed_ticks", executed_ticks_label.as_str()),
+                    (
+                        "completion_reason",
+                        daemon_completion.completion_reason.as_str(),
+                    ),
+                ],
+            )?;
             RuntimeExecutionBundle {
                 daemon: Some(DaemonExecution {
                     max_ticks,

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -421,6 +421,140 @@ fn functional_kolme_live_submit_and_finality_logs_keep_correlation_id() {
 }
 
 #[test]
+fn functional_runtime_daemon_emits_structured_transition_markers() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("daemon execution should succeed");
+    assert_eq!(report.runtime_mode, "daemon");
+
+    let start_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.daemon.execute.start\""))
+        .expect("daemon execution should emit structured start marker");
+    assert_eq!(
+        extract_json_string_field(start_line, "runtime_mode").as_deref(),
+        Some("daemon")
+    );
+    assert_eq!(
+        extract_json_string_field(start_line, "max_ticks").as_deref(),
+        Some("3")
+    );
+    assert_eq!(
+        extract_json_string_field(start_line, "tick_interval_ms").as_deref(),
+        Some("25")
+    );
+
+    let complete_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.daemon.execute.complete\""))
+        .expect("daemon execution should emit structured completion marker");
+    assert_eq!(
+        extract_json_string_field(complete_line, "runtime_mode").as_deref(),
+        Some("daemon")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "executed_ticks").as_deref(),
+        Some("3")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "completion_reason").as_deref(),
+        Some("tick-budget-exhausted")
+    );
+}
+
+#[test]
+fn functional_kolme_live_retry_emits_structured_retry_markers() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"submit unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"pending"}"#,
+        ),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"finality unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(
+            r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"final"}"#,
+        ),
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("runtime should recover from transient provider failures");
+    assert_eq!(report.runtime_mode, "kolme-live");
+
+    let submit_retry_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"kolme.live.submit.retry\""))
+        .expect("kolme-live retry flow should emit submit retry marker");
+    let finality_retry_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"kolme.live.finality.retry\""))
+        .expect("kolme-live retry flow should emit finality retry marker");
+
+    let submit_correlation = extract_json_string_field(submit_retry_line, "correlation_id")
+        .expect("submit retry marker should include correlation id");
+    let finality_correlation = extract_json_string_field(finality_retry_line, "correlation_id")
+        .expect("finality retry marker should include correlation id");
+    assert_eq!(submit_correlation, finality_correlation);
+    assert_eq!(
+        extract_json_string_field(submit_retry_line, "reason").as_deref(),
+        Some("unavailable")
+    );
+    assert_eq!(
+        extract_json_string_field(finality_retry_line, "reason").as_deref(),
+        Some("unavailable")
+    );
+}
+
+#[test]
 fn regression_invalid_log_level_config_fails_closed() {
     let _lock = log_env_lock()
         .lock()

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -146,6 +146,17 @@ pub(crate) fn execute_kolme_live_runtime(
                 if let Some(reason_code) = classify_retry_category(&error) {
                     if submit_attempts < KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS {
                         submit_retry_reason = reason_code;
+                        let attempt_label = submit_attempts.to_string();
+                        let max_attempts_label = KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS.to_string();
+                        log_warn(
+                            "kolme.live.submit.retry",
+                            &[
+                                ("correlation_id", correlation_id.as_str()),
+                                ("attempt", attempt_label.as_str()),
+                                ("max_attempts", max_attempts_label.as_str()),
+                                ("reason", reason_code),
+                            ],
+                        )?;
                         maybe_sleep_retry_backoff(submit_attempts);
                         continue;
                     }
@@ -204,6 +215,19 @@ pub(crate) fn execute_kolme_live_runtime(
                     if let Some(reason_code) = classify_retry_category(&error) {
                         if finality_retry_attempts < KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS {
                             finality_retry_reason = reason_code;
+                            let attempt_label = finality_retry_attempts.to_string();
+                            let max_attempts_label =
+                                KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS.to_string();
+                            log_warn(
+                                "kolme.live.finality.retry",
+                                &[
+                                    ("correlation_id", correlation_id.as_str()),
+                                    ("commit_id", receipt.commit_id.as_str()),
+                                    ("attempt", attempt_label.as_str()),
+                                    ("max_attempts", max_attempts_label.as_str()),
+                                    ("reason", reason_code),
+                                ],
+                            )?;
                             maybe_sleep_retry_backoff(finality_retry_attempts);
                             continue;
                         }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -99,6 +99,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - For `kamn-node` live-runtime wiring/doc changes, keep PR validation on deterministic local harness tests:
   - `cargo test -p kamn-node runtime_kolme_live`
   - `cargo test -p kamn-node integration_runtime_kolme_live_renders_provider_contract_markers`
+  - `cargo test -p kamn-node main_tests::functional_kolme_live_retry_emits_structured_retry_markers -- --exact`
   - `cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_runtime_kolme_live_rules`
   - `cargo test -p kamn-node --test node_runtime_cli_docs regression_requires_runtime_kolme_live_provider_drift_guard_rules`
 - This lane is intentionally bounded and cost-effective:
@@ -111,6 +112,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - For `kamn-node` daemon-shutdown contract changes, keep PR validation on bounded deterministic tests:
   - `cargo test -p kamn-node graceful_shutdown`
   - `cargo test -p kamn-node runtime_daemon`
+  - `cargo test -p kamn-node main_tests::functional_runtime_daemon_emits_structured_transition_markers -- --exact`
   - `cargo test -p kamn-node integration_runtime_daemon_renders_bounded_completion_output`
 - This lane is cost-effective:
   - no external processes or signal orchestration harnesses required
@@ -139,6 +141,8 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - transient categories (`timeout`, `unavailable`) retry with bounded backoff.
   - malformed/config categories fail fast without retry.
   - execution status includes submit/finality retry metadata markers.
+  - structured retry marker events (`kolme.live.submit.retry`, `kolme.live.finality.retry`) retain deterministic `correlation_id` and `reason` fields.
+  - daemon transition marker events (`node.runtime.daemon.execute.start`, `node.runtime.daemon.execute.complete`) retain deterministic runtime execution fields.
 
 ## kamn-core Missing-Docs Velocity Guard
 - Fast-gate missing-docs velocity regression command:


### PR DESCRIPTION
## Summary
This change adds deterministic structured runtime log markers for daemon transitions and kolme-live retry paths in `kamn-node`, then updates CI strategy/docs contracts to fail closed on marker drift. It closes the gap where new marker contract tests existed but runtime emission was missing.

Closes #2708

## Changes
- `crates/kamn-node/src/main.rs`: emit `node.runtime.daemon.execute.start` and `node.runtime.daemon.execute.complete` markers with bounded runtime fields.
- `crates/kamn-node/src/runtime_kolme_live.rs`: emit retry markers `kolme.live.submit.retry` and `kolme.live.finality.retry` with deterministic `correlation_id`, `reason`, and retry-attempt fields.
- `crates/kamn-node/src/main_tests.rs`: add/retain functional marker contract tests for daemon transition markers and retry markers.
- `docs/ci/strategy.md`: add marker-focused fast-lane test commands and explicit marker contract statements for retry and daemon transitions.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: extend docs-contract assertions so CI strategy marker coverage drifts fail closed.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node --tests -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: inspected captured structured JSON logs for daemon start/complete and retry events (`reason=unavailable`, consistent `correlation_id`) in targeted test runs.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node`; `cargo test -p kamn-core --test ci_strategy_docs` |
| Functional  | ✅     | `cargo test -p kamn-node functional_runtime_daemon_emits_structured_transition_markers -- --nocapture`; `cargo test -p kamn-node functional_kolme_live_retry_emits_structured_retry_markers -- --nocapture` |
| Integration | ✅     | `cargo test -p kamn-node` includes integration/doc-contract suites |
| Regression  | ✅     | existing retry/fail-fast/regression suites remain green in `cargo test -p kamn-node` |
