### PR TITLE
docs(core): codify live TLS dependency governance ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ KAMN (Kolme AI Agent Messaging Network) is a privacy-first, auditable coordinati
   - `rustls-pemfile`
   - `webpki-roots`
 - These are used by the Kolme live runtime HTTP transport path; local deterministic flows still run without network/TLS requirements.
+- Decision record: `docs/architecture/adr-kamn-core-live-tls-transport.md`.
 
 ## Quickstart
 

--- a/crates/kamn-core/tests/tls_dependency_governance_docs.rs
+++ b/crates/kamn-core/tests/tls_dependency_governance_docs.rs
@@ -1,0 +1,30 @@
+const ADR: &str = include_str!("../../../docs/architecture/adr-kamn-core-live-tls-transport.md");
+const README: &str = include_str!("../../../README.md");
+const RUNTIME_COMMIT_DOC: &str =
+    include_str!("../../../docs/foundation/kolme-runtime-commit-client.md");
+
+#[test]
+fn adr_documents_live_tls_dependency_decision_and_tradeoffs() {
+    assert!(ADR.contains("`kamn-core` Live TLS Transport Dependency Posture"));
+    assert!(ADR.contains("rustls"));
+    assert!(ADR.contains("rustls-pemfile"));
+    assert!(ADR.contains("webpki-roots"));
+    assert!(ADR.contains("Subprocess TLS paths (`curl`, `openssl s_client`) are not allowed"));
+    assert!(ADR.contains("Compile-time feature gate for local-only builds"));
+    assert!(ADR.contains("`#2756`"));
+    assert!(ADR.contains("crates/kamn-core/src/kolme_runtime_commit/http_transport.rs"));
+    assert!(ADR.contains("crates/kamn-kolme/src/tls_policy.rs"));
+    assert!(ADR.contains("crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs"));
+}
+
+#[test]
+fn readme_and_foundation_transport_doc_reference_tls_dependency_adr() {
+    assert!(README.contains("docs/architecture/adr-kamn-core-live-tls-transport.md"));
+    assert!(RUNTIME_COMMIT_DOC.contains("docs/architecture/adr-kamn-core-live-tls-transport.md"));
+}
+
+#[test]
+fn runtime_commit_transport_doc_keeps_in_process_tls_narrative() {
+    assert!(RUNTIME_COMMIT_DOC.contains("in-process `rustls` transport wiring"));
+    assert!(!RUNTIME_COMMIT_DOC.contains("openssl s_client command wiring"));
+}

--- a/docs/architecture/adr-kamn-core-live-tls-transport.md
+++ b/docs/architecture/adr-kamn-core-live-tls-transport.md
@@ -1,0 +1,69 @@
+# ADR: `kamn-core` Live TLS Transport Dependency Posture
+
+## Status
+
+Accepted (2026-02-13)
+
+## Context
+
+`kamn-core` owns the live runtime-commit HTTP transport used by `kamn-node` when running Kolme live mode. That path must:
+
+- submit signed runtime-commit payloads over HTTPS,
+- poll finality endpoints over HTTPS,
+- classify transport and TLS failures deterministically into fail-closed provider errors.
+
+The previous "dependency-free transport" narrative no longer reflects implementation reality. The live HTTPS path is implemented in-process via:
+
+- `crates/kamn-core/src/kolme_runtime_commit/http_transport.rs`,
+- trust policy contracts from `crates/kamn-kolme/src/tls_policy.rs`,
+- transport-facing integration coverage in `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`.
+
+## Decision
+
+Keep these dependencies in `kamn-core` for live HTTPS transport:
+
+- `rustls`
+- `rustls-pemfile`
+- `webpki-roots`
+
+Enforce the following constraints:
+
+1. TLS execution remains in-process and deterministic.
+2. Subprocess TLS paths (`curl`, `openssl s_client`) are not allowed in runtime transport code paths.
+3. Optional custom trust roots are loaded through `KAMN_KOLME_TLS_CA_FILE` when provided.
+4. Local deterministic/in-memory flows may run without network TLS at runtime.
+
+## Alternatives Considered
+
+### Subprocess `curl` or `openssl s_client`
+
+Rejected. This increases operational variance across host images, adds process-spawn overhead, and weakens deterministic error taxonomy control.
+
+### `reqwest` / async client migration
+
+Deferred. This increases dependency and runtime surface area and would force broader runtime model changes unrelated to the current live-transport hardening scope.
+
+### Compile-time feature gate for local-only builds
+
+Accepted as follow-up candidate, not part of this ADR's baseline decision. Track under `#2756`.
+
+## Consequences
+
+Positive:
+
+- Secure live HTTPS path with deterministic failure classification.
+- No external TLS subprocess dependency in production runtime paths.
+- Clear policy boundary between live mode and in-memory/local deterministic flows.
+
+Tradeoffs:
+
+- `kamn-core` is not dependency-minimal; TLS crates remain part of default build profile.
+- Additional governance is needed to keep docs/tests aligned with this decision.
+
+## Validation and Traceability
+
+- Transport implementation: `crates/kamn-core/src/kolme_runtime_commit/http_transport.rs`
+- TLS policy helpers: `crates/kamn-kolme/src/tls_policy.rs`
+- Transport integration tests: `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`
+- Transport docs contract: `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`
+

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -69,9 +69,10 @@ handling.
   - `KolmeRuntimeCommitHttpTransport::new_with_authorization(...)`
   - emits `Authorization: <value>` header on submit/finality requests.
 - HTTPS/TLS behavior:
-  - `https://` requests execute through TLS-backed `openssl s_client` command wiring.
+  - `https://` requests execute through in-process `rustls` transport wiring.
   - `crates/kamn-kolme/src/tls_policy.rs` owns TLS CA-file env parsing and deterministic stderr failure classification contracts.
   - optional custom CA trust file is read from `KAMN_KOLME_TLS_CA_FILE`.
+  - dependency-governance ADR: `docs/architecture/adr-kamn-core-live-tls-transport.md`.
   - deterministic TLS failure mapping:
     - certificate verification failures => `Unavailable("tls certificate verification failed")`
     - handshake/protocol failures => `Unavailable("tls handshake failed")`


### PR DESCRIPTION
## Summary
Adds an ADR that codifies why `kamn-core` keeps rustls-based TLS dependencies for live Kolme transport, and aligns docs/contracts with that decision. Also removes stale subprocess TLS wording from runtime-commit foundation docs.

Closes #2755

## Changes
- `docs/architecture/adr-kamn-core-live-tls-transport.md`: new decision record with context, alternatives, and traceability links.
- `README.md`: dependency posture now links to the ADR.
- `docs/foundation/kolme-runtime-commit-client.md`: TLS behavior wording updated to in-process rustls and linked ADR.
- `crates/kamn-core/tests/tls_dependency_governance_docs.rs`: docs-contract guard for ADR references and no-subprocess TLS narrative drift.

## Risks & Compatibility
- No runtime behavior change.
- Documentation and docs-contract tests only.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed stale `openssl s_client` wording removed from runtime-commit doc

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test tls_dependency_governance_docs` |
| Functional  | ✅     | ADR references align across README/foundation docs |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client_docs` |
| Regression  | ✅     | docs test guards against subprocess TLS narrative reintroduction |
