### PR TITLE
feat(core): gate kamn-core live HTTPS transport by feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ KAMN (Kolme AI Agent Messaging Network) is a privacy-first, auditable coordinati
   - `rustls`
   - `rustls-pemfile`
   - `webpki-roots`
+- Feature posture:
+  - default build keeps `live-https` enabled.
+  - local-only compile profile can run `cargo check -p kamn-core --no-default-features`.
 - These are used by the Kolme live runtime HTTP transport path; local deterministic flows still run without network/TLS requirements.
 - Decision record: `docs/architecture/adr-kamn-core-live-tls-transport.md`.
 

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -7,12 +7,16 @@ license = "Apache-2.0"
 [lib]
 path = "src/lib.rs"
 
+[features]
+default = ["live-https"]
+live-https = ["dep:rustls", "dep:rustls-pemfile", "dep:webpki-roots"]
+
 [dependencies]
 kamn-kolme = { path = "../kamn-kolme" }
 # Live HTTPS runtime-commit transport uses rustls directly (no subprocess curl path).
-rustls = { version = "0.23.36", default-features = false, features = ["ring", "std", "tls12"] }
-rustls-pemfile = "2.2.0"
-webpki-roots = "1.0.3"
+rustls = { version = "0.23.36", default-features = false, features = ["ring", "std", "tls12"], optional = true }
+rustls-pemfile = { version = "2.2.0", optional = true }
+webpki-roots = { version = "1.0.3", optional = true }
 
 [dev-dependencies]
 k256 = { version = "0.13.4", features = ["ecdsa"] }

--- a/crates/kamn-core/src/kolme_runtime_commit.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit.rs
@@ -1,6 +1,7 @@
 //! Deterministic runtime-commit request/receipt contracts for Kolme integration.
 
 use crate::AgentDid;
+#[cfg_attr(not(feature = "live-https"), allow(unused_imports))]
 use kamn_kolme::{
     are_runtime_commit_request_fields_single_line as are_kolme_runtime_commit_request_fields_single_line_contract,
     build_kolme_fork_broadcast_live_provider_config as build_kamn_kolme_fork_broadcast_live_provider_config,
@@ -108,7 +109,10 @@ mod block_fallback_reconciler;
 mod errors;
 mod finality_checker;
 mod fork_finality_resolver;
+#[cfg(feature = "live-https")]
 mod http_transport;
+#[cfg(not(feature = "live-https"))]
+mod http_transport_disabled;
 mod in_memory_client;
 mod interfaces;
 mod live_provider;
@@ -133,7 +137,10 @@ pub use block_fallback_reconciler::KolmeRuntimeCommitBlockFallbackReconciler;
 pub use errors::KolmeRuntimeCommitError;
 pub use finality_checker::KolmeRuntimeCommitFinalityChecker;
 pub use fork_finality_resolver::KolmeRuntimeCommitForkFinalityResolver;
+#[cfg(feature = "live-https")]
 pub use http_transport::KolmeRuntimeCommitHttpTransport;
+#[cfg(not(feature = "live-https"))]
+pub use http_transport_disabled::KolmeRuntimeCommitHttpTransport;
 pub use in_memory_client::InMemoryKolmeRuntimeCommitClient;
 pub use interfaces::{KolmeRuntimeCommitClient, KolmeRuntimeCommitProvider};
 pub use kamn_kolme::{

--- a/crates/kamn-core/src/kolme_runtime_commit/http_transport_disabled.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/http_transport_disabled.rs
@@ -1,0 +1,118 @@
+//! Fallback runtime-commit transport implementation used when `live-https` is disabled.
+
+use super::{
+    is_kolme_valid_http_transport_timeout_seconds_contract, parse_kolme_authorization_header_value,
+    KamnKolmeTransportRequestPolicyError, KolmeApiBroadcastRequest, KolmeApiBroadcastResponse,
+    KolmeApiNextNonceRequest, KolmeApiNextNonceResponse, KolmeRuntimeCommitError,
+};
+use kamn_kolme::{
+    KolmeRuntimeCommitBlockFallbackTransport, KolmeRuntimeCommitFinalityTransport,
+    KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderTransport,
+};
+
+const LIVE_HTTPS_DISABLED_REASON: &str =
+    "live-https transport feature disabled; rebuild kamn-core with --features live-https";
+
+/// Runtime-commit HTTP transport facade for local-only builds with `live-https` disabled.
+///
+/// This type is intentionally fail-closed for network operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KolmeRuntimeCommitHttpTransport {
+    timeout_seconds: u64,
+    authorization_header: Option<String>,
+}
+
+impl KolmeRuntimeCommitHttpTransport {
+    /// Builds the disabled transport facade with deterministic timeout validation.
+    pub fn new(timeout_seconds: u64) -> Result<Self, KolmeRuntimeCommitError> {
+        if !is_kolme_valid_http_transport_timeout_seconds_contract(timeout_seconds) {
+            return Err(KolmeRuntimeCommitError::InvalidRequest {
+                field: "transport_timeout_seconds",
+                reason: "must be positive",
+            });
+        }
+        Ok(Self {
+            timeout_seconds,
+            authorization_header: None,
+        })
+    }
+
+    /// Builds the disabled transport facade with authorization header validation.
+    pub fn new_with_authorization(
+        timeout_seconds: u64,
+        authorization_header: &str,
+    ) -> Result<Self, KolmeRuntimeCommitError> {
+        let mut transport = Self::new(timeout_seconds)?;
+        transport.authorization_header = Some(
+            parse_kolme_authorization_header_value(authorization_header).map_err(|error| {
+                match error {
+                    KamnKolmeTransportRequestPolicyError::InvalidRequest { field, reason } => {
+                        KolmeRuntimeCommitError::InvalidRequest { field, reason }
+                    }
+                }
+            })?,
+        );
+        Ok(transport)
+    }
+
+    /// Returns an unavailable error because live HTTPS transport is disabled.
+    pub fn fetch_next_nonce(
+        &mut self,
+        _base_url: &str,
+        _nonce_path: &str,
+        _request: &KolmeApiNextNonceRequest,
+    ) -> Result<KolmeApiNextNonceResponse, KolmeRuntimeCommitProviderError> {
+        Err(Self::live_https_disabled_error())
+    }
+
+    /// Returns an unavailable error because live HTTPS transport is disabled.
+    pub fn submit_broadcast_request(
+        &mut self,
+        _base_url: &str,
+        _submit_path: &str,
+        _request: &KolmeApiBroadcastRequest,
+        _idempotency_key: &str,
+    ) -> Result<KolmeApiBroadcastResponse, KolmeRuntimeCommitProviderError> {
+        Err(Self::live_https_disabled_error())
+    }
+
+    fn live_https_disabled_error() -> KolmeRuntimeCommitProviderError {
+        KolmeRuntimeCommitProviderError::Unavailable {
+            reason: LIVE_HTTPS_DISABLED_REASON.to_owned(),
+        }
+    }
+}
+
+impl KolmeRuntimeCommitProviderTransport for KolmeRuntimeCommitHttpTransport {
+    fn submit_runtime_commit(
+        &mut self,
+        _base_url: &str,
+        _submit_path: &str,
+        _wire_payload: &str,
+        _idempotency_key: &str,
+    ) -> Result<String, KolmeRuntimeCommitProviderError> {
+        Err(Self::live_https_disabled_error())
+    }
+}
+
+impl KolmeRuntimeCommitFinalityTransport for KolmeRuntimeCommitHttpTransport {
+    fn fetch_runtime_commit_finality(
+        &mut self,
+        _base_url: &str,
+        _status_path: &str,
+        _commit_id: &str,
+    ) -> Result<String, KolmeRuntimeCommitProviderError> {
+        Err(Self::live_https_disabled_error())
+    }
+}
+
+impl KolmeRuntimeCommitBlockFallbackTransport for KolmeRuntimeCommitHttpTransport {
+    fn fetch_block_by_height(
+        &mut self,
+        _base_url: &str,
+        _block_path_template: &str,
+        _height: u64,
+    ) -> Result<String, KolmeRuntimeCommitProviderError> {
+        Err(Self::live_https_disabled_error())
+    }
+}

--- a/crates/kamn-core/tests/tls_dependency_governance_docs.rs
+++ b/crates/kamn-core/tests/tls_dependency_governance_docs.rs
@@ -11,7 +11,8 @@ fn adr_documents_live_tls_dependency_decision_and_tradeoffs() {
     assert!(ADR.contains("webpki-roots"));
     assert!(ADR.contains("Subprocess TLS paths (`curl`, `openssl s_client`) are not allowed"));
     assert!(ADR.contains("Compile-time feature gate for local-only builds"));
-    assert!(ADR.contains("`#2756`"));
+    assert!(ADR.contains("`live-https` default-on"));
+    assert!(ADR.contains("--no-default-features"));
     assert!(ADR.contains("crates/kamn-core/src/kolme_runtime_commit/http_transport.rs"));
     assert!(ADR.contains("crates/kamn-kolme/src/tls_policy.rs"));
     assert!(ADR.contains("crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs"));

--- a/crates/kamn-core/tests/tls_feature_gate_ci_docs.rs
+++ b/crates/kamn-core/tests/tls_feature_gate_ci_docs.rs
@@ -1,0 +1,9 @@
+const DOC: &str = include_str!("../../../docs/ci/strategy.md");
+
+#[test]
+fn ci_strategy_doc_contains_live_https_feature_gate_contract() {
+    assert!(DOC.contains("## Kolme Live HTTPS Feature-Gate Contract"));
+    assert!(DOC.contains("`live-https` feature remains enabled by default"));
+    assert!(DOC.contains("cargo check -p kamn-core --features live-https"));
+    assert!(DOC.contains("cargo check -p kamn-core --no-default-features"));
+}

--- a/docs/architecture/adr-kamn-core-live-tls-transport.md
+++ b/docs/architecture/adr-kamn-core-live-tls-transport.md
@@ -45,7 +45,7 @@ Deferred. This increases dependency and runtime surface area and would force bro
 
 ### Compile-time feature gate for local-only builds
 
-Accepted as follow-up candidate, not part of this ADR's baseline decision. Track under `#2756`.
+Accepted and implemented as an optional build profile in `kamn-core` (`live-https` default-on). Local-only builds may use `--no-default-features` for low-cost compilation without rustls transport dependencies.
 
 ## Consequences
 
@@ -57,7 +57,7 @@ Positive:
 
 Tradeoffs:
 
-- `kamn-core` is not dependency-minimal; TLS crates remain part of default build profile.
+- `kamn-core` is not dependency-minimal in default profile; TLS crates remain enabled for live transport by default.
 - Additional governance is needed to keep docs/tests aligned with this decision.
 
 ## Validation and Traceability
@@ -66,4 +66,3 @@ Tradeoffs:
 - TLS policy helpers: `crates/kamn-kolme/src/tls_policy.rs`
 - Transport integration tests: `crates/kamn-core/tests/kolme_runtime_commit_http_transport.rs`
 - Transport docs contract: `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`
-

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -130,6 +130,15 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_tls_handshake_failures_to_unavailable -- --exact`
 - Certificate/handshake/timeout reason-code mapping remains deterministic and fail-closed for runtime commit submit/finality/block fallback flows.
 
+## Kolme Live HTTPS Feature-Gate Contract
+- `kamn-core` exposes `live-https` as an optional feature and `live-https` feature remains enabled by default.
+- Fast CI keeps default-profile verification only:
+  - `cargo check -p kamn-core --features live-https`
+- Optional low-cost local-only verification (no rustls transport dependencies):
+  - `cargo check -p kamn-core --no-default-features`
+- Local-only profile remains fail-closed for runtime network transport calls; this profile is for deterministic/local build validation only.
+- Regression: #2756
+
 ## Kolme Live Retry Coverage
 - Runtime commit submit/finality retry behavior must remain deterministic and bounded.
 - Fast-gate coverage commands:

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -70,6 +70,7 @@ handling.
   - emits `Authorization: <value>` header on submit/finality requests.
 - HTTPS/TLS behavior:
   - `https://` requests execute through in-process `rustls` transport wiring.
+  - `kamn-core` keeps `live-https` enabled by default; local-only compile profile uses `--no-default-features`.
   - `crates/kamn-kolme/src/tls_policy.rs` owns TLS CA-file env parsing and deterministic stderr failure classification contracts.
   - optional custom CA trust file is read from `KAMN_KOLME_TLS_CA_FILE`.
   - dependency-governance ADR: `docs/architecture/adr-kamn-core-live-tls-transport.md`.


### PR DESCRIPTION
## Summary
Implements an optional `live-https` feature gate for `kamn-core` while keeping live HTTPS behavior unchanged in the default profile. Adds a fail-closed fallback transport for local-only builds and codifies low-cost CI/local validation commands.

Closes #2756

## Changes
- `crates/kamn-core/Cargo.toml`: add `live-https` feature (`default` includes it) and make rustls dependencies optional.
- `crates/kamn-core/src/kolme_runtime_commit.rs`: gate HTTP transport module export by feature.
- `crates/kamn-core/src/kolme_runtime_commit/http_transport_disabled.rs`: add fail-closed fallback transport when `live-https` is disabled.
- `docs/ci/strategy.md`: add feature-gate CI contract section with default/live and no-default-features commands.
- `docs/architecture/adr-kamn-core-live-tls-transport.md`, `README.md`, `docs/foundation/kolme-runtime-commit-client.md`: update dependency posture docs for implemented feature-gate behavior.
- `crates/kamn-core/tests/tls_feature_gate_ci_docs.rs`: docs-contract guard for feature-gate CI guidance.
- `crates/kamn-core/tests/tls_dependency_governance_docs.rs`: update ADR contract assertions for implemented gate.

## Risks & Compatibility
- Default runtime behavior remains unchanged (`live-https` still enabled by default).
- Local-only build (`--no-default-features`) now compiles with fail-closed runtime network transport behavior.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: `cargo check -p kamn-core --no-default-features` succeeds

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test tls_feature_gate_ci_docs` |
| Functional  | ✅     | fail-closed fallback transport compiles in local-only profile |
| Integration | ✅     | `cargo test -p kamn-core --test kolme_runtime_commit_client_docs` |
| Regression  | ✅     | `cargo test -p kamn-core --test tls_dependency_governance_docs` |
