### PR TITLE
test(ci): add production expect panic guard

### DIFF
--- a/scripts/ci/check_no_production_expect.py
+++ b/scripts/ci/check_no_production_expect.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Fail if `.expect(` appears in production Rust code before `#[cfg(test)]` blocks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def is_excluded(path: Path) -> bool:
+    path_str = path.as_posix()
+    return (
+        "/main_tests/" in path_str
+        or path.name.endswith("_tests.rs")
+        or path.name == "main_tests.rs"
+    )
+
+
+def find_violations(root: Path) -> list[dict[str, object]]:
+    violations: list[dict[str, object]] = []
+    for rust_file in sorted(root.rglob("*.rs")):
+        if is_excluded(rust_file):
+            continue
+        lines = rust_file.read_text(encoding="utf-8").splitlines()
+        cutoff = len(lines)
+        for line_no, line in enumerate(lines, start=1):
+            if line.strip().startswith("#[cfg(test)]"):
+                cutoff = line_no - 1
+                break
+        for line_no, line in enumerate(lines[:cutoff], start=1):
+            if ".expect(" in line:
+                violations.append(
+                    {
+                        "file": rust_file.as_posix(),
+                        "line": line_no,
+                        "snippet": line.strip(),
+                    }
+                )
+    return violations
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        help="Rust source root to scan (repeatable). Default: crates/kamn-node/src",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output path for deterministic check report JSON.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    roots = args.root or ["crates/kamn-node/src"]
+
+    report: dict[str, object] = {
+        "schema_version": "kamn.ci.no-production-expect-report.v1",
+        "roots": roots,
+        "violations": [],
+        "violation_count": 0,
+        "status": "pass",
+    }
+
+    all_violations: list[dict[str, object]] = []
+    for root in roots:
+        root_path = Path(root)
+        if not root_path.exists():
+            report["status"] = "fail"
+            all_violations.append(
+                {
+                    "file": root,
+                    "line": 0,
+                    "snippet": "scan root does not exist",
+                }
+            )
+            continue
+        all_violations.extend(find_violations(root_path))
+
+    report["violations"] = all_violations
+    report["violation_count"] = len(all_violations)
+
+    if all_violations:
+        report["status"] = "fail"
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if report["status"] == "pass":
+        print("status=ok")
+        print("violation_count=0")
+        return 0
+
+    print("status=fail")
+    print(f"violation_count={report['violation_count']}")
+    for violation in all_violations:
+        print(
+            "violation="
+            f"{violation['file']}:{violation['line']}:{violation['snippet']}"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_no_production_expect.sh
+++ b/scripts/ci/check_no_production_expect.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/ci/check_no_production_expect.py" "$@"

--- a/scripts/ci/test_check_no_production_expect.sh
+++ b/scripts/ci/test_check_no_production_expect.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/ci/check_no_production_expect.sh"
+PY_CHECKER="$ROOT_DIR/scripts/ci/check_no_production_expect.py"
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected production expect checker wrapper to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$PY_CHECKER" ]; then
+  echo "expected production expect checker module to be executable" >&2
+  exit 1
+fi
+
+bash "$CHECKER" >/dev/null
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat <<'RS' > "$TMP_DIR/failing.rs"
+fn panic_path() {
+    let _value = std::env::var("X").expect("should fail in production path");
+}
+RS
+
+set +e
+failure_output="$(python3 "$PY_CHECKER" --root "$TMP_DIR" 2>&1)"
+failure_code=$?
+set -e
+
+if [ "$failure_code" -eq 0 ]; then
+  echo "expected checker to fail when production expect() is present" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$failure_output" | grep -q "status=fail"; then
+  echo "expected checker to emit status=fail for production expect() violation" >&2
+  exit 1
+fi
+
+rm -f "$TMP_DIR/failing.rs"
+
+cat <<'RS' > "$TMP_DIR/cfg_test_only.rs"
+fn safe_path() -> Result<(), String> {
+    std::env::var("X").map(|_| ()).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn allows_expect_inside_test_module() {
+        let value = Some(1).expect("test-only expect");
+        assert_eq!(value, 1);
+    }
+}
+RS
+
+python3 "$PY_CHECKER" --root "$TMP_DIR" >/dev/null
+
+echo "production expect checker tests passed."


### PR DESCRIPTION
## Summary
Added a deterministic CI guard that prevents `.expect(` from entering production Rust code paths before `#[cfg(test)]` blocks.
This formalizes the existing non-panic posture in `kamn-node` and provides a regression harness for future edits.

## Changes
- `scripts/ci/check_no_production_expect.py`: new scanner for `.expect(` in production Rust code (test files and test modules excluded).
- `scripts/ci/check_no_production_expect.sh`: shell wrapper entrypoint.
- `scripts/ci/test_check_no_production_expect.sh`: contract test covering pass/fail scenarios.

## Risks & Compatibility
- None. Adds CI tooling only; no runtime/protocol behavior changes.

## Validation
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: `bash scripts/ci/test_check_no_production_expect.sh` and `bash scripts/ci/check_no_production_expect.sh --output-json /tmp/no-production-expect-report.json`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | scanner logic exercised in deterministic pass/fail fixture scenarios |
| Functional  | ✅ | wrapper + module execute against workspace tree |
| Integration | ✅ | script contract test validates end-to-end failure signaling |
| Regression  | ✅ | explicit failing fixture proves `.expect(` in production path is blocked |

Closes #2761
