### PR TITLE
test(ci): add live-https dependency posture contract checker

### DIFF
--- a/scripts/ci/check_kamn_core_live_https_dependency_posture.py
+++ b/scripts/ci/check_kamn_core_live_https_dependency_posture.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Validate kamn-core live HTTPS dependency posture contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import tomllib
+
+SCHEMA_VERSION = "kamn.ci.kamn-core-live-https-dependency-posture-report.v1"
+EXPECTED_DEPS = ("rustls", "rustls-pemfile", "webpki-roots")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cargo-manifest",
+        default="crates/kamn-core/Cargo.toml",
+        help="Path to kamn-core Cargo manifest.",
+    )
+    parser.add_argument(
+        "--readme",
+        default="README.md",
+        help="Path to repository README.",
+    )
+    parser.add_argument(
+        "--adr",
+        default="docs/architecture/adr-kamn-core-live-tls-transport.md",
+        help="Path to live TLS transport ADR.",
+    )
+    parser.add_argument(
+        "--ci-strategy",
+        default="docs/ci/strategy.md",
+        help="Path to CI strategy document.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output file path for report JSON.",
+    )
+    return parser.parse_args()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalize_feature_entries(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for item in value:
+        if isinstance(item, str):
+            normalized.append(item.strip())
+    return normalized
+
+
+def main() -> int:
+    args = parse_args()
+
+    manifest_path = Path(args.cargo_manifest)
+    readme_path = Path(args.readme)
+    adr_path = Path(args.adr)
+    ci_strategy_path = Path(args.ci_strategy)
+
+    checks: dict[str, str] = {}
+    violations: list[str] = []
+
+    for required_path, label in (
+        (manifest_path, "cargo_manifest"),
+        (readme_path, "readme"),
+        (adr_path, "adr"),
+        (ci_strategy_path, "ci_strategy"),
+    ):
+        if required_path.exists():
+            checks[f"{label}_exists"] = "pass"
+        else:
+            checks[f"{label}_exists"] = "fail"
+            violations.append(f"required file is missing: {required_path}")
+
+    manifest_data: dict[str, object] = {}
+    if manifest_path.exists():
+        try:
+            manifest_data = tomllib.loads(read_text(manifest_path))
+        except tomllib.TOMLDecodeError as exc:
+            checks["manifest_parses"] = "fail"
+            violations.append(f"failed to parse Cargo manifest: {exc}")
+        else:
+            checks["manifest_parses"] = "pass"
+    else:
+        checks["manifest_parses"] = "fail"
+
+    features = manifest_data.get("features") if isinstance(manifest_data, dict) else None
+    dependencies = (
+        manifest_data.get("dependencies") if isinstance(manifest_data, dict) else None
+    )
+
+    live_https_entries = normalize_feature_entries(
+        features.get("live-https") if isinstance(features, dict) else None
+    )
+
+    for dep in EXPECTED_DEPS:
+        expected_feature = f"dep:{dep}"
+        key_prefix = dep.replace("-", "_")
+        if expected_feature in live_https_entries:
+            checks[f"{key_prefix}_feature_mapping"] = "pass"
+        else:
+            checks[f"{key_prefix}_feature_mapping"] = "fail"
+            violations.append(
+                f"live-https feature must include mapping `{expected_feature}`"
+            )
+
+        dep_config = dependencies.get(dep) if isinstance(dependencies, dict) else None
+        if dep_config is None:
+            checks[f"{key_prefix}_dependency_declared"] = "fail"
+            violations.append(f"dependency `{dep}` must be declared under [dependencies]")
+            continue
+
+        checks[f"{key_prefix}_dependency_declared"] = "pass"
+        if isinstance(dep_config, dict) and dep_config.get("optional") is True:
+            checks[f"{key_prefix}_dependency_optional"] = "pass"
+        else:
+            checks[f"{key_prefix}_dependency_optional"] = "fail"
+            violations.append(f"dependency `{dep}` must declare optional = true")
+
+    if isinstance(dependencies, dict):
+        rustls_dep = dependencies.get("rustls")
+        if isinstance(rustls_dep, dict) and rustls_dep.get("default-features") is False:
+            checks["rustls_default_features_disabled"] = "pass"
+        else:
+            checks["rustls_default_features_disabled"] = "fail"
+            violations.append(
+                "dependency `rustls` should disable default features for deterministic profile control"
+            )
+    else:
+        checks["rustls_default_features_disabled"] = "fail"
+
+    readme_text = read_text(readme_path) if readme_path.exists() else ""
+    adr_text = read_text(adr_path) if adr_path.exists() else ""
+    ci_strategy_text = read_text(ci_strategy_path) if ci_strategy_path.exists() else ""
+
+    for dep in EXPECTED_DEPS:
+        key_prefix = dep.replace("-", "_")
+        if dep in readme_text:
+            checks[f"readme_mentions_{key_prefix}"] = "pass"
+        else:
+            checks[f"readme_mentions_{key_prefix}"] = "fail"
+            violations.append(f"README must mention dependency `{dep}`")
+
+    if "docs/architecture/adr-kamn-core-live-tls-transport.md" in readme_text:
+        checks["readme_links_adr"] = "pass"
+    else:
+        checks["readme_links_adr"] = "fail"
+        violations.append("README must link live TLS transport ADR")
+
+    if "cargo check -p kamn-core --no-default-features" in readme_text:
+        checks["readme_mentions_no_default_features"] = "pass"
+    else:
+        checks["readme_mentions_no_default_features"] = "fail"
+        violations.append("README must document no-default-features local profile check")
+
+    if "Keep these dependencies in `kamn-core` for live HTTPS transport:" in adr_text:
+        checks["adr_dependency_section_present"] = "pass"
+    else:
+        checks["adr_dependency_section_present"] = "fail"
+        violations.append("ADR must include accepted dependency posture section")
+
+    for dep in EXPECTED_DEPS:
+        key_prefix = dep.replace("-", "_")
+        if dep in adr_text:
+            checks[f"adr_mentions_{key_prefix}"] = "pass"
+        else:
+            checks[f"adr_mentions_{key_prefix}"] = "fail"
+            violations.append(f"ADR must mention dependency `{dep}`")
+
+    if "cargo check -p kamn-core --features live-https" in ci_strategy_text:
+        checks["ci_strategy_mentions_live_https_feature_check"] = "pass"
+    else:
+        checks["ci_strategy_mentions_live_https_feature_check"] = "fail"
+        violations.append("CI strategy must mention live-https feature check command")
+
+    if "cargo check -p kamn-core --no-default-features" in ci_strategy_text:
+        checks["ci_strategy_mentions_no_default_features_check"] = "pass"
+    else:
+        checks["ci_strategy_mentions_no_default_features_check"] = "fail"
+        violations.append("CI strategy must mention no-default-features check command")
+
+    status = "pass" if not violations else "fail"
+    reason_codes = ["none"] if status == "pass" else ["dependency_posture_contract_violation"]
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "reason_codes": reason_codes,
+        "cargo_manifest": str(manifest_path),
+        "readme": str(readme_path),
+        "adr": str(adr_path),
+        "ci_strategy": str(ci_strategy_path),
+        "checks": checks,
+        "violation_count": len(violations),
+        "violations": violations,
+    }
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if status == "pass":
+        print("status=ok")
+        print("reason_codes=none")
+        print("violation_count=0")
+        return 0
+
+    print("status=fail")
+    print(f"reason_codes={','.join(reason_codes)}")
+    print(f"violation_count={len(violations)}")
+    for violation in violations:
+        print(f"violation={violation}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_kamn_core_live_https_dependency_posture.sh
+++ b/scripts/ci/check_kamn_core_live_https_dependency_posture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/ci/check_kamn_core_live_https_dependency_posture.py" "$@"

--- a/scripts/ci/test_check_kamn_core_live_https_dependency_posture.sh
+++ b/scripts/ci/test_check_kamn_core_live_https_dependency_posture.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/ci/check_kamn_core_live_https_dependency_posture.sh"
+PY_CHECKER="$ROOT_DIR/scripts/ci/check_kamn_core_live_https_dependency_posture.py"
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected live-https dependency posture checker wrapper to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$PY_CHECKER" ]; then
+  echo "expected live-https dependency posture checker module to be executable" >&2
+  exit 1
+fi
+
+REPORT_FILE="$(mktemp)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR" "$REPORT_FILE"' EXIT
+
+bash "$CHECKER" --output-json "$REPORT_FILE" >/dev/null
+python3 - "$REPORT_FILE" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["schema_version"] == "kamn.ci.kamn-core-live-https-dependency-posture-report.v1"
+assert report["status"] == "pass"
+assert report["reason_codes"] == ["none"]
+assert report["violation_count"] == 0
+PY
+
+MANIFEST_FIXTURE="$TMP_DIR/Cargo.toml"
+cp "$ROOT_DIR/crates/kamn-core/Cargo.toml" "$MANIFEST_FIXTURE"
+sed -i 's/rustls-pemfile = { version = "2.2.0", optional = true }/rustls-pemfile = { version = "2.2.0", optional = false }/' "$MANIFEST_FIXTURE"
+
+set +e
+manifest_failure_output="$(bash "$CHECKER" --cargo-manifest "$MANIFEST_FIXTURE" 2>&1)"
+manifest_failure_code=$?
+set -e
+
+if [ "$manifest_failure_code" -eq 0 ]; then
+  echo "expected checker to fail when rustls-pemfile optional posture drifts" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$manifest_failure_output" | grep -q 'dependency `rustls-pemfile` must declare optional = true'; then
+  echo "expected optional-flag drift marker from checker" >&2
+  exit 1
+fi
+
+README_FIXTURE="$TMP_DIR/README.md"
+cp "$ROOT_DIR/README.md" "$README_FIXTURE"
+sed -i '/adr-kamn-core-live-tls-transport.md/d' "$README_FIXTURE"
+
+set +e
+readme_failure_output="$(bash "$CHECKER" --readme "$README_FIXTURE" 2>&1)"
+readme_failure_code=$?
+set -e
+
+if [ "$readme_failure_code" -eq 0 ]; then
+  echo "expected checker to fail when README ADR contract reference is missing" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$readme_failure_output" | grep -q 'README must link live TLS transport ADR'; then
+  echo "expected README ADR-link violation marker from checker" >&2
+  exit 1
+fi
+
+echo "kamn-core live-https dependency posture checker tests passed."


### PR DESCRIPTION
## Summary
Added a deterministic CI policy checker that enforces `kamn-core` live-HTTPS dependency posture and docs alignment.
This locks the accepted rustls/webpki design into executable contract checks with explicit regression coverage.

## Changes
- `scripts/ci/check_kamn_core_live_https_dependency_posture.py`: validates Cargo feature/dependency posture and README/ADR/CI-strategy references.
- `scripts/ci/check_kamn_core_live_https_dependency_posture.sh`: shell wrapper entrypoint.
- `scripts/ci/test_check_kamn_core_live_https_dependency_posture.sh`: pass/fail fixture-driven contract tests.

## Risks & Compatibility
- None. CI tooling only; no runtime behavior changes.

## Validation
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: `bash scripts/ci/test_check_kamn_core_live_https_dependency_posture.sh` and `bash scripts/ci/check_kamn_core_live_https_dependency_posture.sh --output-json /tmp/kamn-core-live-https-dependency-posture-report.json`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | validation checks exercised through deterministic fixture cases |
| Functional  | ✅ | checker passes on current repository posture |
| Integration | ✅ | wrapper + module end-to-end execution validated |
| Regression  | ✅ | tampered manifest and README fixtures fail with explicit markers |

Closes #2764
