### PR TITLE
test(ci): add non-kolme wave19 wrapper inventory fixtures

### DIFF
--- a/fixtures/ci/non_kolme_wave19_wrapper_family_baseline.json
+++ b/fixtures/ci/non_kolme_wave19_wrapper_family_baseline.json
@@ -1,0 +1,40 @@
+{
+  "lanes": [
+    {
+      "lane_id": "non_kolme.ci.kamn_core_rustdoc_artifact",
+      "manifest_file": "scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh",
+      "priority": "P0",
+      "shell_loc": 102,
+      "source_entry": "scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh",
+      "status": "planned",
+      "target_runner": "ci_contract_lane",
+      "wrapper_kind": "regular_file"
+    },
+    {
+      "lane_id": "non_kolme.ci.kolme_test_harness_loc_soft_budget",
+      "manifest_file": "scripts/ci/run_kolme_test_harness_loc_soft_budget_contract_lane.sh",
+      "priority": "P0",
+      "shell_loc": 305,
+      "source_entry": "scripts/ci/run_kolme_test_harness_loc_soft_budget_contract_lane.sh",
+      "status": "planned",
+      "target_runner": "ci_contract_lane",
+      "wrapper_kind": "regular_file"
+    },
+    {
+      "lane_id": "non_kolme.ci.test_harness_loc_soft_budget",
+      "manifest_file": "scripts/ci/run_test_harness_loc_soft_budget_contract_lane.sh",
+      "priority": "P0",
+      "shell_loc": 328,
+      "source_entry": "scripts/ci/run_test_harness_loc_soft_budget_contract_lane.sh",
+      "status": "planned",
+      "target_runner": "ci_contract_lane",
+      "wrapper_kind": "regular_file"
+    }
+  ],
+  "regular_file_wrapper_count": 3,
+  "schema_version": "kamn.kolme.wrapper-inventory-baseline.v1",
+  "source_matrix_file": "fixtures/ci/non_kolme_wave19_wrapper_family_matrix.json",
+  "symlink_wrapper_count": 0,
+  "total_shell_loc": 735,
+  "wrapper_count": 3
+}

--- a/fixtures/ci/non_kolme_wave19_wrapper_family_matrix.json
+++ b/fixtures/ci/non_kolme_wave19_wrapper_family_matrix.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "kamn.kolme.lane-migration-matrix.v1",
+  "lanes": [
+    {
+      "lane_id": "non_kolme.ci.kamn_core_rustdoc_artifact",
+      "priority": "P0",
+      "status": "planned",
+      "source_entry": "scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh",
+      "manifest_file": "scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh",
+      "target_runner": "ci_contract_lane",
+      "current_runner": "shell_contract_lane",
+      "owner": "devops",
+      "parent_issue": "#2644",
+      "target_issue": "#2767"
+    },
+    {
+      "lane_id": "non_kolme.ci.kolme_test_harness_loc_soft_budget",
+      "priority": "P0",
+      "status": "planned",
+      "source_entry": "scripts/ci/run_kolme_test_harness_loc_soft_budget_contract_lane.sh",
+      "manifest_file": "scripts/ci/run_kolme_test_harness_loc_soft_budget_contract_lane.sh",
+      "target_runner": "ci_contract_lane",
+      "current_runner": "shell_contract_lane",
+      "owner": "devops",
+      "parent_issue": "#2644",
+      "target_issue": "#2767"
+    },
+    {
+      "lane_id": "non_kolme.ci.test_harness_loc_soft_budget",
+      "priority": "P0",
+      "status": "planned",
+      "source_entry": "scripts/ci/run_test_harness_loc_soft_budget_contract_lane.sh",
+      "manifest_file": "scripts/ci/run_test_harness_loc_soft_budget_contract_lane.sh",
+      "target_runner": "ci_contract_lane",
+      "current_runner": "shell_contract_lane",
+      "owner": "devops",
+      "parent_issue": "#2644",
+      "target_issue": "#2767"
+    }
+  ]
+}

--- a/fixtures/ci/non_kolme_wave19_wrapper_family_trend_thresholds.json
+++ b/fixtures/ci/non_kolme_wave19_wrapper_family_trend_thresholds.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "kamn.kolme.wrapper-budget-trend-thresholds.v1",
+  "max_wrapper_count_increase": 0,
+  "max_total_shell_loc_increase": 0,
+  "enforce_lane_shell_loc_nonincreasing": true,
+  "min_wrapper_count_reduction": 0,
+  "min_total_shell_loc_reduction": 0
+}

--- a/scripts/ci/test_non_kolme_wave19_wrapper_family_baseline_contract.sh
+++ b/scripts/ci/test_non_kolme_wave19_wrapper_family_baseline_contract.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATE_SCRIPT="$ROOT_DIR/scripts/ci/generate_kolme_wrapper_inventory_baseline.sh"
+CHECK_SCRIPT="$ROOT_DIR/scripts/ci/check_kolme_wrapper_inventory_baseline.sh"
+PYTHON_SCRIPT="$ROOT_DIR/scripts/ci/kolme_wrapper_inventory_baseline.py"
+MATRIX_FIXTURE="$ROOT_DIR/fixtures/ci/non_kolme_wave19_wrapper_family_matrix.json"
+BASELINE_FIXTURE="$ROOT_DIR/fixtures/ci/non_kolme_wave19_wrapper_family_baseline.json"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$GENERATE_SCRIPT" ]; then
+  echo "expected baseline generator wrapper to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$CHECK_SCRIPT" ]; then
+  echo "expected baseline checker wrapper to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$PYTHON_SCRIPT" ]; then
+  echo "expected baseline policy python script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$MATRIX_FIXTURE" ]; then
+  echo "expected non-Kolme wave-19 wrapper-family matrix fixture to exist" >&2
+  exit 1
+fi
+
+if [ ! -f "$BASELINE_FIXTURE" ]; then
+  echo "expected non-Kolme wave-19 wrapper-family baseline fixture to exist" >&2
+  exit 1
+fi
+
+GENERATED_BASELINE="$TMP_DIR/generated-baseline.json"
+bash "$GENERATE_SCRIPT" \
+  --matrix-file "$MATRIX_FIXTURE" \
+  --output-json "$GENERATED_BASELINE" >"$TMP_DIR/generate.out"
+
+grep -q '^status=generated$' "$TMP_DIR/generate.out"
+grep -q '^wrapper_count=3$' "$TMP_DIR/generate.out"
+grep -q '^total_shell_loc=735$' "$TMP_DIR/generate.out"
+
+python3 - "$GENERATED_BASELINE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload["symlink_wrapper_count"] != 0:
+    raise SystemExit("expected non-Kolme wave-19 symlink_wrapper_count to be 0")
+if payload["regular_file_wrapper_count"] != 3:
+    raise SystemExit("expected non-Kolme wave-19 regular_file_wrapper_count to be 3")
+if payload["total_shell_loc"] != 735:
+    raise SystemExit("expected non-Kolme wave-19 total_shell_loc to be 735")
+PY
+
+python3 - "$BASELINE_FIXTURE" "$GENERATED_BASELINE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+generated = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+if baseline != generated:
+    raise SystemExit("non-Kolme wave-19 generated baseline fixture drift detected")
+PY
+
+DELTA_REPORT="$TMP_DIR/delta-report.json"
+bash "$CHECK_SCRIPT" \
+  --matrix-file "$MATRIX_FIXTURE" \
+  --baseline-file "$BASELINE_FIXTURE" \
+  --output-json "$DELTA_REPORT" >"$TMP_DIR/check-pass.out"
+
+grep -q '^status=pass$' "$TMP_DIR/check-pass.out"
+grep -q '^wrapper_count_delta=0$' "$TMP_DIR/check-pass.out"
+grep -q '^total_shell_loc_delta=0$' "$TMP_DIR/check-pass.out"
+grep -q '^violation_count=0$' "$TMP_DIR/check-pass.out"
+grep -q '^reason_codes=none$' "$TMP_DIR/check-pass.out"
+
+MUTATED_BASELINE="$TMP_DIR/mutated-baseline.json"
+cp "$BASELINE_FIXTURE" "$MUTATED_BASELINE"
+python3 - "$MUTATED_BASELINE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["lanes"][0]["shell_loc"] = payload["lanes"][0]["shell_loc"] + 1
+payload["total_shell_loc"] = payload["total_shell_loc"] + 1
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if bash "$CHECK_SCRIPT" \
+  --matrix-file "$MATRIX_FIXTURE" \
+  --baseline-file "$MUTATED_BASELINE" >"$TMP_DIR/check-mutated-baseline.out" 2>&1; then
+  echo "expected non-Kolme wave-19 baseline checker to fail on shell_loc drift" >&2
+  exit 1
+fi
+grep -q '^status=fail$' "$TMP_DIR/check-mutated-baseline.out"
+grep -q '^reason_codes=lane_shell_loc_drift$' "$TMP_DIR/check-mutated-baseline.out"
+grep -q 'shell_loc drifted' "$TMP_DIR/check-mutated-baseline.out"
+
+MUTATED_MATRIX="$TMP_DIR/mutated-matrix.json"
+cp "$MATRIX_FIXTURE" "$MUTATED_MATRIX"
+python3 - "$MUTATED_MATRIX" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["lanes"][0]["source_entry"] = "scripts/ci/run_missing_wave19_contract_lane.sh"
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if bash "$CHECK_SCRIPT" \
+  --matrix-file "$MUTATED_MATRIX" \
+  --baseline-file "$BASELINE_FIXTURE" >"$TMP_DIR/check-mutated-matrix.out" 2>&1; then
+  echo "expected non-Kolme wave-19 baseline checker to fail when matrix source_entry wrapper is missing" >&2
+  exit 1
+fi
+grep -q 'lane wrapper path does not exist' "$TMP_DIR/check-mutated-matrix.out"
+
+echo "non-Kolme wave-19 wrapper-family baseline contract tests passed."


### PR DESCRIPTION
## Summary
Added the next non-Kolme wrapper-family inventory wave fixture (`wave19`) focused on the remaining high-impact regular-file CI contract-lane wrappers.
This creates deterministic baseline evidence for follow-on migration and trend enforcement work.

## Changes
- `fixtures/ci/non_kolme_wave19_wrapper_family_matrix.json`: wave19 lane inventory matrix.
- `fixtures/ci/non_kolme_wave19_wrapper_family_baseline.json`: generated deterministic baseline.
- `fixtures/ci/non_kolme_wave19_wrapper_family_trend_thresholds.json`: trend threshold policy fixture.
- `scripts/ci/test_non_kolme_wave19_wrapper_family_baseline_contract.sh`: baseline contract test with drift/missing-wrapper regressions.

## Risks & Compatibility
- None. Fixtures and CI contract tests only.

## Validation
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: `bash scripts/ci/test_non_kolme_wave19_wrapper_family_baseline_contract.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | deterministic fixture and schema assertions |
| Functional  | ✅ | baseline generation/check pass path validated |
| Integration | ✅ | baseline policy wrapper + checker flow validated |
| Regression  | ✅ | shell LOC drift and missing-wrapper scenarios fail closed |

Closes #2767
