### PR TITLE
refactor(ci): loop lightweight wave ci-tools execution blocks (#2796)

### DIFF
--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -10,6 +10,12 @@ run_non_kolme_wave_wrapper_family_contracts() {
   done
 }
 
+run_non_kolme_lightweight_wave_wrapper_matrix_contracts() {
+  for lightweight_wave in {10..18}; do
+    bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave${lightweight_wave}_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
+  done
+}
+
 if [ "${KAMN_CI_TOOLS_FAST_MODE:-false}" = "true" ]; then
   bash "$ROOT_DIR/scripts/ci/test_evaluate_budget.sh"
   bash "$ROOT_DIR/scripts/ci/test_check_script_duplication_budget.sh"
@@ -44,15 +50,7 @@ if [ "${KAMN_CI_TOOLS_FAST_MODE:-false}" = "true" ]; then
   bash "$ROOT_DIR/scripts/framework/test_non_kolme_bridge_contract_lane_dispatch_wrapper_matrix.sh"
   bash "$ROOT_DIR/scripts/framework/test_non_kolme_sdk_contract_lane_dispatch_wrapper_matrix.sh"
   bash "$ROOT_DIR/scripts/framework/test_non_kolme_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave10_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave11_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave12_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave13_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave14_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave15_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave16_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave17_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-  bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave18_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
+  run_non_kolme_lightweight_wave_wrapper_matrix_contracts
   bash "$ROOT_DIR/scripts/ci/test_check_flaky_registry.sh"
   bash "$ROOT_DIR/scripts/ci/test_summarize_budget_artifacts.sh"
   bash "$ROOT_DIR/scripts/ci/test_check_pr_ci_declaration.sh"
@@ -125,15 +123,7 @@ bash "$ROOT_DIR/scripts/framework/test_non_kolme_manifest_backed_contract_lane_d
 bash "$ROOT_DIR/scripts/framework/test_non_kolme_bridge_contract_lane_dispatch_wrapper_matrix.sh"
 bash "$ROOT_DIR/scripts/framework/test_non_kolme_sdk_contract_lane_dispatch_wrapper_matrix.sh"
 bash "$ROOT_DIR/scripts/framework/test_non_kolme_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave10_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave11_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave12_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave13_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave14_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave15_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave16_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave17_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
-bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave18_lightweight_contract_lane_dispatch_wrapper_matrix.sh"
+run_non_kolme_lightweight_wave_wrapper_matrix_contracts
 bash "$ROOT_DIR/scripts/ci/test_check_flaky_registry.sh"
 bash "$ROOT_DIR/scripts/ci/test_summarize_budget_artifacts.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_pr_ci_declaration.sh"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -26,15 +26,6 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/framework/test_non_kolme_bridge_contract_lane_dispatch_wrapper_matrix.sh"'
   'bash "$ROOT_DIR/scripts/framework/test_non_kolme_sdk_contract_lane_dispatch_wrapper_matrix.sh"'
   'bash "$ROOT_DIR/scripts/framework/test_non_kolme_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave10_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave11_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave12_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave13_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave14_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave15_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave16_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave17_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
-  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave18_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_check_lane_migration_matrix_policy.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh"'
   'bash "$ROOT_DIR/scripts/kolme/test_generate_fork_compatibility_evidence.sh"'
@@ -99,6 +90,9 @@ required_wave_loop_snippets=(
   'for wave in {1..19}; do'
   'bash "$ROOT_DIR/scripts/ci/test_non_kolme_wave${wave}_wrapper_family_baseline_contract.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_check_non_kolme_wave${wave}_wrapper_family_budget_trend.sh"'
+  'run_non_kolme_lightweight_wave_wrapper_matrix_contracts()'
+  'for lightweight_wave in {10..18}; do'
+  'bash "$ROOT_DIR/scripts/framework/test_non_kolme_wave${lightweight_wave}_lightweight_contract_lane_dispatch_wrapper_matrix.sh"'
 )
 
 for snippet in "${required_wave_loop_snippets[@]}"; do
@@ -111,6 +105,12 @@ done
 wave_helper_invocation_count="$(grep -Ec '^[[:space:]]*run_non_kolme_wave_wrapper_family_contracts$' "$CI_TOOLS_SCRIPT")"
 if [ "$wave_helper_invocation_count" -ne 2 ]; then
   echo "expected ci tools regression lane to invoke run_non_kolme_wave_wrapper_family_contracts exactly twice; found $wave_helper_invocation_count" >&2
+  exit 1
+fi
+
+lightweight_wave_helper_invocation_count="$(grep -Ec '^[[:space:]]*run_non_kolme_lightweight_wave_wrapper_matrix_contracts$' "$CI_TOOLS_SCRIPT")"
+if [ "$lightweight_wave_helper_invocation_count" -ne 2 ]; then
+  echo "expected ci tools regression lane to invoke run_non_kolme_lightweight_wave_wrapper_matrix_contracts exactly twice; found $lightweight_wave_helper_invocation_count" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Refactors non-Kolme lightweight wave10-18 wrapper-matrix execution in `test_ci_tools.sh` to shared deterministic helper-loop execution.
Updates command-surface contract checks to preserve fail-closed governance for the loop-based structure.

## Changes
- scripts/ci/test_ci_tools.sh: added `run_non_kolme_lightweight_wave_wrapper_matrix_contracts()` and replaced duplicated fast/full wave10-18 command blocks with helper invocation.
- scripts/ci/test_ci_tools_command_surface_contract.sh: replaced literal lightweight wave command assertions with structural loop checks and exact invocation-count enforcement.

## Risks & Compatibility
- None

## Validation
- [x] `bash scripts/ci/test_ci_tools_command_surface_contract.sh`
- [x] `bash scripts/ci/test_ci_strategy_contract.sh`
- [x] `bash scripts/ci/test_select_targets.sh`
- [x] `bash scripts/framework/test_non_kolme_wave10_lightweight_contract_lane_dispatch_wrapper_matrix.sh`
- [x] `bash scripts/framework/test_non_kolme_wave18_lightweight_contract_lane_dispatch_wrapper_matrix.sh`
- [ ] `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` (fails in unrelated pre-existing downstream lanes after non-Kolme wave checks pass)

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Helper-loop shell execution and structural contract checks |
| Functional  | ✅     | CI tools command-surface contract remains green |
| Integration | ✅     | Strategy + selector contracts remain green |
| Regression  | ✅     | Lightweight boundary waves 10 and 18 remain enforced |

Closes #2796
