### PR TITLE
refactor(ci): consolidate qa-doc selector assertions

### DIFF
--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -114,6 +114,15 @@ assert_ci_doc_contract_trend_scope_compact() {
   assert_ci_doc_contract_trend_scope "$output" "$context"
 }
 
+assert_qa_doc_contract_scope_compact() {
+  local output="$1"
+  local context="$2"
+  assert_eq "$(extract_output "$output" "docs_only")" "true" "$context should remain docs-only"
+  assert_eq "$(extract_output "$output" "run_rust")" "false" "$context should avoid rust lane"
+  assert_eq "$(extract_output "$output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "$context must run missing-docs policy checks"
+  assert_eq "$(extract_output "$output" "test_scope")" "qa-doc-contract" "$context should set qa-doc-contract scope"
+}
+
 run_selector_with_bridge_deep() {
   local changed_files="$1"
   local bridge_deep="${2:-false}"
@@ -253,34 +262,19 @@ kolme_harness_trend_report_test_script_output="$(run_selector $'scripts/ci/test_
 assert_ci_doc_contract_trend_scope_compact "$kolme_harness_trend_report_test_script_output" "Kolme harness trend-report test script changes"
 
 hardening_docs_output="$(run_selector $'docs/planning/engineering-hardening-wave.md')"
-assert_eq "$(extract_output "$hardening_docs_output" "docs_only")" "true" "engineering hardening docs should remain docs-only"
-assert_eq "$(extract_output "$hardening_docs_output" "run_rust")" "false" "engineering hardening docs should avoid rust lane"
-assert_eq "$(extract_output "$hardening_docs_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "engineering hardening docs must run kamn-core missing-docs policy checks"
-assert_eq "$(extract_output "$hardening_docs_output" "test_scope")" "qa-doc-contract" "engineering hardening docs should set qa-doc-contract scope"
+assert_qa_doc_contract_scope_compact "$hardening_docs_output" "engineering hardening docs"
 
 velocity_cadence_docs_output="$(run_selector $'docs/planning/issues/missing-docs-velocity-cadence.md')"
-assert_eq "$(extract_output "$velocity_cadence_docs_output" "docs_only")" "true" "missing-docs velocity cadence docs should remain docs-only"
-assert_eq "$(extract_output "$velocity_cadence_docs_output" "run_rust")" "false" "missing-docs velocity cadence docs should avoid rust lane"
-assert_eq "$(extract_output "$velocity_cadence_docs_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "missing-docs velocity cadence docs must run missing-docs policy checks"
-assert_eq "$(extract_output "$velocity_cadence_docs_output" "test_scope")" "qa-doc-contract" "missing-docs velocity cadence docs should set qa-doc-contract scope"
+assert_qa_doc_contract_scope_compact "$velocity_cadence_docs_output" "missing-docs velocity cadence docs"
 
 graduation_batch_docs_output="$(run_selector $'docs/planning/issues/missing-docs-first-batch-graduation-report.md')"
-assert_eq "$(extract_output "$graduation_batch_docs_output" "docs_only")" "true" "missing-docs graduation batch docs should remain docs-only"
-assert_eq "$(extract_output "$graduation_batch_docs_output" "run_rust")" "false" "missing-docs graduation batch docs should avoid rust lane"
-assert_eq "$(extract_output "$graduation_batch_docs_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "missing-docs graduation batch docs must run missing-docs policy checks"
-assert_eq "$(extract_output "$graduation_batch_docs_output" "test_scope")" "qa-doc-contract" "missing-docs graduation batch docs should set qa-doc-contract scope"
+assert_qa_doc_contract_scope_compact "$graduation_batch_docs_output" "missing-docs graduation batch docs"
 
 module_map_docs_output="$(run_selector $'docs/architecture/kamn-core-module-map.md')"
-assert_eq "$(extract_output "$module_map_docs_output" "docs_only")" "true" "kamn-core module map docs should remain docs-only"
-assert_eq "$(extract_output "$module_map_docs_output" "run_rust")" "false" "kamn-core module map docs should avoid rust lane"
-assert_eq "$(extract_output "$module_map_docs_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "kamn-core module map docs must run missing-docs policy checks"
-assert_eq "$(extract_output "$module_map_docs_output" "test_scope")" "qa-doc-contract" "kamn-core module map docs should set qa-doc-contract scope"
+assert_qa_doc_contract_scope_compact "$module_map_docs_output" "kamn-core module map docs"
 
 rustdoc_docs_output="$(run_selector $'docs/developer/rustdoc-publishing.md')"
-assert_eq "$(extract_output "$rustdoc_docs_output" "docs_only")" "true" "rustdoc publishing docs should remain docs-only"
-assert_eq "$(extract_output "$rustdoc_docs_output" "run_rust")" "false" "rustdoc publishing docs should avoid rust lane"
-assert_eq "$(extract_output "$rustdoc_docs_output" "run_kamn_core_missing_docs_policy_contract_tests")" "true" "rustdoc publishing docs must run missing-docs policy checks"
-assert_eq "$(extract_output "$rustdoc_docs_output" "test_scope")" "qa-doc-contract" "rustdoc publishing docs should set qa-doc-contract scope"
+assert_qa_doc_contract_scope_compact "$rustdoc_docs_output" "rustdoc publishing docs"
 
 rustdoc_lane_script_output="$(run_selector $'scripts/ci/run_kamn_core_rustdoc_artifact_contract_lane.sh')"
 assert_eq "$(extract_output "$rustdoc_lane_script_output" "run_rust")" "true" "rustdoc artifact lane script changes should run rust tooling setup"


### PR DESCRIPTION
## Summary
Consolidated repeated qa-doc-contract docs assertions in scripts/ci/test_select_targets.sh into a shared helper. This preserves behavior while reducing repetitive shell checks in the docs-policy selector section.

Closes #2821

## Changes
- scripts/ci/test_select_targets.sh:
  - added `assert_qa_doc_contract_scope_compact` helper.
  - refactored five qa-doc-contract docs blocks (hardening, velocity cadence, graduation batch, module map, rustdoc docs) to helper calls.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Output:
```text
scripts/ci/test_select_targets.sh: line 256: assert_qa_doc_contract_scope_compact: command not found
```

### 🟢 Green Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Output:
```text
select_targets matrix regression tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
```
Output:
```text
CI strategy contract tests passed.
ci tools command surface contract tests passed.
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status     | Tests Added/Modified         | Justification if N/A |
|--------------|------------|------------------------------|----------------------|
| Unit         | N/A | N/A | Shell assertion refactor only |
| Functional   | ✅ | scripts/ci/test_select_targets.sh | |
| Integration  | ✅ | scripts/ci/test_ci_strategy_contract.sh, scripts/ci/test_ci_tools_command_surface_contract.sh | |
| Regression   | ✅ | qa-doc-contract docs assertions preserved via helper calls | |
| Performance  | N/A | N/A | No runtime path changes |

## Risks & Rollback
- None.
- Rollback: revert commit `ff2730a`.

## Documentation Updates
- None required; selector behavior unchanged.

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
