### PR TITLE
refactor(ci): helperize non-kolme wave selector function

### DIFF
--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -123,6 +123,18 @@ assert_qa_doc_contract_scope_compact() {
   assert_eq "$(extract_output "$output" "test_scope")" "qa-doc-contract" "$context should set qa-doc-contract scope"
 }
 
+assert_ci_doc_contract_scope_wave() {
+  local output="$1"
+  local context="$2"
+  assert_ci_doc_contract_scope "$output" "$context"
+}
+
+assert_ci_doc_contract_trend_scope_wave() {
+  local output="$1"
+  local context="$2"
+  assert_ci_doc_contract_trend_scope "$output" "$context"
+}
+
 run_selector_with_bridge_deep() {
   local changed_files="$1"
   local bridge_deep="${2:-false}"
@@ -185,23 +197,13 @@ assert_non_kolme_wave_wrapper_family_contract_scope() {
   local matrix_output threshold_output trend_output
 
   matrix_output="$(run_selector $'fixtures/ci/non_kolme_wave'"$wave"$'_wrapper_family_matrix.json')"
-  assert_eq "$(extract_output "$matrix_output" "run_rust")" "false" "non-Kolme wave-${wave} wrapper-family matrix fixture changes should avoid rust full fallback"
-  assert_eq "$(extract_output "$matrix_output" "run_ci_tool_checks")" "true" "non-Kolme wave-${wave} wrapper-family matrix fixture changes must run CI tool checks"
-  assert_eq "$(extract_output "$matrix_output" "unknown_risk_changed")" "false" "non-Kolme wave-${wave} wrapper-family matrix fixture changes should be classified"
-  assert_eq "$(extract_output "$matrix_output" "test_scope")" "ci-doc-contract" "non-Kolme wave-${wave} wrapper-family matrix fixture changes should use ci-doc-contract scope"
+  assert_ci_doc_contract_scope_wave "$matrix_output" "non-Kolme wave-${wave} wrapper-family matrix fixture changes"
 
   threshold_output="$(run_selector $'fixtures/ci/non_kolme_wave'"$wave"$'_wrapper_family_trend_thresholds.json')"
-  assert_eq "$(extract_output "$threshold_output" "run_rust")" "false" "non-Kolme wave-${wave} trend threshold fixture changes should avoid rust full fallback"
-  assert_eq "$(extract_output "$threshold_output" "run_ci_tool_checks")" "true" "non-Kolme wave-${wave} trend threshold fixture changes must run CI tool checks"
-  assert_eq "$(extract_output "$threshold_output" "unknown_risk_changed")" "false" "non-Kolme wave-${wave} trend threshold fixture changes should be classified"
-  assert_eq "$(extract_output "$threshold_output" "test_scope")" "ci-doc-contract" "non-Kolme wave-${wave} trend threshold fixture changes should use ci-doc-contract scope"
+  assert_ci_doc_contract_scope_wave "$threshold_output" "non-Kolme wave-${wave} trend threshold fixture changes"
 
   trend_output="$(run_selector $'scripts/ci/check_non_kolme_wave'"$wave"$'_wrapper_family_budget_trend.sh')"
-  assert_eq "$(extract_output "$trend_output" "run_rust")" "false" "non-Kolme wave-${wave} trend checker script changes should avoid rust full fallback"
-  assert_eq "$(extract_output "$trend_output" "run_ci_tool_checks")" "true" "non-Kolme wave-${wave} trend checker script changes must run CI tool checks"
-  assert_eq "$(extract_output "$trend_output" "run_script_surface_budget_checks")" "true" "non-Kolme wave-${wave} trend checker script changes should run script-surface budget checks"
-  assert_eq "$(extract_output "$trend_output" "unknown_risk_changed")" "false" "non-Kolme wave-${wave} trend checker script changes should be classified"
-  assert_eq "$(extract_output "$trend_output" "test_scope")" "ci-doc-contract" "non-Kolme wave-${wave} trend checker script changes should use ci-doc-contract scope"
+  assert_ci_doc_contract_trend_scope_wave "$trend_output" "non-Kolme wave-${wave} trend checker script changes"
 }
 
 for wave in $(seq 1 19); do


### PR DESCRIPTION
## Summary
Refactored `assert_non_kolme_wave_wrapper_family_contract_scope` to use shared ci-doc helper functions instead of duplicated inline assertions. This preserves behavior while reducing repetitive test logic.

Closes #2824

## Changes
- scripts/ci/test_select_targets.sh:
  - added `assert_ci_doc_contract_scope_wave` and `assert_ci_doc_contract_trend_scope_wave` wrappers.
  - replaced inline matrix/threshold/trend assertion groups in `assert_non_kolme_wave_wrapper_family_contract_scope` with helper calls.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Output:
```text
scripts/ci/test_select_targets.sh: line 188: assert_ci_doc_contract_scope_wave: command not found
```

### 🟢 Green Phase
Command:
```bash
bash scripts/ci/test_select_targets.sh
```
Output:
```text
select_targets matrix regression tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
```
Output:
```text
CI strategy contract tests passed.
ci tools command surface contract tests passed.
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status     | Tests Added/Modified         | Justification if N/A |
|--------------|------------|------------------------------|----------------------|
| Unit         | N/A | N/A | Shell assertion refactor only |
| Functional   | ✅ | scripts/ci/test_select_targets.sh | |
| Integration  | ✅ | scripts/ci/test_ci_strategy_contract.sh, scripts/ci/test_ci_tools_command_surface_contract.sh | |
| Regression   | ✅ | Non-kolme wave wrapper-family assertions preserve ci-doc-contract expectations via helper calls | |
| Performance  | N/A | N/A | No runtime path changes |

## Risks & Rollback
- None.
- Rollback: revert commit `1b18629`.

## Documentation Updates
- None required; selector behavior unchanged.

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
