### PR TITLE
feat(node): add daemon Unix signal shutdown handling

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -24,6 +24,7 @@ where
     let mut daemon_max_ticks: Option<u64> = None;
     let mut daemon_tick_interval_ms: Option<u64> = None;
     let mut daemon_shutdown_signal_ticks: Vec<u64> = Vec::new();
+    let mut daemon_shutdown_os_signals = false;
     let mut daemon_shutdown_drain_ticks: Option<u64> = None;
     let mut daemon_shutdown_timeout_ticks: Option<u64> = None;
     let mut daemon_peer_id: Option<String> = None;
@@ -137,6 +138,9 @@ where
                     "--daemon-shutdown-signal-tick",
                 ))?;
                 daemon_shutdown_signal_ticks.push(parse_daemon_control_arg(&value)?);
+            }
+            "--daemon-shutdown-os-signals" => {
+                daemon_shutdown_os_signals = true;
             }
             "--daemon-shutdown-drain-ticks" => {
                 let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
@@ -276,7 +280,9 @@ where
                     "--daemon-shutdown-timeout-ticks",
                 ));
             }
-        } else if daemon_shutdown_drain_ticks.is_some() || daemon_shutdown_timeout_ticks.is_some() {
+        } else if (daemon_shutdown_drain_ticks.is_some() || daemon_shutdown_timeout_ticks.is_some())
+            && !daemon_shutdown_os_signals
+        {
             return Err(ConfigError::MissingArgumentValue(
                 "--daemon-shutdown-signal-tick",
             ));
@@ -352,6 +358,7 @@ where
         daemon_max_ticks,
         daemon_tick_interval_ms,
         daemon_shutdown_signal_ticks,
+        daemon_shutdown_os_signals,
         daemon_shutdown_drain_ticks,
         daemon_shutdown_timeout_ticks,
         daemon_peer_id,

--- a/crates/kamn-node/src/cli_tests.rs
+++ b/crates/kamn-node/src/cli_tests.rs
@@ -18,6 +18,7 @@ fn cli_module_parses_required_role_and_defaults() {
     assert_eq!(parsed.sync_mode, SyncMode::Fast);
     assert_eq!(parsed.runtime_mode, RuntimeMode::bootstrap());
     assert!(parsed.daemon_shutdown_signal_ticks.is_empty());
+    assert!(!parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, None);
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, None);
     assert_eq!(parsed.output_mode, OutputMode::text());

--- a/crates/kamn-node/src/daemon_shutdown.rs
+++ b/crates/kamn-node/src/daemon_shutdown.rs
@@ -1,3 +1,6 @@
+use std::thread;
+use std::time::Duration;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct DaemonCompletion {
     pub(super) executed_ticks: u64,
@@ -56,9 +59,117 @@ pub(super) fn evaluate_daemon_completion(
     }
 }
 
+pub(super) fn evaluate_daemon_completion_with_os_signals(
+    max_ticks: u64,
+    tick_interval_ms: u64,
+    drain_ticks: Option<u64>,
+    timeout_ticks: Option<u64>,
+) -> Result<DaemonCompletion, String> {
+    #[cfg(unix)]
+    {
+        os_signal::install_shutdown_handlers()?;
+        let tick_duration = Duration::from_millis(tick_interval_ms);
+        let mut first_signal_tick: Option<u64> = None;
+        for tick in 1..=max_ticks {
+            if first_signal_tick.is_none() && os_signal::shutdown_signal_observed() {
+                first_signal_tick = Some(tick);
+            }
+            if let Some(signal_tick) = first_signal_tick {
+                let completion = evaluate_daemon_completion(
+                    max_ticks,
+                    &[signal_tick],
+                    drain_ticks,
+                    timeout_ticks,
+                );
+                if tick >= completion.executed_ticks {
+                    return Ok(completion);
+                }
+            }
+            if tick < max_ticks {
+                thread::sleep(tick_duration);
+            }
+        }
+        if let Some(signal_tick) = first_signal_tick {
+            return Ok(evaluate_daemon_completion(
+                max_ticks,
+                &[signal_tick],
+                drain_ticks,
+                timeout_ticks,
+            ));
+        }
+        Ok(DaemonCompletion {
+            executed_ticks: max_ticks,
+            completion_reason: "tick-budget-exhausted".to_owned(),
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (max_ticks, tick_interval_ms, drain_ticks, timeout_ticks);
+        Err("daemon os signal shutdown is unsupported on this platform".to_owned())
+    }
+}
+
+#[cfg(unix)]
+mod os_signal {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static SHUTDOWN_SIGNAL_OBSERVED: AtomicBool = AtomicBool::new(false);
+
+    const SIGINT: i32 = 2;
+    const SIGTERM: i32 = 15;
+    const SIG_ERR: usize = usize::MAX;
+
+    unsafe extern "C" {
+        fn signal(signum: i32, handler: usize) -> usize;
+    }
+
+    #[cfg(test)]
+    unsafe extern "C" {
+        fn raise(sig: i32) -> i32;
+    }
+
+    extern "C" fn shutdown_signal_handler(_signal: i32) {
+        SHUTDOWN_SIGNAL_OBSERVED.store(true, Ordering::SeqCst);
+    }
+
+    pub(super) fn install_shutdown_handlers() -> Result<(), String> {
+        SHUTDOWN_SIGNAL_OBSERVED.store(false, Ordering::SeqCst);
+        let sigint_result = unsafe { signal(SIGINT, shutdown_signal_handler as usize) };
+        if sigint_result == SIG_ERR {
+            return Err("failed to install SIGINT shutdown handler".to_owned());
+        }
+        let sigterm_result = unsafe { signal(SIGTERM, shutdown_signal_handler as usize) };
+        if sigterm_result == SIG_ERR {
+            return Err("failed to install SIGTERM shutdown handler".to_owned());
+        }
+        Ok(())
+    }
+
+    pub(super) fn shutdown_signal_observed() -> bool {
+        SHUTDOWN_SIGNAL_OBSERVED.load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(super) fn raise_sigterm_for_test() -> Result<(), String> {
+        let result = unsafe { raise(SIGTERM) };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err("failed to raise SIGTERM".to_owned())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::evaluate_daemon_completion;
+    #[cfg(unix)]
+    use super::os_signal::raise_sigterm_for_test;
+    use super::{evaluate_daemon_completion, evaluate_daemon_completion_with_os_signals};
+    #[cfg(unix)]
+    use std::thread;
+    #[cfg(unix)]
+    use std::time::Duration;
 
     #[test]
     fn unit_daemon_completion_defaults_to_tick_budget_without_shutdown_signal() {
@@ -105,6 +216,41 @@ mod tests {
         assert!(
             completion.executed_ticks <= 9,
             "timeout-bound completion must not exceed max tick budget"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn integration_daemon_completion_with_os_signals_applies_graceful_shutdown() {
+        let trigger = thread::spawn(|| {
+            thread::sleep(Duration::from_millis(5));
+            raise_sigterm_for_test().expect("SIGTERM test signal should be raised");
+        });
+        let completion = evaluate_daemon_completion_with_os_signals(40, 1, Some(2), Some(5))
+            .expect("daemon completion with OS signal handling should succeed");
+        trigger
+            .join()
+            .expect("signal trigger thread should complete");
+        assert!(
+            completion
+                .completion_reason
+                .starts_with("graceful-shutdown:signal@"),
+            "expected graceful shutdown completion reason, got {}",
+            completion.completion_reason
+        );
+        assert!(
+            completion.executed_ticks <= 40,
+            "signal-driven shutdown should remain bounded by max ticks"
+        );
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn integration_daemon_completion_with_os_signals_is_unsupported_on_non_unix() {
+        let result = evaluate_daemon_completion_with_os_signals(5, 1, Some(1), Some(1));
+        assert!(
+            result.is_err(),
+            "non-unix targets should return unsupported error for OS signal handling"
         );
     }
 }

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -19,7 +19,7 @@ mod wire_payload;
 
 use cli::parse_args;
 use daemon_observability::build_daemon_observability_telemetry;
-use daemon_shutdown::evaluate_daemon_completion;
+use daemon_shutdown::{evaluate_daemon_completion, evaluate_daemon_completion_with_os_signals};
 #[cfg(test)]
 use logging::{
     capture_test_logs, render_log_event_line, resolve_log_config_from_inputs, NodeLogConfig,
@@ -265,6 +265,7 @@ struct NodeCli {
     daemon_max_ticks: Option<u64>,
     daemon_tick_interval_ms: Option<u64>,
     daemon_shutdown_signal_ticks: Vec<u64>,
+    daemon_shutdown_os_signals: bool,
     daemon_shutdown_drain_ticks: Option<u64>,
     daemon_shutdown_timeout_ticks: Option<u64>,
     daemon_peer_id: Option<String>,
@@ -454,6 +455,7 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         daemon_max_ticks,
         daemon_tick_interval_ms,
         daemon_shutdown_signal_ticks,
+        daemon_shutdown_os_signals,
         daemon_shutdown_drain_ticks,
         daemon_shutdown_timeout_ticks,
         daemon_peer_id,
@@ -579,12 +581,23 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                     }
                     None => (None, None, None),
                 };
-            let daemon_completion = evaluate_daemon_completion(
-                max_ticks,
-                daemon_shutdown_signal_ticks.as_slice(),
-                daemon_shutdown_drain_ticks,
-                daemon_shutdown_timeout_ticks,
-            );
+            let daemon_completion =
+                if daemon_shutdown_os_signals && daemon_shutdown_signal_ticks.is_empty() {
+                    evaluate_daemon_completion_with_os_signals(
+                        max_ticks,
+                        tick_interval_ms,
+                        daemon_shutdown_drain_ticks,
+                        daemon_shutdown_timeout_ticks,
+                    )
+                    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?
+                } else {
+                    evaluate_daemon_completion(
+                        max_ticks,
+                        daemon_shutdown_signal_ticks.as_slice(),
+                        daemon_shutdown_drain_ticks,
+                        daemon_shutdown_timeout_ticks,
+                    )
+                };
             let daemon_observability = build_daemon_observability_telemetry(
                 tick_interval_ms,
                 daemon_completion.completion_reason.as_str(),

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+#[cfg(unix)]
+const SIGTERM: i32 = 15;
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn raise(sig: i32) -> i32;
+}
+
 #[test]
 fn parses_required_role_and_defaults() {
     let args = vec![
@@ -24,6 +32,7 @@ fn parses_required_role_and_defaults() {
     assert_eq!(parsed.daemon_max_ticks, None);
     assert_eq!(parsed.daemon_tick_interval_ms, None);
     assert!(parsed.daemon_shutdown_signal_ticks.is_empty());
+    assert!(!parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, None);
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, None);
     assert_eq!(parsed.daemon_peer_id, None);
@@ -470,6 +479,7 @@ fn parses_runtime_mode_daemon_with_bounded_controls() {
     assert_eq!(parsed.runtime_mode, RuntimeMode::daemon());
     assert_eq!(parsed.daemon_max_ticks, Some(3));
     assert_eq!(parsed.daemon_tick_interval_ms, Some(25));
+    assert!(!parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_peer_id, Some("peer-alpha".to_owned()));
     assert_eq!(parsed.daemon_lifecycle_events.len(), 2);
 }
@@ -496,6 +506,33 @@ fn parses_runtime_mode_daemon_with_shutdown_controls() {
 
     let parsed = parse_args(args).expect("daemon args with shutdown controls should parse");
     assert_eq!(parsed.daemon_shutdown_signal_ticks, vec![3]);
+    assert!(!parsed.daemon_shutdown_os_signals);
+    assert_eq!(parsed.daemon_shutdown_drain_ticks, Some(2));
+    assert_eq!(parsed.daemon_shutdown_timeout_ticks, Some(4));
+}
+
+#[test]
+fn parses_runtime_mode_daemon_with_os_signal_shutdown_controls() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "12".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "5".to_owned(),
+        "--daemon-shutdown-os-signals".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "4".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("daemon args with os signal controls should parse");
+    assert_eq!(parsed.daemon_shutdown_signal_ticks, Vec::<u64>::new());
+    assert!(parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, Some(2));
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, Some(4));
 }
@@ -923,6 +960,42 @@ fn integration_runtime_daemon_shutdown_timeout_is_fail_closed() {
     assert!(rendered.contains("\"daemon_observability_availability_bps\":9800"));
     assert!(rendered.contains("\"daemon_observability_health\":\"critical\""));
     assert!(rendered.contains("\"daemon_observability_alert_count\":4"));
+}
+
+#[cfg(unix)]
+#[test]
+fn integration_runtime_daemon_applies_graceful_shutdown_on_os_signal() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "100".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "1".to_owned(),
+        "--daemon-shutdown-os-signals".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "5".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("daemon os-signal args should parse");
+    let trigger = std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let result = unsafe { raise(SIGTERM) };
+        assert_eq!(result, 0, "test SIGTERM raise should succeed");
+    });
+    let report = execute(parsed).expect("daemon os-signal execution should succeed");
+    trigger
+        .join()
+        .expect("os-signal trigger thread should complete");
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("\"daemon_completion_reason\":\"graceful-shutdown:signal@"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Added real Unix SIGTERM/SIGINT handling to daemon runtime shutdown flow in `kamn-node`, while preserving existing deterministic tick-script shutdown behavior. Daemon mode now supports OS-signal-triggered graceful drain/timeout via a new CLI flag.

Closes #2828

## Changes
- `crates/kamn-node/src/cli.rs`: added `--daemon-shutdown-os-signals` flag and validation path.
- `crates/kamn-node/src/main.rs`: integrated OS-signal shutdown execution when enabled and no synthetic shutdown ticks are provided.
- `crates/kamn-node/src/daemon_shutdown.rs`: implemented Unix signal registration/observation and signal-aware daemon completion helper.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added parse + runtime tests for OS-signal shutdown behavior.
- `crates/kamn-node/src/cli_tests.rs`: updated default parse assertions for new daemon field.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node core_behavior_tests::functional_runtime_daemon_applies_graceful_shutdown_signal -- --exact
```
Output:
```text
error[E0432]: unresolved import `daemon_shutdown::evaluate_daemon_completion_with_os_signals`
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-node main_tests::core_behavior_tests::parses_runtime_mode_daemon_with_os_signal_shutdown_controls -- --exact
cargo test -p kamn-node main_tests::core_behavior_tests::integration_runtime_daemon_applies_graceful_shutdown_on_os_signal -- --exact
cargo test -p kamn-node daemon_shutdown::tests::integration_daemon_completion_with_os_signals_applies_graceful_shutdown -- --exact
cargo test -p kamn-node cli_tests::cli_module_parses_required_role_and_defaults -- --exact
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node main_tests::core_behavior_tests::functional_runtime_daemon_applies_graceful_shutdown_signal -- --exact
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `daemon_shutdown::tests::integration_daemon_completion_with_os_signals_applies_graceful_shutdown` (signal helper path) | |
| Functional   | ✅ | `main_tests::core_behavior_tests::parses_runtime_mode_daemon_with_os_signal_shutdown_controls` | |
| Integration  | ✅ | `main_tests::core_behavior_tests::integration_runtime_daemon_applies_graceful_shutdown_on_os_signal` | |
| Regression   | ✅ | Existing synthetic shutdown path test kept green (`functional_runtime_daemon_applies_graceful_shutdown_signal`) | |
| Performance  | N/A | N/A | No performance harness change in this slice |

## Risks & Rollback
- Risk: signal handler wiring is Unix-only; non-Unix returns explicit unsupported error path.
- Rollback: revert commit `f6e88bf`.

## Documentation Updates
- None in this PR (implementation + tests only). Planning/docs updates tracked under parent story/epic.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated (or justified why not)
