### PR TITLE
feat(node): add runtime observability endpoint export

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -2,6 +2,8 @@ use super::{
     normalize_kolme_live_signer_key_source, normalize_kolme_live_signer_profile_selector,
     ConfigError, DiagnosticsMode, LocalProfile, NodeCli, NodeRole, OutputMode, PeerLifecycleEvent,
     ProposalCandidate, RejoinAttempt, RuntimeMode, RuntimeModeKind, SyncMode,
+    DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH, DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS,
+    DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS, DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH,
     KOLME_IN_MEMORY_PROVIDER_MARKER, KOLME_LIVE_SIGNING_PROFILE,
 };
 
@@ -35,8 +37,19 @@ where
     let mut kolme_live_strict_signer_contracts = false;
     let mut kolme_live_signer_profile: Option<String> = None;
     let mut kolme_live_signer_key_source: Option<String> = None;
+    let mut observability_endpoint_bind_addr: Option<String> = None;
+    let mut observability_endpoint_metrics_path =
+        DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH.to_owned();
+    let mut observability_endpoint_health_path =
+        DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH.to_owned();
+    let mut observability_endpoint_max_requests = DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS;
+    let mut observability_endpoint_idle_timeout_ms = DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS;
     let mut output_mode = OutputMode::text();
     let mut diagnostics_mode = DiagnosticsMode::basic();
+    let mut observability_endpoint_metrics_path_overridden = false;
+    let mut observability_endpoint_health_path_overridden = false;
+    let mut observability_endpoint_max_requests_overridden = false;
+    let mut observability_endpoint_idle_timeout_ms_overridden = false;
     let mut role_overridden = false;
     let mut chain_id_overridden = false;
     let mut chain_version_overridden = false;
@@ -195,6 +208,37 @@ where
                     ConfigError::MissingArgumentValue("--kolme-live-signer-key-source"),
                 )?);
             }
+            "--observability-endpoint-bind" => {
+                observability_endpoint_bind_addr = Some(iter.next().ok_or(
+                    ConfigError::MissingArgumentValue("--observability-endpoint-bind"),
+                )?);
+            }
+            "--observability-endpoint-metrics-path" => {
+                observability_endpoint_metrics_path = iter.next().ok_or(
+                    ConfigError::MissingArgumentValue("--observability-endpoint-metrics-path"),
+                )?;
+                observability_endpoint_metrics_path_overridden = true;
+            }
+            "--observability-endpoint-health-path" => {
+                observability_endpoint_health_path = iter.next().ok_or(
+                    ConfigError::MissingArgumentValue("--observability-endpoint-health-path"),
+                )?;
+                observability_endpoint_health_path_overridden = true;
+            }
+            "--observability-endpoint-max-requests" => {
+                let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
+                    "--observability-endpoint-max-requests",
+                ))?;
+                observability_endpoint_max_requests = parse_daemon_control_arg(&value)?;
+                observability_endpoint_max_requests_overridden = true;
+            }
+            "--observability-endpoint-idle-timeout-ms" => {
+                let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
+                    "--observability-endpoint-idle-timeout-ms",
+                ))?;
+                observability_endpoint_idle_timeout_ms = parse_daemon_control_arg(&value)?;
+                observability_endpoint_idle_timeout_ms_overridden = true;
+            }
             "--output" => {
                 let value = iter
                     .next()
@@ -341,6 +385,28 @@ where
             normalize_kolme_live_signer_profile_selector(signer_profile)?;
         }
     }
+    if observability_endpoint_bind_addr.is_none()
+        && (observability_endpoint_metrics_path_overridden
+            || observability_endpoint_health_path_overridden
+            || observability_endpoint_max_requests_overridden
+            || observability_endpoint_idle_timeout_ms_overridden)
+    {
+        return Err(ConfigError::MissingArgumentValue(
+            "--observability-endpoint-bind",
+        ));
+    }
+    if observability_endpoint_bind_addr.is_some() {
+        if !observability_endpoint_metrics_path.starts_with('/') {
+            return Err(ConfigError::RuntimeDaemonLifecycle(
+                "observability endpoint metrics path must start with '/'".to_owned(),
+            ));
+        }
+        if !observability_endpoint_health_path.starts_with('/') {
+            return Err(ConfigError::RuntimeDaemonLifecycle(
+                "observability endpoint health path must start with '/'".to_owned(),
+            ));
+        }
+    }
 
     Ok(NodeCli {
         profile,
@@ -369,6 +435,11 @@ where
         kolme_live_strict_signer_contracts,
         kolme_live_signer_profile,
         kolme_live_signer_key_source,
+        observability_endpoint_bind_addr,
+        observability_endpoint_metrics_path,
+        observability_endpoint_health_path,
+        observability_endpoint_max_requests,
+        observability_endpoint_idle_timeout_ms,
         output_mode,
         diagnostics_mode,
     })

--- a/crates/kamn-node/src/cli_tests.rs
+++ b/crates/kamn-node/src/cli_tests.rs
@@ -21,6 +21,11 @@ fn cli_module_parses_required_role_and_defaults() {
     assert!(!parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, None);
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, None);
+    assert_eq!(parsed.observability_endpoint_bind_addr, None);
+    assert_eq!(parsed.observability_endpoint_metrics_path, "/metrics");
+    assert_eq!(parsed.observability_endpoint_health_path, "/healthz");
+    assert_eq!(parsed.observability_endpoint_max_requests, 1);
+    assert_eq!(parsed.observability_endpoint_idle_timeout_ms, 5_000);
     assert_eq!(parsed.output_mode, OutputMode::text());
     assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::basic());
 }

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -11,6 +11,7 @@ mod daemon_observability;
 mod daemon_shutdown;
 mod kolme_live_observability;
 mod logging;
+mod observability_endpoint;
 mod report_builder;
 mod report_render;
 mod runtime_kolme_live;
@@ -26,6 +27,14 @@ use logging::{
     NodeLogFormat, NodeLogLevel,
 };
 use logging::{log_error, log_info};
+#[cfg(test)]
+pub(crate) use observability_endpoint::render_observability_endpoint_response;
+pub(crate) use observability_endpoint::{
+    build_runtime_observability_snapshot, serve_observability_endpoint,
+    ObservabilityEndpointConfig, DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH,
+    DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS, DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS,
+    DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH,
+};
 use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
 #[cfg(test)]
@@ -276,6 +285,11 @@ struct NodeCli {
     kolme_live_strict_signer_contracts: bool,
     kolme_live_signer_profile: Option<String>,
     kolme_live_signer_key_source: Option<String>,
+    observability_endpoint_bind_addr: Option<String>,
+    observability_endpoint_metrics_path: String,
+    observability_endpoint_health_path: String,
+    observability_endpoint_max_requests: u64,
+    observability_endpoint_idle_timeout_ms: u64,
     output_mode: OutputMode,
     diagnostics_mode: DiagnosticsMode,
 }
@@ -425,6 +439,16 @@ fn run() -> Result<(), ConfigError> {
         &[("runtime_mode", runtime_mode)],
     )?;
     let output_mode = cli.output_mode;
+    let observability_endpoint_config =
+        cli.observability_endpoint_bind_addr
+            .as_ref()
+            .map(|bind_addr| ObservabilityEndpointConfig {
+                bind_addr: bind_addr.clone(),
+                metrics_path: cli.observability_endpoint_metrics_path.clone(),
+                health_path: cli.observability_endpoint_health_path.clone(),
+                max_requests: cli.observability_endpoint_max_requests,
+                idle_timeout_ms: cli.observability_endpoint_idle_timeout_ms,
+            });
     let report = execute(cli)?;
     log_info(
         "node.runtime.execute.complete",
@@ -434,6 +458,31 @@ fn run() -> Result<(), ConfigError> {
         ],
     )?;
     println!("{}", render_bootstrap_report(&report, output_mode));
+    if let Some(endpoint_config) = observability_endpoint_config {
+        let snapshot = build_runtime_observability_snapshot(&report).ok_or_else(|| {
+            ConfigError::RuntimeDaemonLifecycle(
+                "observability endpoint export requires daemon or kolme-live telemetry".to_owned(),
+            )
+        })?;
+        let max_requests_label = endpoint_config.max_requests.to_string();
+        let idle_timeout_ms_label = endpoint_config.idle_timeout_ms.to_string();
+        log_info(
+            "node.runtime.observability.endpoint.start",
+            &[
+                ("bind_addr", endpoint_config.bind_addr.as_str()),
+                ("metrics_path", endpoint_config.metrics_path.as_str()),
+                ("health_path", endpoint_config.health_path.as_str()),
+                ("max_requests", max_requests_label.as_str()),
+                ("idle_timeout_ms", idle_timeout_ms_label.as_str()),
+            ],
+        )?;
+        serve_observability_endpoint(&endpoint_config, &snapshot)
+            .map_err(ConfigError::RuntimeDaemonLifecycle)?;
+        log_info(
+            "node.runtime.observability.endpoint.complete",
+            &[("bind_addr", endpoint_config.bind_addr.as_str())],
+        )?;
+    }
 
     Ok(())
 }
@@ -466,6 +515,11 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         kolme_live_strict_signer_contracts,
         kolme_live_signer_profile,
         kolme_live_signer_key_source,
+        observability_endpoint_bind_addr: _,
+        observability_endpoint_metrics_path: _,
+        observability_endpoint_health_path: _,
+        observability_endpoint_max_requests: _,
+        observability_endpoint_idle_timeout_ms: _,
         output_mode: _,
         diagnostics_mode,
     } = cli;

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -1,13 +1,15 @@
 use super::{
     build_bootstrap_report, build_kolme_live_direct_signed_wire_payload,
     build_kolme_live_managed_signing_key, build_kolme_live_request,
-    build_kolme_live_signer_adapter, capture_test_logs, encode_kolme_hex_lower, execute,
-    parse_args, render_bootstrap_report, render_kolme_live_native_direct_message,
-    render_log_event_line, resolve_kolme_live_managed_signer_required_marker,
+    build_kolme_live_signer_adapter, build_runtime_observability_snapshot, capture_test_logs,
+    encode_kolme_hex_lower, execute, parse_args, render_bootstrap_report,
+    render_kolme_live_native_direct_message, render_log_event_line,
+    render_observability_endpoint_response, resolve_kolme_live_managed_signer_required_marker,
     resolve_kolme_live_nonce, resolve_kolme_live_signer_private_key_env_name,
-    resolve_log_config_from_inputs, sign_kolme_live_managed_external_message, DiagnosticsMode,
-    KolmeForkSecp256k1SignerAdapter, LocalProfile, NodeBootstrapReport, NodeLogConfig,
-    NodeLogFormat, NodeLogLevel, OutputMode, RuntimeExecutionBundle, RuntimeMode,
+    resolve_log_config_from_inputs, serve_observability_endpoint,
+    sign_kolme_live_managed_external_message, DiagnosticsMode, KolmeForkSecp256k1SignerAdapter,
+    LocalProfile, NodeBootstrapReport, NodeLogConfig, NodeLogFormat, NodeLogLevel,
+    ObservabilityEndpointConfig, OutputMode, RuntimeExecutionBundle, RuntimeMode,
 };
 use kamn_core::{
     bootstrap, ConfigError, KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitRequest, NodeConfig,
@@ -204,4 +206,5 @@ fn spawn_kolme_live_mock_server(replies: Vec<MockHttpReply>) -> (String, Arc<Mut
 
 mod cli_contract_tests;
 mod core_behavior_tests;
+mod observability_endpoint_tests;
 mod signer_tests;

--- a/crates/kamn-node/src/main_tests/cli_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/cli_contract_tests.rs
@@ -1008,6 +1008,24 @@ fn regression_runtime_daemon_rejects_zero_tick_budget() {
 }
 
 #[test]
+fn regression_runtime_observability_endpoint_rejects_custom_path_without_bind_address() {
+    // Regression: #2830
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--observability-endpoint-metrics-path".to_owned(),
+        "/runtime/metrics".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue(
+            "--observability-endpoint-bind"
+        ))
+    );
+}
+
+#[test]
 fn regression_runtime_daemon_rejects_invalid_lifecycle_transition() {
     // Regression: #349
     let args = vec![

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -40,6 +40,11 @@ fn parses_required_role_and_defaults() {
     assert_eq!(parsed.kolme_live_base_url, None);
     assert_eq!(parsed.kolme_live_provider_hint, None);
     assert_eq!(parsed.kolme_live_signing_profile, None);
+    assert_eq!(parsed.observability_endpoint_bind_addr, None);
+    assert_eq!(parsed.observability_endpoint_metrics_path, "/metrics");
+    assert_eq!(parsed.observability_endpoint_health_path, "/healthz");
+    assert_eq!(parsed.observability_endpoint_max_requests, 1);
+    assert_eq!(parsed.observability_endpoint_idle_timeout_ms, 5_000);
     assert_eq!(parsed.output_mode, OutputMode::text());
     assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::basic());
 }
@@ -535,6 +540,44 @@ fn parses_runtime_mode_daemon_with_os_signal_shutdown_controls() {
     assert!(parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, Some(2));
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, Some(4));
+}
+
+#[test]
+fn parses_runtime_mode_daemon_with_observability_endpoint_controls() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "12".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "5".to_owned(),
+        "--observability-endpoint-bind".to_owned(),
+        "127.0.0.1:9108".to_owned(),
+        "--observability-endpoint-metrics-path".to_owned(),
+        "/runtime/metrics".to_owned(),
+        "--observability-endpoint-health-path".to_owned(),
+        "/runtime/health".to_owned(),
+        "--observability-endpoint-max-requests".to_owned(),
+        "3".to_owned(),
+        "--observability-endpoint-idle-timeout-ms".to_owned(),
+        "1200".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("daemon args with observability endpoint should parse");
+    assert_eq!(
+        parsed.observability_endpoint_bind_addr,
+        Some("127.0.0.1:9108".to_owned())
+    );
+    assert_eq!(
+        parsed.observability_endpoint_metrics_path,
+        "/runtime/metrics"
+    );
+    assert_eq!(parsed.observability_endpoint_health_path, "/runtime/health");
+    assert_eq!(parsed.observability_endpoint_max_requests, 3);
+    assert_eq!(parsed.observability_endpoint_idle_timeout_ms, 1200);
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -1,0 +1,194 @@
+use super::*;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn reserve_loopback_addr() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    drop(listener);
+    addr.to_string()
+}
+
+fn send_http_get(addr: &str, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).expect("endpoint should accept connections");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("read timeout should be configurable");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .expect("request should write");
+    let mut response = String::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                response.push_str(
+                    std::str::from_utf8(&chunk[..read_count]).expect("response must be utf-8"),
+                );
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => panic!("response should be readable: {error}"),
+        }
+    }
+    response
+}
+
+fn wait_for_endpoint_ready(addr: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if TcpStream::connect(addr).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("endpoint did not become ready within timeout");
+}
+
+#[test]
+fn unit_observability_endpoint_maps_daemon_telemetry_into_snapshot() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+    let report = execute(parsed).expect("daemon execution should succeed");
+
+    let snapshot =
+        build_runtime_observability_snapshot(&report).expect("daemon report should map snapshot");
+    assert_eq!(snapshot.source, "daemon");
+    assert_eq!(snapshot.runtime_mode, "daemon");
+    assert_eq!(snapshot.latency_p50_ms, 25);
+    assert_eq!(snapshot.latency_p99_ms, 50);
+    assert_eq!(snapshot.throughput_tps, 2_000);
+    assert_eq!(snapshot.error_rate_bps, 50);
+    assert_eq!(snapshot.availability_bps, 9_990);
+    assert_eq!(snapshot.health, "healthy");
+    assert_eq!(snapshot.alert_count, 0);
+}
+
+#[test]
+fn functional_observability_endpoint_renders_metrics_and_health_payloads() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+    let report = execute(parsed).expect("daemon execution should succeed");
+    let snapshot =
+        build_runtime_observability_snapshot(&report).expect("daemon report should map snapshot");
+
+    let metrics = render_observability_endpoint_response(&snapshot, "/metrics");
+    assert_eq!(metrics.status_code, 200);
+    assert_eq!(metrics.content_type, "text/plain; version=0.0.4");
+    assert!(metrics
+        .body
+        .contains("kamn_observability_latency_p50_ms 25"));
+    assert!(metrics
+        .body
+        .contains("kamn_observability_health{health=\"healthy\"} 1"));
+
+    let health = render_observability_endpoint_response(&snapshot, "/healthz");
+    assert_eq!(health.status_code, 200);
+    assert_eq!(health.content_type, "application/json");
+    assert!(health.body.contains("\"health\":\"healthy\""));
+    assert!(health.body.contains("\"runtime_mode\":\"daemon\""));
+}
+
+#[test]
+fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+    let report = execute(parsed).expect("daemon execution should succeed");
+    let snapshot =
+        build_runtime_observability_snapshot(&report).expect("daemon report should map snapshot");
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 3,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_observability_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let metrics_response = send_http_get(bind_addr.as_str(), "/metrics");
+    let health_response = send_http_get(bind_addr.as_str(), "/healthz");
+
+    assert!(
+        metrics_response.contains("HTTP/1.1 200 OK"),
+        "metrics endpoint should return 200 response"
+    );
+    assert!(metrics_response.contains("kamn_observability_latency_p50_ms 25"));
+    assert!(
+        health_response.contains("HTTP/1.1 200 OK"),
+        "health endpoint should return 200 response"
+    );
+    assert!(health_response.contains("\"health\":\"healthy\""));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "endpoint server should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn regression_observability_endpoint_export_keeps_bootstrap_report_rendering_unchanged() {
+    // Regression: #2830
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+    let report = execute(parsed).expect("daemon execution should succeed");
+    let before = render_bootstrap_report(&report, OutputMode::json());
+
+    let snapshot =
+        build_runtime_observability_snapshot(&report).expect("daemon report should map snapshot");
+    let _metrics = render_observability_endpoint_response(&snapshot, "/metrics");
+    let _health = render_observability_endpoint_response(&snapshot, "/healthz");
+
+    let after = render_bootstrap_report(&report, OutputMode::json());
+    assert_eq!(before, after);
+}

--- a/crates/kamn-node/src/observability_endpoint.rs
+++ b/crates/kamn-node/src/observability_endpoint.rs
@@ -1,0 +1,400 @@
+use crate::NodeBootstrapReport;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH: &str = "/metrics";
+pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH: &str = "/healthz";
+pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS: u64 = 1;
+pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS: u64 = 5_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObservabilityEndpointConfig {
+    pub(crate) bind_addr: String,
+    pub(crate) metrics_path: String,
+    pub(crate) health_path: String,
+    pub(crate) max_requests: u64,
+    pub(crate) idle_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeObservabilitySnapshot {
+    pub(crate) source: String,
+    pub(crate) runtime_mode: String,
+    pub(crate) latency_p50_ms: u64,
+    pub(crate) latency_p99_ms: u64,
+    pub(crate) throughput_tps: u64,
+    pub(crate) error_rate_bps: u64,
+    pub(crate) availability_bps: u64,
+    pub(crate) health: String,
+    pub(crate) alert_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObservabilityEndpointResponse {
+    pub(crate) status_code: u16,
+    pub(crate) content_type: &'static str,
+    pub(crate) body: String,
+}
+
+pub(crate) fn build_runtime_observability_snapshot(
+    report: &NodeBootstrapReport,
+) -> Option<RuntimeObservabilitySnapshot> {
+    if let (
+        Some(latency_p50_ms),
+        Some(latency_p99_ms),
+        Some(throughput_tps),
+        Some(error_rate_bps),
+        Some(availability_bps),
+        Some(health),
+        Some(alert_count),
+    ) = (
+        report.daemon_observability_latency_p50_ms,
+        report.daemon_observability_latency_p99_ms,
+        report.daemon_observability_throughput_tps,
+        report.daemon_observability_error_rate_bps,
+        report.daemon_observability_availability_bps,
+        report.daemon_observability_health.as_deref(),
+        report.daemon_observability_alert_count,
+    ) {
+        return Some(RuntimeObservabilitySnapshot {
+            source: "daemon".to_owned(),
+            runtime_mode: report.runtime_mode.clone(),
+            latency_p50_ms,
+            latency_p99_ms,
+            throughput_tps,
+            error_rate_bps,
+            availability_bps,
+            health: health.to_owned(),
+            alert_count,
+        });
+    }
+
+    if let (
+        Some(latency_p50_ms),
+        Some(latency_p99_ms),
+        Some(throughput_tps),
+        Some(error_rate_bps),
+        Some(availability_bps),
+        Some(health),
+        Some(alert_count),
+    ) = (
+        report.kolme_live_observability_latency_p50_ms,
+        report.kolme_live_observability_latency_p99_ms,
+        report.kolme_live_observability_throughput_tps,
+        report.kolme_live_observability_error_rate_bps,
+        report.kolme_live_observability_availability_bps,
+        report.kolme_live_observability_health.as_deref(),
+        report.kolme_live_observability_alert_count,
+    ) {
+        return Some(RuntimeObservabilitySnapshot {
+            source: "kolme-live".to_owned(),
+            runtime_mode: report.runtime_mode.clone(),
+            latency_p50_ms,
+            latency_p99_ms,
+            throughput_tps,
+            error_rate_bps,
+            availability_bps,
+            health: health.to_owned(),
+            alert_count,
+        });
+    }
+
+    None
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn render_observability_endpoint_response(
+    snapshot: &RuntimeObservabilitySnapshot,
+    path: &str,
+) -> ObservabilityEndpointResponse {
+    render_observability_endpoint_response_with_paths(
+        snapshot,
+        path,
+        DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH,
+        DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH,
+    )
+}
+
+pub(crate) fn serve_observability_endpoint(
+    config: &ObservabilityEndpointConfig,
+    snapshot: &RuntimeObservabilitySnapshot,
+) -> Result<(), String> {
+    if !config.metrics_path.starts_with('/') {
+        return Err("observability metrics path must start with '/'".to_owned());
+    }
+    if !config.health_path.starts_with('/') {
+        return Err("observability health path must start with '/'".to_owned());
+    }
+    if config.max_requests == 0 {
+        return Err("observability endpoint max requests must be greater than zero".to_owned());
+    }
+    if config.idle_timeout_ms == 0 {
+        return Err("observability endpoint idle timeout must be greater than zero".to_owned());
+    }
+
+    let listener = TcpListener::bind(config.bind_addr.as_str())
+        .map_err(|error| format!("observability endpoint bind failed: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("observability endpoint nonblocking mode failed: {error}"))?;
+
+    let deadline = Instant::now() + Duration::from_millis(config.idle_timeout_ms);
+    let mut served_requests = 0_u64;
+    while served_requests < config.max_requests {
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "observability endpoint timed out after {} ms waiting for requests",
+                config.idle_timeout_ms
+            ));
+        }
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let path = read_http_request_path(&mut stream).unwrap_or_else(|_| "/".to_owned());
+                let response = render_observability_endpoint_response_with_paths(
+                    snapshot,
+                    path.as_str(),
+                    config.metrics_path.as_str(),
+                    config.health_path.as_str(),
+                );
+                write_http_response(&mut stream, &response)?;
+                served_requests = served_requests.saturating_add(1);
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => {
+                return Err(format!("observability endpoint accept failed: {error}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_observability_endpoint_response_with_paths(
+    snapshot: &RuntimeObservabilitySnapshot,
+    path: &str,
+    metrics_path: &str,
+    health_path: &str,
+) -> ObservabilityEndpointResponse {
+    if path == metrics_path {
+        return ObservabilityEndpointResponse {
+            status_code: 200,
+            content_type: "text/plain; version=0.0.4",
+            body: render_metrics_body(snapshot),
+        };
+    }
+    if path == health_path {
+        return ObservabilityEndpointResponse {
+            status_code: 200,
+            content_type: "application/json",
+            body: render_health_body(snapshot),
+        };
+    }
+    ObservabilityEndpointResponse {
+        status_code: 404,
+        content_type: "text/plain; charset=utf-8",
+        body: "not found\n".to_owned(),
+    }
+}
+
+fn render_metrics_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
+    let health_value = if snapshot.health == "healthy" { 1 } else { 0 };
+    format!(
+        "kamn_observability_latency_p50_ms {}\nkamn_observability_latency_p99_ms {}\nkamn_observability_throughput_tps {}\nkamn_observability_error_rate_bps {}\nkamn_observability_availability_bps {}\nkamn_observability_alert_count {}\nkamn_observability_source{{source=\"{}\"}} 1\nkamn_observability_runtime_mode{{runtime_mode=\"{}\"}} 1\nkamn_observability_health{{health=\"{}\"}} {}\n",
+        snapshot.latency_p50_ms,
+        snapshot.latency_p99_ms,
+        snapshot.throughput_tps,
+        snapshot.error_rate_bps,
+        snapshot.availability_bps,
+        snapshot.alert_count,
+        escape_metrics_label(snapshot.source.as_str()),
+        escape_metrics_label(snapshot.runtime_mode.as_str()),
+        escape_metrics_label(snapshot.health.as_str()),
+        health_value
+    )
+}
+
+fn render_health_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
+    format!(
+        "{{\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}",
+        escape_json_string(snapshot.source.as_str()),
+        escape_json_string(snapshot.runtime_mode.as_str()),
+        escape_json_string(snapshot.health.as_str()),
+        snapshot.alert_count,
+        snapshot.latency_p50_ms,
+        snapshot.latency_p99_ms,
+        snapshot.throughput_tps,
+        snapshot.error_rate_bps,
+        snapshot.availability_bps
+    )
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    response: &ObservabilityEndpointResponse,
+) -> Result<(), String> {
+    let status_text = match response.status_code {
+        200 => "200 OK",
+        404 => "404 Not Found",
+        _ => "500 Internal Server Error",
+    };
+    let payload = format!(
+        "HTTP/1.1 {status_text}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response.content_type,
+        response.body.len(),
+        response.body
+    );
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(|error| format!("observability endpoint write failed: {error}"))
+}
+
+fn read_http_request_path(stream: &mut TcpStream) -> Result<String, String> {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 256];
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .map_err(|error| format!("observability endpoint read-timeout failed: {error}"))?;
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                request.extend_from_slice(&chunk[..read_count]);
+                if request.windows(2).any(|window| window == b"\r\n") {
+                    break;
+                }
+                if request.len() > 8 * 1024 {
+                    return Err("observability endpoint request header too large".to_owned());
+                }
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => {
+                return Err(format!("observability endpoint read failed: {error}"));
+            }
+        }
+    }
+    let request = String::from_utf8(request)
+        .map_err(|_| "observability endpoint request was not valid utf-8".to_owned())?;
+    let request_line = request
+        .lines()
+        .next()
+        .ok_or_else(|| "observability endpoint request line missing".to_owned())?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| "observability endpoint request method missing".to_owned())?;
+    let path = parts
+        .next()
+        .ok_or_else(|| "observability endpoint request path missing".to_owned())?;
+    if method != "GET" {
+        return Err("observability endpoint only supports GET".to_owned());
+    }
+    Ok(path.to_owned())
+}
+
+fn escape_json_string(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn escape_metrics_label(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        render_observability_endpoint_response, serve_observability_endpoint,
+        ObservabilityEndpointConfig, RuntimeObservabilitySnapshot,
+    };
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    fn reserve_loopback_addr() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let addr = listener.local_addr().expect("local addr should resolve");
+        drop(listener);
+        addr.to_string()
+    }
+
+    fn connect_with_retry(addr: &str) -> TcpStream {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if let Ok(stream) = TcpStream::connect(addr) {
+                return stream;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("server should accept");
+    }
+
+    #[test]
+    fn unit_observability_endpoint_response_returns_not_found_for_unknown_path() {
+        let snapshot = RuntimeObservabilitySnapshot {
+            source: "daemon".to_owned(),
+            runtime_mode: "daemon".to_owned(),
+            latency_p50_ms: 25,
+            latency_p99_ms: 50,
+            throughput_tps: 2_000,
+            error_rate_bps: 50,
+            availability_bps: 9_990,
+            health: "healthy".to_owned(),
+            alert_count: 0,
+        };
+        let response = render_observability_endpoint_response(&snapshot, "/unknown");
+        assert_eq!(response.status_code, 404);
+        assert_eq!(response.content_type, "text/plain; charset=utf-8");
+    }
+
+    #[test]
+    fn integration_observability_endpoint_serves_request_budget() {
+        let snapshot = RuntimeObservabilitySnapshot {
+            source: "daemon".to_owned(),
+            runtime_mode: "daemon".to_owned(),
+            latency_p50_ms: 25,
+            latency_p99_ms: 50,
+            throughput_tps: 2_000,
+            error_rate_bps: 50,
+            availability_bps: 9_990,
+            health: "healthy".to_owned(),
+            alert_count: 0,
+        };
+        let bind_addr = reserve_loopback_addr();
+        let config = ObservabilityEndpointConfig {
+            bind_addr: bind_addr.clone(),
+            metrics_path: "/metrics".to_owned(),
+            health_path: "/healthz".to_owned(),
+            max_requests: 1,
+            idle_timeout_ms: 2_000,
+        };
+        let server = thread::spawn(move || {
+            serve_observability_endpoint(&config, &snapshot).expect("server")
+        });
+        let mut stream = connect_with_retry(bind_addr.as_str());
+        stream
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .expect("request should write");
+        let mut response = String::new();
+        stream
+            .read_to_string(&mut response)
+            .expect("response should be readable");
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        server.join().expect("server thread should join");
+    }
+}

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -40,6 +40,12 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--daemon-shutdown-timeout-ticks <positive-integer>` (required when shutdown signal tick is configured)
   - `--daemon-peer-id <peer-id>` (optional)
   - `--daemon-lifecycle-event <start-connect|handshake-succeeded|heartbeat-missed|heartbeat-restored|disconnect|rejoin>` (repeatable)
+- Added runtime observability endpoint controls:
+  - `--observability-endpoint-bind <host:port>`
+  - `--observability-endpoint-metrics-path </path>` (default: `/metrics`)
+  - `--observability-endpoint-health-path </path>` (default: `/healthz`)
+  - `--observability-endpoint-max-requests <positive-integer>` (default: `1`)
+  - `--observability-endpoint-idle-timeout-ms <positive-integer>` (default: `5000`)
 - Added Kolme live runtime controls:
   - `--kolme-live-base-url <http(s)-endpoint>`
   - `--kolme-live-provider-hint <provider-hint>`
@@ -233,6 +239,24 @@ This document captures node-runtime productionization slices for machine-readabl
   - `daemon_observability_availability_bps`
   - `daemon_observability_health`
   - `daemon_observability_alert_count`
+
+## Runtime Observability Endpoint Rules
+- Endpoint export is optional and enabled only when `--observability-endpoint-bind` is set.
+- Endpoint path controls:
+  - metrics: `--observability-endpoint-metrics-path` (defaults to `/metrics`)
+  - health: `--observability-endpoint-health-path` (defaults to `/healthz`)
+- Endpoint budget controls:
+  - `--observability-endpoint-max-requests` bounds accepted requests before shutdown.
+  - `--observability-endpoint-idle-timeout-ms` bounds wait time for incoming requests.
+- Endpoint validation:
+  - endpoint path controls without bind address are rejected.
+  - metrics/health paths must start with `/`.
+  - request and timeout controls must be positive integers.
+- Supported payloads:
+  - `/metrics` returns deterministic Prometheus text metrics for latency/throughput/error/availability, health, and alert count.
+  - `/healthz` returns deterministic JSON health snapshot for runtime mode and source telemetry.
+- Example:
+  - `kamn-node --role processor --runtime-mode daemon --daemon-max-ticks 3 --daemon-tick-interval-ms 25 --observability-endpoint-bind 127.0.0.1:9108 --observability-endpoint-max-requests 1`
 
 ## Kolme Live Runtime Rules
 - Supported runtime modes:

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -14,6 +14,34 @@ This document captures the first implementation slice for deterministic observab
 - Added frontend dashboard projection linkage in `packages/kamn-dashboard`:
   - deterministic severity mapping from SLO values to UI badge classes.
   - stale snapshot banner behavior for operator triage.
+- Added `kamn-node` runtime observability endpoint export (`Issue #2830`):
+  - `--observability-endpoint-bind <host:port>`
+  - `--observability-endpoint-metrics-path </path>` (default `/metrics`)
+  - `--observability-endpoint-health-path </path>` (default `/healthz`)
+  - bounded request/timeout controls for fast and cost-effective scrape loops.
+
+## Runtime Endpoint Contract (Issue #2830)
+- Endpoint paths:
+  - metrics: `/metrics` (Prometheus text format)
+  - health: `/healthz` (JSON payload)
+- Metrics payload keys:
+  - `kamn_observability_latency_p50_ms`
+  - `kamn_observability_latency_p99_ms`
+  - `kamn_observability_throughput_tps`
+  - `kamn_observability_error_rate_bps`
+  - `kamn_observability_availability_bps`
+  - `kamn_observability_alert_count`
+  - `kamn_observability_health{health="<healthy|degraded|critical>"}`
+- Health payload fields:
+  - `source`
+  - `runtime_mode`
+  - `health`
+  - `alert_count`
+  - latency/throughput/error/availability numeric fields
+- Export characteristics:
+  - deterministic payloads derived from runtime report telemetry fields.
+  - bounded endpoint lifetime controlled by `--observability-endpoint-max-requests` and `--observability-endpoint-idle-timeout-ms`.
+  - no report-rendering mutation: text/json report contracts remain unchanged (`Regression: #2830`).
 
 ## SLO Evaluation Rules
 - `LatencyP50`: warning when above max threshold.


### PR DESCRIPTION
## Summary
Adds a minimal runtime observability endpoint surface in `kamn-node` with deterministic `/metrics` and `/healthz` payloads derived from runtime telemetry. This closes the Gap 2 story slice by providing a scrapeable export path while preserving existing report rendering contracts.

Closes #2830
Refs #2829

## Changes
- `crates/kamn-node/src/observability_endpoint.rs`: new endpoint module with deterministic snapshot mapping, response rendering, and bounded HTTP serving (`std::net` only).
- `crates/kamn-node/src/cli.rs`: adds `--observability-endpoint-*` flags and validation.
- `crates/kamn-node/src/main.rs`: wires optional endpoint serving into runtime execution path after report emission.
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: adds unit/functional/integration/regression tests for endpoint behavior and report non-regression.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: adds daemon CLI parse coverage for endpoint controls.
- `crates/kamn-node/src/main_tests/cli_contract_tests.rs`: adds regression guard for path override without bind address.
- `crates/kamn-node/src/cli_tests.rs`: updates default-parse assertions for endpoint defaults.
- `docs/foundation/node-runtime-cli.md`: documents endpoint CLI contract and runtime rules.
- `docs/foundation/observability-slo-dashboards.md`: documents endpoint payload contract.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `cargo test -p kamn-node observability_endpoint -- --nocapture`

Failing output excerpt:
- `error[E0432]: unresolved imports super::ObservabilityEndpointConfig`
- `no build_runtime_observability_snapshot in the root`
- `no render_observability_endpoint_response in the root`
- `no serve_observability_endpoint in the root`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node observability_endpoint -- --nocapture`
- `cargo test -p kamn-node`

Passing output summary:
- endpoint-focused test set passes (unit/functional/integration/regression)
- full `kamn-node` suite passes (`144 passed; 0 failed; 1 ignored`)

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node`

Result:
- all commands pass cleanly.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_observability_endpoint_maps_daemon_telemetry_into_snapshot`, endpoint response unit tests | |
| Functional   | ✅     | `functional_observability_endpoint_renders_metrics_and_health_payloads` | |
| Integration  | ✅     | `integration_runtime_observability_endpoint_serves_metrics_and_health_paths`, endpoint server integration test | |
| Regression   | ✅     | `regression_observability_endpoint_export_keeps_bootstrap_report_rendering_unchanged`, CLI regression guard | |
| Performance  | N/A    | None | First endpoint slice; bounded request/timeout controls added and validated functionally |

## Risks & Rollback
- Risk: endpoint serve phase can block until request budget or timeout when enabled.
- Rollback: disable endpoint flags or revert commit `0e8e9e6`.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/foundation/observability-slo-dashboards.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-node -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)
