### PR TITLE
fix(ci): stabilize wave-7 wrapper trend stale-baseline mutation

### DIFF
--- a/scripts/ci/test_check_non_kolme_wave_wrapper_family_budget_trend_impl.sh
+++ b/scripts/ci/test_check_non_kolme_wave_wrapper_family_budget_trend_impl.sh
@@ -155,11 +155,11 @@ payload = json.loads(baseline_path.read_text(encoding="utf-8"))
 if not payload.get("lanes"):
     raise SystemExit("expected at least one lane in baseline fixture")
 
-payload["lanes"] = payload["lanes"][:-1]
-payload["wrapper_count"] = len(payload["lanes"])
-payload["regular_file_wrapper_count"] = len(payload["lanes"])
-payload["symlink_wrapper_count"] = sum(1 for lane in payload["lanes"] if lane.get("wrapper_kind") == "symlink")
-payload["total_shell_loc"] = sum(int(lane["shell_loc"]) for lane in payload["lanes"])
+first_lane = payload["lanes"][0]
+lane_id = first_lane.get("lane_id")
+if not isinstance(lane_id, str) or not lane_id.strip():
+    raise SystemExit("expected first baseline lane to include a non-empty lane_id")
+first_lane["lane_id"] = f"{lane_id}__stale_baseline"
 baseline_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
 


### PR DESCRIPTION
## Summary
This fixes the wave-7 non-Kolme wrapper-family trend harness mutation path so stale-baseline tests remain valid when the baseline has a single lane. The stale-baseline mutation now rewrites the first lane id instead of truncating the lane list to empty.

Closes #2851

## Changes
- `scripts/ci/test_check_non_kolme_wave_wrapper_family_budget_trend_impl.sh`
  - Replaced stale-baseline mutation logic that removed lanes (`payload["lanes"] = payload["lanes"][:-1]`) with deterministic lane-id mutation on the first lane.
  - Preserved non-empty baseline schema while still inducing `unexpected_new_lanes_in_current_inventory` contract failure conditions.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`bash scripts/ci/test_check_non_kolme_wave7_wrapper_family_budget_trend.sh`

Key output:
- exited non-zero (1) before completing expected stale-baseline reason-code assertion path.

### 🟢 Green Phase
Command:
`bash scripts/ci/test_check_non_kolme_wave7_wrapper_family_budget_trend.sh`

Key output:
- `non-Kolme wave-7 wrapper-family budget trend checker tests passed.`

### 🔁 Regression
Command:
`KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

Key output:
- non-Kolme wave trend checks pass through waves 1..19 including wave-7.
- final line: `Fast-mode CI tool regression tests passed.`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | Shell contract harness behavior only |
| Functional   | ✅ | `scripts/ci/test_check_non_kolme_wave7_wrapper_family_budget_trend.sh` | |
| Integration  | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅ | stale-baseline reason-code mutation path in `test_check_non_kolme_wave_wrapper_family_budget_trend_impl.sh` | |
| Performance  | N/A | | No runtime-path expansion; assertion path only |

## Risks & Rollback
- Low risk: test-harness mutation logic only.
- Rollback plan: revert commit `1938df6`.

## Documentation Updates
- None required; command surfaces/strategy docs unchanged.

## Validation Checklist
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explained below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: ci-fast-gate (indirectly via scripts/ci/test_ci_tools.sh consuming this harness).
Expected runtime delta: Neutral.
Expected runner-minute delta: Neutral.
Rollback plan if CI cost/runtime regresses: Revert commit 1938df6.
