### PR TITLE
refactor(ci): migrate signer provider deep lane to dispatcher manifest (#2854)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -25,6 +25,15 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
 - Kolme harness+command-surface budget contract lane: `scripts/ci/run_kolme_test_harness_loc_soft_budget_contract_lane.sh`
 - CI helper regression suite: `scripts/ci/test_ci_tools.sh`
 
+## Dispatcher Migration Log
+- `#2854` migrates `scripts/signer/run_signer_provider_deep_lane.sh` to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/signer/run_signer_provider_deep_lane.sh`
+  - implementation: `scripts/signer/run_signer_provider_deep_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/signer_signer_provider_deep_lane.json`
+- Contract coverage for this migration slice:
+  - `scripts/signer/test_run_signer_provider_deep_lane.sh`
+  - `scripts/signer/test_run_signer_emulator_contract_lane.sh`
+
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:
 

--- a/scripts/framework/manifests/signer_signer_provider_deep_lane.json
+++ b/scripts/framework/manifests/signer_signer_provider_deep_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "signer.signer_provider.deep",
+  "evidence_key": "signer_provider_deep_lane:v1",
+  "reason_key": "signer_provider_deep_lane_reason_codes:GO:v1",
+  "phases": {
+    "deep": [
+      "bash",
+      "scripts/signer/run_signer_provider_deep_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -108,6 +108,7 @@ resolve_manifest_name() {
     run_signer_emulator_contract_lane.sh) echo "signer_signer_emulator_contract_lane.json" ;;
     run_signer_incident_recovery_contract_lane.sh) echo "signer_signer_incident_recovery_contract_lane.json" ;;
     run_signer_incident_recovery_lane.sh) echo "signer_signer_incident_recovery_lane.json" ;;
+    run_signer_provider_deep_lane.sh) echo "signer_signer_provider_deep_lane.json" ;;
     run_signer_policy_contract_lane.sh) echo "signer_signer_policy_contract_lane.json" ;;
     run_kamn_core_rustdoc_artifact_contract_lane.sh) echo "ci_kamn_core_rustdoc_artifact_contract_lane.json" ;;
     run_test_harness_loc_soft_budget_contract_lane.sh) echo "ci_test_harness_loc_soft_budget_contract_lane.json" ;;
@@ -141,6 +142,7 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_signer_provider_deep_lane.sh) echo "deep" ;;
     run_signer_incident_recovery_lane.sh) echo "run" ;;
     *) echo "contract" ;;
   esac

--- a/scripts/signer/run_signer_provider_deep_lane.sh
+++ b/scripts/signer/run_signer_provider_deep_lane.sh
@@ -1,13 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$ROOT_DIR"
-
-bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_bulk_signing_deep_lane -- --ignored
-bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend --test transaction_guards --test transaction_guards_docs
-KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled \
-  bash scripts/signer/run_signer_incident_recovery_deep_lane.sh \
-    --output-json /tmp/signer-incident-recovery-deep-report.json
-
-echo "signer provider deep lane tests passed."
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/signer/run_signer_provider_deep_lane_impl.sh
+++ b/scripts/signer/run_signer_provider_deep_lane_impl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend performance_signer_emulator_bulk_signing_deep_lane -- --ignored
+bash scripts/ci/run_cargo_test_with_quarantine.sh -- cargo test -p kamn-core --test signer_backend --test transaction_guards --test transaction_guards_docs
+KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled \
+  bash scripts/signer/run_signer_incident_recovery_deep_lane.sh \
+    --output-json /tmp/signer-incident-recovery-deep-report.json
+
+echo "signer provider deep lane tests passed."

--- a/scripts/signer/test_run_signer_emulator_contract_lane.sh
+++ b/scripts/signer/test_run_signer_emulator_contract_lane.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_emulator_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane.sh"
+DEEP_IMPL_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane_impl.sh"
 POLICY_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_policy_contract_lane.sh"
 LIFECYCLE_SCRIPT="$ROOT_DIR/scripts/signer/run_secure_provider_key_lifecycle_contract_lane.sh"
 INCIDENT_CONTRACT_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_contract_lane.sh"
 INCIDENT_DEEP_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_incident_recovery_deep_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/signer/signer_emulator_contract_lane_contract.sh"
 MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/signer_signer_emulator_contract_lane.json"
+DEEP_MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/signer_signer_provider_deep_lane.json"
 DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
@@ -19,6 +21,10 @@ fi
 
 if [ ! -x "$DEEP_SCRIPT" ]; then
   echo "expected signer provider deep-lane runner to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DEEP_IMPL_SCRIPT" ]; then
+  echo "expected signer provider deep-lane implementation to be executable" >&2
   exit 1
 fi
 
@@ -76,6 +82,24 @@ if ! grep -Fq "signer_emulator_contract_lane_contract.sh" "$MANIFEST_FILE"; then
   exit 1
 fi
 
+if [ ! -L "$DEEP_SCRIPT" ]; then
+  echo "expected signer provider deep-lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$DEEP_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected signer provider deep-lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_deep_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$DEEP_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_deep_manifest" != "$DEEP_MANIFEST_FILE" ]; then
+  echo "expected signer provider deep-lane wrapper to resolve signer provider deep manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -Fq "run_signer_provider_deep_lane_impl.sh" "$DEEP_MANIFEST_FILE"; then
+  echo "expected signer provider deep-lane manifest to dispatch implementation module" >&2
+  exit 1
+fi
+
 if ! grep -q "functional_provider_handshake_matrix_routes_operator_fallback_for_unavailable_provider" "$SHARED_CONTRACT"; then
   echo "expected signer emulator shared contract module to include provider handshake fallback functional coverage" >&2
   exit 1
@@ -116,17 +140,17 @@ if ! grep -q "run_signer_incident_recovery_contract_lane.sh" "$SHARED_CONTRACT";
   exit 1
 fi
 
-if ! grep -Fq "performance_signer_emulator_bulk_signing_deep_lane -- --ignored" "$DEEP_SCRIPT"; then
+if ! grep -Fq "performance_signer_emulator_bulk_signing_deep_lane -- --ignored" "$DEEP_IMPL_SCRIPT"; then
   echo "expected deep-lane script to execute ignored signer provider stress test" >&2
   exit 1
 fi
 
-if ! grep -Fq "run_signer_incident_recovery_deep_lane.sh" "$DEEP_SCRIPT"; then
+if ! grep -Fq "run_signer_incident_recovery_deep_lane.sh" "$DEEP_IMPL_SCRIPT"; then
   echo "expected signer provider deep lane script to execute signer incident recovery deep lane" >&2
   exit 1
 fi
 
-if ! grep -Fq "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled" "$DEEP_SCRIPT"; then
+if ! grep -Fq "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled" "$DEEP_IMPL_SCRIPT"; then
   echo "expected signer provider deep lane script to set scheduled cadence guard for incident recovery deep lane" >&2
   exit 1
 fi

--- a/scripts/signer/test_run_signer_provider_deep_lane.sh
+++ b/scripts/signer/test_run_signer_provider_deep_lane.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LANE_SCRIPT="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane.sh"
+LANE_IMPL="$ROOT_DIR/scripts/signer/run_signer_provider_deep_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/signer_signer_provider_deep_lane.json"
+
+if [ ! -x "$LANE_SCRIPT" ]; then
+  echo "expected signer provider deep lane wrapper to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$LANE_IMPL" ]; then
+  echo "expected signer provider deep lane implementation to be executable" >&2
+  exit 1
+fi
+
+if [ ! -L "$LANE_SCRIPT" ]; then
+  echo "expected signer provider deep lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$LANE_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected signer provider deep lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$LANE_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected signer provider deep lane wrapper to resolve signer manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_signer_provider_deep_lane_impl.sh" "$MANIFEST_FILE"; then
+  echo "expected signer provider deep lane manifest to dispatch to shared implementation module" >&2
+  exit 1
+fi
+
+if ! grep -Fq "performance_signer_emulator_bulk_signing_deep_lane -- --ignored" "$LANE_IMPL"; then
+  echo "expected signer provider deep implementation to execute ignored signer provider stress test" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_signer_incident_recovery_deep_lane.sh" "$LANE_IMPL"; then
+  echo "expected signer provider deep implementation to execute signer incident recovery deep lane" >&2
+  exit 1
+fi
+
+if ! grep -Fq "KAMN_SIGNER_INCIDENT_RECOVERY_DEEP_CADENCE=scheduled" "$LANE_IMPL"; then
+  echo "expected signer provider deep implementation to set scheduled cadence guard for incident recovery deep lane" >&2
+  exit 1
+fi
+
+echo "signer provider deep lane script tests passed."


### PR DESCRIPTION
## Summary
This migrates the signer provider deep lane wrapper to the shared non-Kolme dispatcher/manifest framework, reducing standalone shell wrapper surface while preserving lane behavior. It also adds explicit fail-closed regression coverage for signer deep-lane dispatch wiring.

Closes #2854
Refs #2833
Refs #2826

## Changes
- `scripts/signer/run_signer_provider_deep_lane.sh`: converted to dispatcher symlink wrapper.
- `scripts/signer/run_signer_provider_deep_lane_impl.sh`: extracted original deep-lane implementation.
- `scripts/framework/manifests/signer_signer_provider_deep_lane.json`: added manifest for deep-lane dispatch phase.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added wrapper->manifest mapping and phase resolution for `run_signer_provider_deep_lane.sh`.
- `scripts/signer/test_run_signer_provider_deep_lane.sh`: added dedicated wrapper/manifest regression test.
- `scripts/signer/test_run_signer_emulator_contract_lane.sh`: updated to validate deep-lane wrapper symlink + manifest wiring against `_impl` content.
- `docs/ci/ci-cost-and-lane-framework.md`: logged migration slice and coverage references.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/signer/test_run_signer_provider_deep_lane.sh
```
Output:
```text
expected signer provider deep lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/signer/test_run_signer_provider_deep_lane.sh
bash scripts/signer/test_run_signer_emulator_contract_lane.sh
bash scripts/signer/test_run_signer_incident_recovery_deep_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
signer provider deep lane script tests passed.
signer emulator contract lane script tests passed.
signer incident recovery deep lane script tests passed.
non-Kolme contract lane dispatcher wrapper matrix tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell-wrapper/manifest wiring task; no isolated Rust/public-function changes |
| Functional   | ✅     | `scripts/signer/test_run_signer_provider_deep_lane.sh`; `scripts/signer/test_run_signer_emulator_contract_lane.sh` | |
| Integration  | ✅     | `scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh`; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | `scripts/signer/test_run_signer_provider_deep_lane.sh` fail-closed dispatcher+manifest assertions | |
| Performance  | N/A    | N/A                  | No runtime path/perf characteristics changed; command sequence preserved in `_impl` |

## Risks & Rollback
- Breaking risk: low. Wrapper dispatch mapping is additive and scoped to one signer deep lane.
- Rollback plan: revert this PR commit to restore direct wrapper file and remove manifest mapping.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: dispatcher migration log entry for issue `#2854`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (fast-mode CI tool matrix)
- [x] Docs updated (or justified why not)
