### PR TITLE
refactor(ci): migrate dashboard run-lane wrappers to dispatcher manifests (#2858)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -34,10 +34,19 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/signer/run_signer_incident_recovery_deep_lane.sh`
   - implementation: `scripts/signer/run_signer_incident_recovery_deep_lane_impl.sh`
   - manifest: `scripts/framework/manifests/signer_signer_incident_recovery_deep_lane.json`
+- `#2858` migrates dashboard run-lane wrappers to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/dashboard/run_backend_session_auth_freshness_lane.sh`
+  - implementation: `scripts/dashboard/run_backend_session_auth_freshness_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/dashboard_backend_session_auth_freshness_lane.json`
+  - wrapper: `scripts/dashboard/run_dashboard_stale_error_budget_lane.sh`
+  - implementation: `scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/dashboard_stale_error_budget_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
   - `scripts/signer/test_run_signer_emulator_contract_lane.sh`
+  - `scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh`
+  - `scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/dashboard/run_backend_session_auth_freshness_lane.sh
+++ b/scripts/dashboard/run_backend_session_auth_freshness_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/dashboard/backend_session_auth_freshness_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/dashboard/run_backend_session_auth_freshness_lane_impl.sh
+++ b/scripts/dashboard/run_backend_session_auth_freshness_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/dashboard/backend_session_auth_freshness_lane_contract.py" "$@"

--- a/scripts/dashboard/run_dashboard_stale_error_budget_lane.sh
+++ b/scripts/dashboard/run_dashboard_stale_error_budget_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/dashboard/stale_error_budget_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh
+++ b/scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/dashboard/stale_error_budget_lane_contract.py" "$@"

--- a/scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh
+++ b/scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh
@@ -3,11 +3,39 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/dashboard/run_backend_session_auth_freshness_lane.sh"
+SCRIPT_IMPL="$ROOT_DIR/scripts/dashboard/run_backend_session_auth_freshness_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/dashboard_backend_session_auth_freshness_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$SCRIPT" ]; then
   echo "expected dashboard backend session/auth freshness lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$SCRIPT_IMPL" ]; then
+  echo "expected dashboard backend session/auth freshness lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+if [ ! -L "$SCRIPT" ]; then
+  echo "expected dashboard backend session/auth freshness lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected dashboard backend session/auth freshness lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected dashboard backend session/auth freshness lane wrapper to resolve dashboard manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -Fq "run_backend_session_auth_freshness_lane_impl.sh" "$MANIFEST_FILE"; then
+  echo "expected dashboard backend session/auth freshness lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 

--- a/scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh
+++ b/scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh
@@ -3,11 +3,39 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/dashboard/run_dashboard_stale_error_budget_lane.sh"
+SCRIPT_IMPL="$ROOT_DIR/scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/dashboard_stale_error_budget_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$SCRIPT" ]; then
   echo "expected dashboard stale/error budget lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$SCRIPT_IMPL" ]; then
+  echo "expected dashboard stale/error budget lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+if [ ! -L "$SCRIPT" ]; then
+  echo "expected dashboard stale/error budget lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected dashboard stale/error budget lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected dashboard stale/error budget lane wrapper to resolve dashboard manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -Fq "run_dashboard_stale_error_budget_lane_impl.sh" "$MANIFEST_FILE"; then
+  echo "expected dashboard stale/error budget lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 

--- a/scripts/framework/manifests/dashboard_backend_session_auth_freshness_lane.json
+++ b/scripts/framework/manifests/dashboard_backend_session_auth_freshness_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "dashboard.backend_session_auth_freshness.run",
+  "evidence_key": "dashboard_backend_session_auth_freshness_lane:v1",
+  "reason_key": "dashboard_backend_session_auth_freshness_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/dashboard/run_backend_session_auth_freshness_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/manifests/dashboard_stale_error_budget_lane.json
+++ b/scripts/framework/manifests/dashboard_stale_error_budget_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "dashboard.stale_error_budget.run",
+  "evidence_key": "dashboard_stale_error_budget_lane:v1",
+  "reason_key": "dashboard_stale_error_budget_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -61,8 +61,10 @@ resolve_manifest_name() {
     run_cutover_rollback_contract_lane.sh) echo "cutover_cutover_rollback_contract_lane.json" ;;
     run_dr_evidence_contract_lane.sh) echo "deploy_dr_evidence_contract_lane.json" ;;
     run_backend_session_auth_freshness_contract_lane.sh) echo "dashboard_backend_session_auth_freshness_contract_lane.json" ;;
+    run_backend_session_auth_freshness_lane.sh) echo "dashboard_backend_session_auth_freshness_lane.json" ;;
     run_cross_chain_outbound_intent_contract_lane.sh) echo "bridge_cross_chain_outbound_intent_contract_lane.json" ;;
     run_dashboard_stale_error_budget_contract_lane.sh) echo "dashboard_stale_error_budget_contract_lane.json" ;;
+    run_dashboard_stale_error_budget_lane.sh) echo "dashboard_stale_error_budget_lane.json" ;;
     run_did_registry_contract_lane.sh) echo "did_did_registry_contract_lane.json" ;;
     run_durable_guard_recovery_contract_lane.sh) echo "guard_durable_guard_recovery_contract_lane.json" ;;
     run_federated_did_handshake_contract_lane.sh) echo "did_federated_did_handshake_contract_lane.json" ;;
@@ -143,6 +145,8 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_backend_session_auth_freshness_lane.sh) echo "run" ;;
+    run_dashboard_stale_error_budget_lane.sh) echo "run" ;;
     run_signer_incident_recovery_deep_lane.sh) echo "deep" ;;
     run_signer_provider_deep_lane.sh) echo "deep" ;;
     run_signer_incident_recovery_lane.sh) echo "run" ;;


### PR DESCRIPTION
## Summary
This migrates two dashboard run-lane wrappers to the shared non-Kolme dispatcher/manifest framework, reducing standalone wrapper surface while preserving deterministic GO/NO-GO lane behavior. It adds fail-closed regression assertions for wrapper symlink and manifest resolution drift.

Closes #2858
Refs #2833
Refs #2826

## Changes
- `scripts/dashboard/run_backend_session_auth_freshness_lane.sh`: converted to dispatcher symlink.
- `scripts/dashboard/run_backend_session_auth_freshness_lane_impl.sh`: extracted original lane implementation.
- `scripts/dashboard/run_dashboard_stale_error_budget_lane.sh`: converted to dispatcher symlink.
- `scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh`: extracted original lane implementation.
- `scripts/framework/manifests/dashboard_backend_session_auth_freshness_lane.json`: added run-lane manifest.
- `scripts/framework/manifests/dashboard_stale_error_budget_lane.json`: added run-lane manifest.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added dashboard run-lane mapping and `run` phase resolution.
- `scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh`: added dispatcher/manifest fail-closed assertions.
- `scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh`: added dispatcher/manifest fail-closed assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: migration log updates.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh
```
Output:
```text
expected dashboard backend session/auth freshness lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh
bash scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh
bash scripts/dashboard/test_check_backend_session_auth_freshness_policy.sh
bash scripts/dashboard/test_check_dashboard_stale_error_budget_policy.sh
bash scripts/dashboard/test_run_backend_session_auth_freshness_contract_lane.sh
bash scripts/dashboard/test_run_dashboard_stale_error_budget_contract_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
dashboard backend session/auth freshness lane script tests passed.
dashboard stale/error budget lane script tests passed.
dashboard backend session/auth freshness policy checker tests passed.
dashboard stale/error budget policy checker tests passed.
dashboard backend session/auth freshness contract lane script tests passed.
dashboard stale/error budget contract lane script tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell-wrapper/manifest wiring only; no Rust/public API changes |
| Functional   | ✅     | `scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh`; `scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh` | |
| Integration  | ✅     | dashboard policy/contract lane tests; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | dispatcher/manifest fail-closed assertions in both dashboard run-lane tests | |
| Performance  | N/A    | N/A                  | No runtime algorithm/performance path changes |

## Risks & Rollback
- Breaking risk: low. Wrapper dispatch conversion is scoped to two dashboard run lanes.
- Rollback plan: revert this PR commit to restore direct wrappers and remove manifest mappings.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: logged dashboard run-lane migration slice.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
