### PR TITLE
refactor(ci): migrate classification redaction run lane to dispatcher manifest (#2860)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -41,12 +41,17 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/dashboard/run_dashboard_stale_error_budget_lane.sh`
   - implementation: `scripts/dashboard/run_dashboard_stale_error_budget_lane_impl.sh`
   - manifest: `scripts/framework/manifests/dashboard_stale_error_budget_lane.json`
+- `#2860` migrates classification/redaction run-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/compliance/run_classification_redaction_lane.sh`
+  - implementation: `scripts/compliance/run_classification_redaction_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/compliance_classification_redaction_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
   - `scripts/signer/test_run_signer_emulator_contract_lane.sh`
   - `scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh`
   - `scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh`
+  - `scripts/compliance/test_run_classification_redaction_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/compliance/run_classification_redaction_lane.sh
+++ b/scripts/compliance/run_classification_redaction_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/compliance/classification_redaction_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/compliance/run_classification_redaction_lane_impl.sh
+++ b/scripts/compliance/run_classification_redaction_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/compliance/classification_redaction_lane_contract.py" "$@"

--- a/scripts/compliance/test_run_classification_redaction_lane.sh
+++ b/scripts/compliance/test_run_classification_redaction_lane.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LANE_SCRIPT="$ROOT_DIR/scripts/compliance/run_classification_redaction_lane.sh"
+LANE_IMPL="$ROOT_DIR/scripts/compliance/run_classification_redaction_lane_impl.sh"
 SHARED_LANE="$ROOT_DIR/scripts/compliance/classification_redaction_lane_contract.py"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/compliance_classification_redaction_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -17,9 +20,30 @@ if [ ! -x "$LANE_SCRIPT" ]; then
   echo "expected classification/redaction lane script to be executable" >&2
   exit 1
 fi
+if [ ! -x "$LANE_IMPL" ]; then
+  echo "expected classification/redaction lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
 
-if ! grep -q 'classification_redaction_lane_contract.py' "$LANE_SCRIPT"; then
-  echo "expected classification/redaction lane wrapper to delegate to shared implementation" >&2
+if [ ! -L "$LANE_SCRIPT" ]; then
+  echo "expected classification/redaction lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$LANE_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected classification/redaction lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$LANE_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected classification/redaction lane wrapper to resolve compliance manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -q 'run_classification_redaction_lane_impl.sh' "$MANIFEST_FILE"; then
+  echo "expected classification/redaction lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 

--- a/scripts/framework/manifests/compliance_classification_redaction_lane.json
+++ b/scripts/framework/manifests/compliance_classification_redaction_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "compliance.classification_redaction.run",
+  "evidence_key": "classification_redaction_lane:v1",
+  "reason_key": "classification_redaction_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/compliance/run_classification_redaction_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -73,6 +73,7 @@ resolve_manifest_name() {
     run_localhost_bridge_relay_demo_contract_lane.sh) echo "bridge_localhost_bridge_relay_demo_contract_lane.json" ;;
     run_post_cutover_slo_contract_lane.sh) echo "canary_post_cutover_slo_contract_lane.json" ;;
     run_classification_redaction_contract_lane.sh) echo "compliance_classification_redaction_contract_lane.json" ;;
+    run_classification_redaction_lane.sh) echo "compliance_classification_redaction_lane.json" ;;
     run_dsar_legal_hold_contract_lane.sh) echo "compliance_dsar_legal_hold_contract_lane.json" ;;
     run_channel_lifecycle_contract_lane.sh) echo "channel_channel_lifecycle_contract_lane.json" ;;
     run_channel_policy_contract_lane.sh) echo "channel_channel_policy_contract_lane.json" ;;
@@ -145,6 +146,7 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_classification_redaction_lane.sh) echo "run" ;;
     run_backend_session_auth_freshness_lane.sh) echo "run" ;;
     run_dashboard_stale_error_budget_lane.sh) echo "run" ;;
     run_signer_incident_recovery_deep_lane.sh) echo "deep" ;;


### PR DESCRIPTION
## Summary
This migrates the classification/redaction run-lane wrapper to the shared non-Kolme dispatcher/manifest framework and preserves existing lane semantics. It adds fail-closed regression checks so wrapper/manifest mapping drift is detected immediately.

Closes #2860
Refs #2833
Refs #2826

## Changes
- `scripts/compliance/run_classification_redaction_lane.sh`: converted to dispatcher symlink wrapper.
- `scripts/compliance/run_classification_redaction_lane_impl.sh`: extracted original lane wrapper implementation.
- `scripts/framework/manifests/compliance_classification_redaction_lane.json`: added run-lane manifest.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added wrapper mapping and `run` phase resolution for classification/redaction lane.
- `scripts/compliance/test_run_classification_redaction_lane.sh`: added dispatcher symlink + manifest fail-closed assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: added migration log entry for this slice.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/compliance/test_run_classification_redaction_lane.sh
```
Output:
```text
expected classification/redaction lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/compliance/test_run_classification_redaction_lane.sh
bash scripts/compliance/test_check_classification_redaction_policy.sh
bash scripts/compliance/test_run_classification_redaction_contract_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
classification/redaction lane script tests passed.
classification/redaction policy checker tests passed.
classification/redaction contract lane script tests passed.
non-Kolme contract lane dispatcher wrapper matrix tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell/manifest wiring only; no Rust/public API changes |
| Functional   | ✅     | `scripts/compliance/test_run_classification_redaction_lane.sh` | |
| Integration  | ✅     | `scripts/compliance/test_check_classification_redaction_policy.sh`; `scripts/compliance/test_run_classification_redaction_contract_lane.sh`; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | Dispatcher symlink + manifest fail-closed checks in lane test | |
| Performance  | N/A    | N/A                  | No runtime algorithm/performance path changes |

## Risks & Rollback
- Breaking risk: low. Scoped to one compliance run-lane wrapper.
- Rollback plan: revert this PR to restore direct wrapper script and remove manifest mapping.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: migration log updated for issue `#2860`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
