### PR TITLE
refactor(ci): migrate deployment slo rollback run lane to dispatcher manifest (#2862)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -45,6 +45,10 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/compliance/run_classification_redaction_lane.sh`
   - implementation: `scripts/compliance/run_classification_redaction_lane_impl.sh`
   - manifest: `scripts/framework/manifests/compliance_classification_redaction_lane.json`
+- `#2862` migrates deployment slo/rollback run-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/deploy/run_deployment_slo_rollback_lane.sh`
+  - implementation: `scripts/deploy/run_deployment_slo_rollback_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/deploy_deployment_slo_rollback_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
@@ -52,6 +56,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - `scripts/dashboard/test_run_backend_session_auth_freshness_lane.sh`
   - `scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh`
   - `scripts/compliance/test_run_classification_redaction_lane.sh`
+  - `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/deploy/run_deployment_slo_rollback_lane.sh
+++ b/scripts/deploy/run_deployment_slo_rollback_lane.sh
@@ -1,8 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/deploy/deployment_slo_rollback_lane_contract.py" "$@"
-
-echo "deployment slo/rollback lane tests passed."
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/deploy/run_deployment_slo_rollback_lane_impl.sh
+++ b/scripts/deploy/run_deployment_slo_rollback_lane_impl.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/deploy/deployment_slo_rollback_lane_contract.py" "$@"
+
+echo "deployment slo/rollback lane tests passed."

--- a/scripts/deploy/test_run_deployment_slo_rollback_lane.sh
+++ b/scripts/deploy/test_run_deployment_slo_rollback_lane.sh
@@ -3,11 +3,39 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/deploy/run_deployment_slo_rollback_lane.sh"
+SCRIPT_IMPL="$ROOT_DIR/scripts/deploy/run_deployment_slo_rollback_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/deploy_deployment_slo_rollback_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$SCRIPT" ]; then
   echo "expected deployment slo/rollback lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$SCRIPT_IMPL" ]; then
+  echo "expected deployment slo/rollback lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+if [ ! -L "$SCRIPT" ]; then
+  echo "expected deployment slo/rollback lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected deployment slo/rollback lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected deployment slo/rollback lane wrapper to resolve deploy manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -Fq "run_deployment_slo_rollback_lane_impl.sh" "$MANIFEST_FILE"; then
+  echo "expected deployment slo/rollback lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 

--- a/scripts/framework/manifests/deploy_deployment_slo_rollback_lane.json
+++ b/scripts/framework/manifests/deploy_deployment_slo_rollback_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "deploy.deployment_slo_rollback.run",
+  "evidence_key": "deployment_slo_rollback_lane:v1",
+  "reason_key": "deployment_slo_rollback_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/deploy/run_deployment_slo_rollback_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -60,6 +60,7 @@ resolve_manifest_name() {
     run_bridge_replay_redaction_contract_lane.sh) echo "bridge_bridge_replay_redaction_contract_lane.json" ;;
     run_cutover_rollback_contract_lane.sh) echo "cutover_cutover_rollback_contract_lane.json" ;;
     run_dr_evidence_contract_lane.sh) echo "deploy_dr_evidence_contract_lane.json" ;;
+    run_deployment_slo_rollback_lane.sh) echo "deploy_deployment_slo_rollback_lane.json" ;;
     run_backend_session_auth_freshness_contract_lane.sh) echo "dashboard_backend_session_auth_freshness_contract_lane.json" ;;
     run_backend_session_auth_freshness_lane.sh) echo "dashboard_backend_session_auth_freshness_lane.json" ;;
     run_cross_chain_outbound_intent_contract_lane.sh) echo "bridge_cross_chain_outbound_intent_contract_lane.json" ;;
@@ -146,6 +147,7 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_deployment_slo_rollback_lane.sh) echo "run" ;;
     run_classification_redaction_lane.sh) echo "run" ;;
     run_backend_session_auth_freshness_lane.sh) echo "run" ;;
     run_dashboard_stale_error_budget_lane.sh) echo "run" ;;


### PR DESCRIPTION
## Summary
This migrates the deployment SLO/rollback run-lane wrapper to shared non-Kolme dispatcher/manifest wiring, reducing standalone wrapper surface while preserving existing lane behavior. It adds fail-closed wrapper/manifest assertions in the lane test to detect mapping drift early.

Closes #2862
Refs #2833
Refs #2826

## Changes
- `scripts/deploy/run_deployment_slo_rollback_lane.sh`: converted to dispatcher symlink.
- `scripts/deploy/run_deployment_slo_rollback_lane_impl.sh`: extracted original wrapper implementation.
- `scripts/framework/manifests/deploy_deployment_slo_rollback_lane.json`: added run-lane manifest.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added wrapper mapping + `run` phase resolution.
- `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`: added fail-closed dispatcher symlink/manifest assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: migration log update.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/deploy/test_run_deployment_slo_rollback_lane.sh
```
Output:
```text
expected deployment slo/rollback lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/deploy/test_run_deployment_slo_rollback_lane.sh
bash scripts/deploy/test_check_deployment_slo_rollback_policy.sh
bash scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
deployment slo/rollback lane script tests passed.
deployment slo/rollback policy checker tests passed.
deployment slo/rollback contract lane wrapper tests passed.
non-Kolme contract lane dispatcher wrapper matrix tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell/manifest wiring only; no Rust/public API changes |
| Functional   | ✅     | `scripts/deploy/test_run_deployment_slo_rollback_lane.sh` | |
| Integration  | ✅     | `scripts/deploy/test_check_deployment_slo_rollback_policy.sh`; `scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh`; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | Dispatcher symlink + manifest fail-closed assertions in run-lane test | |
| Performance  | N/A    | N/A                  | No runtime algorithm/performance-path changes |

## Risks & Rollback
- Breaking risk: low. Scoped to one deployment run-lane wrapper.
- Rollback plan: revert this PR commit to restore prior wrapper form and remove manifest mapping.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: migration log updated for issue `#2862`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
