### PR TITLE
refactor(ci): migrate frontend shell matrix run lane to dispatcher manifest (#2864)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -49,6 +49,10 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/deploy/run_deployment_slo_rollback_lane.sh`
   - implementation: `scripts/deploy/run_deployment_slo_rollback_lane_impl.sh`
   - manifest: `scripts/framework/manifests/deploy_deployment_slo_rollback_lane.json`
+- `#2864` migrates frontend shell determinism run-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/frontend/run_dashboard_shell_determinism_matrix_lane.sh`
+  - implementation: `scripts/frontend/run_dashboard_shell_determinism_matrix_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/frontend_dashboard_shell_determinism_matrix_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
@@ -57,6 +61,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - `scripts/dashboard/test_run_dashboard_stale_error_budget_lane.sh`
   - `scripts/compliance/test_run_classification_redaction_lane.sh`
   - `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`
+  - `scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/framework/manifests/frontend_dashboard_shell_determinism_matrix_lane.json
+++ b/scripts/framework/manifests/frontend_dashboard_shell_determinism_matrix_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "frontend.dashboard_shell_determinism_matrix.run",
+  "evidence_key": "dashboard_shell_determinism_matrix_lane:v1",
+  "reason_key": "dashboard_shell_determinism_matrix_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/frontend/run_dashboard_shell_determinism_matrix_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -79,6 +79,7 @@ resolve_manifest_name() {
     run_channel_lifecycle_contract_lane.sh) echo "channel_channel_lifecycle_contract_lane.json" ;;
     run_channel_policy_contract_lane.sh) echo "channel_channel_policy_contract_lane.json" ;;
     run_dashboard_shell_determinism_matrix_contract_lane.sh) echo "frontend_dashboard_shell_determinism_matrix_contract_lane.json" ;;
+    run_dashboard_shell_determinism_matrix_lane.sh) echo "frontend_dashboard_shell_determinism_matrix_lane.json" ;;
     run_a2a_mcp_conformance_contract_lane.sh) echo "message_a2a_mcp_conformance_contract_lane.json" ;;
     run_didcomm_envelope_compatibility_contract_lane.sh) echo "message_didcomm_envelope_compatibility_contract_lane.json" ;;
     run_group_sender_replay_ratchet_contract_lane.sh) echo "message_group_sender_replay_ratchet_contract_lane.json" ;;
@@ -147,6 +148,7 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_dashboard_shell_determinism_matrix_lane.sh) echo "run" ;;
     run_deployment_slo_rollback_lane.sh) echo "run" ;;
     run_classification_redaction_lane.sh) echo "run" ;;
     run_backend_session_auth_freshness_lane.sh) echo "run" ;;

--- a/scripts/frontend/run_dashboard_shell_determinism_matrix_lane.sh
+++ b/scripts/frontend/run_dashboard_shell_determinism_matrix_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/frontend/dashboard_shell_determinism_matrix_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/frontend/run_dashboard_shell_determinism_matrix_lane_impl.sh
+++ b/scripts/frontend/run_dashboard_shell_determinism_matrix_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/frontend/dashboard_shell_determinism_matrix_lane_contract.py" "$@"

--- a/scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh
+++ b/scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/frontend/run_dashboard_shell_determinism_matrix_lane.sh"
 SHARED_SCRIPT="$ROOT_DIR/scripts/frontend/dashboard_shell_determinism_matrix_lane_contract.py"
+SCRIPT_IMPL="$ROOT_DIR/scripts/frontend/run_dashboard_shell_determinism_matrix_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/frontend_dashboard_shell_determinism_matrix_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -11,9 +14,30 @@ if [ ! -x "$SCRIPT" ]; then
   echo "expected dashboard shell determinism matrix lane script to be executable" >&2
   exit 1
 fi
+if [ ! -x "$SCRIPT_IMPL" ]; then
+  echo "expected dashboard shell determinism matrix lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
 
-if ! grep -q 'dashboard_shell_determinism_matrix_lane_contract.py' "$SCRIPT"; then
-  echo "expected dashboard shell matrix lane wrapper to delegate to shared implementation" >&2
+if [ ! -L "$SCRIPT" ]; then
+  echo "expected dashboard shell determinism matrix lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected dashboard shell determinism matrix lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected dashboard shell determinism matrix lane wrapper to resolve frontend manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -q 'run_dashboard_shell_determinism_matrix_lane_impl.sh' "$MANIFEST_FILE"; then
+  echo "expected dashboard shell determinism matrix lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This migrates the frontend dashboard shell determinism run-lane wrapper to shared non-Kolme dispatcher/manifest wiring while preserving deterministic lane behavior. It adds fail-closed wrapper/manifest assertions in the lane test to catch dispatch drift quickly.

Closes #2864
Refs #2833
Refs #2826

## Changes
- `scripts/frontend/run_dashboard_shell_determinism_matrix_lane.sh`: converted to dispatcher symlink.
- `scripts/frontend/run_dashboard_shell_determinism_matrix_lane_impl.sh`: extracted original wrapper implementation.
- `scripts/framework/manifests/frontend_dashboard_shell_determinism_matrix_lane.json`: added run-lane manifest.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added wrapper mapping + `run` phase resolution.
- `scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh`: added dispatcher symlink + manifest fail-closed assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: migration log update.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh
```
Output:
```text
expected dashboard shell determinism matrix lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh
bash scripts/frontend/test_check_dashboard_shell_determinism_matrix_policy.sh
bash scripts/frontend/test_run_dashboard_shell_determinism_matrix_contract_lane.sh
bash scripts/frontend/test_dashboard_contract_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
dashboard shell determinism matrix lane script tests passed.
dashboard shell determinism matrix policy checker tests passed.
dashboard shell determinism matrix contract lane script tests passed.
dashboard contract lane tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell/manifest wiring only; no Rust/public API changes |
| Functional   | ✅     | `scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh` | |
| Integration  | ✅     | `scripts/frontend/test_check_dashboard_shell_determinism_matrix_policy.sh`; `scripts/frontend/test_run_dashboard_shell_determinism_matrix_contract_lane.sh`; `scripts/frontend/test_dashboard_contract_lane.sh`; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | Dispatcher symlink + manifest fail-closed assertions in lane test | |
| Performance  | N/A    | N/A                  | No runtime algorithm/performance-path changes |

## Risks & Rollback
- Breaking risk: low. Scoped to one frontend run-lane wrapper.
- Rollback plan: revert this PR commit to restore previous wrapper and remove manifest mapping.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: migration log updated for issue `#2864`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
