### PR TITLE
refactor(ci): migrate quorum attestation guard run lane to dispatcher manifest (#2868)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -57,6 +57,10 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/governance/run_governance_lifecycle_rollback_lane.sh`
   - implementation: `scripts/governance/run_governance_lifecycle_rollback_lane_impl.sh`
   - manifest: `scripts/framework/manifests/governance_lifecycle_rollback_lane.json`
+- `#2868` migrates governance quorum-attestation replay guard run-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/governance/run_quorum_attestation_replay_guard_lane.sh`
+  - implementation: `scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/governance_quorum_attestation_replay_guard_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
@@ -67,6 +71,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - `scripts/deploy/test_run_deployment_slo_rollback_lane.sh`
   - `scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh`
   - `scripts/governance/test_run_governance_lifecycle_rollback_lane.sh`
+  - `scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/framework/manifests/governance_quorum_attestation_replay_guard_lane.json
+++ b/scripts/framework/manifests/governance_quorum_attestation_replay_guard_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "governance.quorum_attestation_replay_guard.run",
+  "evidence_key": "governance_quorum_attestation_lane:v1",
+  "reason_key": "governance_quorum_attestation_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -100,6 +100,7 @@ resolve_manifest_name() {
     run_governance_lifecycle_rollback_contract_lane.sh) echo "governance_lifecycle_rollback_contract_lane.json" ;;
     run_governance_lifecycle_rollback_lane.sh) echo "governance_lifecycle_rollback_lane.json" ;;
     run_governance_simulation_contract_lane.sh) echo "governance_simulation_contract_lane.json" ;;
+    run_quorum_attestation_replay_guard_lane.sh) echo "governance_quorum_attestation_replay_guard_lane.json" ;;
     run_gonogo_evidence_contract_lane.sh) echo "deploy_gonogo_evidence_contract_lane.json" ;;
     run_mainnet_cutover_contract_lane.sh) echo "cutover_mainnet_cutover_contract_lane.json" ;;
     run_quorum_attestation_replay_contract_lane.sh) echo "governance_quorum_attestation_replay_contract_lane.json" ;;
@@ -149,6 +150,7 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_quorum_attestation_replay_guard_lane.sh) echo "run" ;;
     run_governance_lifecycle_rollback_lane.sh) echo "run" ;;
     run_dashboard_shell_determinism_matrix_lane.sh) echo "run" ;;
     run_deployment_slo_rollback_lane.sh) echo "run" ;;

--- a/scripts/governance/run_quorum_attestation_replay_guard_lane.sh
+++ b/scripts/governance/run_quorum_attestation_replay_guard_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/governance/governance_quorum_attestation_replay_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh
+++ b/scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/governance/governance_quorum_attestation_replay_lane_contract.py" "$@"

--- a/scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh
+++ b/scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LANE_SCRIPT="$ROOT_DIR/scripts/governance/run_quorum_attestation_replay_guard_lane.sh"
+LANE_IMPL="$ROOT_DIR/scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/governance_quorum_attestation_replay_guard_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -14,6 +17,31 @@ extract_value() {
 
 if [ ! -x "$LANE_SCRIPT" ]; then
   echo "expected governance quorum attestation lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$LANE_IMPL" ]; then
+  echo "expected governance quorum attestation lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+if [ ! -L "$LANE_SCRIPT" ]; then
+  echo "expected governance quorum attestation lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+if [ "$(readlink "$LANE_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected governance quorum attestation lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$LANE_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected governance quorum attestation lane wrapper to resolve governance manifest via dispatcher" >&2
+  exit 1
+fi
+if ! grep -q 'run_quorum_attestation_replay_guard_lane_impl.sh' "$MANIFEST_FILE"; then
+  echo "expected governance quorum attestation lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This migrates the governance quorum-attestation replay guard run-lane wrapper to shared non-Kolme dispatcher/manifest wiring while preserving deterministic lane behavior. It adds fail-closed wrapper symlink/manifest assertions to catch dispatch drift.

Closes #2868
Refs #2833
Refs #2826

## Changes
- `scripts/governance/run_quorum_attestation_replay_guard_lane.sh`: converted to dispatcher symlink.
- `scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh`: extracted original wrapper implementation.
- `scripts/framework/manifests/governance_quorum_attestation_replay_guard_lane.json`: added run-lane manifest.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added wrapper mapping + `run` phase resolution.
- `scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh`: added fail-closed dispatcher symlink/manifest assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: migration log update.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh
```
Output:
```text
expected governance quorum attestation lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh
bash scripts/governance/test_check_quorum_attestation_replay_policy.sh
bash scripts/governance/test_run_quorum_attestation_replay_contract_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
governance quorum attestation replay lane script tests passed.
governance quorum attestation replay policy checker tests passed.
governance quorum attestation replay contract lane script tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell/manifest wiring only; no Rust/public API changes |
| Functional   | ✅     | `scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh` | |
| Integration  | ✅     | `scripts/governance/test_check_quorum_attestation_replay_policy.sh`; `scripts/governance/test_run_quorum_attestation_replay_contract_lane.sh`; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | Dispatcher symlink + manifest fail-closed assertions in governance lane test | |
| Performance  | N/A    | N/A                  | No algorithm/performance-path changes |

## Risks & Rollback
- Breaking risk: low. Scoped to one governance run-lane wrapper.
- Rollback plan: revert this PR commit to restore previous wrapper and remove manifest mapping.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: migration log updated for issue `#2868`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
