### PR TITLE
refactor(ci): migrate sdk smoke parity run lane to dispatcher manifest (#2870)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -61,6 +61,10 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/governance/run_quorum_attestation_replay_guard_lane.sh`
   - implementation: `scripts/governance/run_quorum_attestation_replay_guard_lane_impl.sh`
   - manifest: `scripts/framework/manifests/governance_quorum_attestation_replay_guard_lane.json`
+- `#2870` migrates sdk live-transport smoke parity run-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/sdk/run_live_transport_smoke_parity_lane.sh`
+  - implementation: `scripts/sdk/run_live_transport_smoke_parity_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/sdk_live_transport_smoke_parity_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
@@ -72,6 +76,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - `scripts/frontend/test_run_dashboard_shell_determinism_matrix_lane.sh`
   - `scripts/governance/test_run_governance_lifecycle_rollback_lane.sh`
   - `scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh`
+  - `scripts/sdk/test_run_live_transport_smoke_parity_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/framework/manifests/sdk_live_transport_smoke_parity_lane.json
+++ b/scripts/framework/manifests/sdk_live_transport_smoke_parity_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "sdk.live_transport_smoke_parity.run",
+  "evidence_key": "sdk_live_transport_smoke_parity_lane:v1",
+  "reason_key": "sdk_live_transport_smoke_parity_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/sdk/run_live_transport_smoke_parity_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -108,6 +108,7 @@ resolve_manifest_name() {
     run_live_transport_parity_contract_lane.sh) echo "sdk_live_transport_parity_contract_lane.json" ;;
     run_live_transport_replay_tamper_contract_lane.sh) echo "sdk_live_transport_replay_tamper_contract_lane.json" ;;
     run_live_transport_smoke_parity_contract_lane.sh) echo "sdk_live_transport_smoke_parity_contract_lane.json" ;;
+    run_live_transport_smoke_parity_lane.sh) echo "sdk_live_transport_smoke_parity_lane.json" ;;
     run_lifecycle_operator_binding_contract_lane.sh) echo "did_lifecycle_operator_binding_contract_lane.json" ;;
     run_localhost_signed_integration_contract_lane.sh) echo "sdk_localhost_signed_integration_contract_lane.json" ;;
     run_multikey_algorithm_policy_contract_lane.sh) echo "did_multikey_algorithm_policy_contract_lane.json" ;;
@@ -150,6 +151,7 @@ resolve_manifest_name() {
 
 resolve_phase_name() {
   case "$1" in
+    run_live_transport_smoke_parity_lane.sh) echo "run" ;;
     run_quorum_attestation_replay_guard_lane.sh) echo "run" ;;
     run_governance_lifecycle_rollback_lane.sh) echo "run" ;;
     run_dashboard_shell_determinism_matrix_lane.sh) echo "run" ;;

--- a/scripts/sdk/run_live_transport_smoke_parity_lane.sh
+++ b/scripts/sdk/run_live_transport_smoke_parity_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/sdk/live_transport_smoke_parity_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/sdk/run_live_transport_smoke_parity_lane_impl.sh
+++ b/scripts/sdk/run_live_transport_smoke_parity_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/sdk/live_transport_smoke_parity_lane_contract.py" "$@"

--- a/scripts/sdk/test_run_live_transport_smoke_parity_lane.sh
+++ b/scripts/sdk/test_run_live_transport_smoke_parity_lane.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SMOKE_SCRIPT="$ROOT_DIR/scripts/sdk/run_live_transport_smoke_parity_lane.sh"
+SMOKE_IMPL_SCRIPT="$ROOT_DIR/scripts/sdk/run_live_transport_smoke_parity_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/sdk_live_transport_smoke_parity_lane.json"
 TMP_REPORT="$(mktemp)"
 trap 'rm -f "$TMP_REPORT"' EXIT
 
@@ -11,8 +14,34 @@ if [ ! -x "$SMOKE_SCRIPT" ]; then
   exit 1
 fi
 
-if ! grep -q 'live_transport_smoke_parity_lane_contract.py' "$SMOKE_SCRIPT"; then
-  echo "expected sdk smoke parity lane runner to delegate to shared lane contract implementation" >&2
+if [ ! -x "$SMOKE_IMPL_SCRIPT" ]; then
+  echo "expected sdk live transport smoke parity lane implementation to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+
+if [ ! -L "$SMOKE_SCRIPT" ]; then
+  echo "expected sdk smoke parity lane runner to be a dispatcher symlink" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$SMOKE_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected sdk smoke parity lane runner to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SMOKE_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected sdk smoke parity lane runner to resolve sdk manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -q 'run_live_transport_smoke_parity_lane_impl.sh' "$MANIFEST_FILE"; then
+  echo "expected sdk smoke parity lane manifest to dispatch implementation module" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This migrates the SDK live-transport smoke-parity run-lane wrapper to shared non-Kolme dispatcher/manifest wiring while preserving deterministic lane behavior. It adds fail-closed symlink/manifest assertions in lane tests to prevent dispatch drift.

Closes #2870
Refs #2833
Refs #2826

## Changes
- `scripts/sdk/run_live_transport_smoke_parity_lane.sh`: converted to dispatcher symlink.
- `scripts/sdk/run_live_transport_smoke_parity_lane_impl.sh`: extracted original wrapper implementation.
- `scripts/framework/manifests/sdk_live_transport_smoke_parity_lane.json`: added run-lane manifest.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: added wrapper mapping + `run` phase resolution.
- `scripts/sdk/test_run_live_transport_smoke_parity_lane.sh`: added fail-closed dispatcher symlink/manifest assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: migration log update.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/sdk/test_run_live_transport_smoke_parity_lane.sh
```
Output:
```text
expected sdk live transport smoke parity lane implementation to be executable
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/sdk/test_run_live_transport_smoke_parity_lane.sh
bash scripts/sdk/test_check_live_transport_smoke_parity_policy.sh
bash scripts/sdk/test_run_live_transport_smoke_parity_contract_lane.sh
bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/ci/test_select_targets.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Key output markers:
```text
sdk live transport smoke parity lane script tests passed.
sdk live transport smoke parity policy checker tests passed.
sdk live transport smoke parity contract lane script tests passed.
select_targets matrix regression tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Pass (full fast-mode CI tools matrix completed)
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Shell/manifest wiring only; no Rust/public API changes |
| Functional   | ✅     | `scripts/sdk/test_run_live_transport_smoke_parity_lane.sh` | |
| Integration  | ✅     | `scripts/sdk/test_check_live_transport_smoke_parity_policy.sh`; `scripts/sdk/test_run_live_transport_smoke_parity_contract_lane.sh`; `scripts/ci/test_select_targets.sh`; `scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅     | Dispatcher symlink + manifest fail-closed assertions in SDK lane test | |
| Performance  | N/A    | N/A                  | No algorithm/performance-path changes |

## Risks & Rollback
- Breaking risk: low. Scoped to one SDK run-lane wrapper.
- Rollback plan: revert this PR commit to restore previous wrapper and remove manifest mapping.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`: migration log updated for issue `#2870`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
