### PR TITLE
refactor(ci): migrate sdk replay-tamper deep run lane to dispatcher manifest (#2874)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -69,6 +69,10 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/sdk/run_live_transport_replay_tamper_fast_lane.sh`
   - implementation: `scripts/sdk/run_live_transport_replay_tamper_fast_lane_impl.sh`
   - manifest: `scripts/framework/manifests/sdk_live_transport_replay_tamper_fast_lane.json`
+- `#2874` migrates sdk live-transport replay/tamper deep-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh`
+  - implementation: `scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/sdk_live_transport_replay_tamper_deep_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
@@ -82,6 +86,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - `scripts/governance/test_run_quorum_attestation_replay_guard_lane.sh`
   - `scripts/sdk/test_run_live_transport_smoke_parity_lane.sh`
   - `scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh`
+  - `scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/framework/manifests/sdk_live_transport_replay_tamper_deep_lane.json
+++ b/scripts/framework/manifests/sdk_live_transport_replay_tamper_deep_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "sdk.live_transport_replay_tamper_deep.run",
+  "evidence_key": "live_transport_replay_tamper_deep_lane:v1",
+  "reason_key": "live_transport_replay_tamper_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -107,6 +107,7 @@ resolve_manifest_name() {
     run_example_fixture_drift_contract_lane.sh) echo "sdk_example_fixture_drift_contract_lane.json" ;;
     run_live_transport_parity_contract_lane.sh) echo "sdk_live_transport_parity_contract_lane.json" ;;
     run_live_transport_replay_tamper_contract_lane.sh) echo "sdk_live_transport_replay_tamper_contract_lane.json" ;;
+    run_live_transport_replay_tamper_deep_lane.sh) echo "sdk_live_transport_replay_tamper_deep_lane.json" ;;
     run_live_transport_replay_tamper_fast_lane.sh) echo "sdk_live_transport_replay_tamper_fast_lane.json" ;;
     run_live_transport_smoke_parity_contract_lane.sh) echo "sdk_live_transport_smoke_parity_contract_lane.json" ;;
     run_live_transport_smoke_parity_lane.sh) echo "sdk_live_transport_smoke_parity_lane.json" ;;
@@ -153,6 +154,7 @@ resolve_manifest_name() {
 resolve_phase_name() {
   case "$1" in
     run_live_transport_replay_tamper_fast_lane.sh) echo "run" ;;
+    run_live_transport_replay_tamper_deep_lane.sh) echo "run" ;;
     run_live_transport_smoke_parity_lane.sh) echo "run" ;;
     run_quorum_attestation_replay_guard_lane.sh) echo "run" ;;
     run_governance_lifecycle_rollback_lane.sh) echo "run" ;;

--- a/scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh
+++ b/scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec bash "$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh" --mode deep "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh
+++ b/scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec bash "$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_contract_lane.sh" --mode deep "$@"

--- a/scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh
+++ b/scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh"
+SCRIPT_IMPL="$ROOT_DIR/scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/sdk_live_transport_replay_tamper_deep_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -10,9 +13,38 @@ if [ ! -x "$SCRIPT" ]; then
   echo "expected live transport replay/tamper deep lane script to be executable" >&2
   exit 1
 fi
+if [ ! -x "$SCRIPT_IMPL" ]; then
+  echo "expected live transport replay/tamper deep lane implementation to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
 
-if ! grep -q 'run_live_transport_replay_tamper_contract_lane.sh' "$SCRIPT"; then
-  echo "expected replay/tamper deep lane wrapper to delegate to contract lane script" >&2
+if [ ! -L "$SCRIPT" ]; then
+  echo "expected replay/tamper deep lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected replay/tamper deep lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected replay/tamper deep lane wrapper to resolve sdk manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -q 'run_live_transport_replay_tamper_deep_lane_impl.sh' "$MANIFEST_FILE"; then
+  echo "expected replay/tamper deep lane manifest to dispatch implementation module" >&2
+  exit 1
+fi
+
+if ! grep -q 'run_live_transport_replay_tamper_contract_lane.sh' "$SCRIPT_IMPL"; then
+  echo "expected replay/tamper deep lane implementation to delegate to contract lane script" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Migrate the SDK replay/tamper deep run-lane wrapper to the shared non-Kolme dispatcher manifest pattern. This removes wrapper-specific dispatch logic and keeps behavior in a dedicated `_impl` script while preserving deep-lane execution semantics.

## Changes
- `scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh`: converted to dispatcher symlink.
- `scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh`: extracted prior wrapper execution body.
- `scripts/framework/manifests/sdk_live_transport_replay_tamper_deep_lane.json`: added new manifest-backed run-phase contract.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: mapped wrapper to manifest and run phase.
- `scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh`: added fail-closed symlink/manifest/impl assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: recorded migration slice and test coverage.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `bash scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh`
- Failure: `expected live transport replay/tamper deep lane implementation to be executable`

### 🟢 Green Phase
- Command: `bash scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh`
- Result: `live transport replay/tamper deep lane tests passed.`

### 🔁 Regression
- `bash scripts/framework/test_non_kolme_sdk_contract_lane_dispatch_wrapper_matrix.sh`
- `bash scripts/ci/test_select_targets.sh`
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Bash lane migration; behavior validated via lane/contract tests |
| Functional   | ✅     | `scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh` | |
| Integration  | ✅     | `scripts/framework/test_non_kolme_sdk_contract_lane_dispatch_wrapper_matrix.sh`, `scripts/ci/test_select_targets.sh` | |
| Regression   | ✅     | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Performance  | N/A    | None | No runtime/perf-path change in this migration slice |

## Risks & Rollback
- Risk: Low. Dispatcher mapping error could break deep-lane invocation.
- Rollback: Revert this PR to restore previous wrapper execution path.

## Documentation Updates
- Updated: `docs/ci/ci-cost-and-lane-framework.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant regression suites passed

Closes #2874
