### PR TITLE
refactor(ci): migrate runtime live-network smoke run lane to dispatcher manifest (#2876)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -73,6 +73,10 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - wrapper: `scripts/sdk/run_live_transport_replay_tamper_deep_lane.sh`
   - implementation: `scripts/sdk/run_live_transport_replay_tamper_deep_lane_impl.sh`
   - manifest: `scripts/framework/manifests/sdk_live_transport_replay_tamper_deep_lane.json`
+- `#2876` migrates runtime live-network smoke run-lane wrapper to shared non-Kolme dispatcher + manifest wiring:
+  - wrapper: `scripts/runtime/run_live_network_smoke_lane.sh`
+  - implementation: `scripts/runtime/run_live_network_smoke_lane_impl.sh`
+  - manifest: `scripts/framework/manifests/runtime_live_network_smoke_lane.json`
 - Contract coverage for this migration slice:
   - `scripts/signer/test_run_signer_provider_deep_lane.sh`
   - `scripts/signer/test_run_signer_incident_recovery_deep_lane.sh`
@@ -87,6 +91,7 @@ Keep merge-critical CI fast and cost-bounded while preventing silent growth in s
   - `scripts/sdk/test_run_live_transport_smoke_parity_lane.sh`
   - `scripts/sdk/test_run_live_transport_replay_tamper_fast_lane.sh`
   - `scripts/sdk/test_run_live_transport_replay_tamper_deep_lane.sh`
+  - `scripts/runtime/test_run_live_network_smoke_lane.sh`
 
 ## Fast-Gate Delta Policy
 `scripts/ci/generate_fast_gate_budget_delta_report.sh` compares current fast-gate telemetry against a versioned baseline and emits:

--- a/scripts/framework/manifests/runtime_live_network_smoke_lane.json
+++ b/scripts/framework/manifests/runtime_live_network_smoke_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "runtime.live_network_smoke.run",
+  "evidence_key": "live_network_smoke_lane:v1",
+  "reason_key": "runtime_live_network_smoke_reason_codes:GO:v1",
+  "phases": {
+    "run": [
+      "bash",
+      "scripts/runtime/run_live_network_smoke_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -135,6 +135,7 @@ resolve_manifest_name() {
     run_lifecycle_property_contract_lane.sh) echo "runtime_lifecycle_property_contract_lane.json" ;;
     run_live_network_partition_reconnect_contract_lane.sh) echo "runtime_live_network_partition_reconnect_contract_lane.json" ;;
     run_live_network_pilot_deep_contract_lane.sh) echo "runtime_live_network_pilot_deep_contract_lane.json" ;;
+    run_live_network_smoke_lane.sh) echo "runtime_live_network_smoke_lane.json" ;;
     run_live_network_smoke_contract_lane.sh) echo "runtime_live_network_smoke_contract_lane.json" ;;
     run_processor_proof_admission_contract_lane.sh) echo "runtime_processor_proof_admission_contract_lane.json" ;;
     run_runtime_snapshot_contract_lane.sh) echo "runtime_runtime_snapshot_contract_lane.json" ;;
@@ -156,6 +157,7 @@ resolve_phase_name() {
     run_live_transport_replay_tamper_fast_lane.sh) echo "run" ;;
     run_live_transport_replay_tamper_deep_lane.sh) echo "run" ;;
     run_live_transport_smoke_parity_lane.sh) echo "run" ;;
+    run_live_network_smoke_lane.sh) echo "run" ;;
     run_quorum_attestation_replay_guard_lane.sh) echo "run" ;;
     run_governance_lifecycle_rollback_lane.sh) echo "run" ;;
     run_dashboard_shell_determinism_matrix_lane.sh) echo "run" ;;

--- a/scripts/runtime/run_live_network_smoke_lane.sh
+++ b/scripts/runtime/run_live_network_smoke_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/runtime/live_network_smoke_lane_contract.py" "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/runtime/run_live_network_smoke_lane_impl.sh
+++ b/scripts/runtime/run_live_network_smoke_lane_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/live_network_smoke_lane_contract.py" "$@"

--- a/scripts/runtime/test_run_live_network_smoke_lane.sh
+++ b/scripts/runtime/test_run_live_network_smoke_lane.sh
@@ -3,11 +3,48 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SMOKE_SCRIPT="$ROOT_DIR/scripts/runtime/run_live_network_smoke_lane.sh"
+SMOKE_SCRIPT_IMPL="$ROOT_DIR/scripts/runtime/run_live_network_smoke_lane_impl.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_live_network_smoke_lane.json"
 TMP_REPORT="$(mktemp)"
 trap 'rm -f "$TMP_REPORT"' EXIT
 
 if [ ! -x "$SMOKE_SCRIPT" ]; then
   echo "expected live-network smoke lane runner to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$SMOKE_SCRIPT_IMPL" ]; then
+  echo "expected live-network smoke lane implementation runner to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected shared non-Kolme dispatcher to be executable" >&2
+  exit 1
+fi
+
+if [ ! -L "$SMOKE_SCRIPT" ]; then
+  echo "expected live-network smoke lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$SMOKE_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected live-network smoke lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$SMOKE_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected live-network smoke lane wrapper to resolve runtime manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -q 'run_live_network_smoke_lane_impl.sh' "$MANIFEST_FILE"; then
+  echo "expected live-network smoke lane manifest to dispatch implementation module" >&2
+  exit 1
+fi
+
+if ! grep -q 'live_network_smoke_lane_contract.py' "$SMOKE_SCRIPT_IMPL"; then
+  echo "expected live-network smoke lane implementation to delegate to smoke lane contract module" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Migrate the runtime live-network smoke run-lane wrapper to the shared non-Kolme dispatcher manifest pattern. This keeps execution behavior in a dedicated `_impl` script while standardizing wrapper dispatch and reducing legacy shell surface.

## Changes
- `scripts/runtime/run_live_network_smoke_lane.sh`: converted to dispatcher symlink.
- `scripts/runtime/run_live_network_smoke_lane_impl.sh`: extracted prior wrapper execution body.
- `scripts/framework/manifests/runtime_live_network_smoke_lane.json`: added manifest-backed run-phase contract.
- `scripts/framework/run_non_kolme_contract_lane_dispatch.sh`: mapped wrapper to manifest and run phase.
- `scripts/runtime/test_run_live_network_smoke_lane.sh`: added fail-closed symlink/manifest/impl assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: recorded migration slice and test coverage.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `bash scripts/runtime/test_run_live_network_smoke_lane.sh`
- Failure: `expected live-network smoke lane implementation runner to be executable`

### 🟢 Green Phase
- Command: `bash scripts/runtime/test_run_live_network_smoke_lane.sh`
- Result: `live-network smoke lane script tests passed.`

### 🔁 Regression
- `bash scripts/framework/test_non_kolme_manifest_backed_contract_lane_dispatch_wrapper_matrix.sh`
- `bash scripts/ci/test_select_targets.sh`
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Bash lane migration; behavior validated via lane/contract tests |
| Functional   | ✅     | `scripts/runtime/test_run_live_network_smoke_lane.sh` | |
| Integration  | ✅     | `scripts/framework/test_non_kolme_manifest_backed_contract_lane_dispatch_wrapper_matrix.sh`, `scripts/ci/test_select_targets.sh` | |
| Regression   | ✅     | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Performance  | N/A    | None | No throughput/runtime behavior change in this migration slice |

## Risks & Rollback
- Risk: Low. Incorrect mapping could break live-network smoke run-lane dispatch.
- Rollback: Revert this PR to restore previous wrapper execution path.

## Documentation Updates
- Updated: `docs/ci/ci-cost-and-lane-framework.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant regression suites passed

Closes #2876
