### PR TITLE
test(runtime): add daemon os-signal live validation drill (#2898)

### DIFF
--- a/scripts/runtime/test_validate_daemon_os_signal_live.sh
+++ b/scripts/runtime/test_validate_daemon_os_signal_live.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_daemon_os_signal_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected daemon os signal live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected daemon os signal live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected daemon os signal live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^os_signal_shutdown_status=verified$'; then
+  echo "expected daemon os signal live validation shutdown marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^failure_case_status=verified$'; then
+  echo "expected daemon os signal live validation fail-closed marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.daemon-os-signal-live-validation.v1":
+    raise SystemExit("unexpected daemon os signal live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected daemon os signal live validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected daemon os signal live validation final_decision=GO")
+if payload.get("os_signal_shutdown_status") != "verified":
+    raise SystemExit("expected os_signal_shutdown_status=verified")
+if payload.get("failure_case_status") != "verified":
+    raise SystemExit("expected failure_case_status=verified")
+PY
+
+echo "daemon os signal live validation tests passed."

--- a/scripts/runtime/validate_daemon_os_signal_live.sh
+++ b/scripts/runtime/validate_daemon_os_signal_live.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=120
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+
+pushd "$ROOT_DIR" >/dev/null
+cargo build --quiet -p kamn-node
+NODE_BIN="$ROOT_DIR/target/debug/kamn-node"
+popd >/dev/null
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "expected built kamn-node binary to be executable" >&2
+  exit 1
+fi
+
+signal_stdout="$TMP_DIR/daemon-os-signal.out"
+"$NODE_BIN" \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode daemon \
+  --daemon-max-ticks 200 \
+  --daemon-tick-interval-ms 5 \
+  --daemon-shutdown-os-signals \
+  --daemon-shutdown-drain-ticks 2 \
+  --daemon-shutdown-timeout-ticks 8 \
+  --output json >"$signal_stdout" 2>&1 &
+node_pid=$!
+
+started=0
+for _ in $(seq 1 50); do
+  if grep -q 'node.runtime.daemon.execute.start' "$signal_stdout"; then
+    started=1
+    break
+  fi
+  if ! kill -0 "$node_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.02
+done
+
+if [ "$started" -ne 1 ]; then
+  cat "$signal_stdout" >&2
+  echo "expected daemon process to emit startup marker before signal drill" >&2
+  kill -KILL "$node_pid" 2>/dev/null || true
+  wait "$node_pid" 2>/dev/null || true
+  exit 1
+fi
+
+kill -TERM "$node_pid"
+set +e
+wait "$node_pid"
+node_exit_code=$?
+set -e
+if [ "$node_exit_code" -ne 0 ]; then
+  cat "$signal_stdout" >&2
+  echo "expected daemon os signal drill process to exit cleanly" >&2
+  exit 1
+fi
+
+if ! grep -q '"runtime_mode":"daemon"' "$signal_stdout"; then
+  cat "$signal_stdout" >&2
+  echo "expected daemon runtime mode marker in os signal drill output" >&2
+  exit 1
+fi
+
+completion_reason_marker="$(grep -o '"daemon_completion_reason":"[^"]*"' "$signal_stdout" | head -n 1 | cut -d '"' -f 4)"
+if [ -z "$completion_reason_marker" ]; then
+  cat "$signal_stdout" >&2
+  echo "expected daemon completion reason marker in os signal drill output" >&2
+  exit 1
+fi
+
+case "$completion_reason_marker" in
+  graceful-shutdown:*|graceful-shutdown-timeout:*)
+    ;;
+  *)
+    cat "$signal_stdout" >&2
+    echo "expected graceful shutdown completion reason from os signal drill" >&2
+    exit 1
+    ;;
+esac
+
+set +e
+failure_stdout="$($NODE_BIN \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode invalid \
+  --output json 2>&1)"
+failure_code=$?
+set -e
+if [ "$failure_code" -eq 0 ]; then
+  echo "expected invalid runtime-mode drill to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$failure_stdout" | grep -qi 'invalid runtime mode'; then
+  printf '%s\n' "$failure_stdout" >&2
+  echo "expected invalid runtime mode reason marker in fail-closed drill" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "daemon os signal live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/daemon-os-signal-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.daemon-os-signal-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "os_signal_shutdown_status": "verified",
+  "failure_case_status": "verified",
+  "completion_reason_marker": "$completion_reason_marker",
+  "failure_reason_marker": "invalid-runtime-mode",
+  "elapsed_seconds": $elapsed_seconds
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "os_signal_shutdown_status=verified"
+echo "failure_case_status=verified"


### PR DESCRIPTION
## Summary
Add a live-validation drill for daemon OS signal handling. The new lane runs a real `kamn-node` daemon process, sends `SIGTERM`, verifies graceful shutdown markers, and validates a fail-closed invalid runtime-mode path.

## Changes
- `scripts/runtime/validate_daemon_os_signal_live.sh`
  - Builds and runs `target/debug/kamn-node` in daemon mode with `--daemon-shutdown-os-signals`.
  - Waits for daemon startup marker, sends `SIGTERM`, and verifies graceful shutdown completion markers.
  - Executes an invalid runtime-mode drill and verifies fail-closed behavior.
  - Emits deterministic marker lines and JSON artifact schema `kamn.runtime.daemon-os-signal-live-validation.v1`.
- `scripts/runtime/test_validate_daemon_os_signal_live.sh`
  - Contract test for required marker lines and JSON schema fields.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `bash scripts/runtime/test_validate_daemon_os_signal_live.sh`
- Failure: `expected daemon os signal live validation script to be executable`

### 🟢 Green Phase
- Command: `bash scripts/runtime/test_validate_daemon_os_signal_live.sh`
- Result: `daemon os signal live validation tests passed.`

### 🔁 Regression
- `bash scripts/ci/test_select_targets.sh`
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | None | Shell lane orchestration |
| Functional   | ✅ | `scripts/runtime/test_validate_daemon_os_signal_live.sh` | |
| Integration  | ✅ | Real process execution + SIGTERM drill in `validate_daemon_os_signal_live.sh` | |
| Regression   | ✅ | `bash scripts/ci/test_select_targets.sh`, `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Performance  | ✅ | Runtime budget guard via `--max-seconds` in validation lane | |

## Risks & Rollback
- Risk: low. Adds validation scripts only; no production Rust code changes.
- Rollback: revert this PR to remove live validation drill scripts.

## Documentation Updates
- None required for this focused validation lane addition; issue comments carry evidence references.

## Validation Checklist
- [x] TDD Red/Green evidence included above
- [x] Relevant regression suites passed

Closes #2898
Closes #2899
Refs #2895
