### PR TITLE
feat(core): add durable file adapters for content and did chain (#2901)

### DIFF
--- a/crates/kamn-core/src/content_storage.rs
+++ b/crates/kamn-core/src/content_storage.rs
@@ -5,10 +5,15 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 const CID_PREFIX: &str = "kamn:cid:v1:";
 const CONTENT_URI_PREFIX: &str = "kamn:content:v1:";
 const CID_HASH_HEX_LEN: usize = 16;
+const CONTENT_STORE_SCHEMA_VERSION: &str = "kamn.content.file-store.v1";
 
 /// Stored content payload and metadata returned by `get`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,6 +149,91 @@ impl ContentStorageAdapter for InMemoryContentAdapter {
     }
 }
 
+/// File-backed implementation of `ContentStorageAdapter`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileContentAdapter {
+    path: PathBuf,
+    objects: BTreeMap<String, StoredObject>,
+}
+
+impl FileContentAdapter {
+    /// Creates a file-backed content adapter from a persistence path.
+    pub fn new(path: PathBuf) -> Result<Self, ContentStorageError> {
+        if path.as_os_str().is_empty() {
+            return Err(ContentStorageError::InvalidPayload(
+                "content store path cannot be empty".to_owned(),
+            ));
+        }
+        let objects = read_content_store_file(&path)?;
+        Ok(Self { path, objects })
+    }
+}
+
+impl ContentStorageAdapter for FileContentAdapter {
+    fn put(
+        &mut self,
+        media_type: &str,
+        payload: &[u8],
+    ) -> Result<ContentHead, ContentStorageError> {
+        if media_type.trim().is_empty() {
+            return Err(ContentStorageError::EmptyField("media_type"));
+        }
+
+        let cid = cid_for_payload(payload);
+        let record = StoredObject {
+            media_type: media_type.to_owned(),
+            payload: payload.to_vec(),
+            integrity_tag: integrity_tag_for_payload(payload),
+        };
+        self.objects.insert(cid.clone(), record.clone());
+        persist_content_store_file(&self.path, &self.objects)?;
+        Ok(content_head_from_stored(&cid, &record))
+    }
+
+    fn get(&self, cid: &str) -> Result<ContentObject, ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+        Ok(ContentObject {
+            cid: cid.to_owned(),
+            media_type: object.media_type.clone(),
+            payload: object.payload.clone(),
+            integrity_tag: object.integrity_tag.clone(),
+        })
+    }
+
+    fn head(&self, cid: &str) -> Result<ContentHead, ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+        Ok(content_head_from_stored(cid, object))
+    }
+
+    fn verify(&self, cid: &str) -> Result<(), ContentStorageError> {
+        validate_cid(cid)?;
+        let object = self
+            .objects
+            .get(cid)
+            .ok_or_else(|| ContentStorageError::NotFound(cid.to_owned()))?;
+
+        let expected_cid = cid_for_payload(&object.payload);
+        let expected_integrity_tag = integrity_tag_for_payload(&object.payload);
+        if expected_cid != cid || expected_integrity_tag != object.integrity_tag {
+            return Err(ContentStorageError::IntegrityMismatch {
+                cid: cid.to_owned(),
+                expected: expected_integrity_tag,
+                found: object.integrity_tag.clone(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
 /// Converts a CID into canonical content URI form.
 pub fn content_uri_for_cid(cid: &str) -> Result<String, ContentStorageError> {
     validate_cid(cid)?;
@@ -164,6 +254,10 @@ pub fn cid_from_content_uri(uri: &str) -> Result<String, ContentStorageError> {
 pub enum ContentStorageError {
     /// Required string field was empty.
     EmptyField(&'static str),
+    /// Filesystem I/O failed for persistence operation.
+    Io(String),
+    /// Persisted payload format was invalid.
+    InvalidPayload(String),
     /// CID string failed validation.
     InvalidCid(String),
     /// Content URI string failed validation.
@@ -185,6 +279,8 @@ impl fmt::Display for ContentStorageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::Io(value) => write!(f, "content storage I/O error: {value}"),
+            Self::InvalidPayload(value) => write!(f, "content storage invalid payload: {value}"),
             Self::InvalidCid(value) => write!(f, "invalid content identifier: {value}"),
             Self::InvalidContentUri(value) => write!(f, "invalid content uri: {value}"),
             Self::NotFound(value) => write!(f, "content not found: {value}"),
@@ -215,6 +311,150 @@ fn content_head_from_stored(cid: &str, object: &StoredObject) -> ContentHead {
         media_type: object.media_type.clone(),
         size_bytes: object.payload.len() as u64,
         integrity_tag: object.integrity_tag.clone(),
+    }
+}
+
+fn read_content_store_file(
+    path: &Path,
+) -> Result<BTreeMap<String, StoredObject>, ContentStorageError> {
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+
+    let payload =
+        fs::read_to_string(path).map_err(|error| ContentStorageError::Io(error.to_string()))?;
+    if payload.trim().is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    parse_content_store_payload(&payload)
+}
+
+fn persist_content_store_file(
+    path: &Path,
+    objects: &BTreeMap<String, StoredObject>,
+) -> Result<(), ContentStorageError> {
+    let payload = serialize_content_store_payload(objects);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| ContentStorageError::Io(error.to_string()))?;
+    file.write_all(payload.as_bytes())
+        .map_err(|error| ContentStorageError::Io(error.to_string()))
+}
+
+fn serialize_content_store_payload(objects: &BTreeMap<String, StoredObject>) -> String {
+    let mut lines = Vec::with_capacity(objects.len() + 1);
+    lines.push(format!("schema|{CONTENT_STORE_SCHEMA_VERSION}"));
+    for (cid, object) in objects {
+        let media_type_hex = encode_hex(object.media_type.as_bytes());
+        let payload_hex = encode_hex(&object.payload);
+        lines.push(format!(
+            "object|{cid}|{media_type_hex}|{payload_hex}|{}",
+            object.integrity_tag
+        ));
+    }
+    lines.join("\n")
+}
+
+fn parse_content_store_payload(
+    payload: &str,
+) -> Result<BTreeMap<String, StoredObject>, ContentStorageError> {
+    let mut lines = payload.lines().filter(|line| !line.trim().is_empty());
+    let Some(schema_line) = lines.next() else {
+        return Ok(BTreeMap::new());
+    };
+    let expected_schema = format!("schema|{CONTENT_STORE_SCHEMA_VERSION}");
+    if schema_line != expected_schema {
+        return Err(ContentStorageError::InvalidPayload(schema_line.to_owned()));
+    }
+
+    let mut objects = BTreeMap::new();
+    for line in lines {
+        let mut parts = line.split('|');
+        let Some(prefix) = parts.next() else {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        };
+        let Some(cid) = parts.next() else {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        };
+        let Some(media_type_hex) = parts.next() else {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        };
+        let Some(payload_hex) = parts.next() else {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        };
+        let Some(integrity_tag) = parts.next() else {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        };
+        if prefix != "object" || parts.next().is_some() {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        }
+
+        validate_cid(cid)?;
+        let media_type_bytes = decode_hex(media_type_hex)
+            .ok_or_else(|| ContentStorageError::InvalidPayload(line.to_owned()))?;
+        let media_type = String::from_utf8(media_type_bytes)
+            .map_err(|_| ContentStorageError::InvalidPayload(line.to_owned()))?;
+        if media_type.trim().is_empty() {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        }
+        let payload_bytes = decode_hex(payload_hex)
+            .ok_or_else(|| ContentStorageError::InvalidPayload(line.to_owned()))?;
+        let expected_cid = cid_for_payload(&payload_bytes);
+        if expected_cid != cid {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        }
+        let expected_integrity_tag = integrity_tag_for_payload(&payload_bytes);
+        if expected_integrity_tag != integrity_tag {
+            return Err(ContentStorageError::InvalidPayload(line.to_owned()));
+        }
+
+        let object = StoredObject {
+            media_type,
+            payload: payload_bytes,
+            integrity_tag: integrity_tag.to_owned(),
+        };
+        objects.insert(cid.to_owned(), object);
+    }
+
+    Ok(objects)
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let high = decode_nibble(bytes[index])?;
+        let low = decode_nibble(bytes[index + 1])?;
+        decoded.push((high << 4) | low);
+        index += 2;
+    }
+    Some(decoded)
+}
+
+fn decode_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
     }
 }
 

--- a/crates/kamn-core/src/did_registry.rs
+++ b/crates/kamn-core/src/did_registry.rs
@@ -1,8 +1,17 @@
 //! DID registry lifecycle, idempotent submission, and finality tracking contracts.
 
 use crate::{AgentDid, DidDocument};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const DID_CHAIN_ADAPTER_SCHEMA_VERSION: &str = "kamn.did.chain-adapter.v1";
+type SubmissionReceiptIndex = BTreeMap<String, DidChainSubmissionReceipt>;
+type SubmissionRejectIndex = BTreeMap<String, String>;
+type PersistedDidChainAdapterState = (SubmissionReceiptIndex, SubmissionRejectIndex);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DidRegistryRecord {
@@ -212,6 +221,87 @@ impl DidRegistrationChainAdapter for InMemoryDidRegistrationChainAdapter {
         };
         self.receipts_by_key
             .insert(request.idempotency_key.clone(), receipt.clone());
+        Ok(DidChainSubmissionOutcome::Submitted(receipt))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// File-backed chain adapter with deterministic idempotency persistence.
+pub struct FileDidRegistrationChainAdapter {
+    provider: String,
+    path: PathBuf,
+    receipts_by_key: SubmissionReceiptIndex,
+    rejected_reasons_by_key: SubmissionRejectIndex,
+}
+
+impl FileDidRegistrationChainAdapter {
+    /// Creates a file-backed adapter from persisted state.
+    pub fn new(path: PathBuf, provider: &str) -> Result<Self, DidRegistryError> {
+        if path.as_os_str().is_empty() {
+            return Err(DidRegistryError::PersistenceInvalidPayload(
+                "did chain adapter path cannot be empty".to_owned(),
+            ));
+        }
+        if provider.trim().is_empty() {
+            return Err(DidRegistryError::PersistenceInvalidPayload(
+                "did chain adapter provider cannot be empty".to_owned(),
+            ));
+        }
+        let (receipts_by_key, rejected_reasons_by_key) = read_did_chain_adapter_file(&path)?;
+        Ok(Self {
+            provider: provider.to_owned(),
+            path,
+            receipts_by_key,
+            rejected_reasons_by_key,
+        })
+    }
+
+    /// Configures an idempotency key to return a rejected outcome.
+    pub fn reject_idempotency_key(
+        &mut self,
+        idempotency_key: &str,
+        reason: &str,
+    ) -> Result<(), DidRegistryError> {
+        self.rejected_reasons_by_key
+            .insert(idempotency_key.to_owned(), reason.to_owned());
+        persist_did_chain_adapter_file(
+            &self.path,
+            &self.receipts_by_key,
+            &self.rejected_reasons_by_key,
+        )
+    }
+}
+
+impl DidRegistrationChainAdapter for FileDidRegistrationChainAdapter {
+    fn submit_registration(
+        &mut self,
+        request: &DidChainSubmissionRequest,
+    ) -> Result<DidChainSubmissionOutcome, DidRegistryError> {
+        if let Some(reason) = self.rejected_reasons_by_key.get(&request.idempotency_key) {
+            return Ok(DidChainSubmissionOutcome::Rejected {
+                reason: reason.clone(),
+            });
+        }
+
+        if let Some(existing) = self.receipts_by_key.get(&request.idempotency_key) {
+            return Ok(DidChainSubmissionOutcome::Duplicate(existing.clone()));
+        }
+
+        let receipt = DidChainSubmissionReceipt {
+            provider: self.provider.clone(),
+            transaction_id: format!(
+                "did-tx:{}:{}",
+                request.did.method_specific_id(),
+                request.idempotency_key.len()
+            ),
+        };
+        self.receipts_by_key
+            .insert(request.idempotency_key.clone(), receipt.clone());
+        persist_did_chain_adapter_file(
+            &self.path,
+            &self.receipts_by_key,
+            &self.rejected_reasons_by_key,
+        )?;
         Ok(DidChainSubmissionOutcome::Submitted(receipt))
     }
 }
@@ -726,6 +816,10 @@ pub enum DidRegistryError {
         /// Revocation state before action.
         from_revoked: bool,
     },
+    /// Filesystem I/O failed while persisting chain adapter state.
+    PersistenceIo(String),
+    /// Persisted chain adapter payload was invalid.
+    PersistenceInvalidPayload(String),
 }
 
 impl DidRegistryError {
@@ -748,6 +842,8 @@ impl DidRegistryError {
             Self::InvalidLifecycleMutationTransition { .. } => {
                 "did_lifecycle_mutation_invalid_transition"
             }
+            Self::PersistenceIo(_) => "did_registry_persistence_io",
+            Self::PersistenceInvalidPayload(_) => "did_registry_persistence_invalid_payload",
         }
     }
 }
@@ -824,11 +920,191 @@ impl fmt::Display for DidRegistryError {
                     "invalid lifecycle mutation transition for did {did}; action {action}, revoked={from_revoked}"
                 )
             }
+            Self::PersistenceIo(value) => write!(f, "did registry persistence I/O error: {value}"),
+            Self::PersistenceInvalidPayload(value) => {
+                write!(f, "did registry persistence invalid payload: {value}")
+            }
         }
     }
 }
 
 impl std::error::Error for DidRegistryError {}
+
+fn read_did_chain_adapter_file(
+    path: &Path,
+) -> Result<PersistedDidChainAdapterState, DidRegistryError> {
+    if !path.exists() {
+        return Ok((BTreeMap::new(), BTreeMap::new()));
+    }
+
+    let payload = fs::read_to_string(path)
+        .map_err(|error| DidRegistryError::PersistenceIo(error.to_string()))?;
+    if payload.trim().is_empty() {
+        return Ok((BTreeMap::new(), BTreeMap::new()));
+    }
+    parse_did_chain_adapter_payload(&payload)
+}
+
+fn persist_did_chain_adapter_file(
+    path: &Path,
+    receipts_by_key: &SubmissionReceiptIndex,
+    rejected_reasons_by_key: &SubmissionRejectIndex,
+) -> Result<(), DidRegistryError> {
+    let payload = serialize_did_chain_adapter_payload(receipts_by_key, rejected_reasons_by_key);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| DidRegistryError::PersistenceIo(error.to_string()))?;
+    file.write_all(payload.as_bytes())
+        .map_err(|error| DidRegistryError::PersistenceIo(error.to_string()))
+}
+
+fn serialize_did_chain_adapter_payload(
+    receipts_by_key: &SubmissionReceiptIndex,
+    rejected_reasons_by_key: &SubmissionRejectIndex,
+) -> String {
+    let mut lines = vec![format!("schema|{DID_CHAIN_ADAPTER_SCHEMA_VERSION}")];
+
+    for (idempotency_key, reason) in rejected_reasons_by_key {
+        lines.push(format!(
+            "reject|{}|{}",
+            encode_hex(idempotency_key.as_bytes()),
+            encode_hex(reason.as_bytes())
+        ));
+    }
+    for (idempotency_key, receipt) in receipts_by_key {
+        lines.push(format!(
+            "receipt|{}|{}|{}",
+            encode_hex(idempotency_key.as_bytes()),
+            encode_hex(receipt.provider.as_bytes()),
+            encode_hex(receipt.transaction_id.as_bytes())
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn parse_did_chain_adapter_payload(
+    payload: &str,
+) -> Result<PersistedDidChainAdapterState, DidRegistryError> {
+    let mut lines = payload.lines().filter(|line| !line.trim().is_empty());
+    let Some(schema_line) = lines.next() else {
+        return Ok((BTreeMap::new(), BTreeMap::new()));
+    };
+    let expected_schema = format!("schema|{DID_CHAIN_ADAPTER_SCHEMA_VERSION}");
+    if schema_line != expected_schema {
+        return Err(DidRegistryError::PersistenceInvalidPayload(
+            schema_line.to_owned(),
+        ));
+    }
+
+    let mut receipts_by_key = SubmissionReceiptIndex::new();
+    let mut rejected_reasons_by_key = SubmissionRejectIndex::new();
+
+    for line in lines {
+        let mut parts = line.split('|');
+        let Some(prefix) = parts.next() else {
+            return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+        };
+        match prefix {
+            "reject" => {
+                let Some(key_hex) = parts.next() else {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                };
+                let Some(reason_hex) = parts.next() else {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                };
+                if parts.next().is_some() {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                }
+                let key_bytes = decode_hex(key_hex)
+                    .ok_or_else(|| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let reason_bytes = decode_hex(reason_hex)
+                    .ok_or_else(|| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let key = String::from_utf8(key_bytes)
+                    .map_err(|_| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let reason = String::from_utf8(reason_bytes)
+                    .map_err(|_| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                if rejected_reasons_by_key.insert(key, reason).is_some() {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                }
+            }
+            "receipt" => {
+                let Some(key_hex) = parts.next() else {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                };
+                let Some(provider_hex) = parts.next() else {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                };
+                let Some(transaction_hex) = parts.next() else {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                };
+                if parts.next().is_some() {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                }
+                let key_bytes = decode_hex(key_hex)
+                    .ok_or_else(|| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let provider_bytes = decode_hex(provider_hex)
+                    .ok_or_else(|| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let transaction_bytes = decode_hex(transaction_hex)
+                    .ok_or_else(|| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let key = String::from_utf8(key_bytes)
+                    .map_err(|_| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let provider = String::from_utf8(provider_bytes)
+                    .map_err(|_| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let transaction_id = String::from_utf8(transaction_bytes)
+                    .map_err(|_| DidRegistryError::PersistenceInvalidPayload(line.to_owned()))?;
+                let receipt = DidChainSubmissionReceipt {
+                    provider,
+                    transaction_id,
+                };
+                if receipts_by_key.insert(key, receipt).is_some() {
+                    return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned()));
+                }
+            }
+            _ => return Err(DidRegistryError::PersistenceInvalidPayload(line.to_owned())),
+        }
+    }
+
+    Ok((receipts_by_key, rejected_reasons_by_key))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let high = decode_nibble(bytes[index])?;
+        let low = decode_nibble(bytes[index + 1])?;
+        decoded.push((high << 4) | low);
+        index += 2;
+    }
+    Some(decoded)
+}
+
+fn decode_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -178,7 +178,7 @@ pub use content_retrieval::{
 };
 pub use content_storage::{
     cid_from_content_uri, content_uri_for_cid, ContentHead, ContentObject, ContentStorageAdapter,
-    ContentStorageError, InMemoryContentAdapter,
+    ContentStorageError, FileContentAdapter, InMemoryContentAdapter,
 };
 pub use cross_chain_bridge::{
     CrossChainBridgeConfig, CrossChainBridgeEngine, CrossChainBridgeError,
@@ -206,7 +206,7 @@ pub use did_registry::{
     DidChainSubmissionResult, DidLifecycleMutationAction, DidLifecycleMutationEvidence,
     DidLifecycleMutationRequest, DidRegistrationChainAdapter, DidRegistry, DidRegistryError,
     DidSubmissionFinalityRecord, DidSubmissionFinalityStatus, DidSubmissionRetryClass,
-    InMemoryDidRegistrationChainAdapter,
+    FileDidRegistrationChainAdapter, InMemoryDidRegistrationChainAdapter,
 };
 pub use direct_message_crypto::{
     DirectMessageCiphertext, DirectMessageCryptoEngine, DirectMessageCryptoError,

--- a/crates/kamn-core/tests/content_storage_file_adapter.rs
+++ b/crates/kamn-core/tests/content_storage_file_adapter.rs
@@ -1,0 +1,83 @@
+use kamn_core::{
+    cid_from_content_uri, content_uri_for_cid, ContentStorageAdapter, ContentStorageError,
+    FileContentAdapter, TaskArtifactRegistry, TaskArtifactSubmission,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_file(tag: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should advance")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "kamn-content-file-adapter-{tag}-{}-{nonce}.log",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn content_storage_file_adapter_persists_round_trip_across_reopen() {
+    let path = unique_temp_file("roundtrip");
+    let mut adapter = FileContentAdapter::new(path.clone()).expect("store should build");
+    let head = adapter
+        .put("application/json", br#"{"task":"persist"}"#)
+        .expect("put should succeed");
+
+    let reopened = FileContentAdapter::new(path.clone()).expect("reopen should succeed");
+    let object = reopened.get(&head.cid).expect("get should succeed");
+    assert_eq!(object.media_type, "application/json");
+    assert_eq!(object.payload, br#"{"task":"persist"}"#);
+
+    fs::remove_file(path).expect("cleanup should succeed");
+}
+
+#[test]
+fn content_storage_file_adapter_integration_supports_task_artifact_uri_reference() {
+    let path = unique_temp_file("artifact");
+    let mut adapter = FileContentAdapter::new(path.clone()).expect("store should build");
+    let head = adapter
+        .put("application/pdf", b"%PDF-1.7 file adapter")
+        .expect("put should succeed");
+
+    let uri = content_uri_for_cid(&head.cid).expect("uri generation should succeed");
+    let cid = cid_from_content_uri(&uri).expect("uri should decode cid");
+    assert_eq!(cid, head.cid);
+
+    let mut registry = TaskArtifactRegistry::new();
+    let on_chain_hash =
+        TaskArtifactRegistry::integrity_fingerprint("task-file-1", "kamn:did:agent:file-1", &uri);
+    registry
+        .register(TaskArtifactSubmission {
+            artifact_id: "artifact-file-1".to_owned(),
+            task_id: "task-file-1".to_owned(),
+            creator: "kamn:did:agent:file-1".to_owned(),
+            created_at_unix: 1_716_000_000,
+            on_chain_hash,
+            off_chain_uri: uri,
+            content_type: "application/pdf".to_owned(),
+        })
+        .expect("artifact registration should succeed");
+
+    fs::remove_file(path).expect("cleanup should succeed");
+}
+
+#[test]
+fn content_storage_file_adapter_regression_rejects_corrupt_payload_line() {
+    // Regression: #2902
+    let path = unique_temp_file("corrupt");
+    fs::write(
+        &path,
+        "schema|kamn.content.file-store.v1\nobject|not-valid\n",
+    )
+    .expect("fixture write should succeed");
+
+    let result = FileContentAdapter::new(path.clone());
+    assert!(matches!(
+        result,
+        Err(ContentStorageError::InvalidPayload(value)) if value.contains("object|not-valid")
+    ));
+
+    fs::remove_file(path).expect("cleanup should succeed");
+}

--- a/crates/kamn-core/tests/did_registry_file_chain_adapter.rs
+++ b/crates/kamn-core/tests/did_registry_file_chain_adapter.rs
@@ -1,0 +1,80 @@
+use kamn_core::{
+    canonical_did_document, AgentDid, AgentDidMetadata, DidChainSubmissionOutcome, DidDocument,
+    DidRegistry, DidRegistryError, FileDidRegistrationChainAdapter,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn metadata(model_family: &str) -> AgentDidMetadata {
+    AgentDidMetadata {
+        agent_type: "autonomous".to_owned(),
+        model_family: model_family.to_owned(),
+        capabilities: vec!["text".to_owned()],
+        operator: None,
+    }
+}
+
+fn document_for(did: &AgentDid, model_family: &str) -> DidDocument {
+    canonical_did_document(did, "z6Mpub", metadata(model_family))
+        .expect("did document should build")
+}
+
+fn unique_temp_file(tag: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should advance")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "kamn-did-chain-adapter-{tag}-{}-{nonce}.log",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn did_registry_file_chain_adapter_persists_duplicate_detection_across_restart() {
+    let path = unique_temp_file("duplicate");
+
+    let mut first_registry = DidRegistry::new();
+    let mut first_adapter =
+        FileDidRegistrationChainAdapter::new(path.clone(), "ledger-file").expect("adapter");
+    let did = AgentDid::parse("kamn:did:agent:file-adapter-1").expect("did should parse");
+    let document = document_for(&did, "gpt-5");
+
+    let first = first_registry
+        .submit_registration_via_chain_adapter(&mut first_adapter, did.clone(), document.clone())
+        .expect("first submit should succeed");
+    assert!(matches!(
+        first.outcome,
+        DidChainSubmissionOutcome::Submitted(_)
+    ));
+
+    let mut second_registry = DidRegistry::new();
+    let mut second_adapter =
+        FileDidRegistrationChainAdapter::new(path.clone(), "ledger-file").expect("adapter");
+    let second = second_registry
+        .submit_registration_via_chain_adapter(&mut second_adapter, did, document)
+        .expect("retry submit should succeed");
+    assert!(matches!(
+        second.outcome,
+        DidChainSubmissionOutcome::Duplicate(_)
+    ));
+
+    fs::remove_file(path).expect("cleanup should succeed");
+}
+
+#[test]
+fn did_registry_file_chain_adapter_regression_rejects_corrupt_payload_line() {
+    // Regression: #2902
+    let path = unique_temp_file("corrupt");
+    fs::write(&path, "schema|kamn.did.chain-adapter.v1\nreceipt|broken\n")
+        .expect("fixture write should succeed");
+
+    let result = FileDidRegistrationChainAdapter::new(path.clone(), "ledger-file");
+    assert!(matches!(
+        result,
+        Err(DidRegistryError::PersistenceInvalidPayload(value)) if value.contains("receipt|broken")
+    ));
+
+    fs::remove_file(path).expect("cleanup should succeed");
+}

--- a/docs/architecture/persistence-backends.md
+++ b/docs/architecture/persistence-backends.md
@@ -1,0 +1,57 @@
+# Persistence Backends
+
+## Scope
+
+This document tracks durable persistence backends used by `kamn-core` and the validation strategy for low-cost CI.
+
+Current execution slice is Task #2901 under Story #2900.
+
+## Backends
+
+| Surface | In-memory adapter | Durable adapter | Notes |
+|---|---|---|---|
+| Channel snapshots | `InMemoryChannelSnapshotStore` | `FileChannelSnapshotStore` | Snapshot + journal replay/repair |
+| Message lifecycle snapshots | `InMemoryMessageLifecycleSnapshotStore` | `FileMessageLifecycleSnapshotStore` | Snapshot + journal replay/repair |
+| Task operation snapshots | `InMemoryTaskOperationSnapshotStore` | `FileTaskOperationSnapshotStore` | Snapshot + journal replay/repair |
+| Runtime snapshots | `InMemoryRuntimeSnapshotStore` | `FileRuntimeSnapshotStore` | Snapshot continuity guards |
+| Durable guard bundles | `InMemoryDurableGuardSnapshotStore` | `FileDurableGuardSnapshotStore` | Bundle schema validation |
+| Content objects | `InMemoryContentAdapter` | `FileContentAdapter` | Deterministic file payload with CID/integrity verification |
+| DID chain submission idempotency | `InMemoryDidRegistrationChainAdapter` | `FileDidRegistrationChainAdapter` | Durable duplicate/reject state across restarts |
+
+## New File-Backed Formats
+
+### Content Store
+
+- Schema header: `schema|kamn.content.file-store.v1`
+- Record line: `object|<cid>|<media_type_hex>|<payload_hex>|<integrity_tag>`
+- Deterministic behavior:
+  - CIDs are recomputed from payload and must match persisted `cid`.
+  - Integrity tags are recomputed and must match persisted `integrity_tag`.
+  - Malformed records fail closed as `ContentStorageError::InvalidPayload`.
+
+### DID Chain Adapter Store
+
+- Schema header: `schema|kamn.did.chain-adapter.v1`
+- Rejection line: `reject|<idempotency_key_hex>|<reason_hex>`
+- Receipt line: `receipt|<idempotency_key_hex>|<provider_hex>|<transaction_id_hex>`
+- Deterministic behavior:
+  - Duplicate keys in persisted payload fail closed as `DidRegistryError::PersistenceInvalidPayload`.
+  - Restarted adapters preserve duplicate-detection behavior for idempotency keys.
+
+## Validation Matrix
+
+Low-cost lane (PR-safe):
+
+- `cargo test -p kamn-core --test content_storage_file_adapter`
+- `cargo test -p kamn-core --test did_registry_file_chain_adapter`
+- `cargo test -p kamn-core --test content_storage_adapter`
+- `cargo test -p kamn-core --test did_registry_transactions`
+- `cargo fmt --check`
+- `cargo clippy -p kamn-core -- -D warnings`
+
+Cost controls:
+
+- No networked dependencies.
+- No external database services.
+- Deterministic file fixtures only.
+- Runtime stays in sub-second range for targeted tests.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -1,0 +1,274 @@
+# KAMN: From Protocol Spec to Production Service
+
+## Current State (honest assessment)
+
+What you have is **88K lines of Rust that define the rules** — domain types, state machines, validation guards, contract tests — plus a working HTTP/WebSocket client for Kolme blockchain integration and a localhost TCP demo. What you don't have is anything that runs as a service.
+
+There is **zero async code** in the entire codebase. No tokio, no `async fn`, no `.await`. All networking is synchronous blocking I/O. There is no database. There is no HTTP server. There is no P2P layer. Every store is `InMemory*` with no persistence.
+
+---
+
+## Execution Status Update (2026-02-14)
+
+- Phase 1.1 delivered: `kamn-node` now runs with a tokio runtime boundary (Story #2890).
+- Phase 1.2 delivered: daemon shutdown now handles real OS signals on tokio signal streams (Story #2895).
+- Phase 1.3 in progress:
+  - Delivered in this slice: `FileContentAdapter` and `FileDidRegistrationChainAdapter` in `kamn-core` (Task #2901).
+  - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
+
+---
+
+## Phase 1: Make a Node That Stays Running (Foundation)
+
+### 1.1 — Add an async runtime
+
+This is the single biggest blocker. The entire codebase is synchronous. You need tokio.
+
+- Add `tokio` to `kamn-node/Cargo.toml` with `rt-multi-thread`, `macros`, `net`, `time`, `signal` features
+- Convert `fn main()` to `#[tokio::main] async fn main()`
+- The existing synchronous domain logic in `kamn-core` does NOT need to change — it's pure computation. Wrap it at the node boundary
+- Estimated scope: `kamn-node` only. `kamn-core` stays sync
+
+### 1.2 — Real OS signal handling
+
+`daemon_shutdown.rs` currently simulates signals via CLI tick arguments. Replace with actual signal handling:
+
+- Add `tokio::signal::unix::signal(SignalKind::terminate())` and `ctrl_c()`
+- Wire into the existing `evaluate_daemon_completion` logic
+- This is ~50 lines of real code wrapping what already exists
+
+### 1.3 — Persistent storage
+
+Every store is in-memory. You need at minimum one real backend. Recommended: **redb** (embedded, zero-config, Rust-native) or **SQLite via rusqlite**.
+
+Stores that need real backends (priority order):
+
+| Store | What it holds | Current impl |
+|---|---|---|
+| `ReputationStore` | Agent trust scores, endorsements, disputes | `BTreeMap` |
+| `ChannelSnapshotStore` | Channel metadata, membership | `InMemoryChannelSnapshotStore` |
+| `MessageLifecycleSnapshotStore` | Message status, delivery tracking | `InMemoryMessageLifecycleSnapshotStore` |
+| `TaskOperationSnapshotStore` | Task state, dependency graph | `InMemoryTaskOperationSnapshotStore` |
+| `DurableGuardSnapshotStore` | Delivery guard nonces, replay protection | `InMemoryDurableGuardSnapshotStore` |
+| `ContentStorageAdapter` | Content blobs, CIDs | `InMemoryContentAdapter` |
+| `DidRegistry` | Agent DID documents | `InMemoryDidRegistrationChainAdapter` |
+
+The trait interfaces already exist (`ContentStorageAdapter`, `ChannelSnapshotStore`, etc.). You need to implement `SqliteChannelSnapshotStore`, `SqliteMessageLifecycleSnapshotStore`, etc. The `File*` variants exist for some stores but they're single-file JSON dumps — not suitable for concurrent access.
+
+Status update: file-backed adapters now also include content storage and DID chain submission persistence for deterministic restart-safe behavior. Database-backed adapters remain planned follow-up work.
+
+Estimated scope: ~1,500–2,500 lines. One generic key-value store adapter would cover most of these since they all follow put/get/list patterns.
+
+---
+
+## Phase 2: Accept Incoming Connections (Server)
+
+### 2.1 — HTTP/JSON-RPC API server
+
+The node needs to listen for requests. Recommended: **axum** (async, tower-based, lightweight).
+
+Minimum endpoints:
+
+```
+POST /v1/messages/send          — Submit a signed message envelope
+GET  /v1/messages/{id}          — Get message status
+POST /v1/channels/create        — Create a channel
+GET  /v1/channels/{id}/messages — List messages in a channel
+POST /v1/tasks/create           — Create a task
+GET  /v1/tasks/{id}             — Get task state
+GET  /v1/agents/{did}           — Get agent reputation/profile
+GET  /healthz                   — Health check
+GET  /metrics                   — Prometheus metrics
+```
+
+All the request validation, envelope parsing, state machine transitions, and response construction logic **already exists** in `kamn-core`. The API layer is mostly wiring — deserialize request, call domain function, serialize response.
+
+Estimated scope: ~2,000–3,000 lines for the server skeleton + route handlers.
+
+### 2.2 — Authentication middleware
+
+The cryptographic primitives exist (`k256` ECDSA signing, DID verification). You need:
+
+- Request signature verification middleware (extract signature from header, verify against sender DID)
+- The `EnvelopeProof` validation in `message_envelope.rs` already defines the schema
+- Nonce/replay checking via `MessageDeliveryGuards` already works
+
+Estimated scope: ~300–500 lines of axum middleware wrapping existing logic.
+
+### 2.3 — WebSocket server for real-time events
+
+Agents need push notifications (message received, task state changed, payment confirmed). Add WebSocket upgrade support to the axum server:
+
+- Use `axum::extract::ws::WebSocket`
+- The `KolmeRuntimeCommitNotificationsConsumer` already defines the event model
+- Broadcast events when domain state transitions occur
+
+Estimated scope: ~500–800 lines.
+
+---
+
+## Phase 3: Node-to-Node Communication (P2P)
+
+### 3.1 — libp2p gossip layer
+
+The PRD specifies a triadic network (Processor/Listener/Approver) with gossip. The `PeerLifecycle` state machine exists but has no real transport.
+
+- Add `libp2p` with `gossipsub`, `identify`, `kad` (Kademlia DHT for peer discovery), `noise` (encryption), `yamux` (multiplexing)
+- Wire `PeerLifecycleEvent` transitions to actual connection events
+- Gossip topics: `messages`, `blocks`, `reputation-updates`
+- The `RoleSmokeNetwork` (processor/listener/approver) is the skeleton — it needs real networking underneath
+
+This is the largest single piece of work. Estimated scope: ~4,000–6,000 lines.
+
+### 3.2 — Block production and consensus
+
+The `ProducedBlock`, `BaselineTransaction`, and `TransactionGuards` types exist. The processor role needs to:
+
+- Collect transactions from gossip into a real mempool (currently `Vec<BaselineTransaction>` in memory)
+- Produce blocks on demand (the `RoleSmokeNetwork.produce_block()` logic exists)
+- Broadcast blocks to listeners/approvers
+- Validate incoming blocks against `TransactionGuards`
+- Persist committed blocks
+
+This connects to Kolme's block production model. Estimated scope: ~2,000–3,000 lines.
+
+---
+
+## Phase 4: Kolme Blockchain Integration (On-Chain)
+
+### 4.1 — Runtime commit pipeline (partially exists)
+
+The `KolmeRuntimeCommitLiveProvider` HTTP client works. What's missing:
+
+- Automatic transaction submission (currently requires manual CLI invocation)
+- Finality polling loop (the `KolmeRuntimeCommitFinalityChecker` exists but must be driven by async task)
+- WebSocket reconnection (budget tracking exists, reconnect logic doesn't)
+- Block fallback reconciliation on reorgs
+
+Estimated scope: ~1,000–1,500 lines to make the existing client code run continuously.
+
+### 4.2 — DID on-chain registration
+
+`DidRegistry` and `DidRegistrationChainAdapter` traits exist with full lifecycle (create, update, deactivate). The `InMemoryDidRegistrationChainAdapter` needs to be replaced with one that submits DID operations as Kolme transactions.
+
+Estimated scope: ~500–800 lines.
+
+### 4.3 — On-chain message anchoring
+
+Messages are currently processed entirely in-memory. For auditability:
+
+- Hash message envelopes and anchor hashes on-chain via Kolme transactions
+- The `MessageLifecycleStore` status transitions (Created -> Signed -> Broadcast -> Included) map directly to on-chain states
+- Content stays off-chain; only proof/hash goes on-chain
+
+Estimated scope: ~800–1,200 lines.
+
+---
+
+## Phase 5: SDK and Client Libraries
+
+### 5.1 — Rust SDK (partially exists)
+
+`kamn-sdk` is a scaffold with TCP transport examples. Needs:
+
+- HTTP client wrapping the API from Phase 2
+- WebSocket subscription client
+- High-level `KamnClient` with `send_message()`, `create_task()`, `check_reputation()`
+- Connection management, retry, auth
+
+Estimated scope: ~1,500–2,000 lines.
+
+### 5.2 — Python SDK (partially exists)
+
+`tests/python/test_sdk.py` and the `LiveKAMNClient` class exist with a backend adapter pattern. Needs:
+
+- Real HTTP transport (currently uses mock adapter)
+- WebSocket support for events
+- PyPI-publishable package
+
+Estimated scope: ~1,000–1,500 lines.
+
+---
+
+## Phase 6: Operational Readiness
+
+### 6.1 — Observability endpoints
+
+`daemon_observability.rs` and `kolme_live_observability.rs` synthesize SLO metrics but only write to stdout. Need:
+
+- Prometheus `/metrics` endpoint (add `prometheus` or `metrics` crate)
+- Export the existing metrics (latency_p50, throughput_tps, error_rate_bps, availability_bps) as Prometheus gauges/histograms
+- Structured JSON logging already exists (`logging.rs`) — wire it to the async runtime
+
+Estimated scope: ~500–800 lines.
+
+### 6.2 — Configuration management
+
+Currently everything is CLI flags (30+ of them in `cli.rs`). For production:
+
+- TOML/YAML config file support (add `toml` or `serde_yaml`)
+- Environment variable overrides (partially exists for signer keys)
+- Config validation already exists in `NodeConfig.validate()`
+
+Estimated scope: ~300–500 lines.
+
+### 6.3 — Container and deployment
+
+- Dockerfile (multi-stage Rust build)
+- Docker Compose for local multi-node setup (processor + listener + approver)
+- Kubernetes manifests or Helm chart
+- The `upgrade-rollback-runbook.md` exists but needs real deployment tooling
+
+Estimated scope: ~500 lines of infra config.
+
+---
+
+## Priority Order and Effort Estimate
+
+| Phase | What | Depends On | Estimated Lines | Criticality |
+|---|---|---|---|---|
+| **1.1** | Tokio async runtime | Nothing | ~200 | BLOCKER |
+| **1.2** | Real signal handling | 1.1 | ~50 | HIGH |
+| **1.3** | Persistent storage | Nothing | ~2,000 | BLOCKER |
+| **2.1** | HTTP API server | 1.1, 1.3 | ~2,500 | BLOCKER |
+| **2.2** | Auth middleware | 2.1 | ~400 | HIGH |
+| **2.3** | WebSocket server | 2.1 | ~600 | MEDIUM |
+| **3.1** | libp2p P2P layer | 1.1 | ~5,000 | HIGH |
+| **3.2** | Block production | 3.1, 1.3 | ~2,500 | HIGH |
+| **4.1** | Kolme commit pipeline | 1.1 | ~1,200 | MEDIUM |
+| **4.2** | DID on-chain | 4.1 | ~600 | MEDIUM |
+| **4.3** | Message anchoring | 4.1, 1.3 | ~1,000 | MEDIUM |
+| **5.1** | Rust SDK | 2.1 | ~1,500 | MEDIUM |
+| **5.2** | Python SDK | 2.1 | ~1,200 | LOW |
+| **6.1** | Prometheus metrics | 2.1 | ~600 | HIGH |
+| **6.2** | Config file support | Nothing | ~400 | MEDIUM |
+| **6.3** | Container/deploy | 2.1 | ~500 | MEDIUM |
+
+**Total estimated new code: ~20,000–25,000 lines of Rust** on top of the existing 88K.
+
+---
+
+## What You Can Skip (YAGNI)
+
+Given the current state, these PRD features should be deferred past MVP:
+
+- **ZK message proofs** — `zk_message_proofs.rs` has 1,000+ lines of evaluation logic but zero actual ZK circuits. Park it.
+- **Cross-chain bridges** (Ethereum, Solana, Near) — Focus on Kolme only first
+- **Telegram/Discord bridges** — Nice-to-have, not core
+- **Service marketplace** — Requires a working economy first
+- **Group channel encryption** — Start with direct messages
+- **Content replication** — Start with single-node storage
+
+---
+
+## Minimum Viable Production Service
+
+If you do only **Phases 1 + 2 + 6.1**, you get:
+
+- A node that starts, stays running, handles signals
+- Persistent state that survives restarts
+- An HTTP API that agents can call to send messages, create tasks, check reputation
+- Prometheus metrics for monitoring
+- All backed by the 88K lines of domain logic and 2,000 tests that already exist
+
+That's roughly **5,000–6,000 lines of new code** and would be a real, deployable service — single-node, no P2P, no blockchain anchoring, but functional. The P2P and Kolme integration (Phases 3 + 4) turn it into the decentralized network the PRD describes.


### PR DESCRIPTION
## Summary
This change delivers the first bounded Phase 1.3 persistence slice by adding durable file-backed adapters for content storage and DID chain submission idempotency state. It closes the core implementation task for replacing in-memory-only behavior in these two surfaces while keeping CI fast and deterministic.

Closes #2901

## Changes
- `crates/kamn-core/src/content_storage.rs`: added `FileContentAdapter`, deterministic file serialization/parsing, and persistence error variants (`Io`, `InvalidPayload`) with fail-closed validation.
- `crates/kamn-core/src/did_registry.rs`: added `FileDidRegistrationChainAdapter`, durable idempotency receipt/rejection persistence, and persistence error variants on `DidRegistryError`.
- `crates/kamn-core/src/lib.rs`: exported new durable adapters.
- `crates/kamn-core/tests/content_storage_file_adapter.rs`: added unit/functional/integration/regression coverage for durable content adapter behavior.
- `crates/kamn-core/tests/did_registry_file_chain_adapter.rs`: added integration/regression coverage for restart-safe duplicate detection and malformed payload fail-closed behavior.
- `docs/architecture/persistence-backends.md`: documented persistence backends, file formats, and low-cost validation matrix.
- `docs/plans/2026-02-08-production-service-roadmap.md`: updated execution status for completed/in-progress Phase 1 slices.

## Risks & Compatibility
- Low risk: this is additive for existing APIs.
- `DidRegistryError` and `ContentStorageError` gained new variants; downstream exhaustive matches may need to handle them.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified restart-safe duplicate detection and fail-closed corrupt payload handling in new adapters

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `content_storage_file_adapter`, `content_storage_adapter` |
| Functional  | ✅ | Task artifact URI + adapter integration checks |
| Integration | ✅ | `did_registry_file_chain_adapter`, `did_registry_transactions` |
| Regression  | ✅ | Corrupt payload lines fail closed in both new adapters |
