### PR TITLE
feat(node): add runtime-mode api ingress contracts (#2906)

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -4,6 +4,7 @@ use super::{
     ProposalCandidate, RejoinAttempt, RuntimeMode, RuntimeModeKind, SyncMode,
     DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH, DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS,
     DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS, DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH,
+    DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS, DEFAULT_SERVICE_API_MAX_REQUESTS,
     KOLME_IN_MEMORY_PROVIDER_MARKER, KOLME_LIVE_SIGNING_PROFILE,
 };
 
@@ -37,6 +38,9 @@ where
     let mut kolme_live_strict_signer_contracts = false;
     let mut kolme_live_signer_profile: Option<String> = None;
     let mut kolme_live_signer_key_source: Option<String> = None;
+    let mut api_bind_addr: Option<String> = None;
+    let mut api_max_requests = DEFAULT_SERVICE_API_MAX_REQUESTS;
+    let mut api_idle_timeout_ms = DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS;
     let mut observability_endpoint_bind_addr: Option<String> = None;
     let mut observability_endpoint_metrics_path =
         DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH.to_owned();
@@ -50,6 +54,8 @@ where
     let mut observability_endpoint_health_path_overridden = false;
     let mut observability_endpoint_max_requests_overridden = false;
     let mut observability_endpoint_idle_timeout_ms_overridden = false;
+    let mut api_max_requests_overridden = false;
+    let mut api_idle_timeout_ms_overridden = false;
     let mut role_overridden = false;
     let mut chain_id_overridden = false;
     let mut chain_version_overridden = false;
@@ -208,6 +214,26 @@ where
                     ConfigError::MissingArgumentValue("--kolme-live-signer-key-source"),
                 )?);
             }
+            "--api-bind" => {
+                api_bind_addr = Some(
+                    iter.next()
+                        .ok_or(ConfigError::MissingArgumentValue("--api-bind"))?,
+                );
+            }
+            "--api-max-requests" => {
+                let value = iter
+                    .next()
+                    .ok_or(ConfigError::MissingArgumentValue("--api-max-requests"))?;
+                api_max_requests = parse_daemon_control_arg(&value)?;
+                api_max_requests_overridden = true;
+            }
+            "--api-idle-timeout-ms" => {
+                let value = iter
+                    .next()
+                    .ok_or(ConfigError::MissingArgumentValue("--api-idle-timeout-ms"))?;
+                api_idle_timeout_ms = parse_daemon_control_arg(&value)?;
+                api_idle_timeout_ms_overridden = true;
+            }
             "--observability-endpoint-bind" => {
                 observability_endpoint_bind_addr = Some(iter.next().ok_or(
                     ConfigError::MissingArgumentValue("--observability-endpoint-bind"),
@@ -332,6 +358,9 @@ where
             ));
         }
     }
+    if runtime_mode.kind == RuntimeModeKind::Api && api_bind_addr.is_none() {
+        return Err(ConfigError::MissingArgumentValue("--api-bind"));
+    }
     if runtime_mode.kind == RuntimeModeKind::KolmeLive {
         if kolme_live_base_url.is_none() {
             return Err(ConfigError::MissingArgumentValue("--kolme-live-base-url"));
@@ -385,6 +414,9 @@ where
             normalize_kolme_live_signer_profile_selector(signer_profile)?;
         }
     }
+    if api_bind_addr.is_none() && (api_max_requests_overridden || api_idle_timeout_ms_overridden) {
+        return Err(ConfigError::MissingArgumentValue("--api-bind"));
+    }
     if observability_endpoint_bind_addr.is_none()
         && (observability_endpoint_metrics_path_overridden
             || observability_endpoint_health_path_overridden
@@ -435,6 +467,9 @@ where
         kolme_live_strict_signer_contracts,
         kolme_live_signer_profile,
         kolme_live_signer_key_source,
+        api_bind_addr,
+        api_max_requests,
+        api_idle_timeout_ms,
         observability_endpoint_bind_addr,
         observability_endpoint_metrics_path,
         observability_endpoint_health_path,

--- a/crates/kamn-node/src/cli_tests.rs
+++ b/crates/kamn-node/src/cli_tests.rs
@@ -21,6 +21,9 @@ fn cli_module_parses_required_role_and_defaults() {
     assert!(!parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, None);
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, None);
+    assert_eq!(parsed.api_bind_addr, None);
+    assert_eq!(parsed.api_max_requests, 1);
+    assert_eq!(parsed.api_idle_timeout_ms, 5_000);
     assert_eq!(parsed.observability_endpoint_bind_addr, None);
     assert_eq!(parsed.observability_endpoint_metrics_path, "/metrics");
     assert_eq!(parsed.observability_endpoint_health_path, "/healthz");
@@ -28,6 +31,49 @@ fn cli_module_parses_required_role_and_defaults() {
     assert_eq!(parsed.observability_endpoint_idle_timeout_ms, 5_000);
     assert_eq!(parsed.output_mode, OutputMode::text());
     assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::basic());
+}
+
+#[test]
+fn cli_module_runtime_mode_api_requires_bind_address() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+    ];
+
+    let err = cli::parse_args(args).expect_err("api runtime without bind should fail");
+    assert_eq!(
+        err,
+        kamn_core::ConfigError::MissingArgumentValue("--api-bind")
+    );
+}
+
+#[test]
+fn cli_module_parses_api_runtime_endpoint_controls() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34051".to_owned(),
+        "--api-max-requests".to_owned(),
+        "4".to_owned(),
+        "--api-idle-timeout-ms".to_owned(),
+        "2000".to_owned(),
+    ];
+
+    let parsed = cli::parse_args(args).expect("api args should parse");
+    assert_eq!(
+        parsed.runtime_mode,
+        RuntimeMode::parse("api").expect("mode")
+    );
+    assert_eq!(parsed.api_bind_addr.as_deref(), Some("127.0.0.1:34051"));
+    assert_eq!(parsed.api_max_requests, 4);
+    assert_eq!(parsed.api_idle_timeout_ms, 2_000);
 }
 
 #[test]

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -15,6 +15,7 @@ mod observability_endpoint;
 mod report_builder;
 mod report_render;
 mod runtime_kolme_live;
+mod service_api_endpoint;
 mod signer;
 mod wire_payload;
 
@@ -40,6 +41,12 @@ use report_render::render_bootstrap_report;
 #[cfg(test)]
 use runtime_kolme_live::build_kolme_live_request;
 use runtime_kolme_live::execute_kolme_live_runtime;
+#[cfg(test)]
+pub(crate) use service_api_endpoint::render_service_api_endpoint_response;
+pub(crate) use service_api_endpoint::{
+    build_service_api_snapshot, serve_service_api_endpoint, ServiceApiEndpointConfig,
+    DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS, DEFAULT_SERVICE_API_MAX_REQUESTS,
+};
 #[cfg(test)]
 use signer::{
     build_kolme_live_direct_signed_wire_payload, build_kolme_live_managed_signing_key,
@@ -128,6 +135,7 @@ enum RuntimeModeKind {
     Planning,
     RecoveryCheck,
     Daemon,
+    Api,
     KolmeLive,
 }
 
@@ -156,6 +164,12 @@ impl RuntimeMode {
         }
     }
 
+    fn api() -> Self {
+        Self {
+            kind: RuntimeModeKind::Api,
+        }
+    }
+
     fn kolme_live() -> Self {
         Self {
             kind: RuntimeModeKind::KolmeLive,
@@ -168,6 +182,7 @@ impl RuntimeMode {
             "planning" => Ok(Self::planning()),
             "recovery-check" => Ok(Self::recovery_check()),
             "daemon" => Ok(Self::daemon()),
+            "api" => Ok(Self::api()),
             "kolme-live" => Ok(Self::kolme_live()),
             other => Err(ConfigError::InvalidRuntimeMode(other.to_owned())),
         }
@@ -179,6 +194,7 @@ impl RuntimeMode {
             RuntimeModeKind::Planning => "planning",
             RuntimeModeKind::RecoveryCheck => "recovery-check",
             RuntimeModeKind::Daemon => "daemon",
+            RuntimeModeKind::Api => "api",
             RuntimeModeKind::KolmeLive => "kolme-live",
         }
     }
@@ -285,6 +301,9 @@ struct NodeCli {
     kolme_live_strict_signer_contracts: bool,
     kolme_live_signer_profile: Option<String>,
     kolme_live_signer_key_source: Option<String>,
+    api_bind_addr: Option<String>,
+    api_max_requests: u64,
+    api_idle_timeout_ms: u64,
     observability_endpoint_bind_addr: Option<String>,
     observability_endpoint_metrics_path: String,
     observability_endpoint_health_path: String,
@@ -439,6 +458,14 @@ fn run() -> Result<(), ConfigError> {
         &[("runtime_mode", runtime_mode)],
     )?;
     let output_mode = cli.output_mode;
+    let service_api_endpoint_config =
+        cli.api_bind_addr
+            .as_ref()
+            .map(|bind_addr| ServiceApiEndpointConfig {
+                bind_addr: bind_addr.clone(),
+                max_requests: cli.api_max_requests,
+                idle_timeout_ms: cli.api_idle_timeout_ms,
+            });
     let observability_endpoint_config =
         cli.observability_endpoint_bind_addr
             .as_ref()
@@ -458,6 +485,30 @@ fn run() -> Result<(), ConfigError> {
         ],
     )?;
     println!("{}", render_bootstrap_report(&report, output_mode));
+    if let Some(endpoint_config) = service_api_endpoint_config {
+        if report.runtime_mode != "api" {
+            return Err(ConfigError::RuntimeDaemonLifecycle(
+                "service api endpoint requires runtime-mode api".to_owned(),
+            ));
+        }
+        let snapshot = build_service_api_snapshot(&report);
+        let max_requests_label = endpoint_config.max_requests.to_string();
+        let idle_timeout_ms_label = endpoint_config.idle_timeout_ms.to_string();
+        log_info(
+            "node.runtime.service_api.endpoint.start",
+            &[
+                ("bind_addr", endpoint_config.bind_addr.as_str()),
+                ("max_requests", max_requests_label.as_str()),
+                ("idle_timeout_ms", idle_timeout_ms_label.as_str()),
+            ],
+        )?;
+        serve_service_api_endpoint(&endpoint_config, &snapshot)
+            .map_err(ConfigError::RuntimeDaemonLifecycle)?;
+        log_info(
+            "node.runtime.service_api.endpoint.complete",
+            &[("bind_addr", endpoint_config.bind_addr.as_str())],
+        )?;
+    }
     if let Some(endpoint_config) = observability_endpoint_config {
         let snapshot = build_runtime_observability_snapshot(&report).ok_or_else(|| {
             ConfigError::RuntimeDaemonLifecycle(
@@ -521,6 +572,9 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         kolme_live_strict_signer_contracts,
         kolme_live_signer_profile,
         kolme_live_signer_key_source,
+        api_bind_addr: _,
+        api_max_requests: _,
+        api_idle_timeout_ms: _,
         observability_endpoint_bind_addr: _,
         observability_endpoint_metrics_path: _,
         observability_endpoint_health_path: _,
@@ -694,6 +748,13 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 }),
                 ..RuntimeExecutionBundle::default()
             }
+        }
+        RuntimeModeKind::Api => {
+            log_info(
+                "node.runtime.service_api.mode.ready",
+                &[("runtime_mode", runtime_mode.as_str())],
+            )?;
+            RuntimeExecutionBundle::default()
         }
         RuntimeModeKind::KolmeLive => {
             let base_url = kolme_live_base_url

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -1,15 +1,17 @@
 use super::{
     build_bootstrap_report, build_kolme_live_direct_signed_wire_payload,
     build_kolme_live_managed_signing_key, build_kolme_live_request,
-    build_kolme_live_signer_adapter, build_runtime_observability_snapshot, capture_test_logs,
-    encode_kolme_hex_lower, execute, parse_args, render_bootstrap_report,
-    render_kolme_live_native_direct_message, render_log_event_line,
-    render_observability_endpoint_response, resolve_kolme_live_managed_signer_required_marker,
-    resolve_kolme_live_nonce, resolve_kolme_live_signer_private_key_env_name,
-    resolve_log_config_from_inputs, serve_observability_endpoint,
+    build_kolme_live_signer_adapter, build_runtime_observability_snapshot,
+    build_service_api_snapshot, capture_test_logs, encode_kolme_hex_lower, execute, parse_args,
+    render_bootstrap_report, render_kolme_live_native_direct_message, render_log_event_line,
+    render_observability_endpoint_response, render_service_api_endpoint_response,
+    resolve_kolme_live_managed_signer_required_marker, resolve_kolme_live_nonce,
+    resolve_kolme_live_signer_private_key_env_name, resolve_log_config_from_inputs,
+    serve_observability_endpoint, serve_service_api_endpoint,
     sign_kolme_live_managed_external_message, DiagnosticsMode, KolmeForkSecp256k1SignerAdapter,
     LocalProfile, NodeBootstrapReport, NodeLogConfig, NodeLogFormat, NodeLogLevel,
     ObservabilityEndpointConfig, OutputMode, RuntimeExecutionBundle, RuntimeMode,
+    ServiceApiEndpointConfig,
 };
 use kamn_core::{
     bootstrap, ConfigError, KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitRequest, NodeConfig,
@@ -208,4 +210,5 @@ mod async_runtime_contract_tests;
 mod cli_contract_tests;
 mod core_behavior_tests;
 mod observability_endpoint_tests;
+mod service_api_endpoint_tests;
 mod signer_tests;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
@@ -1,0 +1,159 @@
+use super::*;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn reserve_loopback_addr() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    drop(listener);
+    addr.to_string()
+}
+
+fn send_http_request(addr: &str, method: &str, path: &str, body: &str) -> String {
+    let mut stream = TcpStream::connect(addr).expect("endpoint should accept connections");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("read timeout should be configurable");
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream
+        .write_all(request.as_bytes())
+        .expect("request should write");
+    let mut response = String::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                response.push_str(
+                    std::str::from_utf8(&chunk[..read_count]).expect("response must be utf-8"),
+                );
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => panic!("response should be readable: {error}"),
+        }
+    }
+    response
+}
+
+fn wait_for_endpoint_ready(addr: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if TcpStream::connect(addr).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("endpoint did not become ready within timeout");
+}
+
+#[test]
+fn functional_service_api_endpoint_renders_required_route_contracts() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34051".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let send_response = render_service_api_endpoint_response(
+        &snapshot,
+        "POST",
+        "/v1/messages/send",
+        "{\"message\":\"hello\"}",
+    );
+    assert_eq!(send_response.status_code, 202);
+    assert!(send_response.body.contains("\"message_id\":\"msg-local-"));
+
+    let read_response =
+        render_service_api_endpoint_response(&snapshot, "GET", "/v1/messages/msg-7", "");
+    assert_eq!(read_response.status_code, 200);
+    assert!(read_response.body.contains("\"status\":\"created\""));
+
+    let channel_response = render_service_api_endpoint_response(
+        &snapshot,
+        "GET",
+        "/v1/channels/channel-1/messages",
+        "",
+    );
+    assert_eq!(channel_response.status_code, 200);
+
+    let task_response =
+        render_service_api_endpoint_response(&snapshot, "GET", "/v1/tasks/task-1", "");
+    assert_eq!(task_response.status_code, 200);
+
+    let agent_response = render_service_api_endpoint_response(
+        &snapshot,
+        "GET",
+        "/v1/agents/kamn:did:agent:alpha",
+        "",
+    );
+    assert_eq!(agent_response.status_code, 200);
+
+    let health_response = render_service_api_endpoint_response(&snapshot, "GET", "/healthz", "");
+    assert_eq!(health_response.status_code, 200);
+
+    let metrics_response = render_service_api_endpoint_response(&snapshot, "GET", "/metrics", "");
+    assert_eq!(metrics_response.status_code, 200);
+}
+
+#[test]
+fn integration_service_api_endpoint_serves_required_http_routes() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34052".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: 4,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let send_response = send_http_request(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        "{\"message\":\"hello\"}",
+    );
+    let health_response = send_http_request(bind_addr.as_str(), "GET", "/healthz", "");
+    let metrics_response = send_http_request(bind_addr.as_str(), "GET", "/metrics", "");
+
+    assert!(send_response.contains("HTTP/1.1 202 Accepted"));
+    assert!(send_response.contains("\"message_id\":\"msg-local-"));
+    assert!(health_response.contains("HTTP/1.1 200 OK"));
+    assert!(metrics_response.contains("HTTP/1.1 200 OK"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after configured request budget"
+    );
+}

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -1,0 +1,414 @@
+use crate::NodeBootstrapReport;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub(crate) const DEFAULT_SERVICE_API_MAX_REQUESTS: u64 = 1;
+pub(crate) const DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS: u64 = 5_000;
+
+const ROUTE_MESSAGES_SEND: &str = "/v1/messages/send";
+const ROUTE_CHANNELS_CREATE: &str = "/v1/channels/create";
+const ROUTE_TASKS_CREATE: &str = "/v1/tasks/create";
+const ROUTE_MESSAGES_PREFIX: &str = "/v1/messages/";
+const ROUTE_CHANNELS_PREFIX: &str = "/v1/channels/";
+const ROUTE_CHANNELS_MESSAGES_SUFFIX: &str = "/messages";
+const ROUTE_TASKS_PREFIX: &str = "/v1/tasks/";
+const ROUTE_AGENTS_PREFIX: &str = "/v1/agents/";
+const ROUTE_HEALTHZ: &str = "/healthz";
+const ROUTE_METRICS: &str = "/metrics";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceApiEndpointConfig {
+    pub(crate) bind_addr: String,
+    pub(crate) max_requests: u64,
+    pub(crate) idle_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceApiSnapshot {
+    pub(crate) runtime_mode: String,
+    pub(crate) role: String,
+    pub(crate) chain_id: String,
+    pub(crate) chain_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceApiEndpointResponse {
+    pub(crate) status_code: u16,
+    pub(crate) content_type: &'static str,
+    pub(crate) body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedRequest {
+    method: String,
+    path: String,
+    body: String,
+}
+
+pub(crate) fn build_service_api_snapshot(report: &NodeBootstrapReport) -> ServiceApiSnapshot {
+    ServiceApiSnapshot {
+        runtime_mode: report.runtime_mode.clone(),
+        role: report.role.clone(),
+        chain_id: report.chain_id.clone(),
+        chain_version: report.chain_version.clone(),
+    }
+}
+
+pub(crate) fn render_service_api_endpoint_response(
+    snapshot: &ServiceApiSnapshot,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> ServiceApiEndpointResponse {
+    if method == "GET" && path == ROUTE_HEALTHZ {
+        return ServiceApiEndpointResponse {
+            status_code: 200,
+            content_type: "application/json",
+            body: format!(
+                "{{\"status\":\"ok\",\"runtime_mode\":\"{}\",\"role\":\"{}\"}}",
+                escape_json_string(snapshot.runtime_mode.as_str()),
+                escape_json_string(snapshot.role.as_str()),
+            ),
+        };
+    }
+    if method == "GET" && path == ROUTE_METRICS {
+        let metrics = format!(
+            "kamn_service_api_health{{runtime_mode=\"{}\"}} 1\nkamn_service_api_role{{role=\"{}\"}} 1\n",
+            escape_metrics_label(snapshot.runtime_mode.as_str()),
+            escape_metrics_label(snapshot.role.as_str())
+        );
+        return ServiceApiEndpointResponse {
+            status_code: 200,
+            content_type: "text/plain; version=0.0.4",
+            body: metrics,
+        };
+    }
+    if method == "POST" && path == ROUTE_MESSAGES_SEND {
+        let message_id = format!("msg-local-{}", deterministic_body_tag(body.as_bytes()));
+        return ServiceApiEndpointResponse {
+            status_code: 202,
+            content_type: "application/json",
+            body: format!(
+                "{{\"message_id\":\"{}\",\"status\":\"created\",\"runtime_mode\":\"{}\"}}",
+                escape_json_string(message_id.as_str()),
+                escape_json_string(snapshot.runtime_mode.as_str())
+            ),
+        };
+    }
+    if method == "POST" && path == ROUTE_CHANNELS_CREATE {
+        let channel_id = format!("channel-local-{}", deterministic_body_tag(body.as_bytes()));
+        return ServiceApiEndpointResponse {
+            status_code: 201,
+            content_type: "application/json",
+            body: format!(
+                "{{\"channel_id\":\"{}\",\"status\":\"created\"}}",
+                escape_json_string(channel_id.as_str()),
+            ),
+        };
+    }
+    if method == "POST" && path == ROUTE_TASKS_CREATE {
+        let task_id = format!("task-local-{}", deterministic_body_tag(body.as_bytes()));
+        return ServiceApiEndpointResponse {
+            status_code: 201,
+            content_type: "application/json",
+            body: format!(
+                "{{\"task_id\":\"{}\",\"state\":\"submitted\"}}",
+                escape_json_string(task_id.as_str()),
+            ),
+        };
+    }
+    if method == "GET" {
+        if let Some(message_id) = message_path_id(path) {
+            return ServiceApiEndpointResponse {
+                status_code: 200,
+                content_type: "application/json",
+                body: format!(
+                    "{{\"message_id\":\"{}\",\"status\":\"created\"}}",
+                    escape_json_string(message_id)
+                ),
+            };
+        }
+        if let Some(channel_id) = channel_messages_path_id(path) {
+            return ServiceApiEndpointResponse {
+                status_code: 200,
+                content_type: "application/json",
+                body: format!(
+                    "{{\"channel_id\":\"{}\",\"messages\":[]}}",
+                    escape_json_string(channel_id)
+                ),
+            };
+        }
+        if let Some(task_id) = task_path_id(path) {
+            return ServiceApiEndpointResponse {
+                status_code: 200,
+                content_type: "application/json",
+                body: format!(
+                    "{{\"task_id\":\"{}\",\"state\":\"submitted\"}}",
+                    escape_json_string(task_id)
+                ),
+            };
+        }
+        if let Some(agent_did) = agent_path_id(path) {
+            return ServiceApiEndpointResponse {
+                status_code: 200,
+                content_type: "application/json",
+                body: format!(
+                    "{{\"did\":\"{}\",\"reputation_score\":500}}",
+                    escape_json_string(agent_did)
+                ),
+            };
+        }
+    }
+
+    if route_exists_for_other_method(path) {
+        return ServiceApiEndpointResponse {
+            status_code: 405,
+            content_type: "text/plain; charset=utf-8",
+            body: "method not allowed\n".to_owned(),
+        };
+    }
+    ServiceApiEndpointResponse {
+        status_code: 404,
+        content_type: "text/plain; charset=utf-8",
+        body: "not found\n".to_owned(),
+    }
+}
+
+pub(crate) fn serve_service_api_endpoint(
+    config: &ServiceApiEndpointConfig,
+    snapshot: &ServiceApiSnapshot,
+) -> Result<(), String> {
+    if config.max_requests == 0 {
+        return Err("service api max requests must be greater than zero".to_owned());
+    }
+    if config.idle_timeout_ms == 0 {
+        return Err("service api idle timeout must be greater than zero".to_owned());
+    }
+
+    let listener = TcpListener::bind(config.bind_addr.as_str())
+        .map_err(|error| format!("service api bind failed: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("service api nonblocking mode failed: {error}"))?;
+
+    let deadline = Instant::now() + Duration::from_millis(config.idle_timeout_ms);
+    let mut served_requests = 0_u64;
+    while served_requests < config.max_requests {
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "service api timed out after {} ms waiting for requests",
+                config.idle_timeout_ms
+            ));
+        }
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let response = match read_http_request(&mut stream) {
+                    Ok(request) => render_service_api_endpoint_response(
+                        snapshot,
+                        request.method.as_str(),
+                        request.path.as_str(),
+                        request.body.as_str(),
+                    ),
+                    Err(error) => ServiceApiEndpointResponse {
+                        status_code: 400,
+                        content_type: "application/json",
+                        body: format!(
+                            "{{\"error\":\"bad-request\",\"reason\":\"{}\"}}",
+                            escape_json_string(error.as_str())
+                        ),
+                    },
+                };
+                write_http_response(&mut stream, &response)?;
+                served_requests = served_requests.saturating_add(1);
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => return Err(format!("service api accept failed: {error}")),
+        }
+    }
+    Ok(())
+}
+
+fn route_exists_for_other_method(path: &str) -> bool {
+    path == ROUTE_MESSAGES_SEND
+        || path == ROUTE_CHANNELS_CREATE
+        || path == ROUTE_TASKS_CREATE
+        || path == ROUTE_HEALTHZ
+        || path == ROUTE_METRICS
+        || message_path_id(path).is_some()
+        || channel_messages_path_id(path).is_some()
+        || task_path_id(path).is_some()
+        || agent_path_id(path).is_some()
+}
+
+fn message_path_id(path: &str) -> Option<&str> {
+    path.strip_prefix(ROUTE_MESSAGES_PREFIX).and_then(|id| {
+        if id.is_empty() || id == "send" || id.contains('/') {
+            return None;
+        }
+        Some(id)
+    })
+}
+
+fn channel_messages_path_id(path: &str) -> Option<&str> {
+    let channel_path = path.strip_prefix(ROUTE_CHANNELS_PREFIX)?;
+    let channel_id = channel_path.strip_suffix(ROUTE_CHANNELS_MESSAGES_SUFFIX)?;
+    if channel_id.is_empty() || channel_id.contains('/') {
+        return None;
+    }
+    Some(channel_id)
+}
+
+fn task_path_id(path: &str) -> Option<&str> {
+    path.strip_prefix(ROUTE_TASKS_PREFIX).and_then(|id| {
+        if id.is_empty() || id == "create" || id.contains('/') {
+            return None;
+        }
+        Some(id)
+    })
+}
+
+fn agent_path_id(path: &str) -> Option<&str> {
+    path.strip_prefix(ROUTE_AGENTS_PREFIX).and_then(|did| {
+        if did.is_empty() || did.contains('/') {
+            return None;
+        }
+        Some(did)
+    })
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Result<ParsedRequest, String> {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .map_err(|error| format!("service api read-timeout failed: {error}"))?;
+
+    let mut expected_total_bytes: Option<usize> = None;
+    let mut header_end: Option<usize> = None;
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                request.extend_from_slice(&chunk[..read_count]);
+                if header_end.is_none() {
+                    header_end = request
+                        .windows(4)
+                        .position(|window| window == b"\r\n\r\n")
+                        .map(|index| index + 4);
+                    if let Some(header_end_index) = header_end {
+                        let header = String::from_utf8(request[..header_end_index].to_vec())
+                            .map_err(|_| "request header was not valid utf-8".to_owned())?;
+                        let content_length = parse_content_length(header.as_str())?;
+                        expected_total_bytes = Some(header_end_index + content_length);
+                    }
+                }
+                if let Some(total) = expected_total_bytes {
+                    if request.len() >= total {
+                        break;
+                    }
+                }
+                if request.len() > 64 * 1024 {
+                    return Err("request header too large".to_owned());
+                }
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => return Err(format!("request read failed: {error}")),
+        }
+    }
+
+    let request_text =
+        String::from_utf8(request).map_err(|_| "request was not valid utf-8".to_owned())?;
+    let Some((request_head, request_body)) = request_text.split_once("\r\n\r\n") else {
+        return Err("request header terminator missing".to_owned());
+    };
+    let request_line = request_head
+        .lines()
+        .next()
+        .ok_or_else(|| "request line missing".to_owned())?;
+    let mut line_parts = request_line.split_whitespace();
+    let method = line_parts
+        .next()
+        .ok_or_else(|| "request method missing".to_owned())?;
+    let path = line_parts
+        .next()
+        .ok_or_else(|| "request path missing".to_owned())?;
+    Ok(ParsedRequest {
+        method: method.to_owned(),
+        path: path.to_owned(),
+        body: request_body.to_owned(),
+    })
+}
+
+fn parse_content_length(header: &str) -> Result<usize, String> {
+    let value = header
+        .lines()
+        .find_map(|line| {
+            let (name, raw_value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("Content-Length") {
+                return Some(raw_value.trim());
+            }
+            None
+        })
+        .unwrap_or("0");
+    value
+        .parse::<usize>()
+        .map_err(|_| "invalid content-length header".to_owned())
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    response: &ServiceApiEndpointResponse,
+) -> Result<(), String> {
+    let status_text = match response.status_code {
+        200 => "200 OK",
+        201 => "201 Created",
+        202 => "202 Accepted",
+        400 => "400 Bad Request",
+        404 => "404 Not Found",
+        405 => "405 Method Not Allowed",
+        _ => "500 Internal Server Error",
+    };
+    let payload = format!(
+        "HTTP/1.1 {status_text}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response.content_type,
+        response.body.len(),
+        response.body
+    );
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(|error| format!("service api write failed: {error}"))
+}
+
+fn deterministic_body_tag(payload: &[u8]) -> u64 {
+    let mut acc: u64 = 0xcbf29ce484222325;
+    for byte in payload {
+        acc = acc.wrapping_mul(0x00000100000001B3);
+        acc ^= u64::from(*byte);
+    }
+    acc
+}
+
+fn escape_json_string(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn escape_metrics_label(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -1,0 +1,46 @@
+# Service HTTP API (Phase 2 Slice)
+
+## Scope
+
+This document captures the first executable HTTP ingress slice for Story #2905 and Task #2906.
+
+Runtime mode: `api`
+
+## Runtime Controls
+
+- `--runtime-mode api`
+- `--api-bind <host:port>`
+- `--api-max-requests <n>` (default: `1`)
+- `--api-idle-timeout-ms <ms>` (default: `5000`)
+
+Fail-closed behavior:
+
+- `runtime-mode api` without `--api-bind` is rejected.
+- `--api-max-requests` and `--api-idle-timeout-ms` must be positive integers.
+
+## Endpoints
+
+Implemented route contract for local deterministic ingress:
+
+- `POST /v1/messages/send`
+- `GET /v1/messages/{id}`
+- `POST /v1/channels/create`
+- `GET /v1/channels/{id}/messages`
+- `POST /v1/tasks/create`
+- `GET /v1/tasks/{id}`
+- `GET /v1/agents/{did}`
+- `GET /healthz`
+- `GET /metrics`
+
+Response behavior is deterministic and intentionally lightweight for this phase.
+
+## Validation
+
+Low-cost local validation commands:
+
+- `cargo test -p kamn-node service_api_endpoint -- --nocapture`
+- `cargo test -p kamn-node`
+- `cargo fmt --check`
+- `cargo clippy -p kamn-node -- -D warnings`
+
+These checks cover unit, functional, integration, and regression behavior for the API ingress module without requiring external infrastructure.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -16,6 +16,7 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Delivered in this slice: `FileContentAdapter` and `FileDidRegistrationChainAdapter` in `kamn-core` (Task #2901).
   - Live validation lane added for persistence adapter restart and fail-closed checks (Task #2903).
   - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
+- Phase 2.1 initial slice delivered: deterministic `runtime-mode api` ingress server with required messaging/channel/task/profile/health/metrics route contracts (Task #2906).
 
 ---
 


### PR DESCRIPTION
## Summary
This PR delivers the core Phase 2 API ingress slice by adding a deterministic `runtime-mode api` HTTP server path in `kamn-node` and wiring CLI/runtime controls for endpoint execution. It exposes the required messaging/channel/task/profile routes plus `/healthz` and `/metrics` with unit/functional/integration/regression coverage.

Closes #2906
Closes #2907

## Changes
- `crates/kamn-node/src/service_api_endpoint.rs`: added service API endpoint module with route rendering, request parsing, response writing, and bounded serve loop.
- `crates/kamn-node/src/main.rs`: added `RuntimeModeKind::Api`, service API startup wiring, and runtime-mode guardrails.
- `crates/kamn-node/src/cli.rs`: added `--api-bind`, `--api-max-requests`, and `--api-idle-timeout-ms` CLI controls with fail-closed validation.
- `crates/kamn-node/src/cli_tests.rs`: added runtime-mode api parse/validation tests.
- `crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs`: added functional and integration tests for required routes and live socket serving.
- `docs/api/service-http-api.md`: documented endpoint contract, runtime controls, and validation commands.
- `docs/plans/2026-02-08-production-service-roadmap.md`: updated execution status with initial Phase 2.1 delivery marker.

## Risks & Compatibility
- Low to moderate: introduces new runtime mode and CLI flags.
- Existing runtime modes and observability endpoint behavior remain intact (covered by full `kamn-node` test suite).

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: exercised route contract tests and bounded socket server behavior

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cli_module_runtime_mode_api_requires_bind_address`, endpoint route rendering assertions |
| Functional  | ✅ | required route contract checks in `service_api_endpoint_tests` |
| Integration | ✅ | socket server integration in `integration_service_api_endpoint_serves_required_http_routes` |
| Regression  | ✅ | runtime guardrails and full `cargo test -p kamn-node` matrix remained green |
