### PR TITLE
test(runtime): add service api live validation lane (#2908)

### DIFF
--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -42,5 +42,26 @@ Low-cost local validation commands:
 - `cargo test -p kamn-node`
 - `cargo fmt --check`
 - `cargo clippy -p kamn-node -- -D warnings`
+- `bash scripts/runtime/test_validate_service_api_live.sh`
+- `bash scripts/runtime/validate_service_api_live.sh`
 
 These checks cover unit, functional, integration, and regression behavior for the API ingress module without requiring external infrastructure.
+
+## Live Validation Evidence
+
+Task and subtask evidence:
+
+- Task: #2908
+- Subtask: #2909
+
+Deterministic success markers from `validate_service_api_live.sh`:
+
+- `status=pass`
+- `final_decision=GO`
+- `route_contract_status=verified`
+- `failure_case_status=verified`
+
+Deterministic fail-closed marker example:
+
+- `bash scripts/runtime/validate_service_api_live.sh --max-seconds nope`
+- stderr marker: `max-seconds must be an integer`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -17,6 +17,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Live validation lane added for persistence adapter restart and fail-closed checks (Task #2903).
   - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
 - Phase 2.1 initial slice delivered: deterministic `runtime-mode api` ingress server with required messaging/channel/task/profile/health/metrics route contracts (Task #2906).
+- Phase 2.1 live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_service_api_live.sh` and `scripts/runtime/test_validate_service_api_live.sh` (Task #2908, Subtask #2909).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `route_contract_status=verified`, `failure_case_status=verified`.
+  - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 
 ---
 

--- a/scripts/runtime/test_validate_service_api_live.sh
+++ b/scripts/runtime/test_validate_service_api_live.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected service api live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected service api live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected service api live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^route_contract_status=verified$'; then
+  echo "expected service api route contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^failure_case_status=verified$'; then
+  echo "expected service api fail-closed marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.service-api-live-validation.v1":
+    raise SystemExit("unexpected service api live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected service api live validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected service api live validation final_decision=GO")
+if payload.get("route_contract_status") != "verified":
+    raise SystemExit("expected route_contract_status=verified")
+if payload.get("failure_case_status") != "verified":
+    raise SystemExit("expected failure_case_status=verified")
+if not payload.get("message_id"):
+    raise SystemExit("expected non-empty message_id")
+if not payload.get("channel_id"):
+    raise SystemExit("expected non-empty channel_id")
+if not payload.get("task_id"):
+    raise SystemExit("expected non-empty task_id")
+PY
+
+echo "service api live validation tests passed."

--- a/scripts/runtime/validate_service_api_live.sh
+++ b/scripts/runtime/validate_service_api_live.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+
+pushd "$ROOT_DIR" >/dev/null
+cargo build --quiet -p kamn-node
+NODE_BIN="$ROOT_DIR/target/debug/kamn-node"
+popd >/dev/null
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "expected built kamn-node binary to be executable" >&2
+  exit 1
+fi
+
+api_port="$(python3 - <<'PY'
+import socket
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+)"
+api_addr="127.0.0.1:${api_port}"
+
+api_stdout="$TMP_DIR/service-api.out"
+"$NODE_BIN" \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode api \
+  --api-bind "$api_addr" \
+  --api-max-requests 10 \
+  --api-idle-timeout-ms 5000 \
+  --output json >"$api_stdout" 2>&1 &
+node_pid=$!
+
+wait_for_ready=0
+for _ in $(seq 1 120); do
+  if curl -fsS "http://${api_addr}/healthz" >/dev/null 2>&1; then
+    wait_for_ready=1
+    break
+  fi
+  if ! kill -0 "$node_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+
+if [ "$wait_for_ready" -ne 1 ]; then
+  cat "$api_stdout" >&2
+  echo "expected service api endpoint to become ready" >&2
+  kill -KILL "$node_pid" 2>/dev/null || true
+  wait "$node_pid" 2>/dev/null || true
+  exit 1
+fi
+
+message_response_file="$TMP_DIR/message-send.json"
+channel_response_file="$TMP_DIR/channel-create.json"
+task_response_file="$TMP_DIR/task-create.json"
+health_response_file="$TMP_DIR/healthz.json"
+metrics_response_file="$TMP_DIR/metrics.txt"
+agent_response_file="$TMP_DIR/agent.json"
+message_get_response_file="$TMP_DIR/message-get.json"
+channel_get_response_file="$TMP_DIR/channel-get.json"
+task_get_response_file="$TMP_DIR/task-get.json"
+
+curl -fsS -X POST "http://${api_addr}/v1/messages/send" \
+  -H 'content-type: application/json' \
+  --data '{"message":"hello"}' >"$message_response_file"
+
+message_id="$(python3 - "$message_response_file" <<'PY'
+import json
+import pathlib
+import sys
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["message_id"])
+PY
+)"
+
+curl -fsS "http://${api_addr}/v1/messages/${message_id}" >"$message_get_response_file"
+
+curl -fsS -X POST "http://${api_addr}/v1/channels/create" \
+  -H 'content-type: application/json' \
+  --data '{"name":"operators"}' >"$channel_response_file"
+channel_id="$(python3 - "$channel_response_file" <<'PY'
+import json
+import pathlib
+import sys
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["channel_id"])
+PY
+)"
+
+curl -fsS "http://${api_addr}/v1/channels/${channel_id}/messages" >"$channel_get_response_file"
+
+curl -fsS -X POST "http://${api_addr}/v1/tasks/create" \
+  -H 'content-type: application/json' \
+  --data '{"title":"task"}' >"$task_response_file"
+task_id="$(python3 - "$task_response_file" <<'PY'
+import json
+import pathlib
+import sys
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["task_id"])
+PY
+)"
+
+curl -fsS "http://${api_addr}/v1/tasks/${task_id}" >"$task_get_response_file"
+curl -fsS "http://${api_addr}/v1/agents/kamn:did:agent:alpha" >"$agent_response_file"
+curl -fsS "http://${api_addr}/healthz" >"$health_response_file"
+curl -fsS "http://${api_addr}/metrics" >"$metrics_response_file"
+
+set +e
+wait "$node_pid"
+node_exit_code=$?
+set -e
+if [ "$node_exit_code" -ne 0 ]; then
+  cat "$api_stdout" >&2
+  echo "expected service api process to exit cleanly after request budget" >&2
+  exit 1
+fi
+
+if ! grep -q '"status":"ok"' "$health_response_file"; then
+  cat "$health_response_file" >&2
+  echo "expected health endpoint status marker" >&2
+  exit 1
+fi
+if ! grep -q 'kamn_service_api_health' "$metrics_response_file"; then
+  cat "$metrics_response_file" >&2
+  echo "expected metrics endpoint marker" >&2
+  exit 1
+fi
+if ! grep -q '"messages":\[\]' "$channel_get_response_file"; then
+  cat "$channel_get_response_file" >&2
+  echo "expected channel messages endpoint payload marker" >&2
+  exit 1
+fi
+if ! grep -q '"reputation_score":500' "$agent_response_file"; then
+  cat "$agent_response_file" >&2
+  echo "expected agent endpoint payload marker" >&2
+  exit 1
+fi
+if ! grep -q '"state":"submitted"' "$task_get_response_file"; then
+  cat "$task_get_response_file" >&2
+  echo "expected task endpoint payload marker" >&2
+  exit 1
+fi
+if ! grep -q '"status":"created"' "$message_get_response_file"; then
+  cat "$message_get_response_file" >&2
+  echo "expected message endpoint payload marker" >&2
+  exit 1
+fi
+
+set +e
+failure_stdout="$($NODE_BIN \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode api \
+  --output json 2>&1)"
+failure_code=$?
+set -e
+if [ "$failure_code" -eq 0 ]; then
+  echo "expected runtime-mode api without --api-bind to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$failure_stdout" | grep -q -- '--api-bind'; then
+  printf '%s\n' "$failure_stdout" >&2
+  echo "expected missing --api-bind reason marker" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "service api live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/service-api-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.service-api-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "route_contract_status": "verified",
+  "failure_case_status": "verified",
+  "message_id": "${message_id}",
+  "channel_id": "${channel_id}",
+  "task_id": "${task_id}",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "route_contract_status=verified"
+echo "failure_case_status=verified"


### PR DESCRIPTION
## Summary
Adds the Phase 2.1 live-validation lane for the service HTTP API and documents deterministic evidence markers for GO/no-go decisions. This lands the integration validation task/subtask for Story #2905 with fail-closed checks.

## Changes
- `scripts/runtime/validate_service_api_live.sh`: new live validation lane that boots `kamn-node` in `runtime-mode api`, exercises all required endpoints, validates deterministic pass markers, and verifies fail-closed CLI behavior.
- `scripts/runtime/test_validate_service_api_live.sh`: new contract test for the live validation lane output schema and markers.
- `docs/api/service-http-api.md`: adds lane commands and evidence protocol for operators.
- `docs/plans/2026-02-08-production-service-roadmap.md`: records Phase 2.1 live-validation delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/runtime/test_validate_service_api_live.sh`

Failing output markers captured before lane budget alignment:
- `curl: (7) Failed to connect to 127.0.0.1 port <port> after 0 ms: Could not connect to server`
- `runtime daemon lifecycle validation failed: service api timed out after 5000 ms waiting for requests`

### 🟢 Green Phase
Commands:
- `bash scripts/runtime/test_validate_service_api_live.sh`
- `bash scripts/runtime/validate_service_api_live.sh`

Passing output markers:
- `service api live validation tests passed.`
- `status=pass`
- `final_decision=GO`
- `route_contract_status=verified`
- `failure_case_status=verified`

### 🔁 Regression
Commands:
- `bash scripts/runtime/test_validate_service_api_live.sh`
- `bash scripts/runtime/validate_service_api_live.sh --max-seconds nope`

Result markers:
- Lane test remains green.
- Fail-closed path returns exit code `1` and marker `max-seconds must be an integer`.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified                              | Justification if N/A |
|--------------|--------|---------------------------------------------------|----------------------|
| Unit         | N/A    | None                                              | Script/orchestration change only |
| Functional   | ✅     | `scripts/runtime/test_validate_service_api_live.sh` |                      |
| Integration  | ✅     | `scripts/runtime/validate_service_api_live.sh`      |                      |
| Regression   | ✅     | fail-closed argument validation check in live lane  |                      |
| Performance  | ✅     | bounded by `--max-seconds` guard in lane            |                      |

## Risks & Rollback
- Risk: minimal; lane-only plus docs.
- Rollback: revert this PR to remove live-validation lane scripts and docs references.

## Documentation Updates
- `docs/api/service-http-api.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (not required for script/docs-only delta)
- [x] `cargo clippy -- -D warnings` — clean (not required for script/docs-only delta)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing for changed scope
- [x] Docs updated

Closes #2908
Closes #2909
