### PR TITLE
test(runtime): add request-auth live validation lane (#2913)

### DIFF
--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -65,6 +65,8 @@ Low-cost local validation commands:
 - `cargo test -p kamn-node service_api_endpoint_rejects_ -- --nocapture`
 - `bash scripts/runtime/test_validate_service_api_live.sh`
 - `bash scripts/runtime/validate_service_api_live.sh`
+- `bash scripts/runtime/test_validate_service_api_request_auth_live.sh`
+- `bash scripts/runtime/validate_service_api_request_auth_live.sh`
 
 These checks cover unit, functional, integration, and regression behavior for the API ingress module without requiring external infrastructure.
 

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -22,6 +22,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `route_contract_status=verified`, `failure_case_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 - Phase 2.2 initial slice delivered: request signature auth and per-sender nonce replay middleware enforcement on service API ingress (Task #2911, Subtask #2912).
+- Phase 2.2 live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_service_api_request_auth_live.sh` and `scripts/runtime/test_validate_service_api_request_auth_live.sh` (Task #2913, Subtask #2914).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `unauthorized_guard_status=verified`, `replay_guard_status=verified`, `probe_status=verified`.
+  - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 
 ---
 

--- a/docs/security/request-auth.md
+++ b/docs/security/request-auth.md
@@ -46,6 +46,28 @@ Live lane compatibility:
 
 - `bash scripts/runtime/test_validate_service_api_live.sh`
 - `bash scripts/runtime/validate_service_api_live.sh`
+- `bash scripts/runtime/test_validate_service_api_request_auth_live.sh`
+- `bash scripts/runtime/validate_service_api_request_auth_live.sh`
+
+## Live Validation Evidence
+
+Task and subtask evidence:
+
+- Task: #2913
+- Subtask: #2914
+
+Deterministic success markers from `validate_service_api_request_auth_live.sh`:
+
+- `status=pass`
+- `final_decision=GO`
+- `unauthorized_guard_status=verified`
+- `replay_guard_status=verified`
+- `probe_status=verified`
+
+Deterministic fail-closed marker example:
+
+- `bash scripts/runtime/validate_service_api_request_auth_live.sh --max-seconds nope`
+- stderr marker: `max-seconds must be an integer`
 
 ## TDD Evidence
 

--- a/scripts/runtime/test_validate_service_api_request_auth_live.sh
+++ b/scripts/runtime/test_validate_service_api_request_auth_live.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_request_auth_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected request-auth live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected request-auth live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected request-auth live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^unauthorized_guard_status=verified$'; then
+  echo "expected unauthorized guard marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^replay_guard_status=verified$'; then
+  echo "expected replay guard marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^probe_status=verified$'; then
+  echo "expected probe status marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.service-api-request-auth-live-validation.v1":
+    raise SystemExit("unexpected request-auth live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected request-auth live validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected request-auth live validation final_decision=GO")
+if payload.get("unauthorized_guard_status") != "verified":
+    raise SystemExit("expected unauthorized_guard_status=verified")
+if payload.get("replay_guard_status") != "verified":
+    raise SystemExit("expected replay_guard_status=verified")
+if payload.get("probe_status") != "verified":
+    raise SystemExit("expected probe_status=verified")
+PY
+
+echo "service api request-auth live validation tests passed."

--- a/scripts/runtime/validate_service_api_request_auth_live.sh
+++ b/scripts/runtime/validate_service_api_request_auth_live.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+
+pushd "$ROOT_DIR" >/dev/null
+cargo build --quiet -p kamn-node
+NODE_BIN="$ROOT_DIR/target/debug/kamn-node"
+popd >/dev/null
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "expected built kamn-node binary to be executable" >&2
+  exit 1
+fi
+
+api_port="$(python3 - <<'PY'
+import socket
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+)"
+api_addr="127.0.0.1:${api_port}"
+
+api_stdout="$TMP_DIR/service-api-auth.out"
+"$NODE_BIN" \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode api \
+  --api-bind "$api_addr" \
+  --api-max-requests 6 \
+  --api-idle-timeout-ms 5000 \
+  --output json >"$api_stdout" 2>&1 &
+node_pid=$!
+
+auth_sender_did="kamn:did:agent:request-auth-validator"
+auth_state_hash="service-api:kamn-devnet:v0.1.0"
+auth_body='{"message":"auth-drill"}'
+
+build_signature() {
+  local nonce="$1"
+  local payload="$2"
+  printf 'sig:ed25519:baseline-v1:%s:%s:%s:%s' \
+    "$auth_sender_did" \
+    "$nonce" \
+    "$auth_state_hash" \
+    "${#payload}"
+}
+
+wait_for_ready=0
+for _ in $(seq 1 120); do
+  if curl -fsS "http://${api_addr}/healthz" >/dev/null 2>&1; then
+    wait_for_ready=1
+    break
+  fi
+  if ! kill -0 "$node_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+
+if [ "$wait_for_ready" -ne 1 ]; then
+  cat "$api_stdout" >&2
+  echo "expected service api auth endpoint to become ready" >&2
+  kill -KILL "$node_pid" 2>/dev/null || true
+  wait "$node_pid" 2>/dev/null || true
+  exit 1
+fi
+
+unauthorized_file="$TMP_DIR/unauthorized.json"
+authorized_file="$TMP_DIR/authorized.json"
+replay_file="$TMP_DIR/replay.json"
+health_file="$TMP_DIR/health.json"
+metrics_file="$TMP_DIR/metrics.txt"
+
+unauthorized_status="$(curl -sS -o "$unauthorized_file" -w '%{http_code}' \
+  -X POST "http://${api_addr}/v1/messages/send" \
+  -H 'content-type: application/json' \
+  --data "$auth_body")"
+if [ "$unauthorized_status" != "401" ]; then
+  cat "$unauthorized_file" >&2
+  echo "expected unauthorized request to return 401" >&2
+  exit 1
+fi
+if ! grep -q '"error":"unauthorized"' "$unauthorized_file"; then
+  cat "$unauthorized_file" >&2
+  echo "expected unauthorized response marker" >&2
+  exit 1
+fi
+if ! grep -q 'x-kamn-sender-did' "$unauthorized_file"; then
+  cat "$unauthorized_file" >&2
+  echo "expected missing sender header reason marker" >&2
+  exit 1
+fi
+
+nonce=1
+signature="$(build_signature "$nonce" "$auth_body")"
+authorized_status="$(curl -sS -o "$authorized_file" -w '%{http_code}' \
+  -X POST "http://${api_addr}/v1/messages/send" \
+  -H 'content-type: application/json' \
+  -H "X-KAMN-Sender-DID: ${auth_sender_did}" \
+  -H "X-KAMN-Request-Nonce: ${nonce}" \
+  -H "X-KAMN-Request-Signature: ${signature}" \
+  --data "$auth_body")"
+if [ "$authorized_status" != "202" ]; then
+  cat "$authorized_file" >&2
+  echo "expected authorized request to return 202" >&2
+  exit 1
+fi
+if ! grep -q '"status":"created"' "$authorized_file"; then
+  cat "$authorized_file" >&2
+  echo "expected authorized response creation marker" >&2
+  exit 1
+fi
+
+replay_status="$(curl -sS -o "$replay_file" -w '%{http_code}' \
+  -X POST "http://${api_addr}/v1/messages/send" \
+  -H 'content-type: application/json' \
+  -H "X-KAMN-Sender-DID: ${auth_sender_did}" \
+  -H "X-KAMN-Request-Nonce: ${nonce}" \
+  -H "X-KAMN-Request-Signature: ${signature}" \
+  --data "$auth_body")"
+if [ "$replay_status" != "409" ]; then
+  cat "$replay_file" >&2
+  echo "expected replayed request to return 409" >&2
+  exit 1
+fi
+if ! grep -q '"error":"replay"' "$replay_file"; then
+  cat "$replay_file" >&2
+  echo "expected replay response marker" >&2
+  exit 1
+fi
+
+health_status="$(curl -sS -o "$health_file" -w '%{http_code}' "http://${api_addr}/healthz")"
+if [ "$health_status" != "200" ]; then
+  cat "$health_file" >&2
+  echo "expected health probe to return 200" >&2
+  exit 1
+fi
+if ! grep -q '"status":"ok"' "$health_file"; then
+  cat "$health_file" >&2
+  echo "expected health payload status marker" >&2
+  exit 1
+fi
+
+metrics_status="$(curl -sS -o "$metrics_file" -w '%{http_code}' "http://${api_addr}/metrics")"
+if [ "$metrics_status" != "200" ]; then
+  cat "$metrics_file" >&2
+  echo "expected metrics probe to return 200" >&2
+  exit 1
+fi
+if ! grep -q 'kamn_service_api_health' "$metrics_file"; then
+  cat "$metrics_file" >&2
+  echo "expected metrics payload marker" >&2
+  exit 1
+fi
+
+set +e
+wait "$node_pid"
+node_exit_code=$?
+set -e
+if [ "$node_exit_code" -ne 0 ]; then
+  cat "$api_stdout" >&2
+  echo "expected service api auth process to exit cleanly after request budget" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "service api request-auth live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/service-api-request-auth-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.service-api-request-auth-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "unauthorized_guard_status": "verified",
+  "replay_guard_status": "verified",
+  "probe_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "unauthorized_guard_status=verified"
+echo "replay_guard_status=verified"
+echo "probe_status=verified"


### PR DESCRIPTION
## Summary
Adds a dedicated live-validation lane for service API request-auth middleware so unauthorized and replayed requests are continuously validated with deterministic GO/no-go evidence markers.

## Changes
- `scripts/runtime/validate_service_api_request_auth_live.sh`: new live drill lane for unauthorized `401`, replay `409`, and probe checks.
- `scripts/runtime/test_validate_service_api_request_auth_live.sh`: contract test harness for lane markers and evidence schema.
- `docs/security/request-auth.md`: adds live-validation commands and evidence references for #2913/#2914.
- `docs/api/service-http-api.md`: adds request-auth live validation commands.
- `docs/plans/2026-02-08-production-service-roadmap.md`: records Phase 2.2 live-validation delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/runtime/test_validate_service_api_request_auth_live.sh`

Failing marker before lane implementation:
- `expected request-auth live validation script to be executable`

### 🟢 Green Phase
Commands:
- `bash scripts/runtime/test_validate_service_api_request_auth_live.sh`
- `bash scripts/runtime/validate_service_api_request_auth_live.sh`

Passing markers:
- `service api request-auth live validation tests passed.`
- `status=pass`
- `final_decision=GO`
- `unauthorized_guard_status=verified`
- `replay_guard_status=verified`
- `probe_status=verified`

### 🔁 Regression
Commands:
- `bash scripts/runtime/validate_service_api_request_auth_live.sh --max-seconds nope`
- `bash scripts/runtime/test_validate_service_api_live.sh`
- `cargo fmt --check`

Result markers:
- fail-closed arg handling returns exit code `1` with `max-seconds must be an integer`
- prior service API live lane remains green
- formatting check is clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None | Orchestration/docs-only lane addition |
| Functional   | ✅     | `scripts/runtime/test_validate_service_api_request_auth_live.sh` marker checks | |
| Integration  | ✅     | `scripts/runtime/validate_service_api_request_auth_live.sh` live process + HTTP checks | |
| Regression   | ✅     | fail-closed arg check + prior lane compatibility run | |
| Performance  | ✅     | bounded by `--max-seconds` and request-budget limits | |

## Risks & Rollback
- Risk: low; no production Rust logic changes, only validation/documentation.
- Rollback: revert this PR to remove auth live-validation lane scripts/docs references.

## Documentation Updates
- `docs/security/request-auth.md`
- `docs/api/service-http-api.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (not required for script/docs-only delta)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing for changed scope
- [x] Docs updated

Closes #2913
Closes #2914
