### PR TITLE
test(runtime): add websocket live validation lane (#2918)

### DIFF
--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -68,6 +68,8 @@ Low-cost local validation commands:
 - `bash scripts/runtime/validate_service_api_live.sh`
 - `bash scripts/runtime/test_validate_service_api_request_auth_live.sh`
 - `bash scripts/runtime/validate_service_api_request_auth_live.sh`
+- `bash scripts/runtime/test_validate_service_api_websocket_live.sh`
+- `bash scripts/runtime/validate_service_api_websocket_live.sh`
 
 These checks cover unit, functional, integration, and regression behavior for the API ingress module without requiring external infrastructure.
 

--- a/docs/api/websocket-events.md
+++ b/docs/api/websocket-events.md
@@ -52,3 +52,25 @@ Low-cost local commands:
 - `cargo test -p kamn-node`
 - `cargo fmt --check`
 - `cargo clippy -p kamn-node -- -D warnings`
+- `bash scripts/runtime/test_validate_service_api_websocket_live.sh`
+- `bash scripts/runtime/validate_service_api_websocket_live.sh`
+
+## Live Validation Evidence
+
+Task and subtask evidence:
+
+- Task: #2918
+- Subtask: #2919
+
+Deterministic success markers from `validate_service_api_websocket_live.sh`:
+
+- `status=pass`
+- `final_decision=GO`
+- `websocket_upgrade_status=verified`
+- `fail_closed_status=verified`
+- `probe_status=verified`
+
+Deterministic fail-closed marker example:
+
+- `bash scripts/runtime/validate_service_api_websocket_live.sh --max-seconds nope`
+- stderr marker: `max-seconds must be an integer`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -27,6 +27,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `unauthorized_guard_status=verified`, `replay_guard_status=verified`, `probe_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 - Phase 2.3 initial slice delivered: realtime websocket event route with deterministic upgrade/frame contract and fail-closed upgrade/auth/replay guards (Task #2916, Subtask #2917).
+- Phase 2.3 live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_service_api_websocket_live.sh` and `scripts/runtime/test_validate_service_api_websocket_live.sh` (Task #2918, Subtask #2919).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `websocket_upgrade_status=verified`, `fail_closed_status=verified`, `probe_status=verified`.
+  - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 
 ---
 

--- a/scripts/runtime/test_validate_service_api_websocket_live.sh
+++ b/scripts/runtime/test_validate_service_api_websocket_live.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_websocket_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected websocket live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected websocket live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected websocket live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^websocket_upgrade_status=verified$'; then
+  echo "expected websocket upgrade status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
+  echo "expected websocket fail-closed marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^probe_status=verified$'; then
+  echo "expected websocket probe status marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.service-api-websocket-live-validation.v1":
+    raise SystemExit("unexpected websocket live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected websocket live validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected websocket live validation final_decision=GO")
+if payload.get("websocket_upgrade_status") != "verified":
+    raise SystemExit("expected websocket_upgrade_status=verified")
+if payload.get("fail_closed_status") != "verified":
+    raise SystemExit("expected fail_closed_status=verified")
+if payload.get("probe_status") != "verified":
+    raise SystemExit("expected probe_status=verified")
+PY
+
+echo "service api websocket live validation tests passed."

--- a/scripts/runtime/validate_service_api_websocket_live.sh
+++ b/scripts/runtime/validate_service_api_websocket_live.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+
+pushd "$ROOT_DIR" >/dev/null
+cargo build --quiet -p kamn-node
+NODE_BIN="$ROOT_DIR/target/debug/kamn-node"
+popd >/dev/null
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "expected built kamn-node binary to be executable" >&2
+  exit 1
+fi
+
+api_port="$(python3 - <<'PY'
+import socket
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+)"
+api_addr="127.0.0.1:${api_port}"
+
+api_stdout="$TMP_DIR/service-api-websocket.out"
+"$NODE_BIN" \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode api \
+  --api-bind "$api_addr" \
+  --api-max-requests 7 \
+  --api-idle-timeout-ms 5000 \
+  --output json >"$api_stdout" 2>&1 &
+node_pid=$!
+
+wait_for_ready=0
+for _ in $(seq 1 120); do
+  if curl -fsS "http://${api_addr}/healthz" >/dev/null 2>&1; then
+    wait_for_ready=1
+    break
+  fi
+  if ! kill -0 "$node_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+
+if [ "$wait_for_ready" -ne 1 ]; then
+  cat "$api_stdout" >&2
+  echo "expected websocket api endpoint to become ready" >&2
+  kill -KILL "$node_pid" 2>/dev/null || true
+  wait "$node_pid" 2>/dev/null || true
+  exit 1
+fi
+
+ws_results_json="$TMP_DIR/websocket-results.json"
+python3 - "$api_addr" "$ws_results_json" <<'PY'
+import json
+import socket
+import sys
+
+api_addr = sys.argv[1]
+report_path = sys.argv[2]
+host, port_text = api_addr.rsplit(":", 1)
+port = int(port_text)
+
+sender_did = "kamn:did:agent:websocket-live-validator"
+state_hash = "service-api:kamn-devnet:v0.1.0"
+
+
+def signature(nonce: int, payload: str) -> str:
+    return f"sig:ed25519:baseline-v1:{sender_did}:{nonce}:{state_hash}:{len(payload)}"
+
+
+def send_raw_request(request: str) -> bytes:
+    sock = socket.create_connection((host, port), timeout=2)
+    try:
+        sock.sendall(request.encode("utf-8"))
+        sock.shutdown(socket.SHUT_WR)
+        chunks: list[bytes] = []
+        while True:
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        sock.close()
+
+
+def split_response(response: bytes) -> tuple[str, bytes]:
+    marker = b"\r\n\r\n"
+    index = response.find(marker)
+    if index == -1:
+        raise SystemExit("websocket response header terminator missing")
+    header = response[: index + len(marker)].decode("utf-8")
+    return header, response[index + len(marker) :]
+
+
+def parse_small_text_frame(payload: bytes) -> str:
+    if len(payload) < 2:
+        raise SystemExit("websocket frame missing")
+    if payload[0] != 0x81:
+        raise SystemExit("websocket opcode mismatch")
+    length = payload[1] & 0x7F
+    if payload[1] & 0x80:
+        raise SystemExit("server websocket frame must not be masked")
+    if len(payload) < 2 + length:
+        raise SystemExit("websocket frame payload truncated")
+    return payload[2 : 2 + length].decode("utf-8")
+
+
+def ws_upgrade_request(nonce: int, version: str, include_upgrade: bool, include_auth: bool) -> str:
+    headers = [
+        f"Host: {api_addr}",
+        "Sec-WebSocket-Key: test-live-key",
+        f"Sec-WebSocket-Version: {version}",
+    ]
+    if include_upgrade:
+        headers.extend(["Connection: Upgrade", "Upgrade: websocket"])
+    if include_auth:
+        headers.extend(
+            [
+                f"X-KAMN-Sender-DID: {sender_did}",
+                f"X-KAMN-Request-Nonce: {nonce}",
+                f"X-KAMN-Request-Signature: {signature(nonce, '')}",
+            ]
+        )
+    header_block = "\r\n".join(headers)
+    return (
+        "GET /v1/events/ws HTTP/1.1\r\n"
+        + header_block
+        + "\r\nContent-Length: 0\r\n\r\n"
+    )
+
+
+result = {
+    "websocket_upgrade_status": "unknown",
+    "fail_closed_status": "unknown",
+}
+
+# Success: proper upgrade + auth + version
+success_response = send_raw_request(
+    ws_upgrade_request(nonce=1, version="13", include_upgrade=True, include_auth=True)
+)
+success_header, success_payload = split_response(success_response)
+if "HTTP/1.1 101 Switching Protocols" not in success_header:
+    raise SystemExit("expected websocket success status line")
+if "X-KAMN-WebSocket-Contract: v1" not in success_header:
+    raise SystemExit("expected websocket contract header")
+success_event = parse_small_text_frame(success_payload)
+if "\"event\":\"state-transition\"" not in success_event:
+    raise SystemExit("expected websocket event marker")
+result["websocket_upgrade_status"] = "verified"
+
+# Fail-closed: invalid websocket version
+invalid_version_response = send_raw_request(
+    ws_upgrade_request(nonce=2, version="12", include_upgrade=True, include_auth=True)
+)
+invalid_version_header, invalid_version_body = split_response(invalid_version_response)
+if "HTTP/1.1 400 Bad Request" not in invalid_version_header:
+    raise SystemExit("expected invalid websocket version rejection")
+if "invalid websocket version header" not in invalid_version_body.decode("utf-8", errors="ignore"):
+    raise SystemExit("expected invalid websocket version reason marker")
+
+# Fail-closed: missing upgrade headers
+missing_upgrade_response = send_raw_request(
+    ws_upgrade_request(nonce=3, version="13", include_upgrade=False, include_auth=True)
+)
+missing_upgrade_header, missing_upgrade_body = split_response(missing_upgrade_response)
+if "HTTP/1.1 400 Bad Request" not in missing_upgrade_header:
+    raise SystemExit("expected missing upgrade header rejection")
+if "missing required websocket upgrade header" not in missing_upgrade_body.decode(
+    "utf-8", errors="ignore"
+):
+    raise SystemExit("expected missing upgrade reason marker")
+
+# Fail-closed: unauthorized websocket request
+unauthorized_response = send_raw_request(
+    ws_upgrade_request(nonce=4, version="13", include_upgrade=True, include_auth=False)
+)
+unauthorized_header, unauthorized_body = split_response(unauthorized_response)
+if "HTTP/1.1 401 Unauthorized" not in unauthorized_header:
+    raise SystemExit("expected unauthorized websocket rejection")
+if "\"error\":\"unauthorized\"" not in unauthorized_body.decode("utf-8", errors="ignore"):
+    raise SystemExit("expected unauthorized error marker")
+
+result["fail_closed_status"] = "verified"
+
+with open(report_path, "w", encoding="utf-8") as handle:
+    json.dump(result, handle)
+PY
+
+websocket_upgrade_status="$(python3 - "$ws_results_json" <<'PY'
+import json
+import pathlib
+import sys
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["websocket_upgrade_status"])
+PY
+)"
+if [ "$websocket_upgrade_status" != "verified" ]; then
+  echo "expected websocket upgrade status to be verified" >&2
+  exit 1
+fi
+
+fail_closed_status="$(python3 - "$ws_results_json" <<'PY'
+import json
+import pathlib
+import sys
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["fail_closed_status"])
+PY
+)"
+if [ "$fail_closed_status" != "verified" ]; then
+  echo "expected websocket fail-closed status to be verified" >&2
+  exit 1
+fi
+
+health_file="$TMP_DIR/health.json"
+metrics_file="$TMP_DIR/metrics.txt"
+health_status="$(curl -sS -o "$health_file" -w '%{http_code}' "http://${api_addr}/healthz")"
+if [ "$health_status" != "200" ]; then
+  cat "$health_file" >&2
+  echo "expected websocket live health probe to return 200" >&2
+  exit 1
+fi
+if ! grep -q '"status":"ok"' "$health_file"; then
+  cat "$health_file" >&2
+  echo "expected websocket live health payload marker" >&2
+  exit 1
+fi
+metrics_status="$(curl -sS -o "$metrics_file" -w '%{http_code}' "http://${api_addr}/metrics")"
+if [ "$metrics_status" != "200" ]; then
+  cat "$metrics_file" >&2
+  echo "expected websocket live metrics probe to return 200" >&2
+  exit 1
+fi
+if ! grep -q 'kamn_service_api_health' "$metrics_file"; then
+  cat "$metrics_file" >&2
+  echo "expected websocket live metrics marker" >&2
+  exit 1
+fi
+probe_status="verified"
+
+set +e
+wait "$node_pid"
+node_exit_code=$?
+set -e
+if [ "$node_exit_code" -ne 0 ]; then
+  cat "$api_stdout" >&2
+  echo "expected websocket live process to exit cleanly after request budget" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "websocket live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/websocket-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.service-api-websocket-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "websocket_upgrade_status": "${websocket_upgrade_status}",
+  "fail_closed_status": "${fail_closed_status}",
+  "probe_status": "${probe_status}",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "websocket_upgrade_status=${websocket_upgrade_status}"
+echo "fail_closed_status=${fail_closed_status}"
+echo "probe_status=${probe_status}"


### PR DESCRIPTION
## Summary
Adds dedicated live-validation lanes for websocket state-transition streaming with deterministic GO/fail-closed evidence markers and documentation updates.

## Changes
- `scripts/runtime/validate_service_api_websocket_live.sh`: websocket live drill lane validating upgrade success, fail-closed cases, and probe accessibility.
- `scripts/runtime/test_validate_service_api_websocket_live.sh`: contract harness for marker/schema verification.
- `docs/api/websocket-events.md`: adds live validation commands and evidence references (#2918/#2919).
- `docs/api/service-http-api.md`: adds websocket live-lane commands.
- `docs/plans/2026-02-08-production-service-roadmap.md`: records Phase 2.3 live-validation delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/runtime/test_validate_service_api_websocket_live.sh`

Failing marker before lane implementation:
- `expected websocket live validation script to be executable`

### 🟢 Green Phase
Commands:
- `bash scripts/runtime/test_validate_service_api_websocket_live.sh`
- `bash scripts/runtime/validate_service_api_websocket_live.sh`

Passing markers:
- `service api websocket live validation tests passed.`
- `status=pass`
- `final_decision=GO`
- `websocket_upgrade_status=verified`
- `fail_closed_status=verified`
- `probe_status=verified`

### 🔁 Regression
Commands:
- `bash scripts/runtime/validate_service_api_websocket_live.sh --max-seconds nope`
- `bash scripts/runtime/test_validate_service_api_request_auth_live.sh`
- `bash scripts/runtime/test_validate_service_api_live.sh`
- `cargo fmt --check`

Result markers:
- invalid runtime budget arg fails closed with `max-seconds must be an integer`
- prior request-auth and service-api live lanes remain green
- formatting remains clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None | Orchestration/docs-only delta |
| Functional   | ✅     | websocket lane marker checks in `test_validate_service_api_websocket_live.sh` | |
| Integration  | ✅     | websocket live drill against running `kamn-node` | |
| Regression   | ✅     | fail-closed arg handling + compatibility lanes | |
| Performance  | ✅     | bounded by request budget and `--max-seconds` guard | |

## Risks & Rollback
- Risk: low; introduces validation/docs only.
- Rollback: revert this PR to remove websocket live-validation lane artifacts.

## Documentation Updates
- `docs/api/websocket-events.md`
- `docs/api/service-http-api.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (not required for script/docs-only delta)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing for changed scope
- [x] Docs updated

Closes #2918
Closes #2919
