### PR TITLE
feat(node): export service api observability telemetry (#2961)

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
@@ -204,6 +204,18 @@ fn functional_service_api_endpoint_renders_required_route_contracts() {
 
     let metrics_response = render_service_api_endpoint_response(&snapshot, "GET", "/metrics", "");
     assert_eq!(metrics_response.status_code, 200);
+    assert!(metrics_response
+        .body
+        .contains("kamn_service_api_observability_source{source=\"unknown\"} 1"));
+    assert!(metrics_response
+        .body
+        .contains("kamn_service_api_observability_health{health=\"unknown\"} 0"));
+    assert!(
+        metrics_response
+            .body
+            .contains("kamn_service_api_observability_latency_p50_ms 0"),
+        "metrics payload should publish runtime telemetry gauges even before daemon/kolme telemetry is available"
+    );
 
     let ws_response = render_service_api_endpoint_response(&snapshot, "GET", "/v1/events/ws", "");
     assert_eq!(ws_response.status_code, 400);
@@ -265,12 +277,44 @@ fn integration_service_api_endpoint_serves_required_http_routes() {
     assert!(send_response.contains("\"message_id\":\"msg-local-"));
     assert!(health_response.contains("HTTP/1.1 200 OK"));
     assert!(metrics_response.contains("HTTP/1.1 200 OK"));
+    assert!(
+        metrics_response.contains("kamn_service_api_observability_source{source=\"unknown\"} 1")
+    );
 
     let server_result = server.join().expect("endpoint thread should complete");
     assert!(
         server_result.is_ok(),
         "service api endpoint should stop cleanly after configured request budget"
     );
+}
+
+#[test]
+fn unit_service_api_endpoint_metrics_use_runtime_observability_when_present() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+    let report = execute(parsed).expect("daemon execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    assert_eq!(snapshot.observability_source, "daemon");
+    assert_eq!(snapshot.observability_health, "healthy");
+    let metrics_response = render_service_api_endpoint_response(&snapshot, "GET", "/metrics", "");
+    assert_eq!(metrics_response.status_code, 200);
+    assert!(metrics_response
+        .body
+        .contains("kamn_service_api_observability_source{source=\"daemon\"} 1"));
+    assert!(metrics_response
+        .body
+        .contains("kamn_service_api_observability_health{health=\"healthy\"} 1"));
 }
 
 #[test]

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -37,6 +37,14 @@ pub(crate) struct ServiceApiSnapshot {
     pub(crate) role: String,
     pub(crate) chain_id: String,
     pub(crate) chain_version: String,
+    pub(crate) observability_source: String,
+    pub(crate) observability_latency_p50_ms: u64,
+    pub(crate) observability_latency_p99_ms: u64,
+    pub(crate) observability_throughput_tps: u64,
+    pub(crate) observability_error_rate_bps: u64,
+    pub(crate) observability_availability_bps: u64,
+    pub(crate) observability_health: String,
+    pub(crate) observability_alert_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,11 +69,20 @@ enum RequestAuthFailure {
 }
 
 pub(crate) fn build_service_api_snapshot(report: &NodeBootstrapReport) -> ServiceApiSnapshot {
+    let observability = resolve_service_api_observability(report);
     ServiceApiSnapshot {
         runtime_mode: report.runtime_mode.clone(),
         role: report.role.clone(),
         chain_id: report.chain_id.clone(),
         chain_version: report.chain_version.clone(),
+        observability_source: observability.source,
+        observability_latency_p50_ms: observability.latency_p50_ms,
+        observability_latency_p99_ms: observability.latency_p99_ms,
+        observability_throughput_tps: observability.throughput_tps,
+        observability_error_rate_bps: observability.error_rate_bps,
+        observability_availability_bps: observability.availability_bps,
+        observability_health: observability.health,
+        observability_alert_count: observability.alert_count,
     }
 }
 
@@ -80,17 +97,35 @@ pub(crate) fn render_service_api_endpoint_response(
             status_code: 200,
             content_type: "application/json",
             body: format!(
-                "{{\"status\":\"ok\",\"runtime_mode\":\"{}\",\"role\":\"{}\"}}",
+                "{{\"status\":\"ok\",\"runtime_mode\":\"{}\",\"role\":\"{}\",\"observability_source\":\"{}\",\"observability_health\":\"{}\"}}",
                 escape_json_string(snapshot.runtime_mode.as_str()),
                 escape_json_string(snapshot.role.as_str()),
+                escape_json_string(snapshot.observability_source.as_str()),
+                escape_json_string(snapshot.observability_health.as_str()),
             ),
         };
     }
     if method == "GET" && path == ROUTE_METRICS {
+        let health_value = if snapshot.observability_health == "healthy" {
+            1
+        } else {
+            0
+        };
         let metrics = format!(
-            "kamn_service_api_health{{runtime_mode=\"{}\"}} 1\nkamn_service_api_role{{role=\"{}\"}} 1\n",
+            "kamn_service_api_health{{runtime_mode=\"{}\"}} 1\nkamn_service_api_role{{role=\"{}\"}} 1\nkamn_service_api_chain_info{{chain_id=\"{}\",chain_version=\"{}\"}} 1\nkamn_service_api_observability_latency_p50_ms {}\nkamn_service_api_observability_latency_p99_ms {}\nkamn_service_api_observability_throughput_tps {}\nkamn_service_api_observability_error_rate_bps {}\nkamn_service_api_observability_availability_bps {}\nkamn_service_api_observability_alert_count {}\nkamn_service_api_observability_source{{source=\"{}\"}} 1\nkamn_service_api_observability_health{{health=\"{}\"}} {}\n",
             escape_metrics_label(snapshot.runtime_mode.as_str()),
-            escape_metrics_label(snapshot.role.as_str())
+            escape_metrics_label(snapshot.role.as_str()),
+            escape_metrics_label(snapshot.chain_id.as_str()),
+            escape_metrics_label(snapshot.chain_version.as_str()),
+            snapshot.observability_latency_p50_ms,
+            snapshot.observability_latency_p99_ms,
+            snapshot.observability_throughput_tps,
+            snapshot.observability_error_rate_bps,
+            snapshot.observability_availability_bps,
+            snapshot.observability_alert_count,
+            escape_metrics_label(snapshot.observability_source.as_str()),
+            escape_metrics_label(snapshot.observability_health.as_str()),
+            health_value,
         );
         return ServiceApiEndpointResponse {
             status_code: 200,
@@ -309,6 +344,91 @@ fn service_api_signature_state_hash(snapshot: &ServiceApiSnapshot) -> String {
         snapshot.chain_id.as_str(),
         snapshot.chain_version.as_str()
     )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServiceApiObservabilitySnapshot {
+    source: String,
+    latency_p50_ms: u64,
+    latency_p99_ms: u64,
+    throughput_tps: u64,
+    error_rate_bps: u64,
+    availability_bps: u64,
+    health: String,
+    alert_count: usize,
+}
+
+fn resolve_service_api_observability(
+    report: &NodeBootstrapReport,
+) -> ServiceApiObservabilitySnapshot {
+    if let (
+        Some(latency_p50_ms),
+        Some(latency_p99_ms),
+        Some(throughput_tps),
+        Some(error_rate_bps),
+        Some(availability_bps),
+        Some(health),
+        Some(alert_count),
+    ) = (
+        report.daemon_observability_latency_p50_ms,
+        report.daemon_observability_latency_p99_ms,
+        report.daemon_observability_throughput_tps,
+        report.daemon_observability_error_rate_bps,
+        report.daemon_observability_availability_bps,
+        report.daemon_observability_health.as_deref(),
+        report.daemon_observability_alert_count,
+    ) {
+        return ServiceApiObservabilitySnapshot {
+            source: "daemon".to_owned(),
+            latency_p50_ms,
+            latency_p99_ms,
+            throughput_tps,
+            error_rate_bps,
+            availability_bps,
+            health: health.to_owned(),
+            alert_count,
+        };
+    }
+
+    if let (
+        Some(latency_p50_ms),
+        Some(latency_p99_ms),
+        Some(throughput_tps),
+        Some(error_rate_bps),
+        Some(availability_bps),
+        Some(health),
+        Some(alert_count),
+    ) = (
+        report.kolme_live_observability_latency_p50_ms,
+        report.kolme_live_observability_latency_p99_ms,
+        report.kolme_live_observability_throughput_tps,
+        report.kolme_live_observability_error_rate_bps,
+        report.kolme_live_observability_availability_bps,
+        report.kolme_live_observability_health.as_deref(),
+        report.kolme_live_observability_alert_count,
+    ) {
+        return ServiceApiObservabilitySnapshot {
+            source: "kolme-live".to_owned(),
+            latency_p50_ms,
+            latency_p99_ms,
+            throughput_tps,
+            error_rate_bps,
+            availability_bps,
+            health: health.to_owned(),
+            alert_count,
+        };
+    }
+
+    ServiceApiObservabilitySnapshot {
+        source: "unknown".to_owned(),
+        latency_p50_ms: 0,
+        latency_p99_ms: 0,
+        throughput_tps: 0,
+        error_rate_bps: 0,
+        availability_bps: 0,
+        health: "unknown".to_owned(),
+        alert_count: 0,
+    }
 }
 
 fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {

--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -35,6 +35,19 @@ Implemented route contract for local deterministic ingress:
 
 Response behavior is deterministic and intentionally lightweight for this phase.
 
+`GET /metrics` now includes deterministic runtime telemetry gauges/labels:
+
+- `kamn_service_api_observability_latency_p50_ms`
+- `kamn_service_api_observability_latency_p99_ms`
+- `kamn_service_api_observability_throughput_tps`
+- `kamn_service_api_observability_error_rate_bps`
+- `kamn_service_api_observability_availability_bps`
+- `kamn_service_api_observability_alert_count`
+- `kamn_service_api_observability_source{source="<daemon|kolme-live|unknown>"}`
+- `kamn_service_api_observability_health{health="<healthy|degraded|critical|unknown>"}`
+
+`GET /healthz` now also includes `observability_source` and `observability_health` fields.
+
 ## Request Auth
 
 Protected routes require deterministic request-envelope headers:
@@ -60,6 +73,7 @@ Signature profile:
 Low-cost local validation commands:
 
 - `cargo test -p kamn-node service_api_endpoint -- --nocapture`
+- `cargo test -p kamn-node unit_service_api_endpoint_metrics_use_runtime_observability_when_present -- --nocapture`
 - `cargo test -p kamn-node`
 - `cargo fmt --check`
 - `cargo clippy -p kamn-node -- -D warnings`

--- a/docs/ops/observability.md
+++ b/docs/ops/observability.md
@@ -1,0 +1,54 @@
+# Runtime Observability (Phase 6.1)
+
+This document captures the current production-service observability surface for roadmap
+Story #2960 and Task #2961.
+
+## Endpoints
+
+- Service API metrics: `GET /metrics`
+- Service API health: `GET /healthz`
+- Optional standalone observability endpoint:
+  - `--observability-endpoint-bind <host:port>`
+  - `--observability-endpoint-metrics-path </path>` (default `/metrics`)
+  - `--observability-endpoint-health-path </path>` (default `/healthz`)
+
+## Prometheus Metrics Contract
+
+Service API `/metrics` exports deterministic Prometheus text format metrics:
+
+- `kamn_service_api_health{runtime_mode="<mode>"}`
+- `kamn_service_api_role{role="<role>"}`
+- `kamn_service_api_chain_info{chain_id="<id>",chain_version="<version>"}`
+- `kamn_service_api_observability_latency_p50_ms`
+- `kamn_service_api_observability_latency_p99_ms`
+- `kamn_service_api_observability_throughput_tps`
+- `kamn_service_api_observability_error_rate_bps`
+- `kamn_service_api_observability_availability_bps`
+- `kamn_service_api_observability_alert_count`
+- `kamn_service_api_observability_source{source="<daemon|kolme-live|unknown>"}`
+- `kamn_service_api_observability_health{health="<healthy|degraded|critical|unknown>"}`
+
+When daemon/kolme runtime telemetry is unavailable, the export fails closed to deterministic
+unknown defaults (`source=unknown`, health value `0`, numeric gauges `0`) instead of omitting
+the metric families.
+
+## Structured Telemetry
+
+- Node runtime logs support machine-parsable JSON output through `KAMN_NODE_LOG_FORMAT=json`.
+- Runtime telemetry values are mapped from daemon or kolme-live execution snapshots and exposed
+  through the service metrics contract above.
+- Health payload includes telemetry source and health classification:
+  - `{"status":"ok","runtime_mode":"...","role":"...","observability_source":"...","observability_health":"..."}`
+
+## Local Validation
+
+Low-cost local checks:
+
+- `cargo test -p kamn-node service_api_endpoint -- --nocapture`
+- `cargo test -p kamn-node unit_service_api_endpoint_metrics_use_runtime_observability_when_present -- --nocapture`
+- `cargo fmt --check`
+- `cargo clippy -p kamn-node -- -D warnings`
+- `bash scripts/runtime/validate_service_api_live.sh`
+
+These checks validate metrics export behavior without introducing external metrics backends or
+long-running CI load.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -31,6 +31,7 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_service_api_websocket_live.sh` and `scripts/runtime/test_validate_service_api_websocket_live.sh` (Task #2918, Subtask #2919).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `websocket_upgrade_status=verified`, `fail_closed_status=verified`, `probe_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
+- Phase 6.1 initial slice delivered: service API `/metrics` now exports deterministic runtime telemetry gauges and source/health labels with fail-closed unknown defaults when daemon/kolme telemetry is unavailable (Task #2961, Subtask #2962).
 
 ---
 


### PR DESCRIPTION
## Summary
Added deterministic runtime telemetry export to the service API `/metrics` endpoint and extended `/healthz` with observability source/health fields. This closes the core implementation slice for Prometheus-style observability in Phase 6.1.

Closes #2961
Closes #2962

## Changes
- `crates/kamn-node/src/service_api_endpoint.rs`: extended `ServiceApiSnapshot` with observability fields, added daemon/kolme-live telemetry resolution with fail-closed unknown defaults, and expanded `/metrics` payload with runtime telemetry gauges/labels.
- `crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs`: added red/green contract assertions for telemetry markers and added a daemon-backed unit test validating non-default telemetry export.
- `docs/api/service-http-api.md`: documented `/metrics` telemetry families and updated validation commands.
- `docs/ops/observability.md`: added operations-oriented observability endpoint contract and low-cost validation guidance.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded Phase 6.1 initial slice delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `cargo test -p kamn-node functional_service_api_endpoint_renders_required_route_contracts -- --nocapture`

Failure marker:
- `assertion failed: metrics_response.body.contains("kamn_service_api_observability_source{source=\"unknown\"} 1")`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node functional_service_api_endpoint_renders_required_route_contracts -- --nocapture`
- `cargo test -p kamn-node unit_service_api_endpoint_metrics_use_runtime_observability_when_present -- --nocapture`

Result:
- Both pass after implementation.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo test -p kamn-node service_api_endpoint -- --nocapture`
- `cargo test -p kamn-node`
- `cargo clippy -p kamn-node -- -D warnings`
- `bash scripts/runtime/test_validate_service_api_live.sh`

Result:
- All commands passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_service_api_endpoint_metrics_use_runtime_observability_when_present` |                      |
| Functional   | ✅     | `functional_service_api_endpoint_renders_required_route_contracts` (extended metrics contract assertions) |                      |
| Integration  | ✅     | `integration_service_api_endpoint_serves_required_http_routes` (metrics marker assertion) |                      |
| Regression   | ✅     | Existing service API regression suite rerun in full crate regression |                      |
| Performance  | N/A    |                      | No hotspot/path-length algorithm change; export remains deterministic O(1) formatting. |

## Risks & Rollback
- None expected; behavior is additive for metrics payload and health JSON fields.
- Rollback: revert this PR to restore previous lightweight `/metrics` payload contract.

## Documentation Updates
- `docs/api/service-http-api.md`
- `docs/ops/observability.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to `-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)
