### PR TITLE
test(runtime): add observability live validation lane (#2963)

### DIFF
--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -84,6 +84,8 @@ Low-cost local validation commands:
 - `bash scripts/runtime/validate_service_api_request_auth_live.sh`
 - `bash scripts/runtime/test_validate_service_api_websocket_live.sh`
 - `bash scripts/runtime/validate_service_api_websocket_live.sh`
+- `bash scripts/runtime/test_validate_service_api_observability_live.sh`
+- `bash scripts/runtime/validate_service_api_observability_live.sh`
 
 These checks cover unit, functional, integration, and regression behavior for the API ingress module without requiring external infrastructure.
 

--- a/docs/ops/observability.md
+++ b/docs/ops/observability.md
@@ -49,6 +49,28 @@ Low-cost local checks:
 - `cargo fmt --check`
 - `cargo clippy -p kamn-node -- -D warnings`
 - `bash scripts/runtime/validate_service_api_live.sh`
+- `bash scripts/runtime/test_validate_service_api_observability_live.sh`
+- `bash scripts/runtime/validate_service_api_observability_live.sh`
 
 These checks validate metrics export behavior without introducing external metrics backends or
 long-running CI load.
+
+## Live Validation Evidence
+
+Task and subtask:
+
+- Task: #2963
+- Subtask: #2964
+
+Deterministic success markers from `validate_service_api_observability_live.sh`:
+
+- `status=pass`
+- `final_decision=GO`
+- `metrics_contract_status=verified`
+- `health_contract_status=verified`
+- `fail_closed_status=verified`
+
+Fail-closed marker:
+
+- `bash scripts/runtime/validate_service_api_observability_live.sh --max-seconds nope`
+- stderr marker: `max-seconds must be an integer`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -32,6 +32,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `websocket_upgrade_status=verified`, `fail_closed_status=verified`, `probe_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 - Phase 6.1 initial slice delivered: service API `/metrics` now exports deterministic runtime telemetry gauges and source/health labels with fail-closed unknown defaults when daemon/kolme telemetry is unavailable (Task #2961, Subtask #2962).
+- Phase 6.1 live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_service_api_observability_live.sh` and `scripts/runtime/test_validate_service_api_observability_live.sh` (Task #2963, Subtask #2964).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `metrics_contract_status=verified`, `health_contract_status=verified`, `fail_closed_status=verified`.
+  - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 
 ---
 

--- a/scripts/runtime/test_validate_service_api_observability_live.sh
+++ b/scripts/runtime/test_validate_service_api_observability_live.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_observability_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected service api observability live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected service api observability live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected service api observability live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^metrics_contract_status=verified$'; then
+  echo "expected observability metrics contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^health_contract_status=verified$'; then
+  echo "expected observability health contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
+  echo "expected observability fail-closed marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.service-api-observability-live-validation.v1":
+    raise SystemExit("unexpected service api observability validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision=GO")
+if payload.get("metrics_contract_status") != "verified":
+    raise SystemExit("expected metrics_contract_status=verified")
+if payload.get("health_contract_status") != "verified":
+    raise SystemExit("expected health_contract_status=verified")
+if payload.get("fail_closed_status") != "verified":
+    raise SystemExit("expected fail_closed_status=verified")
+PY
+
+set +e
+invalid_arg_output="$(bash "$VALIDATION_SCRIPT" --max-seconds nope 2>&1)"
+invalid_arg_code=$?
+set -e
+if [ "$invalid_arg_code" -eq 0 ]; then
+  echo "expected invalid --max-seconds to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_arg_output" | grep -q 'max-seconds must be an integer'; then
+  printf '%s\n' "$invalid_arg_output" >&2
+  echo "expected invalid --max-seconds reason marker" >&2
+  exit 1
+fi
+
+echo "service api observability live validation tests passed."

--- a/scripts/runtime/validate_service_api_observability_live.sh
+++ b/scripts/runtime/validate_service_api_observability_live.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+
+pushd "$ROOT_DIR" >/dev/null
+cargo build --quiet -p kamn-node
+NODE_BIN="$ROOT_DIR/target/debug/kamn-node"
+popd >/dev/null
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "expected built kamn-node binary to be executable" >&2
+  exit 1
+fi
+
+api_port="$(python3 - <<'PY'
+import socket
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+)"
+api_addr="127.0.0.1:${api_port}"
+
+api_stdout="$TMP_DIR/service-api-observability.out"
+"$NODE_BIN" \
+  --role processor \
+  --chain-id kamn-devnet \
+  --chain-version v0.1.0 \
+  --runtime-mode api \
+  --api-bind "$api_addr" \
+  --api-max-requests 3 \
+  --api-idle-timeout-ms 5000 \
+  --output json >"$api_stdout" 2>&1 &
+node_pid=$!
+
+ready=0
+for _ in $(seq 1 120); do
+  if grep -q 'node.runtime.service_api.endpoint.start' "$api_stdout"; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$node_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+
+if [ "$ready" -ne 1 ]; then
+  cat "$api_stdout" >&2
+  echo "expected service api observability endpoint to start" >&2
+  kill -KILL "$node_pid" 2>/dev/null || true
+  wait "$node_pid" 2>/dev/null || true
+  exit 1
+fi
+
+health_file="$TMP_DIR/healthz.json"
+metrics_file="$TMP_DIR/metrics.txt"
+post_metrics_file="$TMP_DIR/post-metrics.txt"
+
+health_status="$(curl -sS -o "$health_file" -w '%{http_code}' "http://${api_addr}/healthz")"
+if [ "$health_status" != "200" ]; then
+  cat "$health_file" >&2
+  echo "expected health endpoint to return 200" >&2
+  exit 1
+fi
+if ! grep -q '"status":"ok"' "$health_file"; then
+  cat "$health_file" >&2
+  echo "expected health status marker" >&2
+  exit 1
+fi
+if ! grep -q '"observability_source":"unknown"' "$health_file"; then
+  cat "$health_file" >&2
+  echo "expected health observability source marker" >&2
+  exit 1
+fi
+if ! grep -q '"observability_health":"unknown"' "$health_file"; then
+  cat "$health_file" >&2
+  echo "expected health observability marker" >&2
+  exit 1
+fi
+
+metrics_status="$(curl -sS -o "$metrics_file" -w '%{http_code}' "http://${api_addr}/metrics")"
+if [ "$metrics_status" != "200" ]; then
+  cat "$metrics_file" >&2
+  echo "expected metrics endpoint to return 200" >&2
+  exit 1
+fi
+if ! grep -q 'kamn_service_api_observability_source{source="unknown"} 1' "$metrics_file"; then
+  cat "$metrics_file" >&2
+  echo "expected observability source metrics marker" >&2
+  exit 1
+fi
+if ! grep -q 'kamn_service_api_observability_health{health="unknown"} 0' "$metrics_file"; then
+  cat "$metrics_file" >&2
+  echo "expected observability health metrics marker" >&2
+  exit 1
+fi
+if ! grep -q 'kamn_service_api_observability_latency_p50_ms 0' "$metrics_file"; then
+  cat "$metrics_file" >&2
+  echo "expected observability latency metrics marker" >&2
+  exit 1
+fi
+
+sender_did="kamn:did:agent:service-api-observability-validator"
+nonce=1
+state_hash="service-api:kamn-devnet:v0.1.0"
+signature="sig:ed25519:baseline-v1:${sender_did}:${nonce}:${state_hash}:0"
+post_metrics_status="$(curl -sS -o "$post_metrics_file" -w '%{http_code}' \
+  -X POST "http://${api_addr}/metrics" \
+  -H "X-KAMN-Sender-DID: ${sender_did}" \
+  -H "X-KAMN-Request-Nonce: ${nonce}" \
+  -H "X-KAMN-Request-Signature: ${signature}" \
+  --data '')"
+if [ "$post_metrics_status" != "405" ]; then
+  cat "$post_metrics_file" >&2
+  echo "expected invalid method on /metrics to fail closed with 405" >&2
+  exit 1
+fi
+if ! grep -q 'method not allowed' "$post_metrics_file"; then
+  cat "$post_metrics_file" >&2
+  echo "expected fail-closed method marker for /metrics" >&2
+  exit 1
+fi
+
+set +e
+wait "$node_pid"
+node_exit_code=$?
+set -e
+if [ "$node_exit_code" -ne 0 ]; then
+  cat "$api_stdout" >&2
+  echo "expected service api observability process to exit cleanly after request budget" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "service api observability live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/service-api-observability-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.service-api-observability-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "metrics_contract_status": "verified",
+  "health_contract_status": "verified",
+  "fail_closed_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "metrics_contract_status=verified"
+echo "health_contract_status=verified"
+echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
Added a dedicated low-cost live validation lane for service API observability contracts. The lane validates deterministic `/metrics` and `/healthz` telemetry markers and includes a fail-closed invalid-method drill.

Closes #2963
Closes #2964

## Changes
- `scripts/runtime/validate_service_api_observability_live.sh`: new live drill that validates observability metrics markers, health payload markers, fail-closed `POST /metrics` (`405`), runtime budget, and emits deterministic evidence markers/json.
- `scripts/runtime/test_validate_service_api_observability_live.sh`: new lane test harness with schema assertions and fail-closed argument validation (`--max-seconds nope`).
- `docs/ops/observability.md`: added lane commands, evidence markers, and fail-closed marker reference.
- `docs/api/service-http-api.md`: added observability live lane commands.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded Phase 6.1 live validation delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/runtime/test_validate_service_api_observability_live.sh`

Failure marker:
- `bash: scripts/runtime/test_validate_service_api_observability_live.sh: No such file or directory`

### 🟢 Green Phase
Commands:
- `bash scripts/runtime/test_validate_service_api_observability_live.sh`
- `bash scripts/runtime/validate_service_api_observability_live.sh`

Result:
- Both pass with deterministic markers:
  - `status=pass`
  - `final_decision=GO`
  - `metrics_contract_status=verified`
  - `health_contract_status=verified`
  - `fail_closed_status=verified`

### 🔁 Regression
Commands:
- `bash scripts/runtime/test_validate_service_api_live.sh`
- `cargo fmt --check`

Result:
- Both passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    |                      | Lane scripts/harness only; no new Rust unit logic introduced. |
| Functional   | ✅     | `scripts/runtime/test_validate_service_api_observability_live.sh` |                      |
| Integration  | ✅     | `scripts/runtime/validate_service_api_observability_live.sh` (live process + HTTP probes) |                      |
| Regression   | ✅     | fail-closed checks for invalid `--max-seconds` and invalid method on `/metrics` |                      |
| Performance  | ✅     | bounded by `--max-seconds` runtime budget gate in lane script |                      |

## Risks & Rollback
- None expected; additions are new validation scripts and docs only.
- Rollback: revert this PR to remove the lane and docs references.

## Documentation Updates
- `docs/api/service-http-api.md`
- `docs/ops/observability.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (N/A for script-only changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant lane regression commands)
- [x] Docs updated (or justified why not)
