### PR TITLE
test(deploy): add deployment assets live validation lane (#2973)

### DIFF
--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -69,6 +69,31 @@ kubectl delete -f deploy/k8s/kamn-node.yaml
 Low-cost local checks:
 
 - `bash scripts/deploy/test_deployment_assets.sh`
+- `bash scripts/deploy/test_validate_deployment_assets_live.sh`
+- `bash scripts/deploy/validate_deployment_assets_live.sh`
 - `cargo fmt --check`
 
 The deployment-assets contract test fails closed when any required artifact or required marker is missing.
+
+## Live Validation Evidence
+
+Task and subtask:
+
+- Task: #2973
+- Subtask: #2974
+
+Deterministic success markers:
+
+- `status=pass`
+- `final_decision=GO`
+- `asset_contract_status=verified`
+- `fail_closed_status=verified`
+
+Fail-closed markers:
+
+- `bash scripts/deploy/validate_deployment_assets_live.sh --max-seconds nope`
+- stderr marker: `max-seconds must be an integer`
+
+- negative drill inside live lane:
+  - invalid Dockerfile missing builder `FROM rust:` marker
+  - deterministic reason marker: `expected Dockerfile multi-stage builder image marker`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -37,6 +37,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `metrics_contract_status=verified`, `health_contract_status=verified`, `fail_closed_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 - Phase 6.3 initial slice delivered: deployment artifacts now include a multi-stage `Dockerfile`, `deploy/docker-compose.yml` role topology, and `deploy/k8s/kamn-node.yaml` baseline manifests (Task #2971, Subtask #2972).
+- Phase 6.3 live validation delivered:
+  - Runtime lane: `scripts/deploy/validate_deployment_assets_live.sh` and `scripts/deploy/test_validate_deployment_assets_live.sh` (Task #2973, Subtask #2974).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `asset_contract_status=verified`, `fail_closed_status=verified`.
+  - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
 
 ---
 

--- a/scripts/deploy/test_deployment_assets.sh
+++ b/scripts/deploy/test_deployment_assets.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-DOCKERFILE="$ROOT_DIR/Dockerfile"
-COMPOSE_FILE="$ROOT_DIR/deploy/docker-compose.yml"
-K8S_MANIFEST="$ROOT_DIR/deploy/k8s/kamn-node.yaml"
-DEPLOY_DOC="$ROOT_DIR/docs/ops/deployment.md"
+DOCKERFILE="${DOCKERFILE_PATH:-$ROOT_DIR/Dockerfile}"
+COMPOSE_FILE="${COMPOSE_FILE_PATH:-$ROOT_DIR/deploy/docker-compose.yml}"
+K8S_MANIFEST="${K8S_MANIFEST_PATH:-$ROOT_DIR/deploy/k8s/kamn-node.yaml}"
+DEPLOY_DOC="${DEPLOY_DOC_PATH:-$ROOT_DIR/docs/ops/deployment.md}"
 
 if [ ! -f "$DOCKERFILE" ]; then
   echo "expected Dockerfile for deployment assets story" >&2

--- a/scripts/deploy/test_validate_deployment_assets_live.sh
+++ b/scripts/deploy/test_validate_deployment_assets_live.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/deploy/validate_deployment_assets_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected deployment assets live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected deployment assets live validation status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected deployment assets live validation GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^asset_contract_status=verified$'; then
+  echo "expected deployment asset contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
+  echo "expected deployment fail-closed marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.deploy.assets.live-validation.v1":
+    raise SystemExit("unexpected deployment assets live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision=GO")
+if payload.get("asset_contract_status") != "verified":
+    raise SystemExit("expected asset_contract_status=verified")
+if payload.get("fail_closed_status") != "verified":
+    raise SystemExit("expected fail_closed_status=verified")
+PY
+
+set +e
+invalid_arg_output="$(bash "$VALIDATION_SCRIPT" --max-seconds nope 2>&1)"
+invalid_arg_code=$?
+set -e
+if [ "$invalid_arg_code" -eq 0 ]; then
+  echo "expected invalid --max-seconds to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_arg_output" | grep -q 'max-seconds must be an integer'; then
+  printf '%s\n' "$invalid_arg_output" >&2
+  echo "expected invalid --max-seconds reason marker" >&2
+  exit 1
+fi
+
+echo "deployment assets live validation tests passed."

--- a/scripts/deploy/validate_deployment_assets_live.sh
+++ b/scripts/deploy/validate_deployment_assets_live.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+start_epoch="$(date +%s)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+pushd "$ROOT_DIR" >/dev/null
+bash scripts/deploy/test_deployment_assets.sh
+popd >/dev/null
+
+bad_dockerfile="$TMP_DIR/Dockerfile.bad"
+grep -v '^FROM rust:' "$ROOT_DIR/Dockerfile" >"$bad_dockerfile"
+
+set +e
+negative_output="$(DOCKERFILE_PATH="$bad_dockerfile" bash "$ROOT_DIR/scripts/deploy/test_deployment_assets.sh" 2>&1)"
+negative_code=$?
+set -e
+if [ "$negative_code" -eq 0 ]; then
+  echo "expected deployment assets checker to fail closed for invalid Dockerfile" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$negative_output" | grep -q 'expected Dockerfile multi-stage builder image marker'; then
+  printf '%s\n' "$negative_output" >&2
+  echo "expected deterministic fail-closed reason marker for invalid Dockerfile" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "deployment assets live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/deployment-assets-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.deploy.assets.live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "asset_contract_status": "verified",
+  "fail_closed_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "asset_contract_status=verified"
+echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
Added a dedicated live validation lane for deployment assets with deterministic evidence markers and a fail-closed negative drill. This completes the validation half of the deployment-assets story.

Closes #2973
Closes #2974

## Changes
- `scripts/deploy/validate_deployment_assets_live.sh`: new live validation lane with runtime budget control, pass/fail markers, and invalid Dockerfile negative drill.
- `scripts/deploy/test_validate_deployment_assets_live.sh`: new harness validating lane markers, schema contract, and invalid-argument fail-closed behavior.
- `scripts/deploy/test_deployment_assets.sh`: supports optional path overrides for deterministic negative drills.
- `docs/ops/deployment.md`: added live-lane commands and evidence markers.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded Phase 6.3 live validation delivery.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `bash scripts/deploy/test_validate_deployment_assets_live.sh`

Failure marker:
- `bash: scripts/deploy/test_validate_deployment_assets_live.sh: No such file or directory`

### 🟢 Green Phase
Commands:
- `bash scripts/deploy/test_validate_deployment_assets_live.sh`
- `bash scripts/deploy/validate_deployment_assets_live.sh`

Result:
- Both pass with deterministic markers:
  - `status=pass`
  - `final_decision=GO`
  - `asset_contract_status=verified`
  - `fail_closed_status=verified`

### 🔁 Regression
Commands:
- `bash scripts/deploy/test_deployment_assets.sh`
- `cargo fmt --check`

Result:
- Both passed after changes.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    |                      | Script-only validation orchestration changes. |
| Functional   | ✅     | `scripts/deploy/test_validate_deployment_assets_live.sh` |                      |
| Integration  | ✅     | `scripts/deploy/validate_deployment_assets_live.sh` (live artifact + negative drill execution) |                      |
| Regression   | ✅     | fail-closed invalid arg and invalid Dockerfile checks |                      |
| Performance  | ✅     | bounded by `--max-seconds` budget guard in lane script |                      |

## Risks & Rollback
- Low risk; changes are additive deployment validation scripts/docs.
- Rollback: revert this PR to restore previous deployment validation surface.

## Documentation Updates
- `docs/ops/deployment.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant deployment validation lanes)
- [x] Docs updated (or justified why not)
