### PR TITLE
test(runtime): validate failure drills live evidence lane (#2983)

### DIFF
--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -53,6 +53,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/run_network_signer_finality_failure_drills_lane.sh` and `scripts/runtime/test_run_network_signer_finality_failure_drills_lane.sh` (Task #2981, Subtask #2982).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `network_partition_status=verified`, `signer_fault_status=verified`, `finality_fault_status=verified`.
   - Injected signer fault profile validated as fail-closed: `signer_fault_injection_triggered`.
+- Failure-drills live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_failure_drills_live.sh` and `scripts/runtime/test_validate_failure_drills_live.sh` (Task #2983, Subtask #2984).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `baseline_contract_status=verified`, `fault_injection_status=verified`, `fail_closed_status=verified`.
+  - Fail-closed validation confirmed for signer fault injection: `signer_fault_injection_triggered`.
 
 ---
 

--- a/docs/validation/failure-drills.md
+++ b/docs/validation/failure-drills.md
@@ -69,4 +69,27 @@ Includes:
 
 ## Live Validation (Task #2983 / Subtask #2984)
 
-Dedicated live-validation drill scripts and evidence markers are tracked in Task #2983 and Subtask #2984.
+Live validation artifacts:
+
+- `scripts/runtime/validate_failure_drills_live.sh`
+- `scripts/runtime/test_validate_failure_drills_live.sh`
+
+Run validation harness:
+
+```bash
+bash scripts/runtime/test_validate_failure_drills_live.sh
+```
+
+Deterministic success markers:
+
+- `status=pass`
+- `final_decision=GO`
+- `baseline_contract_status=verified`
+- `fault_injection_status=verified`
+- `fail_closed_status=verified`
+
+Injected fail-closed drill:
+
+- signer fault profile:
+  - `bash scripts/runtime/run_network_signer_finality_failure_drills_lane.sh --fault-profile signer --max-seconds 180 --partition-max-seconds 60 --signer-max-seconds 60`
+  - deterministic reason marker: `signer_fault_injection_triggered`

--- a/scripts/runtime/test_validate_failure_drills_live.sh
+++ b/scripts/runtime/test_validate_failure_drills_live.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_failure_drills_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected failure drills live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected failure drills live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected failure drills live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^baseline_contract_status=verified$'; then
+  echo "expected failure drills live validation baseline marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fault_injection_status=verified$'; then
+  echo "expected failure drills live validation fault injection marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
+  echo "expected failure drills live validation fail-closed marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.failure-drills-live-validation.v1":
+    raise SystemExit("unexpected failure drills live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected failure drills live validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected failure drills live validation final_decision=GO")
+if payload.get("baseline_contract_status") != "verified":
+    raise SystemExit("expected baseline_contract_status=verified")
+if payload.get("fault_injection_status") != "verified":
+    raise SystemExit("expected fault_injection_status=verified")
+if payload.get("fail_closed_status") != "verified":
+    raise SystemExit("expected fail_closed_status=verified")
+PY
+
+set +e
+invalid_budget_output="$(
+  bash "$VALIDATION_SCRIPT" --max-seconds nope 2>&1
+)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected failure drills live validation script to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q 'max-seconds must be an integer'; then
+  echo "expected deterministic invalid max-seconds marker for failure drills live validation script" >&2
+  exit 1
+fi
+
+echo "failure drills live validation tests passed."

--- a/scripts/runtime/validate_failure_drills_live.sh
+++ b/scripts/runtime/validate_failure_drills_live.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+baseline_report="$TMP_DIR/failure-drills-baseline.json"
+baseline_output="$(
+  bash "$ROOT_DIR/scripts/runtime/run_network_signer_finality_failure_drills_lane.sh" \
+    --max-seconds 180 \
+    --partition-max-seconds 60 \
+    --signer-max-seconds 60 \
+    --output-json "$baseline_report"
+)"
+
+if ! printf '%s\n' "$baseline_output" | grep -q '^status=pass$'; then
+  echo "expected failure drills baseline status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^final_decision=GO$'; then
+  echo "expected failure drills baseline GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^network_partition_status=verified$'; then
+  echo "expected failure drills baseline network partition marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^signer_fault_status=verified$'; then
+  echo "expected failure drills baseline signer marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^finality_fault_status=verified$'; then
+  echo "expected failure drills baseline finality marker" >&2
+  exit 1
+fi
+
+fault_report="$TMP_DIR/failure-drills-fault.json"
+set +e
+fault_output="$(
+  bash "$ROOT_DIR/scripts/runtime/run_network_signer_finality_failure_drills_lane.sh" \
+    --fault-profile signer \
+    --max-seconds 180 \
+    --partition-max-seconds 60 \
+    --signer-max-seconds 60 \
+    --output-json "$fault_report" 2>&1
+)"
+fault_code=$?
+set -e
+if [ "$fault_code" -eq 0 ]; then
+  echo "expected failure drills signer fault profile to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$fault_output" | grep -q 'signer_fault_injection_triggered'; then
+  echo "expected signer fault-injection reason marker in failure drills live validation" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "failure drills live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/failure-drills-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.failure-drills-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "baseline_contract_status": "verified",
+  "fault_injection_status": "verified",
+  "fail_closed_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "baseline_contract_status=verified"
+echo "fault_injection_status=verified"
+echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
Added the dedicated live-validation evidence lane for failure drills, proving baseline GO behavior and an injected signer fault fail-closed path with deterministic markers. Updated validation and roadmap docs with the live drill protocol and evidence markers.

Closes #2983
Closes #2984

## Changes
- `scripts/runtime/validate_failure_drills_live.sh`: new live-validation drill script for failure drills.
- `scripts/runtime/test_validate_failure_drills_live.sh`: harness for schema/marker and fail-closed checks.
- `docs/validation/failure-drills.md`: added live validation commands, markers, and fail-closed drill notes.
- `docs/plans/2026-02-08-production-service-roadmap.md`: added failure-drills live validation delivered status markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_validate_failure_drills_live.sh
```
Output before implementation:
```text
bash: scripts/runtime/test_validate_failure_drills_live.sh: No such file or directory
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/runtime/test_validate_failure_drills_live.sh
bash scripts/runtime/validate_failure_drills_live.sh --max-seconds 120
```
Key output markers:
```text
failure drills live validation tests passed.
status=pass
final_decision=GO
baseline_contract_status=verified
fault_injection_status=verified
fail_closed_status=verified
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
bash scripts/runtime/test_run_network_signer_finality_failure_drills_lane.sh
bash scripts/runtime/test_run_live_network_partition_reconnect_smoke_lane.sh
bash scripts/signer/test_run_signer_incident_recovery_lane.sh
```
Result: all passed.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status   | Tests Added/Modified | Justification if N/A |
|--------------|----------|----------------------|----------------------|
| Unit         | ✅       | `scripts/runtime/test_validate_failure_drills_live.sh` schema/marker assertions |                      |
| Functional   | ✅       | `validate_failure_drills_live.sh` baseline run markers |                      |
| Integration  | ✅       | Live validation runs composite failure-drills lane and injected fault path |                      |
| Regression   | ✅       | Signer injected-fault fail-closed marker (`signer_fault_injection_triggered`) validated |                      |
| Performance  | N/A      | Runtime budget guard enforced for validation lane | bounded runtime check |

## Risks & Rollback
- None.
- Rollback plan: revert this PR to remove live-validation lane and docs if policy criteria changes.

## Documentation Updates
- `docs/validation/failure-drills.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean (not run; no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated
