### PR TITLE
test(runtime): validate go-no-go gate live evidence lane (#2988)

### DIFF
--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -61,6 +61,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/run_go_no_go_gate_lane.sh` and `scripts/runtime/test_run_go_no_go_gate_lane.sh` (Task #2986, Subtask #2987).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `go_no_go_evidence_status=verified`, `rollback_readiness_status=verified`, `dr_readiness_status=verified`.
   - Injected decision-fault profile validated as fail-closed: `gate_decision_fault_injection_triggered`.
+- Go/no-go gate live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_go_no_go_gate_live.sh` and `scripts/runtime/test_validate_go_no_go_gate_live.sh` (Task #2988, Subtask #2989).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `baseline_contract_status=verified`, `fault_injection_status=verified`, `fail_closed_status=verified`.
+  - Fail-closed validation confirmed for decision fault injection: `gate_decision_fault_injection_triggered`.
 
 ---
 

--- a/docs/validation/go-no-go.md
+++ b/docs/validation/go-no-go.md
@@ -69,4 +69,27 @@ Includes:
 
 ## Live Validation (Task #2988 / Subtask #2989)
 
-Dedicated live-validation drill scripts and evidence markers are tracked in Task #2988 and Subtask #2989.
+Live validation artifacts:
+
+- `scripts/runtime/validate_go_no_go_gate_live.sh`
+- `scripts/runtime/test_validate_go_no_go_gate_live.sh`
+
+Run validation harness:
+
+```bash
+bash scripts/runtime/test_validate_go_no_go_gate_live.sh
+```
+
+Deterministic success markers:
+
+- `status=pass`
+- `final_decision=GO`
+- `baseline_contract_status=verified`
+- `fault_injection_status=verified`
+- `fail_closed_status=verified`
+
+Injected fail-closed drill:
+
+- decision fault profile:
+  - `bash scripts/runtime/run_go_no_go_gate_lane.sh --fault-profile gate_decision --max-seconds 120`
+  - deterministic reason marker: `gate_decision_fault_injection_triggered`

--- a/scripts/runtime/test_validate_go_no_go_gate_live.sh
+++ b/scripts/runtime/test_validate_go_no_go_gate_live.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_go_no_go_gate_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected go/no-go gate live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected go/no-go gate live validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected go/no-go gate live validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^baseline_contract_status=verified$'; then
+  echo "expected go/no-go gate live validation baseline marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fault_injection_status=verified$'; then
+  echo "expected go/no-go gate live validation fault injection marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
+  echo "expected go/no-go gate live validation fail-closed marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.go-no-go-gate-live-validation.v1":
+    raise SystemExit("unexpected go/no-go gate live validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected go/no-go gate live validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected go/no-go gate live validation final_decision=GO")
+if payload.get("baseline_contract_status") != "verified":
+    raise SystemExit("expected baseline_contract_status=verified")
+if payload.get("fault_injection_status") != "verified":
+    raise SystemExit("expected fault_injection_status=verified")
+if payload.get("fail_closed_status") != "verified":
+    raise SystemExit("expected fail_closed_status=verified")
+PY
+
+set +e
+invalid_budget_output="$(
+  bash "$VALIDATION_SCRIPT" --max-seconds nope 2>&1
+)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected go/no-go gate live validation script to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q 'max-seconds must be an integer'; then
+  echo "expected deterministic invalid max-seconds marker for go/no-go gate live validation script" >&2
+  exit 1
+fi
+
+echo "go/no-go gate live validation tests passed."

--- a/scripts/runtime/validate_go_no_go_gate_live.sh
+++ b/scripts/runtime/validate_go_no_go_gate_live.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+baseline_report="$TMP_DIR/go-no-go-gate-baseline.json"
+baseline_output="$(
+  bash "$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh" \
+    --max-seconds 120 \
+    --output-json "$baseline_report"
+)"
+
+if ! printf '%s\n' "$baseline_output" | grep -q '^status=pass$'; then
+  echo "expected go/no-go gate baseline status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^final_decision=GO$'; then
+  echo "expected go/no-go gate baseline GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^go_no_go_evidence_status=verified$'; then
+  echo "expected go/no-go gate baseline evidence marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^rollback_readiness_status=verified$'; then
+  echo "expected go/no-go gate baseline rollback marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^dr_readiness_status=verified$'; then
+  echo "expected go/no-go gate baseline dr marker" >&2
+  exit 1
+fi
+
+fault_report="$TMP_DIR/go-no-go-gate-fault.json"
+set +e
+fault_output="$(
+  bash "$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh" \
+    --fault-profile gate_decision \
+    --max-seconds 120 \
+    --output-json "$fault_report" 2>&1
+)"
+fault_code=$?
+set -e
+if [ "$fault_code" -eq 0 ]; then
+  echo "expected go/no-go gate decision fault profile to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$fault_output" | grep -q 'gate_decision_fault_injection_triggered'; then
+  echo "expected go/no-go decision fault reason marker in live validation" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "go/no-go gate live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/go-no-go-gate-live-validation-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.go-no-go-gate-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "baseline_contract_status": "verified",
+  "fault_injection_status": "verified",
+  "fail_closed_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "baseline_contract_status=verified"
+echo "fault_injection_status=verified"
+echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
Added the dedicated go/no-go gate live-validation lane that verifies baseline GO evidence and an injected decision fault fail-closed path with deterministic markers. Updated validation and roadmap docs with live protocol and results.

Closes #2988
Closes #2989

## Changes
- `scripts/runtime/validate_go_no_go_gate_live.sh`: new live-validation drill script for go/no-go gate.
- `scripts/runtime/test_validate_go_no_go_gate_live.sh`: harness for schema/marker and fail-closed checks.
- `docs/validation/go-no-go.md`: added live validation commands, markers, and fail-closed drill protocol.
- `docs/plans/2026-02-08-production-service-roadmap.md`: added go/no-go gate live validation delivered status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_validate_go_no_go_gate_live.sh
```
Output before implementation:
```text
bash: scripts/runtime/test_validate_go_no_go_gate_live.sh: No such file or directory
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/runtime/test_validate_go_no_go_gate_live.sh
bash scripts/runtime/validate_go_no_go_gate_live.sh --max-seconds 120
```
Key output markers:
```text
go/no-go gate live validation tests passed.
status=pass
final_decision=GO
baseline_contract_status=verified
fault_injection_status=verified
fail_closed_status=verified
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
bash scripts/runtime/test_run_go_no_go_gate_lane.sh
bash scripts/deploy/test_run_gonogo_evidence_contract_lane.sh
bash scripts/deploy/test_run_deployment_slo_rollback_contract_lane.sh
bash scripts/deploy/test_run_dr_evidence_contract_lane.sh
```
Result: all passed.

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status   | Tests Added/Modified | Justification if N/A |
|--------------|----------|----------------------|----------------------|
| Unit         | ✅       | `test_validate_go_no_go_gate_live.sh` schema/marker assertions |                      |
| Functional   | ✅       | `validate_go_no_go_gate_live.sh` baseline run markers |                      |
| Integration  | ✅       | Live validation executes go/no-go core lane baseline + injected decision fault path |                      |
| Regression   | ✅       | Decision fault fail-closed marker (`gate_decision_fault_injection_triggered`) validated |                      |
| Performance  | N/A      | Runtime budget guard enforced for validation lane | bounded runtime check |

## Risks & Rollback
- None.
- Rollback plan: revert this PR to remove go/no-go live validation lane if policy criteria changes.

## Documentation Updates
- `docs/validation/go-no-go.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean (not run; no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated
