### PR TITLE
feat(node): add config file layering with env override validation

### DIFF
--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -199,6 +199,8 @@ pub enum ConfigError {
     InvalidOutputMode(String),
     /// Unknown or invalid node profile string.
     InvalidNodeProfile(String),
+    /// Invalid node configuration file or layered override declaration.
+    InvalidNodeConfig(String),
     /// Unknown or invalid diagnostics mode string.
     InvalidDiagnosticsMode(String),
     /// Unknown or invalid node log configuration.
@@ -245,6 +247,7 @@ impl fmt::Display for ConfigError {
             Self::InvalidSyncMode(value) => write!(f, "invalid sync mode: {value}"),
             Self::InvalidOutputMode(value) => write!(f, "invalid output mode: {value}"),
             Self::InvalidNodeProfile(value) => write!(f, "invalid node profile: {value}"),
+            Self::InvalidNodeConfig(value) => write!(f, "invalid node config: {value}"),
             Self::InvalidDiagnosticsMode(value) => {
                 write!(f, "invalid diagnostics mode: {value}")
             }

--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -7,11 +7,317 @@ use super::{
     DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS, DEFAULT_SERVICE_API_MAX_REQUESTS,
     KOLME_IN_MEMORY_PROVIDER_MARKER, KOLME_LIVE_SIGNING_PROFILE,
 };
+use std::{env, fs};
+
+const CONFIG_FILE_FLAG: &str = "--config-file";
+const NODE_CONFIG_FILE_ENV: &str = "KAMN_NODE_CONFIG_FILE";
+
+fn read_env_var_trimmed(name: &str) -> Result<Option<String>, ConfigError> {
+    match env::var(name) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Err(ConfigError::InvalidNodeConfig(format!(
+                    "{name} must not be empty when set"
+                )));
+            }
+            Ok(Some(trimmed.to_owned()))
+        }
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err(ConfigError::InvalidNodeConfig(format!(
+            "{name} must be valid utf-8"
+        ))),
+    }
+}
+
+fn parse_bool_override(value: &str, source: &str) -> Result<bool, ConfigError> {
+    match value {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(ConfigError::InvalidNodeConfig(format!(
+            "{source} must be one of: true,false"
+        ))),
+    }
+}
+
+fn push_key_value_flag(args: &mut Vec<String>, value: &str, flag: &str) {
+    args.push(flag.to_owned());
+    args.push(value.to_owned());
+}
+
+fn map_config_entry_to_args(
+    key: &str,
+    value: &str,
+    source: &str,
+) -> Result<Vec<String>, ConfigError> {
+    let mut mapped = Vec::new();
+    match key {
+        "profile" => push_key_value_flag(&mut mapped, value, "--profile"),
+        "role" => push_key_value_flag(&mut mapped, value, "--role"),
+        "chain_id" => push_key_value_flag(&mut mapped, value, "--chain-id"),
+        "chain_version" => push_key_value_flag(&mut mapped, value, "--chain-version"),
+        "storage_dir" => push_key_value_flag(&mut mapped, value, "--storage-dir"),
+        "enable_gossip" => {
+            if !parse_bool_override(value, source)? {
+                mapped.push("--disable-gossip".to_owned());
+            }
+        }
+        "sync_mode" => push_key_value_flag(&mut mapped, value, "--sync-mode"),
+        "runtime_mode" => push_key_value_flag(&mut mapped, value, "--runtime-mode"),
+        "expected_state_version" => {
+            push_key_value_flag(&mut mapped, value, "--expected-state-version")
+        }
+        "expected_state_hash" => push_key_value_flag(&mut mapped, value, "--expected-state-hash"),
+        "proposal" => push_key_value_flag(&mut mapped, value, "--proposal"),
+        "rejoin_attempt" => push_key_value_flag(&mut mapped, value, "--rejoin-attempt"),
+        "daemon_max_ticks" => push_key_value_flag(&mut mapped, value, "--daemon-max-ticks"),
+        "daemon_tick_interval_ms" => {
+            push_key_value_flag(&mut mapped, value, "--daemon-tick-interval-ms")
+        }
+        "daemon_shutdown_signal_tick" => {
+            push_key_value_flag(&mut mapped, value, "--daemon-shutdown-signal-tick")
+        }
+        "daemon_shutdown_os_signals" => {
+            if parse_bool_override(value, source)? {
+                mapped.push("--daemon-shutdown-os-signals".to_owned());
+            }
+        }
+        "daemon_shutdown_drain_ticks" => {
+            push_key_value_flag(&mut mapped, value, "--daemon-shutdown-drain-ticks")
+        }
+        "daemon_shutdown_timeout_ticks" => {
+            push_key_value_flag(&mut mapped, value, "--daemon-shutdown-timeout-ticks")
+        }
+        "daemon_peer_id" => push_key_value_flag(&mut mapped, value, "--daemon-peer-id"),
+        "daemon_lifecycle_event" => {
+            push_key_value_flag(&mut mapped, value, "--daemon-lifecycle-event")
+        }
+        "kolme_live_base_url" => push_key_value_flag(&mut mapped, value, "--kolme-live-base-url"),
+        "kolme_live_provider_hint" => {
+            push_key_value_flag(&mut mapped, value, "--kolme-live-provider-hint")
+        }
+        "kolme_live_signing_profile" => {
+            push_key_value_flag(&mut mapped, value, "--kolme-live-signing-profile")
+        }
+        "kolme_live_strict_signer_contracts" => {
+            if parse_bool_override(value, source)? {
+                mapped.push("--kolme-live-strict-signer-contracts".to_owned());
+            }
+        }
+        "kolme_live_signer_profile" => {
+            push_key_value_flag(&mut mapped, value, "--kolme-live-signer-profile")
+        }
+        "kolme_live_signer_key_source" => {
+            push_key_value_flag(&mut mapped, value, "--kolme-live-signer-key-source")
+        }
+        "api_bind" => push_key_value_flag(&mut mapped, value, "--api-bind"),
+        "api_max_requests" => push_key_value_flag(&mut mapped, value, "--api-max-requests"),
+        "api_idle_timeout_ms" => push_key_value_flag(&mut mapped, value, "--api-idle-timeout-ms"),
+        "observability_endpoint_bind" => {
+            push_key_value_flag(&mut mapped, value, "--observability-endpoint-bind")
+        }
+        "observability_endpoint_metrics_path" => {
+            push_key_value_flag(&mut mapped, value, "--observability-endpoint-metrics-path")
+        }
+        "observability_endpoint_health_path" => {
+            push_key_value_flag(&mut mapped, value, "--observability-endpoint-health-path")
+        }
+        "observability_endpoint_max_requests" => {
+            push_key_value_flag(&mut mapped, value, "--observability-endpoint-max-requests")
+        }
+        "observability_endpoint_idle_timeout_ms" => push_key_value_flag(
+            &mut mapped,
+            value,
+            "--observability-endpoint-idle-timeout-ms",
+        ),
+        "output" => push_key_value_flag(&mut mapped, value, "--output"),
+        "diagnostics" => push_key_value_flag(&mut mapped, value, "--diagnostics"),
+        _ => {
+            return Err(ConfigError::InvalidNodeConfig(format!(
+                "{source} contains unsupported key: {key}"
+            )));
+        }
+    }
+    Ok(mapped)
+}
+
+fn parse_config_file_args(path: &str) -> Result<Vec<String>, ConfigError> {
+    let content = fs::read_to_string(path).map_err(|error| {
+        ConfigError::InvalidNodeConfig(format!("failed to read config file {path}: {error}"))
+    })?;
+    let mut args = Vec::new();
+    for (line_index, raw_line) in content.lines().enumerate() {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let (key, value) = trimmed.split_once('=').ok_or_else(|| {
+            ConfigError::InvalidNodeConfig(format!(
+                "config file {path} line {} must match key=value",
+                line_index + 1
+            ))
+        })?;
+        let key = key.trim();
+        let value = value.trim();
+        let source = format!("config file {path} line {}", line_index + 1);
+        args.extend(map_config_entry_to_args(key, value, source.as_str())?);
+    }
+    Ok(args)
+}
+
+fn append_env_override(
+    args: &mut Vec<String>,
+    env_name: &str,
+    key: &str,
+) -> Result<(), ConfigError> {
+    if let Some(value) = read_env_var_trimmed(env_name)? {
+        let source = format!("environment variable {env_name}");
+        args.extend(map_config_entry_to_args(
+            key,
+            value.as_str(),
+            source.as_str(),
+        )?);
+    }
+    Ok(())
+}
+
+fn collect_env_override_args() -> Result<Vec<String>, ConfigError> {
+    let mut args = Vec::new();
+    append_env_override(&mut args, "KAMN_NODE_PROFILE", "profile")?;
+    append_env_override(&mut args, "KAMN_NODE_ROLE", "role")?;
+    append_env_override(&mut args, "KAMN_NODE_CHAIN_ID", "chain_id")?;
+    append_env_override(&mut args, "KAMN_NODE_CHAIN_VERSION", "chain_version")?;
+    append_env_override(&mut args, "KAMN_NODE_STORAGE_DIR", "storage_dir")?;
+    append_env_override(&mut args, "KAMN_NODE_ENABLE_GOSSIP", "enable_gossip")?;
+    append_env_override(&mut args, "KAMN_NODE_SYNC_MODE", "sync_mode")?;
+    append_env_override(&mut args, "KAMN_NODE_RUNTIME_MODE", "runtime_mode")?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_EXPECTED_STATE_VERSION",
+        "expected_state_version",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_EXPECTED_STATE_HASH",
+        "expected_state_hash",
+    )?;
+    append_env_override(&mut args, "KAMN_NODE_API_BIND", "api_bind")?;
+    append_env_override(&mut args, "KAMN_NODE_API_MAX_REQUESTS", "api_max_requests")?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_API_IDLE_TIMEOUT_MS",
+        "api_idle_timeout_ms",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_OBSERVABILITY_ENDPOINT_BIND",
+        "observability_endpoint_bind",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_OBSERVABILITY_ENDPOINT_METRICS_PATH",
+        "observability_endpoint_metrics_path",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_OBSERVABILITY_ENDPOINT_HEALTH_PATH",
+        "observability_endpoint_health_path",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_OBSERVABILITY_ENDPOINT_MAX_REQUESTS",
+        "observability_endpoint_max_requests",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS",
+        "observability_endpoint_idle_timeout_ms",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_KOLME_LIVE_BASE_URL",
+        "kolme_live_base_url",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_KOLME_LIVE_PROVIDER_HINT",
+        "kolme_live_provider_hint",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_KOLME_LIVE_SIGNING_PROFILE",
+        "kolme_live_signing_profile",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_KOLME_LIVE_STRICT_SIGNER_CONTRACTS",
+        "kolme_live_strict_signer_contracts",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_KOLME_LIVE_SIGNER_PROFILE",
+        "kolme_live_signer_profile",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_KOLME_LIVE_SIGNER_KEY_SOURCE",
+        "kolme_live_signer_key_source",
+    )?;
+    append_env_override(&mut args, "KAMN_NODE_OUTPUT", "output")?;
+    append_env_override(&mut args, "KAMN_NODE_DIAGNOSTICS", "diagnostics")?;
+    Ok(args)
+}
+
+fn extract_config_file_path(
+    raw_args: Vec<String>,
+) -> Result<(Option<String>, Vec<String>), ConfigError> {
+    let mut args_without_config = Vec::new();
+    let mut config_file_path: Option<String> = None;
+    let mut iter = raw_args.into_iter();
+    if let Some(bin) = iter.next() {
+        args_without_config.push(bin);
+    }
+    while let Some(arg) = iter.next() {
+        if arg == CONFIG_FILE_FLAG {
+            let value = iter
+                .next()
+                .ok_or(ConfigError::MissingArgumentValue(CONFIG_FILE_FLAG))?;
+            if config_file_path.is_some() {
+                return Err(ConfigError::InvalidNodeConfig(
+                    "duplicate --config-file declarations are not allowed".to_owned(),
+                ));
+            }
+            config_file_path = Some(value);
+            continue;
+        }
+        args_without_config.push(arg);
+    }
+    Ok((config_file_path, args_without_config))
+}
+
+fn build_layered_cli_args(raw_args: Vec<String>) -> Result<Vec<String>, ConfigError> {
+    let (config_file_from_cli, args_without_config) = extract_config_file_path(raw_args)?;
+    let mut layered_args = Vec::new();
+    let bin = args_without_config
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "kamn-node".to_owned());
+    layered_args.push(bin);
+    let config_file_from_env = read_env_var_trimmed(NODE_CONFIG_FILE_ENV)?;
+    let config_file_path = config_file_from_cli.or(config_file_from_env);
+    if let Some(path) = config_file_path.as_deref() {
+        layered_args.extend(parse_config_file_args(path)?);
+        layered_args.extend(collect_env_override_args()?);
+    }
+    layered_args.extend(args_without_config.into_iter().skip(1));
+    Ok(layered_args)
+}
 
 pub(super) fn parse_args<I>(args: I) -> Result<NodeCli, ConfigError>
 where
     I: IntoIterator<Item = String>,
 {
+    let layered_args = build_layered_cli_args(args.into_iter().collect())?;
     let mut role: Option<NodeRole> = None;
     let mut profile: Option<LocalProfile> = None;
     let mut chain_id = String::from("kamn-devnet");
@@ -63,7 +369,7 @@ where
     let mut gossip_overridden = false;
     let mut sync_mode_overridden = false;
 
-    let mut iter = args.into_iter();
+    let mut iter = layered_args.into_iter();
     let _bin = iter.next();
 
     while let Some(arg) = iter.next() {

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -8,6 +8,20 @@ unsafe extern "C" {
     fn raise(sig: i32) -> i32;
 }
 
+fn write_temp_node_config(contents: &str) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    let unique_suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    path.push(format!(
+        "kamn-node-config-layering-{}-{unique_suffix}.conf",
+        std::process::id()
+    ));
+    std::fs::write(&path, contents).expect("temp config file should write");
+    path
+}
+
 #[test]
 fn parses_required_role_and_defaults() {
     let args = vec![
@@ -659,6 +673,131 @@ fn profile_defaults_can_be_overridden_by_explicit_flags() {
     assert_eq!(parsed.storage_dir, "./tmp/custom-listener");
     assert_eq!(parsed.sync_mode, SyncMode::Archive);
     assert!(!parsed.enable_gossip);
+}
+
+#[test]
+fn parses_config_file_layer_for_core_node_fields() {
+    let config_path = write_temp_node_config(
+        "role=listener\nchain_id=kamn-config-file\nchain_version=v0.2.0\nstorage_dir=./tmp/config-listener\nenable_gossip=false\nsync_mode=archive\noutput=json\ndiagnostics=snapshot\n",
+    );
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--config-file".to_owned(),
+        config_path.to_string_lossy().to_string(),
+    ];
+
+    let parsed_result = parse_args(args);
+    std::fs::remove_file(config_path).expect("temp config file should clean up");
+    let parsed = parsed_result.expect("config file args should parse");
+
+    assert_eq!(parsed.role, NodeRole::Listener);
+    assert_eq!(parsed.chain_id, "kamn-config-file");
+    assert_eq!(parsed.chain_version, "v0.2.0");
+    assert_eq!(parsed.storage_dir, "./tmp/config-listener");
+    assert_eq!(parsed.sync_mode, SyncMode::Archive);
+    assert!(!parsed.enable_gossip);
+    assert_eq!(parsed.output_mode, OutputMode::json());
+    assert_eq!(parsed.diagnostics_mode, DiagnosticsMode::snapshot());
+}
+
+#[test]
+fn env_overrides_config_file_chain_id_and_sync_mode() {
+    let _env_lock = signer_env_lock()
+        .lock()
+        .expect("env lock should guard process-level overrides");
+    let _chain_id_guard = EnvVarGuard::set("KAMN_NODE_CHAIN_ID", Some("kamn-env"));
+    let _sync_mode_guard = EnvVarGuard::set("KAMN_NODE_SYNC_MODE", Some("slow"));
+    let config_path = write_temp_node_config(
+        "role=listener\nchain_id=kamn-config-file\nsync_mode=archive\nstorage_dir=./tmp/config-listener\n",
+    );
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--config-file".to_owned(),
+        config_path.to_string_lossy().to_string(),
+    ];
+
+    let parsed_result = parse_args(args);
+    std::fs::remove_file(config_path).expect("temp config file should clean up");
+    let parsed = parsed_result.expect("config + env layered args should parse");
+
+    assert_eq!(parsed.role, NodeRole::Listener);
+    assert_eq!(parsed.chain_id, "kamn-env");
+    assert_eq!(parsed.sync_mode, SyncMode::Slow);
+}
+
+#[test]
+fn cli_values_override_env_and_config_layers() {
+    let _env_lock = signer_env_lock()
+        .lock()
+        .expect("env lock should guard process-level overrides");
+    let _chain_id_guard = EnvVarGuard::set("KAMN_NODE_CHAIN_ID", Some("kamn-env"));
+    let config_path = write_temp_node_config("role=listener\nchain_id=kamn-config-file\n");
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--config-file".to_owned(),
+        config_path.to_string_lossy().to_string(),
+        "--chain-id".to_owned(),
+        "kamn-cli".to_owned(),
+    ];
+
+    let parsed_result = parse_args(args);
+    std::fs::remove_file(config_path).expect("temp config file should clean up");
+    let parsed = parsed_result.expect("config + env + cli layered args should parse");
+
+    assert_eq!(parsed.role, NodeRole::Listener);
+    assert_eq!(parsed.chain_id, "kamn-cli");
+}
+
+#[test]
+fn regression_2967_invalid_env_override_fails_closed() {
+    let _env_lock = signer_env_lock()
+        .lock()
+        .expect("env lock should guard process-level overrides");
+    let _sync_mode_guard = EnvVarGuard::set("KAMN_NODE_SYNC_MODE", Some("turbo"));
+    let config_path = write_temp_node_config("role=processor\n");
+
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--config-file".to_owned(),
+        config_path.to_string_lossy().to_string(),
+    ];
+
+    let parse_result = parse_args(args);
+    std::fs::remove_file(config_path).expect("temp config file should clean up");
+
+    assert!(
+        matches!(
+            parse_result,
+            Err(ConfigError::InvalidSyncMode(value)) if value == "turbo"
+        ),
+        "invalid KAMN_NODE_SYNC_MODE override must fail closed with typed config error"
+    );
+}
+
+#[test]
+fn integration_config_layering_executes_bootstrap_report_with_expected_precedence() {
+    let _env_lock = signer_env_lock()
+        .lock()
+        .expect("env lock should guard process-level overrides");
+    let _chain_id_guard = EnvVarGuard::set("KAMN_NODE_CHAIN_ID", Some("kamn-env"));
+    let config_path = write_temp_node_config("role=listener\nchain_id=kamn-config-file\n");
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--config-file".to_owned(),
+        config_path.to_string_lossy().to_string(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--chain-id".to_owned(),
+        "kamn-cli".to_owned(),
+    ];
+
+    let parsed_result = parse_args(args);
+    std::fs::remove_file(config_path).expect("temp config file should clean up");
+    let parsed = parsed_result.expect("layered args should parse");
+    let report = execute(parsed).expect("bootstrap execution should succeed");
+
+    assert_eq!(report.role, "processor");
+    assert_eq!(report.chain_id, "kamn-cli");
 }
 
 #[test]

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -14,6 +14,9 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--profile local-processor`
   - `--profile local-listener`
   - `--profile local-approver`
+- Added config layering command surface:
+  - `--config-file <path>`
+  - `KAMN_NODE_CONFIG_FILE=<path>`
 - Added explicit invalid-profile handling through `ConfigError::InvalidNodeProfile`.
 - Added diagnostics mode command surface:
   - `--diagnostics basic` (default)
@@ -138,6 +141,20 @@ This document captures node-runtime productionization slices for machine-readabl
   - `role`: mapped from selected profile
 - Explicit CLI flags override profile defaults (`--chain-id`, `--storage-dir`, `--sync-mode`, `--disable-gossip`, `--role`).
 - Invalid profiles are rejected with explicit typed error.
+
+## Configuration Layering Rules
+- Config layering is enabled when either `--config-file` or `KAMN_NODE_CONFIG_FILE` is set.
+- Config format is deterministic line-oriented `key=value` with optional `#` comments.
+- Boolean keys use strict `true|false`; invalid values fail closed.
+- Precedence order (low -> high):
+  - built-in defaults
+  - profile defaults
+  - config file values
+  - `KAMN_NODE_*` environment overrides
+  - explicit CLI flags
+- Environment overrides are projected only when config layering is active.
+- Invalid config lines, unknown keys, duplicate `--config-file` declarations, and invalid env marker values are rejected with typed `ConfigError::InvalidNodeConfig` or existing typed parse errors (for example `InvalidSyncMode`).
+- Full operator reference: `docs/ops/configuration.md`.
 
 ## Diagnostics Snapshot Rules
 - Supported diagnostics modes:

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -1,0 +1,92 @@
+# Node Configuration Layering
+
+This document defines the deterministic configuration contracts for `kamn-node`.
+
+## Scope
+
+Phase 6.2 implementation adds:
+
+- `--config-file <path>` support using a deterministic `key=value` format.
+- Environment-variable overrides for selected node settings.
+- Strict validation with fail-closed behavior on malformed config or invalid override values.
+
+## Precedence
+
+When `--config-file` or `KAMN_NODE_CONFIG_FILE` is set, `kamn-node` resolves settings in this order (low to high):
+
+1. Built-in defaults
+2. Profile defaults (`--profile`)
+3. Config-file entries
+4. `KAMN_NODE_*` environment overrides
+5. Explicit CLI flags
+
+If no config file is declared, environment overrides are not applied by this layer.
+
+## Config File Format
+
+- File format is line-oriented `key=value`.
+- Empty lines and lines starting with `#` are ignored.
+- Unknown keys fail closed.
+- Boolean keys must use `true` or `false`.
+
+Example:
+
+```text
+# node-runtime.conf
+role=listener
+chain_id=kamn-localnet
+chain_version=v0.2.0
+storage_dir=./data/listener
+enable_gossip=false
+sync_mode=archive
+output=json
+diagnostics=snapshot
+```
+
+## Supported Keys
+
+Core keys:
+
+- `profile`, `role`, `chain_id`, `chain_version`, `storage_dir`, `enable_gossip`, `sync_mode`
+- `runtime_mode`, `expected_state_version`, `expected_state_hash`
+- `proposal`, `rejoin_attempt`
+- `output`, `diagnostics`
+
+Runtime/API keys:
+
+- `daemon_max_ticks`, `daemon_tick_interval_ms`, `daemon_shutdown_signal_tick`
+- `daemon_shutdown_os_signals`, `daemon_shutdown_drain_ticks`, `daemon_shutdown_timeout_ticks`
+- `daemon_peer_id`, `daemon_lifecycle_event`
+- `api_bind`, `api_max_requests`, `api_idle_timeout_ms`
+- `observability_endpoint_bind`, `observability_endpoint_metrics_path`
+- `observability_endpoint_health_path`, `observability_endpoint_max_requests`
+- `observability_endpoint_idle_timeout_ms`
+
+Kolme-live keys:
+
+- `kolme_live_base_url`, `kolme_live_provider_hint`, `kolme_live_signing_profile`
+- `kolme_live_strict_signer_contracts`, `kolme_live_signer_profile`, `kolme_live_signer_key_source`
+
+## Environment Override Contracts
+
+Environment override names map to the same key contracts when a config file is active.
+
+Examples:
+
+- `KAMN_NODE_CHAIN_ID` -> `chain_id`
+- `KAMN_NODE_SYNC_MODE` -> `sync_mode`
+- `KAMN_NODE_ENABLE_GOSSIP` -> `enable_gossip`
+- `KAMN_NODE_API_BIND` -> `api_bind`
+- `KAMN_NODE_KOLME_LIVE_BASE_URL` -> `kolme_live_base_url`
+- `KAMN_NODE_OUTPUT` -> `output`
+
+Invalid override values fail closed with typed `ConfigError` variants.
+
+## Validation Evidence
+
+Implemented and validated by `kamn-node` tests:
+
+- config file parse + core field projection
+- precedence `config < env < CLI`
+- invalid env override fail-closed regression
+- integration execution path (`parse_args` -> `execute`) with layered precedence

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -36,6 +36,11 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_service_api_observability_live.sh` and `scripts/runtime/test_validate_service_api_observability_live.sh` (Task #2963, Subtask #2964).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `metrics_contract_status=verified`, `health_contract_status=verified`, `fail_closed_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
+- Phase 6.2 initial slice delivered:
+  - Added deterministic config layering in `kamn-node` with `--config-file` and `KAMN_NODE_CONFIG_FILE`.
+  - Added validated `KAMN_NODE_*` override projection over config-file values with precedence `config < env < CLI`.
+  - Added fail-closed config/override validation with typed `ConfigError` surfaces and regression coverage for invalid env override values (Story #2965, Task #2966, Subtask #2967).
+  - Operator contracts documented in `docs/ops/configuration.md`.
 - Phase 6.3 initial slice delivered: deployment artifacts now include a multi-stage `Dockerfile`, `deploy/docker-compose.yml` role topology, and `deploy/k8s/kamn-node.yaml` baseline manifests (Task #2971, Subtask #2972).
 - Phase 6.3 live validation delivered:
   - Runtime lane: `scripts/deploy/validate_deployment_assets_live.sh` and `scripts/deploy/test_validate_deployment_assets_live.sh` (Task #2973, Subtask #2974).


### PR DESCRIPTION
## Summary
Implemented deterministic node configuration layering for `kamn-node` by adding `--config-file` support plus validated `KAMN_NODE_*` environment overrides with explicit precedence. This closes the core-delivery and TDD subtask path for story #2965.

Closes #2966
Closes #2967
Refs #2965

## Changes
- `crates/kamn-node/src/cli.rs`: Added layered config resolution (`--config-file`, `KAMN_NODE_CONFIG_FILE`), deterministic `key=value` config parsing, `KAMN_NODE_*` env projection, and strict fail-closed validation.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: Added new unit/functional/integration/regression coverage for config parsing, precedence (`config < env < CLI`), and invalid env override rejection (`Regression: #2967`).
- `crates/kamn-core/src/config.rs`: Added `ConfigError::InvalidNodeConfig` for typed invalid layered-config failures.
- `docs/ops/configuration.md`: Added operator-facing configuration layering contracts and supported key/env mappings.
- `docs/foundation/node-runtime-cli.md`: Added CLI contract documentation for config layering rules and precedence.
- `docs/plans/2026-02-08-production-service-roadmap.md`: Updated execution status with delivered Phase 6.2 initial slice details.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-node main_tests::core_behavior_tests::parses_config_file_layer_for_core_node_fields -- --exact --nocapture`
  - Failed with: `UnknownArgument("--config-file")`
- `cargo test -p kamn-node main_tests::core_behavior_tests::regression_2967_invalid_env_override_fails_closed -- --exact --nocapture`
  - Failed because invalid `KAMN_NODE_SYNC_MODE` override was ignored pre-implementation.

### 🟢 Green Phase
- `cargo test -p kamn-node main_tests::core_behavior_tests::`
  - Passed including new tests:
    - `main_tests::core_behavior_tests::parses_config_file_layer_for_core_node_fields`
    - `main_tests::core_behavior_tests::env_overrides_config_file_chain_id_and_sync_mode`
    - `main_tests::core_behavior_tests::cli_values_override_env_and_config_layers`
    - `main_tests::core_behavior_tests::regression_2967_invalid_env_override_fails_closed`
    - `main_tests::core_behavior_tests::integration_config_layering_executes_bootstrap_report_with_expected_precedence`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-node -p kamn-core -- -D warnings`
- `cargo test -p kamn-node`
- Result: all clean/passing.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `parses_config_file_layer_for_core_node_fields` | |
| Functional   | ✅     | `env_overrides_config_file_chain_id_and_sync_mode`, `cli_values_override_env_and_config_layers` | |
| Integration  | ✅     | `integration_config_layering_executes_bootstrap_report_with_expected_precedence` | |
| Regression   | ✅     | `regression_2967_invalid_env_override_fails_closed` | |
| Performance  | N/A    | N/A | No runtime hotspot or throughput-sensitive path changed; parser-layer logic only. |

## Risks & Rollback
- No breaking API changes for existing CLI flags.
- New behavior: env overrides are applied only when config layering is active (`--config-file` or `KAMN_NODE_CONFIG_FILE`).
- Rollback: revert commit `4bbfc55` to restore prior CLI-only behavior.

## Documentation Updates
- `docs/ops/configuration.md`
- `docs/foundation/node-runtime-cli.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (run scoped to changed crates: `-p kamn-node -p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-node`)
- [x] Docs updated (or justified why not)
