### PR TITLE
test(runtime): live-validate config layering with deterministic evidence

### DIFF
--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -90,3 +90,22 @@ Implemented and validated by `kamn-node` tests:
 - precedence `config < env < CLI`
 - invalid env override fail-closed regression
 - integration execution path (`parse_args` -> `execute`) with layered precedence
+
+Live validation lane:
+
+- `bash scripts/runtime/test_validate_config_layering_live.sh`
+- `bash scripts/runtime/validate_config_layering_live.sh --output-json /tmp/config-layering-live-report.json`
+
+Deterministic success markers:
+
+- `status=pass`
+- `final_decision=GO`
+- `layering_contract_status=verified`
+- `precedence_contract_status=verified`
+- `fail_closed_status=verified`
+- `fail_closed_reason_code=invalid_sync_mode_override`
+
+Deterministic fail-closed drill:
+
+- inject invalid override `KAMN_NODE_SYNC_MODE=turbo` while config layering is active
+- expected failure marker: `invalid sync mode: turbo`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -41,6 +41,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Added validated `KAMN_NODE_*` override projection over config-file values with precedence `config < env < CLI`.
   - Added fail-closed config/override validation with typed `ConfigError` surfaces and regression coverage for invalid env override values (Story #2965, Task #2966, Subtask #2967).
   - Operator contracts documented in `docs/ops/configuration.md`.
+- Phase 6.2 live validation delivered:
+  - Runtime lane: `scripts/runtime/validate_config_layering_live.sh` and `scripts/runtime/test_validate_config_layering_live.sh` (Task #2968).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `layering_contract_status=verified`, `precedence_contract_status=verified`, `fail_closed_status=verified`.
+  - Fail-closed validation confirmed for invalid override injection: `invalid sync mode: turbo`.
 - Phase 6.3 initial slice delivered: deployment artifacts now include a multi-stage `Dockerfile`, `deploy/docker-compose.yml` role topology, and `deploy/k8s/kamn-node.yaml` baseline manifests (Task #2971, Subtask #2972).
 - Phase 6.3 live validation delivered:
   - Runtime lane: `scripts/deploy/validate_deployment_assets_live.sh` and `scripts/deploy/test_validate_deployment_assets_live.sh` (Task #2973, Subtask #2974).

--- a/scripts/runtime/test_validate_config_layering_live.sh
+++ b/scripts/runtime/test_validate_config_layering_live.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_config_layering_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected config layering live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(bash "$VALIDATION_SCRIPT" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected config layering live pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected config layering live GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^layering_contract_status=verified$'; then
+  echo "expected config layering live layering contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^precedence_contract_status=verified$'; then
+  echo "expected config layering live precedence contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
+  echo "expected config layering live fail-closed marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_reason_code=invalid_sync_mode_override$'; then
+  echo "expected config layering live fail-closed reason marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.config-layering-live-validation.v1":
+    raise SystemExit("unexpected config layering live schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected config layering live status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected config layering live final_decision=GO")
+if payload.get("layering_contract_status") != "verified":
+    raise SystemExit("expected layering_contract_status=verified")
+if payload.get("precedence_contract_status") != "verified":
+    raise SystemExit("expected precedence_contract_status=verified")
+if payload.get("fail_closed_status") != "verified":
+    raise SystemExit("expected fail_closed_status=verified")
+if payload.get("fail_closed_reason_code") != "invalid_sync_mode_override":
+    raise SystemExit("expected fail_closed_reason_code=invalid_sync_mode_override")
+PY
+
+set +e
+invalid_budget_output="$({ bash "$VALIDATION_SCRIPT" --max-seconds invalid; } 2>&1)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected config layering live script to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q 'max-seconds must be an integer'; then
+  echo "expected deterministic invalid max-seconds marker for config layering live script" >&2
+  exit 1
+fi
+
+echo "config layering live validation tests passed."

--- a/scripts/runtime/validate_config_layering_live.sh
+++ b/scripts/runtime/validate_config_layering_live.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+config_file="$TMP_DIR/kamn-node-runtime.conf"
+cat >"$config_file" <<'CONFIG'
+role=listener
+chain_id=kamn-config-file
+chain_version=v0.2.0
+storage_dir=./tmp/config-listener
+sync_mode=archive
+enable_gossip=false
+output=json
+CONFIG
+
+config_only_output="$({
+  cargo run -q -p kamn-node -- \
+    --config-file "$config_file" \
+    --output json;
+} 2>&1)"
+if ! printf '%s\n' "$config_only_output" | grep -q '"chain_id":"kamn-config-file"'; then
+  echo "expected config-only probe to resolve chain_id from config file" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$config_only_output" | grep -q '"sync_mode":"archive"'; then
+  echo "expected config-only probe to project sync_mode from config file" >&2
+  exit 1
+fi
+
+env_override_output="$({
+  KAMN_NODE_CHAIN_ID=kamn-env \
+  cargo run -q -p kamn-node -- \
+    --config-file "$config_file" \
+    --output json;
+} 2>&1)"
+if ! printf '%s\n' "$env_override_output" | grep -q '"chain_id":"kamn-env"'; then
+  echo "expected env override probe to project chain_id from KAMN_NODE_CHAIN_ID" >&2
+  exit 1
+fi
+
+cli_override_output="$({
+  KAMN_NODE_CHAIN_ID=kamn-env \
+  cargo run -q -p kamn-node -- \
+    --config-file "$config_file" \
+    --chain-id kamn-cli \
+    --output json;
+} 2>&1)"
+if ! printf '%s\n' "$cli_override_output" | grep -q '"chain_id":"kamn-cli"'; then
+  echo "expected CLI override probe to win over env/config chain_id" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$cli_override_output" | grep -q '"role":"listener"'; then
+  echo "expected CLI override probe to preserve config-driven role" >&2
+  exit 1
+fi
+
+set +e
+fail_closed_output="$({
+  KAMN_NODE_SYNC_MODE=turbo \
+  cargo run -q -p kamn-node -- \
+    --config-file "$config_file";
+} 2>&1)"
+fail_closed_code=$?
+set -e
+if [ "$fail_closed_code" -eq 0 ]; then
+  echo "expected invalid env override probe to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$fail_closed_output" | grep -q 'invalid sync mode: turbo'; then
+  echo "expected deterministic invalid sync-mode failure marker" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "config layering live validation exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/config-layering-live-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.runtime.config-layering-live-validation.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "layering_contract_status": "verified",
+  "precedence_contract_status": "verified",
+  "fail_closed_status": "verified",
+  "fail_closed_reason_code": "invalid_sync_mode_override",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "layering_contract_status=verified"
+echo "precedence_contract_status=verified"
+echo "fail_closed_status=verified"
+echo "fail_closed_reason_code=invalid_sync_mode_override"


### PR DESCRIPTION
## Summary
Added a bounded, deterministic live-validation lane for node config layering with machine-readable GO/no-go evidence and fail-closed fault injection verification. This completes the story-level validation path for config layering.

Closes #2968
Closes #2965

## Changes
- `scripts/runtime/validate_config_layering_live.sh`: Added live validation lane that probes config-only projection, env-over-config precedence, CLI-over-env precedence, and fail-closed invalid env override handling.
- `scripts/runtime/test_validate_config_layering_live.sh`: Added deterministic harness validating lane markers, JSON schema, and invalid-argument fail-closed behavior.
- `docs/ops/configuration.md`: Added live validation protocol, expected markers, and fail-closed drill contract.
- `docs/plans/2026-02-08-production-service-roadmap.md`: Added Phase 6.2 live-validation delivery status and evidence markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/runtime/test_validate_config_layering_live.sh`
  - Failed with: `expected config layering live validation script to be executable`

### 🟢 Green Phase
- `bash scripts/runtime/test_validate_config_layering_live.sh`
  - Passed with deterministic validation checks.

### 🔁 Regression
- `bash scripts/runtime/validate_config_layering_live.sh --output-json /tmp/config-layering-live-report.json`
  - Output markers:
    - `status=pass`
    - `final_decision=GO`
    - `layering_contract_status=verified`
    - `precedence_contract_status=verified`
    - `fail_closed_status=verified`
    - `fail_closed_reason_code=invalid_sync_mode_override`
  - JSON schema marker: `kamn.runtime.config-layering-live-validation.v1`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A | Script lane does not introduce new Rust/unit-level functions. |
| Functional   | ✅     | `scripts/runtime/test_validate_config_layering_live.sh` | |
| Integration  | ✅     | `scripts/runtime/validate_config_layering_live.sh` (real `cargo run` probes against `kamn-node`) | |
| Regression   | ✅     | fail-closed invalid override probe (`KAMN_NODE_SYNC_MODE=turbo`) + invalid budget argument guard | |
| Performance  | ✅     | bounded runtime gate via `--max-seconds` and elapsed-time enforcement | |

## Risks & Rollback
- No production code changes; validation/docs only.
- Rollback: revert commit `db59164` to remove the lane/harness/docs updates.

## Documentation Updates
- `docs/ops/configuration.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] TDD Red/Green evidence included above
- [x] Live validation script and harness pass locally
- [x] Docs updated
