### PR TITLE
feat(sdk): unify cross-language parity matrix orchestration

### DIFF
--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -45,6 +45,11 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_config_layering_live.sh` and `scripts/runtime/test_validate_config_layering_live.sh` (Task #2968).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `layering_contract_status=verified`, `precedence_contract_status=verified`, `fail_closed_status=verified`.
   - Fail-closed validation confirmed for invalid override injection: `invalid sync mode: turbo`.
+- Phase 5 parity-matrix implementation delivered:
+  - Added unified SDK parity orchestration runner: `scripts/sdk/run_cross_language_sdk_parity_matrix.sh`.
+  - Runner composes register validation parity and live transport contract parity with bounded runtime and deterministic machine-readable markers.
+  - Added deterministic harness: `scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh` (Task #2956, Subtask #2957).
+  - Added operator/reference documentation: `docs/sdk/parity-matrix.md`.
 - Phase 6.3 initial slice delivered: deployment artifacts now include a multi-stage `Dockerfile`, `deploy/docker-compose.yml` role topology, and `deploy/k8s/kamn-node.yaml` baseline manifests (Task #2971, Subtask #2972).
 - Phase 6.3 live validation delivered:
   - Runtime lane: `scripts/deploy/validate_deployment_assets_live.sh` and `scripts/deploy/test_validate_deployment_assets_live.sh` (Task #2973, Subtask #2974).

--- a/docs/sdk/parity-matrix.md
+++ b/docs/sdk/parity-matrix.md
@@ -1,0 +1,64 @@
+# SDK Parity Matrix
+
+This document defines the cross-language SDK parity matrix contract for Rust, Python, and TypeScript surfaces.
+
+## Scope
+
+The matrix validates two parity layers:
+
+- Register payload validation parity (`scripts/sdk/run_sdk_parity_matrix.sh`)
+- Live transport contract parity (`scripts/sdk/run_live_transport_parity_contract_lane.sh`)
+
+Unified runner:
+
+- `scripts/sdk/run_cross_language_sdk_parity_matrix.sh`
+
+## Runner Contract
+
+```bash
+bash scripts/sdk/run_cross_language_sdk_parity_matrix.sh \
+  --mode contract \
+  --languages all \
+  --fixture fixtures/sdk_parity/register_validation_cases.json \
+  --output-json /tmp/cross-language-sdk-parity-report.json
+```
+
+Arguments:
+
+- `--mode`: `contract` (default) or `deep`
+- `--languages`: language selector for contract mode (`all`, or comma-separated subset)
+- `--fixture`: register parity fixture JSON path
+- `--output-json`: optional report output path
+- `--max-seconds`: runtime budget guard (default `180`)
+
+Deterministic success markers:
+
+- `status=pass`
+- `final_decision=GO`
+- `mode=<contract|deep>`
+- `register_parity_status=verified`
+- `live_transport_parity_status=verified`
+
+JSON schema marker:
+
+- `schema_version=kamn.sdk.cross-language-parity.v1`
+
+## Fail-Closed Guardrails
+
+The runner fails closed for:
+
+- invalid mode (`mode must be one of: contract,deep`)
+- invalid runtime budget (`max-seconds must be an integer`)
+- unsupported deep-mode language override (`deep mode only supports languages=all`)
+- upstream parity runner failures
+
+## Validation Commands
+
+Core harness:
+
+- `bash scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh`
+
+Supporting parity harnesses:
+
+- `bash scripts/sdk/test_run_sdk_parity_matrix.sh`
+- `bash scripts/sdk/test_run_live_transport_parity_contract_lane.sh`

--- a/scripts/sdk/run_cross_language_sdk_parity_matrix.sh
+++ b/scripts/sdk/run_cross_language_sdk_parity_matrix.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+mode="contract"
+languages="all"
+fixture="$ROOT_DIR/fixtures/sdk_parity/register_validation_cases.json"
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    --languages)
+      languages="${2:-}"
+      shift 2
+      ;;
+    --fixture)
+      fixture="${2:-}"
+      shift 2
+      ;;
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$mode" != "contract" && "$mode" != "deep" ]]; then
+  echo "mode must be one of: contract,deep" >&2
+  exit 1
+fi
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+if [[ "$mode" == "deep" && "$languages" != "all" ]]; then
+  echo "deep mode only supports languages=all" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+register_report="$TMP_DIR/register-parity-report.json"
+register_output="$({
+  bash "$ROOT_DIR/scripts/sdk/run_sdk_parity_matrix.sh" \
+    --fixture "$fixture" \
+    --output-json "$register_report"
+} 2>&1)"
+if ! printf '%s\n' "$register_output" | grep -q '^status=pass;'; then
+  echo "cross-language register parity matrix failed" >&2
+  printf '%s\n' "$register_output" >&2
+  exit 1
+fi
+
+if [[ "$mode" == "contract" ]]; then
+  live_output="$({
+    bash "$ROOT_DIR/scripts/sdk/run_live_transport_parity_contract_lane.sh" \
+      --languages "$languages"
+  } 2>&1)"
+  if ! printf '%s\n' "$live_output" | grep -q 'live transport parity contract lane tests passed'; then
+    echo "live transport parity contract lane did not emit success marker" >&2
+    printf '%s\n' "$live_output" >&2
+    exit 1
+  fi
+else
+  live_output="$({
+    bash "$ROOT_DIR/scripts/sdk/run_live_transport_parity_deep_lane.sh"
+  } 2>&1)"
+  if ! printf '%s\n' "$live_output" | grep -q 'live transport parity deep lane tests passed.'; then
+    echo "live transport parity deep lane did not emit success marker" >&2
+    printf '%s\n' "$live_output" >&2
+    exit 1
+  fi
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "cross-language sdk parity matrix exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/cross-language-sdk-parity-matrix-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.sdk.cross-language-parity.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "mode": "${mode}",
+  "languages": "${languages}",
+  "fixture": "${fixture}",
+  "register_parity_status": "verified",
+  "live_transport_parity_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "mode=${mode}"
+echo "register_parity_status=verified"
+echo "live_transport_parity_status=verified"

--- a/scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh
+++ b/scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/sdk/run_cross_language_sdk_parity_matrix.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected cross-language sdk parity matrix runner to be executable" >&2
+  exit 1
+fi
+
+FIXTURE="$TMP_DIR/parity-fixture.json"
+cat >"$FIXTURE" <<'JSON'
+{
+  "cases": [
+    {
+      "id": "baseline-ok",
+      "agent_type": "autonomous",
+      "model_family": "claude-4",
+      "capabilities": ["text"],
+      "expected": {
+        "status": "ok"
+      }
+    }
+  ]
+}
+JSON
+
+REPORT="$TMP_DIR/parity-matrix-report.json"
+run_output="$({
+  bash "$RUNNER" \
+    --mode contract \
+    --languages python \
+    --fixture "$FIXTURE" \
+    --max-seconds 180 \
+    --output-json "$REPORT"
+} 2>&1)"
+
+if ! printf '%s\n' "$run_output" | grep -q '^status=pass$'; then
+  echo "expected cross-language sdk parity matrix pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^final_decision=GO$'; then
+  echo "expected cross-language sdk parity matrix GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^register_parity_status=verified$'; then
+  echo "expected register parity marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^live_transport_parity_status=verified$'; then
+  echo "expected live transport parity marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^mode=contract$'; then
+  echo "expected contract mode marker" >&2
+  exit 1
+fi
+
+python3 - "$REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.sdk.cross-language-parity.v1":
+    raise SystemExit("unexpected cross-language parity report schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected report status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected report final_decision=GO")
+if payload.get("mode") != "contract":
+    raise SystemExit("expected report mode=contract")
+if payload.get("register_parity_status") != "verified":
+    raise SystemExit("expected register_parity_status=verified")
+if payload.get("live_transport_parity_status") != "verified":
+    raise SystemExit("expected live_transport_parity_status=verified")
+PY
+
+set +e
+invalid_mode_output="$({ bash "$RUNNER" --mode invalid; } 2>&1)"
+invalid_mode_code=$?
+set -e
+if [ "$invalid_mode_code" -eq 0 ]; then
+  echo "expected runner to fail for invalid mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_mode_output" | grep -q 'mode must be one of: contract,deep'; then
+  echo "expected deterministic invalid mode marker" >&2
+  exit 1
+fi
+
+echo "cross-language sdk parity matrix runner tests passed."


### PR DESCRIPTION
## Summary
Delivered the core SDK parity story slice by introducing a unified cross-language parity matrix runner that composes existing register-validation parity and live transport parity checks under one deterministic contract. Added dedicated documentation and harness coverage.

Closes #2956
Closes #2957
Refs #2955

## Changes
- `scripts/sdk/run_cross_language_sdk_parity_matrix.sh`: Added unified parity orchestrator with deterministic markers, runtime budget guard, mode controls (`contract|deep`), and JSON evidence output.
- `scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh`: Added red/green harness for runner contracts and invalid mode fail-closed behavior.
- `docs/sdk/parity-matrix.md`: Added operator/developer contract docs for the unified SDK parity matrix flow.
- `docs/plans/2026-02-08-production-service-roadmap.md`: Added Phase 5 parity-matrix implementation status entry.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh`
  - Failed with: `expected cross-language sdk parity matrix runner to be executable`

### 🟢 Green Phase
- `bash scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh`
  - Passed with deterministic success markers and JSON schema checks.

### 🔁 Regression
- `bash scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh`
- `bash scripts/sdk/test_run_sdk_parity_matrix.sh`
- `bash scripts/sdk/test_run_live_transport_parity_contract_lane.sh`
- Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A | Shell orchestration script; no new Rust/Python unit helpers added. |
| Functional   | ✅     | `scripts/sdk/test_run_cross_language_sdk_parity_matrix.sh` | |
| Integration  | ✅     | `scripts/sdk/run_cross_language_sdk_parity_matrix.sh` composes real parity runners/lanes | |
| Regression   | ✅     | Invalid mode fail-closed guard (`mode must be one of: contract,deep`) and existing parity harnesses rerun | |
| Performance  | ✅     | `--max-seconds` bounded runtime guard enforced by runner | |

## Risks & Rollback
- No breaking API changes to existing SDK probes; additive wrapper only.
- Rollback: revert commit `5030811`.

## Documentation Updates
- `docs/sdk/parity-matrix.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] TDD Red/Green evidence included above
- [x] Relevant parity regression harnesses pass
- [x] Docs updated
