### PR TITLE
feat(sdk): add Python SDK publishable packaging contracts

### DIFF
--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -54,6 +54,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/sdk/validate_cross_language_sdk_parity_matrix_live.sh` and `scripts/sdk/test_validate_cross_language_sdk_parity_matrix_live.sh` (Task #2958, Subtask #2959).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `matrix_contract_status=verified`, `evidence_bundle_status=verified`, `fail_closed_status=verified`.
   - Fail-closed validation confirmed for invalid mode drill: `mode must be one of: contract,deep`.
+- Phase 5 Python SDK packaging implementation delivered:
+  - Added publishable packaging metadata at repository root: `pyproject.toml`.
+  - Added deterministic packaging contract runner/harness: `scripts/sdk/run_python_sdk_packaging_contract.sh` and `scripts/sdk/test_run_python_sdk_packaging_contract.sh` (Task #2951, Subtask #2952).
+  - Added operator/developer packaging contract documentation: `docs/sdk/python-sdk.md`.
 - Phase 6.3 initial slice delivered: deployment artifacts now include a multi-stage `Dockerfile`, `deploy/docker-compose.yml` role topology, and `deploy/k8s/kamn-node.yaml` baseline manifests (Task #2971, Subtask #2972).
 - Phase 6.3 live validation delivered:
   - Runtime lane: `scripts/deploy/validate_deployment_assets_live.sh` and `scripts/deploy/test_validate_deployment_assets_live.sh` (Task #2973, Subtask #2974).

--- a/docs/sdk/python-sdk.md
+++ b/docs/sdk/python-sdk.md
@@ -1,0 +1,54 @@
+# Python SDK Packaging Contract
+
+This document defines the production packaging contract for the KAMN Python SDK.
+
+## Scope
+
+The Python SDK surface is provided by module `kamn_sdk.py` and includes:
+
+- in-memory client (`KAMNClient`)
+- live transport client (`LiveKAMNClient`)
+- transport error taxonomy and parity contracts
+
+Packaging metadata is published through repository-root `pyproject.toml`.
+
+## Packaging Metadata
+
+Required project contract:
+
+- `project.name = "kamn-sdk"`
+- `project.version` is non-empty
+- `project.requires-python = ">=3.10"`
+- build backend is `setuptools.build_meta`
+- `tool.setuptools.py-modules` includes `kamn_sdk`
+
+## Packaging Contract Runner
+
+```bash
+bash scripts/sdk/run_python_sdk_packaging_contract.sh --output-json /tmp/python-sdk-packaging-report.json
+```
+
+Deterministic success markers:
+
+- `status=pass`
+- `final_decision=GO`
+- `package_metadata_status=verified`
+- `sdk_import_status=verified`
+- `packaging_contract_status=verified`
+
+JSON schema marker:
+
+- `schema_version=kamn.sdk.python-packaging-contract.v1`
+
+## Validation Harness
+
+```bash
+bash scripts/sdk/test_run_python_sdk_packaging_contract.sh
+```
+
+Fail-closed guardrails:
+
+- invalid runtime budget: `max-seconds must be an integer`
+- missing/invalid packaging metadata in `pyproject.toml`
+- SDK import/contract probe drift
+- Python SDK unit suite drift (`python3 -m unittest tests/python/test_sdk.py`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kamn-sdk"
+version = "0.1.0"
+description = "Python SDK contracts for KAMN protocol integration"
+readme = "docs/sdk/python-sdk.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "KAMN Maintainers" }
+]
+keywords = ["kamn", "sdk", "python", "agent-network"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Software Development :: Libraries"
+]
+
+[tool.setuptools]
+py-modules = ["kamn_sdk"]
+
+[project.urls]
+Repository = "https://github.com/njfio/kamn"

--- a/scripts/sdk/run_python_sdk_packaging_contract.sh
+++ b/scripts/sdk/run_python_sdk_packaging_contract.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+output_json=""
+max_seconds=180
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+start_epoch="$(date +%s)"
+pyproject_file="$ROOT_DIR/pyproject.toml"
+if [ ! -f "$pyproject_file" ]; then
+  echo "expected python sdk packaging metadata file: pyproject.toml" >&2
+  exit 1
+fi
+
+python3 - "$pyproject_file" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+pyproject_path = pathlib.Path(sys.argv[1])
+payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+build_system = payload.get("build-system", {})
+if build_system.get("build-backend") != "setuptools.build_meta":
+    raise SystemExit("invalid python sdk build backend; expected setuptools.build_meta")
+
+project = payload.get("project", {})
+if project.get("name") != "kamn-sdk":
+    raise SystemExit("invalid python sdk project.name; expected kamn-sdk")
+if not project.get("version"):
+    raise SystemExit("invalid python sdk project.version; expected non-empty string")
+if project.get("requires-python") != ">=3.10":
+    raise SystemExit("invalid python sdk requires-python; expected >=3.10")
+
+tool = payload.get("tool", {})
+setuptools_config = tool.get("setuptools", {})
+modules = setuptools_config.get("py-modules", [])
+if "kamn_sdk" not in modules:
+    raise SystemExit("python sdk py-modules must include kamn_sdk")
+PY
+
+import_output="$(python3 - <<'PY'
+from kamn_sdk import KAMNClient, LiveKAMNClient
+
+client = KAMNClient()
+did = client.register("autonomous", "claude-4", ["text"])
+if not did.startswith("kamn:did:agent:"):
+    raise SystemExit("unexpected DID contract from KAMNClient.register")
+
+live = LiveKAMNClient("https://live.kamn.testnet/python-packaging-contract")
+live_did = live.register("autonomous", "claude-4", ["text"])
+if not live_did.startswith("kamn:did:agent:"):
+    raise SystemExit("unexpected DID contract from LiveKAMNClient.register")
+
+print("sdk_import_status=verified")
+PY
+)"
+if ! printf '%s\n' "$import_output" | grep -q '^sdk_import_status=verified$'; then
+  echo "expected python sdk import probe verification marker" >&2
+  exit 1
+fi
+
+python_test_output="$({
+  python3 -m unittest tests/python/test_sdk.py
+} 2>&1)"
+if ! printf '%s\n' "$python_test_output" | grep -q '^OK$'; then
+  echo "expected python sdk unittest suite to pass" >&2
+  printf '%s\n' "$python_test_output" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "python sdk packaging contract exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+report_json="$TMP_DIR/python-sdk-packaging-contract-report.json"
+cat >"$report_json" <<JSON
+{
+  "schema_version": "kamn.sdk.python-packaging-contract.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "package_metadata_status": "verified",
+  "sdk_import_status": "verified",
+  "packaging_contract_status": "verified",
+  "elapsed_seconds": ${elapsed_seconds}
+}
+JSON
+
+if [[ -n "$output_json" ]]; then
+  cp "$report_json" "$output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "package_metadata_status=verified"
+echo "sdk_import_status=verified"
+echo "packaging_contract_status=verified"

--- a/scripts/sdk/test_run_python_sdk_packaging_contract.sh
+++ b/scripts/sdk/test_run_python_sdk_packaging_contract.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/sdk/run_python_sdk_packaging_contract.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected python sdk packaging contract runner to be executable" >&2
+  exit 1
+fi
+
+run_output="$(bash "$RUNNER" --output-json "$TMP_REPORT")"
+if ! printf '%s\n' "$run_output" | grep -q '^status=pass$'; then
+  echo "expected python sdk packaging contract pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^final_decision=GO$'; then
+  echo "expected python sdk packaging contract GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^package_metadata_status=verified$'; then
+  echo "expected python sdk packaging metadata marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^sdk_import_status=verified$'; then
+  echo "expected python sdk import marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^packaging_contract_status=verified$'; then
+  echo "expected python sdk packaging contract marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.sdk.python-packaging-contract.v1":
+    raise SystemExit("unexpected python packaging schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision=GO")
+if payload.get("package_metadata_status") != "verified":
+    raise SystemExit("expected package_metadata_status=verified")
+if payload.get("sdk_import_status") != "verified":
+    raise SystemExit("expected sdk_import_status=verified")
+if payload.get("packaging_contract_status") != "verified":
+    raise SystemExit("expected packaging_contract_status=verified")
+PY
+
+set +e
+invalid_budget_output="$({ bash "$RUNNER" --max-seconds invalid; } 2>&1)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected python sdk packaging contract runner to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q 'max-seconds must be an integer'; then
+  echo "expected deterministic invalid max-seconds marker" >&2
+  exit 1
+fi
+
+echo "python sdk packaging contract runner tests passed."


### PR DESCRIPTION
## Summary
Delivered the core Python SDK packaging slice by adding publishable package metadata plus deterministic packaging contract runner/harness coverage. This establishes an auditable packaging baseline before the live-validation task path.

Closes #2951
Closes #2952
Refs #2950

## Changes
- `pyproject.toml`: Added Python package metadata/build backend contract for `kamn-sdk`.
- `scripts/sdk/run_python_sdk_packaging_contract.sh`: Added deterministic packaging contract runner with metadata checks, SDK import probe, Python unit suite check, and bounded runtime.
- `scripts/sdk/test_run_python_sdk_packaging_contract.sh`: Added red/green harness validating runner markers/schema and invalid-budget fail-closed guard.
- `docs/sdk/python-sdk.md`: Added packaging contract documentation and validation protocol.
- `docs/plans/2026-02-08-production-service-roadmap.md`: Added Phase 5 Python SDK packaging implementation status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/sdk/test_run_python_sdk_packaging_contract.sh`
  - Failed with: `expected python sdk packaging contract runner to be executable`

### 🟢 Green Phase
- `bash scripts/sdk/test_run_python_sdk_packaging_contract.sh`
  - Passed with deterministic marker + JSON schema checks.

### 🔁 Regression
- `bash scripts/sdk/test_run_python_sdk_packaging_contract.sh`
- `python3 -m unittest tests/python/test_sdk.py`
- `bash scripts/sdk/test_run_sdk_parity_matrix.sh`
- Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `python3 -m unittest tests/python/test_sdk.py` (runner-enforced) | |
| Functional   | ✅     | `scripts/sdk/test_run_python_sdk_packaging_contract.sh` | |
| Integration  | ✅     | `scripts/sdk/run_python_sdk_packaging_contract.sh` (metadata + import + suite orchestration) | |
| Regression   | ✅     | invalid budget guard (`max-seconds must be an integer`) + existing SDK parity harness rerun | |
| Performance  | ✅     | `--max-seconds` runtime budget guard | |

## Risks & Rollback
- Additive packaging/config artifacts only.
- Rollback: revert commit `412c49f`.

## Documentation Updates
- `docs/sdk/python-sdk.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] TDD Red/Green evidence included above
- [x] Relevant SDK/Python checks pass locally
- [x] Docs updated
