### PR TITLE
feat(sdk): add rust service api http/ws client core delivery (#2946)

### DIFF
--- a/crates/kamn-sdk/src/lib.rs
+++ b/crates/kamn-sdk/src/lib.rs
@@ -9,6 +9,8 @@ pub mod error;
 pub mod live;
 /// In-memory reference client used for deterministic local flows and tests.
 pub mod memory;
+/// Service HTTP and websocket client for runtime API routes.
+pub mod service;
 /// TCP relay transport adapter and deterministic wire envelope models.
 pub mod tcp;
 /// Core data structures used by agent, task, messaging, and escrow APIs.
@@ -22,6 +24,12 @@ pub use error::SdkError;
 pub use live::{LiveTransportConfig, LiveTransportKamnClient};
 /// Re-exported in-memory client.
 pub use memory::InMemoryKamnClient;
+/// Re-exported service API client primitives.
+pub use service::{
+    service_signature_for_fields, ServiceAgentProfile, ServiceApiClient, ServiceChannelReceipt,
+    ServiceHealthStatus, ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth,
+    ServiceRouteEvent, ServiceTaskReceipt, ServiceTaskStatus,
+};
 /// Re-exported TCP relay adapter and envelope helpers.
 pub use tcp::{
     signature_for_fields, TcpReceivedEnvelope, TcpSignedEnvelope, TcpTransportAdapter,

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -1,0 +1,663 @@
+use crate::{signature_for_fields, AgentDid, SdkError};
+use std::io::{ErrorKind, Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT_SECONDS: u64 = 2;
+const REQUEST_AUTH_SENDER_DID_HEADER: &str = "x-kamn-sender-did";
+const REQUEST_AUTH_NONCE_HEADER: &str = "x-kamn-request-nonce";
+const REQUEST_AUTH_SIGNATURE_HEADER: &str = "x-kamn-request-signature";
+const SERVICE_WS_ROUTE: &str = "/v1/events/ws";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceScheme {
+    Http,
+    Https,
+}
+
+impl ServiceScheme {
+    fn default_port(self) -> u16 {
+        match self {
+            Self::Http => 80,
+            Self::Https => 443,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServiceEndpoint {
+    scheme: ServiceScheme,
+    host: String,
+    port: u16,
+    base_path: String,
+}
+
+impl ServiceEndpoint {
+    fn parse(endpoint: &str) -> Result<Self, SdkError> {
+        let trimmed = endpoint.trim();
+        if trimmed.is_empty() {
+            return Err(SdkError::InvalidInput {
+                field: "service.endpoint",
+                reason: "must not be empty",
+            });
+        }
+
+        let (scheme, suffix) = if let Some(suffix) = trimmed.strip_prefix("http://") {
+            (ServiceScheme::Http, suffix)
+        } else if let Some(suffix) = trimmed.strip_prefix("https://") {
+            (ServiceScheme::Https, suffix)
+        } else {
+            return Err(SdkError::InvalidInput {
+                field: "service.endpoint",
+                reason: "must start with http:// or https://",
+            });
+        };
+
+        let (authority, base_path) = match suffix.split_once('/') {
+            Some((authority, path)) => (
+                authority,
+                format!("/{path}").trim_end_matches('/').to_owned(),
+            ),
+            None => (suffix, String::new()),
+        };
+        if authority.trim().is_empty() {
+            return Err(SdkError::InvalidInput {
+                field: "service.endpoint",
+                reason: "host is required",
+            });
+        }
+
+        let (host, port) = parse_host_port(authority, scheme.default_port())?;
+        Ok(Self {
+            scheme,
+            host,
+            port,
+            base_path,
+        })
+    }
+
+    fn route_path(&self, route: &str) -> String {
+        if self.base_path.is_empty() {
+            return route.to_owned();
+        }
+        format!("{}{}", self.base_path, route)
+    }
+
+    fn connect_stream(&self) -> Result<TcpStream, SdkError> {
+        if self.scheme == ServiceScheme::Https {
+            return Err(SdkError::NotImplemented(
+                "https transport is not yet supported by the std service client",
+            ));
+        }
+
+        let stream = TcpStream::connect((self.host.as_str(), self.port))
+            .map_err(|_| SdkError::TransportFailure("failed to connect to service endpoint"))?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(REQUEST_TIMEOUT_SECONDS)))
+            .map_err(|_| SdkError::TransportFailure("failed to configure service read timeout"))?;
+        stream
+            .set_write_timeout(Some(Duration::from_secs(REQUEST_TIMEOUT_SECONDS)))
+            .map_err(|_| SdkError::TransportFailure("failed to configure service write timeout"))?;
+        Ok(stream)
+    }
+}
+
+/// Request authentication envelope for service API routes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceRequestAuth {
+    sender_did: AgentDid,
+    nonce: u64,
+    signature: String,
+}
+
+impl ServiceRequestAuth {
+    /// Builds a validated request auth envelope.
+    pub fn new(sender_did: AgentDid, nonce: u64, signature: String) -> Result<Self, SdkError> {
+        if nonce == 0 {
+            return Err(SdkError::InvalidInput {
+                field: "request_auth.nonce",
+                reason: "must be greater than zero",
+            });
+        }
+        if signature.trim().is_empty() {
+            return Err(SdkError::InvalidInput {
+                field: "request_auth.signature",
+                reason: "must not be empty",
+            });
+        }
+        Ok(Self {
+            sender_did,
+            nonce,
+            signature,
+        })
+    }
+
+    fn sender_did(&self) -> &AgentDid {
+        &self.sender_did
+    }
+
+    fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    fn signature(&self) -> &str {
+        self.signature.as_str()
+    }
+}
+
+/// Deterministic request signature builder for service API fields.
+pub fn service_signature_for_fields(
+    sender_did: &AgentDid,
+    nonce: u64,
+    chain_id: &str,
+    chain_version: &str,
+    body: &str,
+) -> String {
+    let state_hash = format!("service-api:{chain_id}:{chain_version}");
+    signature_for_fields(sender_did.as_str(), nonce, state_hash.as_str(), body)
+}
+
+/// Parsed response for `POST /v1/messages/send`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceMessageReceipt {
+    /// Service-generated message identifier.
+    pub message_id: String,
+    /// Lifecycle status marker.
+    pub status: String,
+    /// Runtime mode reported by the service.
+    pub runtime_mode: String,
+}
+
+/// Parsed response for `GET /v1/messages/{id}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceMessageStatus {
+    /// Message identifier.
+    pub message_id: String,
+    /// Lifecycle status marker.
+    pub status: String,
+}
+
+/// Parsed response for `POST /v1/channels/create`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceChannelReceipt {
+    /// Service-generated channel identifier.
+    pub channel_id: String,
+    /// Route status marker.
+    pub status: String,
+}
+
+/// Parsed response for `POST /v1/tasks/create`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceTaskReceipt {
+    /// Service-generated task identifier.
+    pub task_id: String,
+    /// Initial lifecycle state.
+    pub state: String,
+}
+
+/// Parsed response for `GET /v1/tasks/{id}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceTaskStatus {
+    /// Task identifier.
+    pub task_id: String,
+    /// Current lifecycle state.
+    pub state: String,
+}
+
+/// Parsed response for `GET /v1/agents/{did}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceAgentProfile {
+    /// Agent DID.
+    pub did: String,
+    /// Current reputation score.
+    pub reputation_score: u64,
+}
+
+/// Parsed response for `GET /healthz`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceHealthStatus {
+    /// Service health marker.
+    pub status: String,
+    /// Runtime mode marker.
+    pub runtime_mode: String,
+    /// Node role marker.
+    pub role: String,
+    /// Observability source marker.
+    pub observability_source: String,
+    /// Observability health marker.
+    pub observability_health: String,
+}
+
+/// Parsed event frame payload from `GET /v1/events/ws`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceRouteEvent {
+    /// Event name.
+    pub event: String,
+    /// Runtime mode marker.
+    pub runtime_mode: String,
+    /// Node role marker.
+    pub role: String,
+    /// Event sequence identifier.
+    pub sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HttpResponse {
+    status: u16,
+    body: String,
+}
+
+/// Synchronous SDK client for KAMN service HTTP and WebSocket routes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceApiClient {
+    endpoint: ServiceEndpoint,
+}
+
+impl ServiceApiClient {
+    /// Connects and validates the base service endpoint.
+    pub fn connect(endpoint: &str) -> Result<Self, SdkError> {
+        Ok(Self {
+            endpoint: ServiceEndpoint::parse(endpoint)?,
+        })
+    }
+
+    /// Sends a signed message payload through the service API.
+    pub fn send_message(
+        &self,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceMessageReceipt, SdkError> {
+        let response = self.request("POST", "/v1/messages/send", payload, Some(auth))?;
+        expect_status(response.status, 202)?;
+        Ok(ServiceMessageReceipt {
+            message_id: json_string_field(response.body.as_str(), "message_id")?,
+            status: json_string_field(response.body.as_str(), "status")?,
+            runtime_mode: json_string_field(response.body.as_str(), "runtime_mode")?,
+        })
+    }
+
+    /// Queries a message status by identifier.
+    pub fn get_message(
+        &self,
+        message_id: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceMessageStatus, SdkError> {
+        if message_id.trim().is_empty() {
+            return Err(SdkError::InvalidInput {
+                field: "message_id",
+                reason: "must not be empty",
+            });
+        }
+        let route = format!("/v1/messages/{message_id}");
+        let response = self.request("GET", route.as_str(), "", Some(auth))?;
+        expect_status(response.status, 200)?;
+        Ok(ServiceMessageStatus {
+            message_id: json_string_field(response.body.as_str(), "message_id")?,
+            status: json_string_field(response.body.as_str(), "status")?,
+        })
+    }
+
+    /// Creates a channel payload through the service API.
+    pub fn create_channel(
+        &self,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceChannelReceipt, SdkError> {
+        let response = self.request("POST", "/v1/channels/create", payload, Some(auth))?;
+        expect_status(response.status, 201)?;
+        Ok(ServiceChannelReceipt {
+            channel_id: json_string_field(response.body.as_str(), "channel_id")?,
+            status: json_string_field(response.body.as_str(), "status")?,
+        })
+    }
+
+    /// Creates a task payload through the service API.
+    pub fn create_task(
+        &self,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceTaskReceipt, SdkError> {
+        let response = self.request("POST", "/v1/tasks/create", payload, Some(auth))?;
+        expect_status(response.status, 201)?;
+        Ok(ServiceTaskReceipt {
+            task_id: json_string_field(response.body.as_str(), "task_id")?,
+            state: json_string_field(response.body.as_str(), "state")?,
+        })
+    }
+
+    /// Queries task lifecycle state by identifier.
+    pub fn get_task(
+        &self,
+        task_id: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceTaskStatus, SdkError> {
+        if task_id.trim().is_empty() {
+            return Err(SdkError::InvalidInput {
+                field: "task_id",
+                reason: "must not be empty",
+            });
+        }
+        let route = format!("/v1/tasks/{task_id}");
+        let response = self.request("GET", route.as_str(), "", Some(auth))?;
+        expect_status(response.status, 200)?;
+        Ok(ServiceTaskStatus {
+            task_id: json_string_field(response.body.as_str(), "task_id")?,
+            state: json_string_field(response.body.as_str(), "state")?,
+        })
+    }
+
+    /// Queries an agent reputation/profile by DID.
+    pub fn get_agent_profile(
+        &self,
+        did: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceAgentProfile, SdkError> {
+        if did.trim().is_empty() {
+            return Err(SdkError::InvalidInput {
+                field: "did",
+                reason: "must not be empty",
+            });
+        }
+        let route = format!("/v1/agents/{did}");
+        let response = self.request("GET", route.as_str(), "", Some(auth))?;
+        expect_status(response.status, 200)?;
+        Ok(ServiceAgentProfile {
+            did: json_string_field(response.body.as_str(), "did")?,
+            reputation_score: json_u64_field(response.body.as_str(), "reputation_score")?,
+        })
+    }
+
+    /// Queries service health route without request auth.
+    pub fn health(&self) -> Result<ServiceHealthStatus, SdkError> {
+        let response = self.request("GET", "/healthz", "", None)?;
+        expect_status(response.status, 200)?;
+        Ok(ServiceHealthStatus {
+            status: json_string_field(response.body.as_str(), "status")?,
+            runtime_mode: json_string_field(response.body.as_str(), "runtime_mode")?,
+            role: json_string_field(response.body.as_str(), "role")?,
+            observability_source: json_string_field(
+                response.body.as_str(),
+                "observability_source",
+            )?,
+            observability_health: json_string_field(
+                response.body.as_str(),
+                "observability_health",
+            )?,
+        })
+    }
+
+    /// Reads raw prometheus metrics exposition text.
+    pub fn metrics(&self) -> Result<String, SdkError> {
+        let response = self.request("GET", "/metrics", "", None)?;
+        expect_status(response.status, 200)?;
+        Ok(response.body)
+    }
+
+    /// Performs WebSocket upgrade on `/v1/events/ws` and reads one event frame.
+    pub fn read_event_once(
+        &self,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceRouteEvent, SdkError> {
+        let mut stream = self.endpoint.connect_stream()?;
+        let route = self.endpoint.route_path(SERVICE_WS_ROUTE);
+        let authority = format!("{}:{}", self.endpoint.host, self.endpoint.port);
+        let request = format!(
+            "GET {route} HTTP/1.1\r\nHost: {authority}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: kamn-sdk-test-key\r\nSec-WebSocket-Version: 13\r\n{}: {}\r\n{}: {}\r\n{}: {}\r\nContent-Length: 0\r\n\r\n",
+            REQUEST_AUTH_SENDER_DID_HEADER,
+            auth.sender_did().as_str(),
+            REQUEST_AUTH_NONCE_HEADER,
+            auth.nonce(),
+            REQUEST_AUTH_SIGNATURE_HEADER,
+            auth.signature(),
+        );
+        stream
+            .write_all(request.as_bytes())
+            .map_err(|_| SdkError::TransportFailure("failed to write service websocket request"))?;
+
+        let response_bytes = read_response_bytes(&mut stream)?;
+        let header_end = response_bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|index| index + 4)
+            .ok_or(SdkError::TransportFailure(
+                "service websocket response missing header terminator",
+            ))?;
+        let header_text =
+            String::from_utf8(response_bytes[..header_end].to_vec()).map_err(|_| {
+                SdkError::TransportFailure("service websocket response header not utf-8")
+            })?;
+        if !header_text.starts_with("HTTP/1.1 101") {
+            let body = String::from_utf8(response_bytes[header_end..].to_vec()).unwrap_or_default();
+            return map_non_success_response(
+                status_from_header(header_text.as_str()),
+                body.as_str(),
+            );
+        }
+
+        let frame = &response_bytes[header_end..];
+        if frame.len() < 2 {
+            return Err(SdkError::TransportFailure(
+                "service websocket response missing event frame",
+            ));
+        }
+        if frame[0] != 0x81 {
+            return Err(SdkError::TransportFailure(
+                "service websocket response frame opcode unsupported",
+            ));
+        }
+        if frame[1] & 0x80 != 0 {
+            return Err(SdkError::TransportFailure(
+                "service websocket response frame unexpectedly masked",
+            ));
+        }
+        let payload_len = (frame[1] & 0x7f) as usize;
+        if frame.len() < payload_len + 2 {
+            return Err(SdkError::TransportFailure(
+                "service websocket response frame payload truncated",
+            ));
+        }
+        let payload = String::from_utf8(frame[2..2 + payload_len].to_vec())
+            .map_err(|_| SdkError::TransportFailure("service websocket event payload not utf-8"))?;
+        Ok(ServiceRouteEvent {
+            event: json_string_field(payload.as_str(), "event")?,
+            runtime_mode: json_string_field(payload.as_str(), "runtime_mode")?,
+            role: json_string_field(payload.as_str(), "role")?,
+            sequence: json_u64_field(payload.as_str(), "sequence")?,
+        })
+    }
+
+    fn request(
+        &self,
+        method: &str,
+        route: &str,
+        body: &str,
+        auth: Option<&ServiceRequestAuth>,
+    ) -> Result<HttpResponse, SdkError> {
+        let mut stream = self.endpoint.connect_stream()?;
+        let path = self.endpoint.route_path(route);
+        let authority = format!("{}:{}", self.endpoint.host, self.endpoint.port);
+        let mut auth_headers = String::new();
+        if let Some(auth) = auth {
+            auth_headers.push_str(
+                format!(
+                    "{REQUEST_AUTH_SENDER_DID_HEADER}: {}\r\n",
+                    auth.sender_did().as_str()
+                )
+                .as_str(),
+            );
+            auth_headers
+                .push_str(format!("{REQUEST_AUTH_NONCE_HEADER}: {}\r\n", auth.nonce()).as_str());
+            auth_headers.push_str(
+                format!("{REQUEST_AUTH_SIGNATURE_HEADER}: {}\r\n", auth.signature()).as_str(),
+            );
+        }
+        let request = format!(
+            "{method} {path} HTTP/1.1\r\nHost: {authority}\r\nContent-Type: application/json\r\n{auth_headers}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(request.as_bytes())
+            .map_err(|_| SdkError::TransportFailure("failed to write service request"))?;
+
+        let response_text = read_response_text(&mut stream)?;
+        parse_http_response(response_text.as_str())
+    }
+}
+
+fn parse_host_port(authority: &str, default_port: u16) -> Result<(String, u16), SdkError> {
+    if authority.starts_with('[') {
+        let closing = authority.find(']').ok_or(SdkError::InvalidInput {
+            field: "service.endpoint",
+            reason: "unterminated ipv6 host",
+        })?;
+        let host = authority[..=closing].to_owned();
+        let suffix = &authority[closing + 1..];
+        if suffix.is_empty() {
+            return Ok((host, default_port));
+        }
+        let port = suffix
+            .strip_prefix(':')
+            .ok_or(SdkError::InvalidInput {
+                field: "service.endpoint",
+                reason: "invalid ipv6 authority suffix",
+            })?
+            .parse::<u16>()
+            .map_err(|_| SdkError::InvalidInput {
+                field: "service.endpoint",
+                reason: "port must be an unsigned integer in range",
+            })?;
+        return Ok((host, port));
+    }
+
+    match authority.rsplit_once(':') {
+        Some((host, raw_port)) if !host.is_empty() => {
+            let port = raw_port
+                .parse::<u16>()
+                .map_err(|_| SdkError::InvalidInput {
+                    field: "service.endpoint",
+                    reason: "port must be an unsigned integer in range",
+                })?;
+            Ok((host.to_owned(), port))
+        }
+        _ => Ok((authority.to_owned(), default_port)),
+    }
+}
+
+fn read_response_bytes(stream: &mut TcpStream) -> Result<Vec<u8>, SdkError> {
+    let mut response = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => response.extend_from_slice(&chunk[..read_count]),
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(_) => {
+                return Err(SdkError::TransportFailure(
+                    "failed to read service response payload",
+                ));
+            }
+        }
+    }
+    Ok(response)
+}
+
+fn read_response_text(stream: &mut TcpStream) -> Result<String, SdkError> {
+    String::from_utf8(read_response_bytes(stream)?)
+        .map_err(|_| SdkError::TransportFailure("service response payload was not utf-8"))
+}
+
+fn parse_http_response(response: &str) -> Result<HttpResponse, SdkError> {
+    let (header, body) = response
+        .split_once("\r\n\r\n")
+        .ok_or(SdkError::TransportFailure(
+            "service response missing header terminator",
+        ))?;
+    let status = status_from_header(header).ok_or(SdkError::TransportFailure(
+        "service response status line invalid",
+    ))?;
+    if status >= 400 {
+        return map_non_success_response(Some(status), body);
+    }
+
+    Ok(HttpResponse {
+        status,
+        body: body.to_owned(),
+    })
+}
+
+fn status_from_header(header: &str) -> Option<u16> {
+    let line = header.lines().next()?;
+    let raw_code = line.split_whitespace().nth(1)?;
+    raw_code.parse::<u16>().ok()
+}
+
+fn map_non_success_response<T>(status: Option<u16>, _body: &str) -> Result<T, SdkError> {
+    match status {
+        Some(409) => Err(SdkError::Conflict("request rejected by service api")),
+        Some(401) => Err(SdkError::TransportFailure(
+            "request rejected by service api",
+        )),
+        Some(400) => Err(SdkError::TransportFailure(
+            "request rejected by service api",
+        )),
+        Some(404) => Err(SdkError::NotFound {
+            entity: "service-route",
+            id: "requested-route".to_owned(),
+        }),
+        _ => Err(SdkError::TransportFailure(
+            "request rejected by service api",
+        )),
+    }
+}
+
+fn expect_status(actual: u16, expected: u16) -> Result<(), SdkError> {
+    if actual == expected {
+        return Ok(());
+    }
+    if actual == 409 {
+        return Err(SdkError::Conflict("request rejected by service api"));
+    }
+    Err(SdkError::TransportFailure(
+        "request rejected by service api",
+    ))
+}
+
+fn json_string_field(payload: &str, key: &str) -> Result<String, SdkError> {
+    let marker = format!("\"{key}\":\"");
+    let start = payload
+        .find(marker.as_str())
+        .map(|index| index + marker.len())
+        .ok_or(SdkError::TransportFailure(
+            "service response missing required field",
+        ))?;
+    let rest = &payload[start..];
+    let end = rest.find('"').ok_or(SdkError::TransportFailure(
+        "service response field was not terminated",
+    ))?;
+    Ok(rest[..end].to_owned())
+}
+
+fn json_u64_field(payload: &str, key: &str) -> Result<u64, SdkError> {
+    let marker = format!("\"{key}\":");
+    let start = payload
+        .find(marker.as_str())
+        .map(|index| index + marker.len())
+        .ok_or(SdkError::TransportFailure(
+            "service response missing required field",
+        ))?;
+    let rest = payload[start..].trim_start();
+    let value_end = rest
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(rest.len());
+    if value_end == 0 {
+        return Err(SdkError::TransportFailure(
+            "service response numeric field was malformed",
+        ));
+    }
+    rest[..value_end]
+        .parse::<u64>()
+        .map_err(|_| SdkError::TransportFailure("service response numeric field was malformed"))
+}

--- a/crates/kamn-sdk/tests/service_api_client.rs
+++ b/crates/kamn-sdk/tests/service_api_client.rs
@@ -1,0 +1,470 @@
+use kamn_sdk::{
+    service_signature_for_fields, AgentDid, SdkError, ServiceApiClient, ServiceRequestAuth,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const CHAIN_ID: &str = "kolme-localnet";
+const CHAIN_VERSION: &str = "v0";
+
+fn reserve_loopback_addr() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    drop(listener);
+    addr.to_string()
+}
+
+fn parse_http_request(
+    stream: &mut TcpStream,
+) -> Result<(String, String, String, BTreeMap<String, String>), String> {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("request read-timeout failed: {error}"))?;
+
+    let mut expected_total_bytes: Option<usize> = None;
+    let mut header_end: Option<usize> = None;
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                request.extend_from_slice(&chunk[..read_count]);
+                if header_end.is_none() {
+                    header_end = request
+                        .windows(4)
+                        .position(|window| window == b"\r\n\r\n")
+                        .map(|index| index + 4);
+                    if let Some(header_end_index) = header_end {
+                        let header = String::from_utf8(request[..header_end_index].to_vec())
+                            .map_err(|_| "request header was not valid utf-8".to_owned())?;
+                        let content_length = parse_content_length(header.as_str())?;
+                        expected_total_bytes = Some(header_end_index + content_length);
+                    }
+                }
+                if let Some(total) = expected_total_bytes {
+                    if request.len() >= total {
+                        break;
+                    }
+                }
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => return Err(format!("request read failed: {error}")),
+        }
+    }
+
+    let request_text =
+        String::from_utf8(request).map_err(|_| "request was not valid utf-8".to_owned())?;
+    let Some((request_head, request_body)) = request_text.split_once("\r\n\r\n") else {
+        return Err("request header terminator missing".to_owned());
+    };
+    let request_line = request_head
+        .lines()
+        .next()
+        .ok_or_else(|| "request line missing".to_owned())?;
+    let mut headers = BTreeMap::new();
+    for line in request_head.lines().skip(1) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| "request header line missing ':' separator".to_owned())?;
+        headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_owned());
+    }
+    let mut parts = request_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| "request method missing".to_owned())?
+        .to_owned();
+    let path = parts
+        .next()
+        .ok_or_else(|| "request path missing".to_owned())?
+        .to_owned();
+    Ok((method, path, request_body.to_owned(), headers))
+}
+
+fn parse_content_length(header: &str) -> Result<usize, String> {
+    let value = header
+        .lines()
+        .find_map(|line| {
+            let (name, raw_value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("Content-Length") {
+                return Some(raw_value.trim());
+            }
+            None
+        })
+        .unwrap_or("0");
+    value
+        .parse::<usize>()
+        .map_err(|_| "invalid content-length header".to_owned())
+}
+
+fn write_http_response(stream: &mut TcpStream, status: u16, body: &str) -> Result<(), String> {
+    let status_text = match status {
+        200 => "200 OK",
+        201 => "201 Created",
+        202 => "202 Accepted",
+        400 => "400 Bad Request",
+        401 => "401 Unauthorized",
+        404 => "404 Not Found",
+        409 => "409 Conflict",
+        _ => "500 Internal Server Error",
+    };
+    let payload = format!(
+        "HTTP/1.1 {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(|error| format!("service api write failed: {error}"))
+}
+
+fn deterministic_tag(payload: &[u8]) -> u64 {
+    let mut acc: u64 = 0xcbf29ce484222325;
+    for byte in payload {
+        acc = acc.wrapping_mul(0x00000100000001B3);
+        acc ^= u64::from(*byte);
+    }
+    acc
+}
+
+fn write_websocket_upgrade_response(stream: &mut TcpStream) -> Result<(), String> {
+    let handshake = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: kamn-test-accept\r\nX-KAMN-WebSocket-Contract: v1\r\n\r\n";
+    stream
+        .write_all(handshake.as_bytes())
+        .map_err(|error| format!("websocket handshake write failed: {error}"))?;
+    let payload =
+        r#"{"event":"state-transition","runtime_mode":"api","role":"processor","sequence":1}"#;
+    let mut frame = Vec::with_capacity(2 + payload.len());
+    frame.push(0x81);
+    frame.push(payload.len() as u8);
+    frame.extend_from_slice(payload.as_bytes());
+    stream
+        .write_all(frame.as_slice())
+        .map_err(|error| format!("websocket frame write failed: {error}"))
+}
+
+fn validate_auth(
+    body: &str,
+    headers: &BTreeMap<String, String>,
+    replay_guard: &mut BTreeSet<(String, u64)>,
+) -> Result<(), (u16, &'static str)> {
+    let did = headers
+        .get("x-kamn-sender-did")
+        .ok_or((401, "missing required header: x-kamn-sender-did"))?
+        .to_owned();
+    AgentDid::parse(did.clone()).map_err(|_| (401, "invalid sender did"))?;
+    let nonce = headers
+        .get("x-kamn-request-nonce")
+        .ok_or((401, "missing required header: x-kamn-request-nonce"))?
+        .parse::<u64>()
+        .map_err(|_| (401, "invalid request nonce header: x-kamn-request-nonce"))?;
+    if nonce == 0 {
+        return Err((401, "request nonce must be positive: x-kamn-request-nonce"));
+    }
+    let signature = headers
+        .get("x-kamn-request-signature")
+        .ok_or((401, "missing required header: x-kamn-request-signature"))?;
+    let expected = service_signature_for_fields(
+        &AgentDid::parse(did.clone()).map_err(|_| (401, "invalid sender did"))?,
+        nonce,
+        CHAIN_ID,
+        CHAIN_VERSION,
+        body,
+    );
+    if &expected != signature {
+        return Err((401, "signature verification failed for request envelope"));
+    }
+    if !replay_guard.insert((did, nonce)) {
+        return Err((409, "request nonce replay detected for sender"));
+    }
+    Ok(())
+}
+
+fn run_service_contract_server(bind_addr: String, max_requests: u64) -> Result<(), String> {
+    let listener = TcpListener::bind(bind_addr.as_str())
+        .map_err(|error| format!("server bind failed: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("server nonblocking mode failed: {error}"))?;
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut served = 0_u64;
+    let mut replay_guard: BTreeSet<(String, u64)> = BTreeSet::new();
+    while served < max_requests {
+        if Instant::now() > deadline {
+            return Err("server timed out before serving request budget".to_owned());
+        }
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let (method, path, body, headers) = parse_http_request(&mut stream)?;
+                if method == "GET" && path == "/healthz" {
+                    write_http_response(
+                        &mut stream,
+                        200,
+                        r#"{"status":"ok","runtime_mode":"api","role":"processor","observability_source":"unknown","observability_health":"unknown"}"#,
+                    )?;
+                    served = served.saturating_add(1);
+                    continue;
+                }
+                if method == "GET" && path == "/metrics" {
+                    let body = "kamn_service_api_health{runtime_mode=\"api\"} 1\n";
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .map_err(|error| format!("metrics write failed: {error}"))?;
+                    served = served.saturating_add(1);
+                    continue;
+                }
+
+                if let Err((status, reason)) = validate_auth(&body, &headers, &mut replay_guard) {
+                    let payload = format!(
+                        "{{\"error\":\"{}\",\"reason\":\"{}\"}}",
+                        if status == 409 {
+                            "replay"
+                        } else {
+                            "unauthorized"
+                        },
+                        reason
+                    );
+                    write_http_response(&mut stream, status, payload.as_str())?;
+                    served = served.saturating_add(1);
+                    continue;
+                }
+
+                if method == "GET" && path == "/v1/events/ws" {
+                    let upgrade = headers.get("upgrade").cloned().unwrap_or_default();
+                    let connection = headers.get("connection").cloned().unwrap_or_default();
+                    let websocket_key = headers
+                        .get("sec-websocket-key")
+                        .cloned()
+                        .unwrap_or_default();
+                    let version = headers
+                        .get("sec-websocket-version")
+                        .cloned()
+                        .unwrap_or_default();
+                    if !upgrade.eq_ignore_ascii_case("websocket")
+                        || !connection.to_ascii_lowercase().contains("upgrade")
+                        || websocket_key.trim().is_empty()
+                        || version.trim() != "13"
+                    {
+                        write_http_response(
+                            &mut stream,
+                            400,
+                            r#"{"error":"bad-request","reason":"websocket upgrade required"}"#,
+                        )?;
+                    } else {
+                        write_websocket_upgrade_response(&mut stream)?;
+                    }
+                    served = served.saturating_add(1);
+                    continue;
+                }
+
+                if method == "POST" && path == "/v1/messages/send" {
+                    let message_id =
+                        format!("msg-local-{:016x}", deterministic_tag(body.as_bytes()));
+                    let payload = format!(
+                        "{{\"message_id\":\"{}\",\"status\":\"created\",\"runtime_mode\":\"api\"}}",
+                        message_id
+                    );
+                    write_http_response(&mut stream, 202, payload.as_str())?;
+                } else if method == "GET" && path.starts_with("/v1/messages/") {
+                    let message_id = path.trim_start_matches("/v1/messages/");
+                    let payload = format!(
+                        "{{\"message_id\":\"{}\",\"status\":\"created\"}}",
+                        message_id
+                    );
+                    write_http_response(&mut stream, 200, payload.as_str())?;
+                } else if method == "POST" && path == "/v1/channels/create" {
+                    let channel_id =
+                        format!("channel-local-{:016x}", deterministic_tag(body.as_bytes()));
+                    let payload = format!(
+                        "{{\"channel_id\":\"{}\",\"status\":\"created\"}}",
+                        channel_id
+                    );
+                    write_http_response(&mut stream, 201, payload.as_str())?;
+                } else if method == "POST" && path == "/v1/tasks/create" {
+                    let task_id = format!("task-local-{:016x}", deterministic_tag(body.as_bytes()));
+                    let payload =
+                        format!("{{\"task_id\":\"{}\",\"state\":\"submitted\"}}", task_id);
+                    write_http_response(&mut stream, 201, payload.as_str())?;
+                } else if method == "GET" && path.starts_with("/v1/tasks/") {
+                    let task_id = path.trim_start_matches("/v1/tasks/");
+                    let payload =
+                        format!("{{\"task_id\":\"{}\",\"state\":\"submitted\"}}", task_id);
+                    write_http_response(&mut stream, 200, payload.as_str())?;
+                } else if method == "GET" && path.starts_with("/v1/agents/") {
+                    let did = path.trim_start_matches("/v1/agents/");
+                    let payload = format!("{{\"did\":\"{}\",\"reputation_score\":500}}", did);
+                    write_http_response(&mut stream, 200, payload.as_str())?;
+                } else {
+                    write_http_response(&mut stream, 404, "not found")?;
+                }
+
+                served = served.saturating_add(1);
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => return Err(format!("server accept failed: {error}")),
+        }
+    }
+    Ok(())
+}
+
+fn wait_for_server_ready(addr: &str) {
+    assert!(!addr.trim().is_empty(), "server address must not be empty");
+    thread::sleep(Duration::from_millis(40));
+}
+
+fn auth(sender: &AgentDid, nonce: u64, body: &str) -> ServiceRequestAuth {
+    ServiceRequestAuth::new(
+        sender.clone(),
+        nonce,
+        service_signature_for_fields(sender, nonce, CHAIN_ID, CHAIN_VERSION, body),
+    )
+    .expect("request auth should build")
+}
+
+#[test]
+fn unit_service_api_client_rejects_invalid_endpoint_scheme() {
+    assert_eq!(
+        ServiceApiClient::connect("tcp://127.0.0.1:35001"),
+        Err(SdkError::InvalidInput {
+            field: "service.endpoint",
+            reason: "must start with http:// or https://",
+        })
+    );
+}
+
+#[test]
+fn functional_service_api_client_executes_signed_http_route_contracts() {
+    let bind_addr = reserve_loopback_addr();
+    let server_addr = bind_addr.clone();
+    let server = thread::spawn(move || run_service_contract_server(server_addr, 8));
+    wait_for_server_ready(bind_addr.as_str());
+
+    let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str())
+        .expect("client should connect");
+    let sender = AgentDid::parse("kamn:did:agent:sdk-client").expect("sender did should parse");
+
+    let send_payload = r#"{"message":"hello from sdk"}"#;
+    let send_response = client
+        .send_message(send_payload, &auth(&sender, 1, send_payload))
+        .expect("send message should succeed");
+    assert!(send_response.message_id.starts_with("msg-local-"));
+    assert_eq!(send_response.status, "created");
+
+    let message_status = client
+        .get_message(send_response.message_id.as_str(), &auth(&sender, 2, ""))
+        .expect("get message should succeed");
+    assert_eq!(message_status.message_id, send_response.message_id);
+    assert_eq!(message_status.status, "created");
+
+    let channel_payload = r#"{"name":"ops"}"#;
+    let channel_response = client
+        .create_channel(channel_payload, &auth(&sender, 3, channel_payload))
+        .expect("create channel should succeed");
+    assert!(channel_response.channel_id.starts_with("channel-local-"));
+
+    let task_payload = r#"{"task":"triage"}"#;
+    let task_response = client
+        .create_task(task_payload, &auth(&sender, 4, task_payload))
+        .expect("create task should succeed");
+    assert!(task_response.task_id.starts_with("task-local-"));
+
+    let task_status = client
+        .get_task(task_response.task_id.as_str(), &auth(&sender, 5, ""))
+        .expect("get task should succeed");
+    assert_eq!(task_status.state, "submitted");
+
+    let profile = client
+        .get_agent_profile(sender.as_str(), &auth(&sender, 6, ""))
+        .expect("agent profile should resolve");
+    assert_eq!(profile.did, sender.as_str());
+    assert_eq!(profile.reputation_score, 500);
+
+    let health = client.health().expect("health route should succeed");
+    assert_eq!(health.status, "ok");
+    assert_eq!(health.runtime_mode, "api");
+
+    let metrics = client.metrics().expect("metrics route should succeed");
+    assert!(
+        metrics.contains("kamn_service_api_health{runtime_mode=\"api\"} 1"),
+        "metrics contract should include service health gauge"
+    );
+
+    let server_result = server.join().expect("server thread should join");
+    assert!(
+        server_result.is_ok(),
+        "test service contract server should satisfy request budget"
+    );
+}
+
+#[test]
+fn integration_service_api_client_reads_websocket_event_frame() {
+    let bind_addr = reserve_loopback_addr();
+    let server_addr = bind_addr.clone();
+    let server = thread::spawn(move || run_service_contract_server(server_addr, 1));
+    wait_for_server_ready(bind_addr.as_str());
+
+    let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str())
+        .expect("client should connect");
+    let sender = AgentDid::parse("kamn:did:agent:sdk-events").expect("sender did should parse");
+
+    let event = client
+        .read_event_once(&auth(&sender, 9, ""))
+        .expect("event read should succeed");
+    assert_eq!(event.event, "state-transition");
+    assert_eq!(event.runtime_mode, "api");
+    assert_eq!(event.role, "processor");
+    assert_eq!(event.sequence, 1);
+
+    let server_result = server.join().expect("server thread should join");
+    assert!(
+        server_result.is_ok(),
+        "test service contract server should satisfy websocket request budget"
+    );
+}
+
+#[test]
+fn regression_service_api_client_rejects_replayed_nonce() {
+    // Regression: #2946
+    let bind_addr = reserve_loopback_addr();
+    let server_addr = bind_addr.clone();
+    let server = thread::spawn(move || run_service_contract_server(server_addr, 2));
+    wait_for_server_ready(bind_addr.as_str());
+
+    let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str())
+        .expect("client should connect");
+    let sender = AgentDid::parse("kamn:did:agent:sdk-replay").expect("sender did should parse");
+    let payload = r#"{"message":"nonce replay"}"#;
+    let replay_auth = auth(&sender, 11, payload);
+
+    client
+        .send_message(payload, &replay_auth)
+        .expect("first send should pass");
+    assert_eq!(
+        client
+            .send_message(payload, &replay_auth)
+            .expect_err("replayed nonce should fail closed"),
+        SdkError::Conflict("request rejected by service api")
+    );
+
+    let server_result = server.join().expect("server thread should join");
+    assert!(
+        server_result.is_ok(),
+        "test service contract server should satisfy replay request budget"
+    );
+}

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -62,6 +62,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/sdk/validate_python_sdk_packaging_live.sh` and `scripts/sdk/test_validate_python_sdk_packaging_live.sh` (Task #2953, Subtask #2954).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `packaging_contract_status=verified`, `evidence_bundle_status=verified`, `fail_closed_status=verified`.
   - Fail-closed validation confirmed for missing metadata drill: `expected python sdk packaging metadata file: pyproject.toml`.
+- Phase 5 Rust SDK service-client implementation delivered:
+  - Added synchronous service API client primitives in `kamn-sdk`: `ServiceApiClient`, `ServiceRequestAuth`, `service_signature_for_fields`, and typed route/event response models (Task #2946).
+  - Added deterministic unit/functional/integration/regression coverage in `crates/kamn-sdk/tests/service_api_client.rs`.
+  - Added operator/developer reference documentation: `docs/sdk/rust-sdk.md`.
 - Phase 6.3 initial slice delivered: deployment artifacts now include a multi-stage `Dockerfile`, `deploy/docker-compose.yml` role topology, and `deploy/k8s/kamn-node.yaml` baseline manifests (Task #2971, Subtask #2972).
 - Phase 6.3 live validation delivered:
   - Runtime lane: `scripts/deploy/validate_deployment_assets_live.sh` and `scripts/deploy/test_validate_deployment_assets_live.sh` (Task #2973, Subtask #2974).

--- a/docs/sdk/rust-sdk.md
+++ b/docs/sdk/rust-sdk.md
@@ -1,0 +1,59 @@
+# Rust SDK Service Client
+
+This document covers the Rust SDK service client added for Service Phase 5 core delivery (Task #2946).
+
+## Scope
+
+The `kamn-sdk` crate now includes a synchronous service client for the runtime API contract:
+
+- `ServiceApiClient`
+- `ServiceRequestAuth`
+- `service_signature_for_fields`
+- typed response models for messages/channels/tasks/agent profile/health/events
+
+The client targets deterministic service routes exposed by `kamn-node` runtime mode `api`:
+
+- `POST /v1/messages/send`
+- `GET /v1/messages/{id}`
+- `POST /v1/channels/create`
+- `POST /v1/tasks/create`
+- `GET /v1/tasks/{id}`
+- `GET /v1/agents/{did}`
+- `GET /healthz`
+- `GET /metrics`
+- `GET /v1/events/ws` (upgrade + single event frame)
+
+## Usage
+
+```rust
+use kamn_sdk::{
+    service_signature_for_fields, AgentDid, ServiceApiClient, ServiceRequestAuth,
+};
+
+let client = ServiceApiClient::connect("http://127.0.0.1:34052")?;
+let sender = AgentDid::parse("kamn:did:agent:alpha")?;
+
+let body = r#"{"message":"hello"}"#;
+let signature = service_signature_for_fields(&sender, 1, "kolme-localnet", "v0", body);
+let auth = ServiceRequestAuth::new(sender.clone(), 1, signature)?;
+
+let receipt = client.send_message(body, &auth)?;
+let status = client.get_message(receipt.message_id.as_str(), &ServiceRequestAuth::new(
+    sender.clone(),
+    2,
+    service_signature_for_fields(&sender, 2, "kolme-localnet", "v0", ""),
+)?)?;
+
+assert_eq!(status.status, "created");
+```
+
+## Validation
+
+Core delivery validation for Task #2946:
+
+- `cargo test -p kamn-sdk --test service_api_client`
+- `cargo test -p kamn-sdk`
+- `cargo clippy -p kamn-sdk -- -D warnings`
+- `cargo fmt --check`
+
+Live validation lane evidence is tracked separately in Task #2948 / Subtask #2949.


### PR DESCRIPTION
## Summary
Implemented the Rust SDK core delivery slice for service API transport by adding a synchronous HTTP/WebSocket client surface with deterministic request-auth support. This closes the implementation gap tracked by Task #2946 and Subtask #2947 and adds the required test/doc coverage.

## Changes
- `crates/kamn-sdk/src/service.rs`: added `ServiceApiClient`, `ServiceRequestAuth`, `service_signature_for_fields`, typed route response models, and WebSocket one-frame event reader.
- `crates/kamn-sdk/src/lib.rs`: exported the new service client primitives.
- `crates/kamn-sdk/tests/service_api_client.rs`: added unit, functional, integration, and regression tests with a deterministic local contract server.
- `docs/sdk/rust-sdk.md`: documented SDK service-client usage and validation workflow.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded Phase 5 Rust SDK implementation delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:

`cargo test -p kamn-sdk --test service_api_client`

Failing evidence excerpt:

`unresolved imports kamn_sdk::service_signature_for_fields, kamn_sdk::ServiceApiClient, kamn_sdk::ServiceRequestAuth`

### 🟢 Green Phase
Commands:

- `cargo test -p kamn-sdk --test service_api_client`
- `cargo test -p kamn-sdk`

Passing evidence summary:

- `service_api_client`: 4 passed, 0 failed
- `kamn-sdk` full suite: all tests passed (existing ignored deep-lane tests unchanged)

### 🔁 Regression
Commands:

- `cargo clippy -p kamn-sdk -- -D warnings`
- `cargo fmt --check`

Result: both commands pass cleanly.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_service_api_client_rejects_invalid_endpoint_scheme` | |
| Functional   | ✅     | `functional_service_api_client_executes_signed_http_route_contracts` | |
| Integration  | ✅     | `integration_service_api_client_reads_websocket_event_frame` | |
| Regression   | ✅     | `regression_service_api_client_rejects_replayed_nonce` | |
| Performance  | N/A    | None | No new performance-sensitive loop/throughput path introduced beyond deterministic single-request client flow |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `2542956` to remove the new service client surface and tests.

## Documentation Updates
- `docs/sdk/rust-sdk.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-sdk -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-sdk`)
- [x] Docs updated

Closes #2946
Closes #2947
