### PR TITLE
feat(kolme): add continuous runtime commit cycles (#2931)

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -703,6 +703,14 @@ where
                 signing_profile.to_owned(),
             ));
         }
+        if daemon_max_ticks.is_some() && daemon_tick_interval_ms.is_none() {
+            return Err(ConfigError::MissingArgumentValue(
+                "--daemon-tick-interval-ms",
+            ));
+        }
+        if daemon_tick_interval_ms.is_some() && daemon_max_ticks.is_none() {
+            return Err(ConfigError::MissingArgumentValue("--daemon-max-ticks"));
+        }
         let key_source =
             kolme_live_signer_key_source
                 .as_deref()

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -40,7 +40,9 @@ use report_builder::build_bootstrap_report;
 use report_render::render_bootstrap_report;
 #[cfg(test)]
 use runtime_kolme_live::build_kolme_live_request;
-use runtime_kolme_live::execute_kolme_live_runtime;
+use runtime_kolme_live::{
+    execute_kolme_live_runtime, execute_kolme_live_runtime_continuous, KolmeLiveContinuousMode,
+};
 #[cfg(test)]
 pub(crate) use service_api_endpoint::render_service_api_endpoint_response;
 pub(crate) use service_api_endpoint::{
@@ -783,14 +785,35 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             } else {
                 None
             };
-            let kolme_live_execution = execute_kolme_live_runtime(
-                &plan,
-                base_url,
-                provider_hint,
-                signing_profile,
-                strict_signer_profile,
-                strict_signer_key_source,
-            )?;
+            let kolme_live_execution =
+                if daemon_max_ticks.is_some() || daemon_tick_interval_ms.is_some() {
+                    let max_cycles = daemon_max_ticks
+                        .ok_or(ConfigError::MissingArgumentValue("--daemon-max-ticks"))?;
+                    let cycle_interval_ms = daemon_tick_interval_ms.ok_or(
+                        ConfigError::MissingArgumentValue("--daemon-tick-interval-ms"),
+                    )?;
+                    execute_kolme_live_runtime_continuous(
+                        &plan,
+                        base_url,
+                        provider_hint,
+                        signing_profile,
+                        strict_signer_profile,
+                        strict_signer_key_source,
+                        KolmeLiveContinuousMode {
+                            max_cycles,
+                            cycle_interval_ms,
+                        },
+                    )?
+                } else {
+                    execute_kolme_live_runtime(
+                        &plan,
+                        base_url,
+                        provider_hint,
+                        signing_profile,
+                        strict_signer_profile,
+                        strict_signer_key_source,
+                    )?
+                };
             RuntimeExecutionBundle {
                 kolme_live: Some(kolme_live_execution),
                 ..RuntimeExecutionBundle::default()

--- a/crates/kamn-node/src/main_tests/cli_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/cli_contract_tests.rs
@@ -391,6 +391,60 @@ fn rejects_kolme_live_without_signer_key_source() {
 }
 
 #[test]
+fn rejects_kolme_live_continuous_mode_without_tick_interval() {
+    // Regression: #2931
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        "http://127.0.0.1:3000".to_owned(),
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "2".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue(
+            "--daemon-tick-interval-ms"
+        ))
+    );
+}
+
+#[test]
+fn rejects_kolme_live_continuous_mode_without_max_ticks() {
+    // Regression: #2931
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        "http://127.0.0.1:3000".to_owned(),
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue("--daemon-max-ticks"))
+    );
+}
+
+#[test]
 fn rejects_kolme_live_strict_signer_contracts_without_signer_profile_selector() {
     // Regression: #2246
     let args = vec![

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -1271,6 +1271,72 @@ fn integration_runtime_kolme_live_renders_provider_contract_markers() {
 }
 
 #[test]
+fn functional_runtime_kolme_live_continuous_mode_executes_multiple_cycles() {
+    // Regression: #2931
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor-cycle-1"}"#),
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:cycle-1","finality":"pending"}"#,
+        ),
+        MockHttpReply::ok(
+            r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:cycle-1","finality":"final"}"#,
+        ),
+        MockHttpReply::ok(r#"{"next_nonce":18,"account_id":"acct-live-processor-cycle-2"}"#),
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:cycle-2","finality":"pending"}"#,
+        ),
+        MockHttpReply::ok(
+            r#"{"provider":"kolme-fork-local","commit_id":"kolme-commit:cycle-2","finality":"final"}"#,
+        ),
+    ]);
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "1".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ];
+    let parsed = parse_args(args).expect("kolme-live continuous args should parse");
+    let report = execute(parsed).expect("kolme-live continuous execution should succeed");
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("\"runtime_mode\":\"kolme-live\""));
+    assert!(rendered.contains("continuous_mode=enabled"));
+    assert!(rendered.contains("continuous_cycle_count=2"));
+    assert!(rendered.contains("continuous_completed_cycles=2"));
+    assert!(rendered.contains("continuous_cycle_interval_ms=1"));
+
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        6,
+        "continuous mode should execute nonce/submit/finality sequence for each cycle"
+    );
+}
+
+#[test]
 fn functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailable_errors() {
     let _lock = signer_env_lock()
         .lock()

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -20,6 +20,11 @@ const KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS: u32 = 3;
 const KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS: u64 = 10;
 const KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS: u64 = 40;
 
+pub(crate) struct KolmeLiveContinuousMode {
+    pub(crate) max_cycles: u64,
+    pub(crate) cycle_interval_ms: u64,
+}
+
 pub(crate) fn build_kolme_live_request(
     plan: &BootstrapPlan,
 ) -> Result<KolmeRuntimeCommitRequest, ConfigError> {
@@ -304,6 +309,58 @@ pub(crate) fn execute_kolme_live_runtime(
         observability_health: observability.health,
         observability_alert_count: observability.alert_count,
     })
+}
+
+pub(crate) fn execute_kolme_live_runtime_continuous(
+    plan: &BootstrapPlan,
+    base_url: String,
+    provider_hint: String,
+    signing_profile: String,
+    strict_signer_profile: Option<&'static str>,
+    strict_signer_key_source: Option<&'static str>,
+    mode: KolmeLiveContinuousMode,
+) -> Result<KolmeLiveExecution, ConfigError> {
+    let max_cycles = mode.max_cycles;
+    let cycle_interval_ms = mode.cycle_interval_ms;
+    if max_cycles == 0 {
+        return Err(ConfigError::RuntimeKolmeLive(
+            "kolme-live continuous cycle budget must be greater than zero".to_owned(),
+        ));
+    }
+    if cycle_interval_ms == 0 {
+        return Err(ConfigError::RuntimeKolmeLive(
+            "kolme-live continuous cycle interval must be greater than zero".to_owned(),
+        ));
+    }
+
+    let mut last_execution: Option<KolmeLiveExecution> = None;
+    for cycle in 1..=max_cycles {
+        let mut execution = execute_kolme_live_runtime(
+            plan,
+            base_url.clone(),
+            provider_hint.clone(),
+            signing_profile.clone(),
+            strict_signer_profile,
+            strict_signer_key_source,
+        )?;
+        execution.execution_status = format!(
+            "{};continuous_mode=enabled;continuous_cycle={cycle};continuous_cycle_count={max_cycles};continuous_cycle_interval_ms={cycle_interval_ms}",
+            execution.execution_status
+        );
+        last_execution = Some(execution);
+        if cycle < max_cycles {
+            thread::sleep(Duration::from_millis(cycle_interval_ms));
+        }
+    }
+
+    let mut execution = last_execution.ok_or_else(|| {
+        ConfigError::RuntimeKolmeLive("kolme-live continuous mode executed zero cycles".to_owned())
+    })?;
+    execution.execution_status = format!(
+        "{};continuous_completed_cycles={max_cycles}",
+        execution.execution_status
+    );
+    Ok(execution)
 }
 
 #[cfg(test)]

--- a/docs/architecture/kolme-runtime-commit.md
+++ b/docs/architecture/kolme-runtime-commit.md
@@ -1,0 +1,63 @@
+# Kolme Runtime Commit Architecture
+
+This document captures the `kamn-node` runtime-commit execution path for `--runtime-mode kolme-live`, including continuous-cycle behavior.
+
+## Core Flow
+
+Entry point:
+
+- `crates/kamn-node/src/main.rs`
+- `RuntimeModeKind::KolmeLive`
+
+Execution module:
+
+- `crates/kamn-node/src/runtime_kolme_live.rs`
+
+Per-cycle sequence:
+
+1. Build deterministic runtime-commit request payload.
+2. Resolve signer material and emit signed wire payload.
+3. Submit payload through `KolmeRuntimeCommitLiveProvider`.
+4. Resolve receipt finality (`submitted`/`duplicate` plus `pending|final|failed`).
+5. Poll finality when receipt is pending.
+6. Emit deterministic execution status and observability telemetry.
+
+## Continuous Mode
+
+Continuous mode is enabled in `runtime-mode kolme-live` when both controls are present:
+
+- `--daemon-max-ticks <positive-integer>`
+- `--daemon-tick-interval-ms <positive-integer>`
+
+Behavior:
+
+- one runtime-commit/finality cycle per configured tick
+- deterministic sleep between cycles using the provided interval
+- fail-closed validation when one control is provided without the other
+- final execution status includes continuity markers:
+  - `continuous_mode=enabled`
+  - `continuous_cycle=<n>`
+  - `continuous_cycle_count=<N>`
+  - `continuous_cycle_interval_ms=<ms>`
+  - `continuous_completed_cycles=<N>`
+
+## Failure Handling
+
+Fail-closed behavior is preserved for continuous and single-cycle modes:
+
+- malformed provider responses fail immediately
+- provider hint drift fails immediately
+- unsupported signer/profile declarations fail immediately
+- transient submit/finality transport errors retry with bounded deterministic backoff
+
+## Validation Evidence
+
+Primary tests:
+
+- `main_tests::core_behavior_tests::functional_runtime_kolme_live_continuous_mode_executes_multiple_cycles`
+- `main_tests::cli_contract_tests::rejects_kolme_live_continuous_mode_without_tick_interval`
+- `main_tests::cli_contract_tests::rejects_kolme_live_continuous_mode_without_max_ticks`
+
+Command:
+
+- `cargo test -p kamn-node -- rejects_kolme_live_continuous_mode_without_tick_interval rejects_kolme_live_continuous_mode_without_max_ticks functional_runtime_kolme_live_continuous_mode_executes_multiple_cycles`

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -283,6 +283,11 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--kolme-live-base-url`
   - `--kolme-live-provider-hint`
   - `--kolme-live-signing-profile`
+  - `--kolme-live-signer-key-source`
+- Optional continuous mode controls for kolm-live:
+  - `--daemon-max-ticks <positive-integer>`
+  - `--daemon-tick-interval-ms <positive-integer>`
+  - both controls are fail-closed pair requirements in kolm-live mode
 - Strict signer contracts:
   - when `--kolme-live-strict-signer-contracts` is present, `--kolme-live-signer-profile` and `--kolme-live-signer-key-source` are both required
   - supported signer profiles: `ops-primary`, `ops-secondary`
@@ -315,7 +320,9 @@ This document captures node-runtime productionization slices for machine-readabl
 - Provider wiring is fail-closed:
   - runtime config must reject in-memory provider-hint markers such as `InMemoryKolmeRuntimeCommitClient`
   - signing profile must match `kolme-fork-secp256k1-v1`
-- Runtime path constructs `KolmeRuntimeCommitLiveProvider` with deterministic transport timeout, submits one deterministic runtime-commit request, and emits bounded finality follow-up checks:
+- Runtime path constructs `KolmeRuntimeCommitLiveProvider` with deterministic transport timeout and runs bounded runtime-commit/finality cycles:
+  - default mode executes one deterministic runtime-commit request
+  - continuous mode executes one runtime-commit/finality sequence per `--daemon-max-ticks` cycle
   - pending submit receipts poll finality via `/runtime-commit/status` with max-attempt budget `2`
   - malformed finality responses fail closed
   - finality transport timeout/unavailable keeps execution in pending status without falling back to in-memory adapters

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -31,6 +31,7 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_service_api_websocket_live.sh` and `scripts/runtime/test_validate_service_api_websocket_live.sh` (Task #2918, Subtask #2919).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `websocket_upgrade_status=verified`, `fail_closed_status=verified`, `probe_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
+- Phase 4.1 initial slice delivered: `runtime-mode kolme-live` now supports bounded continuous commit/finality execution when paired cycle controls are supplied (`--daemon-max-ticks` and `--daemon-tick-interval-ms`) with fail-closed guardrails for partial declarations (Task #2931, Subtask #2932).
 - Phase 6.1 initial slice delivered: service API `/metrics` now exports deterministic runtime telemetry gauges and source/health labels with fail-closed unknown defaults when daemon/kolme telemetry is unavailable (Task #2961, Subtask #2962).
 - Phase 6.1 live validation delivered:
   - Runtime lane: `scripts/runtime/validate_service_api_observability_live.sh` and `scripts/runtime/test_validate_service_api_observability_live.sh` (Task #2963, Subtask #2964).


### PR DESCRIPTION
## Summary
Implemented the core delivery slice for continuous Kolme runtime commits by adding bounded multi-cycle execution in `runtime-mode kolme-live` with fail-closed paired control validation. This closes Task #2931 and Subtask #2932.

## Changes
- `crates/kamn-node/src/runtime_kolme_live.rs`: added `execute_kolme_live_runtime_continuous` and cycle-control model for deterministic multi-cycle execution.
- `crates/kamn-node/src/main.rs`: wired kolm-live runtime dispatch to use continuous mode when paired cycle controls are supplied.
- `crates/kamn-node/src/cli.rs`: added fail-closed validation requiring paired `--daemon-max-ticks` and `--daemon-tick-interval-ms` controls in kolm-live mode.
- `crates/kamn-node/src/main_tests/cli_contract_tests.rs`: added regression guards for missing paired-cycle arguments.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added multi-cycle runtime integration test verifying two complete nonce/submit/finality cycles.
- `docs/architecture/kolme-runtime-commit.md`: documented runtime commit architecture and continuous-mode behavior.
- `docs/foundation/node-runtime-cli.md`: documented kolm-live optional continuous controls and pairing requirement.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded Phase 4.1 initial slice delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- New regression guards were introduced for incomplete continuous-mode declarations; these fail-closed paths are now covered by tests that validate the rejected argument combinations.

### 🟢 Green Phase
Command:

`cargo test -p kamn-node -- rejects_kolme_live_continuous_mode_without_tick_interval rejects_kolme_live_continuous_mode_without_max_ticks functional_runtime_kolme_live_continuous_mode_executes_multiple_cycles`

Result: 3 passed, 0 failed.

### 🔁 Regression
Commands:

- `cargo clippy -p kamn-node -- -D warnings`
- `cargo fmt --check`

Result: clean.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | paired-argument validation tests in `cli_contract_tests.rs` | |
| Functional   | ✅     | multi-cycle kolm-live runtime behavior test | |
| Integration  | ✅     | end-to-end mock-server request-cycle validation for continuous mode | |
| Regression   | ✅     | explicit fail-closed pair-guard tests (`Regression: #2931`) | |
| Performance  | N/A    | None | No new throughput hotspot; bounded cycles use existing deterministic retry/sleep controls |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `60f99d7`.

## Documentation Updates
- `docs/architecture/kolme-runtime-commit.md`
- `docs/foundation/node-runtime-cli.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Focused runtime/CLI regression tests passing
- [x] Docs updated

Closes #2931
Closes #2932
