### PR TITLE
feat(did): submit lifecycle mutations through Kolme chain adapter (#2936)

### DIFF
--- a/crates/kamn-core/src/did_registry.rs
+++ b/crates/kamn-core/src/did_registry.rs
@@ -1,5 +1,9 @@
 //! DID registry lifecycle, idempotent submission, and finality tracking contracts.
 
+use crate::kolme_runtime_commit::{
+    KolmeRuntimeCommitClient, KolmeRuntimeCommitError, KolmeRuntimeCommitOutcome,
+    KolmeRuntimeCommitRequest,
+};
 use crate::{AgentDid, DidDocument};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -12,6 +16,7 @@ const DID_CHAIN_ADAPTER_SCHEMA_VERSION: &str = "kamn.did.chain-adapter.v1";
 type SubmissionReceiptIndex = BTreeMap<String, DidChainSubmissionReceipt>;
 type SubmissionRejectIndex = BTreeMap<String, String>;
 type PersistedDidChainAdapterState = (SubmissionReceiptIndex, SubmissionRejectIndex);
+type DidMutationSubmissionKey = (AgentDid, u64);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DidRegistryRecord {
@@ -162,6 +167,40 @@ pub struct DidChainSubmissionResult {
     pub outcome: DidChainSubmissionOutcome,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Chain adapter request for DID lifecycle mutation submission.
+pub struct DidLifecycleChainSubmissionRequest {
+    /// Target DID for lifecycle submission.
+    pub did: AgentDid,
+    /// Actor DID that initiated the lifecycle mutation.
+    pub actor_did: String,
+    /// Monotonic mutation nonce.
+    pub nonce: u64,
+    /// Lifecycle action label associated with submission.
+    pub action: &'static str,
+    /// Deterministic idempotency key for lifecycle submission.
+    pub idempotency_key: String,
+    /// Deterministic lifecycle payload hash marker.
+    pub payload_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Result envelope for registry + chain adapter lifecycle mutation flow.
+pub struct DidLifecycleChainSubmissionResult {
+    /// DID processed by submission flow.
+    pub did: AgentDid,
+    /// Mutation nonce processed by submission flow.
+    pub nonce: u64,
+    /// Idempotency key used for this flow.
+    pub idempotency_key: String,
+    /// Retry classification returned by registry.
+    pub retry_class: DidSubmissionRetryClass,
+    /// Provider/registry submission outcome.
+    pub outcome: DidChainSubmissionOutcome,
+    /// Lifecycle evidence emitted by mutation state machine.
+    pub evidence: DidLifecycleMutationEvidence,
+}
+
 /// Chain adapter abstraction for DID registration backends.
 pub trait DidRegistrationChainAdapter {
     /// Submits a DID registration request via backing provider.
@@ -169,6 +208,74 @@ pub trait DidRegistrationChainAdapter {
         &mut self,
         request: &DidChainSubmissionRequest,
     ) -> Result<DidChainSubmissionOutcome, DidRegistryError>;
+}
+
+/// Chain adapter abstraction for DID lifecycle mutation backends.
+pub trait DidLifecycleChainAdapter {
+    /// Submits a DID lifecycle mutation request via backing provider.
+    fn submit_lifecycle_mutation(
+        &mut self,
+        request: &DidLifecycleChainSubmissionRequest,
+    ) -> Result<DidChainSubmissionOutcome, DidRegistryError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Kolme-backed DID lifecycle chain adapter.
+pub struct KolmeDidLifecycleChainAdapter<C> {
+    client: C,
+    state_root_prefix: String,
+}
+
+impl<C> KolmeDidLifecycleChainAdapter<C> {
+    /// Creates a Kolme-backed lifecycle adapter.
+    pub fn new(client: C, state_root_prefix: &str) -> Result<Self, DidRegistryError> {
+        if state_root_prefix.trim().is_empty() {
+            return Err(DidRegistryError::ChainAdapterSubmitFailed {
+                context: "state_root_prefix",
+                reason: "must not be empty".to_owned(),
+            });
+        }
+        Ok(Self {
+            client,
+            state_root_prefix: state_root_prefix.to_owned(),
+        })
+    }
+
+    fn runtime_request_for_lifecycle(
+        &self,
+        request: &DidLifecycleChainSubmissionRequest,
+    ) -> Result<KolmeRuntimeCommitRequest, DidRegistryError> {
+        let operation_id = format!(
+            "did-lifecycle:{}:{}:{}",
+            request.did.method_specific_id(),
+            request.action,
+            request.nonce
+        );
+        let state_root = format!("{}:{}", self.state_root_prefix, request.nonce);
+        KolmeRuntimeCommitRequest::deterministic(
+            operation_id.as_str(),
+            state_root.as_str(),
+            request.did.as_str(),
+            request.nonce,
+            request.payload_hash.as_str(),
+        )
+        .map_err(Self::map_runtime_commit_error)
+    }
+
+    fn map_runtime_commit_error(error: KolmeRuntimeCommitError) -> DidRegistryError {
+        match error {
+            KolmeRuntimeCommitError::InvalidRequest { field, reason } => {
+                DidRegistryError::ChainAdapterSubmitFailed {
+                    context: field,
+                    reason: reason.to_owned(),
+                }
+            }
+            _ => DidRegistryError::ChainAdapterSubmitFailed {
+                context: "kolme_runtime_commit",
+                reason: error.to_string(),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -217,6 +324,35 @@ impl DidRegistrationChainAdapter for InMemoryDidRegistrationChainAdapter {
                 "did-tx:{}:{}",
                 request.did.method_specific_id(),
                 request.idempotency_key.len()
+            ),
+        };
+        self.receipts_by_key
+            .insert(request.idempotency_key.clone(), receipt.clone());
+        Ok(DidChainSubmissionOutcome::Submitted(receipt))
+    }
+}
+
+impl DidLifecycleChainAdapter for InMemoryDidRegistrationChainAdapter {
+    fn submit_lifecycle_mutation(
+        &mut self,
+        request: &DidLifecycleChainSubmissionRequest,
+    ) -> Result<DidChainSubmissionOutcome, DidRegistryError> {
+        if let Some(reason) = self.rejected_reasons_by_key.get(&request.idempotency_key) {
+            return Ok(DidChainSubmissionOutcome::Rejected {
+                reason: reason.clone(),
+            });
+        }
+
+        if let Some(existing) = self.receipts_by_key.get(&request.idempotency_key) {
+            return Ok(DidChainSubmissionOutcome::Duplicate(existing.clone()));
+        }
+
+        let receipt = DidChainSubmissionReceipt {
+            provider: self.provider.clone(),
+            transaction_id: format!(
+                "did-lifecycle-tx:{}:{}",
+                request.did.method_specific_id(),
+                request.nonce
             ),
         };
         self.receipts_by_key
@@ -306,12 +442,80 @@ impl DidRegistrationChainAdapter for FileDidRegistrationChainAdapter {
     }
 }
 
+impl DidLifecycleChainAdapter for FileDidRegistrationChainAdapter {
+    fn submit_lifecycle_mutation(
+        &mut self,
+        request: &DidLifecycleChainSubmissionRequest,
+    ) -> Result<DidChainSubmissionOutcome, DidRegistryError> {
+        if let Some(reason) = self.rejected_reasons_by_key.get(&request.idempotency_key) {
+            return Ok(DidChainSubmissionOutcome::Rejected {
+                reason: reason.clone(),
+            });
+        }
+
+        if let Some(existing) = self.receipts_by_key.get(&request.idempotency_key) {
+            return Ok(DidChainSubmissionOutcome::Duplicate(existing.clone()));
+        }
+
+        let receipt = DidChainSubmissionReceipt {
+            provider: self.provider.clone(),
+            transaction_id: format!(
+                "did-lifecycle-tx:{}:{}",
+                request.did.method_specific_id(),
+                request.nonce
+            ),
+        };
+        self.receipts_by_key
+            .insert(request.idempotency_key.clone(), receipt.clone());
+        persist_did_chain_adapter_file(
+            &self.path,
+            &self.receipts_by_key,
+            &self.rejected_reasons_by_key,
+        )?;
+        Ok(DidChainSubmissionOutcome::Submitted(receipt))
+    }
+}
+
+impl<C: KolmeRuntimeCommitClient> DidLifecycleChainAdapter for KolmeDidLifecycleChainAdapter<C> {
+    fn submit_lifecycle_mutation(
+        &mut self,
+        request: &DidLifecycleChainSubmissionRequest,
+    ) -> Result<DidChainSubmissionOutcome, DidRegistryError> {
+        let runtime_request = self.runtime_request_for_lifecycle(request)?;
+        let outcome = self
+            .client
+            .submit_commit(&runtime_request)
+            .map_err(Self::map_runtime_commit_error)?;
+        match outcome {
+            KolmeRuntimeCommitOutcome::Submitted(receipt) => Ok(
+                DidChainSubmissionOutcome::Submitted(DidChainSubmissionReceipt {
+                    provider: receipt.provider,
+                    transaction_id: receipt.commit_id,
+                }),
+            ),
+            KolmeRuntimeCommitOutcome::Duplicate(receipt) => Ok(
+                DidChainSubmissionOutcome::Duplicate(DidChainSubmissionReceipt {
+                    provider: receipt.provider,
+                    transaction_id: receipt.commit_id,
+                }),
+            ),
+            KolmeRuntimeCommitOutcome::Rejected { reason } => {
+                Ok(DidChainSubmissionOutcome::Rejected { reason })
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 /// DID registry state machine and submission/finality index.
 pub struct DidRegistry {
     records: HashMap<AgentDid, DidRegistryRecord>,
     submission_keys_by_did: HashMap<AgentDid, String>,
     finality_by_did: HashMap<AgentDid, DidSubmissionFinalityRecord>,
+    lifecycle_submission_keys_by_did_nonce: HashMap<DidMutationSubmissionKey, String>,
+    lifecycle_finality_by_did_nonce: HashMap<DidMutationSubmissionKey, DidSubmissionFinalityRecord>,
+    lifecycle_evidence_by_did_nonce:
+        HashMap<DidMutationSubmissionKey, DidLifecycleMutationEvidence>,
     last_mutation_nonce_by_did: HashMap<AgentDid, u64>,
 }
 
@@ -499,6 +703,109 @@ impl DidRegistry {
         })
     }
 
+    /// Computes deterministic idempotency key for lifecycle mutation request.
+    pub fn idempotency_key_for_lifecycle_mutation(
+        &self,
+        request: &DidLifecycleMutationRequest,
+    ) -> Result<String, DidRegistryError> {
+        if request.nonce == 0 {
+            return Err(DidRegistryError::InvalidMutationNonce {
+                did: request.did.as_str().to_owned(),
+                nonce: request.nonce,
+            });
+        }
+        let action = request.action.label();
+        let action_fingerprint = Self::lifecycle_action_fingerprint(&request.did, &request.action)?;
+        Ok(format!(
+            "did-lifecycle:{}:{}:{}:{}:{}",
+            request.did.as_str(),
+            request.actor_did,
+            request.nonce,
+            action,
+            action_fingerprint
+        ))
+    }
+
+    /// Submits lifecycle mutation through chain adapter with deterministic retry classification.
+    pub fn submit_lifecycle_mutation_via_chain_adapter<A: DidLifecycleChainAdapter>(
+        &mut self,
+        adapter: &mut A,
+        request: DidLifecycleMutationRequest,
+    ) -> Result<DidLifecycleChainSubmissionResult, DidRegistryError> {
+        let did = request.did.clone();
+        let nonce = request.nonce;
+        let idempotency_key = self.idempotency_key_for_lifecycle_mutation(&request)?;
+        let submission_key = (did.clone(), nonce);
+        let retry_class =
+            self.classify_lifecycle_retry_by_key(&submission_key, idempotency_key.as_str());
+        if retry_class == DidSubmissionRetryClass::ConflictNoRetry {
+            let existing_key = self
+                .lifecycle_submission_keys_by_did_nonce
+                .get(&submission_key)
+                .cloned()
+                .unwrap_or_default();
+            return Err(DidRegistryError::ConflictingSubmissionIdempotencyKey {
+                did: did.as_str().to_owned(),
+                existing_key,
+                provided_key: idempotency_key,
+            });
+        }
+
+        let evidence = match retry_class {
+            DidSubmissionRetryClass::NewSubmission => {
+                let value = self.apply_lifecycle_mutation(request.clone())?;
+                self.lifecycle_submission_keys_by_did_nonce
+                    .insert(submission_key.clone(), idempotency_key.clone());
+                self.lifecycle_evidence_by_did_nonce
+                    .insert(submission_key.clone(), value.clone());
+                value
+            }
+            DidSubmissionRetryClass::RetryableInFlight
+            | DidSubmissionRetryClass::FinalizedNoRetry => self
+                .lifecycle_evidence_by_did_nonce
+                .get(&submission_key)
+                .cloned()
+                .ok_or_else(|| DidRegistryError::UnknownSubmissionIdempotencyKey {
+                    did: did.as_str().to_owned(),
+                    idempotency_key: idempotency_key.clone(),
+                })?,
+            DidSubmissionRetryClass::ConflictNoRetry => {
+                return Err(DidRegistryError::ConflictingSubmissionIdempotencyKey {
+                    did: did.as_str().to_owned(),
+                    existing_key: self
+                        .lifecycle_submission_keys_by_did_nonce
+                        .get(&submission_key)
+                        .cloned()
+                        .unwrap_or_default(),
+                    provided_key: idempotency_key,
+                });
+            }
+        };
+
+        let payload_hash = self.payload_hash_for_lifecycle_mutation(&request)?;
+        let outcome = if retry_class == DidSubmissionRetryClass::FinalizedNoRetry {
+            DidChainSubmissionOutcome::FinalizedNoOp
+        } else {
+            adapter.submit_lifecycle_mutation(&DidLifecycleChainSubmissionRequest {
+                did: did.clone(),
+                actor_did: request.actor_did,
+                nonce,
+                action: request.action.label(),
+                idempotency_key: idempotency_key.clone(),
+                payload_hash,
+            })?
+        };
+
+        Ok(DidLifecycleChainSubmissionResult {
+            did,
+            nonce,
+            idempotency_key,
+            retry_class,
+            outcome,
+            evidence,
+        })
+    }
+
     /// Records finality update for prior register submission.
     pub fn record_register_finality(
         &mut self,
@@ -567,6 +874,86 @@ impl DidRegistry {
     /// Returns most recent finality record for DID, if present.
     pub fn register_finality(&self, did: &AgentDid) -> Option<&DidSubmissionFinalityRecord> {
         self.finality_by_did.get(did)
+    }
+
+    /// Records finality update for prior lifecycle mutation submission.
+    pub fn record_lifecycle_finality(
+        &mut self,
+        did: &AgentDid,
+        nonce: u64,
+        idempotency_key: &str,
+        sequence: u64,
+        status: DidSubmissionFinalityStatus,
+        receipt: &str,
+    ) -> Result<(), DidRegistryError> {
+        let mutation_key = (did.clone(), nonce);
+        let Some(expected_key) = self
+            .lifecycle_submission_keys_by_did_nonce
+            .get(&mutation_key)
+        else {
+            return Err(DidRegistryError::UnknownSubmissionIdempotencyKey {
+                did: did.as_str().to_owned(),
+                idempotency_key: idempotency_key.to_owned(),
+            });
+        };
+        if expected_key != idempotency_key {
+            return Err(DidRegistryError::UnknownSubmissionIdempotencyKey {
+                did: did.as_str().to_owned(),
+                idempotency_key: idempotency_key.to_owned(),
+            });
+        }
+
+        if let Some(current) = self.lifecycle_finality_by_did_nonce.get(&mutation_key) {
+            if sequence < current.sequence {
+                return Err(DidRegistryError::StaleFinalityUpdate {
+                    did: did.as_str().to_owned(),
+                    current_sequence: current.sequence,
+                    attempted_sequence: sequence,
+                });
+            }
+
+            if sequence == current.sequence {
+                if current.idempotency_key == idempotency_key
+                    && current.status == status
+                    && current.receipt == receipt
+                {
+                    return Ok(());
+                }
+
+                return Err(DidRegistryError::ConflictingFinalityUpdate {
+                    did: did.as_str().to_owned(),
+                    sequence,
+                });
+            }
+
+            if current.idempotency_key != idempotency_key {
+                return Err(DidRegistryError::ConflictingFinalityUpdate {
+                    did: did.as_str().to_owned(),
+                    sequence,
+                });
+            }
+        }
+
+        self.lifecycle_finality_by_did_nonce.insert(
+            mutation_key,
+            DidSubmissionFinalityRecord {
+                idempotency_key: idempotency_key.to_owned(),
+                sequence,
+                status,
+                receipt: receipt.to_owned(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Returns most recent lifecycle finality record for DID nonce, if present.
+    pub fn lifecycle_finality(
+        &self,
+        did: &AgentDid,
+        nonce: u64,
+    ) -> Option<&DidSubmissionFinalityRecord> {
+        self.lifecycle_finality_by_did_nonce
+            .get(&(did.clone(), nonce))
     }
 
     /// Applies lifecycle mutation with nonce and actor authorization checks.
@@ -693,6 +1080,26 @@ impl DidRegistry {
         DidSubmissionRetryClass::RetryableInFlight
     }
 
+    fn classify_lifecycle_retry_by_key(
+        &self,
+        key: &DidMutationSubmissionKey,
+        idempotency_key: &str,
+    ) -> DidSubmissionRetryClass {
+        let Some(existing_key) = self.lifecycle_submission_keys_by_did_nonce.get(key) else {
+            return DidSubmissionRetryClass::NewSubmission;
+        };
+
+        if existing_key != idempotency_key {
+            return DidSubmissionRetryClass::ConflictNoRetry;
+        }
+
+        if self.lifecycle_finality_by_did_nonce.contains_key(key) {
+            return DidSubmissionRetryClass::FinalizedNoRetry;
+        }
+
+        DidSubmissionRetryClass::RetryableInFlight
+    }
+
     fn validate_document_did(
         did: &AgentDid,
         document: &DidDocument,
@@ -731,6 +1138,67 @@ impl DidRegistry {
         }
 
         Ok(())
+    }
+
+    fn lifecycle_action_fingerprint(
+        did: &AgentDid,
+        action: &DidLifecycleMutationAction,
+    ) -> Result<String, DidRegistryError> {
+        match action {
+            DidLifecycleMutationAction::Rotate { document }
+            | DidLifecycleMutationAction::Recover { document } => {
+                Self::validate_document_did(did, document)?;
+                let capability_fingerprint = document.metadata.capabilities.join(",");
+                let verification_fingerprint = document
+                    .verification_method
+                    .iter()
+                    .map(|verification| {
+                        format!(
+                            "{}:{}:{}",
+                            verification.id,
+                            verification.type_name,
+                            verification.public_key_multibase
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|");
+                let service_fingerprint = document
+                    .service
+                    .iter()
+                    .map(|service| {
+                        format!(
+                            "{}:{}:{}",
+                            service.id, service.type_name, service.service_endpoint
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|");
+                Ok(format!(
+                    "{}:{}:{}:{}:{}",
+                    document.metadata.agent_type,
+                    document.metadata.model_family,
+                    capability_fingerprint,
+                    verification_fingerprint,
+                    service_fingerprint
+                ))
+            }
+            DidLifecycleMutationAction::Revoke => Ok("revoke".to_owned()),
+        }
+    }
+
+    fn payload_hash_for_lifecycle_mutation(
+        &self,
+        request: &DidLifecycleMutationRequest,
+    ) -> Result<String, DidRegistryError> {
+        let fingerprint = Self::lifecycle_action_fingerprint(&request.did, &request.action)?;
+        Ok(format!(
+            "did-lifecycle-payload:{}:{}:{}:{}:{}",
+            request.did.as_str(),
+            request.actor_did,
+            request.nonce,
+            request.action.label(),
+            fingerprint
+        ))
     }
 }
 
@@ -816,6 +1284,13 @@ pub enum DidRegistryError {
         /// Revocation state before action.
         from_revoked: bool,
     },
+    /// Chain adapter submission failed while preparing or submitting payload.
+    ChainAdapterSubmitFailed {
+        /// Failure context field.
+        context: &'static str,
+        /// Failure reason.
+        reason: String,
+    },
     /// Filesystem I/O failed while persisting chain adapter state.
     PersistenceIo(String),
     /// Persisted chain adapter payload was invalid.
@@ -842,6 +1317,7 @@ impl DidRegistryError {
             Self::InvalidLifecycleMutationTransition { .. } => {
                 "did_lifecycle_mutation_invalid_transition"
             }
+            Self::ChainAdapterSubmitFailed { .. } => "did_chain_adapter_submit_failed",
             Self::PersistenceIo(_) => "did_registry_persistence_io",
             Self::PersistenceInvalidPayload(_) => "did_registry_persistence_invalid_payload",
         }
@@ -919,6 +1395,9 @@ impl fmt::Display for DidRegistryError {
                     f,
                     "invalid lifecycle mutation transition for did {did}; action {action}, revoked={from_revoked}"
                 )
+            }
+            Self::ChainAdapterSubmitFailed { context, reason } => {
+                write!(f, "did chain adapter submission failed for {context}: {reason}")
             }
             Self::PersistenceIo(value) => write!(f, "did registry persistence I/O error: {value}"),
             Self::PersistenceInvalidPayload(value) => {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -203,10 +203,12 @@ pub use did::{
 };
 pub use did_registry::{
     DidChainSubmissionOutcome, DidChainSubmissionReceipt, DidChainSubmissionRequest,
-    DidChainSubmissionResult, DidLifecycleMutationAction, DidLifecycleMutationEvidence,
+    DidChainSubmissionResult, DidLifecycleChainAdapter, DidLifecycleChainSubmissionRequest,
+    DidLifecycleChainSubmissionResult, DidLifecycleMutationAction, DidLifecycleMutationEvidence,
     DidLifecycleMutationRequest, DidRegistrationChainAdapter, DidRegistry, DidRegistryError,
     DidSubmissionFinalityRecord, DidSubmissionFinalityStatus, DidSubmissionRetryClass,
     FileDidRegistrationChainAdapter, InMemoryDidRegistrationChainAdapter,
+    KolmeDidLifecycleChainAdapter,
 };
 pub use direct_message_crypto::{
     DirectMessageCiphertext, DirectMessageCryptoEngine, DirectMessageCryptoError,

--- a/crates/kamn-core/tests/did_registry_transactions.rs
+++ b/crates/kamn-core/tests/did_registry_transactions.rs
@@ -2,6 +2,7 @@ use kamn_core::{
     canonical_did_document, AgentDid, AgentDidMetadata, DidChainSubmissionOutcome, DidDocument,
     DidLifecycleMutationAction, DidLifecycleMutationRequest, DidRegistry, DidRegistryError,
     DidSubmissionFinalityStatus, DidSubmissionRetryClass, InMemoryDidRegistrationChainAdapter,
+    InMemoryKolmeRuntimeCommitClient, KolmeDidLifecycleChainAdapter,
 };
 use std::time::Instant;
 
@@ -543,4 +544,150 @@ fn performance_lifecycle_mutation_contract_lane_stays_within_budget() {
         elapsed_millis < 800,
         "did lifecycle mutation contract lane exceeded budget: {elapsed_millis}ms"
     );
+}
+
+#[test]
+fn functional_lifecycle_chain_submission_through_kolme_adapter_returns_typed_outcome() {
+    let mut registry = DidRegistry::new();
+    let did =
+        AgentDid::parse("kamn:did:agent:lifecycle-chain-functional").expect("did should parse");
+    let mut document = document_for(&did, "claude-4");
+    document.metadata.operator = Some("kamn:did:human:ops-chain-functional".to_owned());
+    registry
+        .register(did.clone(), document)
+        .expect("register should succeed");
+
+    let client = InMemoryKolmeRuntimeCommitClient::new("kolme-live").expect("client should build");
+    let mut adapter =
+        KolmeDidLifecycleChainAdapter::new(client, "did-lifecycle-state").expect("adapter");
+    let result = registry
+        .submit_lifecycle_mutation_via_chain_adapter(
+            &mut adapter,
+            DidLifecycleMutationRequest {
+                did: did.clone(),
+                actor_did: "kamn:did:human:ops-chain-functional".to_owned(),
+                nonce: 1,
+                action: DidLifecycleMutationAction::Revoke,
+            },
+        )
+        .expect("lifecycle chain submission should succeed");
+
+    assert_eq!(result.retry_class, DidSubmissionRetryClass::NewSubmission);
+    assert_eq!(
+        result.evidence.reason_code,
+        "did_lifecycle_mutation_allowed"
+    );
+    assert!(matches!(
+        result.outcome,
+        DidChainSubmissionOutcome::Submitted(_)
+    ));
+}
+
+#[test]
+fn integration_lifecycle_chain_submission_allows_retry_without_reapplying_mutation() {
+    let mut registry = DidRegistry::new();
+    let did =
+        AgentDid::parse("kamn:did:agent:lifecycle-chain-integration").expect("did should parse");
+    let mut document = document_for(&did, "claude-4");
+    document.metadata.operator = Some("kamn:did:human:ops-chain-integration".to_owned());
+    registry
+        .register(did.clone(), document)
+        .expect("register should succeed");
+
+    let rotated_document = {
+        let mut value = document_for(&did, "gpt-5");
+        value.metadata.operator = Some("kamn:did:human:ops-chain-integration".to_owned());
+        value
+    };
+    let request = DidLifecycleMutationRequest {
+        did: did.clone(),
+        actor_did: "kamn:did:human:ops-chain-integration".to_owned(),
+        nonce: 8,
+        action: DidLifecycleMutationAction::Rotate {
+            document: rotated_document,
+        },
+    };
+
+    let client = InMemoryKolmeRuntimeCommitClient::new("kolme-live").expect("client should build");
+    let mut adapter =
+        KolmeDidLifecycleChainAdapter::new(client, "did-lifecycle-state").expect("adapter");
+    let first = registry
+        .submit_lifecycle_mutation_via_chain_adapter(&mut adapter, request.clone())
+        .expect("first lifecycle submission should succeed");
+    let second = registry
+        .submit_lifecycle_mutation_via_chain_adapter(&mut adapter, request)
+        .expect("retry lifecycle submission should succeed");
+
+    assert_eq!(first.retry_class, DidSubmissionRetryClass::NewSubmission);
+    assert_eq!(
+        second.retry_class,
+        DidSubmissionRetryClass::RetryableInFlight
+    );
+    assert!(matches!(
+        first.outcome,
+        DidChainSubmissionOutcome::Submitted(_)
+    ));
+    assert!(matches!(
+        second.outcome,
+        DidChainSubmissionOutcome::Duplicate(_)
+    ));
+    assert_eq!(
+        registry
+            .resolve(&did)
+            .expect("rotate should remain applied")
+            .metadata
+            .model_family,
+        "gpt-5"
+    );
+}
+
+#[test]
+fn regression_lifecycle_chain_submission_rejects_conflicting_same_nonce_payload() {
+    // Regression: #2936
+    let mut registry = DidRegistry::new();
+    let did =
+        AgentDid::parse("kamn:did:agent:lifecycle-chain-regression").expect("did should parse");
+    let mut document = document_for(&did, "claude-4");
+    document.metadata.operator = Some("kamn:did:human:ops-chain-regression".to_owned());
+    registry
+        .register(did.clone(), document)
+        .expect("register should succeed");
+
+    let client = InMemoryKolmeRuntimeCommitClient::new("kolme-live").expect("client should build");
+    let mut adapter =
+        KolmeDidLifecycleChainAdapter::new(client, "did-lifecycle-state").expect("adapter");
+
+    registry
+        .submit_lifecycle_mutation_via_chain_adapter(
+            &mut adapter,
+            DidLifecycleMutationRequest {
+                did: did.clone(),
+                actor_did: "kamn:did:human:ops-chain-regression".to_owned(),
+                nonce: 4,
+                action: DidLifecycleMutationAction::Revoke,
+            },
+        )
+        .expect("first lifecycle submission should succeed");
+
+    let conflicting = registry.submit_lifecycle_mutation_via_chain_adapter(
+        &mut adapter,
+        DidLifecycleMutationRequest {
+            did: did.clone(),
+            actor_did: "kamn:did:human:ops-chain-regression".to_owned(),
+            nonce: 4,
+            action: DidLifecycleMutationAction::Recover {
+                document: {
+                    let mut recovered = document_for(&did, "gpt-5");
+                    recovered.metadata.operator =
+                        Some("kamn:did:human:ops-chain-regression".to_owned());
+                    recovered
+                },
+            },
+        },
+    );
+
+    assert!(matches!(
+        conflicting,
+        Err(DidRegistryError::ConflictingSubmissionIdempotencyKey { .. })
+    ));
 }

--- a/crates/kamn-core/tests/did_registry_transactions_docs.rs
+++ b/crates/kamn-core/tests/did_registry_transactions_docs.rs
@@ -34,13 +34,23 @@ fn regression_doc_marks_stale_duplicate_conflict_guard() {
 fn doc_contains_lifecycle_mutation_transaction_contracts() {
     assert!(DOC.contains("DidLifecycleMutationRequest"));
     assert!(DOC.contains("apply_lifecycle_mutation"));
+    assert!(DOC.contains("submit_lifecycle_mutation_via_chain_adapter"));
+    assert!(DOC.contains("KolmeDidLifecycleChainAdapter"));
+    assert!(DOC.contains("record_lifecycle_finality"));
     assert!(DOC.contains("did_lifecycle_mutation_allowed"));
     assert!(DOC.contains("did_lifecycle_mutation_nonce_replay"));
     assert!(DOC.contains("did_lifecycle_mutation_unauthorized_actor"));
+    assert!(DOC.contains("did_chain_adapter_submit_failed"));
 }
 
 #[test]
 fn regression_doc_marks_lifecycle_mutation_fail_closed_guard() {
     // Regression: #889
     assert!(DOC.contains("Regression: #889"));
+}
+
+#[test]
+fn regression_doc_marks_lifecycle_chain_submission_conflict_guard() {
+    // Regression: #2936
+    assert!(DOC.contains("Regression: #2936"));
 }

--- a/docs/architecture/did-chain-adapter.md
+++ b/docs/architecture/did-chain-adapter.md
@@ -1,0 +1,66 @@
+# DID Chain Adapter Architecture
+
+This document captures the DID chain-adapter flow delivered for roadmap Phase 4.2 core implementation (Task #2936, Subtask #2937).
+
+## Scope
+
+- Deterministic chain-submission contracts for DID registration and lifecycle mutation.
+- Retry classification and finality tracking for lifecycle mutation submissions.
+- Kolme-backed lifecycle adapter path that reuses runtime-commit client contracts.
+
+## Core Types
+
+- `DidRegistrationChainAdapter`
+  - Handles registration submission via `submit_registration`.
+- `DidLifecycleChainAdapter`
+  - Handles lifecycle mutation submission via `submit_lifecycle_mutation`.
+- `DidLifecycleChainSubmissionRequest`
+  - Canonical request envelope:
+    - `did`
+    - `actor_did`
+    - `nonce`
+    - `action`
+    - `idempotency_key`
+    - `payload_hash`
+- `DidLifecycleChainSubmissionResult`
+  - Result envelope with `retry_class`, `outcome`, and mutation `evidence`.
+
+## Registry Flow
+
+Entry points in `crates/kamn-core/src/did_registry.rs`:
+
+- `idempotency_key_for_lifecycle_mutation(request)`
+- `submit_lifecycle_mutation_via_chain_adapter(adapter, request)`
+- `record_lifecycle_finality(did, nonce, idempotency_key, sequence, status, receipt)`
+- `lifecycle_finality(did, nonce)`
+
+Behavior:
+
+1. Compute deterministic lifecycle idempotency key from DID, actor, nonce, action, and action payload fingerprint.
+2. Classify retry posture for `(did, nonce)`:
+   - `NewSubmission`
+   - `RetryableInFlight`
+   - `FinalizedNoRetry`
+   - `ConflictNoRetry`
+3. Apply mutation exactly once on `NewSubmission`, store deterministic evidence, and fail closed on nonce/key conflicts.
+4. Submit lifecycle request to adapter unless already finalized (`FinalizedNoOp`).
+
+## Kolme Adapter
+
+- `KolmeDidLifecycleChainAdapter<C>`
+  - Generic over `KolmeRuntimeCommitClient`.
+  - Converts lifecycle request into deterministic `KolmeRuntimeCommitRequest`.
+  - Maps runtime-commit outcomes to DID chain outcomes:
+    - `Submitted` -> `Submitted(receipt)`
+    - `Duplicate` -> `Duplicate(receipt)`
+    - `Rejected` -> `Rejected { reason }`
+  - Maps runtime-commit errors to `DidRegistryError::ChainAdapterSubmitFailed`.
+
+## Validation Commands
+
+```bash
+cargo test -p kamn-core --test did_registry_transactions
+cargo test -p kamn-core --test did_registry_transactions_docs
+cargo clippy -p kamn-core -- -D warnings
+cargo fmt --check
+```

--- a/docs/foundation/did-registry-transactions.md
+++ b/docs/foundation/did-registry-transactions.md
@@ -1,4 +1,4 @@
-# DID Registry Transactions (Issues #110, #685)
+# DID Registry Transactions (Issues #110, #685, #2936)
 
 This document defines the first implementation slice for DID
 register/resolve/update/revoke transaction behavior.
@@ -39,11 +39,27 @@ register/resolve/update/revoke transaction behavior.
 - `DidLifecycleMutationRequest` includes `did`, `actor_did`, `nonce`, and `action`.
 - Successful mutation emits `DidLifecycleMutationEvidence` with
   `reason_code=did_lifecycle_mutation_allowed`.
+- `idempotency_key_for_lifecycle_mutation(request)` derives deterministic lifecycle submission keys.
+- `submit_lifecycle_mutation_via_chain_adapter(adapter, request)` executes lifecycle submission with retry classes:
+  - `NewSubmission`
+  - `RetryableInFlight`
+  - `FinalizedNoRetry`
+  - `ConflictNoRetry`
+- lifecycle chain adapter request contract:
+  - `DidLifecycleChainSubmissionRequest { did, actor_did, nonce, action, idempotency_key, payload_hash }`
+- lifecycle finality tracking:
+  - `record_lifecycle_finality(did, nonce, key, sequence, status, receipt)`
+  - `lifecycle_finality(did, nonce)`
+- Kolme-backed lifecycle integration path:
+  - `KolmeDidLifecycleChainAdapter`
+  - maps lifecycle mutation submissions into deterministic `KolmeRuntimeCommitRequest` payloads
+  - maps provider outcomes back into DID chain submission outcomes
 - Lifecycle mutation reason codes are deterministic:
   - `did_lifecycle_mutation_nonce_invalid`
   - `did_lifecycle_mutation_nonce_replay`
   - `did_lifecycle_mutation_unauthorized_actor`
   - `did_lifecycle_mutation_invalid_transition`
+  - `did_chain_adapter_submit_failed`
 
 ## Validation Rules
 - The DID document `id` must match the target `did`.
@@ -51,6 +67,7 @@ register/resolve/update/revoke transaction behavior.
 - retry classification and finality checks are deterministic across duplicate/stale/conflict outcomes (`Regression: #678`).
 - chain adapter submission contract remains deterministic through `InMemoryDidRegistrationChainAdapter` for low-cost CI verification.
 - Lifecycle mutation nonce replay, unauthorized actor mutation, and invalid revoke/recover transitions fail closed (`Regression: #889`).
+- Lifecycle mutation submission rejects conflicting payloads for same DID+nonce idempotency window (`Regression: #2936`).
 
 ## Local Validation
 Run from repository root:
@@ -67,6 +84,9 @@ cargo test -p kamn-core --test did_registry_transactions -- regression_register_
 cargo test -p kamn-core --test did_registry_transactions -- functional_lifecycle_rotate_mutation_updates_document_and_emits_allowed_reason_code
 cargo test -p kamn-core --test did_registry_transactions -- integration_lifecycle_revoke_then_recover_restores_active_resolution
 cargo test -p kamn-core --test did_registry_transactions -- regression_lifecycle_replayed_or_unauthorized_mutation_fails_closed
+cargo test -p kamn-core --test did_registry_transactions -- functional_lifecycle_chain_submission_through_kolme_adapter_returns_typed_outcome
+cargo test -p kamn-core --test did_registry_transactions -- integration_lifecycle_chain_submission_allows_retry_without_reapplying_mutation
+cargo test -p kamn-core --test did_registry_transactions -- regression_lifecycle_chain_submission_rejects_conflicting_same_nonce_payload
 bash scripts/did/run_did_registry_contract_lane.sh
 cargo test -p kamn-core
 ```

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -36,6 +36,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/kolme/validate_continuous_runtime_commit_live.sh` and `scripts/kolme/test_validate_continuous_runtime_commit_live.sh` (Task #2933, Subtask #2934).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `continuous_runtime_contract_status=verified`, `evidence_bundle_status=verified`, `fail_closed_status=verified`.
   - Fail-closed validation confirmed for partial cycle-control declarations: `--daemon-tick-interval-ms`.
+- Phase 4.2 initial slice delivered:
+  - Added lifecycle chain-submission contracts in `DidRegistry`: deterministic lifecycle idempotency keys, lifecycle retry classification, and nonce-scoped lifecycle finality recording (Task #2936, Subtask #2937).
+  - Added `KolmeDidLifecycleChainAdapter` to project lifecycle mutations into deterministic runtime-commit submissions through `KolmeRuntimeCommitClient`.
+  - Added unit/functional/integration/regression coverage in `crates/kamn-core/tests/did_registry_transactions.rs` for lifecycle submission through Kolme-backed adapters.
 - Phase 6.1 initial slice delivered: service API `/metrics` now exports deterministic runtime telemetry gauges and source/health labels with fail-closed unknown defaults when daemon/kolme telemetry is unavailable (Task #2961, Subtask #2962).
 - Phase 6.1 live validation delivered:
   - Runtime lane: `scripts/runtime/validate_service_api_observability_live.sh` and `scripts/runtime/test_validate_service_api_observability_live.sh` (Task #2963, Subtask #2964).


### PR DESCRIPTION
## Summary
Delivered Phase 4.2 core DID lifecycle on-chain submission slice by adding deterministic lifecycle chain-adapter contracts and a Kolme-backed adapter path in `kamn-core`. This closes the missing execution path from lifecycle mutation requests to chain-submission outcomes with retry/finality tracking and fail-closed conflict handling.

Closes #2936
Closes #2937

## Changes
- `crates/kamn-core/src/did_registry.rs`: added lifecycle chain submission contracts, retry/finality tracking, and `KolmeDidLifecycleChainAdapter` implementation over `KolmeRuntimeCommitClient`.
- `crates/kamn-core/src/lib.rs`: exported new lifecycle chain adapter/request/result types.
- `crates/kamn-core/tests/did_registry_transactions.rs`: added functional/integration/regression coverage for lifecycle submission through Kolme adapter.
- `crates/kamn-core/tests/did_registry_transactions_docs.rs`: extended doc-contract tests for lifecycle chain submission and regression markers.
- `docs/foundation/did-registry-transactions.md`: documented lifecycle chain submission contracts and validation commands.
- `docs/architecture/did-chain-adapter.md`: added architecture reference for DID chain adapter flow.
- `docs/plans/2026-02-08-production-service-roadmap.md`: updated Phase 4.2 execution status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test did_registry_transactions -- functional_lifecycle_chain_submission_through_kolme_adapter_returns_typed_outcome integration_lifecycle_chain_submission_allows_retry_without_reapplying_mutation regression_lifecycle_chain_submission_rejects_conflicting_same_nonce_payload`

Observed failures (expected):
- unresolved import `kamn_core::KolmeDidLifecycleChainAdapter`
- no method named `submit_lifecycle_mutation_via_chain_adapter` found for `DidRegistry`

### 🟢 Green Phase
Command:
`cargo test -p kamn-core --test did_registry_transactions -- functional_lifecycle_chain_submission_through_kolme_adapter_returns_typed_outcome integration_lifecycle_chain_submission_allows_retry_without_reapplying_mutation regression_lifecycle_chain_submission_rejects_conflicting_same_nonce_payload`

Observed result:
- 3 passed; 0 failed

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test did_registry_transactions`
- `cargo test -p kamn-core --test did_registry_transactions_docs`
- `cargo test -p kamn-core`

Observed result:
- all passing (including full `kamn-core` suite)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified                                                                                                  | Justification if N/A |
|--------------|--------|------------------------------------------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | `did_registry_transactions.rs` (`functional_lifecycle_chain_submission_through_kolme_adapter_returns_typed_outcome`) |                      |
| Functional   | ✅     | lifecycle chain submission success path through Kolme adapter                                                          |                      |
| Integration  | ✅     | lifecycle retry/duplicate path without re-applying mutation                                                            |                      |
| Regression   | ✅     | conflicting same DID+nonce payload rejection (`Regression: #2936`)                                                    |                      |
| Performance  | N/A    | No new hotspot loop; existing lifecycle performance lane remains intact                                               | bounded scope        |

## Risks & Rollback
- None expected for existing registration flow; changes are additive to lifecycle submission path.
- Rollback plan: revert commit `feat(did): submit lifecycle mutations through Kolme chain adapter (#2936)`.

## Documentation Updates
- `docs/foundation/did-registry-transactions.md`
- `docs/architecture/did-chain-adapter.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
