### PR TITLE
feat: add deterministic p2p transport lifecycle core

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -82,6 +82,8 @@ pub mod operator_binding;
 pub mod operator_dashboard_api;
 /// Operator dashboard UI composition contracts and presentation-ready projections.
 pub mod operator_dashboard_ui;
+/// Peer discovery and gossip transport adapter contracts for runtime lifecycle flows.
+pub mod p2p_transport;
 /// Performance target thresholds and benchmark outcome classification contracts.
 pub mod performance_targets;
 /// Redaction request approval, audit-event, and visibility compliance contracts.
@@ -319,6 +321,10 @@ pub use operator_dashboard_ui::{
     OperatorDashboardUi, OperatorDashboardUiError, OperatorDashboardUiModel,
     OperatorEscrowStatusEntry, OperatorMessageTraceEntry, OperatorReputationOverviewEntry,
     OperatorTaskTimelineEntry, ReputationRiskTier,
+};
+pub use p2p_transport::{
+    InMemoryPeerLifecycleTransport, P2pTransportError, PeerDiscoveryRecord, PeerGossipFrame,
+    PeerLifecycleTransport, PeerLifecycleTransportCoordinator,
 };
 pub use performance_targets::{
     evaluate_performance_from_observability, evaluate_performance_run, PerformanceAggregate,

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -1,0 +1,464 @@
+//! Deterministic peer discovery and gossip transport adapters for runtime integration.
+
+use crate::config::NodeRole;
+use crate::runtime::{
+    PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, RuntimeLifecycleError,
+};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::sync::{Arc, Mutex};
+
+/// Transport-level discovery metadata advertised by each active peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerDiscoveryRecord {
+    /// Unique transport peer identifier.
+    pub peer_id: String,
+    /// Runtime role advertised by the peer.
+    pub role: NodeRole,
+    /// Gossip topics advertised by this peer.
+    pub gossip_topics: Vec<String>,
+}
+
+impl PeerDiscoveryRecord {
+    /// Builds a validated discovery record with deterministic topic normalization.
+    pub fn new(
+        peer_id: &str,
+        role: NodeRole,
+        gossip_topics: Vec<String>,
+    ) -> Result<Self, P2pTransportError> {
+        validate_peer_id(peer_id)?;
+        if gossip_topics.is_empty() {
+            return Err(P2pTransportError::MissingGossipTopics);
+        }
+
+        let mut normalized = BTreeSet::new();
+        for topic in gossip_topics {
+            validate_topic(&topic)?;
+            normalized.insert(topic.trim().to_owned());
+        }
+
+        Ok(Self {
+            peer_id: peer_id.to_owned(),
+            role,
+            gossip_topics: normalized.into_iter().collect(),
+        })
+    }
+
+    fn supports_topic(&self, topic: &str) -> bool {
+        self.gossip_topics.iter().any(|value| value == topic)
+    }
+}
+
+/// Deterministic gossip frame exchanged between peers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerGossipFrame {
+    /// Gossip topic used for fan-out delivery.
+    pub topic: String,
+    /// Sender peer identifier.
+    pub sender_peer_id: String,
+    /// Recipient peer identifier.
+    pub recipient_peer_id: String,
+    /// Canonical payload body.
+    pub payload: String,
+}
+
+impl PeerGossipFrame {
+    /// Builds a validated gossip frame.
+    pub fn new(
+        topic: &str,
+        sender_peer_id: &str,
+        recipient_peer_id: &str,
+        payload: &str,
+    ) -> Result<Self, P2pTransportError> {
+        validate_topic(topic)?;
+        validate_peer_id(sender_peer_id)?;
+        validate_peer_id(recipient_peer_id)?;
+        if payload.trim().is_empty() {
+            return Err(P2pTransportError::EmptyPayload);
+        }
+        Ok(Self {
+            topic: topic.trim().to_owned(),
+            sender_peer_id: sender_peer_id.to_owned(),
+            recipient_peer_id: recipient_peer_id.to_owned(),
+            payload: payload.to_owned(),
+        })
+    }
+}
+
+/// Transport adapter contract used by peer lifecycle coordinators.
+pub trait PeerLifecycleTransport {
+    /// Advertises a local peer for topic-based discovery.
+    fn advertise(&self, record: PeerDiscoveryRecord) -> Result<(), P2pTransportError>;
+    /// Discovers peers that support the requested topic.
+    fn discover(
+        &self,
+        requester_peer_id: &str,
+        topic: &str,
+    ) -> Result<Vec<PeerDiscoveryRecord>, P2pTransportError>;
+    /// Sends a gossip frame to the recipient inbox.
+    fn send(&self, frame: PeerGossipFrame) -> Result<(), P2pTransportError>;
+    /// Drains all queued frames for the local recipient.
+    fn drain_inbox(
+        &self,
+        recipient_peer_id: &str,
+    ) -> Result<Vec<PeerGossipFrame>, P2pTransportError>;
+}
+
+#[derive(Debug, Default)]
+struct InMemoryPeerLifecycleTransportState {
+    peers_by_id: BTreeMap<String, PeerDiscoveryRecord>,
+    inbox_by_peer: BTreeMap<String, VecDeque<PeerGossipFrame>>,
+}
+
+/// Shared in-memory transport adapter used by deterministic tests and local smoke lanes.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryPeerLifecycleTransport {
+    state: Arc<Mutex<InMemoryPeerLifecycleTransportState>>,
+}
+
+impl PeerLifecycleTransport for InMemoryPeerLifecycleTransport {
+    fn advertise(&self, record: PeerDiscoveryRecord) -> Result<(), P2pTransportError> {
+        let mut state = self.lock_state_mut()?;
+        state
+            .inbox_by_peer
+            .entry(record.peer_id.clone())
+            .or_insert_with(VecDeque::new);
+        state.peers_by_id.insert(record.peer_id.clone(), record);
+        Ok(())
+    }
+
+    fn discover(
+        &self,
+        requester_peer_id: &str,
+        topic: &str,
+    ) -> Result<Vec<PeerDiscoveryRecord>, P2pTransportError> {
+        validate_peer_id(requester_peer_id)?;
+        validate_topic(topic)?;
+        let state = self.lock_state()?;
+
+        Ok(state
+            .peers_by_id
+            .values()
+            .filter(|record| record.peer_id != requester_peer_id && record.supports_topic(topic))
+            .cloned()
+            .collect())
+    }
+
+    fn send(&self, frame: PeerGossipFrame) -> Result<(), P2pTransportError> {
+        let mut state = self.lock_state_mut()?;
+        if !state.peers_by_id.contains_key(&frame.sender_peer_id) {
+            return Err(P2pTransportError::UnknownSenderPeer(
+                frame.sender_peer_id.clone(),
+            ));
+        }
+        if !state.peers_by_id.contains_key(&frame.recipient_peer_id) {
+            return Err(P2pTransportError::UnknownRecipientPeer(
+                frame.recipient_peer_id.clone(),
+            ));
+        }
+        state
+            .inbox_by_peer
+            .entry(frame.recipient_peer_id.clone())
+            .or_insert_with(VecDeque::new)
+            .push_back(frame);
+        Ok(())
+    }
+
+    fn drain_inbox(
+        &self,
+        recipient_peer_id: &str,
+    ) -> Result<Vec<PeerGossipFrame>, P2pTransportError> {
+        validate_peer_id(recipient_peer_id)?;
+        let mut state = self.lock_state_mut()?;
+        let queue = state
+            .inbox_by_peer
+            .entry(recipient_peer_id.to_owned())
+            .or_insert_with(VecDeque::new);
+        Ok(queue.drain(..).collect())
+    }
+}
+
+impl InMemoryPeerLifecycleTransport {
+    fn lock_state(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, InMemoryPeerLifecycleTransportState>, P2pTransportError>
+    {
+        self.state
+            .lock()
+            .map_err(|_| P2pTransportError::StateUnavailable)
+    }
+
+    fn lock_state_mut(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, InMemoryPeerLifecycleTransportState>, P2pTransportError>
+    {
+        self.state
+            .lock()
+            .map_err(|_| P2pTransportError::StateUnavailable)
+    }
+}
+
+/// Coordinator that wires lifecycle transitions to transport discovery and gossip operations.
+#[derive(Debug, Clone)]
+pub struct PeerLifecycleTransportCoordinator<T: PeerLifecycleTransport> {
+    local_peer_id: String,
+    local_role: NodeRole,
+    lifecycle: PeerLifecycle,
+    transport: T,
+}
+
+impl<T: PeerLifecycleTransport> PeerLifecycleTransportCoordinator<T> {
+    /// Builds a coordinator for the local peer identity.
+    pub fn new(
+        local_peer_id: &str,
+        local_role: NodeRole,
+        transport: T,
+    ) -> Result<Self, P2pTransportError> {
+        let lifecycle = PeerLifecycle::new(local_peer_id)?;
+        Ok(Self {
+            local_peer_id: local_peer_id.to_owned(),
+            local_role,
+            lifecycle,
+            transport,
+        })
+    }
+
+    /// Returns the current lifecycle state.
+    pub fn lifecycle_state(&self) -> PeerLifecycleState {
+        self.lifecycle.state()
+    }
+
+    /// Executes connect + handshake transitions and advertises the peer for gossip discovery.
+    pub fn connect_and_advertise(
+        &mut self,
+        gossip_topics: Vec<String>,
+    ) -> Result<PeerLifecycleState, P2pTransportError> {
+        self.lifecycle
+            .transition(PeerLifecycleEvent::StartConnect)?;
+        let next = self
+            .lifecycle
+            .transition(PeerLifecycleEvent::HandshakeSucceeded)?;
+        let record =
+            PeerDiscoveryRecord::new(&self.local_peer_id, self.local_role.clone(), gossip_topics)?;
+        self.transport.advertise(record)?;
+        Ok(next)
+    }
+
+    /// Transitions the peer to disconnected lifecycle state.
+    pub fn disconnect(&mut self) -> Result<PeerLifecycleState, P2pTransportError> {
+        Ok(self.lifecycle.transition(PeerLifecycleEvent::Disconnect)?)
+    }
+
+    /// Discovers peers that advertise support for the provided gossip topic.
+    pub fn discover(&self, topic: &str) -> Result<Vec<PeerDiscoveryRecord>, P2pTransportError> {
+        self.require_active_state()?;
+        self.transport.discover(&self.local_peer_id, topic)
+    }
+
+    /// Broadcasts payload to all discovered peers for a topic and returns delivery fan-out count.
+    pub fn broadcast(&self, topic: &str, payload: &str) -> Result<usize, P2pTransportError> {
+        self.require_active_state()?;
+        validate_topic(topic)?;
+        if payload.trim().is_empty() {
+            return Err(P2pTransportError::EmptyPayload);
+        }
+
+        let discovered = self.transport.discover(&self.local_peer_id, topic)?;
+        for peer in &discovered {
+            let frame = PeerGossipFrame::new(topic, &self.local_peer_id, &peer.peer_id, payload)?;
+            self.transport.send(frame)?;
+        }
+        Ok(discovered.len())
+    }
+
+    /// Drains all inbound frames currently queued for this peer.
+    pub fn drain_inbox(&self) -> Result<Vec<PeerGossipFrame>, P2pTransportError> {
+        self.transport.drain_inbox(&self.local_peer_id)
+    }
+
+    fn require_active_state(&self) -> Result<(), P2pTransportError> {
+        match self.lifecycle.state() {
+            PeerLifecycleState::Active => Ok(()),
+            state => Err(P2pTransportError::InactivePeerLifecycleState(state)),
+        }
+    }
+}
+
+/// Deterministic p2p discovery and gossip transport error variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum P2pTransportError {
+    /// Peer identifier is empty.
+    InvalidPeerId,
+    /// Topic is empty or malformed for deterministic wire handling.
+    InvalidTopic,
+    /// Discovery record has no gossip topics.
+    MissingGossipTopics,
+    /// Gossip payload cannot be empty.
+    EmptyPayload,
+    /// Sender peer has not been advertised.
+    UnknownSenderPeer(String),
+    /// Recipient peer has not been advertised.
+    UnknownRecipientPeer(String),
+    /// Transport state lock is unavailable.
+    StateUnavailable,
+    /// Lifecycle state does not permit transport I/O.
+    InactivePeerLifecycleState(PeerLifecycleState),
+    /// Lifecycle transition error.
+    Lifecycle(RuntimeLifecycleError),
+}
+
+impl From<RuntimeLifecycleError> for P2pTransportError {
+    fn from(value: RuntimeLifecycleError) -> Self {
+        Self::Lifecycle(value)
+    }
+}
+
+impl Display for P2pTransportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPeerId => write!(f, "p2p peer id cannot be empty"),
+            Self::InvalidTopic => write!(f, "p2p topic cannot be empty or contain wire delimiters"),
+            Self::MissingGossipTopics => write!(f, "p2p discovery topics cannot be empty"),
+            Self::EmptyPayload => write!(f, "p2p gossip payload cannot be empty"),
+            Self::UnknownSenderPeer(peer_id) => {
+                write!(f, "p2p sender peer is not advertised: {peer_id}")
+            }
+            Self::UnknownRecipientPeer(peer_id) => {
+                write!(f, "p2p recipient peer is not advertised: {peer_id}")
+            }
+            Self::StateUnavailable => write!(f, "p2p in-memory transport state is unavailable"),
+            Self::InactivePeerLifecycleState(state) => {
+                write!(
+                    f,
+                    "p2p transport requires active lifecycle state, found {state:?}"
+                )
+            }
+            Self::Lifecycle(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl Error for P2pTransportError {}
+
+fn validate_peer_id(peer_id: &str) -> Result<(), P2pTransportError> {
+    if peer_id.trim().is_empty() {
+        return Err(P2pTransportError::InvalidPeerId);
+    }
+    Ok(())
+}
+
+fn validate_topic(topic: &str) -> Result<(), P2pTransportError> {
+    let trimmed = topic.trim();
+    if trimmed.is_empty()
+        || trimmed.contains('|')
+        || trimmed.contains('\n')
+        || trimmed.contains('\r')
+    {
+        return Err(P2pTransportError::InvalidTopic);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        InMemoryPeerLifecycleTransport, P2pTransportError, PeerGossipFrame, PeerLifecycleTransport,
+    };
+    use crate::config::NodeRole;
+    use crate::p2p_transport::{PeerDiscoveryRecord, PeerLifecycleTransportCoordinator};
+    use crate::runtime::PeerLifecycleState;
+
+    #[test]
+    fn transport_discovery_filters_by_topic_and_excludes_requester() {
+        let transport = InMemoryPeerLifecycleTransport::default();
+        transport
+            .advertise(
+                PeerDiscoveryRecord::new(
+                    "peer-a",
+                    NodeRole::Processor,
+                    vec!["messages".to_owned(), "blocks".to_owned()],
+                )
+                .expect("record should be valid"),
+            )
+            .expect("advertise peer-a");
+        transport
+            .advertise(
+                PeerDiscoveryRecord::new("peer-b", NodeRole::Listener, vec!["messages".to_owned()])
+                    .expect("record should be valid"),
+            )
+            .expect("advertise peer-b");
+        transport
+            .advertise(
+                PeerDiscoveryRecord::new("peer-c", NodeRole::Approver, vec!["blocks".to_owned()])
+                    .expect("record should be valid"),
+            )
+            .expect("advertise peer-c");
+
+        let discovered = transport
+            .discover("peer-a", "messages")
+            .expect("discovery should pass");
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].peer_id, "peer-b");
+    }
+
+    #[test]
+    fn coordinator_connect_and_advertise_transitions_to_active_state() {
+        let transport = InMemoryPeerLifecycleTransport::default();
+        let mut coordinator = PeerLifecycleTransportCoordinator::new(
+            "peer-processor",
+            NodeRole::Processor,
+            transport,
+        )
+        .expect("coordinator should initialize");
+        let state = coordinator
+            .connect_and_advertise(vec!["messages".to_owned()])
+            .expect("connect and advertise should pass");
+        assert_eq!(state, PeerLifecycleState::Active);
+        assert_eq!(coordinator.lifecycle_state(), PeerLifecycleState::Active);
+    }
+
+    #[test]
+    fn transport_send_rejects_unknown_recipient() {
+        let transport = InMemoryPeerLifecycleTransport::default();
+        transport
+            .advertise(
+                PeerDiscoveryRecord::new(
+                    "peer-sender",
+                    NodeRole::Processor,
+                    vec!["messages".to_owned()],
+                )
+                .expect("record should be valid"),
+            )
+            .expect("advertise sender");
+
+        let frame = PeerGossipFrame::new("messages", "peer-sender", "peer-missing", "tx:001")
+            .expect("frame should be valid");
+        let result = transport.send(frame);
+        assert_eq!(
+            result,
+            Err(P2pTransportError::UnknownRecipientPeer(
+                "peer-missing".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn regression_coordinator_requires_active_state_for_broadcast() {
+        // Regression: #2922
+        let transport = InMemoryPeerLifecycleTransport::default();
+        let coordinator = PeerLifecycleTransportCoordinator::new(
+            "peer-processor",
+            NodeRole::Processor,
+            transport,
+        )
+        .expect("coordinator should initialize");
+
+        assert_eq!(
+            coordinator.broadcast("messages", "tx:001"),
+            Err(P2pTransportError::InactivePeerLifecycleState(
+                PeerLifecycleState::Disconnected
+            ))
+        );
+    }
+}

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -3126,7 +3126,13 @@ impl RuntimeWiring {
 
 /// Handles build runtime wiring.
 pub fn build_runtime_wiring(config: &NodeConfig) -> RuntimeWiring {
-    let common_components = vec!["state-store", "message-router", "audit-log", "api-surface"];
+    let mut common_components = vec!["state-store", "message-router", "audit-log", "api-surface"];
+    if config.enable_gossip {
+        common_components.push("p2p-discovery");
+        common_components.push("p2p-gossip-transport");
+    } else {
+        common_components.push("gossip-transport-disabled");
+    }
 
     let role_components = match config.role {
         NodeRole::Processor => vec!["mempool", "executor", "block-producer"],

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -1,0 +1,34 @@
+const DOC: &str = include_str!("../../../docs/architecture/p2p-transport.md");
+const ROADMAP: &str = include_str!("../../../docs/plans/2026-02-08-production-service-roadmap.md");
+
+#[test]
+fn architecture_doc_contains_p2p_transport_core_components() {
+    assert!(DOC.contains("PeerLifecycleTransport"));
+    assert!(DOC.contains("InMemoryPeerLifecycleTransport"));
+    assert!(DOC.contains("PeerDiscoveryRecord"));
+    assert!(DOC.contains("PeerGossipFrame"));
+    assert!(DOC.contains("PeerLifecycleTransportCoordinator"));
+}
+
+#[test]
+fn architecture_doc_contains_runtime_wiring_and_guardrails() {
+    assert!(DOC.contains("p2p-discovery"));
+    assert!(DOC.contains("p2p-gossip-transport"));
+    assert!(DOC.contains("gossip-transport-disabled"));
+    assert!(DOC.contains("P2pTransportError::InvalidPeerId"));
+    assert!(DOC.contains("P2pTransportError::InvalidTopic"));
+    assert!(DOC.contains("P2pTransportError::InactivePeerLifecycleState"));
+}
+
+#[test]
+fn roadmap_references_phase_31_initial_p2p_slice() {
+    assert!(ROADMAP.contains("Phase 3.1 initial slice delivered"));
+    assert!(ROADMAP.contains("Task #2921, Subtask #2922"));
+    assert!(ROADMAP.contains("docs/architecture/p2p-transport.md"));
+}
+
+#[test]
+fn regression_doc_tracks_disconnected_broadcast_guard() {
+    // Regression: #2922
+    assert!(DOC.contains("Regression: #2922"));
+}

--- a/crates/kamn-core/tests/p2p_transport_runtime.rs
+++ b/crates/kamn-core/tests/p2p_transport_runtime.rs
@@ -1,0 +1,137 @@
+use kamn_core::{
+    bootstrap, InMemoryPeerLifecycleTransport, NodeConfig, NodeRole, P2pTransportError,
+    PeerGossipFrame, PeerLifecycleState, PeerLifecycleTransportCoordinator, SyncMode,
+};
+
+fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: gossip_enabled,
+        sync_mode: SyncMode::Fast,
+    }
+}
+
+fn assert_single_frame(
+    frames: &[PeerGossipFrame],
+    expected_sender: &str,
+    expected_topic: &str,
+    expected_payload: &str,
+) {
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0].sender_peer_id, expected_sender);
+    assert_eq!(frames[0].topic, expected_topic);
+    assert_eq!(frames[0].payload, expected_payload);
+}
+
+#[test]
+fn functional_p2p_transport_gossip_broadcast_reaches_discovered_roles() {
+    let shared_transport = InMemoryPeerLifecycleTransport::default();
+    let mut processor = PeerLifecycleTransportCoordinator::new(
+        "peer-processor",
+        NodeRole::Processor,
+        shared_transport.clone(),
+    )
+    .expect("processor coordinator should initialize");
+    let mut listener = PeerLifecycleTransportCoordinator::new(
+        "peer-listener",
+        NodeRole::Listener,
+        shared_transport.clone(),
+    )
+    .expect("listener coordinator should initialize");
+    let mut approver = PeerLifecycleTransportCoordinator::new(
+        "peer-approver",
+        NodeRole::Approver,
+        shared_transport,
+    )
+    .expect("approver coordinator should initialize");
+
+    assert_eq!(
+        processor.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+    assert_eq!(
+        listener.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+    assert_eq!(
+        approver.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+
+    let discovered = processor
+        .discover("messages")
+        .expect("discovery should succeed when active");
+    assert_eq!(discovered.len(), 2);
+
+    let delivered = processor
+        .broadcast("messages", "tx:001")
+        .expect("broadcast should succeed");
+    assert_eq!(delivered, 2);
+
+    let listener_frames = listener
+        .drain_inbox()
+        .expect("listener drain should succeed");
+    assert_single_frame(&listener_frames, "peer-processor", "messages", "tx:001");
+
+    let approver_frames = approver
+        .drain_inbox()
+        .expect("approver drain should succeed");
+    assert_single_frame(&approver_frames, "peer-processor", "messages", "tx:001");
+}
+
+#[test]
+fn integration_bootstrap_wiring_includes_p2p_transport_components_when_gossip_enabled() {
+    let gossip_plan =
+        bootstrap(config_for(NodeRole::Processor, true)).expect("gossip bootstrap should pass");
+    assert!(gossip_plan
+        .wiring
+        .all_components()
+        .contains(&"p2p-discovery"));
+    assert!(gossip_plan
+        .wiring
+        .all_components()
+        .contains(&"p2p-gossip-transport"));
+
+    let disabled_plan = bootstrap(config_for(NodeRole::Processor, false))
+        .expect("gossip-disabled bootstrap should pass");
+    assert!(!disabled_plan
+        .wiring
+        .all_components()
+        .contains(&"p2p-discovery"));
+    assert!(disabled_plan
+        .wiring
+        .all_components()
+        .contains(&"gossip-transport-disabled"));
+}
+
+#[test]
+fn regression_p2p_transport_rejects_broadcast_while_disconnected() {
+    // Regression: #2922
+    let shared_transport = InMemoryPeerLifecycleTransport::default();
+    let mut listener = PeerLifecycleTransportCoordinator::new(
+        "peer-listener",
+        NodeRole::Listener,
+        shared_transport.clone(),
+    )
+    .expect("listener coordinator should initialize");
+    let processor = PeerLifecycleTransportCoordinator::new(
+        "peer-processor",
+        NodeRole::Processor,
+        shared_transport,
+    )
+    .expect("processor coordinator should initialize");
+    listener
+        .connect_and_advertise(vec!["messages".to_owned()])
+        .expect("listener must be discoverable");
+
+    let result = processor.broadcast("messages", "tx:001");
+    assert_eq!(
+        result,
+        Err(P2pTransportError::InactivePeerLifecycleState(
+            PeerLifecycleState::Disconnected
+        ))
+    );
+}

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -1,0 +1,83 @@
+# P2P Transport Architecture
+
+This document captures Phase 3.1 initial core delivery for peer discovery and
+gossip lifecycle integration (Task #2921, Subtask #2922).
+
+## Scope
+
+- Add deterministic peer discovery and gossip transport abstractions in
+  `kamn-core`.
+- Integrate peer lifecycle transitions with transport advertisement and fan-out
+  behavior.
+- Wire bootstrap/runtime component planning so gossip-enabled nodes explicitly
+  include p2p transport surfaces.
+
+This slice is intentionally dependency-light and does not yet bind to live
+libp2p transport networking. Live validation/rehearsal is tracked separately in
+Task #2923 and Subtask #2924.
+
+## Core Components
+
+- `PeerLifecycleTransport`
+  - transport adapter contract for advertise/discover/send/drain operations.
+- `InMemoryPeerLifecycleTransport`
+  - shared deterministic adapter for low-cost local tests and smoke lanes.
+- `PeerDiscoveryRecord`
+  - normalized peer advertisement payload with role and gossip topic set.
+- `PeerGossipFrame`
+  - deterministic topic/sender/recipient/payload frame contract.
+- `PeerLifecycleTransportCoordinator`
+  - lifecycle-aware coordinator that:
+    - transitions through connect/handshake state
+    - advertises local discovery metadata
+    - discovers peers by topic
+    - broadcasts fan-out gossip frames
+    - drains inbound queue frames
+
+## Runtime Wiring Integration
+
+`build_runtime_wiring(...)` now adds deterministic p2p components:
+
+- with `enable_gossip=true`:
+  - `p2p-discovery`
+  - `p2p-gossip-transport`
+- with `enable_gossip=false`:
+  - `gossip-transport-disabled`
+
+This makes bootstrap planning explicitly reflect whether gossip transport is
+enabled for a node profile.
+
+## Deterministic Guardrails
+
+- Empty peer IDs fail closed with `P2pTransportError::InvalidPeerId`.
+- Empty/malformed topics fail closed with `P2pTransportError::InvalidTopic`.
+- Empty payloads fail closed with `P2pTransportError::EmptyPayload`.
+- Unadvertised recipients fail closed with
+  `P2pTransportError::UnknownRecipientPeer`.
+- Transport I/O requires active lifecycle state:
+  `P2pTransportError::InactivePeerLifecycleState`.
+
+Regression marker:
+- `Regression: #2922` ensures disconnected peers cannot broadcast gossip frames.
+
+## Validation Commands
+
+```bash
+cargo test -p kamn-core --test p2p_transport_runtime
+cargo test -p kamn-core p2p_transport
+cargo clippy -p kamn-core -- -D warnings
+cargo fmt --check
+```
+
+## Live Validation Follow-Up
+
+Live transport rehearsal and evidence bundles are tracked by:
+
+- Task #2923
+- Subtask #2924
+
+Expected live-validation outcomes:
+
+- deterministic `status=pass` / `final_decision=GO` markers
+- explicit fail-closed injected fault markers
+- bounded runtime budget reporting for low-cost local execution

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -4,7 +4,7 @@
 
 What you have is **88K lines of Rust that define the rules** — domain types, state machines, validation guards, contract tests — plus a working HTTP/WebSocket client for Kolme blockchain integration and a localhost TCP demo. What you don't have is anything that runs as a service.
 
-There is **zero async code** in the entire codebase. No tokio, no `async fn`, no `.await`. All networking is synchronous blocking I/O. There is no database. There is no HTTP server. There is no P2P layer. Every store is `InMemory*` with no persistence.
+There is **zero async code** in the entire codebase. No tokio, no `async fn`, no `.await`. All networking is synchronous blocking I/O. There is no database. There is no HTTP server. There is no live libp2p network layer yet; current p2p coverage is deterministic in-memory transport contracts. Every store is `InMemory*` with no persistence.
 
 ---
 
@@ -31,6 +31,11 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_service_api_websocket_live.sh` and `scripts/runtime/test_validate_service_api_websocket_live.sh` (Task #2918, Subtask #2919).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `websocket_upgrade_status=verified`, `fail_closed_status=verified`, `probe_status=verified`.
   - Fail-closed validation confirmed for invalid runtime budget argument: `max-seconds must be an integer`.
+- Phase 3.1 initial slice delivered:
+  - Added deterministic p2p transport contracts in `kamn-core`: `PeerLifecycleTransport`, `InMemoryPeerLifecycleTransport`, `PeerDiscoveryRecord`, `PeerGossipFrame`, and `PeerLifecycleTransportCoordinator` (Task #2921, Subtask #2922).
+  - Added bootstrap/runtime wiring integration so `enable_gossip` toggles explicit `p2p-discovery`/`p2p-gossip-transport` components (or `gossip-transport-disabled` when off).
+  - Added unit/functional/integration/regression coverage in `crates/kamn-core/src/p2p_transport.rs` and `crates/kamn-core/tests/p2p_transport_runtime.rs`.
+  - Architecture documentation added at `docs/architecture/p2p-transport.md`.
 - Phase 4.1 initial slice delivered: `runtime-mode kolme-live` now supports bounded continuous commit/finality execution when paired cycle controls are supplied (`--daemon-max-ticks` and `--daemon-tick-interval-ms`) with fail-closed guardrails for partial declarations (Task #2931, Subtask #2932).
 - Phase 4.1 live validation delivered:
   - Runtime lane: `scripts/kolme/validate_continuous_runtime_commit_live.sh` and `scripts/kolme/test_validate_continuous_runtime_commit_live.sh` (Task #2933, Subtask #2934).


### PR DESCRIPTION
## Summary
Implement Phase 3.1 core delivery for peer discovery + gossip transport lifecycle integration in `kamn-core` without new dependencies. This adds deterministic transport contracts, runtime wiring projection, and auditable docs/test coverage for Task #2921 and Subtask #2922.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`: added `PeerLifecycleTransport`, `InMemoryPeerLifecycleTransport`, `PeerDiscoveryRecord`, `PeerGossipFrame`, `PeerLifecycleTransportCoordinator`, and `P2pTransportError`.
- `crates/kamn-core/src/runtime.rs`: `build_runtime_wiring(...)` now projects `p2p-discovery`/`p2p-gossip-transport` when gossip is enabled and `gossip-transport-disabled` otherwise.
- `crates/kamn-core/src/lib.rs`: exported new p2p transport module and public API surface.
- `crates/kamn-core/tests/p2p_transport_runtime.rs`: added functional/integration/regression transport tests.
- `crates/kamn-core/tests/p2p_transport_docs.rs`: added doc-contract tests for architecture + roadmap markers.
- `docs/architecture/p2p-transport.md`: documented implementation contracts/guardrails and validation commands.
- `docs/plans/2026-02-08-production-service-roadmap.md`: added Phase 3.1 status update for Task #2921/#2922.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_transport_runtime`

Failing output excerpt:
```text
error[E0432]: unresolved imports `kamn_core::InMemoryPeerLifecycleTransport`, `kamn_core::P2pTransportError`, `kamn_core::PeerGossipFrame`, `kamn_core::PeerLifecycleTransportCoordinator`
```

### 🟢 Green Phase
Commands:
`cargo test -p kamn-core --test p2p_transport_runtime`
`cargo test -p kamn-core p2p_transport`

Passing summary:
- `p2p_transport_runtime`: 3 passed, 0 failed
- `p2p_transport` module lane: 4 passed, 0 failed

### 🔁 Regression
Commands:
`cargo fmt --check`
`cargo clippy -p kamn-core -- -D warnings`
`cargo test -p kamn-core`

Passing summary:
- `fmt`: clean
- `clippy`: clean
- `kamn-core` full suite: pass

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `p2p_transport::tests::*` in `crates/kamn-core/src/p2p_transport.rs` | |
| Functional   | ✅ | `functional_p2p_transport_gossip_broadcast_reaches_discovered_roles` | |
| Integration  | ✅ | `integration_bootstrap_wiring_includes_p2p_transport_components_when_gossip_enabled` | |
| Regression   | ✅ | `regression_p2p_transport_rejects_broadcast_while_disconnected` and `regression_doc_tracks_disconnected_broadcast_guard` | |
| Performance  | N/A | | No hotspot/perf-critical path was introduced; transport is deterministic in-memory contract scaffolding for this phase. |

## Risks & Rollback
- None expected for existing runtime behavior; new components are additive and gated by `enable_gossip` wiring projection.
- Rollback plan: revert this PR commit to remove p2p transport contracts and runtime wiring component markers.

## Documentation Updates
- `docs/architecture/p2p-transport.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-core`)
- [x] Docs updated (or justified why not)

Closes #2921
Closes #2922
Refs #2920
