### PR TITLE
feat(kamn-core): add mempool consensus block pipeline

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -1,0 +1,275 @@
+//! Mempool block production and consensus validation pipeline contracts.
+
+use crate::runtime::{
+    ApproverAttestation, ApproverQuorumDecision, ApproverQuorumError, ApproverQuorumEvaluator,
+    ApproverQuorumInput, ListenerAttestation, ListenerQuorumDecision, ListenerQuorumError,
+    ListenerQuorumEvaluator, ListenerQuorumInput,
+};
+use crate::smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
+use crate::transaction::BaselineTransaction;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// Input contract for one consensus-validation and block-commit round.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockConsensusRoundInput {
+    /// Listener quorum event identifier.
+    pub listener_event_id: String,
+    /// Listener quorum event sequence.
+    pub listener_event_sequence: u64,
+    /// Approver outbound action identifier.
+    pub outbound_action_id: String,
+    /// Listener votes as `(listener_did, attestation_id)`.
+    pub listener_votes: Vec<(String, String)>,
+    /// Approver votes as `(approver_did, attestation_id, payload_digest_override)`.
+    pub approver_votes: Vec<(String, String, Option<String>)>,
+}
+
+/// Commit report emitted when a consensus round commits a block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockPipelineCommitReport {
+    /// Committed block payload.
+    pub block: ProducedBlock,
+    /// Listener quorum decision used for admission.
+    pub listener_decision: ListenerQuorumDecision,
+    /// Approver quorum decision used for authorization.
+    pub approver_decision: ApproverQuorumDecision,
+    /// Deterministic payload digest used by approver quorum validation.
+    pub payload_digest: String,
+}
+
+/// Error variants for block pipeline validation and commit flows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlockPipelineError {
+    /// Listener quorum validation failed.
+    Listener(ListenerQuorumError),
+    /// Approver quorum validation failed.
+    Approver(ApproverQuorumError),
+    /// Smoke network transport/guard operation failed.
+    Smoke(SmokeError),
+    /// Pipeline attempted a consensus round with an empty mempool.
+    EmptyMempool,
+    /// Approver payload digest override mismatched deterministic block digest.
+    ConsensusPayloadDigestMismatch {
+        /// Expected deterministic digest.
+        expected: String,
+        /// Found override digest.
+        found: String,
+    },
+}
+
+impl From<ListenerQuorumError> for BlockPipelineError {
+    fn from(value: ListenerQuorumError) -> Self {
+        Self::Listener(value)
+    }
+}
+
+impl From<ApproverQuorumError> for BlockPipelineError {
+    fn from(value: ApproverQuorumError) -> Self {
+        Self::Approver(value)
+    }
+}
+
+impl From<SmokeError> for BlockPipelineError {
+    fn from(value: SmokeError) -> Self {
+        Self::Smoke(value)
+    }
+}
+
+impl Display for BlockPipelineError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Listener(error) => write!(f, "{error}"),
+            Self::Approver(error) => write!(f, "{error}"),
+            Self::Smoke(error) => write!(f, "{error}"),
+            Self::EmptyMempool => write!(
+                f,
+                "block pipeline requires at least one mempool transaction"
+            ),
+            Self::ConsensusPayloadDigestMismatch { expected, found } => {
+                write!(
+                    f,
+                    "block pipeline payload digest mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for BlockPipelineError {}
+
+/// Deterministic mempool->consensus->commit pipeline for processor runtime flows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MempoolBlockPipeline {
+    network: RoleSmokeNetwork,
+    listener_evaluator: ListenerQuorumEvaluator,
+    approver_required_approvals: usize,
+}
+
+impl MempoolBlockPipeline {
+    /// Builds a new block pipeline with explicit listener/approver quorum thresholds.
+    pub fn new(
+        gossip_enabled: bool,
+        listener_required_confirmations: usize,
+        approver_required_approvals: usize,
+    ) -> Result<Self, BlockPipelineError> {
+        let listener_evaluator = ListenerQuorumEvaluator::new(listener_required_confirmations)?;
+        // Validate approver threshold during construction.
+        let _ = ApproverQuorumEvaluator::new(approver_required_approvals)?;
+
+        Ok(Self {
+            network: RoleSmokeNetwork::new(gossip_enabled),
+            listener_evaluator,
+            approver_required_approvals,
+        })
+    }
+
+    /// Returns expected state hash for the next mempool submission.
+    pub fn expected_state_hash(&self) -> &str {
+        self.network.expected_state_hash()
+    }
+
+    /// Returns current processor mempool length.
+    pub fn processor_mempool_len(&self) -> usize {
+        self.network.processor.mempool_len()
+    }
+
+    /// Submits a transaction into the pipeline mempool using existing guardrails.
+    pub fn submit_transaction(
+        &mut self,
+        tx: BaselineTransaction,
+    ) -> Result<(), BlockPipelineError> {
+        self.network.submit_transaction(tx)?;
+        Ok(())
+    }
+
+    /// Runs listener/approver consensus validation and commits one produced block.
+    pub fn run_consensus_round(
+        &mut self,
+        input: BlockConsensusRoundInput,
+    ) -> Result<BlockPipelineCommitReport, BlockPipelineError> {
+        let pending = self.network.processor_mempool_snapshot();
+        if pending.is_empty() {
+            return Err(BlockPipelineError::EmptyMempool);
+        }
+
+        let payload_digest = payload_digest_for_transactions(&pending);
+        for (_, _, override_digest) in &input.approver_votes {
+            if let Some(found) = override_digest {
+                if found != &payload_digest {
+                    return Err(BlockPipelineError::ConsensusPayloadDigestMismatch {
+                        expected: payload_digest.clone(),
+                        found: found.clone(),
+                    });
+                }
+            }
+        }
+
+        let listener_attestations = input
+            .listener_votes
+            .into_iter()
+            .map(|(listener_did, attestation_id)| {
+                ListenerAttestation::new(&listener_did, &attestation_id)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let listener_input = ListenerQuorumInput::new(
+            &input.listener_event_id,
+            input.listener_event_sequence,
+            listener_attestations,
+        )?;
+        let listener_decision = self.listener_evaluator.evaluate(listener_input)?;
+
+        let approver_attestations = input
+            .approver_votes
+            .into_iter()
+            .map(|(approver_did, attestation_id, override_digest)| {
+                let digest = override_digest.unwrap_or_else(|| payload_digest.clone());
+                ApproverAttestation::new(&approver_did, &digest, &attestation_id)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let approver_input = ApproverQuorumInput::new(
+            &input.outbound_action_id,
+            &payload_digest,
+            approver_attestations,
+        )?;
+        let approver_evaluator = ApproverQuorumEvaluator::new(self.approver_required_approvals)?;
+        let approver_decision = approver_evaluator.authorize(approver_input)?;
+
+        let block = self.network.produce_block()?;
+
+        Ok(BlockPipelineCommitReport {
+            block,
+            listener_decision,
+            approver_decision,
+            payload_digest,
+        })
+    }
+}
+
+fn payload_digest_for_transactions(transactions: &[BaselineTransaction]) -> String {
+    let mut ordered = transactions.to_vec();
+    ordered.sort_by(|left, right| {
+        left.nonce
+            .cmp(&right.nonce)
+            .then_with(|| left.id.cmp(&right.id))
+            .then_with(|| left.sender.cmp(&right.sender))
+    });
+
+    let mut digest = String::from("block-payload");
+    for tx in ordered {
+        digest.push('|');
+        digest.push_str(&tx.id);
+        digest.push(':');
+        digest.push_str(&tx.sender);
+        digest.push(':');
+        digest.push_str(&tx.nonce.to_string());
+        digest.push(':');
+        digest.push_str(&tx.state_hash);
+    }
+    digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{payload_digest_for_transactions, BlockPipelineError, MempoolBlockPipeline};
+    use crate::transaction::BaselineTransaction;
+
+    #[test]
+    fn constructor_rejects_zero_listener_quorum_threshold() {
+        let result = MempoolBlockPipeline::new(true, 0, 1);
+        assert!(matches!(result, Err(BlockPipelineError::Listener(_))));
+    }
+
+    #[test]
+    fn constructor_rejects_zero_approver_quorum_threshold() {
+        let result = MempoolBlockPipeline::new(true, 1, 0);
+        assert!(matches!(result, Err(BlockPipelineError::Approver(_))));
+    }
+
+    #[test]
+    fn regression_consensus_round_rejects_empty_mempool() {
+        // Regression: #2927
+        let mut pipeline = MempoolBlockPipeline::new(true, 1, 1).expect("pipeline builds");
+        let result = pipeline.run_consensus_round(super::BlockConsensusRoundInput {
+            listener_event_id: "event-1".to_owned(),
+            listener_event_sequence: 1,
+            outbound_action_id: "outbound-1".to_owned(),
+            listener_votes: vec![("kamn:did:listener:alpha".to_owned(), "att-1".to_owned())],
+            approver_votes: vec![(
+                "kamn:did:agent:approver-alpha".to_owned(),
+                "att-1".to_owned(),
+                None,
+            )],
+        });
+        assert_eq!(result, Err(BlockPipelineError::EmptyMempool));
+    }
+
+    #[test]
+    fn payload_digest_is_deterministic_across_orderings() {
+        let tx1 = BaselineTransaction::signed("tx-1", "agent-a", 1, "p1", "state:genesis");
+        let tx2 = BaselineTransaction::signed("tx-2", "agent-b", 1, "p2", "state:genesis");
+        let digest_a = payload_digest_for_transactions(&[tx1.clone(), tx2.clone()]);
+        let digest_b = payload_digest_for_transactions(&[tx2, tx1]);
+        assert_eq!(digest_a, digest_b);
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -13,6 +13,8 @@ pub mod agent_upgrade_workflow;
 pub mod anti_spam;
 /// Audit export filters, bundles, and governance evidence contracts.
 pub mod audit_exports;
+/// Mempool block production and consensus-validation pipeline contracts.
+pub mod block_pipeline;
 pub mod bootstrap;
 /// Bridge ingress and egress normalization plus policy evaluation contracts.
 pub mod bridge_adapter;
@@ -144,6 +146,9 @@ pub use anti_spam::{
 pub use audit_exports::{
     AuditDomain, AuditEventRecord, AuditExportBundle, AuditExportEngine, AuditExportError,
     AuditExportFilter, AuditExportFormat, AuditExportManifest, AuditExportRequest,
+};
+pub use block_pipeline::{
+    BlockConsensusRoundInput, BlockPipelineCommitReport, BlockPipelineError, MempoolBlockPipeline,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -3135,7 +3135,12 @@ pub fn build_runtime_wiring(config: &NodeConfig) -> RuntimeWiring {
     }
 
     let role_components = match config.role {
-        NodeRole::Processor => vec!["mempool", "executor", "block-producer"],
+        NodeRole::Processor => vec![
+            "mempool",
+            "executor",
+            "block-producer",
+            "consensus-validator",
+        ],
         NodeRole::Listener => vec!["external-listener", "event-normalizer"],
         NodeRole::Approver => vec!["quorum-approver", "outbound-authorizer"],
     };

--- a/crates/kamn-core/src/smoke.rs
+++ b/crates/kamn-core/src/smoke.rs
@@ -98,6 +98,11 @@ impl RoleSmokeNetwork {
         self.guards.expected_state_hash()
     }
 
+    /// Returns a deterministic snapshot of processor mempool transactions.
+    pub fn processor_mempool_snapshot(&self) -> Vec<BaselineTransaction> {
+        self.processor.mempool.clone()
+    }
+
     /// Validates and submits a transaction into processor state.
     pub fn submit_transaction(&mut self, tx: BaselineTransaction) -> Result<(), SmokeError> {
         self.guards.validate_and_record(&tx)?;

--- a/crates/kamn-core/tests/block_pipeline.rs
+++ b/crates/kamn-core/tests/block_pipeline.rs
@@ -1,0 +1,115 @@
+use kamn_core::{
+    bootstrap, BaselineTransaction, BlockConsensusRoundInput, BlockPipelineError,
+    MempoolBlockPipeline, NodeConfig, NodeRole, SyncMode,
+};
+
+fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: gossip_enabled,
+        sync_mode: SyncMode::Fast,
+    }
+}
+
+fn sample_tx(
+    pipeline: &MempoolBlockPipeline,
+    id: &str,
+    sender: &str,
+    nonce: u64,
+) -> BaselineTransaction {
+    BaselineTransaction::signed(
+        id,
+        sender,
+        nonce,
+        &format!("payload-{id}"),
+        pipeline.expected_state_hash(),
+    )
+}
+
+#[test]
+fn functional_block_pipeline_commits_after_listener_and_approver_quorum() {
+    let mut pipeline = MempoolBlockPipeline::new(true, 2, 2).expect("pipeline should initialize");
+    pipeline
+        .submit_transaction(sample_tx(&pipeline, "tx-1", "agent-a", 1))
+        .expect("tx-1 should be accepted");
+    pipeline
+        .submit_transaction(sample_tx(&pipeline, "tx-2", "agent-b", 1))
+        .expect("tx-2 should be accepted");
+
+    let report = pipeline
+        .run_consensus_round(BlockConsensusRoundInput {
+            listener_event_id: "listener-event-1".to_owned(),
+            listener_event_sequence: 1,
+            outbound_action_id: "outbound-action-1".to_owned(),
+            listener_votes: vec![
+                (
+                    "kamn:did:listener:alpha".to_owned(),
+                    "listen-att-1".to_owned(),
+                ),
+                (
+                    "kamn:did:listener:beta".to_owned(),
+                    "listen-att-2".to_owned(),
+                ),
+            ],
+            approver_votes: vec![
+                (
+                    "kamn:did:agent:approver-alpha".to_owned(),
+                    "approve-att-1".to_owned(),
+                    None,
+                ),
+                (
+                    "kamn:did:agent:approver-beta".to_owned(),
+                    "approve-att-2".to_owned(),
+                    None,
+                ),
+            ],
+        })
+        .expect("consensus round should commit block");
+
+    assert_eq!(report.block.height, 1);
+    assert_eq!(report.block.transactions.len(), 2);
+    assert!(report.listener_decision.accepted);
+    assert!(report.approver_decision.authorized);
+}
+
+#[test]
+fn integration_bootstrap_processor_wiring_includes_consensus_validator_component() {
+    let plan = bootstrap(config_for(NodeRole::Processor, true)).expect("bootstrap should succeed");
+    assert!(plan
+        .wiring
+        .all_components()
+        .contains(&"consensus-validator"));
+}
+
+#[test]
+fn regression_block_pipeline_rejects_payload_digest_mismatch_before_commit() {
+    // Regression: #2927
+    let mut pipeline = MempoolBlockPipeline::new(true, 1, 1).expect("pipeline should initialize");
+    pipeline
+        .submit_transaction(sample_tx(&pipeline, "tx-1", "agent-a", 1))
+        .expect("transaction should be accepted");
+
+    let result = pipeline.run_consensus_round(BlockConsensusRoundInput {
+        listener_event_id: "listener-event-1".to_owned(),
+        listener_event_sequence: 1,
+        outbound_action_id: "outbound-action-1".to_owned(),
+        listener_votes: vec![(
+            "kamn:did:listener:alpha".to_owned(),
+            "listen-att-1".to_owned(),
+        )],
+        approver_votes: vec![(
+            "kamn:did:agent:approver-alpha".to_owned(),
+            "approve-att-1".to_owned(),
+            Some("digest:mismatch".to_owned()),
+        )],
+    });
+
+    assert!(matches!(
+        result,
+        Err(BlockPipelineError::ConsensusPayloadDigestMismatch { .. })
+    ));
+    assert_eq!(pipeline.processor_mempool_len(), 1);
+}

--- a/crates/kamn-core/tests/block_pipeline_docs.rs
+++ b/crates/kamn-core/tests/block_pipeline_docs.rs
@@ -1,0 +1,31 @@
+const DOC: &str = include_str!("../../../docs/architecture/block-pipeline.md");
+const ROADMAP: &str = include_str!("../../../docs/plans/2026-02-08-production-service-roadmap.md");
+
+#[test]
+fn architecture_doc_contains_block_pipeline_core_components() {
+    assert!(DOC.contains("MempoolBlockPipeline"));
+    assert!(DOC.contains("BlockConsensusRoundInput"));
+    assert!(DOC.contains("BlockPipelineCommitReport"));
+    assert!(DOC.contains("BlockPipelineError"));
+}
+
+#[test]
+fn architecture_doc_contains_consensus_and_runtime_wiring_contracts() {
+    assert!(DOC.contains("ListenerQuorumEvaluator"));
+    assert!(DOC.contains("ApproverQuorumEvaluator"));
+    assert!(DOC.contains("RoleSmokeNetwork::produce_block"));
+    assert!(DOC.contains("consensus-validator"));
+}
+
+#[test]
+fn roadmap_references_phase_32_initial_block_pipeline_slice() {
+    assert!(ROADMAP.contains("Phase 3.2 initial slice delivered"));
+    assert!(ROADMAP.contains("Task #2926, Subtask #2927"));
+    assert!(ROADMAP.contains("docs/architecture/block-pipeline.md"));
+}
+
+#[test]
+fn regression_doc_tracks_digest_mismatch_fail_closed_guard() {
+    // Regression: #2927
+    assert!(DOC.contains("Regression: #2927"));
+}

--- a/docs/architecture/block-pipeline.md
+++ b/docs/architecture/block-pipeline.md
@@ -1,0 +1,64 @@
+# Block Pipeline Architecture
+
+This document captures Phase 3.2 initial core delivery for mempool block
+production and consensus validation (Task #2926, Subtask #2927).
+
+## Scope
+
+- Add explicit mempool -> listener quorum -> approver quorum -> block commit
+  pipeline contracts in `kamn-core`.
+- Keep deterministic fail-closed outcomes for consensus mismatch and empty
+  mempool conditions.
+- Wire processor runtime planning so consensus validation is explicitly visible
+  in runtime component topology.
+
+## Core Components
+
+- `MempoolBlockPipeline`
+  - orchestrates one consensus round over pending mempool transactions.
+- `BlockConsensusRoundInput`
+  - listener and approver attestation input envelope for a round.
+- `BlockPipelineCommitReport`
+  - committed block + listener/approver decisions + payload digest.
+- `BlockPipelineError`
+  - typed fail-closed errors for listener/approver/smoke failures and
+    deterministic digest mismatches.
+
+## Consensus Round Flow
+
+1. Snapshot processor mempool transactions.
+2. Compute deterministic payload digest from ordered transaction identity.
+3. Validate listener quorum using `ListenerQuorumEvaluator`.
+4. Validate approver quorum using `ApproverQuorumEvaluator`.
+5. Commit produced block through `RoleSmokeNetwork::produce_block`.
+
+Commit is blocked if either quorum validation fails.
+
+## Runtime Wiring Integration
+
+Processor role runtime wiring now includes:
+
+- `mempool`
+- `executor`
+- `block-producer`
+- `consensus-validator`
+
+## Deterministic Guardrails
+
+- Empty mempool is rejected before consensus evaluation:
+  `BlockPipelineError::EmptyMempool`.
+- Approver payload-digest overrides must match deterministic digest:
+  `BlockPipelineError::ConsensusPayloadDigestMismatch`.
+- Listener and approver quorum errors are surfaced as typed failures.
+
+Regression marker:
+- `Regression: #2927` keeps digest mismatch fail-closed before commit.
+
+## Validation Commands
+
+```bash
+cargo test -p kamn-core --test block_pipeline
+cargo test -p kamn-core block_pipeline
+cargo clippy -p kamn-core -- -D warnings
+cargo fmt --check
+```

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -40,6 +40,12 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_p2p_transport_live.sh` and `scripts/runtime/test_validate_p2p_transport_live.sh` (Task #2923, Subtask #2924).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `p2p_transport_contract_status=verified`, `docs_contract_status=verified`, `fail_closed_status=verified`, `performance_budget_status=verified`.
   - Fail-closed validation confirmed for disconnected broadcast guard behavior: `fail_closed_reason_code=p2p_transport_inactive_lifecycle_state`.
+- Phase 3.2 initial slice delivered:
+  - Added `MempoolBlockPipeline` with explicit listener quorum, approver quorum, and commit orchestration over pending mempool transactions (Task #2926, Subtask #2927).
+  - Added deterministic fail-closed digest mismatch and empty-mempool guards before commit.
+  - Added processor runtime wiring component projection for `consensus-validator`.
+  - Added unit/functional/integration/regression coverage in `crates/kamn-core/src/block_pipeline.rs` and `crates/kamn-core/tests/block_pipeline.rs`.
+  - Architecture documentation added at `docs/architecture/block-pipeline.md`.
 - Phase 4.1 initial slice delivered: `runtime-mode kolme-live` now supports bounded continuous commit/finality execution when paired cycle controls are supplied (`--daemon-max-ticks` and `--daemon-tick-interval-ms`) with fail-closed guardrails for partial declarations (Task #2931, Subtask #2932).
 - Phase 4.1 live validation delivered:
   - Runtime lane: `scripts/kolme/validate_continuous_runtime_commit_live.sh` and `scripts/kolme/test_validate_continuous_runtime_commit_live.sh` (Task #2933, Subtask #2934).


### PR DESCRIPTION
## Summary
Implements the first Phase 3.2 mempool block production and consensus-validation pipeline slice in `kamn-core`.
Adds deterministic listener+approver quorum gating before commit, explicit fail-closed mismatch/empty-mempool guards, and runtime wiring visibility for `consensus-validator`.

Closes #2926
Closes #2927
Refs #2925

## Changes
- `crates/kamn-core/src/block_pipeline.rs`: added `MempoolBlockPipeline`, `BlockConsensusRoundInput`, `BlockPipelineCommitReport`, `BlockPipelineError`, deterministic payload digest flow, and fail-closed checks.
- `crates/kamn-core/src/smoke.rs`: added `RoleSmokeNetwork::processor_mempool_snapshot()` for pipeline orchestration.
- `crates/kamn-core/src/runtime.rs`: updated processor wiring to include `consensus-validator`.
- `crates/kamn-core/src/lib.rs`: exported new block-pipeline module/types.
- `crates/kamn-core/tests/block_pipeline.rs`: added functional/integration/regression tests.
- `crates/kamn-core/tests/block_pipeline_docs.rs`: added docs-contract/regression assertions.
- `docs/architecture/block-pipeline.md`: added architecture and validation contract doc.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded Phase 3.2 initial slice delivery.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test block_pipeline
```
Observed failure before implementation:
```text
error[E0432]: unresolved imports `kamn_core::BlockConsensusRoundInput`, `kamn_core::BlockPipelineError`, `kamn_core::MempoolBlockPipeline`
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-core --test block_pipeline --test block_pipeline_docs
```
Result:
```text
block_pipeline: 3 passed
block_pipeline_docs: 4 passed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-core -- -D warnings
cargo test -p kamn-core
```
Result:
```text
All passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `crates/kamn-core/src/block_pipeline.rs` internal tests | |
| Functional   | ✅     | `functional_block_pipeline_commits_after_listener_and_approver_quorum` | |
| Integration  | ✅     | `integration_bootstrap_processor_wiring_includes_consensus_validator_component` | |
| Regression   | ✅     | `regression_block_pipeline_rejects_payload_digest_mismatch_before_commit`; docs regression marker checks | |
| Performance  | N/A    | | This slice adds deterministic orchestration contracts only; no new throughput/latency code path requiring performance lane in this task. |

## Risks & Rollback
- No breaking API change for existing call sites.
- Risk: deterministic digest composition drift if transaction identity fields evolve; mitigated by regression coverage and docs contracts.
- Rollback plan: revert this commit to remove block-pipeline module and wiring change if integration unexpectedly regresses runtime composition.

## Documentation Updates
- `docs/architecture/block-pipeline.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (`cargo test -p kamn-core`)
- [x] Docs updated (or justified why not)
