### PR TITLE
feat(kamn-node): add execution-id log correlation contract

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -452,12 +452,21 @@ fn peer_lifecycle_state_as_str(state: PeerLifecycleState) -> &'static str {
     }
 }
 
+fn build_runtime_execution_id(runtime_mode: RuntimeMode, chain_id: &str, role: &str) -> String {
+    format!("node-runtime:{}:{chain_id}:{role}", runtime_mode.as_str())
+}
+
 fn run() -> Result<(), ConfigError> {
     let cli = parse_args(env::args())?;
     let runtime_mode = cli.runtime_mode.as_str();
+    let execution_id =
+        build_runtime_execution_id(cli.runtime_mode, cli.chain_id.as_str(), cli.role.as_str());
     log_info(
         "node.runtime.execute.start",
-        &[("runtime_mode", runtime_mode)],
+        &[
+            ("runtime_mode", runtime_mode),
+            ("execution_id", execution_id.as_str()),
+        ],
     )?;
     let output_mode = cli.output_mode;
     let service_api_endpoint_config =
@@ -484,6 +493,7 @@ fn run() -> Result<(), ConfigError> {
         &[
             ("runtime_mode", report.runtime_mode.as_str()),
             ("role", report.role.as_str()),
+            ("execution_id", execution_id.as_str()),
         ],
     )?;
     println!("{}", render_bootstrap_report(&report, output_mode));
@@ -502,13 +512,17 @@ fn run() -> Result<(), ConfigError> {
                 ("bind_addr", endpoint_config.bind_addr.as_str()),
                 ("max_requests", max_requests_label.as_str()),
                 ("idle_timeout_ms", idle_timeout_ms_label.as_str()),
+                ("execution_id", execution_id.as_str()),
             ],
         )?;
         serve_service_api_endpoint(&endpoint_config, &snapshot)
             .map_err(ConfigError::RuntimeDaemonLifecycle)?;
         log_info(
             "node.runtime.service_api.endpoint.complete",
-            &[("bind_addr", endpoint_config.bind_addr.as_str())],
+            &[
+                ("bind_addr", endpoint_config.bind_addr.as_str()),
+                ("execution_id", execution_id.as_str()),
+            ],
         )?;
     }
     if let Some(endpoint_config) = observability_endpoint_config {
@@ -527,13 +541,17 @@ fn run() -> Result<(), ConfigError> {
                 ("health_path", endpoint_config.health_path.as_str()),
                 ("max_requests", max_requests_label.as_str()),
                 ("idle_timeout_ms", idle_timeout_ms_label.as_str()),
+                ("execution_id", execution_id.as_str()),
             ],
         )?;
         serve_observability_endpoint(&endpoint_config, &snapshot)
             .map_err(ConfigError::RuntimeDaemonLifecycle)?;
         log_info(
             "node.runtime.observability.endpoint.complete",
-            &[("bind_addr", endpoint_config.bind_addr.as_str())],
+            &[
+                ("bind_addr", endpoint_config.bind_addr.as_str()),
+                ("execution_id", execution_id.as_str()),
+            ],
         )?;
     }
 
@@ -585,6 +603,8 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         output_mode: _,
         diagnostics_mode,
     } = cli;
+    let execution_id = build_runtime_execution_id(runtime_mode, chain_id.as_str(), role.as_str());
+
     let config = NodeConfig {
         chain_id: chain_id.clone(),
         chain_version: chain_version.clone(),
@@ -597,7 +617,10 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
     let plan = bootstrap(config)?;
     log_info(
         "node.runtime.mode.dispatch",
-        &[("runtime_mode", runtime_mode.as_str())],
+        &[
+            ("runtime_mode", runtime_mode.as_str()),
+            ("execution_id", execution_id.as_str()),
+        ],
     )?;
     let runtime_execution = match runtime_mode.kind {
         RuntimeModeKind::Bootstrap => {
@@ -606,6 +629,7 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 &[
                     ("chain_id", plan.config.chain_id.as_str()),
                     ("role", plan.config.role.as_str()),
+                    ("execution_id", execution_id.as_str()),
                 ],
             )?;
             RuntimeExecutionBundle::default()
@@ -674,6 +698,7 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                     ("runtime_mode", runtime_mode.as_str()),
                     ("max_ticks", max_ticks_label.as_str()),
                     ("tick_interval_ms", tick_interval_ms_label.as_str()),
+                    ("execution_id", execution_id.as_str()),
                 ],
             )?;
             let (peer_id, peer_lifecycle_final_state, peer_lifecycle_applied_events) =
@@ -729,6 +754,7 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                         "completion_reason",
                         daemon_completion.completion_reason.as_str(),
                     ),
+                    ("execution_id", execution_id.as_str()),
                 ],
             )?;
             RuntimeExecutionBundle {
@@ -754,7 +780,10 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         RuntimeModeKind::Api => {
             log_info(
                 "node.runtime.service_api.mode.ready",
-                &[("runtime_mode", runtime_mode.as_str())],
+                &[
+                    ("runtime_mode", runtime_mode.as_str()),
+                    ("execution_id", execution_id.as_str()),
+                ],
             )?;
             RuntimeExecutionBundle::default()
         }

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -176,6 +176,19 @@ fn integration_bootstrap_runtime_emits_structured_marker() {
             .any(|line| line.contains("\"event\":\"node.runtime.bootstrap.plan.ready\"")),
         "bootstrap runtime should emit structured bootstrap marker"
     );
+    let dispatch_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.mode.dispatch\""))
+        .expect("runtime dispatch marker should be emitted");
+    let ready_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.bootstrap.plan.ready\""))
+        .expect("bootstrap ready marker should be emitted");
+    let dispatch_execution_id = extract_json_string_field(dispatch_line, "execution_id")
+        .expect("runtime dispatch marker should include execution_id");
+    let ready_execution_id = extract_json_string_field(ready_line, "execution_id")
+        .expect("bootstrap ready marker should include execution_id");
+    assert_eq!(dispatch_execution_id, ready_execution_id);
 }
 
 #[test]
@@ -286,6 +299,8 @@ fn functional_runtime_daemon_emits_structured_transition_markers() {
         extract_json_string_field(start_line, "tick_interval_ms").as_deref(),
         Some("25")
     );
+    let start_execution_id = extract_json_string_field(start_line, "execution_id")
+        .expect("daemon start marker should include execution_id");
 
     let complete_line = captured_logs
         .iter()
@@ -303,6 +318,9 @@ fn functional_runtime_daemon_emits_structured_transition_markers() {
         extract_json_string_field(complete_line, "completion_reason").as_deref(),
         Some("tick-budget-exhausted")
     );
+    let complete_execution_id = extract_json_string_field(complete_line, "execution_id")
+        .expect("daemon completion marker should include execution_id");
+    assert_eq!(start_execution_id, complete_execution_id);
 }
 
 #[test]

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -43,6 +43,19 @@ This document captures the first implementation slice for deterministic observab
   - bounded endpoint lifetime controlled by `--observability-endpoint-max-requests` and `--observability-endpoint-idle-timeout-ms`.
   - no report-rendering mutation: text/json report contracts remain unchanged (`Regression: #2830`).
 
+## Structured Runtime Logging Correlation Contract (Issue #3032)
+- Runtime structured log events now include deterministic `execution_id` correlation fields for runtime-dispatch/start/complete lifecycle markers.
+- Contract markers include:
+  - `node.runtime.mode.dispatch`
+  - `node.runtime.bootstrap.plan.ready`
+  - `node.runtime.daemon.execute.start`
+  - `node.runtime.daemon.execute.complete`
+- `execution_id` format baseline:
+  - `node-runtime:<runtime_mode>:<chain_id>:<role>`
+- Regression policy:
+  - dispatch and completion/start markers for one execution must retain the same `execution_id`.
+  - missing `execution_id` in structured runtime markers fails closed (`Regression: #3033`).
+
 ## SLO Evaluation Rules
 - `LatencyP50`: warning when above max threshold.
 - `LatencyP99`: critical when above max threshold.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -16,6 +16,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Delivered in this slice: `FileContentAdapter` and `FileDidRegistrationChainAdapter` in `kamn-core` (Task #2901).
   - Live validation lane added for persistence adapter restart and fail-closed checks (Task #2903).
   - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
+- Post-roadmap hardening wave 1 initial slice delivered:
+  - Added deterministic `execution_id` structured logging correlation field for runtime dispatch/start/complete lifecycle events in `kamn-node` (Task #3032, Subtask #3033).
+  - Added regression assertions in `crates/kamn-node/src/main_tests/core_behavior_tests.rs` to fail closed when runtime structured events omit `execution_id`.
+  - Updated observability documentation contracts in `docs/foundation/observability-slo-dashboards.md`.
 - Phase 2.1 initial slice delivered: deterministic `runtime-mode api` ingress server with required messaging/channel/task/profile/health/metrics route contracts (Task #2906).
 - Phase 2.1 live validation delivered:
   - Runtime lane: `scripts/runtime/validate_service_api_live.sh` and `scripts/runtime/test_validate_service_api_live.sh` (Task #2908, Subtask #2909).


### PR DESCRIPTION
## Summary
Adds deterministic `execution_id` correlation fields to structured runtime lifecycle logs in `kamn-node` and enforces the contract via new regression assertions.
This is the first delivery slice under post-roadmap hardening wave 1 for structured logging/correlation.

Closes #3032
Closes #3033
Refs #3031
Refs #3030

## Changes
- `crates/kamn-node/src/main.rs`: added `build_runtime_execution_id` and propagated `execution_id` field into runtime structured events (`mode.dispatch`, bootstrap-ready, daemon start/complete, runtime execute start/complete, endpoint start/complete, api-ready).
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added/extended assertions requiring `execution_id` presence and consistency across bootstrap and daemon lifecycle markers.
- `docs/foundation/observability-slo-dashboards.md`: documented runtime structured logging correlation contract and regression policy.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded post-roadmap hardening wave 1 initial slice delivery status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Commands:
```bash
cargo test -p kamn-node integration_bootstrap_runtime_emits_structured_marker
cargo test -p kamn-node functional_runtime_daemon_emits_structured_transition_markers
```
Observed failures before implementation:
```text
runtime dispatch marker should include execution_id
daemon start marker should include execution_id
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-node integration_bootstrap_runtime_emits_structured_marker
cargo test -p kamn-node functional_runtime_daemon_emits_structured_transition_markers
```
Result:
```text
Both tests passed
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node
cargo test -p kamn-core --test observability_stack_docs
```
Result:
```text
All passed
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | | This slice changes runtime event wiring; coverage is functional/integration/regression focused. |
| Functional   | ✅     | `functional_runtime_daemon_emits_structured_transition_markers` updated with `execution_id` contract checks | |
| Integration  | ✅     | `integration_bootstrap_runtime_emits_structured_marker` updated with dispatch/bootstrap correlation checks | |
| Regression   | ✅     | New fail-closed assertions requiring `execution_id` presence/consistency | |
| Performance  | N/A    | | No algorithmic hot-path change; existing performance baselines remain unchanged. |

## Risks & Rollback
- Risk: downstream tooling parsing log events may need to tolerate added `execution_id` fields.
- Rollback plan: revert this commit to restore previous logging field set.
- Compatibility: additive structured field change only; no public API surface changes.

## Documentation Updates
- `docs/foundation/observability-slo-dashboards.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-node -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
