### PR TITLE
fix(kamn-node): add deterministic nonce retry/backoff resilience

### DIFF
--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -399,6 +399,60 @@ fn functional_kolme_live_retry_emits_structured_retry_markers() {
 }
 
 #[test]
+fn functional_kolme_live_nonce_retry_emits_structured_retry_marker() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"nonce unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"final"}"#,
+        ),
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("runtime should recover from transient nonce failure");
+    assert_eq!(report.runtime_mode, "kolme-live");
+
+    let nonce_retry_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"kolme.live.nonce.retry\""))
+        .expect("kolme-live retry flow should emit nonce retry marker");
+    assert_eq!(
+        extract_json_string_field(nonce_retry_line, "reason").as_deref(),
+        Some("unavailable")
+    );
+}
+
+#[test]
 fn regression_invalid_log_level_config_fails_closed() {
     let _lock = log_env_lock()
         .lock()

--- a/crates/kamn-node/src/main_tests/signer_tests.rs
+++ b/crates/kamn-node/src/main_tests/signer_tests.rs
@@ -502,9 +502,33 @@ fn integration_kolme_live_nonce_resolver_fetches_next_nonce() {
 }
 
 #[test]
+fn integration_kolme_live_nonce_resolver_retries_unavailable_then_succeeds() {
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"nonce unavailable\"}".to_owned(),
+        },
+        MockHttpReply::ok(r#"{"next_nonce":29,"account_id":"acct-2207"}"#),
+    ]);
+    let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
+    let pubkey = "03c9e9fd7028a8b17f4fbe0f6f7d38af2ec527f6bb2af04d4d2e2b0eb4f1f01b8a";
+
+    let nonce = resolve_kolme_live_nonce(base_url.as_str(), &mut transport, pubkey)
+        .expect("nonce resolver should recover from transient unavailable response");
+    assert_eq!(nonce, 29);
+
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        2,
+        "nonce resolver should retry once after unavailable response"
+    );
+}
+
+#[test]
 fn regression_kolme_live_nonce_resolver_rejects_malformed_response() {
     // Regression: #2207
-    let (base_url, _requests) = spawn_kolme_live_mock_server(vec![MockHttpReply::ok(
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![MockHttpReply::ok(
         r#"{"next_nonce":0,"account_id":"acct-2207"}"#,
     )]);
     let mut transport = KolmeRuntimeCommitHttpTransport::new(2).expect("transport should build");
@@ -517,6 +541,12 @@ fn regression_kolme_live_nonce_resolver_rejects_malformed_response() {
     assert!(
         matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("nonce response malformed")),
         "expected fail-closed nonce parser error"
+    );
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        1,
+        "malformed nonce responses must fail fast without retry"
     );
 }
 

--- a/crates/kamn-node/src/signer.rs
+++ b/crates/kamn-node/src/signer.rs
@@ -13,6 +13,7 @@ use kamn_core::{
 };
 use zeroize::Zeroize;
 
+use super::logging::log_warn;
 use super::wire_payload::render_kolme_live_native_direct_message;
 use super::{
     KOLME_LIVE_MANAGED_SIGNER_COMMAND_ENV, KOLME_LIVE_MANAGED_SIGNER_POLL_INTERVAL_MILLIS,
@@ -25,6 +26,10 @@ use super::{
     KOLME_LIVE_SIGNER_PROFILE_PRIMARY, KOLME_LIVE_SIGNER_PROFILE_SECONDARY,
     KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_ENV, KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX_SECONDARY_ENV,
 };
+
+const KOLME_LIVE_NONCE_RETRY_MAX_ATTEMPTS: u32 = 3;
+const KOLME_LIVE_NONCE_RETRY_BASE_BACKOFF_MILLIS: u64 = 10;
+const KOLME_LIVE_NONCE_RETRY_MAX_BACKOFF_MILLIS: u64 = 40;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct KolmeLiveSignerSelection {
@@ -1015,20 +1020,67 @@ pub(crate) fn resolve_kolme_live_nonce(
 ) -> Result<u64, ConfigError> {
     let request = KolmeApiNextNonceRequest::new(pubkey)
         .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
-    let response = transport
-        .fetch_next_nonce(base_url, KOLME_LIVE_NONCE_PATH, &request)
-        .map_err(|error| match error {
-            KolmeRuntimeCommitProviderError::Timeout => {
-                ConfigError::RuntimeKolmeLive("nonce request timed out".to_owned())
+    let mut attempt = 0_u32;
+    loop {
+        attempt += 1;
+        match transport.fetch_next_nonce(base_url, KOLME_LIVE_NONCE_PATH, &request) {
+            Ok(response) => return Ok(response.next_nonce),
+            Err(error) => {
+                if let Some(reason_code) = classify_nonce_retry_category(&error) {
+                    if attempt < KOLME_LIVE_NONCE_RETRY_MAX_ATTEMPTS {
+                        let attempt_label = attempt.to_string();
+                        let max_attempts_label = KOLME_LIVE_NONCE_RETRY_MAX_ATTEMPTS.to_string();
+                        log_warn(
+                            "kolme.live.nonce.retry",
+                            &[
+                                ("pubkey", pubkey),
+                                ("attempt", attempt_label.as_str()),
+                                ("max_attempts", max_attempts_label.as_str()),
+                                ("reason", reason_code),
+                            ],
+                        )?;
+                        maybe_sleep_nonce_retry_backoff(attempt);
+                        continue;
+                    }
+                }
+                return Err(map_nonce_provider_error(error));
             }
-            KolmeRuntimeCommitProviderError::Unavailable { reason } => {
-                ConfigError::RuntimeKolmeLive(format!("nonce request unavailable: {reason}"))
-            }
-            KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
-                ConfigError::RuntimeKolmeLive(format!("nonce response malformed: {reason}"))
-            }
-        })?;
-    Ok(response.next_nonce)
+        }
+    }
+}
+
+fn classify_nonce_retry_category(error: &KolmeRuntimeCommitProviderError) -> Option<&'static str> {
+    match error {
+        KolmeRuntimeCommitProviderError::Timeout => Some("timeout"),
+        KolmeRuntimeCommitProviderError::Unavailable { .. } => Some("unavailable"),
+        KolmeRuntimeCommitProviderError::MalformedResponse { .. } => None,
+    }
+}
+
+fn map_nonce_provider_error(error: KolmeRuntimeCommitProviderError) -> ConfigError {
+    match error {
+        KolmeRuntimeCommitProviderError::Timeout => {
+            ConfigError::RuntimeKolmeLive("nonce request timed out".to_owned())
+        }
+        KolmeRuntimeCommitProviderError::Unavailable { reason } => {
+            ConfigError::RuntimeKolmeLive(format!("nonce request unavailable: {reason}"))
+        }
+        KolmeRuntimeCommitProviderError::MalformedResponse { reason } => {
+            ConfigError::RuntimeKolmeLive(format!("nonce response malformed: {reason}"))
+        }
+    }
+}
+
+fn deterministic_nonce_retry_backoff_millis(attempt: u32) -> u64 {
+    let exponent = attempt.saturating_sub(1).min(4);
+    let multiplier = 1_u64 << exponent;
+    (KOLME_LIVE_NONCE_RETRY_BASE_BACKOFF_MILLIS * multiplier)
+        .min(KOLME_LIVE_NONCE_RETRY_MAX_BACKOFF_MILLIS)
+}
+
+fn maybe_sleep_nonce_retry_backoff(attempt: u32) {
+    let backoff = deterministic_nonce_retry_backoff_millis(attempt);
+    thread::sleep(Duration::from_millis(backoff));
 }
 
 pub(crate) fn build_kolme_live_direct_signed_wire_payload(
@@ -1101,7 +1153,10 @@ pub(crate) fn build_kolme_live_direct_signed_wire_payload(
 #[cfg(test)]
 mod tests {
     use super::KolmeForkSecp256k1SignerAdapter;
-    use super::{ConfigError, Duration, Instant};
+    use super::{
+        classify_nonce_retry_category, deterministic_nonce_retry_backoff_millis, ConfigError,
+        Duration, Instant, KolmeRuntimeCommitProviderError,
+    };
 
     const TEST_PRIVATE_KEY_HEX: &str =
         "658c3528422eb527b4c108b8f6d1e5f629543c304ea49cf608c67794424291c4";
@@ -1143,6 +1198,34 @@ mod tests {
             is_zeroized_hex_buffer(private_key_hex.as_str()),
             "private key hex buffer must be scrubbed after parse failure"
         );
+    }
+
+    #[test]
+    fn unit_nonce_retry_classifier_marks_transient_provider_errors() {
+        assert_eq!(
+            classify_nonce_retry_category(&KolmeRuntimeCommitProviderError::Timeout),
+            Some("timeout")
+        );
+        assert_eq!(
+            classify_nonce_retry_category(&KolmeRuntimeCommitProviderError::Unavailable {
+                reason: "network unavailable".to_owned(),
+            }),
+            Some("unavailable")
+        );
+        assert_eq!(
+            classify_nonce_retry_category(&KolmeRuntimeCommitProviderError::MalformedResponse {
+                reason: "missing next_nonce".to_owned(),
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn unit_nonce_retry_backoff_policy_is_deterministic_and_bounded() {
+        assert_eq!(deterministic_nonce_retry_backoff_millis(1), 10);
+        assert_eq!(deterministic_nonce_retry_backoff_millis(2), 20);
+        assert_eq!(deterministic_nonce_retry_backoff_millis(3), 40);
+        assert_eq!(deterministic_nonce_retry_backoff_millis(8), 40);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add deterministic retry/backoff for Kolme nonce fetch in `kamn-node` so transient provider failures recover instead of failing immediately. Keep malformed nonce responses fail-fast. This closes the nonce resiliency task/subtask under story #3038.

## Changes
- `crates/kamn-node/src/signer.rs`: added nonce retry classifier, bounded deterministic backoff, structured `kolme.live.nonce.retry` warning marker, and preserved fail-fast malformed mapping.
- `crates/kamn-node/src/main_tests/signer_tests.rs`: added integration test for transient unavailable recovery and strengthened malformed-response regression to assert no retry.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added functional log-contract test for `kolme.live.nonce.retry` marker emission.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node integration_kolme_live_nonce_resolver_retries_unavailable_then_succeeds`

Failure excerpt:
`nonce resolver should recover from transient unavailable response: RuntimeKolmeLive("nonce request unavailable: http response status indicates upstream failure: 503")`

Command:
`cargo test -p kamn-node functional_kolme_live_nonce_retry_emits_structured_retry_marker`

Failure excerpt:
`runtime should recover from transient nonce failure: RuntimeKolmeLive("nonce request unavailable: http response status indicates upstream failure: 503")`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node integration_kolme_live_nonce_resolver_retries_unavailable_then_succeeds`
- `cargo test -p kamn-node functional_kolme_live_nonce_retry_emits_structured_retry_marker`

Result: both pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node`

Result: all pass (`171` unit/module tests + node docs/contracts integration tests).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `signer::tests::unit_nonce_retry_classifier_marks_transient_provider_errors`, `signer::tests::unit_nonce_retry_backoff_policy_is_deterministic_and_bounded` | |
| Functional   | ✅     | `main_tests::core_behavior_tests::functional_kolme_live_nonce_retry_emits_structured_retry_marker` | |
| Integration  | ✅     | `main_tests::signer_tests::integration_kolme_live_nonce_resolver_retries_unavailable_then_succeeds` | |
| Regression   | ✅     | `main_tests::signer_tests::regression_kolme_live_nonce_resolver_rejects_malformed_response` (asserts fail-fast no retry) | |
| Performance  | N/A    | None | Existing retry backoff bounds are deterministic and low-latency; no new throughput path introduced |

## Risks & Rollback
- None.
- Rollback: revert this PR commit to restore previous single-attempt nonce behavior.

## Documentation Updates
- None required: behavior change is covered by code-level tests and structured log contract assertions in existing docs-guarded test suites.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #3039
Closes #3040
Refs #3038
