### PR TITLE
refactor(runtime): migrate deep wrapper tranche to dispatcher manifests

### DIFF
--- a/scripts/framework/manifests/runtime_concurrency_state_mutation_deep_lane.json
+++ b/scripts/framework/manifests/runtime_concurrency_state_mutation_deep_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "runtime.concurrency_state_mutation.deep",
+  "evidence_key": "concurrency_state_mutation_deep_lane:v1",
+  "reason_key": "runtime_concurrency_state_mutation_deep_reason_codes:GO:v1",
+  "phases": {
+    "deep": [
+      "bash",
+      "scripts/runtime/run_concurrency_state_mutation_deep_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/manifests/runtime_live_network_partition_reconnect_deep_lane.json
+++ b/scripts/framework/manifests/runtime_live_network_partition_reconnect_deep_lane.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "runtime.live_network_partition_reconnect.deep",
+  "evidence_key": "live_network_partition_reconnect_deep_lane:v1",
+  "reason_key": "runtime_live_network_partition_reconnect_deep_reason_codes:GO:v1",
+  "phases": {
+    "deep": [
+      "python3",
+      "scripts/runtime/live_network_partition_reconnect_contract.py",
+      "run-deep"
+    ]
+  }
+}

--- a/scripts/framework/manifests/runtime_runtime_snapshot_deep_lane.json
+++ b/scripts/framework/manifests/runtime_runtime_snapshot_deep_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "runtime.runtime_snapshot.deep",
+  "evidence_key": "runtime_snapshot_deep_lane:v1",
+  "reason_key": "runtime_snapshot_deep_reason_codes:GO:v1",
+  "phases": {
+    "deep": [
+      "bash",
+      "scripts/runtime/run_runtime_snapshot_deep_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/manifests/runtime_zk_witness_mutation_deep_lane.json
+++ b/scripts/framework/manifests/runtime_zk_witness_mutation_deep_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "runtime.zk_witness_mutation.deep",
+  "evidence_key": "zk_witness_mutation_deep_lane:v1",
+  "reason_key": "runtime_zk_witness_mutation_deep_reason_codes:GO:v1",
+  "phases": {
+    "deep": [
+      "bash",
+      "scripts/runtime/run_zk_witness_mutation_deep_lane_impl.sh"
+    ]
+  }
+}

--- a/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
+++ b/scripts/framework/run_non_kolme_contract_lane_dispatch.sh
@@ -129,12 +129,14 @@ resolve_manifest_name() {
     run_staging_rehearsal_contract_lane.sh) echo "deploy_staging_rehearsal_contract_lane.json" ;;
     run_task_operation_snapshot_contract_lane.sh) echo "task_task_operation_snapshot_contract_lane.json" ;;
     run_concurrency_state_mutation_contract_lane.sh) echo "runtime_concurrency_state_mutation_contract_lane.json" ;;
+    run_concurrency_state_mutation_deep_lane.sh) echo "runtime_concurrency_state_mutation_deep_lane.json" ;;
     run_failover_sync_drill_preflight_contract_lane.sh) echo "runtime_failover_sync_drill_preflight_contract_lane.json" ;;
     run_input_mutation_contract_lane.sh) echo "runtime_input_mutation_contract_lane.json" ;;
     run_input_mutation_coverage_guided_contract_lane.sh) echo "runtime_input_mutation_coverage_guided_contract_lane.json" ;;
     run_invariant_fuzz_concurrency_contract_lane.sh) echo "runtime_invariant_fuzz_concurrency_contract_lane.json" ;;
     run_lifecycle_property_contract_lane.sh) echo "runtime_lifecycle_property_contract_lane.json" ;;
     run_live_network_partition_reconnect_smoke_lane.sh) echo "runtime_live_network_partition_reconnect_smoke_lane.json" ;;
+    run_live_network_partition_reconnect_deep_lane.sh) echo "runtime_live_network_partition_reconnect_deep_lane.json" ;;
     run_network_signer_finality_failure_drills_lane.sh) echo "runtime_network_signer_finality_failure_drills_lane.json" ;;
     run_live_network_partition_reconnect_contract_lane.sh) echo "runtime_live_network_partition_reconnect_contract_lane.json" ;;
     run_live_network_pilot_deep_lane.sh) echo "runtime_live_network_pilot_deep_lane.json" ;;
@@ -144,8 +146,10 @@ resolve_manifest_name() {
     run_live_network_smoke_contract_lane.sh) echo "runtime_live_network_smoke_contract_lane.json" ;;
     run_processor_proof_admission_contract_lane.sh) echo "runtime_processor_proof_admission_contract_lane.json" ;;
     run_runtime_snapshot_contract_lane.sh) echo "runtime_runtime_snapshot_contract_lane.json" ;;
+    run_runtime_snapshot_deep_lane.sh) echo "runtime_runtime_snapshot_deep_lane.json" ;;
     run_watchdog_proof_consensus_contract_lane.sh) echo "runtime_watchdog_proof_consensus_contract_lane.json" ;;
     run_zk_witness_mutation_contract_lane.sh) echo "runtime_zk_witness_mutation_contract_lane.json" ;;
+    run_zk_witness_mutation_deep_lane.sh) echo "runtime_zk_witness_mutation_deep_lane.json" ;;
     run_soc2_control_evidence_contract_lane.sh) echo "compliance_soc2_control_evidence_contract_lane.json" ;;
     run_stake_slash_risk_contract_lane.sh) echo "governance_stake_slash_risk_contract_lane.json" ;;
     run_telegram_ingress_contract_lane.sh) echo "bridge_telegram_ingress_contract_lane.json" ;;
@@ -168,6 +172,7 @@ resolve_phase_name() {
     run_network_signer_finality_failure_drills_lane.sh) echo "run" ;;
     run_live_network_pilot_deep_lane.sh) echo "run" ;;
     run_live_network_partition_reconnect_smoke_lane.sh) echo "run" ;;
+    run_live_network_partition_reconnect_deep_lane.sh) echo "deep" ;;
     run_quorum_attestation_replay_guard_lane.sh) echo "run" ;;
     run_governance_lifecycle_rollback_lane.sh) echo "run" ;;
     run_dashboard_shell_determinism_matrix_lane.sh) echo "run" ;;
@@ -177,6 +182,9 @@ resolve_phase_name() {
     run_dashboard_stale_error_budget_lane.sh) echo "run" ;;
     run_signer_incident_recovery_deep_lane.sh) echo "deep" ;;
     run_signer_provider_deep_lane.sh) echo "deep" ;;
+    run_concurrency_state_mutation_deep_lane.sh) echo "deep" ;;
+    run_runtime_snapshot_deep_lane.sh) echo "deep" ;;
+    run_zk_witness_mutation_deep_lane.sh) echo "deep" ;;
     run_signer_incident_recovery_lane.sh) echo "run" ;;
     *) echo "contract" ;;
   esac

--- a/scripts/framework/test_non_kolme_wave19_lightweight_contract_lane_dispatch_wrapper_matrix.sh
+++ b/scripts/framework/test_non_kolme_wave19_lightweight_contract_lane_dispatch_wrapper_matrix.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected non-Kolme contract-lane dispatcher to be executable: $DISPATCHER" >&2
+  exit 1
+fi
+
+lane_wrappers=(
+  "scripts/runtime/run_concurrency_state_mutation_deep_lane.sh"
+  "scripts/runtime/run_runtime_snapshot_deep_lane.sh"
+  "scripts/runtime/run_zk_witness_mutation_deep_lane.sh"
+  "scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh"
+)
+
+for wrapper_rel_path in "${lane_wrappers[@]}"; do
+  wrapper_path="$ROOT_DIR/$wrapper_rel_path"
+  wrapper_name="$(basename "$wrapper_path")"
+
+  if [ ! -x "$wrapper_path" ]; then
+    echo "expected lightweight wrapper to be executable: $wrapper_path" >&2
+    exit 1
+  fi
+
+  if [ ! -L "$wrapper_path" ]; then
+    echo "expected lightweight wrapper to be a symlink to shared dispatcher: $wrapper_path" >&2
+    exit 1
+  fi
+
+  manifest_path="$(bash "$DISPATCHER" --lane-wrapper "$wrapper_name" --resolve-manifest-path)"
+  if [ ! -f "$manifest_path" ]; then
+    echo "expected dispatcher to resolve existing manifest for $wrapper_name: $manifest_path" >&2
+    exit 1
+  fi
+done
+
+if bash "$DISPATCHER" --lane-wrapper run_missing_non_kolme_wave19_lightweight_contract_lane.sh --resolve-manifest-path >/dev/null 2>&1; then
+  echo "expected non-Kolme dispatcher to fail for unknown wave-19 lightweight wrapper" >&2
+  exit 1
+fi
+
+echo "non-Kolme wave-19 lightweight contract lane dispatcher wrapper matrix tests passed."

--- a/scripts/runtime/run_concurrency_state_mutation_deep_lane.sh
+++ b/scripts/runtime/run_concurrency_state_mutation_deep_lane.sh
@@ -1,10 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$ROOT_DIR"
-
-bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh >/dev/null
-cargo test -p kamn-core --test concurrency_state_mutation performance_concurrency_state_mutation_deep_lane_stress -- --ignored >/dev/null
-
-echo "runtime concurrency state mutation deep lane tests passed."
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/runtime/run_concurrency_state_mutation_deep_lane_impl.sh
+++ b/scripts/runtime/run_concurrency_state_mutation_deep_lane_impl.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+bash scripts/runtime/run_concurrency_state_mutation_contract_lane.sh >/dev/null
+cargo test -p kamn-core --test concurrency_state_mutation performance_concurrency_state_mutation_deep_lane_stress -- --ignored >/dev/null
+
+echo "runtime concurrency state mutation deep lane tests passed."

--- a/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh
+++ b/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-exec python3 "$ROOT_DIR/scripts/runtime/live_network_partition_reconnect_contract.py" run-deep "$@"
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/runtime/run_runtime_snapshot_deep_lane.sh
+++ b/scripts/runtime/run_runtime_snapshot_deep_lane.sh
@@ -1,11 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_runtime_snapshot_contract_lane.sh"
-
-bash "$CONTRACT_LANE"
-
-cargo test -p kamn-core runtime::tests::performance_file_snapshot_store_recovery_deep_lane_large_payload -- --ignored >/dev/null
-
-echo "runtime snapshot deep lane tests passed."
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/runtime/run_runtime_snapshot_deep_lane_impl.sh
+++ b/scripts/runtime/run_runtime_snapshot_deep_lane_impl.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/run_runtime_snapshot_contract_lane.sh"
+
+bash "$CONTRACT_LANE"
+
+cargo test -p kamn-core runtime::tests::performance_file_snapshot_store_recovery_deep_lane_large_payload -- --ignored >/dev/null
+
+echo "runtime snapshot deep lane tests passed."

--- a/scripts/runtime/run_zk_witness_mutation_deep_lane.sh
+++ b/scripts/runtime/run_zk_witness_mutation_deep_lane.sh
@@ -1,10 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-FAST_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
-
-bash "$FAST_LANE" >/dev/null
-cargo test -p kamn-core --test zk_witness_fuzz_smoke performance_zk_witness_mutation_deep_lane_stress -- --ignored >/dev/null
-
-echo "runtime zk witness mutation deep lane tests passed."
+../framework/run_non_kolme_contract_lane_dispatch.sh

--- a/scripts/runtime/run_zk_witness_mutation_deep_lane_impl.sh
+++ b/scripts/runtime/run_zk_witness_mutation_deep_lane_impl.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAST_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
+
+bash "$FAST_LANE" >/dev/null
+cargo test -p kamn-core --test zk_witness_fuzz_smoke performance_zk_witness_mutation_deep_lane_stress -- --ignored >/dev/null
+
+echo "runtime zk witness mutation deep lane tests passed."

--- a/scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
+++ b/scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
@@ -7,6 +7,8 @@ SHARED_CONTRACT="$ROOT_DIR/scripts/runtime/concurrency_state_mutation_contract_l
 MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_concurrency_state_mutation_contract_lane.json"
 DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/runtime/run_concurrency_state_mutation_deep_lane.sh"
+DEEP_IMPL="$ROOT_DIR/scripts/runtime/run_concurrency_state_mutation_deep_lane_impl.sh"
+DEEP_MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_concurrency_state_mutation_deep_lane.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -17,6 +19,11 @@ fi
 
 if [ ! -x "$DEEP_SCRIPT" ]; then
   echo "expected runtime concurrency state mutation deep lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_IMPL" ]; then
+  echo "expected runtime concurrency state mutation deep lane implementation script to be executable" >&2
   exit 1
 fi
 
@@ -111,13 +118,34 @@ if ! grep -Fq "concurrency_state_mutation_contract_lane_contract.sh" "$MANIFEST_
   exit 1
 fi
 
-if ! grep -Fq "run_concurrency_state_mutation_contract_lane.sh" "$DEEP_SCRIPT"; then
-  echo "expected deep lane to execute concurrency contract lane baseline first" >&2
+if [ ! -L "$DEEP_SCRIPT" ]; then
+  echo "expected runtime concurrency state mutation deep lane wrapper to be a dispatcher symlink" >&2
   exit 1
 fi
 
-if ! grep -q "performance_concurrency_state_mutation_deep_lane_stress -- --ignored" "$DEEP_SCRIPT"; then
-  echo "expected deep lane to execute ignored concurrency stress test" >&2
+if [ "$(readlink "$DEEP_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected runtime concurrency state mutation deep lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_deep_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$DEEP_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_deep_manifest" != "$DEEP_MANIFEST_FILE" ]; then
+  echo "expected runtime concurrency state mutation deep lane wrapper to resolve runtime deep manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_concurrency_state_mutation_deep_lane_impl.sh" "$DEEP_MANIFEST_FILE"; then
+  echo "expected runtime concurrency state mutation deep manifest to dispatch implementation module" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_concurrency_state_mutation_contract_lane.sh" "$DEEP_IMPL"; then
+  echo "expected deep lane implementation to execute concurrency contract lane baseline first" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_concurrency_state_mutation_deep_lane_stress -- --ignored" "$DEEP_IMPL"; then
+  echo "expected deep lane implementation to execute ignored concurrency stress test" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh
+++ b/scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh
@@ -3,11 +3,34 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEEP_LANE="$ROOT_DIR/scripts/runtime/run_live_network_partition_reconnect_deep_lane.sh"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_live_network_partition_reconnect_deep_lane.json"
 TMP_REPORT="$(mktemp)"
 trap 'rm -f "$TMP_REPORT"' EXIT
 
 if [ ! -x "$DEEP_LANE" ]; then
   echo "expected partition/reconnect deep lane script to be executable" >&2
+  exit 1
+fi
+
+if [ ! -L "$DEEP_LANE" ]; then
+  echo "expected partition/reconnect deep lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$DEEP_LANE")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected partition/reconnect deep lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$DEEP_LANE")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST_FILE" ]; then
+  echo "expected partition/reconnect deep lane wrapper to resolve runtime deep manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -q '"run-deep"' "$MANIFEST_FILE"; then
+  echo "expected partition/reconnect deep manifest to dispatch python deep runner entrypoint" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
+++ b/scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
@@ -7,6 +7,8 @@ SHARED_CONTRACT="$ROOT_DIR/scripts/runtime/runtime_snapshot_contract_lane_contra
 MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_runtime_snapshot_contract_lane.json"
 DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/runtime/run_runtime_snapshot_deep_lane.sh"
+DEEP_IMPL="$ROOT_DIR/scripts/runtime/run_runtime_snapshot_deep_lane_impl.sh"
+DEEP_MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_runtime_snapshot_deep_lane.json"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected runtime snapshot fast-lane runner to be executable" >&2
@@ -15,6 +17,11 @@ fi
 
 if [ ! -x "$DEEP_SCRIPT" ]; then
   echo "expected runtime snapshot deep-lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DEEP_IMPL" ]; then
+  echo "expected runtime snapshot deep-lane implementation runner to be executable" >&2
   exit 1
 fi
 
@@ -177,13 +184,34 @@ if ! grep -q "run_live_network_smoke_contract_lane.sh" "$SHARED_CONTRACT"; then
   exit 1
 fi
 
-if ! grep -Fq "run_runtime_snapshot_contract_lane.sh" "$DEEP_SCRIPT"; then
-  echo "expected deep-lane script to execute runtime snapshot fast-lane checks first" >&2
+if [ ! -L "$DEEP_SCRIPT" ]; then
+  echo "expected runtime snapshot deep-lane wrapper to be a dispatcher symlink" >&2
   exit 1
 fi
 
-if ! grep -q "performance_file_snapshot_store_recovery_deep_lane_large_payload -- --ignored" "$DEEP_SCRIPT"; then
-  echo "expected deep-lane script to run ignored snapshot recovery stress test" >&2
+if [ "$(readlink "$DEEP_SCRIPT")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected runtime snapshot deep-lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_deep_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$DEEP_SCRIPT")" --resolve-manifest-path)"
+if [ "$resolved_deep_manifest" != "$DEEP_MANIFEST_FILE" ]; then
+  echo "expected runtime snapshot deep-lane wrapper to resolve runtime deep manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_runtime_snapshot_deep_lane_impl.sh" "$DEEP_MANIFEST_FILE"; then
+  echo "expected runtime snapshot deep-lane manifest to dispatch implementation module" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_runtime_snapshot_contract_lane.sh" "$DEEP_IMPL"; then
+  echo "expected deep-lane implementation to execute runtime snapshot fast-lane checks first" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_file_snapshot_store_recovery_deep_lane_large_payload -- --ignored" "$DEEP_IMPL"; then
+  echo "expected deep-lane implementation to run ignored snapshot recovery stress test" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh
+++ b/scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_contract_lane.sh"
 DEEP_LANE="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_deep_lane.sh"
+DEEP_LANE_IMPL="$ROOT_DIR/scripts/runtime/run_zk_witness_mutation_deep_lane_impl.sh"
+DEEP_MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_zk_witness_mutation_deep_lane.json"
+DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
 
 if [ ! -x "$FAST_LANE" ]; then
   echo "expected runtime zk witness mutation fast-lane script to be executable" >&2
@@ -15,13 +18,39 @@ if [ ! -x "$DEEP_LANE" ]; then
   exit 1
 fi
 
-if ! grep -Fq "run_zk_witness_mutation_contract_lane.sh" "$DEEP_LANE"; then
-  echo "expected zk witness mutation deep lane to execute fast-lane checks first" >&2
+if [ ! -x "$DEEP_LANE_IMPL" ]; then
+  echo "expected runtime zk witness mutation deep-lane implementation script to be executable" >&2
   exit 1
 fi
 
-if ! grep -q "performance_zk_witness_mutation_deep_lane_stress -- --ignored" "$DEEP_LANE"; then
-  echo "expected zk witness mutation deep lane to include ignored deep stress coverage" >&2
+if [ ! -L "$DEEP_LANE" ]; then
+  echo "expected runtime zk witness mutation deep-lane wrapper to be a dispatcher symlink" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$DEEP_LANE")" != "../framework/run_non_kolme_contract_lane_dispatch.sh" ]; then
+  echo "expected runtime zk witness mutation deep-lane wrapper to target shared non-Kolme dispatcher" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$DEEP_LANE")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$DEEP_MANIFEST_FILE" ]; then
+  echo "expected runtime zk witness mutation deep-lane wrapper to resolve runtime deep manifest via dispatcher" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_zk_witness_mutation_deep_lane_impl.sh" "$DEEP_MANIFEST_FILE"; then
+  echo "expected runtime zk witness mutation deep-lane manifest to dispatch implementation module" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_zk_witness_mutation_contract_lane.sh" "$DEEP_LANE_IMPL"; then
+  echo "expected zk witness mutation deep lane implementation to execute fast-lane checks first" >&2
+  exit 1
+fi
+
+if ! grep -q "performance_zk_witness_mutation_deep_lane_stress -- --ignored" "$DEEP_LANE_IMPL"; then
+  echo "expected zk witness mutation deep lane implementation to include ignored deep stress coverage" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #3054

## Summary
Migrates a bounded runtime deep-lane wrapper tranche onto the shared non-Kolme dispatcher and manifest framework. This keeps deep lane behavior unchanged while enforcing fail-closed wrapper-to-manifest resolution and reducing bespoke wrapper drift risk.

## Changes
- scripts/framework/run_non_kolme_contract_lane_dispatch.sh: add manifest and phase mappings for migrated runtime deep wrappers.
- scripts/framework/manifests/runtime_*_deep_lane.json: add four runtime deep-lane manifests.
- scripts/runtime/run_*_deep_lane.sh: convert four runtime deep wrappers to dispatcher symlinks.
- scripts/runtime/run_*_deep_lane_impl.sh: add implementation runners for concurrency/snapshot/zk deep lanes.
- scripts/runtime/test_*deep*: update runtime deep-lane tests to assert symlink+manifest+impl wiring.
- scripts/framework/test_non_kolme_wave19_lightweight_contract_lane_dispatch_wrapper_matrix.sh: add wrapper-matrix fail-closed coverage for this tranche.

## Risks & Compatibility
- None

## Validation
- [ ] cargo fmt --check - clean
- [ ] cargo clippy -- -D warnings - clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: targeted deep-lane wrapper/manifest tests pass and fail-closed unknown-wrapper path is validated.

Executed validations:
- bash scripts/framework/test_non_kolme_wave19_lightweight_contract_lane_dispatch_wrapper_matrix.sh
- bash scripts/framework/test_non_kolme_lightweight_contract_lane_dispatch_wrapper_matrix.sh
- bash scripts/runtime/test_run_live_network_partition_reconnect_deep_lane.sh
- bash scripts/runtime/test_run_zk_witness_mutation_deep_lane.sh
- bash scripts/runtime/test_run_concurrency_state_mutation_contract_lane.sh
- bash scripts/runtime/test_run_runtime_snapshot_contract_lane.sh
- bash scripts/runtime/test_run_live_network_pilot_deep_lane.sh
- bash scripts/ci/check_non_kolme_wave19_wrapper_family_budget_trend.sh --matrix-file fixtures/ci/non_kolme_wave19_wrapper_family_matrix.json --baseline-file fixtures/ci/non_kolme_wave19_wrapper_family_baseline.json

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Shell/python framework unit behavior exercised via wrapper/manifest contract tests |
| Functional  | ✅ | Deep-lane scripts execute and emit expected success markers |
| Integration | ✅ | Dispatcher resolves wrappers to manifests and executes deep-phase routes |
| Regression  | ✅ | Unknown-wrapper dispatch path fails closed in matrix test |
