### PR TITLE
test(kolme): add managed-signer startup live validation lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,34 @@ bash scripts/kolme/run_managed_signer_backend_slo_policy_contract_lane.sh --outp
 # managed_signer_backend_replay_ci_fast_gate
 ```
 
+### Managed Signer Startup Live Validation Contract Lane
+
+```bash
+# managed-signer startup live validation contract lane (local/scheduled default)
+bash scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh \
+  --output-json /tmp/managed-signer-startup-live-validation-contract-report.json
+
+# schema: kamn.kolme.managed-signer-startup-live-validation-contract-report.v1
+# status=pass
+# final_decision=GO
+# managed_signer_profile_status=verified
+# managed_signer_missing_key_source_fail_closed_status=verified
+# managed_signer_invalid_profile_fail_closed_status=verified
+# managed_signer_stale_rotation_fail_closed_status=verified
+# managed_signer_reason_code_status=verified
+# execution_scope=local-scheduled
+# baseline pass marker: deployment_preflight_passed
+# missing key-source fail-closed markers
+# checkpoint_failed_signer_provenance_contract
+# signer_key_source_production_managed_external_required
+# invalid signer-profile fail-closed markers
+# checkpoint_failed_signer_profile_contract
+# signer_profile_mismatch
+# stale-rotation fail-closed markers
+# checkpoint_failed_signer_rotation_freshness_contract
+# signer_rotation_epoch_stale
+```
+
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`
 
 ### Run Local Live-Node Validation Bundle Lane

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -212,6 +212,29 @@ Cost boundary:
 - generation + policy + contract-lane checks are offline, bounded, and PR fast-gate friendly.
 - no local-heavy selector or external metrics backend calls are required.
 
+## Managed-Signer Startup Live Validation Contract Lane
+Managed-signer startup validation for production profile admission and fail-closed reason-code drills is emitted through:
+
+- `scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh`
+- `scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py`
+
+Deterministic contract markers:
+
+- `kamn.kolme.managed-signer-startup-live-validation-contract-report.v1`
+- `deployment_preflight_passed`
+- `checkpoint_failed_signer_provenance_contract`
+- `checkpoint_failed_signer_profile_contract`
+- `checkpoint_failed_signer_rotation_freshness_contract`
+- `signer_key_source_production_managed_external_required`
+- `signer_profile_mismatch`
+- `signer_rotation_epoch_stale`
+- `execution_scope=local-scheduled`
+
+Cost boundary:
+
+- lane runtime is hard-bounded by `--max-seconds`.
+- lane defaults to local/scheduled execution (`ci_fast_gate_eligible=false`) to avoid PR fast-gate runtime cost.
+
 ## Script-Surface Budget Policy
 `scripts/ci/check_script_duplication_budget.py` computes deterministic metrics over non-test shell command surface under `scripts/**/*.sh`:
 

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -884,6 +884,35 @@ JSON`
   - checker and contract lane remain local-fast and bounded.
   - no local-heavy selector or external metrics backend call is required.
 
+## Managed Signer Startup Live Validation Contract Lane (Issue #3067)
+
+- Managed-signer startup live validation contract lane:
+  - `bash scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh --output-json /tmp/managed-signer-startup-live-validation-contract-report.json`
+- Required schema/decision markers:
+  - `kamn.kolme.managed-signer-startup-live-validation-contract-report.v1`
+  - `status=pass`
+  - `final_decision=GO`
+  - `managed_signer_profile_status=verified`
+  - `managed_signer_missing_key_source_fail_closed_status=verified`
+  - `managed_signer_invalid_profile_fail_closed_status=verified`
+  - `managed_signer_stale_rotation_fail_closed_status=verified`
+  - `managed_signer_reason_code_status=verified`
+  - `execution_scope=local-scheduled`
+- Fault-injection matrix and deterministic fail-closed reason codes:
+  - missing managed-external key source:
+    - checkpoint: `checkpoint_failed_signer_provenance_contract`
+    - policy reason: `signer_key_source_production_managed_external_required`
+  - invalid signer profile:
+    - checkpoint: `checkpoint_failed_signer_profile_contract`
+    - policy reason: `signer_profile_mismatch`
+  - stale signer rotation metadata:
+    - checkpoint: `checkpoint_failed_signer_rotation_freshness_contract`
+    - policy reason: `signer_rotation_epoch_stale`
+- Cost policy:
+  - lane runtime is bounded via `--max-seconds`.
+  - lane is local/scheduled by default (`ci_fast_gate_eligible=false`).
+  - lane composes existing deployment preflight runner/policy checker and does not call external infrastructure.
+
 ## Staging Soak Telemetry Lane (Issue #2422)
 
 - Fast lane command:

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -41,6 +41,15 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Post-roadmap hardening wave 2 runtime decomposition tranche 3 delivered:
   - Extracted watchdog/transport-coordination simulation orchestration from `crates/kamn-core/src/runtime.rs` into dedicated module `crates/kamn-core/src/runtime_transport_coordination.rs` with unchanged external behavior (Task #3050, Subtask #3059).
   - Module-ownership contract documented in `docs/foundation/runtime-network.md` and enforced by `crates/kamn-core/tests/runtime_network_docs.rs` and `crates/kamn-core/tests/runtime_module_extraction_contract.rs`.
+- Post-roadmap hardening wave 3 managed-signer startup live validation delivered:
+  - Contract lane: `scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh` and `scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh` (Subtask #3067).
+  - Contract report schema: `kamn.kolme.managed-signer-startup-live-validation-contract-report.v1`.
+  - Baseline startup pass marker: `deployment_preflight_passed`.
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `managed_signer_profile_status=verified`, `managed_signer_reason_code_status=verified`, `execution_scope=local-scheduled`, `performance_budget_status=verified`.
+  - Fail-closed validation confirmed for startup fault-injection matrix:
+    - missing managed-external key-source contract: `checkpoint_failed_signer_provenance_contract` + `signer_key_source_production_managed_external_required`
+    - invalid signer profile: `checkpoint_failed_signer_profile_contract` + `signer_profile_mismatch`
+    - stale signer rotation metadata: `checkpoint_failed_signer_rotation_freshness_contract` + `signer_rotation_epoch_stale`
 - Phase 2.1 initial slice delivered: deterministic `runtime-mode api` ingress server with required messaging/channel/task/profile/health/metrics route contracts (Task #2906).
 - Phase 2.1 live validation delivered:
   - Runtime lane: `scripts/runtime/validate_service_api_live.sh` and `scripts/runtime/test_validate_service_api_live.sh` (Task #2908, Subtask #2909).

--- a/scripts/framework/manifests/kolme_managed_signer_startup_live_validation_contract_lane.json
+++ b/scripts/framework/manifests/kolme_managed_signer_startup_live_validation_contract_lane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kamn.contract-lane.manifest.v1",
+  "lane_id": "kolme.managed_signer_startup_live_validation.contract",
+  "evidence_key": "kolme_managed_signer_startup_live_validation_contract_lane:v1",
+  "reason_key": "kolme_managed_signer_startup_live_validation_contract_lane_reason_codes:GO:v1",
+  "phases": {
+    "contract": [
+      "python3",
+      "scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py"
+    ]
+  }
+}

--- a/scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py
+++ b/scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Contract lane for managed-signer startup live validation behavior."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+RUNNER = ROOT_DIR / "scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh"
+CHECKER = ROOT_DIR / "scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py"
+DOC_FILES = [
+    ROOT_DIR / "docs/planning/kolme-devnet-ops.md",
+    ROOT_DIR / "docs/ci/ci-cost-and-lane-framework.md",
+    ROOT_DIR / "docs/plans/2026-02-08-production-service-roadmap.md",
+    ROOT_DIR / "README.md",
+]
+DOC_MARKERS = [
+    "run_managed_signer_startup_live_validation_contract_lane.sh",
+    "kamn.kolme.managed-signer-startup-live-validation-contract-report.v1",
+    "deployment_preflight_passed",
+    "checkpoint_failed_signer_profile_contract",
+    "checkpoint_failed_signer_provenance_contract",
+    "checkpoint_failed_signer_rotation_freshness_contract",
+    "signer_key_source_production_managed_external_required",
+    "signer_profile_mismatch",
+    "signer_rotation_epoch_stale",
+    "execution_scope=local-scheduled",
+]
+
+PRIMARY_TEST_PRIVATE_KEY_HEX = "1" * 64
+SECONDARY_TEST_PRIVATE_KEY_HEX = "2" * 64
+
+
+def run_command(command: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def ensure_markers_present(text: str, markers: list[str], source_name: str) -> list[str]:
+    missing: list[str] = []
+    for marker in markers:
+        if marker not in text:
+            missing.append(f"{source_name}_missing_marker:{marker}")
+    return missing
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected JSON object in {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_evidence_bundle(case_dir: Path) -> tuple[Path, Path, Path]:
+    custody_path = case_dir / "custody.json"
+    provenance_path = case_dir / "provenance.json"
+    quorum_path = case_dir / "quorum.json"
+
+    custody_payload = {
+        "schema_version": "kamn.kolme.runtime-signer-custody.v1",
+        "attestation": "ops-primary custody epoch-3",
+    }
+    _write_json(custody_path, custody_payload)
+    custody_sha256 = hashlib.sha256(custody_path.read_bytes()).hexdigest()
+
+    provenance_payload = {
+        "schema_version": "kamn.kolme.runtime-signer-provenance.v1",
+        "source": "managed-external",
+        "signer_profile": "ops-primary",
+    }
+    _write_json(provenance_path, provenance_payload)
+
+    quorum_payload = {
+        "schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+        "required_approvals": 2,
+        "received_approvals": 2,
+        "approved_signers": ["ops-primary", "ops-secondary"],
+        "signer_roles": {"ops-primary": "primary", "ops-secondary": "secondary"},
+        "signer_rotation_epochs": {"ops-primary": 3, "ops-secondary": 2},
+        "custody_evidence_sha256": custody_sha256,
+    }
+    _write_json(quorum_path, quorum_payload)
+    return custody_path, provenance_path, quorum_path
+
+
+def _assert_marker(output: str, marker: str, message: str) -> None:
+    if marker not in output:
+        raise RuntimeError(message)
+
+
+def run_preflight_scenario(
+    *,
+    temp_root: Path,
+    scenario_id: str,
+    signer_profile: str,
+    signer_key_source: str,
+    signer_rotation_epoch: int,
+    signer_previous_rotation_epoch: int,
+    expected_runner_status: str,
+    expected_reason_code: str,
+    expected_final_decision: str,
+    expected_policy_reason_code: str | None,
+) -> dict[str, Any]:
+    case_dir = temp_root / scenario_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+    custody_path, provenance_path, quorum_path = _write_evidence_bundle(case_dir)
+    summary_path = case_dir / "summary.json"
+    policy_path = case_dir / "policy.json"
+
+    env = os.environ.copy()
+    env["KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX"] = PRIMARY_TEST_PRIVATE_KEY_HEX
+    env["KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY"] = SECONDARY_TEST_PRIVATE_KEY_HEX
+    env.pop("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK", None)
+
+    runner_result = run_command(
+        [
+            "bash",
+            str(RUNNER),
+            "--mode",
+            "run",
+            "--runtime-mode",
+            "kolme-live",
+            "--signer-profile",
+            signer_profile,
+            "--required-approvals",
+            "2",
+            "--received-approvals",
+            "2",
+            "--quorum-evidence-file",
+            str(quorum_path),
+            "--custody-evidence-file",
+            str(custody_path),
+            "--signer-provenance-file",
+            str(provenance_path),
+            "--signer-key-source-contract-version",
+            "v1",
+            "--signer-key-source",
+            signer_key_source,
+            "--signer-rotation-epoch",
+            str(signer_rotation_epoch),
+            "--signer-previous-rotation-epoch",
+            str(signer_previous_rotation_epoch),
+            "--signer-rotation-freshness-max-delta",
+            "2",
+            "--max-seconds",
+            "20",
+            "--output-json",
+            str(summary_path),
+        ],
+        env=env,
+    )
+
+    runner_output = f"{runner_result.stdout}{runner_result.stderr}"
+    _assert_marker(
+        runner_output,
+        f"status={expected_runner_status}",
+        f"expected runner status marker for scenario {scenario_id}: status={expected_runner_status}",
+    )
+    _assert_marker(
+        runner_output,
+        f"reason_code={expected_reason_code}",
+        f"expected reason-code marker for scenario {scenario_id}: reason_code={expected_reason_code}",
+    )
+
+    if expected_runner_status == "ok" and runner_result.returncode != 0:
+        raise RuntimeError(
+            f"expected scenario {scenario_id} to succeed but runner failed: {runner_output.strip()}"
+        )
+    if expected_runner_status == "fail" and runner_result.returncode == 0:
+        raise RuntimeError(f"expected scenario {scenario_id} to fail closed")
+
+    summary_payload = _read_json(summary_path)
+    if summary_payload.get("reason_code") != expected_reason_code:
+        raise RuntimeError(f"scenario {scenario_id} summary reason code mismatch")
+
+    checker_result = run_command(
+        [
+            "python3",
+            str(CHECKER),
+            "--report-file",
+            str(summary_path),
+            "--expected-final-decision",
+            expected_final_decision,
+            "--ci-fast-gate",
+            "PASS",
+            "--require-reason-code",
+            expected_reason_code,
+            "--output-json",
+            str(policy_path),
+        ]
+    )
+    checker_output = f"{checker_result.stdout}{checker_result.stderr}"
+    _assert_marker(
+        checker_output,
+        f"final_decision={expected_final_decision}",
+        f"expected checker decision marker for scenario {scenario_id}: final_decision={expected_final_decision}",
+    )
+
+    if expected_final_decision == "GO" and checker_result.returncode != 0:
+        raise RuntimeError(
+            f"expected scenario {scenario_id} policy checker GO path to pass: {checker_output.strip()}"
+        )
+    if expected_final_decision == "NO-GO" and checker_result.returncode == 0:
+        raise RuntimeError(f"expected scenario {scenario_id} policy checker to fail closed")
+
+    policy_payload = _read_json(policy_path)
+    if policy_payload.get("final_decision") != expected_final_decision:
+        raise RuntimeError(f"scenario {scenario_id} policy report final decision mismatch")
+
+    if expected_policy_reason_code is not None:
+        reason_codes = policy_payload.get("reason_codes")
+        if not isinstance(reason_codes, list) or expected_policy_reason_code not in reason_codes:
+            raise RuntimeError(
+                f"scenario {scenario_id} missing expected policy reason code: {expected_policy_reason_code}"
+            )
+
+    return {
+        "scenario_id": scenario_id,
+        "summary_report": str(summary_path),
+        "policy_report": str(policy_path),
+        "expected_reason_code": expected_reason_code,
+        "expected_policy_reason_code": expected_policy_reason_code,
+        "final_decision": expected_final_decision,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run managed-signer startup live validation contract lane."
+    )
+    parser.add_argument(
+        "--output-json",
+        default="/tmp/managed-signer-startup-live-validation-contract-report.json",
+    )
+    parser.add_argument("--max-seconds", type=int, default=120)
+    args = parser.parse_args()
+
+    if args.max_seconds <= 0:
+        print("max-seconds must be a positive integer", file=sys.stderr)
+        return 1
+
+    if not RUNNER.is_file() or not RUNNER.stat().st_mode & 0o111:
+        print("expected deployment preflight runner to be executable", file=sys.stderr)
+        return 1
+    if not CHECKER.is_file() or not CHECKER.stat().st_mode & 0o111:
+        print("expected deployment preflight policy checker to be executable", file=sys.stderr)
+        return 1
+
+    missing_doc_markers: list[str] = []
+    for doc_file in DOC_FILES:
+        if not doc_file.is_file():
+            print(f"expected documentation file to exist: {doc_file}", file=sys.stderr)
+            return 1
+        missing_doc_markers.extend(
+            ensure_markers_present(
+                doc_file.read_text(encoding="utf-8"),
+                DOC_MARKERS,
+                str(doc_file.relative_to(ROOT_DIR)),
+            )
+        )
+    if missing_doc_markers:
+        print(",".join(missing_doc_markers), file=sys.stderr)
+        return 1
+
+    start_time = time.time()
+    try:
+        with tempfile.TemporaryDirectory(prefix="managed-signer-startup-live-contract-") as temp_dir:
+            temp_root = Path(temp_dir)
+            scenario_reports = [
+                run_preflight_scenario(
+                    temp_root=temp_root,
+                    scenario_id="go_baseline",
+                    signer_profile="ops-primary",
+                    signer_key_source="managed-external",
+                    signer_rotation_epoch=3,
+                    signer_previous_rotation_epoch=1,
+                    expected_runner_status="ok",
+                    expected_reason_code="deployment_preflight_passed",
+                    expected_final_decision="GO",
+                    expected_policy_reason_code=None,
+                ),
+                run_preflight_scenario(
+                    temp_root=temp_root,
+                    scenario_id="no_go_missing_key_source",
+                    signer_profile="ops-primary",
+                    signer_key_source="env-local",
+                    signer_rotation_epoch=3,
+                    signer_previous_rotation_epoch=1,
+                    expected_runner_status="fail",
+                    expected_reason_code="checkpoint_failed_signer_provenance_contract",
+                    expected_final_decision="NO-GO",
+                    expected_policy_reason_code="signer_key_source_production_managed_external_required",
+                ),
+                run_preflight_scenario(
+                    temp_root=temp_root,
+                    scenario_id="no_go_invalid_signer_profile",
+                    signer_profile="ops-tertiary",
+                    signer_key_source="managed-external",
+                    signer_rotation_epoch=3,
+                    signer_previous_rotation_epoch=1,
+                    expected_runner_status="fail",
+                    expected_reason_code="checkpoint_failed_signer_profile_contract",
+                    expected_final_decision="NO-GO",
+                    expected_policy_reason_code="signer_profile_mismatch",
+                ),
+                run_preflight_scenario(
+                    temp_root=temp_root,
+                    scenario_id="no_go_stale_rotation_metadata",
+                    signer_profile="ops-primary",
+                    signer_key_source="managed-external",
+                    signer_rotation_epoch=5,
+                    signer_previous_rotation_epoch=1,
+                    expected_runner_status="fail",
+                    expected_reason_code="checkpoint_failed_signer_rotation_freshness_contract",
+                    expected_final_decision="NO-GO",
+                    expected_policy_reason_code="signer_rotation_epoch_stale",
+                ),
+            ]
+
+            elapsed_seconds = int(time.time() - start_time)
+            if elapsed_seconds > args.max_seconds:
+                raise RuntimeError(
+                    f"managed-signer startup live validation exceeded runtime budget: "
+                    f"{elapsed_seconds}s > {args.max_seconds}s"
+                )
+
+            report_payload = {
+                "schema_version": "kamn.kolme.managed-signer-startup-live-validation-contract-report.v1",
+                "status": "pass",
+                "final_decision": "GO",
+                "execution_scope": "local-scheduled",
+                "ci_fast_gate_eligible": False,
+                "max_seconds": args.max_seconds,
+                "elapsed_seconds": elapsed_seconds,
+                "managed_signer_profile_status": "verified",
+                "managed_signer_missing_key_source_fail_closed_status": "verified",
+                "managed_signer_invalid_profile_fail_closed_status": "verified",
+                "managed_signer_stale_rotation_fail_closed_status": "verified",
+                "managed_signer_reason_code_status": "verified",
+                "performance_budget_status": "verified",
+                "scenario_reports": scenario_reports,
+            }
+
+            output_path = Path(args.output_json).resolve()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(report_payload, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print("status=pass")
+    print("final_decision=GO")
+    print("managed_signer_profile_status=verified")
+    print("managed_signer_missing_key_source_fail_closed_status=verified")
+    print("managed_signer_invalid_profile_fail_closed_status=verified")
+    print("managed_signer_stale_rotation_fail_closed_status=verified")
+    print("managed_signer_reason_code_status=verified")
+    print("execution_scope=local-scheduled")
+    print("performance_budget_status=verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kolme/run_contract_lane_dispatch.sh
+++ b/scripts/kolme/run_contract_lane_dispatch.sh
@@ -74,6 +74,7 @@ resolve_manifest_name() {
     run_local_kolme_live_api_conformance_contract_lane.sh) echo "kolme_local_kolme_live_api_conformance_contract_lane.json" ;;
     run_managed_signer_backend_slo_policy_contract_lane.sh) echo "kolme_managed_signer_backend_slo_policy_contract_lane.json" ;;
     run_managed_signer_backend_slo_telemetry_contract_lane.sh) echo "kolme_managed_signer_backend_slo_telemetry_contract_lane.json" ;;
+    run_managed_signer_startup_live_validation_contract_lane.sh) echo "kolme_managed_signer_startup_live_validation_contract_lane.json" ;;
     run_local_runtime_commit_live_finality_evidence_contract_lane.sh) echo "kolme_local_runtime_commit_live_finality_evidence_contract_lane.json" ;;
     run_local_native_api_parity_live_proof_contract_lane.sh) echo "kolme_local_native_api_parity_live_proof_contract_lane.json" ;;
     run_local_signed_to_kolme_demo_contract_lane.sh) echo "kolme_local_signed_to_kolme_demo_contract_lane.json" ;;

--- a/scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh
+++ b/scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh
@@ -1,0 +1,1 @@
+run_contract_lane_dispatch.sh

--- a/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
+++ b/scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
@@ -31,6 +31,7 @@ lane_wrappers=(
   "run_local_kolme_live_api_conformance_contract_lane.sh"
   "run_managed_signer_backend_slo_policy_contract_lane.sh"
   "run_managed_signer_backend_slo_telemetry_contract_lane.sh"
+  "run_managed_signer_startup_live_validation_contract_lane.sh"
   "run_local_runtime_commit_live_finality_evidence_contract_lane.sh"
   "run_local_native_api_parity_live_proof_contract_lane.sh"
   "run_local_signed_to_kolme_demo_contract_lane.sh"

--- a/scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
+++ b/scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh"
+DISPATCHER="$ROOT_DIR/scripts/kolme/run_contract_lane_dispatch.sh"
+MANIFEST="$ROOT_DIR/scripts/framework/manifests/kolme_managed_signer_startup_live_validation_contract_lane.json"
+CONTRACT_IMPL="$ROOT_DIR/scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py"
+PREFLIGHT_RUNNER="$ROOT_DIR/scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh"
+PREFLIGHT_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py"
+DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
+CI_COST_DOC="$ROOT_DIR/docs/ci/ci-cost-and-lane-framework.md"
+ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
+README_FILE="$ROOT_DIR/README.md"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$RUNNER" ]; then
+  echo "expected managed-signer startup live validation contract lane runner to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$DISPATCHER" ]; then
+  echo "expected managed-signer startup live validation dispatcher to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "expected managed-signer startup live validation manifest to exist" >&2
+  exit 1
+fi
+
+if [ ! -f "$CONTRACT_IMPL" ]; then
+  echo "expected managed-signer startup live validation contract implementation to exist" >&2
+  exit 1
+fi
+
+if [ ! -x "$PREFLIGHT_RUNNER" ]; then
+  echo "expected deployment preflight runner dependency to be executable" >&2
+  exit 1
+fi
+
+if [ ! -x "$PREFLIGHT_CHECKER" ]; then
+  echo "expected deployment preflight policy checker dependency to be executable" >&2
+  exit 1
+fi
+
+if [ ! -L "$RUNNER" ]; then
+  echo "expected managed-signer startup live validation runner to be a symlink to shared dispatcher" >&2
+  exit 1
+fi
+
+if [ "$(readlink "$RUNNER")" != "run_contract_lane_dispatch.sh" ]; then
+  echo "expected managed-signer startup live validation runner symlink target to be run_contract_lane_dispatch.sh" >&2
+  exit 1
+fi
+
+resolved_manifest="$(bash "$DISPATCHER" --lane-wrapper "$(basename "$RUNNER")" --resolve-manifest-path)"
+if [ "$resolved_manifest" != "$MANIFEST" ]; then
+  echo "expected managed-signer startup live validation dispatcher to resolve deterministic manifest path" >&2
+  exit 1
+fi
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest_path = pathlib.Path(sys.argv[1])
+payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.contract-lane.manifest.v1":
+    raise SystemExit("unexpected managed-signer startup live validation manifest schema")
+if payload.get("lane_id") != "kolme.managed_signer_startup_live_validation.contract":
+    raise SystemExit("unexpected managed-signer startup live validation manifest lane_id")
+contract_command = payload.get("phases", {}).get("contract")
+if contract_command != [
+    "python3",
+    "scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py",
+]:
+    raise SystemExit("unexpected managed-signer startup live validation manifest contract command")
+PY
+
+required_markers=(
+  "run_managed_signer_startup_live_validation_contract_lane.sh"
+  "kamn.kolme.managed-signer-startup-live-validation-contract-report.v1"
+  "deployment_preflight_passed"
+  "checkpoint_failed_signer_profile_contract"
+  "checkpoint_failed_signer_provenance_contract"
+  "checkpoint_failed_signer_rotation_freshness_contract"
+  "signer_key_source_production_managed_external_required"
+  "signer_profile_mismatch"
+  "signer_rotation_epoch_stale"
+  "execution_scope=local-scheduled"
+)
+
+for docs_file in "$DOC_FILE" "$CI_COST_DOC" "$ROADMAP_DOC" "$README_FILE"; do
+  for marker in "${required_markers[@]}"; do
+    if ! grep -q -- "$marker" "$docs_file"; then
+      echo "expected docs parity marker '$marker' in $docs_file" >&2
+      exit 1
+    fi
+  done
+done
+
+run_output="$(bash "$RUNNER" --output-json "$TMP_REPORT")"
+for marker in \
+  "status=pass" \
+  "final_decision=GO" \
+  "managed_signer_profile_status=verified" \
+  "managed_signer_missing_key_source_fail_closed_status=verified" \
+  "managed_signer_invalid_profile_fail_closed_status=verified" \
+  "managed_signer_stale_rotation_fail_closed_status=verified" \
+  "managed_signer_reason_code_status=verified" \
+  "execution_scope=local-scheduled" \
+  "performance_budget_status=verified"; do
+  if ! printf '%s\n' "$run_output" | grep -q "^${marker}$"; then
+    echo "expected managed-signer startup live validation output marker: $marker" >&2
+    exit 1
+  fi
+done
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.kolme.managed-signer-startup-live-validation-contract-report.v1":
+    raise SystemExit("unexpected managed-signer startup live validation contract report schema")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected managed-signer startup live validation final decision GO")
+if payload.get("execution_scope") != "local-scheduled":
+    raise SystemExit("expected execution_scope=local-scheduled")
+if payload.get("ci_fast_gate_eligible") is not False:
+    raise SystemExit("expected ci_fast_gate_eligible=false")
+if payload.get("managed_signer_profile_status") != "verified":
+    raise SystemExit("expected managed_signer_profile_status=verified")
+if payload.get("managed_signer_missing_key_source_fail_closed_status") != "verified":
+    raise SystemExit("expected managed_signer_missing_key_source_fail_closed_status=verified")
+if payload.get("managed_signer_invalid_profile_fail_closed_status") != "verified":
+    raise SystemExit("expected managed_signer_invalid_profile_fail_closed_status=verified")
+if payload.get("managed_signer_stale_rotation_fail_closed_status") != "verified":
+    raise SystemExit("expected managed_signer_stale_rotation_fail_closed_status=verified")
+if payload.get("managed_signer_reason_code_status") != "verified":
+    raise SystemExit("expected managed_signer_reason_code_status=verified")
+if payload.get("performance_budget_status") != "verified":
+    raise SystemExit("expected performance_budget_status=verified")
+scenario_reports = payload.get("scenario_reports")
+if not isinstance(scenario_reports, list) or len(scenario_reports) != 4:
+    raise SystemExit("expected four scenario reports")
+expected = {
+    "go_baseline": ("GO", "deployment_preflight_passed"),
+    "no_go_missing_key_source": ("NO-GO", "checkpoint_failed_signer_provenance_contract"),
+    "no_go_invalid_signer_profile": ("NO-GO", "checkpoint_failed_signer_profile_contract"),
+    "no_go_stale_rotation_metadata": ("NO-GO", "checkpoint_failed_signer_rotation_freshness_contract"),
+}
+for entry in scenario_reports:
+    if not isinstance(entry, dict):
+        raise SystemExit("scenario report entry must be an object")
+    scenario_id = entry.get("scenario_id")
+    if scenario_id not in expected:
+        raise SystemExit(f"unexpected scenario id: {scenario_id}")
+    final_decision, reason_code = expected[scenario_id]
+    if entry.get("final_decision") != final_decision:
+        raise SystemExit(f"unexpected final decision for {scenario_id}")
+    if entry.get("expected_reason_code") != reason_code:
+        raise SystemExit(f"unexpected expected_reason_code for {scenario_id}")
+PY
+
+set +e
+invalid_budget_output="$(
+  bash "$RUNNER" \
+    --max-seconds invalid 2>&1
+)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected managed-signer startup live validation runner to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q "invalid int value"; then
+  echo "expected deterministic invalid max-seconds marker" >&2
+  exit 1
+fi
+
+echo "managed-signer startup live validation contract lane tests passed."


### PR DESCRIPTION
## Summary
Adds a dedicated managed-signer startup live-validation contract lane that validates production signer startup admission and deterministic fail-closed behavior for key-source, signer-profile, and rotation-freshness faults. This composes existing deployment preflight + policy primitives into one bounded local/scheduled validation entry point.

## Changes
- `scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py`: new contract lane implementation with GO baseline + 3 NO-GO fault injections and machine-readable markers.
- `scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh`: dispatcher symlink wrapper.
- `scripts/framework/manifests/kolme_managed_signer_startup_live_validation_contract_lane.json`: new manifest.
- `scripts/kolme/run_contract_lane_dispatch.sh`: added manifest resolution mapping for new wrapper.
- `scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh`: new contract lane test coverage.
- `scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh`: added new wrapper to matrix.
- `docs/planning/kolme-devnet-ops.md`, `docs/ci/ci-cost-and-lane-framework.md`, `docs/plans/2026-02-08-production-service-roadmap.md`, `README.md`: command/schema/reason-code parity updates.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
```
Output excerpt:
```text
expected docs parity marker 'kamn.kolme.managed-signer-startup-live-validation-contract-report.v1' in /home/n/Code/kamn/docs/plans/2026-02-08-production-service-roadmap.md
```

### 🟢 Green Phase
Command:
```bash
bash scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
```
Output excerpt:
```text
managed-signer startup live validation contract lane tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
bash scripts/kolme/test_contract_lane_dispatch_wrapper_matrix.sh
bash scripts/kolme/test_run_managed_signer_backend_slo_policy_contract_lane.sh
```
Output excerpts:
```text
managed-signer startup live validation contract lane tests passed.
Kolme contract lane dispatcher wrapper matrix tests passed.
managed-signer backend SLO policy contract lane tests passed.
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Lane is orchestration over existing scripts; behavior is validated through contract/integration harnesses. |
| Functional   | ✅     | `scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh` |                      |
| Integration  | ✅     | `scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py` composes preflight runner + policy checker in GO/NO-GO scenarios |                      |
| Regression   | ✅     | deterministic fail-closed reason-code checks for key-source/profile/rotation drills in new lane test and contract implementation |                      |
| Performance  | ✅     | bounded runtime contract via `--max-seconds` in contract lane + invalid-budget guard in test |                      |

## Risks & Rollback
- None.
- Rollback: revert commit `d19de10`.

## Documentation Updates
- Updated:
  - `docs/planning/kolme-devnet-ops.md`
  - `docs/ci/ci-cost-and-lane-framework.md`
  - `docs/plans/2026-02-08-production-service-roadmap.md`
  - `README.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean (N/A: no Rust changes)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: no Rust changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)

Closes #3067
