### PR TITLE
test(runtime): expand persistence live validation lane

### DIFF
--- a/docs/architecture/persistence-backends.md
+++ b/docs/architecture/persistence-backends.md
@@ -50,14 +50,24 @@ Live validation lane (local realistic dependency path):
   - `final_decision=GO`
   - `content_persistence_status=verified`
   - `did_duplicate_detection_status=verified`
+  - `restart_recovery_status=verified`
+  - `corruption_fail_closed_status=verified`
+  - `incompatible_schema_fail_closed_status=verified`
   - `fail_closed_status=verified`
+  - `evidence_bundle_status=verified`
+  - `execution_scope=local-scheduled`
+  - `performance_budget_status=verified`
+  - `fail_closed_reason_codes=content_storage_corrupt_payload_rejected,did_registry_corrupt_payload_rejected,task_operation_snapshot_schema_mismatch_rejected,durable_guard_snapshot_schema_mismatch_rejected`
 
 Low-cost lane (PR-safe):
 
-- `cargo test -p kamn-core --test content_storage_file_adapter`
-- `cargo test -p kamn-core --test did_registry_file_chain_adapter`
-- `cargo test -p kamn-core --test content_storage_adapter`
-- `cargo test -p kamn-core --test did_registry_transactions`
+- `cargo test -p kamn-core --test content_storage_file_adapter content_storage_file_adapter_persists_round_trip_across_reopen`
+- `cargo test -p kamn-core --test did_registry_file_chain_adapter did_registry_file_chain_adapter_persists_duplicate_detection_across_restart`
+- `cargo test -p kamn-core --test content_storage_file_adapter content_storage_file_adapter_regression_rejects_corrupt_payload_line`
+- `cargo test -p kamn-core --test did_registry_file_chain_adapter did_registry_file_chain_adapter_regression_rejects_corrupt_payload_line`
+- `cargo test -p kamn-core --test task_operation_snapshot task_operation_snapshot_rejects_schema_version_mismatch`
+- `cargo test -p kamn-core --test durable_guard_snapshot_store unit_bundle_schema_mismatch_is_rejected`
+- `cargo test -p kamn-core --test task_operation_snapshot task_operation_snapshot_bounded_roundtrip_benchmark_is_fast_for_ci`
 - `cargo fmt --check`
 - `cargo clippy -p kamn-core -- -D warnings`
 

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -16,6 +16,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Delivered in this slice: `FileContentAdapter` and `FileDidRegistrationChainAdapter` in `kamn-core` (Task #2901).
   - Live validation lane added for persistence adapter restart and fail-closed checks (Task #2903).
   - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
+- Post-roadmap hardening wave 3 persistence live-validation expansion delivered:
+  - Runtime lane: `scripts/runtime/validate_persistence_adapters_live.sh` and `scripts/runtime/test_validate_persistence_adapters_live.sh` (Task #3068, Subtask #3070).
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `restart_recovery_status=verified`, `corruption_fail_closed_status=verified`, `incompatible_schema_fail_closed_status=verified`, `execution_scope=local-scheduled`, `performance_budget_status=verified`.
+  - Fail-closed reason-code matrix validated: `content_storage_corrupt_payload_rejected`, `did_registry_corrupt_payload_rejected`, `task_operation_snapshot_schema_mismatch_rejected`, `durable_guard_snapshot_schema_mismatch_rejected`.
 - Post-roadmap hardening wave 1 initial slice delivered:
   - Added deterministic `execution_id` structured logging correlation field for runtime dispatch/start/complete lifecycle events in `kamn-node` (Task #3032, Subtask #3033).
   - Added regression assertions in `crates/kamn-node/src/main_tests/core_behavior_tests.rs` to fail closed when runtime structured events omit `execution_id`.

--- a/scripts/runtime/test_validate_persistence_adapters_live.sh
+++ b/scripts/runtime/test_validate_persistence_adapters_live.sh
@@ -28,8 +28,32 @@ if ! printf '%s\n' "$validation_output" | grep -q '^did_duplicate_detection_stat
   echo "expected persistence adapter live validation did marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^restart_recovery_status=verified$'; then
+  echo "expected persistence adapter live validation restart marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^corruption_fail_closed_status=verified$'; then
+  echo "expected persistence adapter live validation corruption marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^incompatible_schema_fail_closed_status=verified$'; then
+  echo "expected persistence adapter live validation incompatible-schema marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
   echo "expected persistence adapter live validation fail-closed marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^evidence_bundle_status=verified$'; then
+  echo "expected persistence adapter live validation evidence marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^execution_scope=local-scheduled$'; then
+  echo "expected persistence adapter live validation execution scope marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^performance_budget_status=verified$'; then
+  echo "expected persistence adapter live validation performance marker" >&2
   exit 1
 fi
 
@@ -49,8 +73,60 @@ if payload.get("content_persistence_status") != "verified":
     raise SystemExit("expected content_persistence_status=verified")
 if payload.get("did_duplicate_detection_status") != "verified":
     raise SystemExit("expected did_duplicate_detection_status=verified")
+if payload.get("restart_recovery_status") != "verified":
+    raise SystemExit("expected restart_recovery_status=verified")
+if payload.get("corruption_fail_closed_status") != "verified":
+    raise SystemExit("expected corruption_fail_closed_status=verified")
+if payload.get("incompatible_schema_fail_closed_status") != "verified":
+    raise SystemExit("expected incompatible_schema_fail_closed_status=verified")
 if payload.get("fail_closed_status") != "verified":
     raise SystemExit("expected fail_closed_status=verified")
+if payload.get("evidence_bundle_status") != "verified":
+    raise SystemExit("expected evidence_bundle_status=verified")
+if payload.get("execution_scope") != "local-scheduled":
+    raise SystemExit("expected execution_scope=local-scheduled")
+if payload.get("performance_budget_status") != "verified":
+    raise SystemExit("expected performance_budget_status=verified")
+reason_codes = payload.get("fail_closed_reason_codes")
+if reason_codes != [
+    "content_storage_corrupt_payload_rejected",
+    "did_registry_corrupt_payload_rejected",
+    "task_operation_snapshot_schema_mismatch_rejected",
+    "durable_guard_snapshot_schema_mismatch_rejected",
+]:
+    raise SystemExit("expected deterministic fail_closed_reason_codes contract list")
 PY
+
+set +e
+invalid_budget_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --max-seconds invalid 2>&1
+)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected persistence adapter live validation script to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q "max-seconds must be an integer"; then
+  echo "expected deterministic invalid max-seconds marker" >&2
+  exit 1
+fi
+
+set +e
+zero_budget_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --max-seconds 0 2>&1
+)"
+zero_budget_code=$?
+set -e
+if [ "$zero_budget_code" -eq 0 ]; then
+  echo "expected persistence adapter live validation script to reject zero max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$zero_budget_output" | grep -q "max-seconds must be greater than zero"; then
+  echo "expected deterministic zero max-seconds marker" >&2
+  exit 1
+fi
 
 echo "persistence adapter live validation tests passed."

--- a/scripts/runtime/validate_persistence_adapters_live.sh
+++ b/scripts/runtime/validate_persistence_adapters_live.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PERSISTENCE_DOC="$ROOT_DIR/docs/architecture/persistence-backends.md"
+ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
 output_json=""
 max_seconds=180
@@ -27,17 +29,73 @@ if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
   echo "max-seconds must be an integer" >&2
   exit 1
 fi
+if [ "$max_seconds" -le 0 ]; then
+  echo "max-seconds must be greater than zero" >&2
+  exit 1
+fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 start_epoch="$(date +%s)"
 
+if [ ! -f "$PERSISTENCE_DOC" ]; then
+  echo "expected persistence architecture doc to exist: $PERSISTENCE_DOC" >&2
+  exit 1
+fi
+if [ ! -f "$ROADMAP_DOC" ]; then
+  echo "expected roadmap doc to exist: $ROADMAP_DOC" >&2
+  exit 1
+fi
+
+for marker in \
+  "validate_persistence_adapters_live.sh" \
+  "test_validate_persistence_adapters_live.sh" \
+  "kamn.persistence.adapters-live-validation.v1" \
+  "restart_recovery_status=verified" \
+  "corruption_fail_closed_status=verified" \
+  "incompatible_schema_fail_closed_status=verified" \
+  "execution_scope=local-scheduled"; do
+  if ! grep -q -- "$marker" "$PERSISTENCE_DOC"; then
+    echo "expected persistence architecture doc marker: $marker" >&2
+    exit 1
+  fi
+done
+
+for marker in \
+  "Task #3068, Subtask #3070" \
+  "scripts/runtime/validate_persistence_adapters_live.sh" \
+  "content_storage_corrupt_payload_rejected" \
+  "task_operation_snapshot_schema_mismatch_rejected" \
+  "durable_guard_snapshot_schema_mismatch_rejected"; do
+  if ! grep -q -- "$marker" "$ROADMAP_DOC"; then
+    echo "expected roadmap marker for persistence live validation: $marker" >&2
+    exit 1
+  fi
+done
+
 pushd "$ROOT_DIR" >/dev/null
-cargo test -p kamn-core --test content_storage_file_adapter -- --nocapture \
-  >"$TMP_DIR/content-storage-file-adapter.log" 2>&1
-cargo test -p kamn-core --test did_registry_file_chain_adapter -- --nocapture \
-  >"$TMP_DIR/did-registry-file-adapter.log" 2>&1
+cargo test -p kamn-core --test content_storage_file_adapter \
+  content_storage_file_adapter_persists_round_trip_across_reopen -- --nocapture \
+  >"$TMP_DIR/content-storage-restart.log" 2>&1
+cargo test -p kamn-core --test did_registry_file_chain_adapter \
+  did_registry_file_chain_adapter_persists_duplicate_detection_across_restart -- --nocapture \
+  >"$TMP_DIR/did-chain-restart.log" 2>&1
+cargo test -p kamn-core --test content_storage_file_adapter \
+  content_storage_file_adapter_regression_rejects_corrupt_payload_line -- --nocapture \
+  >"$TMP_DIR/content-storage-corrupt.log" 2>&1
+cargo test -p kamn-core --test did_registry_file_chain_adapter \
+  did_registry_file_chain_adapter_regression_rejects_corrupt_payload_line -- --nocapture \
+  >"$TMP_DIR/did-chain-corrupt.log" 2>&1
+cargo test -p kamn-core --test task_operation_snapshot \
+  task_operation_snapshot_rejects_schema_version_mismatch -- --nocapture \
+  >"$TMP_DIR/task-snapshot-schema-mismatch.log" 2>&1
+cargo test -p kamn-core --test durable_guard_snapshot_store \
+  unit_bundle_schema_mismatch_is_rejected -- --nocapture \
+  >"$TMP_DIR/durable-guard-schema-mismatch.log" 2>&1
+cargo test -p kamn-core --test task_operation_snapshot \
+  task_operation_snapshot_bounded_roundtrip_benchmark_is_fast_for_ci -- --nocapture \
+  >"$TMP_DIR/task-snapshot-performance.log" 2>&1
 popd >/dev/null
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
@@ -54,7 +112,19 @@ cat >"$report_json" <<JSON
   "final_decision": "GO",
   "content_persistence_status": "verified",
   "did_duplicate_detection_status": "verified",
+  "restart_recovery_status": "verified",
+  "corruption_fail_closed_status": "verified",
+  "incompatible_schema_fail_closed_status": "verified",
   "fail_closed_status": "verified",
+  "evidence_bundle_status": "verified",
+  "execution_scope": "local-scheduled",
+  "performance_budget_status": "verified",
+  "fail_closed_reason_codes": [
+    "content_storage_corrupt_payload_rejected",
+    "did_registry_corrupt_payload_rejected",
+    "task_operation_snapshot_schema_mismatch_rejected",
+    "durable_guard_snapshot_schema_mismatch_rejected"
+  ],
   "elapsed_seconds": $elapsed_seconds
 }
 JSON
@@ -67,4 +137,11 @@ echo "status=pass"
 echo "final_decision=GO"
 echo "content_persistence_status=verified"
 echo "did_duplicate_detection_status=verified"
+echo "restart_recovery_status=verified"
+echo "corruption_fail_closed_status=verified"
+echo "incompatible_schema_fail_closed_status=verified"
 echo "fail_closed_status=verified"
+echo "evidence_bundle_status=verified"
+echo "execution_scope=local-scheduled"
+echo "performance_budget_status=verified"
+echo "fail_closed_reason_codes=content_storage_corrupt_payload_rejected,did_registry_corrupt_payload_rejected,task_operation_snapshot_schema_mismatch_rejected,durable_guard_snapshot_schema_mismatch_rejected"


### PR DESCRIPTION
## Summary
Expands the persistence live-validation lane to cover deterministic restart recovery, corruption fail-closed behavior, and incompatible schema rejection with machine-readable GO/NO-GO evidence markers. Keeps runtime bounded and explicitly local/scheduled for cost control.

## Changes
- `scripts/runtime/validate_persistence_adapters_live.sh`: expanded to run targeted restart/corruption/schema-mismatch/performance drills; added docs parity checks; added runtime budget guards and reason-code evidence output.
- `scripts/runtime/test_validate_persistence_adapters_live.sh`: expanded contract assertions for new markers, fail-closed reason-code matrix, and max-seconds invalid/zero guards.
- `docs/architecture/persistence-backends.md`: updated validation matrix and low-cost command set for expanded persistence lane coverage.
- `docs/plans/2026-02-08-production-service-roadmap.md`: added Wave 3 persistence live-validation expansion execution status markers (Task #3068, Subtask #3070).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_validate_persistence_adapters_live.sh
```
Output excerpt:
```text
expected persistence adapter live validation restart marker
```

### 🟢 Green Phase
Command:
```bash
bash scripts/runtime/test_validate_persistence_adapters_live.sh
```
Output excerpt:
```text
persistence adapter live validation tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/runtime/test_validate_persistence_adapters_live.sh
```
Output excerpt:
```text
persistence adapter live validation tests passed.
```

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Lane change is script-level orchestration over existing integration tests. |
| Functional   | ✅     | `scripts/runtime/test_validate_persistence_adapters_live.sh` |                      |
| Integration  | ✅     | `scripts/runtime/validate_persistence_adapters_live.sh` targeted cargo integration tests |                      |
| Regression   | ✅     | corruption + schema mismatch deterministic reason-code assertions in lane/test |                      |
| Performance  | ✅     | bounded roundtrip benchmark + max-seconds budget guards |                      |

## Risks & Rollback
- None.
- Rollback: revert commit `ec420b9`.

## Documentation Updates
- Updated:
  - `docs/architecture/persistence-backends.md`
  - `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean (N/A: no Rust source changes)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: no Rust source changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)

Closes #3070
