### PR TITLE
feat(bootstrap): wire durable runtime stores with fail-closed startup checks

### DIFF
--- a/crates/kamn-core/src/bootstrap.rs
+++ b/crates/kamn-core/src/bootstrap.rs
@@ -1,11 +1,42 @@
 //! Bootstrap planning for validated config, schema migrations, and runtime wiring.
 
 use crate::config::{ConfigError, NodeConfig};
+use crate::content_storage::{ContentStorageError, FileContentAdapter};
+use crate::did_registry::{DidRegistryError, FileDidRegistrationChainAdapter};
+use crate::durable_guard_store::{
+    DurableGuardBundleSnapshotStore, DurableGuardSnapshotStoreError, FileDurableGuardSnapshotStore,
+};
 use crate::migrations::{MigrationPlan, MigrationRegistry};
 use crate::namespaces::StateNamespaces;
 use crate::runtime::{build_runtime_wiring, RuntimeWiring};
 use crate::state::{AppStateSchema, StateVersion, APP_STATE_VERSION};
+use crate::task_operations::{
+    FileTaskOperationSnapshotStore, TaskOperationError, TaskOperationSnapshotStore,
+    TaskOperationSnapshotStoreError,
+};
 use crate::token::{default_token_config, TokenConfig};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CONTENT_STORE_FILE_NAME: &str = "content-store.snapshot";
+const DID_REGISTRY_STORE_FILE_NAME: &str = "did-chain-adapter.snapshot";
+const TASK_OPERATION_STORE_FILE_NAME: &str = "task-operation.snapshot";
+const DURABLE_GUARD_STORE_FILE_NAME: &str = "durable-guard.snapshot";
+
+const CONTENT_STORE_COMPONENT: &str = "content-storage:file-default";
+const DID_REGISTRY_STORE_COMPONENT: &str = "did-registry:file-default";
+const TASK_OPERATION_STORE_COMPONENT: &str = "task-operation-snapshot-store:file-default";
+const DURABLE_GUARD_STORE_COMPONENT: &str = "durable-guard-snapshot-store:file-default";
+const DID_REGISTRY_BOOTSTRAP_PROVIDER: &str = "bootstrap-runtime-compatibility";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimePersistenceLayout {
+    storage_root: PathBuf,
+    content_store_path: PathBuf,
+    did_registry_store_path: PathBuf,
+    task_operation_store_path: PathBuf,
+    durable_guard_store_path: PathBuf,
+}
 
 /// Deterministic bootstrap artifact bundling validated config, schema, and wiring.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,7 +80,15 @@ pub fn bootstrap_from_state_version(
     token_config
         .validate()
         .map_err(|error| ConfigError::TokenModel(error.to_string()))?;
-    let wiring = build_runtime_wiring(&config);
+    let persistence_layout = resolve_runtime_persistence_layout(config.storage_dir.as_str());
+    validate_runtime_persistence_layout(&persistence_layout)?;
+
+    let mut wiring = build_runtime_wiring(&config);
+    for component in prioritized_runtime_store_components() {
+        if !wiring.common_components.contains(&component) {
+            wiring.common_components.push(component);
+        }
+    }
 
     Ok(BootstrapPlan {
         config,
@@ -61,12 +100,203 @@ pub fn bootstrap_from_state_version(
     })
 }
 
+fn resolve_runtime_persistence_layout(storage_dir: &str) -> RuntimePersistenceLayout {
+    let storage_root = PathBuf::from(storage_dir);
+    RuntimePersistenceLayout {
+        content_store_path: storage_root.join(CONTENT_STORE_FILE_NAME),
+        did_registry_store_path: storage_root.join(DID_REGISTRY_STORE_FILE_NAME),
+        task_operation_store_path: storage_root.join(TASK_OPERATION_STORE_FILE_NAME),
+        durable_guard_store_path: storage_root.join(DURABLE_GUARD_STORE_FILE_NAME),
+        storage_root,
+    }
+}
+
+fn prioritized_runtime_store_components() -> [&'static str; 4] {
+    [
+        CONTENT_STORE_COMPONENT,
+        DID_REGISTRY_STORE_COMPONENT,
+        TASK_OPERATION_STORE_COMPONENT,
+        DURABLE_GUARD_STORE_COMPONENT,
+    ]
+}
+
+fn validate_runtime_persistence_layout(
+    layout: &RuntimePersistenceLayout,
+) -> Result<(), ConfigError> {
+    fs::create_dir_all(&layout.storage_root).map_err(|error| {
+        ConfigError::RuntimeStoreCompatibility {
+            store: "runtime-storage-root",
+            reason_code: "runtime_storage_root_unavailable",
+            detail: error.to_string(),
+        }
+    })?;
+    validate_content_store_path(&layout.content_store_path)?;
+    validate_did_registry_store_path(&layout.did_registry_store_path)?;
+    validate_task_operation_store_path(&layout.task_operation_store_path)?;
+    validate_durable_guard_store_path(&layout.durable_guard_store_path)?;
+    Ok(())
+}
+
+fn validate_content_store_path(path: &Path) -> Result<(), ConfigError> {
+    FileContentAdapter::new(path.to_path_buf())
+        .map(|_| ())
+        .map_err(map_content_store_validation_error)
+}
+
+fn validate_did_registry_store_path(path: &Path) -> Result<(), ConfigError> {
+    FileDidRegistrationChainAdapter::new(path.to_path_buf(), DID_REGISTRY_BOOTSTRAP_PROVIDER)
+        .map(|_| ())
+        .map_err(map_did_registry_store_validation_error)
+}
+
+fn validate_task_operation_store_path(path: &Path) -> Result<(), ConfigError> {
+    let store = FileTaskOperationSnapshotStore::new(path.to_path_buf())
+        .map_err(map_task_operation_store_validation_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_task_operation_store_validation_error)
+}
+
+fn validate_durable_guard_store_path(path: &Path) -> Result<(), ConfigError> {
+    let store = FileDurableGuardSnapshotStore::new(path.to_path_buf())
+        .map_err(map_durable_guard_store_validation_error)?;
+    store
+        .load_bundle()
+        .map(|_| ())
+        .map_err(map_durable_guard_store_validation_error)
+}
+
+fn map_content_store_validation_error(error: ContentStorageError) -> ConfigError {
+    match error {
+        ContentStorageError::InvalidPayload(detail) => ConfigError::RuntimeStoreCorruptPayload {
+            store: "content-storage",
+            reason_code: "content_storage_corrupt_payload_rejected",
+            detail,
+        },
+        ContentStorageError::Io(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "content-storage",
+            reason_code: "content_storage_io_error",
+            detail,
+        },
+        other => ConfigError::RuntimeStoreCompatibility {
+            store: "content-storage",
+            reason_code: "content_storage_compatibility_failed",
+            detail: other.to_string(),
+        },
+    }
+}
+
+fn map_did_registry_store_validation_error(error: DidRegistryError) -> ConfigError {
+    match error {
+        DidRegistryError::PersistenceInvalidPayload(detail) => {
+            ConfigError::RuntimeStoreCorruptPayload {
+                store: "did-registry",
+                reason_code: "did_registry_corrupt_payload_rejected",
+                detail,
+            }
+        }
+        DidRegistryError::PersistenceIo(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "did-registry",
+            reason_code: "did_registry_io_error",
+            detail,
+        },
+        other => ConfigError::RuntimeStoreCompatibility {
+            store: "did-registry",
+            reason_code: "did_registry_compatibility_failed",
+            detail: other.to_string(),
+        },
+    }
+}
+
+fn map_task_operation_store_validation_error(
+    error: TaskOperationSnapshotStoreError,
+) -> ConfigError {
+    match error {
+        TaskOperationSnapshotStoreError::InvalidPayload(detail) => {
+            ConfigError::RuntimeStoreCorruptPayload {
+                store: "task-operation-snapshot-store",
+                reason_code: "task_operation_snapshot_corrupt_payload_rejected",
+                detail,
+            }
+        }
+        TaskOperationSnapshotStoreError::Io(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "task-operation-snapshot-store",
+            reason_code: "task_operation_snapshot_io_error",
+            detail,
+        },
+        TaskOperationSnapshotStoreError::Snapshot(
+            TaskOperationError::SnapshotVersionMismatch { expected, found },
+        ) => ConfigError::RuntimeStoreSchemaIncompatible {
+            store: "task-operation-snapshot-store",
+            reason_code: "task_operation_snapshot_schema_mismatch_rejected",
+            expected: expected.to_string(),
+            found: found.to_string(),
+        },
+        TaskOperationSnapshotStoreError::Snapshot(other) => {
+            ConfigError::RuntimeStoreCompatibility {
+                store: "task-operation-snapshot-store",
+                reason_code: "task_operation_snapshot_restore_validation_failed",
+                detail: other.to_string(),
+            }
+        }
+    }
+}
+
+fn map_durable_guard_store_validation_error(error: DurableGuardSnapshotStoreError) -> ConfigError {
+    match error {
+        DurableGuardSnapshotStoreError::BundleSchemaVersionMismatch { expected, found } => {
+            ConfigError::RuntimeStoreSchemaIncompatible {
+                store: "durable-guard-snapshot-store",
+                reason_code: "durable_guard_snapshot_schema_mismatch_rejected",
+                expected: expected.to_string(),
+                found: found.to_string(),
+            }
+        }
+        DurableGuardSnapshotStoreError::InvalidPayload(detail) => {
+            ConfigError::RuntimeStoreCorruptPayload {
+                store: "durable-guard-snapshot-store",
+                reason_code: "durable_guard_snapshot_corrupt_payload_rejected",
+                detail,
+            }
+        }
+        DurableGuardSnapshotStoreError::Io(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "durable-guard-snapshot-store",
+            reason_code: "durable_guard_snapshot_io_error",
+            detail,
+        },
+        DurableGuardSnapshotStoreError::DeliverySnapshot(other) => {
+            ConfigError::RuntimeStoreCompatibility {
+                store: "durable-guard-snapshot-store",
+                reason_code: "durable_guard_snapshot_restore_validation_failed",
+                detail: other.to_string(),
+            }
+        }
+        DurableGuardSnapshotStoreError::ChannelPolicySnapshot(other) => {
+            ConfigError::RuntimeStoreCompatibility {
+                store: "durable-guard-snapshot-store",
+                reason_code: "durable_guard_snapshot_restore_validation_failed",
+                detail: other.to_string(),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{bootstrap, bootstrap_from_state_version};
     use crate::config::{ConfigError, NodeConfig, NodeRole, SyncMode};
     use crate::state::{StateVersion, APP_STATE_VERSION};
+    use crate::task_operations::{
+        FileTaskOperationSnapshotStore, TaskOperationSnapshot, TaskOperationSnapshotStore,
+    };
     use crate::token::DEFAULT_TOKEN_SYMBOL;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const CONTENT_STORE_FIXTURE: &str = "content-store.snapshot";
+    const TASK_OPERATION_STORE_FIXTURE: &str = "task-operation.snapshot";
 
     #[test]
     fn bootstrap_plan_builds_for_valid_config() {
@@ -115,5 +345,111 @@ mod tests {
 
         let result = bootstrap_from_state_version(config, StateVersion(APP_STATE_VERSION.0 + 1));
         assert!(matches!(result, Err(ConfigError::MigrationPlan(_))));
+    }
+
+    #[test]
+    fn bootstrap_wiring_includes_durable_store_components() {
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: temp_storage_dir("durable-components")
+                .to_string_lossy()
+                .into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let plan = bootstrap(config).expect("bootstrap should succeed");
+        let components = plan.wiring.all_components();
+        assert!(components.contains(&"content-storage:file-default"));
+        assert!(components.contains(&"did-registry:file-default"));
+        assert!(components.contains(&"task-operation-snapshot-store:file-default"));
+        assert!(components.contains(&"durable-guard-snapshot-store:file-default"));
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_content_store_payload_is_corrupt() {
+        let storage_dir = temp_storage_dir("corrupt-content-store");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(
+            storage_dir.join(CONTENT_STORE_FIXTURE),
+            "schema|kamn.content.file-store.v1\nobject|broken\n",
+        )
+        .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreCorruptPayload {
+                    store,
+                    reason_code,
+                    ..
+                }) if store == "content-storage" && reason_code == "content_storage_corrupt_payload_rejected"
+            ),
+            "corrupt content-store payload must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_task_snapshot_schema_is_incompatible() {
+        let storage_dir = temp_storage_dir("incompatible-task-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        let path = storage_dir.join(TASK_OPERATION_STORE_FIXTURE);
+        let mut store = FileTaskOperationSnapshotStore::new(path.clone()).expect("store");
+        store
+            .write(TaskOperationSnapshot {
+                schema_version: 1,
+                tasks: vec![],
+            })
+            .expect("fixture snapshot should persist");
+        fs::write(path, "schema|99\n").expect("fixture mutation should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreSchemaIncompatible {
+                    store,
+                    reason_code,
+                    expected,
+                    found,
+                }) if store == "task-operation-snapshot-store"
+                    && reason_code == "task_operation_snapshot_schema_mismatch_rejected"
+                    && expected == "1"
+                    && found == "99"
+            ),
+            "incompatible task snapshot schema must fail closed with deterministic reason code"
+        );
+    }
+
+    fn temp_storage_dir(tag: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be monotonic")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "kamn-bootstrap-{tag}-{}-{nonce}",
+            std::process::id()
+        ))
     }
 }

--- a/crates/kamn-core/src/config.rs
+++ b/crates/kamn-core/src/config.rs
@@ -229,6 +229,35 @@ pub enum ConfigError {
     RuntimeDaemonLifecycle(String),
     /// Runtime Kolme live-provider wiring validation failure.
     RuntimeKolmeLive(String),
+    /// Runtime startup detected corrupt persisted store payload.
+    RuntimeStoreCorruptPayload {
+        /// Logical store identifier that failed validation.
+        store: &'static str,
+        /// Stable reason code for fail-closed policy lanes.
+        reason_code: &'static str,
+        /// Detailed validation failure message.
+        detail: String,
+    },
+    /// Runtime startup detected incompatible persisted store schema/version.
+    RuntimeStoreSchemaIncompatible {
+        /// Logical store identifier that failed validation.
+        store: &'static str,
+        /// Stable reason code for fail-closed policy lanes.
+        reason_code: &'static str,
+        /// Expected schema/version marker.
+        expected: String,
+        /// Observed schema/version marker.
+        found: String,
+    },
+    /// Runtime startup detected a non-corruption compatibility failure.
+    RuntimeStoreCompatibility {
+        /// Logical store identifier that failed validation.
+        store: &'static str,
+        /// Stable reason code for fail-closed policy lanes.
+        reason_code: &'static str,
+        /// Detailed validation failure message.
+        detail: String,
+    },
     /// Unknown command-line/config argument.
     UnknownArgument(String),
     /// Argument flag required a value but none was provided.
@@ -286,6 +315,31 @@ impl fmt::Display for ConfigError {
             Self::RuntimeKolmeLive(message) => {
                 write!(f, "runtime kolme live validation failed: {message}")
             }
+            Self::RuntimeStoreCorruptPayload {
+                store,
+                reason_code,
+                detail,
+            } => write!(
+                f,
+                "runtime store {store} corrupt payload ({reason_code}): {detail}"
+            ),
+            Self::RuntimeStoreSchemaIncompatible {
+                store,
+                reason_code,
+                expected,
+                found,
+            } => write!(
+                f,
+                "runtime store {store} schema incompatible ({reason_code}): expected {expected}, found {found}"
+            ),
+            Self::RuntimeStoreCompatibility {
+                store,
+                reason_code,
+                detail,
+            } => write!(
+                f,
+                "runtime store {store} compatibility failure ({reason_code}): {detail}"
+            ),
             Self::UnknownArgument(value) => write!(f, "unknown argument: {value}"),
             Self::MissingArgumentValue(flag) => {
                 write!(f, "missing value for argument: {flag}")

--- a/docs/architecture/persistence-backends.md
+++ b/docs/architecture/persistence-backends.md
@@ -18,6 +18,28 @@ Current execution slices are Task #2901 (core implementation) and Task #2903 (li
 | Content objects | `InMemoryContentAdapter` | `FileContentAdapter` | Deterministic file payload with CID/integrity verification |
 | DID chain submission idempotency | `InMemoryDidRegistrationChainAdapter` | `FileDidRegistrationChainAdapter` | Durable duplicate/reject state across restarts |
 
+## Bootstrap Wiring and Startup Compatibility (Task #3068)
+
+Bootstrap now validates prioritized runtime stores against durable file adapters before emitting a runtime plan:
+
+- `content-storage:file-default` -> `content-store.snapshot`
+- `did-registry:file-default` -> `did-chain-adapter.snapshot`
+- `task-operation-snapshot-store:file-default` -> `task-operation.snapshot`
+- `durable-guard-snapshot-store:file-default` -> `durable-guard.snapshot`
+
+Bootstrap fail-closed compatibility error taxonomy:
+
+- `ConfigError::RuntimeStoreCorruptPayload { store, reason_code, detail }`
+- `ConfigError::RuntimeStoreSchemaIncompatible { store, reason_code, expected, found }`
+- `ConfigError::RuntimeStoreCompatibility { store, reason_code, detail }`
+
+Deterministic reason codes enforced for prioritized corruption/schema checks:
+
+- `content_storage_corrupt_payload_rejected`
+- `did_registry_corrupt_payload_rejected`
+- `task_operation_snapshot_schema_mismatch_rejected`
+- `durable_guard_snapshot_schema_mismatch_rejected`
+
 ## New File-Backed Formats
 
 ### Content Store
@@ -68,6 +90,9 @@ Low-cost lane (PR-safe):
 - `cargo test -p kamn-core --test task_operation_snapshot task_operation_snapshot_rejects_schema_version_mismatch`
 - `cargo test -p kamn-core --test durable_guard_snapshot_store unit_bundle_schema_mismatch_is_rejected`
 - `cargo test -p kamn-core --test task_operation_snapshot task_operation_snapshot_bounded_roundtrip_benchmark_is_fast_for_ci`
+- `cargo test -p kamn-core bootstrap_wiring_includes_durable_store_components`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_content_store_payload_is_corrupt`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_task_snapshot_schema_is_incompatible`
 - `cargo fmt --check`
 - `cargo clippy -p kamn-core -- -D warnings`
 

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -20,6 +20,10 @@ This document describes the initial KAMN chain bootstrap scaffold.
 - Migration scaffolding:
   - `MigrationRegistry`, `MigrationStep`, and `MigrationPlan` for deterministic, contiguous state upgrades.
   - `bootstrap_from_state_version(...)` to compute the startup migration plan from persisted state to current schema.
+- Runtime persistence startup checks:
+  - bootstrap validates prioritized durable store adapters under `storage_dir` before plan emission.
+  - default store components include `content-storage:file-default`, `did-registry:file-default`, `task-operation-snapshot-store:file-default`, and `durable-guard-snapshot-store:file-default`.
+  - compatibility failures fail closed with typed `ConfigError` variants for corrupt payloads and schema incompatibility.
 
 ## Local Validation
 Run from repository root:

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -18,6 +18,15 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
 - Post-roadmap hardening wave 3 persistence live-validation expansion delivered:
   - Runtime lane: `scripts/runtime/validate_persistence_adapters_live.sh` and `scripts/runtime/test_validate_persistence_adapters_live.sh` (Task #3068, Subtask #3070).
+  - Bootstrap/runtime wiring now defaults prioritized persistence surfaces to durable file adapters in plan components:
+    - `content-storage:file-default`
+    - `did-registry:file-default`
+    - `task-operation-snapshot-store:file-default`
+    - `durable-guard-snapshot-store:file-default`
+  - Bootstrap startup now validates prioritized persisted store compatibility and fails closed with typed config errors:
+    - `ConfigError::RuntimeStoreCorruptPayload`
+    - `ConfigError::RuntimeStoreSchemaIncompatible`
+    - `ConfigError::RuntimeStoreCompatibility`
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `restart_recovery_status=verified`, `corruption_fail_closed_status=verified`, `incompatible_schema_fail_closed_status=verified`, `execution_scope=local-scheduled`, `performance_budget_status=verified`.
   - Fail-closed reason-code matrix validated: `content_storage_corrupt_payload_rejected`, `did_registry_corrupt_payload_rejected`, `task_operation_snapshot_schema_mismatch_rejected`, `durable_guard_snapshot_schema_mismatch_rejected`.
 - Post-roadmap hardening wave 1 initial slice delivered:


### PR DESCRIPTION
## Summary
Wire prioritized runtime persistence surfaces to durable file-backed defaults during bootstrap planning and add fail-closed startup compatibility checks for corrupt payloads and schema/version incompatibility.

Closes #3068

## Changes
- `crates/kamn-core/src/bootstrap.rs`: add prioritized durable store layout resolution under `storage_dir`, startup compatibility validation for content/DID/task-snapshot/durable-guard stores, deterministic component projection, and bootstrap tests.
- `crates/kamn-core/src/config.rs`: add typed runtime store startup error variants (`RuntimeStoreCorruptPayload`, `RuntimeStoreSchemaIncompatible`, `RuntimeStoreCompatibility`) with display formatting.
- `docs/architecture/persistence-backends.md`: document bootstrap durable-default wiring components, startup fail-closed taxonomy, and low-cost validation commands.
- `docs/foundation/bootstrap.md`: document bootstrap startup persistence validation behavior and durable-default component projection.
- `docs/plans/2026-02-08-production-service-roadmap.md`: record #3068 delivery details.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-core bootstrap_wiring_includes_durable_store_components -- --nocapture`
  - failed: assertion missing `content-storage:file-default`
- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_content_store_payload_is_corrupt -- --nocapture`
  - failed: bootstrap did not fail closed on corrupt persisted content fixture
- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_task_snapshot_schema_is_incompatible -- --nocapture`
  - failed: bootstrap did not fail closed on schema-incompatible task snapshot fixture

### 🟢 Green Phase
- `cargo test -p kamn-core bootstrap::tests:: -- --nocapture`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core --test content_storage_file_adapter --test did_registry_file_chain_adapter --test task_operation_snapshot --test durable_guard_snapshot_store -- --nocapture`
- `cargo test -p kamn-core --test state_migration_bootstrap -- --nocapture`
- `cargo test -p kamn-core --test p2p_transport_runtime -- --nocapture`
- `cargo test -p kamn-core --test role_smoke_network -- --nocapture`
- `cargo test -p kamn-core --test kolme_integration_roadmap_docs -- --nocapture`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `bootstrap::tests::bootstrap_wiring_includes_durable_store_components` | |
| Functional   | ✅ | durable-default bootstrap wiring + store compatibility checks | |
| Integration  | ✅ | state migration + runtime wiring regression suites re-run | |
| Regression   | ✅ | new fail-closed bootstrap tests for corrupt payload and schema mismatch | |
| Performance  | N/A | none in this slice | no new throughput-sensitive path; existing persistence budget tests re-run in targeted suite |

## Risks & Rollback
- Behavior change: bootstrap now fails closed for incompatible prioritized persisted stores.
- Rollback: revert commit `5bd671e`.

## Documentation Updates
- `docs/architecture/persistence-backends.md`
- `docs/foundation/bootstrap.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated
