### PR TITLE
feat(bootstrap): extend startup compatibility checks to remaining snapshot stores

### DIFF
--- a/crates/kamn-core/src/bootstrap.rs
+++ b/crates/kamn-core/src/bootstrap.rs
@@ -1,14 +1,24 @@
 //! Bootstrap planning for validated config, schema migrations, and runtime wiring.
 
+use crate::channel_models::{
+    ChannelSnapshotError, ChannelSnapshotStore, ChannelSnapshotStoreError, FileChannelSnapshotStore,
+};
 use crate::config::{ConfigError, NodeConfig};
 use crate::content_storage::{ContentStorageError, FileContentAdapter};
 use crate::did_registry::{DidRegistryError, FileDidRegistrationChainAdapter};
 use crate::durable_guard_store::{
     DurableGuardBundleSnapshotStore, DurableGuardSnapshotStoreError, FileDurableGuardSnapshotStore,
 };
+use crate::message_lifecycle::{
+    FileMessageLifecycleSnapshotStore, MessageLifecycleSnapshotError,
+    MessageLifecycleSnapshotStore, MessageLifecycleSnapshotStoreError,
+};
 use crate::migrations::{MigrationPlan, MigrationRegistry};
 use crate::namespaces::StateNamespaces;
-use crate::runtime::{build_runtime_wiring, RuntimeWiring};
+use crate::runtime::{
+    build_runtime_wiring, FileRuntimeSnapshotStore, RuntimeSnapshotStore, RuntimeWiring,
+    SnapshotStoreError,
+};
 use crate::state::{AppStateSchema, StateVersion, APP_STATE_VERSION};
 use crate::task_operations::{
     FileTaskOperationSnapshotStore, TaskOperationError, TaskOperationSnapshotStore,
@@ -22,11 +32,18 @@ const CONTENT_STORE_FILE_NAME: &str = "content-store.snapshot";
 const DID_REGISTRY_STORE_FILE_NAME: &str = "did-chain-adapter.snapshot";
 const TASK_OPERATION_STORE_FILE_NAME: &str = "task-operation.snapshot";
 const DURABLE_GUARD_STORE_FILE_NAME: &str = "durable-guard.snapshot";
+const CHANNEL_SNAPSHOT_STORE_FILE_NAME: &str = "channel.snapshot";
+const MESSAGE_LIFECYCLE_SNAPSHOT_STORE_FILE_NAME: &str = "message-lifecycle.snapshot";
+const RUNTIME_SNAPSHOT_STORE_FILE_NAME: &str = "runtime.snapshot";
 
 const CONTENT_STORE_COMPONENT: &str = "content-storage:file-default";
 const DID_REGISTRY_STORE_COMPONENT: &str = "did-registry:file-default";
 const TASK_OPERATION_STORE_COMPONENT: &str = "task-operation-snapshot-store:file-default";
 const DURABLE_GUARD_STORE_COMPONENT: &str = "durable-guard-snapshot-store:file-default";
+const CHANNEL_SNAPSHOT_STORE_COMPONENT: &str = "channel-snapshot-store:file-default";
+const MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT: &str =
+    "message-lifecycle-snapshot-store:file-default";
+const RUNTIME_SNAPSHOT_STORE_COMPONENT: &str = "runtime-snapshot-store:file-default";
 const DID_REGISTRY_BOOTSTRAP_PROVIDER: &str = "bootstrap-runtime-compatibility";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,6 +53,9 @@ struct RuntimePersistenceLayout {
     did_registry_store_path: PathBuf,
     task_operation_store_path: PathBuf,
     durable_guard_store_path: PathBuf,
+    channel_snapshot_store_path: PathBuf,
+    message_lifecycle_snapshot_store_path: PathBuf,
+    runtime_snapshot_store_path: PathBuf,
 }
 
 /// Deterministic bootstrap artifact bundling validated config, schema, and wiring.
@@ -107,16 +127,23 @@ fn resolve_runtime_persistence_layout(storage_dir: &str) -> RuntimePersistenceLa
         did_registry_store_path: storage_root.join(DID_REGISTRY_STORE_FILE_NAME),
         task_operation_store_path: storage_root.join(TASK_OPERATION_STORE_FILE_NAME),
         durable_guard_store_path: storage_root.join(DURABLE_GUARD_STORE_FILE_NAME),
+        channel_snapshot_store_path: storage_root.join(CHANNEL_SNAPSHOT_STORE_FILE_NAME),
+        message_lifecycle_snapshot_store_path: storage_root
+            .join(MESSAGE_LIFECYCLE_SNAPSHOT_STORE_FILE_NAME),
+        runtime_snapshot_store_path: storage_root.join(RUNTIME_SNAPSHOT_STORE_FILE_NAME),
         storage_root,
     }
 }
 
-fn prioritized_runtime_store_components() -> [&'static str; 4] {
+fn prioritized_runtime_store_components() -> [&'static str; 7] {
     [
         CONTENT_STORE_COMPONENT,
         DID_REGISTRY_STORE_COMPONENT,
         TASK_OPERATION_STORE_COMPONENT,
         DURABLE_GUARD_STORE_COMPONENT,
+        CHANNEL_SNAPSHOT_STORE_COMPONENT,
+        MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT,
+        RUNTIME_SNAPSHOT_STORE_COMPONENT,
     ]
 }
 
@@ -134,6 +161,9 @@ fn validate_runtime_persistence_layout(
     validate_did_registry_store_path(&layout.did_registry_store_path)?;
     validate_task_operation_store_path(&layout.task_operation_store_path)?;
     validate_durable_guard_store_path(&layout.durable_guard_store_path)?;
+    validate_channel_snapshot_store_path(&layout.channel_snapshot_store_path)?;
+    validate_message_lifecycle_snapshot_store_path(&layout.message_lifecycle_snapshot_store_path)?;
+    validate_runtime_snapshot_store_path(&layout.runtime_snapshot_store_path)?;
     Ok(())
 }
 
@@ -165,6 +195,33 @@ fn validate_durable_guard_store_path(path: &Path) -> Result<(), ConfigError> {
         .load_bundle()
         .map(|_| ())
         .map_err(map_durable_guard_store_validation_error)
+}
+
+fn validate_channel_snapshot_store_path(path: &Path) -> Result<(), ConfigError> {
+    let store = FileChannelSnapshotStore::new(path.to_path_buf())
+        .map_err(map_channel_store_validation_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_channel_store_validation_error)
+}
+
+fn validate_message_lifecycle_snapshot_store_path(path: &Path) -> Result<(), ConfigError> {
+    let store = FileMessageLifecycleSnapshotStore::new(path.to_path_buf())
+        .map_err(map_message_lifecycle_store_validation_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_message_lifecycle_store_validation_error)
+}
+
+fn validate_runtime_snapshot_store_path(path: &Path) -> Result<(), ConfigError> {
+    let store = FileRuntimeSnapshotStore::new(path.to_path_buf())
+        .map_err(map_runtime_snapshot_store_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_runtime_snapshot_store_error)
 }
 
 fn map_content_store_validation_error(error: ContentStorageError) -> ConfigError {
@@ -282,6 +339,112 @@ fn map_durable_guard_store_validation_error(error: DurableGuardSnapshotStoreErro
     }
 }
 
+fn map_channel_store_validation_error(error: ChannelSnapshotStoreError) -> ConfigError {
+    match error {
+        ChannelSnapshotStoreError::InvalidPayload(detail) => {
+            ConfigError::RuntimeStoreCorruptPayload {
+                store: "channel-snapshot-store",
+                reason_code: "channel_snapshot_corrupt_payload_rejected",
+                detail,
+            }
+        }
+        ChannelSnapshotStoreError::Io(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "channel-snapshot-store",
+            reason_code: "channel_snapshot_io_error",
+            detail,
+        },
+        ChannelSnapshotStoreError::Snapshot(ChannelSnapshotError::SnapshotVersionMismatch {
+            expected,
+            found,
+        }) => ConfigError::RuntimeStoreSchemaIncompatible {
+            store: "channel-snapshot-store",
+            reason_code: "channel_snapshot_schema_mismatch_rejected",
+            expected: expected.to_string(),
+            found: found.to_string(),
+        },
+        ChannelSnapshotStoreError::Snapshot(other) => ConfigError::RuntimeStoreCompatibility {
+            store: "channel-snapshot-store",
+            reason_code: "channel_snapshot_restore_validation_failed",
+            detail: other.to_string(),
+        },
+    }
+}
+
+fn map_message_lifecycle_store_validation_error(
+    error: MessageLifecycleSnapshotStoreError,
+) -> ConfigError {
+    match error {
+        MessageLifecycleSnapshotStoreError::InvalidPayload(detail) => {
+            ConfigError::RuntimeStoreCorruptPayload {
+                store: "message-lifecycle-snapshot-store",
+                reason_code: "message_lifecycle_snapshot_corrupt_payload_rejected",
+                detail,
+            }
+        }
+        MessageLifecycleSnapshotStoreError::Io(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "message-lifecycle-snapshot-store",
+            reason_code: "message_lifecycle_snapshot_io_error",
+            detail,
+        },
+        MessageLifecycleSnapshotStoreError::Snapshot(
+            MessageLifecycleSnapshotError::SnapshotVersionMismatch { expected, found },
+        ) => ConfigError::RuntimeStoreSchemaIncompatible {
+            store: "message-lifecycle-snapshot-store",
+            reason_code: "message_lifecycle_snapshot_schema_mismatch_rejected",
+            expected: expected.to_string(),
+            found: found.to_string(),
+        },
+        MessageLifecycleSnapshotStoreError::Snapshot(other) => {
+            ConfigError::RuntimeStoreCompatibility {
+                store: "message-lifecycle-snapshot-store",
+                reason_code: "message_lifecycle_snapshot_restore_validation_failed",
+                detail: other.to_string(),
+            }
+        }
+    }
+}
+
+fn map_runtime_snapshot_store_error(error: SnapshotStoreError) -> ConfigError {
+    match error {
+        SnapshotStoreError::InvalidPayload(detail) => ConfigError::RuntimeStoreCorruptPayload {
+            store: "runtime-snapshot-store",
+            reason_code: "runtime_snapshot_corrupt_payload_rejected",
+            detail,
+        },
+        SnapshotStoreError::Io(detail) => ConfigError::RuntimeStoreCompatibility {
+            store: "runtime-snapshot-store",
+            reason_code: "runtime_snapshot_io_error",
+            detail,
+        },
+        SnapshotStoreError::StateVersionRegression { previous, found } => {
+            ConfigError::RuntimeStoreSchemaIncompatible {
+                store: "runtime-snapshot-store",
+                reason_code: "runtime_snapshot_state_version_regression_rejected",
+                expected: format!(">{previous}"),
+                found: found.to_string(),
+            }
+        }
+        SnapshotStoreError::CursorRegression { previous, found } => {
+            ConfigError::RuntimeStoreSchemaIncompatible {
+                store: "runtime-snapshot-store",
+                reason_code: "runtime_snapshot_cursor_regression_rejected",
+                expected: format!(">{previous}"),
+                found: found.to_string(),
+            }
+        }
+        SnapshotStoreError::StaleStateHash {
+            state_hash,
+            previous_version,
+            found_version,
+        } => ConfigError::RuntimeStoreSchemaIncompatible {
+            store: "runtime-snapshot-store",
+            reason_code: "runtime_snapshot_stale_hash_regression_rejected",
+            expected: format!("{state_hash}@>{previous_version}"),
+            found: format!("{state_hash}@{found_version}"),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{bootstrap, bootstrap_from_state_version};
@@ -297,6 +460,9 @@ mod tests {
 
     const CONTENT_STORE_FIXTURE: &str = "content-store.snapshot";
     const TASK_OPERATION_STORE_FIXTURE: &str = "task-operation.snapshot";
+    const CHANNEL_STORE_FIXTURE: &str = "channel.snapshot";
+    const MESSAGE_LIFECYCLE_STORE_FIXTURE: &str = "message-lifecycle.snapshot";
+    const RUNTIME_SNAPSHOT_STORE_FIXTURE: &str = "runtime.snapshot";
 
     #[test]
     fn bootstrap_plan_builds_for_valid_config() {
@@ -366,6 +532,9 @@ mod tests {
         assert!(components.contains(&"did-registry:file-default"));
         assert!(components.contains(&"task-operation-snapshot-store:file-default"));
         assert!(components.contains(&"durable-guard-snapshot-store:file-default"));
+        assert!(components.contains(&"channel-snapshot-store:file-default"));
+        assert!(components.contains(&"message-lifecycle-snapshot-store:file-default"));
+        assert!(components.contains(&"runtime-snapshot-store:file-default"));
     }
 
     #[test]
@@ -439,6 +608,216 @@ mod tests {
                     && found == "99"
             ),
             "incompatible task snapshot schema must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_channel_snapshot_payload_is_corrupt() {
+        let storage_dir = temp_storage_dir("corrupt-channel-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(
+            storage_dir.join(CHANNEL_STORE_FIXTURE),
+            "schema|1\nbroken\n",
+        )
+        .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreCorruptPayload {
+                    store,
+                    reason_code,
+                    ..
+                }) if store == "channel-snapshot-store"
+                    && reason_code == "channel_snapshot_corrupt_payload_rejected"
+            ),
+            "corrupt channel snapshot payload must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_channel_snapshot_schema_is_incompatible() {
+        let storage_dir = temp_storage_dir("incompatible-channel-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(storage_dir.join(CHANNEL_STORE_FIXTURE), "schema|99\n")
+            .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreSchemaIncompatible {
+                    store,
+                    reason_code,
+                    expected,
+                    found,
+                }) if store == "channel-snapshot-store"
+                    && reason_code == "channel_snapshot_schema_mismatch_rejected"
+                    && expected == "1"
+                    && found == "99"
+            ),
+            "incompatible channel snapshot schema must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_message_snapshot_payload_is_corrupt() {
+        let storage_dir = temp_storage_dir("corrupt-message-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(
+            storage_dir.join(MESSAGE_LIFECYCLE_STORE_FIXTURE),
+            "schema|1\nbroken\n",
+        )
+        .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreCorruptPayload {
+                    store,
+                    reason_code,
+                    ..
+                }) if store == "message-lifecycle-snapshot-store"
+                    && reason_code == "message_lifecycle_snapshot_corrupt_payload_rejected"
+            ),
+            "corrupt message snapshot payload must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_message_snapshot_schema_is_incompatible() {
+        let storage_dir = temp_storage_dir("incompatible-message-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(
+            storage_dir.join(MESSAGE_LIFECYCLE_STORE_FIXTURE),
+            "schema|99\n",
+        )
+        .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreSchemaIncompatible {
+                    store,
+                    reason_code,
+                    expected,
+                    found,
+                }) if store == "message-lifecycle-snapshot-store"
+                    && reason_code == "message_lifecycle_snapshot_schema_mismatch_rejected"
+                    && expected == "1"
+                    && found == "99"
+            ),
+            "incompatible message snapshot schema must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_runtime_snapshot_payload_is_corrupt() {
+        let storage_dir = temp_storage_dir("corrupt-runtime-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(
+            storage_dir.join(RUNTIME_SNAPSHOT_STORE_FIXTURE),
+            "not-a-valid-snapshot-line\n",
+        )
+        .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreCorruptPayload {
+                    store,
+                    reason_code,
+                    ..
+                }) if store == "runtime-snapshot-store"
+                    && reason_code == "runtime_snapshot_corrupt_payload_rejected"
+            ),
+            "corrupt runtime snapshot payload must fail closed with deterministic reason code"
+        );
+    }
+
+    #[test]
+    fn regression_bootstrap_fails_closed_when_runtime_snapshot_state_version_regresses() {
+        let storage_dir = temp_storage_dir("incompatible-runtime-snapshot");
+        fs::create_dir_all(&storage_dir).expect("fixture directory should build");
+        fs::write(
+            storage_dir.join(RUNTIME_SNAPSHOT_STORE_FIXTURE),
+            "10|statehash_a|10\n9|statehash_b|11\n",
+        )
+        .expect("fixture should write");
+
+        let config = NodeConfig {
+            chain_id: "kamn-devnet".to_owned(),
+            chain_version: "v0.1.0".to_owned(),
+            role: NodeRole::Processor,
+            storage_dir: storage_dir.to_string_lossy().into_owned(),
+            enable_gossip: true,
+            sync_mode: SyncMode::Fast,
+        };
+
+        let result = bootstrap(config);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::RuntimeStoreSchemaIncompatible {
+                    store,
+                    reason_code,
+                    expected,
+                    found,
+                }) if store == "runtime-snapshot-store"
+                    && reason_code == "runtime_snapshot_state_version_regression_rejected"
+                    && expected == ">10"
+                    && found == "9"
+            ),
+            "runtime snapshot state version regression must fail closed with deterministic reason code"
         );
     }
 

--- a/docs/architecture/persistence-backends.md
+++ b/docs/architecture/persistence-backends.md
@@ -18,7 +18,7 @@ Current execution slices are Task #2901 (core implementation) and Task #2903 (li
 | Content objects | `InMemoryContentAdapter` | `FileContentAdapter` | Deterministic file payload with CID/integrity verification |
 | DID chain submission idempotency | `InMemoryDidRegistrationChainAdapter` | `FileDidRegistrationChainAdapter` | Durable duplicate/reject state across restarts |
 
-## Bootstrap Wiring and Startup Compatibility (Task #3068)
+## Bootstrap Wiring and Startup Compatibility (Task #3068, Task #3078)
 
 Bootstrap now validates prioritized runtime stores against durable file adapters before emitting a runtime plan:
 
@@ -26,6 +26,9 @@ Bootstrap now validates prioritized runtime stores against durable file adapters
 - `did-registry:file-default` -> `did-chain-adapter.snapshot`
 - `task-operation-snapshot-store:file-default` -> `task-operation.snapshot`
 - `durable-guard-snapshot-store:file-default` -> `durable-guard.snapshot`
+- `channel-snapshot-store:file-default` -> `channel.snapshot`
+- `message-lifecycle-snapshot-store:file-default` -> `message-lifecycle.snapshot`
+- `runtime-snapshot-store:file-default` -> `runtime.snapshot`
 
 Bootstrap fail-closed compatibility error taxonomy:
 
@@ -39,6 +42,12 @@ Deterministic reason codes enforced for prioritized corruption/schema checks:
 - `did_registry_corrupt_payload_rejected`
 - `task_operation_snapshot_schema_mismatch_rejected`
 - `durable_guard_snapshot_schema_mismatch_rejected`
+- `channel_snapshot_corrupt_payload_rejected`
+- `channel_snapshot_schema_mismatch_rejected`
+- `message_lifecycle_snapshot_corrupt_payload_rejected`
+- `message_lifecycle_snapshot_schema_mismatch_rejected`
+- `runtime_snapshot_corrupt_payload_rejected`
+- `runtime_snapshot_state_version_regression_rejected`
 
 ## New File-Backed Formats
 
@@ -79,7 +88,7 @@ Live validation lane (local realistic dependency path):
   - `evidence_bundle_status=verified`
   - `execution_scope=local-scheduled`
   - `performance_budget_status=verified`
-  - `fail_closed_reason_codes=content_storage_corrupt_payload_rejected,did_registry_corrupt_payload_rejected,task_operation_snapshot_schema_mismatch_rejected,durable_guard_snapshot_schema_mismatch_rejected`
+  - `fail_closed_reason_codes=content_storage_corrupt_payload_rejected,did_registry_corrupt_payload_rejected,task_operation_snapshot_schema_mismatch_rejected,durable_guard_snapshot_schema_mismatch_rejected,channel_snapshot_corrupt_payload_rejected,channel_snapshot_schema_mismatch_rejected,message_lifecycle_snapshot_corrupt_payload_rejected,message_lifecycle_snapshot_schema_mismatch_rejected,runtime_snapshot_corrupt_payload_rejected,runtime_snapshot_state_version_regression_rejected`
 
 Low-cost lane (PR-safe):
 
@@ -93,6 +102,12 @@ Low-cost lane (PR-safe):
 - `cargo test -p kamn-core bootstrap_wiring_includes_durable_store_components`
 - `cargo test -p kamn-core regression_bootstrap_fails_closed_when_content_store_payload_is_corrupt`
 - `cargo test -p kamn-core regression_bootstrap_fails_closed_when_task_snapshot_schema_is_incompatible`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_channel_snapshot_payload_is_corrupt`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_channel_snapshot_schema_is_incompatible`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_message_snapshot_payload_is_corrupt`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_message_snapshot_schema_is_incompatible`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_runtime_snapshot_payload_is_corrupt`
+- `cargo test -p kamn-core regression_bootstrap_fails_closed_when_runtime_snapshot_state_version_regresses`
 - `cargo fmt --check`
 - `cargo clippy -p kamn-core -- -D warnings`
 

--- a/docs/foundation/bootstrap.md
+++ b/docs/foundation/bootstrap.md
@@ -22,7 +22,7 @@ This document describes the initial KAMN chain bootstrap scaffold.
   - `bootstrap_from_state_version(...)` to compute the startup migration plan from persisted state to current schema.
 - Runtime persistence startup checks:
   - bootstrap validates prioritized durable store adapters under `storage_dir` before plan emission.
-  - default store components include `content-storage:file-default`, `did-registry:file-default`, `task-operation-snapshot-store:file-default`, and `durable-guard-snapshot-store:file-default`.
+  - default store components include `content-storage:file-default`, `did-registry:file-default`, `task-operation-snapshot-store:file-default`, `durable-guard-snapshot-store:file-default`, `channel-snapshot-store:file-default`, `message-lifecycle-snapshot-store:file-default`, and `runtime-snapshot-store:file-default`.
   - compatibility failures fail closed with typed `ConfigError` variants for corrupt payloads and schema incompatibility.
 
 ## Local Validation

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -18,17 +18,21 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Remaining: broader persistence backend consolidation and runtime wiring across additional stores.
 - Post-roadmap hardening wave 3 persistence live-validation expansion delivered:
   - Runtime lane: `scripts/runtime/validate_persistence_adapters_live.sh` and `scripts/runtime/test_validate_persistence_adapters_live.sh` (Task #3068, Subtask #3070).
+  - Follow-on bootstrap coverage expansion delivered (Task #3078) for remaining snapshot stores.
   - Bootstrap/runtime wiring now defaults prioritized persistence surfaces to durable file adapters in plan components:
     - `content-storage:file-default`
     - `did-registry:file-default`
     - `task-operation-snapshot-store:file-default`
     - `durable-guard-snapshot-store:file-default`
+    - `channel-snapshot-store:file-default`
+    - `message-lifecycle-snapshot-store:file-default`
+    - `runtime-snapshot-store:file-default`
   - Bootstrap startup now validates prioritized persisted store compatibility and fails closed with typed config errors:
     - `ConfigError::RuntimeStoreCorruptPayload`
     - `ConfigError::RuntimeStoreSchemaIncompatible`
     - `ConfigError::RuntimeStoreCompatibility`
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `restart_recovery_status=verified`, `corruption_fail_closed_status=verified`, `incompatible_schema_fail_closed_status=verified`, `execution_scope=local-scheduled`, `performance_budget_status=verified`.
-  - Fail-closed reason-code matrix validated: `content_storage_corrupt_payload_rejected`, `did_registry_corrupt_payload_rejected`, `task_operation_snapshot_schema_mismatch_rejected`, `durable_guard_snapshot_schema_mismatch_rejected`.
+  - Fail-closed reason-code matrix validated: `content_storage_corrupt_payload_rejected`, `did_registry_corrupt_payload_rejected`, `task_operation_snapshot_schema_mismatch_rejected`, `durable_guard_snapshot_schema_mismatch_rejected`, `channel_snapshot_corrupt_payload_rejected`, `channel_snapshot_schema_mismatch_rejected`, `message_lifecycle_snapshot_corrupt_payload_rejected`, `message_lifecycle_snapshot_schema_mismatch_rejected`, `runtime_snapshot_corrupt_payload_rejected`, `runtime_snapshot_state_version_regression_rejected`.
 - Post-roadmap hardening wave 1 initial slice delivered:
   - Added deterministic `execution_id` structured logging correlation field for runtime dispatch/start/complete lifecycle events in `kamn-node` (Task #3032, Subtask #3033).
   - Added regression assertions in `crates/kamn-node/src/main_tests/core_behavior_tests.rs` to fail closed when runtime structured events omit `execution_id`.


### PR DESCRIPTION
## Summary
Extends bootstrap runtime persistence validation to the remaining durable snapshot stores so startup fails closed for corrupt and schema/version-incompatible persisted payloads before runtime wiring is emitted. This closes the remaining store coverage gap in Story #3069.

Closes #3078

## Changes
- `crates/kamn-core/src/bootstrap.rs`: added durable-default wiring components and startup compatibility checks for channel/message/runtime snapshots.
- `crates/kamn-core/src/bootstrap.rs`: mapped channel/message/runtime snapshot corruption and schema/version failures into typed `ConfigError` fail-closed variants with deterministic reason codes.
- `crates/kamn-core/src/bootstrap.rs`: added regression coverage for corrupt payload and schema/version incompatibility paths across the new stores.
- `docs/architecture/persistence-backends.md`: expanded bootstrap coverage table and fail-closed reason-code matrix.
- `docs/foundation/bootstrap.md`: documented expanded default persistence components.
- `docs/plans/2026-02-08-production-service-roadmap.md`: updated execution status with Task #3078 coverage expansion.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Added failing assertions for channel/message/runtime store coverage and fail-closed mappings in bootstrap tests before finalizing mappings and startup validation checks.

### 🟢 Green Phase
- `cargo test -p kamn-core --lib bootstrap::tests:: -- --nocapture`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core --test state_migration_bootstrap -- --nocapture`
- `cargo test -p kamn-core --test kolme_integration_roadmap_docs -- --nocapture`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `bootstrap::tests::regression_bootstrap_fails_closed_when_channel_snapshot_payload_is_corrupt`, `bootstrap::tests::regression_bootstrap_fails_closed_when_channel_snapshot_schema_is_incompatible`, `bootstrap::tests::regression_bootstrap_fails_closed_when_message_snapshot_payload_is_corrupt`, `bootstrap::tests::regression_bootstrap_fails_closed_when_message_snapshot_schema_is_incompatible`, `bootstrap::tests::regression_bootstrap_fails_closed_when_runtime_snapshot_payload_is_corrupt`, `bootstrap::tests::regression_bootstrap_fails_closed_when_runtime_snapshot_state_version_regresses` | |
| Functional   | ✅ | `bootstrap::tests::bootstrap_wiring_includes_durable_store_components` | |
| Integration  | ✅ | `state_migration_bootstrap` | |
| Regression   | ✅ | bootstrap fail-closed regression tests above | |
| Performance  | N/A | | No throughput path changes; startup validation remains bounded file parsing. |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `11e0458` to restore previous bootstrap validation scope.

## Documentation Updates
- `docs/architecture/persistence-backends.md`
- `docs/foundation/bootstrap.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted regression suite)
- [x] Docs updated (or justified why not)
