### PR TITLE
test(runtime): align persistence lane reason-code matrix with bootstrap coverage

### DIFF
--- a/docs/architecture/persistence-backends.md
+++ b/docs/architecture/persistence-backends.md
@@ -75,6 +75,7 @@ Live validation lane (local realistic dependency path):
 
 - `bash scripts/runtime/validate_persistence_adapters_live.sh --output-json /tmp/persistence-adapters-live.json`
 - `bash scripts/runtime/test_validate_persistence_adapters_live.sh`
+- lane contract now executes bootstrap fail-closed regressions for channel/message/runtime snapshot stores in addition to prior content/DID/task/durable-guard checks.
 - Evidence schema: `kamn.persistence.adapters-live-validation.v1`
 - Required markers:
   - `status=pass`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -19,6 +19,7 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Post-roadmap hardening wave 3 persistence live-validation expansion delivered:
   - Runtime lane: `scripts/runtime/validate_persistence_adapters_live.sh` and `scripts/runtime/test_validate_persistence_adapters_live.sh` (Task #3068, Subtask #3070).
   - Follow-on bootstrap coverage expansion delivered (Task #3078) for remaining snapshot stores.
+  - Lane reason-code matrix and harness expectations expanded to include new bootstrap snapshot reason codes (Task #3080).
   - Bootstrap/runtime wiring now defaults prioritized persistence surfaces to durable file adapters in plan components:
     - `content-storage:file-default`
     - `did-registry:file-default`

--- a/scripts/runtime/test_validate_persistence_adapters_live.sh
+++ b/scripts/runtime/test_validate_persistence_adapters_live.sh
@@ -93,6 +93,12 @@ if reason_codes != [
     "did_registry_corrupt_payload_rejected",
     "task_operation_snapshot_schema_mismatch_rejected",
     "durable_guard_snapshot_schema_mismatch_rejected",
+    "channel_snapshot_corrupt_payload_rejected",
+    "channel_snapshot_schema_mismatch_rejected",
+    "message_lifecycle_snapshot_corrupt_payload_rejected",
+    "message_lifecycle_snapshot_schema_mismatch_rejected",
+    "runtime_snapshot_corrupt_payload_rejected",
+    "runtime_snapshot_state_version_regression_rejected",
 ]:
     raise SystemExit("expected deterministic fail_closed_reason_codes contract list")
 PY

--- a/scripts/runtime/validate_persistence_adapters_live.sh
+++ b/scripts/runtime/validate_persistence_adapters_live.sh
@@ -55,7 +55,13 @@ for marker in \
   "restart_recovery_status=verified" \
   "corruption_fail_closed_status=verified" \
   "incompatible_schema_fail_closed_status=verified" \
-  "execution_scope=local-scheduled"; do
+  "execution_scope=local-scheduled" \
+  "channel_snapshot_corrupt_payload_rejected" \
+  "channel_snapshot_schema_mismatch_rejected" \
+  "message_lifecycle_snapshot_corrupt_payload_rejected" \
+  "message_lifecycle_snapshot_schema_mismatch_rejected" \
+  "runtime_snapshot_corrupt_payload_rejected" \
+  "runtime_snapshot_state_version_regression_rejected"; do
   if ! grep -q -- "$marker" "$PERSISTENCE_DOC"; then
     echo "expected persistence architecture doc marker: $marker" >&2
     exit 1
@@ -64,10 +70,17 @@ done
 
 for marker in \
   "Task #3068, Subtask #3070" \
+  "Task #3078" \
   "scripts/runtime/validate_persistence_adapters_live.sh" \
   "content_storage_corrupt_payload_rejected" \
   "task_operation_snapshot_schema_mismatch_rejected" \
-  "durable_guard_snapshot_schema_mismatch_rejected"; do
+  "durable_guard_snapshot_schema_mismatch_rejected" \
+  "channel_snapshot_corrupt_payload_rejected" \
+  "channel_snapshot_schema_mismatch_rejected" \
+  "message_lifecycle_snapshot_corrupt_payload_rejected" \
+  "message_lifecycle_snapshot_schema_mismatch_rejected" \
+  "runtime_snapshot_corrupt_payload_rejected" \
+  "runtime_snapshot_state_version_regression_rejected"; do
   if ! grep -q -- "$marker" "$ROADMAP_DOC"; then
     echo "expected roadmap marker for persistence live validation: $marker" >&2
     exit 1
@@ -96,6 +109,24 @@ cargo test -p kamn-core --test durable_guard_snapshot_store \
 cargo test -p kamn-core --test task_operation_snapshot \
   task_operation_snapshot_bounded_roundtrip_benchmark_is_fast_for_ci -- --nocapture \
   >"$TMP_DIR/task-snapshot-performance.log" 2>&1
+cargo test -p kamn-core --lib \
+  bootstrap::tests::regression_bootstrap_fails_closed_when_channel_snapshot_payload_is_corrupt -- --nocapture \
+  >"$TMP_DIR/bootstrap-channel-corrupt.log" 2>&1
+cargo test -p kamn-core --lib \
+  bootstrap::tests::regression_bootstrap_fails_closed_when_channel_snapshot_schema_is_incompatible -- --nocapture \
+  >"$TMP_DIR/bootstrap-channel-schema.log" 2>&1
+cargo test -p kamn-core --lib \
+  bootstrap::tests::regression_bootstrap_fails_closed_when_message_snapshot_payload_is_corrupt -- --nocapture \
+  >"$TMP_DIR/bootstrap-message-corrupt.log" 2>&1
+cargo test -p kamn-core --lib \
+  bootstrap::tests::regression_bootstrap_fails_closed_when_message_snapshot_schema_is_incompatible -- --nocapture \
+  >"$TMP_DIR/bootstrap-message-schema.log" 2>&1
+cargo test -p kamn-core --lib \
+  bootstrap::tests::regression_bootstrap_fails_closed_when_runtime_snapshot_payload_is_corrupt -- --nocapture \
+  >"$TMP_DIR/bootstrap-runtime-corrupt.log" 2>&1
+cargo test -p kamn-core --lib \
+  bootstrap::tests::regression_bootstrap_fails_closed_when_runtime_snapshot_state_version_regresses -- --nocapture \
+  >"$TMP_DIR/bootstrap-runtime-version-regression.log" 2>&1
 popd >/dev/null
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
@@ -123,7 +154,13 @@ cat >"$report_json" <<JSON
     "content_storage_corrupt_payload_rejected",
     "did_registry_corrupt_payload_rejected",
     "task_operation_snapshot_schema_mismatch_rejected",
-    "durable_guard_snapshot_schema_mismatch_rejected"
+    "durable_guard_snapshot_schema_mismatch_rejected",
+    "channel_snapshot_corrupt_payload_rejected",
+    "channel_snapshot_schema_mismatch_rejected",
+    "message_lifecycle_snapshot_corrupt_payload_rejected",
+    "message_lifecycle_snapshot_schema_mismatch_rejected",
+    "runtime_snapshot_corrupt_payload_rejected",
+    "runtime_snapshot_state_version_regression_rejected"
   ],
   "elapsed_seconds": $elapsed_seconds
 }
@@ -144,4 +181,4 @@ echo "fail_closed_status=verified"
 echo "evidence_bundle_status=verified"
 echo "execution_scope=local-scheduled"
 echo "performance_budget_status=verified"
-echo "fail_closed_reason_codes=content_storage_corrupt_payload_rejected,did_registry_corrupt_payload_rejected,task_operation_snapshot_schema_mismatch_rejected,durable_guard_snapshot_schema_mismatch_rejected"
+echo "fail_closed_reason_codes=content_storage_corrupt_payload_rejected,did_registry_corrupt_payload_rejected,task_operation_snapshot_schema_mismatch_rejected,durable_guard_snapshot_schema_mismatch_rejected,channel_snapshot_corrupt_payload_rejected,channel_snapshot_schema_mismatch_rejected,message_lifecycle_snapshot_corrupt_payload_rejected,message_lifecycle_snapshot_schema_mismatch_rejected,runtime_snapshot_corrupt_payload_rejected,runtime_snapshot_state_version_regression_rejected"


### PR DESCRIPTION
## Summary
Aligns the persistence live-validation lane contract with Task #3078 by extending the fail-closed reason-code matrix and harness assertions to include channel/message/runtime bootstrap snapshot coverage.

Closes #3080

## Changes
- `scripts/runtime/validate_persistence_adapters_live.sh`: extended doc marker checks, fail-closed reason-code output matrix, and bootstrap regression test execution for new snapshot stores.
- `scripts/runtime/test_validate_persistence_adapters_live.sh`: updated deterministic `fail_closed_reason_codes` contract expectation list.
- `docs/architecture/persistence-backends.md`: added explicit note that live lane now exercises bootstrap regressions for channel/message/runtime snapshots.
- `docs/plans/2026-02-08-production-service-roadmap.md`: updated persistence wave status with Task #3080 reason-code matrix expansion.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/runtime/test_validate_persistence_adapters_live.sh`
- Failure marker: `expected deterministic fail_closed_reason_codes contract list`

### 🟢 Green Phase
- `bash scripts/runtime/test_validate_persistence_adapters_live.sh`

### 🔁 Regression
- `bash scripts/runtime/validate_persistence_adapters_live.sh --output-json /tmp/persistence3080.json`
- `cargo test -p kamn-core --test kolme_integration_roadmap_docs -- --nocapture`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | Shell contract lane task; no Rust unit surface modified. |
| Functional   | ✅ | `scripts/runtime/validate_persistence_adapters_live.sh` live-run status and reason-code markers | |
| Integration  | ✅ | `scripts/runtime/test_validate_persistence_adapters_live.sh` end-to-end script+JSON contract assertions | |
| Regression   | ✅ | invalid `--max-seconds` checks in harness + deterministic reason-code list assertion | |
| Performance  | ✅ | lane still enforces existing `max_seconds` runtime budget gate | |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `25b8087` to restore previous lane reason-code contract.

## Documentation Updates
- `docs/architecture/persistence-backends.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (no Rust source formatting changes required)
- [x] `cargo clippy -- -D warnings` — clean (unchanged Rust code paths)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted regression suite)
- [x] Docs updated (or justified why not)
