### PR TITLE
test(kolme-live): add durable component regression guards

### DIFF
--- a/crates/kamn-core/tests/persistence_live_validation_roadmap_docs.rs
+++ b/crates/kamn-core/tests/persistence_live_validation_roadmap_docs.rs
@@ -1,0 +1,10 @@
+const ROADMAP: &str = include_str!("../../../docs/plans/2026-02-08-production-service-roadmap.md");
+
+#[test]
+fn roadmap_tracks_kolme_live_runtime_durable_component_guard_status() {
+    assert!(ROADMAP.contains("Task #3078"));
+    assert!(ROADMAP.contains("Task #3082"));
+    assert!(ROADMAP.contains("channel-snapshot-store:file-default"));
+    assert!(ROADMAP.contains("message-lifecycle-snapshot-store:file-default"));
+    assert!(ROADMAP.contains("runtime-snapshot-store:file-default"));
+}

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -1359,6 +1359,13 @@ fn integration_runtime_kolme_live_renders_provider_contract_markers() {
     let report = execute(parsed).expect("kolme-live execution should succeed");
     let rendered = render_bootstrap_report(&report, OutputMode::json());
     assert!(rendered.contains("\"runtime_mode\":\"kolme-live\""));
+    assert!(rendered.contains("\"content-storage:file-default\""));
+    assert!(rendered.contains("\"did-registry:file-default\""));
+    assert!(rendered.contains("\"task-operation-snapshot-store:file-default\""));
+    assert!(rendered.contains("\"durable-guard-snapshot-store:file-default\""));
+    assert!(rendered.contains("\"channel-snapshot-store:file-default\""));
+    assert!(rendered.contains("\"message-lifecycle-snapshot-store:file-default\""));
+    assert!(rendered.contains("\"runtime-snapshot-store:file-default\""));
     assert!(rendered
         .contains("\"kolme_live_provider_client_contract\":\"KolmeRuntimeCommitLiveProvider\""));
     assert!(rendered.contains("\"kolme_live_signing_profile\":\"kolme-fork-secp256k1-v1\""));

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -20,6 +20,7 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_persistence_adapters_live.sh` and `scripts/runtime/test_validate_persistence_adapters_live.sh` (Task #3068, Subtask #3070).
   - Follow-on bootstrap coverage expansion delivered (Task #3078) for remaining snapshot stores.
   - Lane reason-code matrix and harness expectations expanded to include new bootstrap snapshot reason codes (Task #3080).
+  - Runtime `kolme-live` report-contract assertions now fail closed if any durable bootstrap component marker is missing (Task #3082).
   - Bootstrap/runtime wiring now defaults prioritized persistence surfaces to durable file adapters in plan components:
     - `content-storage:file-default`
     - `did-registry:file-default`


### PR DESCRIPTION
## Summary
Adds regression guards proving runtime `kolme-live` reports retain the full durable bootstrap component marker set introduced by persistence hardening, and anchors this status in the production roadmap.

Closes #3082

## Changes
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: strengthened `integration_runtime_kolme_live_renders_provider_contract_markers` with explicit durable-component marker assertions.
- `crates/kamn-core/tests/persistence_live_validation_roadmap_docs.rs`: added roadmap contract test for Task #3082 and durable component marker status.
- `docs/plans/2026-02-08-production-service-roadmap.md`: added execution status marker for Task #3082 runtime coverage guard.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-core --test persistence_live_validation_roadmap_docs -- --nocapture`
- Failure marker: `assertion failed: ROADMAP.contains("Task #3082")`

### 🟢 Green Phase
- `cargo test -p kamn-core --test persistence_live_validation_roadmap_docs -- --nocapture`
- `cargo test -p kamn-node integration_runtime_kolme_live_renders_provider_contract_markers -- --nocapture`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo clippy -p kamn-core -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | Assertion-only contract coverage on existing integration/docs test surfaces. |
| Functional   | ✅ | `integration_runtime_kolme_live_renders_provider_contract_markers` | |
| Integration  | ✅ | runtime `kolme-live` execute/report flow test above | |
| Regression   | ✅ | `persistence_live_validation_roadmap_docs` (new fail-closed roadmap marker guard) | |
| Performance  | N/A | | No runtime path/throughput changes. |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `9b2ec71` to remove new assertion contracts.

## Documentation Updates
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant targeted regression suite)
- [x] Docs updated (or justified why not)
