### PR TITLE
test(ci): enforce deterministic reason codes for kolme wrapper trend guards

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,0 +1,22 @@
+# CI Docs Index
+
+This directory tracks CI policy, cost controls, and contract-lane strategy.
+
+- Primary policy guide: `docs/ci/ci-cost-and-lane-framework.md`
+- CI routing and selector contracts: `docs/ci/strategy.md`
+- Billing closeout runbook: `docs/ci/post-billing-closeout.md`
+
+## Kolme Wrapper Trend Guard Reason Codes
+
+`scripts/ci/check_kolme_wrapper_budget_trend.sh` is backed by
+`scripts/ci/kolme_wrapper_inventory_baseline.py` in `--trend-mode`.
+Fail-closed reason codes are deterministic and include:
+
+- `wrapper_count_delta_threshold_exceeded`
+- `total_shell_loc_delta_threshold_exceeded`
+- `lane_shell_loc_increase_violation`
+- `unexpected_new_lanes_in_current_inventory`
+- `baseline_wrapper_count_invalid`
+- `trend_threshold_total_shell_loc_invalid`
+
+These markers are asserted in `scripts/ci/test_check_kolme_wrapper_budget_trend.sh`.

--- a/scripts/ci/kolme_wrapper_inventory_baseline.py
+++ b/scripts/ci/kolme_wrapper_inventory_baseline.py
@@ -16,19 +16,53 @@ MATRIX_SCHEMA_VERSION = "kamn.kolme.lane-migration-matrix.v1"
 TREND_THRESHOLD_SCHEMA_VERSION = "kamn.kolme.wrapper-budget-trend-thresholds.v1"
 
 
+class PolicyValidationError(Exception):
+    """Structured policy-validation failure carrying a deterministic reason code."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
 def fail(message: str) -> None:
-    raise SystemExit(message)
+    raise PolicyValidationError("policy_validation_failed", message)
+
+
+def fail_with_reason(reason_code: str, message: str) -> None:
+    raise PolicyValidationError(reason_code, message)
 
 
 def load_json_object(path: Path, *, label: str) -> dict[str, Any]:
     if not path.is_file():
-        fail(f"{label} not found: {path}")
+        reason_code = "input_file_not_found"
+        if label == "wrapper inventory baseline":
+            reason_code = "baseline_file_not_found"
+        elif label == "wrapper budget trend thresholds":
+            reason_code = "trend_threshold_file_not_found"
+        elif label == "lane migration matrix":
+            reason_code = "lane_matrix_file_not_found"
+        fail_with_reason(reason_code, f"{label} not found: {path}")
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        fail(f"invalid JSON in {label} {path}: {exc}")
+        reason_code = "input_json_invalid"
+        if label == "wrapper inventory baseline":
+            reason_code = "baseline_json_invalid"
+        elif label == "wrapper budget trend thresholds":
+            reason_code = "trend_threshold_json_invalid"
+        elif label == "lane migration matrix":
+            reason_code = "lane_matrix_json_invalid"
+        fail_with_reason(reason_code, f"invalid JSON in {label} {path}: {exc}")
     if not isinstance(payload, dict):
-        fail(f"expected JSON object for {label}: {path}")
+        reason_code = "input_payload_not_object"
+        if label == "wrapper inventory baseline":
+            reason_code = "baseline_payload_not_object"
+        elif label == "wrapper budget trend thresholds":
+            reason_code = "trend_threshold_payload_not_object"
+        elif label == "lane migration matrix":
+            reason_code = "lane_matrix_payload_not_object"
+        fail_with_reason(reason_code, f"expected JSON object for {label}: {path}")
     return payload
 
 
@@ -227,29 +261,33 @@ def build_inventory(*, matrix_file: Path, repo_root: Path) -> dict[str, Any]:
 
 def validate_baseline_payload(payload: dict[str, Any]) -> None:
     if payload.get("schema_version") != BASELINE_SCHEMA_VERSION:
-        fail(
+        fail_with_reason(
+            "baseline_schema_mismatch",
             "baseline schema_version must be "
             f"{BASELINE_SCHEMA_VERSION}"
         )
 
     lanes = payload.get("lanes")
     if not isinstance(lanes, list) or not lanes:
-        fail("baseline lanes must be a non-empty array")
+        fail_with_reason("baseline_lanes_invalid", "baseline lanes must be a non-empty array")
 
     lane_ids_seen: set[str] = set()
     for index, lane in enumerate(lanes):
         if not isinstance(lane, dict):
-            fail(f"baseline lane[{index}] must be an object")
+            fail_with_reason("baseline_lane_object_invalid", f"baseline lane[{index}] must be an object")
         lane_id = require_non_empty_string(lane, "lane_id", label=f"baseline lane[{index}]")
         if lane_id in lane_ids_seen:
-            fail(f"baseline lane_id must be unique, found duplicate: {lane_id}")
+            fail_with_reason(
+                "baseline_lane_id_duplicate",
+                f"baseline lane_id must be unique, found duplicate: {lane_id}",
+            )
         lane_ids_seen.add(lane_id)
         require_non_empty_string(lane, "source_entry", label=f"baseline lane[{index}]")
         require_non_empty_string(lane, "manifest_file", label=f"baseline lane[{index}]")
         require_non_empty_string(lane, "wrapper_kind", label=f"baseline lane[{index}]")
         shell_loc = require_int(lane, "shell_loc", label=f"baseline lane[{index}]")
         if shell_loc < 1:
-            fail(f"baseline lane[{index}] shell_loc must be >= 1")
+            fail_with_reason("baseline_lane_shell_loc_invalid", f"baseline lane[{index}] shell_loc must be >= 1")
 
     for key in (
         "wrapper_count",
@@ -257,59 +295,104 @@ def validate_baseline_payload(payload: dict[str, Any]) -> None:
         "regular_file_wrapper_count",
         "total_shell_loc",
     ):
-        value = require_int(payload, key, label="baseline")
+        try:
+            value = require_int(payload, key, label="baseline")
+        except PolicyValidationError as error:
+            if key == "wrapper_count":
+                fail_with_reason("baseline_wrapper_count_invalid", error.message)
+            if key == "symlink_wrapper_count":
+                fail_with_reason("baseline_symlink_wrapper_count_invalid", error.message)
+            if key == "regular_file_wrapper_count":
+                fail_with_reason("baseline_regular_file_wrapper_count_invalid", error.message)
+            if key == "total_shell_loc":
+                fail_with_reason("baseline_total_shell_loc_invalid", error.message)
+            raise
         if value < 0:
-            fail(f"baseline {key} must be >= 0")
+            if key == "wrapper_count":
+                fail_with_reason("baseline_wrapper_count_invalid", f"baseline {key} must be >= 0")
+            if key == "symlink_wrapper_count":
+                fail_with_reason("baseline_symlink_wrapper_count_invalid", f"baseline {key} must be >= 0")
+            if key == "regular_file_wrapper_count":
+                fail_with_reason("baseline_regular_file_wrapper_count_invalid", f"baseline {key} must be >= 0")
+            if key == "total_shell_loc":
+                fail_with_reason("baseline_total_shell_loc_invalid", f"baseline {key} must be >= 0")
+            fail_with_reason("baseline_totals_invalid", f"baseline {key} must be >= 0")
 
 
 def load_trend_thresholds(path: Path) -> dict[str, Any]:
     payload = load_json_object(path, label="wrapper budget trend thresholds")
     if payload.get("schema_version") != TREND_THRESHOLD_SCHEMA_VERSION:
-        fail(
+        fail_with_reason(
+            "trend_threshold_schema_mismatch",
             "wrapper budget trend threshold schema_version must be "
             f"{TREND_THRESHOLD_SCHEMA_VERSION}"
         )
 
-    max_wrapper_count_increase = require_int(
-        payload,
-        "max_wrapper_count_increase",
-        label="wrapper budget trend thresholds",
-    )
+    try:
+        max_wrapper_count_increase = require_int(
+            payload,
+            "max_wrapper_count_increase",
+            label="wrapper budget trend thresholds",
+        )
+    except PolicyValidationError as error:
+        fail_with_reason("trend_threshold_wrapper_count_invalid", error.message)
     if max_wrapper_count_increase < 0:
-        fail("wrapper budget trend max_wrapper_count_increase must be >= 0")
+        fail_with_reason(
+            "trend_threshold_wrapper_count_invalid",
+            "wrapper budget trend max_wrapper_count_increase must be >= 0",
+        )
 
-    max_total_shell_loc_increase = require_int(
-        payload,
-        "max_total_shell_loc_increase",
-        label="wrapper budget trend thresholds",
-    )
+    try:
+        max_total_shell_loc_increase = require_int(
+            payload,
+            "max_total_shell_loc_increase",
+            label="wrapper budget trend thresholds",
+        )
+    except PolicyValidationError as error:
+        fail_with_reason("trend_threshold_total_shell_loc_invalid", error.message)
     if max_total_shell_loc_increase < 0:
-        fail("wrapper budget trend max_total_shell_loc_increase must be >= 0")
+        fail_with_reason(
+            "trend_threshold_total_shell_loc_invalid",
+            "wrapper budget trend max_total_shell_loc_increase must be >= 0",
+        )
 
     enforce_lane_shell_loc_nonincreasing = payload.get(
         "enforce_lane_shell_loc_nonincreasing"
     )
     if not isinstance(enforce_lane_shell_loc_nonincreasing, bool):
-        fail(
+        fail_with_reason(
+            "trend_threshold_lane_nonincreasing_invalid",
             "wrapper budget trend thresholds enforce_lane_shell_loc_nonincreasing "
             "must be a boolean"
         )
 
-    min_wrapper_count_reduction = require_int(
-        payload,
-        "min_wrapper_count_reduction",
-        label="wrapper budget trend thresholds",
-    )
+    try:
+        min_wrapper_count_reduction = require_int(
+            payload,
+            "min_wrapper_count_reduction",
+            label="wrapper budget trend thresholds",
+        )
+    except PolicyValidationError as error:
+        fail_with_reason("trend_threshold_min_wrapper_reduction_invalid", error.message)
     if min_wrapper_count_reduction < 0:
-        fail("wrapper budget trend min_wrapper_count_reduction must be >= 0")
+        fail_with_reason(
+            "trend_threshold_min_wrapper_reduction_invalid",
+            "wrapper budget trend min_wrapper_count_reduction must be >= 0",
+        )
 
-    min_total_shell_loc_reduction = require_int(
-        payload,
-        "min_total_shell_loc_reduction",
-        label="wrapper budget trend thresholds",
-    )
+    try:
+        min_total_shell_loc_reduction = require_int(
+            payload,
+            "min_total_shell_loc_reduction",
+            label="wrapper budget trend thresholds",
+        )
+    except PolicyValidationError as error:
+        fail_with_reason("trend_threshold_min_total_shell_loc_reduction_invalid", error.message)
     if min_total_shell_loc_reduction < 0:
-        fail("wrapper budget trend min_total_shell_loc_reduction must be >= 0")
+        fail_with_reason(
+            "trend_threshold_min_total_shell_loc_reduction_invalid",
+            "wrapper budget trend min_total_shell_loc_reduction must be >= 0",
+        )
 
     return {
         "max_wrapper_count_increase": max_wrapper_count_increase,
@@ -362,32 +445,54 @@ def command_check(args: argparse.Namespace) -> int:
     min_total_shell_loc_reduction = int(args.min_total_shell_loc_reduction)
     enforce_lane_shell_loc_nonincreasing = True
 
-    if max_wrapper_count_increase < 0:
-        fail("--max-wrapper-count-increase must be >= 0")
-    if max_total_shell_loc_increase < 0:
-        fail("--max-total-shell-loc-increase must be >= 0")
-    if min_wrapper_count_reduction < 0:
-        fail("--min-wrapper-count-reduction must be >= 0")
-    if min_total_shell_loc_reduction < 0:
-        fail("--min-total-shell-loc-reduction must be >= 0")
-    if args.threshold_file and not trend_mode:
-        fail("--threshold-file requires --trend-mode")
+    try:
+        if max_wrapper_count_increase < 0:
+            fail_with_reason("trend_threshold_wrapper_count_invalid", "--max-wrapper-count-increase must be >= 0")
+        if max_total_shell_loc_increase < 0:
+            fail_with_reason(
+                "trend_threshold_total_shell_loc_invalid",
+                "--max-total-shell-loc-increase must be >= 0",
+            )
+        if min_wrapper_count_reduction < 0:
+            fail_with_reason(
+                "trend_threshold_min_wrapper_reduction_invalid",
+                "--min-wrapper-count-reduction must be >= 0",
+            )
+        if min_total_shell_loc_reduction < 0:
+            fail_with_reason(
+                "trend_threshold_min_total_shell_loc_reduction_invalid",
+                "--min-total-shell-loc-reduction must be >= 0",
+            )
+        if args.threshold_file and not trend_mode:
+            fail_with_reason(
+                "trend_mode_required_for_threshold_file",
+                "--threshold-file requires --trend-mode",
+            )
 
-    if args.threshold_file:
-        threshold_file = Path(args.threshold_file).resolve()
-        thresholds = load_trend_thresholds(threshold_file)
-        max_wrapper_count_increase = int(thresholds["max_wrapper_count_increase"])
-        max_total_shell_loc_increase = int(thresholds["max_total_shell_loc_increase"])
-        enforce_lane_shell_loc_nonincreasing = bool(
-            thresholds["enforce_lane_shell_loc_nonincreasing"]
-        )
-        min_wrapper_count_reduction = int(thresholds["min_wrapper_count_reduction"])
-        min_total_shell_loc_reduction = int(thresholds["min_total_shell_loc_reduction"])
+        if args.threshold_file:
+            threshold_file = Path(args.threshold_file).resolve()
+            thresholds = load_trend_thresholds(threshold_file)
+            max_wrapper_count_increase = int(thresholds["max_wrapper_count_increase"])
+            max_total_shell_loc_increase = int(thresholds["max_total_shell_loc_increase"])
+            enforce_lane_shell_loc_nonincreasing = bool(
+                thresholds["enforce_lane_shell_loc_nonincreasing"]
+            )
+            min_wrapper_count_reduction = int(thresholds["min_wrapper_count_reduction"])
+            min_total_shell_loc_reduction = int(thresholds["min_total_shell_loc_reduction"])
 
-    baseline = load_json_object(baseline_file, label="wrapper inventory baseline")
-    validate_baseline_payload(baseline)
+        baseline = load_json_object(baseline_file, label="wrapper inventory baseline")
+        validate_baseline_payload(baseline)
 
-    current = build_inventory(matrix_file=matrix_file, repo_root=repo_root)
+        current = build_inventory(matrix_file=matrix_file, repo_root=repo_root)
+    except PolicyValidationError as error:
+        print("status=fail")
+        print(f"mode={'trend' if trend_mode else 'strict'}")
+        print("wrapper_count_delta=0")
+        print("total_shell_loc_delta=0")
+        print("violation_count=1")
+        print(f"reason_codes={error.reason_code}")
+        print(f"error={error.message}")
+        return 1
 
     baseline_lanes = index_lanes(baseline, label="baseline")
     current_lanes = index_lanes(current, label="current")
@@ -613,7 +718,7 @@ def main() -> int:
     if args.command == "check":
         return command_check(args)
 
-    fail(f"unsupported command: {args.command}")
+    fail_with_reason("unsupported_command", f"unsupported command: {args.command}")
     return 1
 
 

--- a/scripts/ci/test_check_kolme_wrapper_budget_trend.sh
+++ b/scripts/ci/test_check_kolme_wrapper_budget_trend.sh
@@ -99,6 +99,83 @@ grep -q '^mode=trend$' "$TMP_DIR/fail.out"
 grep -q '^reason_codes=total_shell_loc_delta_threshold_exceeded$' "$TMP_DIR/fail.out"
 grep -q 'total_shell_loc_delta exceeded trend threshold' "$TMP_DIR/fail.out"
 
+MUTATED_WRAPPER_COUNT_BASELINE="$TMP_DIR/mutated-wrapper-count-baseline.json"
+cp "$BASELINE_FIXTURE" "$MUTATED_WRAPPER_COUNT_BASELINE"
+python3 - "$MUTATED_WRAPPER_COUNT_BASELINE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline_path = Path(sys.argv[1])
+payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+payload["wrapper_count"] = 0
+baseline_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if bash "$TREND_CHECKER" \
+  --matrix-file "$MATRIX_FIXTURE" \
+  --baseline-file "$MUTATED_WRAPPER_COUNT_BASELINE" >"$TMP_DIR/fail-wrapper-count.out" 2>&1; then
+  echo "expected trend checker to fail when wrapper_count delta exceeds configured threshold" >&2
+  exit 1
+fi
+
+grep -q '^status=fail$' "$TMP_DIR/fail-wrapper-count.out"
+grep -q '^mode=trend$' "$TMP_DIR/fail-wrapper-count.out"
+grep -q '^reason_codes=wrapper_count_delta_threshold_exceeded$' "$TMP_DIR/fail-wrapper-count.out"
+grep -q 'wrapper_count_delta exceeded trend threshold' "$TMP_DIR/fail-wrapper-count.out"
+
+MUTATED_MISSING_BASELINE_METADATA="$TMP_DIR/mutated-missing-baseline-metadata.json"
+cp "$BASELINE_FIXTURE" "$MUTATED_MISSING_BASELINE_METADATA"
+python3 - "$MUTATED_MISSING_BASELINE_METADATA" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline_path = Path(sys.argv[1])
+payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+payload.pop("wrapper_count", None)
+baseline_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if bash "$TREND_CHECKER" \
+  --matrix-file "$MATRIX_FIXTURE" \
+  --baseline-file "$MUTATED_MISSING_BASELINE_METADATA" >"$TMP_DIR/fail-missing-baseline-metadata.out" 2>&1; then
+  echo "expected trend checker to fail with deterministic reason code when baseline metadata is missing" >&2
+  exit 1
+fi
+
+grep -q '^status=fail$' "$TMP_DIR/fail-missing-baseline-metadata.out"
+grep -q '^mode=trend$' "$TMP_DIR/fail-missing-baseline-metadata.out"
+grep -q '^reason_codes=baseline_wrapper_count_invalid$' "$TMP_DIR/fail-missing-baseline-metadata.out"
+grep -q 'baseline wrapper_count must be an integer' "$TMP_DIR/fail-missing-baseline-metadata.out"
+
+MUTATED_MISSING_THRESHOLD_METADATA="$TMP_DIR/mutated-missing-threshold-metadata.json"
+cp "$THRESHOLD_FILE" "$MUTATED_MISSING_THRESHOLD_METADATA"
+python3 - "$MUTATED_MISSING_THRESHOLD_METADATA" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+threshold_path = Path(sys.argv[1])
+payload = json.loads(threshold_path.read_text(encoding="utf-8"))
+payload.pop("max_total_shell_loc_increase", None)
+threshold_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if python3 "$PYTHON_CHECKER" check \
+  --trend-mode \
+  --threshold-file "$MUTATED_MISSING_THRESHOLD_METADATA" \
+  --matrix-file "$MATRIX_FIXTURE" \
+  --baseline-file "$BASELINE_FIXTURE" >"$TMP_DIR/fail-missing-threshold-metadata.out" 2>&1; then
+  echo "expected trend checker to fail with deterministic reason code when threshold metadata is missing" >&2
+  exit 1
+fi
+
+grep -q '^status=fail$' "$TMP_DIR/fail-missing-threshold-metadata.out"
+grep -q '^mode=trend$' "$TMP_DIR/fail-missing-threshold-metadata.out"
+grep -q '^reason_codes=trend_threshold_total_shell_loc_invalid$' "$TMP_DIR/fail-missing-threshold-metadata.out"
+grep -q 'max_total_shell_loc_increase' "$TMP_DIR/fail-missing-threshold-metadata.out"
+
 RELAXED_THRESHOLD="$TMP_DIR/relaxed-threshold.json"
 cat >"$RELAXED_THRESHOLD" <<'JSON'
 {


### PR DESCRIPTION
## Summary
Strengthen Kolme wrapper trend-budget policy diagnostics by adding deterministic fail-closed reason codes for malformed baseline/threshold metadata and extending fixture-driven drift assertions. This keeps CI signals precise and low-cost while wrapper migration continues.

Closes #3096
Closes #3097

## Changes
- `scripts/ci/kolme_wrapper_inventory_baseline.py`
  - Added structured `PolicyValidationError` flow for deterministic reason-code failures.
  - Added explicit reason-code mapping for baseline metadata failures (for example `baseline_wrapper_count_invalid`).
  - Added explicit reason-code mapping for threshold metadata failures (for example `trend_threshold_total_shell_loc_invalid`).
  - Updated trend checker to emit stable fail markers (`status`, `mode`, `reason_codes`, `error`) on input-validation failures.
- `scripts/ci/test_check_kolme_wrapper_budget_trend.sh`
  - Added new fixture-driven drift case for `wrapper_count_delta_threshold_exceeded`.
  - Added baseline metadata missing fixture case and assertion for `baseline_wrapper_count_invalid`.
  - Added threshold metadata missing fixture case and assertion for `trend_threshold_total_shell_loc_invalid`.
- `docs/ci/README.md`
  - Added CI docs index and Kolme wrapper trend reason-code reference section.

## Risks & Compatibility
- Existing pass/fail behavior for trend drift remains unchanged.
- New error paths now emit deterministic reason-code markers instead of unstructured early exits.

## Validation
- [x] `bash scripts/ci/test_check_kolme_wrapper_budget_trend.sh`

## Test Matrix Evidence
| Category | Status | Notes |
|---|---|---|
| Unit | ✅ | Checker reason-code mapping paths validated through fixture-driven assertions |
| Functional | ✅ | Trend checker pass/fail behavior verified for baseline and wave-10 paths |
| Integration | ✅ | Wrapper shell checker + Python policy integration verified via shell harness |
| Regression | ✅ | New deterministic reason-code assertions prevent metadata-drift silent failures |
| Performance | ✅ | Validation remains low-cost single-harness execution |
