### PR TITLE
test: extend managed-signer lane with key-source profile matrix validation

### DIFF
--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -269,6 +269,36 @@ fn functional_kolme_live_strict_env_local_key_source_rejects_with_reason_code() 
 }
 
 #[test]
+fn functional_kolme_live_strict_env_local_key_source_allows_with_local_override() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        "http://127.0.0.1:3000".to_owned(),
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-strict-signer-contracts".to_owned(),
+        "--kolme-live-signer-profile".to_owned(),
+        "ops-primary".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("strict args should parse");
+    enforce_kolme_live_signer_key_source_policy(
+        parsed.kolme_live_strict_signer_contracts,
+        parsed.kolme_live_signer_key_source.as_deref(),
+        true,
+        false,
+    )
+    .expect("explicit local override should allow strict env-local key source");
+}
+
+#[test]
 fn integration_kolme_live_strict_managed_external_key_source_policy_passes() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -159,6 +159,16 @@ Fallback private-key surfaces are forbidden in deployment preflight and runtime 
   - `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
+- Signer key-source profile matrix validation:
+  - `bash scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh --output-json /tmp/managed-signer-startup-live-validation-contract-report.json`
+  - matrix status markers:
+    - `signer_key_source_profile_matrix_status=verified`
+    - `signer_key_source_production_reject_status=verified`
+    - `signer_key_source_local_override_allow_status=verified`
+  - production strict env-local fail-closed marker:
+    - `production_signer_key_source_env_local_forbidden`
+  - explicit local override marker for controlled local testing:
+    - `KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true`
 - Required schema/reason markers:
   - `runtime_signer_fallback_guard_contract_version=v2`
   - `runtime_signer_fallback_guard_mode=reject_if_present`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -68,6 +68,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Contract report schema: `kamn.kolme.managed-signer-startup-live-validation-contract-report.v1`.
   - Baseline startup pass marker: `deployment_preflight_passed`.
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `managed_signer_profile_status=verified`, `managed_signer_reason_code_status=verified`, `execution_scope=local-scheduled`, `performance_budget_status=verified`.
+  - Signer key-source profile matrix validation delivered (Task #3108, Subtask #3109):
+    - matrix markers: `signer_key_source_profile_matrix_status=verified`, `signer_key_source_production_reject_status=verified`, `signer_key_source_local_override_allow_status=verified`.
+    - production strict env-local fail-closed reason code: `production_signer_key_source_env_local_forbidden`.
+    - explicit local override marker: `KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true`.
   - Fail-closed validation confirmed for startup fault-injection matrix:
     - missing managed-external key-source contract: `checkpoint_failed_signer_provenance_contract` + `signer_key_source_production_managed_external_required`
     - invalid signer profile: `checkpoint_failed_signer_profile_contract` + `signer_profile_mismatch`

--- a/scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py
+++ b/scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py
@@ -17,10 +17,12 @@ from typing import Any
 ROOT_DIR = Path(__file__).resolve().parents[3]
 RUNNER = ROOT_DIR / "scripts/kolme/run_local_kolme_live_deployment_preflight_lane.sh"
 CHECKER = ROOT_DIR / "scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py"
+UPGRADE_ROLLBACK_RUNBOOK = ROOT_DIR / "docs/foundation/upgrade-rollback-runbook.md"
+ROADMAP_DOC = ROOT_DIR / "docs/plans/2026-02-08-production-service-roadmap.md"
 DOC_FILES = [
     ROOT_DIR / "docs/planning/kolme-devnet-ops.md",
     ROOT_DIR / "docs/ci/ci-cost-and-lane-framework.md",
-    ROOT_DIR / "docs/plans/2026-02-08-production-service-roadmap.md",
+    ROADMAP_DOC,
     ROOT_DIR / "README.md",
 ]
 DOC_MARKERS = [
@@ -34,6 +36,17 @@ DOC_MARKERS = [
     "signer_profile_mismatch",
     "signer_rotation_epoch_stale",
     "execution_scope=local-scheduled",
+]
+PROFILE_MATRIX_DOC_FILES = [
+    ROADMAP_DOC,
+    UPGRADE_ROLLBACK_RUNBOOK,
+]
+PROFILE_MATRIX_DOC_MARKERS = [
+    "signer_key_source_profile_matrix_status=verified",
+    "signer_key_source_production_reject_status=verified",
+    "signer_key_source_local_override_allow_status=verified",
+    "production_signer_key_source_env_local_forbidden",
+    "KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true",
 ]
 
 PRIMARY_TEST_PRIVATE_KEY_HEX = "1" * 64
@@ -244,6 +257,37 @@ def run_preflight_scenario(
     }
 
 
+def run_key_source_policy_matrix_test(
+    *,
+    scenario_id: str,
+    test_name: str,
+    expected_policy_outcome: str,
+    expected_reason_code: str,
+) -> dict[str, Any]:
+    command = [
+        "cargo",
+        "test",
+        "-p",
+        "kamn-node",
+        test_name,
+        "--",
+        "--exact",
+    ]
+    result = run_command(command)
+    output = f"{result.stdout}{result.stderr}"
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"signer key-source matrix scenario {scenario_id} failed: {output.strip()}"
+        )
+    return {
+        "scenario_id": scenario_id,
+        "command": " ".join(command),
+        "expected_policy_outcome": expected_policy_outcome,
+        "expected_reason_code": expected_reason_code,
+        "status": "pass",
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run managed-signer startup live validation contract lane."
@@ -275,6 +319,14 @@ def main() -> int:
             ensure_markers_present(
                 doc_file.read_text(encoding="utf-8"),
                 DOC_MARKERS,
+                str(doc_file.relative_to(ROOT_DIR)),
+            )
+        )
+    for doc_file in PROFILE_MATRIX_DOC_FILES:
+        missing_doc_markers.extend(
+            ensure_markers_present(
+                doc_file.read_text(encoding="utf-8"),
+                PROFILE_MATRIX_DOC_MARKERS,
                 str(doc_file.relative_to(ROOT_DIR)),
             )
         )
@@ -336,6 +388,26 @@ def main() -> int:
                     expected_policy_reason_code="signer_rotation_epoch_stale",
                 ),
             ]
+            key_source_matrix_reports = [
+                run_key_source_policy_matrix_test(
+                    scenario_id="production_strict_env_local_rejected",
+                    test_name="main_tests::core_behavior_tests::functional_kolme_live_strict_env_local_key_source_rejects_with_reason_code",
+                    expected_policy_outcome="NO-GO",
+                    expected_reason_code="production_signer_key_source_env_local_forbidden",
+                ),
+                run_key_source_policy_matrix_test(
+                    scenario_id="local_override_env_local_allowed",
+                    test_name="main_tests::core_behavior_tests::functional_kolme_live_strict_env_local_key_source_allows_with_local_override",
+                    expected_policy_outcome="GO",
+                    expected_reason_code="local_override_enabled",
+                ),
+                run_key_source_policy_matrix_test(
+                    scenario_id="production_strict_managed_external_allowed",
+                    test_name="main_tests::core_behavior_tests::integration_kolme_live_strict_managed_external_key_source_policy_passes",
+                    expected_policy_outcome="GO",
+                    expected_reason_code="managed_external_required",
+                ),
+            ]
 
             elapsed_seconds = int(time.time() - start_time)
             if elapsed_seconds > args.max_seconds:
@@ -357,8 +429,13 @@ def main() -> int:
                 "managed_signer_invalid_profile_fail_closed_status": "verified",
                 "managed_signer_stale_rotation_fail_closed_status": "verified",
                 "managed_signer_reason_code_status": "verified",
+                "signer_key_source_profile_matrix_status": "verified",
+                "signer_key_source_production_reject_status": "verified",
+                "signer_key_source_local_override_allow_status": "verified",
+                "signer_key_source_managed_external_allow_status": "verified",
                 "performance_budget_status": "verified",
                 "scenario_reports": scenario_reports,
+                "signer_key_source_matrix_reports": key_source_matrix_reports,
             }
 
             output_path = Path(args.output_json).resolve()
@@ -378,6 +455,10 @@ def main() -> int:
     print("managed_signer_invalid_profile_fail_closed_status=verified")
     print("managed_signer_stale_rotation_fail_closed_status=verified")
     print("managed_signer_reason_code_status=verified")
+    print("signer_key_source_profile_matrix_status=verified")
+    print("signer_key_source_production_reject_status=verified")
+    print("signer_key_source_local_override_allow_status=verified")
+    print("signer_key_source_managed_external_allow_status=verified")
     print("execution_scope=local-scheduled")
     print("performance_budget_status=verified")
     return 0

--- a/scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
+++ b/scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh
@@ -11,6 +11,7 @@ PREFLIGHT_CHECKER="$ROOT_DIR/scripts/kolme/check_local_kolme_live_deployment_pre
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 CI_COST_DOC="$ROOT_DIR/docs/ci/ci-cost-and-lane-framework.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
+RUNBOOK_DOC="$ROOT_DIR/docs/foundation/upgrade-rollback-runbook.md"
 README_FILE="$ROOT_DIR/README.md"
 TMP_REPORT="$(mktemp)"
 trap 'rm -f "$TMP_REPORT"' EXIT
@@ -102,6 +103,23 @@ for docs_file in "$DOC_FILE" "$CI_COST_DOC" "$ROADMAP_DOC" "$README_FILE"; do
   done
 done
 
+profile_matrix_markers=(
+  "signer_key_source_profile_matrix_status=verified"
+  "signer_key_source_production_reject_status=verified"
+  "signer_key_source_local_override_allow_status=verified"
+  "production_signer_key_source_env_local_forbidden"
+  "KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true"
+)
+
+for docs_file in "$ROADMAP_DOC" "$RUNBOOK_DOC"; do
+  for marker in "${profile_matrix_markers[@]}"; do
+    if ! grep -q -- "$marker" "$docs_file"; then
+      echo "expected profile matrix docs marker '$marker' in $docs_file" >&2
+      exit 1
+    fi
+  done
+done
+
 run_output="$(bash "$RUNNER" --output-json "$TMP_REPORT")"
 for marker in \
   "status=pass" \
@@ -111,6 +129,10 @@ for marker in \
   "managed_signer_invalid_profile_fail_closed_status=verified" \
   "managed_signer_stale_rotation_fail_closed_status=verified" \
   "managed_signer_reason_code_status=verified" \
+  "signer_key_source_profile_matrix_status=verified" \
+  "signer_key_source_production_reject_status=verified" \
+  "signer_key_source_local_override_allow_status=verified" \
+  "signer_key_source_managed_external_allow_status=verified" \
   "execution_scope=local-scheduled" \
   "performance_budget_status=verified"; do
   if ! printf '%s\n' "$run_output" | grep -q "^${marker}$"; then
@@ -143,6 +165,14 @@ if payload.get("managed_signer_stale_rotation_fail_closed_status") != "verified"
     raise SystemExit("expected managed_signer_stale_rotation_fail_closed_status=verified")
 if payload.get("managed_signer_reason_code_status") != "verified":
     raise SystemExit("expected managed_signer_reason_code_status=verified")
+if payload.get("signer_key_source_profile_matrix_status") != "verified":
+    raise SystemExit("expected signer_key_source_profile_matrix_status=verified")
+if payload.get("signer_key_source_production_reject_status") != "verified":
+    raise SystemExit("expected signer_key_source_production_reject_status=verified")
+if payload.get("signer_key_source_local_override_allow_status") != "verified":
+    raise SystemExit("expected signer_key_source_local_override_allow_status=verified")
+if payload.get("signer_key_source_managed_external_allow_status") != "verified":
+    raise SystemExit("expected signer_key_source_managed_external_allow_status=verified")
 if payload.get("performance_budget_status") != "verified":
     raise SystemExit("expected performance_budget_status=verified")
 scenario_reports = payload.get("scenario_reports")
@@ -165,6 +195,28 @@ for entry in scenario_reports:
         raise SystemExit(f"unexpected final decision for {scenario_id}")
     if entry.get("expected_reason_code") != reason_code:
         raise SystemExit(f"unexpected expected_reason_code for {scenario_id}")
+
+matrix_reports = payload.get("signer_key_source_matrix_reports")
+if not isinstance(matrix_reports, list) or len(matrix_reports) != 3:
+    raise SystemExit("expected three signer key-source matrix reports")
+expected_matrix = {
+    "production_strict_env_local_rejected": ("NO-GO", "production_signer_key_source_env_local_forbidden"),
+    "local_override_env_local_allowed": ("GO", "local_override_enabled"),
+    "production_strict_managed_external_allowed": ("GO", "managed_external_required"),
+}
+for entry in matrix_reports:
+    if not isinstance(entry, dict):
+        raise SystemExit("matrix report entry must be an object")
+    scenario_id = entry.get("scenario_id")
+    if scenario_id not in expected_matrix:
+        raise SystemExit(f"unexpected matrix scenario id: {scenario_id}")
+    expected_outcome, expected_reason = expected_matrix[scenario_id]
+    if entry.get("expected_policy_outcome") != expected_outcome:
+        raise SystemExit(f"unexpected expected policy outcome for {scenario_id}")
+    if entry.get("expected_reason_code") != expected_reason:
+        raise SystemExit(f"unexpected expected reason code for {scenario_id}")
+    if entry.get("status") != "pass":
+        raise SystemExit(f"expected matrix scenario status pass for {scenario_id}")
 PY
 
 set +e


### PR DESCRIPTION
Closes #3108
Closes #3109

## Summary
Extends the managed-signer startup local validation contract lane with deterministic signer key-source profile matrix coverage, including production strict env-local rejection and explicit local override allow behavior. Adds a local override functional Rust test and enforces new roadmap/runbook docs markers for operator-facing rollback guidance.

## Changes
- `scripts/kolme/contracts/managed_signer_startup_live_validation_contract_lane.py`: added profile-matrix test execution/reporting and docs-marker enforcement for roadmap + upgrade/rollback runbook.
- `scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh`: added output/report assertions for matrix status/scenarios and docs parity markers.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added `functional_kolme_live_strict_env_local_key_source_allows_with_local_override`.
- `docs/plans/2026-02-08-production-service-roadmap.md`: documented #3108/#3109 matrix markers and reason-code/override markers.
- `docs/foundation/upgrade-rollback-runbook.md`: added signer key-source profile matrix validation workflow + markers.

## Risks & Compatibility
- No runtime behavior changes in production paths; this PR adds validation/test/docs coverage only.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated new matrix/report markers and docs parity assertions through updated contract-lane harness

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅  | `cargo test -p kamn-node main_tests::core_behavior_tests::functional_kolme_live_strict_env_local_key_source_allows_with_local_override -- --exact` |
| Functional  | ✅  | `cargo test -p kamn-node main_tests::core_behavior_tests::functional_kolme_live_strict_env_local_key_source_rejects_with_reason_code -- --exact` |
| Integration | ✅  | `bash scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh` |
| Regression  | ✅  | `bash scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh` (JSON schema + scenario/marker parity assertions) |
