### PR TITLE
docs(kolme): codify local-live runtime profile closure evidence

### DIFF
--- a/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs
@@ -113,3 +113,20 @@ fn roadmap_tracks_post_roadmap_wave1_nonce_retry_live_validation() {
     assert!(ROADMAP.contains("nonce_retry_contract_status=verified"));
     assert!(ROADMAP.contains("fail_closed_reason_code=nonce_response_malformed"));
 }
+
+#[test]
+fn roadmap_tracks_post_roadmap_wave4_local_live_runtime_profile_matrix() {
+    assert!(ROADMAP.contains("Story #3088"));
+    assert!(ROADMAP.contains("Task #3102"));
+    assert!(ROADMAP.contains("Subtask #3103"));
+    assert!(ROADMAP.contains("Task #3104"));
+    assert!(ROADMAP.contains("Subtask #3105"));
+    assert!(ROADMAP.contains("run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"));
+    assert!(ROADMAP.contains("test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"));
+    assert!(ROADMAP.contains("test_check_local_kamn_live_runtime_real_node_profile_policy.sh"));
+    assert!(ROADMAP.contains("runtime_commit_command_profile_mismatch"));
+    assert!(ROADMAP.contains("runtime_signer_rotation_epoch_stale"));
+    assert!(ROADMAP.contains("runtime_signer_key_source_profile_pair_disallowed"));
+    assert!(ROADMAP.contains("transport.preflight.timeout"));
+    assert!(ROADMAP.contains("transport.preflight.failed"));
+}

--- a/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
+++ b/crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs
@@ -90,6 +90,25 @@ fn runbook_contains_kolme_fallback_signer_runtime_deploy_guard() {
 }
 
 #[test]
+fn runbook_tracks_story_3088_local_live_runtime_profile_matrix_contracts() {
+    assert!(RUNBOOK.contains("Story #3088, Task #3102, Task #3104"));
+    assert!(RUNBOOK.contains("Subtask #3103, Subtask #3105"));
+    assert!(RUNBOOK.contains("run_local_kamn_live_runtime_real_node_profile_contract_lane.sh"));
+    assert!(RUNBOOK
+        .contains("schema_version=kamn.kolme.local-kamn-live-runtime-integration-summary.v1"));
+    assert!(RUNBOOK.contains("runtime_profile=real-node"));
+    assert!(RUNBOOK.contains("runtime_commit_command_profile=real-node-non-synthetic-v1"));
+    assert!(RUNBOOK.contains("runtime_commit_policy_command_profile=real-node-non-synthetic-v1"));
+    assert!(RUNBOOK.contains("runtime_commit_command_profile_mismatch"));
+    assert!(RUNBOOK.contains("runtime_signer_failover_profile_unchanged"));
+    assert!(RUNBOOK.contains("runtime_signer_rotation_epoch_stale"));
+    assert!(RUNBOOK.contains("runtime_signer_key_source_profile_pair_disallowed"));
+    assert!(RUNBOOK.contains("runtime_commit_live_policy_report_missing"));
+    assert!(RUNBOOK.contains("transport.preflight.timeout"));
+    assert!(RUNBOOK.contains("transport.preflight.failed"));
+}
+
+#[test]
 fn runbook_contains_live_network_pilot_rollback_evidence_gate() {
     assert!(RUNBOOK.contains("## Live-Network Pilot Rollback Evidence Gate"));
     assert!(RUNBOOK.contains("run_live_network_pilot_deep_lane.sh"));

--- a/docs/foundation/upgrade-rollback-runbook.md
+++ b/docs/foundation/upgrade-rollback-runbook.md
@@ -159,6 +159,22 @@ Fallback private-key surfaces are forbidden in deployment preflight and runtime 
   - `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
   - `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
+- Local-live managed-signer runtime/finality composition (Story #3088, Task #3102, Task #3104):
+  - `bash scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh --output-json /tmp/kolme-local-kamn-live-runtime-integration-summary.json --policy-output-json /tmp/kolme-local-kamn-live-runtime-real-node-policy.json`
+  - required deterministic markers:
+    - `schema_version=kamn.kolme.local-kamn-live-runtime-integration-summary.v1`
+    - `runtime_profile=real-node`
+    - `runtime_commit_command_profile=real-node-non-synthetic-v1`
+    - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
+  - fail-closed reason-code matrix checkpoints (Subtask #3103, Subtask #3105):
+    - `runtime_commit_command_profile_mismatch`
+    - `runtime_signer_failover_profile_unchanged`
+    - `runtime_signer_rotation_epoch_stale`
+    - `runtime_signer_key_source_profile_pair_disallowed`
+    - `runtime_commit_live_policy_report_missing`
+  - runtime endpoint failure taxonomy checkpoints:
+    - `transport.preflight.timeout`
+    - `transport.preflight.failed`
 - Signer key-source profile matrix validation:
   - `bash scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh --output-json /tmp/managed-signer-startup-live-validation-contract-report.json`
   - matrix status markers:

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -76,6 +76,31 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
     - missing managed-external key-source contract: `checkpoint_failed_signer_provenance_contract` + `signer_key_source_production_managed_external_required`
     - invalid signer profile: `checkpoint_failed_signer_profile_contract` + `signer_profile_mismatch`
     - stale signer rotation metadata: `checkpoint_failed_signer_rotation_freshness_contract` + `signer_rotation_epoch_stale`
+- Post-roadmap hardening wave 4 local-live managed-signer runtime+finality validation delivered (Story #3088):
+  - Local-live composition lane delivered and validated (Task #3102, Task #3104):
+    - `scripts/kolme/run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
+    - `scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
+    - `scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
+    - `scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
+    - `scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
+  - Runtime submit/finality checks are composed through:
+    - `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
+    - `scripts/kolme/check_local_kamn_live_runtime_real_node_profile_policy.py`
+  - Local-only heavy execution gate remains enforced for run mode via `KAMN_KOLME_LOCAL_HEAVY=1`.
+  - Deterministic marker/schema contracts validated:
+    - `schema_version=kamn.kolme.local-kamn-live-runtime-integration-summary.v1`
+    - `runtime_profile=real-node`
+    - `runtime_commit_command_profile=real-node-non-synthetic-v1`
+    - `runtime_commit_policy_command_profile=real-node-non-synthetic-v1`
+  - Fail-closed reason-code matrix validated (Subtask #3103, Subtask #3105):
+    - `runtime_commit_command_profile_mismatch`
+    - `runtime_signer_failover_profile_unchanged`
+    - `runtime_signer_rotation_epoch_stale`
+    - `runtime_signer_key_source_profile_pair_disallowed`
+    - `runtime_commit_live_policy_report_missing`
+  - Runtime endpoint failure taxonomy remains deterministic for preflight/connectivity classes:
+    - `transport.preflight.timeout`
+    - `transport.preflight.failed`
 - Post-roadmap hardening wave 4 wrapper migration tranche A delivered:
   - Migrated contract wrappers to dispatcher symlink + manifest execution path (Task #3094, Subtask #3095):
     - `scripts/kolme/run_continuous_runtime_commit_contract_lane.sh`


### PR DESCRIPTION
## Summary
This PR closes the documentation/evidence traceability gap for the `#3088` child chain by explicitly recording delivered local-live managed-signer runtime/finality coverage in roadmap/runbook artifacts and locking those markers with docs-contract tests.

## Changes
- `docs/plans/2026-02-08-production-service-roadmap.md`: added post-roadmap wave-4 delivery block for Story `#3088` + Task/Subtask chain `#3102/#3103/#3104/#3105`, including deterministic marker and reason/taxonomy coverage.
- `docs/foundation/upgrade-rollback-runbook.md`: added explicit local-live real-node profile composition guidance and required fail-closed matrix markers.
- `crates/kamn-core/tests/kolme_runtime_commit_client_docs.rs`: added roadmap docs-contract assertions for `#3102/#3103/#3104/#3105` markers.
- `crates/kamn-core/tests/upgrade_rollback_runbook_docs.rs`: added runbook docs-contract assertions for the same story/task chain markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `rg -n "#3102|#3103|#3104|#3105" docs/plans/2026-02-08-production-service-roadmap.md docs/foundation/upgrade-rollback-runbook.md`
- Result before this PR: no explicit traceability markers for this issue chain in roadmap/runbook status blocks.

### 🟢 Green Phase
- `cargo test -p kamn-core --test kolme_runtime_commit_client_docs roadmap_tracks_post_roadmap_wave4_local_live_runtime_profile_matrix -- --exact`
- `cargo test -p kamn-core --test upgrade_rollback_runbook_docs runbook_tracks_story_3088_local_live_runtime_profile_matrix_contracts -- --exact`

### 🔁 Regression
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_contract_lane.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_integration_real_node_profile.sh`
- `bash scripts/kolme/test_check_local_kamn_live_runtime_real_node_profile_policy.sh`
- `bash scripts/kolme/test_run_local_kamn_live_runtime_real_node_profile_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --test kolme_runtime_commit_client_docs --test upgrade_rollback_runbook_docs -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Docs/tests-only change; no production logic touched |
| Functional   | ✅     | local-live harness scripts listed above |                      |
| Integration  | ✅     | real-node profile contract lane + integration contract lane harness |                      |
| Regression   | ✅     | new docs-contract tests in `kolme_runtime_commit_client_docs` and `upgrade_rollback_runbook_docs` |                      |
| Performance  | N/A    | None                 | No runtime path changes |

## Risks & Rollback
- None.
- Rollback: revert this docs/tests commit if marker contracts need rewording.

## Documentation Updates
- `docs/plans/2026-02-08-production-service-roadmap.md`
- `docs/foundation/upgrade-rollback-runbook.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted docs tests)
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated

Closes #3102
Closes #3103
Closes #3104
Closes #3105
Refs #3088