### PR TITLE
refactor(runtime): extract tranche-5 recovery guard module

### DIFF
--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -1,5 +1,6 @@
 use crate::config::{NodeConfig, NodeRole};
 use crate::signature_profile::baseline_signature_for_fields;
+use runtime_recovery_guard::{is_valid_kamn_did, is_valid_listener_did};
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -8,6 +9,8 @@ use std::fmt::{Display, Formatter};
 mod runtime_backpressure;
 #[path = "runtime_phase_coordination.rs"]
 mod runtime_phase_coordination;
+#[path = "runtime_recovery_guard.rs"]
+mod runtime_recovery_guard;
 #[path = "runtime_snapshot_store.rs"]
 mod runtime_snapshot_store;
 #[path = "runtime_state_divergence.rs"]
@@ -25,6 +28,9 @@ pub use runtime_phase_coordination::{
     ApproverQuorumError, ApproverQuorumEvaluator, ApproverQuorumInput, ConstructLockError,
     ConstructLockGuard, ConstructLockLease, ListenerAttestation, ListenerQuorumDecision,
     ListenerQuorumError, ListenerQuorumEvaluator, ListenerQuorumInput,
+};
+pub use runtime_recovery_guard::{
+    RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
 };
 pub use runtime_snapshot_store::{
     FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore, RuntimeSnapshot, RuntimeSnapshotStore,
@@ -912,207 +918,6 @@ impl DeterministicProposalPlanner {
         Ok(ProposalPlan {
             ordered_candidates: candidates,
         })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Rejoin attempt.
-pub struct RejoinAttempt {
-    node_id: String,
-    state_version: u64,
-    state_hash: String,
-    resume_token: String,
-}
-
-impl RejoinAttempt {
-    /// Handles new.
-    pub fn new(
-        node_id: &str,
-        state_version: u64,
-        state_hash: &str,
-        resume_token: &str,
-    ) -> Result<Self, RecoveryGuardError> {
-        if node_id.trim().is_empty() {
-            return Err(RecoveryGuardError::InvalidNodeId);
-        }
-        if state_version == 0 {
-            return Err(RecoveryGuardError::InvalidStateVersion);
-        }
-        if state_hash.trim().is_empty() {
-            return Err(RecoveryGuardError::InvalidStateHash);
-        }
-        if resume_token.trim().is_empty() {
-            return Err(RecoveryGuardError::InvalidResumeToken);
-        }
-        Ok(Self {
-            node_id: node_id.to_owned(),
-            state_version,
-            state_hash: state_hash.to_owned(),
-            resume_token: resume_token.to_owned(),
-        })
-    }
-
-    /// Handles node id.
-    pub fn node_id(&self) -> &str {
-        &self.node_id
-    }
-
-    /// Handles state version.
-    pub fn state_version(&self) -> u64 {
-        self.state_version
-    }
-
-    /// Handles state hash.
-    pub fn state_hash(&self) -> &str {
-        &self.state_hash
-    }
-
-    /// Handles resume token.
-    pub fn resume_token(&self) -> &str {
-        &self.resume_token
-    }
-}
-fn is_valid_listener_did(value: &str) -> bool {
-    is_valid_kamn_did(value)
-}
-
-fn is_valid_kamn_did(value: &str) -> bool {
-    let trimmed = value.trim();
-    !trimmed.is_empty() && trimmed.starts_with("kamn:did:")
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Recovery status.
-pub enum RecoveryStatus {
-    /// Rejoin accepted.
-    RejoinAccepted,
-    /// Catch up required.
-    CatchUpRequired {
-        /// Current local state version.
-        from_version: u64,
-        /// Target remote state version.
-        to_version: u64,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Recovery guard error.
-pub enum RecoveryGuardError {
-    /// Invalid node id.
-    InvalidNodeId,
-    /// Invalid state version.
-    InvalidStateVersion,
-    /// Invalid state hash.
-    InvalidStateHash,
-    /// Invalid resume token.
-    InvalidResumeToken,
-    /// Replay resume token.
-    ReplayResumeToken(String),
-    /// State version mismatch.
-    StateVersionMismatch {
-        /// Expected state version.
-        expected: u64,
-        /// Observed state version.
-        found: u64,
-    },
-    /// State hash mismatch.
-    StateHashMismatch {
-        /// Expected state hash.
-        expected: String,
-        /// Observed state hash.
-        found: String,
-    },
-}
-
-impl Display for RecoveryGuardError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InvalidNodeId => write!(f, "rejoin node id cannot be empty"),
-            Self::InvalidStateVersion => write!(f, "rejoin state version must be positive"),
-            Self::InvalidStateHash => write!(f, "rejoin state hash cannot be empty"),
-            Self::InvalidResumeToken => write!(f, "rejoin resume token cannot be empty"),
-            Self::ReplayResumeToken(token) => {
-                write!(f, "rejoin resume token replayed: {token}")
-            }
-            Self::StateVersionMismatch { expected, found } => {
-                write!(
-                    f,
-                    "rejoin state version mismatch: expected {expected}, found {found}"
-                )
-            }
-            Self::StateHashMismatch { expected, found } => {
-                write!(
-                    f,
-                    "rejoin state hash mismatch: expected {expected}, found {found}"
-                )
-            }
-        }
-    }
-}
-
-impl Error for RecoveryGuardError {}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Recovery rejoin guard.
-pub struct RecoveryRejoinGuard {
-    expected_state_version: u64,
-    expected_state_hash: String,
-    consumed_resume_tokens: HashSet<String>,
-}
-
-impl RecoveryRejoinGuard {
-    /// Handles new.
-    pub fn new(
-        expected_state_version: u64,
-        expected_state_hash: &str,
-    ) -> Result<Self, RecoveryGuardError> {
-        if expected_state_version == 0 {
-            return Err(RecoveryGuardError::InvalidStateVersion);
-        }
-        if expected_state_hash.trim().is_empty() {
-            return Err(RecoveryGuardError::InvalidStateHash);
-        }
-        Ok(Self {
-            expected_state_version,
-            expected_state_hash: expected_state_hash.to_owned(),
-            consumed_resume_tokens: HashSet::new(),
-        })
-    }
-
-    /// Handles evaluate.
-    pub fn evaluate(
-        &mut self,
-        attempt: RejoinAttempt,
-    ) -> Result<RecoveryStatus, RecoveryGuardError> {
-        if self.consumed_resume_tokens.contains(attempt.resume_token()) {
-            return Err(RecoveryGuardError::ReplayResumeToken(
-                attempt.resume_token.clone(),
-            ));
-        }
-
-        if attempt.state_version < self.expected_state_version {
-            return Ok(RecoveryStatus::CatchUpRequired {
-                from_version: attempt.state_version,
-                to_version: self.expected_state_version,
-            });
-        }
-
-        if attempt.state_version > self.expected_state_version {
-            return Err(RecoveryGuardError::StateVersionMismatch {
-                expected: self.expected_state_version,
-                found: attempt.state_version,
-            });
-        }
-
-        if attempt.state_hash != self.expected_state_hash {
-            return Err(RecoveryGuardError::StateHashMismatch {
-                expected: self.expected_state_hash.clone(),
-                found: attempt.state_hash,
-            });
-        }
-
-        self.consumed_resume_tokens.insert(attempt.resume_token);
-        Ok(RecoveryStatus::RejoinAccepted)
     }
 }
 

--- a/crates/kamn-core/src/runtime_recovery_guard.rs
+++ b/crates/kamn-core/src/runtime_recovery_guard.rs
@@ -1,0 +1,207 @@
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// Handles listener DID format validation.
+pub(crate) fn is_valid_listener_did(value: &str) -> bool {
+    is_valid_kamn_did(value)
+}
+
+/// Handles runtime DID format validation.
+pub(crate) fn is_valid_kamn_did(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty() && trimmed.starts_with("kamn:did:")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Rejoin attempt.
+pub struct RejoinAttempt {
+    node_id: String,
+    state_version: u64,
+    state_hash: String,
+    resume_token: String,
+}
+
+impl RejoinAttempt {
+    /// Handles new.
+    pub fn new(
+        node_id: &str,
+        state_version: u64,
+        state_hash: &str,
+        resume_token: &str,
+    ) -> Result<Self, RecoveryGuardError> {
+        if node_id.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidNodeId);
+        }
+        if state_version == 0 {
+            return Err(RecoveryGuardError::InvalidStateVersion);
+        }
+        if state_hash.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidStateHash);
+        }
+        if resume_token.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidResumeToken);
+        }
+        Ok(Self {
+            node_id: node_id.to_owned(),
+            state_version,
+            state_hash: state_hash.to_owned(),
+            resume_token: resume_token.to_owned(),
+        })
+    }
+
+    /// Handles node id.
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    /// Handles state version.
+    pub fn state_version(&self) -> u64 {
+        self.state_version
+    }
+
+    /// Handles state hash.
+    pub fn state_hash(&self) -> &str {
+        &self.state_hash
+    }
+
+    /// Handles resume token.
+    pub fn resume_token(&self) -> &str {
+        &self.resume_token
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Recovery status.
+pub enum RecoveryStatus {
+    /// Rejoin accepted.
+    RejoinAccepted,
+    /// Catch up required.
+    CatchUpRequired {
+        /// Current local state version.
+        from_version: u64,
+        /// Target remote state version.
+        to_version: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Recovery guard error.
+pub enum RecoveryGuardError {
+    /// Invalid node id.
+    InvalidNodeId,
+    /// Invalid state version.
+    InvalidStateVersion,
+    /// Invalid state hash.
+    InvalidStateHash,
+    /// Invalid resume token.
+    InvalidResumeToken,
+    /// Replay resume token.
+    ReplayResumeToken(String),
+    /// State version mismatch.
+    StateVersionMismatch {
+        /// Expected state version.
+        expected: u64,
+        /// Observed state version.
+        found: u64,
+    },
+    /// State hash mismatch.
+    StateHashMismatch {
+        /// Expected state hash.
+        expected: String,
+        /// Observed state hash.
+        found: String,
+    },
+}
+
+impl Display for RecoveryGuardError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidNodeId => write!(f, "rejoin node id cannot be empty"),
+            Self::InvalidStateVersion => write!(f, "rejoin state version must be positive"),
+            Self::InvalidStateHash => write!(f, "rejoin state hash cannot be empty"),
+            Self::InvalidResumeToken => write!(f, "rejoin resume token cannot be empty"),
+            Self::ReplayResumeToken(token) => {
+                write!(f, "rejoin resume token replayed: {token}")
+            }
+            Self::StateVersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "rejoin state version mismatch: expected {expected}, found {found}"
+                )
+            }
+            Self::StateHashMismatch { expected, found } => {
+                write!(
+                    f,
+                    "rejoin state hash mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for RecoveryGuardError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Recovery rejoin guard.
+pub struct RecoveryRejoinGuard {
+    expected_state_version: u64,
+    expected_state_hash: String,
+    consumed_resume_tokens: HashSet<String>,
+}
+
+impl RecoveryRejoinGuard {
+    /// Handles new.
+    pub fn new(
+        expected_state_version: u64,
+        expected_state_hash: &str,
+    ) -> Result<Self, RecoveryGuardError> {
+        if expected_state_version == 0 {
+            return Err(RecoveryGuardError::InvalidStateVersion);
+        }
+        if expected_state_hash.trim().is_empty() {
+            return Err(RecoveryGuardError::InvalidStateHash);
+        }
+        Ok(Self {
+            expected_state_version,
+            expected_state_hash: expected_state_hash.to_owned(),
+            consumed_resume_tokens: HashSet::new(),
+        })
+    }
+
+    /// Handles evaluate.
+    pub fn evaluate(
+        &mut self,
+        attempt: RejoinAttempt,
+    ) -> Result<RecoveryStatus, RecoveryGuardError> {
+        if self.consumed_resume_tokens.contains(attempt.resume_token()) {
+            return Err(RecoveryGuardError::ReplayResumeToken(
+                attempt.resume_token.clone(),
+            ));
+        }
+
+        if attempt.state_version < self.expected_state_version {
+            return Ok(RecoveryStatus::CatchUpRequired {
+                from_version: attempt.state_version,
+                to_version: self.expected_state_version,
+            });
+        }
+
+        if attempt.state_version > self.expected_state_version {
+            return Err(RecoveryGuardError::StateVersionMismatch {
+                expected: self.expected_state_version,
+                found: attempt.state_version,
+            });
+        }
+
+        if attempt.state_hash != self.expected_state_hash {
+            return Err(RecoveryGuardError::StateHashMismatch {
+                expected: self.expected_state_hash.clone(),
+                found: attempt.state_hash,
+            });
+        }
+
+        self.consumed_resume_tokens.insert(attempt.resume_token);
+        Ok(RecoveryStatus::RejoinAccepted)
+    }
+}

--- a/crates/kamn-core/tests/runtime_module_extraction_contract.rs
+++ b/crates/kamn-core/tests/runtime_module_extraction_contract.rs
@@ -223,3 +223,46 @@ fn runtime_module_extraction_contract_keeps_runtime_snapshot_types_in_new_module
         "runtime_snapshot_store module should own FileRuntimeSnapshotStore"
     );
 }
+
+#[test]
+fn runtime_module_extraction_contract_declares_runtime_recovery_guard_module() {
+    let runtime_rs = read_repo_file("runtime.rs");
+    assert!(
+        runtime_rs.contains("mod runtime_recovery_guard;"),
+        "runtime.rs should declare extracted runtime_recovery_guard module"
+    );
+}
+
+#[test]
+fn runtime_module_extraction_contract_moves_recovery_guard_types_out_of_runtime_rs() {
+    let runtime_rs = read_repo_file("runtime.rs");
+    assert!(
+        !runtime_rs.contains("pub struct RejoinAttempt {"),
+        "runtime.rs should not keep inline RejoinAttempt definition"
+    );
+    assert!(
+        !runtime_rs.contains("pub enum RecoveryGuardError {"),
+        "runtime.rs should not keep inline RecoveryGuardError definition"
+    );
+    assert!(
+        !runtime_rs.contains("pub struct RecoveryRejoinGuard {"),
+        "runtime.rs should not keep inline RecoveryRejoinGuard definition"
+    );
+}
+
+#[test]
+fn runtime_module_extraction_contract_keeps_recovery_guard_types_in_new_module() {
+    let runtime_recovery_guard_rs = read_repo_file("runtime_recovery_guard.rs");
+    assert!(
+        runtime_recovery_guard_rs.contains("pub struct RejoinAttempt {"),
+        "runtime_recovery_guard module should own RejoinAttempt"
+    );
+    assert!(
+        runtime_recovery_guard_rs.contains("pub enum RecoveryGuardError {"),
+        "runtime_recovery_guard module should own RecoveryGuardError"
+    );
+    assert!(
+        runtime_recovery_guard_rs.contains("pub struct RecoveryRejoinGuard {"),
+        "runtime_recovery_guard module should own RecoveryRejoinGuard"
+    );
+}

--- a/crates/kamn-core/tests/runtime_module_extraction_roadmap_docs.rs
+++ b/crates/kamn-core/tests/runtime_module_extraction_roadmap_docs.rs
@@ -9,3 +9,12 @@ fn roadmap_tracks_runtime_decomposition_tranche4_snapshot_module_extraction() {
     assert!(ROADMAP.contains("runtime_module_extraction_contract.rs"));
     assert!(ROADMAP.contains("runtime_network_docs.rs"));
 }
+
+#[test]
+fn roadmap_tracks_runtime_decomposition_tranche5_recovery_guard_module_extraction() {
+    assert!(ROADMAP.contains("Task #3129"));
+    assert!(ROADMAP.contains("Subtask #3130"));
+    assert!(ROADMAP.contains("crates/kamn-core/src/runtime_recovery_guard.rs"));
+    assert!(ROADMAP.contains("runtime_module_extraction_contract.rs"));
+    assert!(ROADMAP.contains("runtime_network_docs.rs"));
+}

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -6,6 +6,7 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("crates/kamn-core/src/runtime_phase_coordination.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_transport_coordination.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_snapshot_store.rs"));
+    assert!(DOC.contains("crates/kamn-core/src/runtime_recovery_guard.rs"));
     assert!(DOC.contains("## Node CLI Recovery-Check Mapping"));
     assert!(DOC.contains("## Node CLI Daemon Lifecycle Mapping"));
     assert!(DOC.contains("## Bridge Quorum Runtime Mapping"));

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -44,7 +44,7 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `DeterministicProposalPlanner`
   - `ProposalPlan`
   - `ProposalPlannerError`
-- Added recovery/rejoin guard primitives in `crates/kamn-core/src/runtime.rs`:
+- Added recovery/rejoin guard primitives in `crates/kamn-core/src/runtime_recovery_guard.rs`:
   - `RejoinAttempt`
   - `RecoveryRejoinGuard`
   - `RecoveryStatus`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -63,6 +63,9 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Post-roadmap hardening wave 4 runtime decomposition tranche 4 delivered:
   - Extracted runtime snapshot persistence/restore/store orchestration from `crates/kamn-core/src/runtime.rs` into dedicated module `crates/kamn-core/src/runtime_snapshot_store.rs` with unchanged external behavior (Task #3090, Subtask #3091).
   - Module-ownership and docs-contract markers enforced by `crates/kamn-core/tests/runtime_module_extraction_contract.rs` and `crates/kamn-core/tests/runtime_network_docs.rs` (Task #3092, Subtask #3093).
+- Post-roadmap hardening wave 4 runtime decomposition tranche 5 delivered:
+  - Extracted recovery/rejoin guard orchestration from `crates/kamn-core/src/runtime.rs` into dedicated module `crates/kamn-core/src/runtime_recovery_guard.rs` with unchanged external behavior (Task #3129, Subtask #3130).
+  - Module-ownership and docs-contract markers enforced by `crates/kamn-core/tests/runtime_module_extraction_contract.rs` and `crates/kamn-core/tests/runtime_network_docs.rs`.
 - Post-roadmap hardening wave 3 managed-signer startup live validation delivered:
   - Contract lane: `scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh` and `scripts/kolme/test_run_managed_signer_startup_live_validation_contract_lane.sh` (Subtask #3067).
   - Contract report schema: `kamn.kolme.managed-signer-startup-live-validation-contract-report.v1`.


### PR DESCRIPTION
## Summary
Extract runtime decomposition tranche-5 by moving recovery/rejoin guard primitives out of `runtime.rs` into a dedicated module. This keeps behavior stable while reducing monolith pressure and hardening module ownership contracts.

## Changes
- `crates/kamn-core/src/runtime_recovery_guard.rs`: new module owning `RejoinAttempt`, `RecoveryStatus`, `RecoveryGuardError`, `RecoveryRejoinGuard`, and runtime DID helper validators.
- `crates/kamn-core/src/runtime.rs`: removed inline recovery/rejoin guard definitions; wired module declaration/import/re-export to preserve external API behavior.
- `crates/kamn-core/tests/runtime_module_extraction_contract.rs`: added tranche-5 extraction boundary assertions.
- `crates/kamn-core/tests/runtime_network_docs.rs`: enforced docs marker for `runtime_recovery_guard.rs`.
- `crates/kamn-core/tests/runtime_module_extraction_roadmap_docs.rs`: enforced roadmap marker for Task #3129 / Subtask #3130.
- `docs/foundation/runtime-network.md`: updated recovery primitive module path.
- `docs/plans/2026-02-08-production-service-roadmap.md`: recorded tranche-5 delivery.

## Risks & Compatibility
- None (internal module extraction with re-export parity maintained).

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core --test runtime_module_extraction_contract --test runtime_network_docs --test runtime_module_extraction_roadmap_docs -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: extraction/docs contracts and targeted runtime rejoin guard behavior test pass locally.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core functional_rejoin_guard_accepts_matching_snapshot -- --nocapture` |
| Functional  | ✅     | `cargo test -p kamn-core --test runtime_module_extraction_contract -- --nocapture` |
| Integration | ✅     | `cargo test -p kamn-core --test runtime_network_docs -- --nocapture` |
| Regression  | ✅     | `cargo test -p kamn-core --test runtime_module_extraction_roadmap_docs -- --nocapture` |

Closes #3130
Closes #3129
Closes #3128
