### PR TITLE
feat(runtime): add observability endpoint policy contract lane

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -382,3 +382,14 @@ fn regression_requires_make_and_selector_demo_contract_marker() {
     assert!(DOC.contains("Regression: #2738"));
     assert!(DOC.contains("Regression: #2741"));
 }
+
+#[test]
+fn doc_contains_runtime_observability_endpoint_contract_lane_ci_mode_markers() {
+    assert!(DOC.contains("## Runtime Observability Endpoint Contract Lane"));
+    assert!(DOC.contains("validate_runtime_observability_endpoint_live_contract_lane.sh"));
+    assert!(DOC.contains("check_runtime_observability_endpoint_live_policy.sh"));
+    assert!(DOC.contains("test_validate_runtime_observability_endpoint_live_contract_lane.sh"));
+    assert!(DOC.contains("ci-fast-gate mode: fast"));
+    assert!(DOC.contains("local-dev mode: local"));
+    assert!(DOC.contains("manual-hardened mode: manual"));
+}

--- a/crates/kamn-core/tests/observability_stack_docs.rs
+++ b/crates/kamn-core/tests/observability_stack_docs.rs
@@ -98,6 +98,24 @@ fn roadmap_tracks_wave2_runtime_observability_stream_live_validation() {
 }
 
 #[test]
+fn doc_contains_runtime_observability_stream_contract_lane_and_policy() {
+    assert!(DOC.contains("validate_runtime_observability_endpoint_live_contract_lane.sh"));
+    assert!(DOC.contains("check_runtime_observability_endpoint_live_policy.sh"));
+    assert!(DOC.contains("test_validate_runtime_observability_endpoint_live_contract_lane.sh"));
+    assert!(DOC.contains("runtime_observability_policy_status=verified"));
+    assert!(DOC.contains("runtime_observability_contract_lane_status=verified"));
+}
+
+#[test]
+fn roadmap_tracks_wave2_runtime_observability_stream_contract_lane_and_policy() {
+    assert!(ROADMAP.contains("Task #3150, Subtask #3160"));
+    assert!(ROADMAP
+        .contains("scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh"));
+    assert!(ROADMAP.contains("scripts/runtime/check_runtime_observability_endpoint_live_policy.sh"));
+    assert!(ROADMAP.contains("runtime_observability_policy_status=verified"));
+}
+
+#[test]
 fn regression_requires_availability_critical_rule() {
     // Regression: #206
     assert!(DOC.contains("`Availability`: critical when below minimum threshold."));

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -119,6 +119,21 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - deterministic tick-budget simulation with bounded loop-free assertions
   - timeout behavior and observability telemetry validated through direct state transitions instead of wall-clock waits
 
+## Runtime Observability Endpoint Contract Lane
+- Entry commands:
+  - `bash scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh --output-json /tmp/runtime-observability-endpoint-contract-lane-report.json --policy-output-json /tmp/runtime-observability-endpoint-policy-report.json`
+  - `bash scripts/runtime/check_runtime_observability_endpoint_live_policy.sh --report-file /tmp/runtime-observability-endpoint-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/runtime-observability-endpoint-policy-report.json`
+  - `bash scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh`
+  - `bash scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`
+- ci-fast-gate mode: fast
+- local-dev mode: local
+- manual-hardened mode: manual
+- Cost controls:
+  - reuses bounded local cargo integration tests from `validate_runtime_observability_endpoint_live.sh`
+  - no external network dependency or remote runtime process orchestration
+  - explicit runtime budget cap via `KAMN_RUNTIME_OBSERVABILITY_ENDPOINT_CONTRACT_MAX_SECONDS`
+  - deterministic fail-closed policy tamper drill executed in-process
+
 ## Kolme HTTPS Native Transport Contract
 - Runtime-commit HTTPS transport uses an in-process native TLS client path.
 - `openssl s_client` subprocess execution is prohibited in transport code paths (`Regression: #2671`).

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -69,15 +69,22 @@ This document captures the first implementation slice for deterministic observab
 
 Live validation lane:
 - `scripts/runtime/validate_runtime_observability_endpoint_live.sh`
+- `scripts/runtime/check_runtime_observability_endpoint_live_policy.sh`
+- `scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh`
 - `scripts/runtime/test_validate_runtime_observability_endpoint_live.sh`
+- `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`
+- `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh`
 
 Expected markers:
 - `status=pass`
 - `final_decision=GO`
 - `runtime_observability_stream_contract_status=verified`
+- `runtime_observability_policy_status=verified`
+- `runtime_observability_contract_lane_status=verified`
 - `fail_closed_status=verified`
 - `docs_contract_status=verified`
 - `fail_closed_reason_code=observability_endpoint_not_found`
+- `fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch`
 - `performance_budget_status=verified`
 
 ## Structured Runtime Logging Correlation Contract (Issue #3032)
@@ -231,6 +238,8 @@ bash scripts/reputation/test_run_reputation_recovery_contract_lane.sh
 bash scripts/canary/test_generate_post_cutover_slo_evidence_bundle.sh
 bash scripts/canary/test_run_post_cutover_slo_contract_lane.sh
 bash scripts/runtime/test_validate_runtime_observability_endpoint_live.sh
+bash scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh
+bash scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh
 cargo test -p kamn-core --test observability_stack
 npm --prefix packages/kamn-dashboard test
 cargo fmt --check

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -51,6 +51,11 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Runtime lane: `scripts/runtime/validate_runtime_observability_endpoint_live.sh` and `scripts/runtime/test_validate_runtime_observability_endpoint_live.sh` (Task #3047, Subtask #3048).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `runtime_observability_stream_contract_status=verified`, `fail_closed_status=verified`, `docs_contract_status=verified`, `performance_budget_status=verified`.
   - Fail-closed validation confirmed for unknown-path guard behavior: `fail_closed_reason_code=observability_endpoint_not_found`.
+- Post-roadmap hardening wave 6 runtime observability endpoint contract-lane policy delivered:
+  - Runtime lane: `scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh` and `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh` (Task #3150, Subtask #3160).
+  - Policy checker: `scripts/runtime/check_runtime_observability_endpoint_live_policy.sh` and `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`.
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `runtime_observability_stream_contract_status=verified`, `runtime_observability_policy_status=verified`, `runtime_observability_contract_lane_status=verified`, `docs_contract_status=verified`, `performance_budget_status=verified`.
+  - Fail-closed validation confirmed for policy tamper drill behavior: `fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch`.
 - Post-roadmap hardening wave 2 runtime decomposition initial tranche delivered:
   - Extracted state-divergence orchestration from `crates/kamn-core/src/runtime.rs` into dedicated module `crates/kamn-core/src/runtime_state_divergence.rs` with unchanged external behavior (Task #3050, Subtask #3051).
   - Module-ownership contract documented in `docs/foundation/runtime-watchdog-attestation.md` and enforced by `crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs`.

--- a/scripts/runtime/check_runtime_observability_endpoint_live_policy.sh
+++ b/scripts/runtime/check_runtime_observability_endpoint_live_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/runtime_observability_endpoint_live_contract.py" check-policy "$@"

--- a/scripts/runtime/runtime_observability_endpoint_live_contract.py
+++ b/scripts/runtime/runtime_observability_endpoint_live_contract.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Runtime observability endpoint live policy contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    write_json,
+)
+
+REPORT_SCHEMA = "kamn.runtime.observability-endpoint-live-validation.v1"
+POLICY_SCHEMA = "kamn.runtime.observability-endpoint-live-policy-report.v1"
+EXPECTED_FAIL_CLOSED_REASON_CODE = "observability_endpoint_not_found"
+
+REQUIRED_REPORT_FIELDS = [
+    "schema_version",
+    "status",
+    "final_decision",
+    "runtime_observability_stream_contract_status",
+    "fail_closed_status",
+    "docs_contract_status",
+    "fail_closed_reason_code",
+    "performance_budget_status",
+    "elapsed_seconds",
+]
+
+REQUIRED_VERIFIED_FIELDS = [
+    "runtime_observability_stream_contract_status",
+    "fail_closed_status",
+    "docs_contract_status",
+    "performance_budget_status",
+]
+
+
+def _is_non_negative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _check_policy(args: argparse.Namespace) -> int:
+    report_file = Path(args.report_file).resolve()
+    if not report_file.is_file():
+        fail(f"report file not found: {report_file}")
+
+    report = load_json(report_file)
+    missing_fields = [field_name for field_name in REQUIRED_REPORT_FIELDS if field_name not in report]
+    if missing_fields:
+        fail(f"missing required report fields: {','.join(missing_fields)}")
+
+    expected_final_decision = require_enum(
+        "--expected-final-decision",
+        args.expected_final_decision,
+        ("GO", "NO-GO"),
+    )
+    ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate, ("PASS", "FAIL"))
+
+    observed_status = report.get("status")
+    observed_final_decision = report.get("final_decision")
+
+    decision = DecisionAccumulator()
+    decision.reject_if(
+        report.get("schema_version") != REPORT_SCHEMA,
+        "runtime_observability_policy_schema_mismatch",
+    )
+    decision.reject_if(
+        observed_status not in {"pass", "fail"},
+        "runtime_observability_policy_status_invalid",
+    )
+    decision.reject_if(
+        observed_final_decision not in {"GO", "NO-GO"},
+        "runtime_observability_policy_final_decision_invalid",
+    )
+    decision.reject_if(
+        observed_final_decision != expected_final_decision,
+        "runtime_observability_policy_final_decision_mismatch",
+    )
+
+    for field_name in REQUIRED_VERIFIED_FIELDS:
+        decision.reject_if(
+            report.get(field_name) != "verified",
+            f"runtime_observability_policy_marker_missing:{field_name}",
+        )
+
+    decision.reject_if(
+        report.get("fail_closed_reason_code") != EXPECTED_FAIL_CLOSED_REASON_CODE,
+        "runtime_observability_policy_fail_closed_reason_code_mismatch",
+    )
+    decision.reject_if(
+        not _is_non_negative_int(report.get("elapsed_seconds")),
+        "runtime_observability_policy_elapsed_seconds_invalid",
+    )
+    decision.reject_if(ci_fast_gate != "PASS", "ci_fast_gate_failed")
+
+    final_decision, reason_codes = decision.finalize("none")
+    status = "pass" if final_decision == "GO" else "fail"
+    policy_status = "verified" if final_decision == "GO" else "rejected"
+
+    policy_report: dict[str, Any] = {
+        "schema_version": POLICY_SCHEMA,
+        "status": status,
+        "final_decision": final_decision,
+        "runtime_observability_policy_status": policy_status,
+        "expected_final_decision": expected_final_decision,
+        "observed_status": observed_status,
+        "observed_final_decision": observed_final_decision,
+        "reason_codes": reason_codes,
+        "ci_fast_gate": ci_fast_gate,
+        "fail_closed_reason_code": report.get("fail_closed_reason_code"),
+        "source_report_file": str(report_file),
+        "generated_at_epoch": int(time.time()),
+    }
+
+    output_json = None
+    if args.output_json:
+        output_json = Path(args.output_json).resolve()
+        write_json(output_json, policy_report)
+
+    reason_codes_csv = ",".join(reason_codes)
+    print(f"status={'ok' if final_decision == 'GO' else 'error'}")
+    print(f"final_decision={final_decision}")
+    print(f"runtime_observability_policy_status={policy_status}")
+    print(f"reason_codes={reason_codes_csv}")
+    if output_json is not None:
+        print(f"policy_report_file={output_json}")
+
+    if final_decision != "GO":
+        fail(f"runtime observability endpoint live policy rejected: {reason_codes_csv}")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Runtime observability endpoint live policy checker contract."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_policy_parser = subparsers.add_parser(
+        "check-policy",
+        help="Validate runtime observability endpoint live report policy.",
+    )
+    check_policy_parser.add_argument(
+        "--report-file",
+        required=True,
+        help="Path to runtime observability endpoint live validation report JSON.",
+    )
+    check_policy_parser.add_argument(
+        "--expected-final-decision",
+        default="GO",
+        help="Expected report final decision (GO|NO-GO).",
+    )
+    check_policy_parser.add_argument(
+        "--ci-fast-gate",
+        default="PASS",
+        help="CI fast-gate marker (PASS|FAIL).",
+    )
+    check_policy_parser.add_argument(
+        "--output-json",
+        help="Optional output path for policy report JSON.",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        if args.command == "check-policy":
+            return _check_policy(args)
+    except ContractError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"unknown command: {args.command}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh
+++ b/scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_runtime_observability_endpoint_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_runtime_observability_endpoint_live_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected runtime observability endpoint live validation script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected runtime observability endpoint live policy checker script to be executable" >&2
+  exit 1
+fi
+
+summary_report="$TMP_DIR/runtime-observability-endpoint-live-summary.json"
+policy_report="$TMP_DIR/runtime-observability-endpoint-live-policy.json"
+tampered_report="$TMP_DIR/runtime-observability-endpoint-live-summary.tampered.json"
+
+bash "$VALIDATION_SCRIPT" --output-json "$summary_report" >/dev/null
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$summary_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected runtime observability endpoint live policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected runtime observability endpoint live policy checker GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^runtime_observability_policy_status=verified$'; then
+  echo "expected runtime observability endpoint live policy checker status marker" >&2
+  exit 1
+fi
+
+python3 - "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.observability-endpoint-live-policy-report.v1":
+    raise SystemExit("unexpected runtime observability endpoint policy report schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision=GO")
+if payload.get("runtime_observability_policy_status") != "verified":
+    raise SystemExit("expected runtime_observability_policy_status=verified")
+if payload.get("reason_codes") != ["none"]:
+    raise SystemExit("expected policy checker success reason code ['none']")
+PY
+
+cp "$summary_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/runtime-observability-endpoint-live-policy.tampered.json" 2>&1
+)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered runtime observability endpoint report to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'runtime_observability_policy_final_decision_mismatch'; then
+  echo "expected deterministic mismatch reason code for tampered policy validation" >&2
+  exit 1
+fi
+
+echo "runtime observability endpoint live policy checker tests passed."

--- a/scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_runtime_observability_endpoint_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_runtime_observability_endpoint_live_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected runtime observability endpoint contract lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected runtime observability endpoint validation script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected runtime observability endpoint policy checker script to be executable" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/runtime-observability-endpoint-contract-lane-report.json"
+policy_report="$TMP_DIR/runtime-observability-endpoint-policy-report.json"
+
+lane_output="$(
+  bash "$CONTRACT_LANE" \
+    --output-json "$lane_report" \
+    --policy-output-json "$policy_report"
+)"
+if ! printf '%s\n' "$lane_output" | grep -q '^status=pass$'; then
+  echo "expected runtime observability endpoint contract lane status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
+  echo "expected runtime observability endpoint contract lane final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^runtime_observability_policy_status=verified$'; then
+  echo "expected runtime observability endpoint contract lane policy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^runtime_observability_contract_lane_status=verified$'; then
+  echo "expected runtime observability endpoint contract lane status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch$'; then
+  echo "expected runtime observability endpoint contract lane fail-closed reason marker" >&2
+  exit 1
+fi
+
+python3 - "$lane_report" "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+lane_payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if lane_payload.get("schema_version") != "kamn.runtime.observability-endpoint-live-contract-lane-report.v1":
+    raise SystemExit("unexpected runtime observability endpoint contract lane report schema")
+if lane_payload.get("status") != "pass":
+    raise SystemExit("expected contract lane status=pass")
+if lane_payload.get("final_decision") != "GO":
+    raise SystemExit("expected contract lane final_decision=GO")
+if lane_payload.get("runtime_observability_policy_status") != "verified":
+    raise SystemExit("expected runtime_observability_policy_status=verified")
+if lane_payload.get("runtime_observability_contract_lane_status") != "verified":
+    raise SystemExit("expected runtime_observability_contract_lane_status=verified")
+if lane_payload.get("fail_closed_reason_code") != "runtime_observability_policy_final_decision_mismatch":
+    raise SystemExit("expected deterministic fail-closed reason code marker")
+if lane_payload.get("performance_budget_status") != "verified":
+    raise SystemExit("expected performance_budget_status=verified")
+
+policy_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if policy_payload.get("schema_version") != "kamn.runtime.observability-endpoint-live-policy-report.v1":
+    raise SystemExit("unexpected runtime observability endpoint policy report schema")
+if policy_payload.get("final_decision") != "GO":
+    raise SystemExit("expected policy final_decision=GO")
+if policy_payload.get("runtime_observability_policy_status") != "verified":
+    raise SystemExit("expected runtime_observability_policy_status=verified in policy report")
+PY
+
+if ! grep -q "check_runtime_observability_endpoint_live_policy.sh" "$CONTRACT_LANE"; then
+  echo "expected runtime observability endpoint contract lane to compose policy checker" >&2
+  exit 1
+fi
+if ! grep -q "validate_runtime_observability_endpoint_live.sh" "$CONTRACT_LANE"; then
+  echo "expected runtime observability endpoint contract lane to compose validation lane" >&2
+  exit 1
+fi
+
+echo "runtime observability endpoint contract lane tests passed."

--- a/scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh
+++ b/scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_runtime_observability_endpoint_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_runtime_observability_endpoint_live_policy.sh"
+OBSERVABILITY_DOC="$ROOT_DIR/docs/foundation/observability-slo-dashboards.md"
+ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
+
+output_json=""
+policy_output_json=""
+max_seconds="${KAMN_RUNTIME_OBSERVABILITY_ENDPOINT_CONTRACT_MAX_SECONDS:-180}"
+ci_fast_gate="PASS"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --policy-output-json)
+      policy_output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+if [ "$max_seconds" -le 0 ]; then
+  echo "max-seconds must be greater than zero" >&2
+  exit 1
+fi
+if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
+  echo "ci-fast-gate must be PASS or FAIL" >&2
+  exit 1
+fi
+
+for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
+  if [ ! -x "$required_exec" ]; then
+    echo "expected required executable script '$required_exec'" >&2
+    exit 1
+  fi
+done
+
+for required_doc in "$OBSERVABILITY_DOC" "$ROADMAP_DOC"; do
+  if [ ! -f "$required_doc" ]; then
+    echo "expected required documentation file '$required_doc'" >&2
+    exit 1
+  fi
+done
+
+start_epoch="$(date +%s)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+summary_report="$TMP_DIR/runtime-observability-endpoint-live-summary.json"
+policy_report="$TMP_DIR/runtime-observability-endpoint-live-policy.json"
+tampered_report="$TMP_DIR/runtime-observability-endpoint-live-summary.tampered.json"
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --output-json "$summary_report" \
+    --max-seconds "$max_seconds"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected runtime observability endpoint live validation pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected runtime observability endpoint live validation GO marker" >&2
+  exit 1
+fi
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$summary_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate "$ci_fast_gate" \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected runtime observability endpoint policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected runtime observability endpoint policy checker GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^runtime_observability_policy_status=verified$'; then
+  echo "expected runtime observability endpoint policy status marker" >&2
+  exit 1
+fi
+
+cp "$summary_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["final_decision"] = "NO-GO"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate "$ci_fast_gate" \
+    --output-json "$TMP_DIR/runtime-observability-endpoint-live-policy.tampered.json" 2>&1
+)"
+tampered_policy_code=$?
+set -e
+
+if [ "$tampered_policy_code" -eq 0 ]; then
+  echo "expected tampered runtime observability endpoint report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'runtime_observability_policy_final_decision_mismatch'; then
+  echo "expected deterministic fail-closed reason for tampered runtime observability report" >&2
+  exit 1
+fi
+
+for required_ref in \
+  "validate_runtime_observability_endpoint_live.sh" \
+  "check_runtime_observability_endpoint_live_policy.sh" \
+  "validate_runtime_observability_endpoint_live_contract_lane.sh" \
+  "test_validate_runtime_observability_endpoint_live_contract_lane.sh"; do
+  if ! grep -q "$required_ref" "$OBSERVABILITY_DOC"; then
+    echo "expected observability docs to reference $required_ref" >&2
+    exit 1
+  fi
+done
+
+if ! grep -q "Task #3150, Subtask #3160" "$ROADMAP_DOC"; then
+  echo "expected roadmap marker for Task #3150, Subtask #3160" >&2
+  exit 1
+fi
+if ! grep -q "scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh" "$ROADMAP_DOC"; then
+  echo "expected roadmap to reference runtime observability endpoint contract lane script" >&2
+  exit 1
+fi
+if ! grep -q "scripts/runtime/check_runtime_observability_endpoint_live_policy.sh" "$ROADMAP_DOC"; then
+  echo "expected roadmap to reference runtime observability endpoint policy checker script" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "runtime observability endpoint contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/runtime-observability-endpoint-live-contract-lane-report.json"
+python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" <<'PY'
+import json
+import pathlib
+import sys
+
+summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+lane_report_file = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
+
+if summary_report.get("schema_version") != "kamn.runtime.observability-endpoint-live-validation.v1":
+    raise SystemExit("unexpected runtime observability endpoint live summary schema")
+if policy_report.get("schema_version") != "kamn.runtime.observability-endpoint-live-policy-report.v1":
+    raise SystemExit("unexpected runtime observability endpoint live policy schema")
+if summary_report.get("final_decision") != "GO":
+    raise SystemExit("expected runtime observability endpoint live summary final_decision=GO")
+if policy_report.get("final_decision") != "GO":
+    raise SystemExit("expected runtime observability endpoint live policy final_decision=GO")
+
+lane_report = {
+    "schema_version": "kamn.runtime.observability-endpoint-live-contract-lane-report.v1",
+    "status": "pass",
+    "final_decision": "GO",
+    "runtime_observability_stream_contract_status": summary_report.get(
+        "runtime_observability_stream_contract_status"
+    ),
+    "runtime_observability_policy_status": policy_report.get(
+        "runtime_observability_policy_status"
+    ),
+    "runtime_observability_contract_lane_status": "verified",
+    "docs_contract_status": "verified",
+    "fail_closed_status": "verified",
+    "fail_closed_reason_code": "runtime_observability_policy_final_decision_mismatch",
+    "performance_budget_status": "verified",
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+}
+lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [[ -n "$output_json" ]]; then
+  cp "$lane_report" "$output_json"
+fi
+if [[ -n "$policy_output_json" ]]; then
+  cp "$policy_report" "$policy_output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "runtime_observability_stream_contract_status=verified"
+echo "runtime_observability_policy_status=verified"
+echo "runtime_observability_contract_lane_status=verified"
+echo "docs_contract_status=verified"
+echo "fail_closed_status=verified"
+echo "fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch"
+echo "performance_budget_status=verified"


### PR DESCRIPTION
## Summary
Adds a deterministic runtime observability endpoint policy checker and contract-lane composition so `/metrics` + `/healthz` stream validation now has explicit GO/NO-GO policy enforcement, docs parity guards, and fail-closed tamper validation.

Closes #3160
Closes #3150
Refs #3143
Refs #3136

## Changes
- `scripts/runtime/runtime_observability_endpoint_live_contract.py`: added policy contract implementation (`check-policy`) with stable reason-code rejection.
- `scripts/runtime/check_runtime_observability_endpoint_live_policy.sh`: added stable checker wrapper.
- `scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh`: added bounded contract-lane composition (validation + policy + tamper drill + docs parity checks).
- `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`: added checker harness for success/fail-closed tamper behavior.
- `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh`: added contract-lane harness for success/fail-closed markers.
- `docs/foundation/observability-slo-dashboards.md`: documented lane/checker/harness commands and deterministic markers.
- `docs/plans/2026-02-08-production-service-roadmap.md`: added Task #3150/Subtask #3160 delivery entry.
- `docs/ci/strategy.md`: added explicit execution mode mapping (`fast/local/manual`) and cost controls.
- `crates/kamn-core/tests/observability_stack_docs.rs`: added docs-contract assertions for new lane/policy markers.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: added CI strategy contract assertions for new mode markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-core --test observability_stack_docs`
  - failed on missing `run/validate_runtime_observability_endpoint_live_contract_lane` marker and missing roadmap marker `Task #3150, Subtask #3160`.
- `cargo test -p kamn-core --test ci_strategy_docs`
  - failed on missing `## Runtime Observability Endpoint Contract Lane` section.

### 🟢 Green Phase
- `cargo test -p kamn-core --test observability_stack_docs` (20 passed)
- `cargo test -p kamn-core --test ci_strategy_docs` (3 passed)
- `bash scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh` (passed)
- `bash scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh` (passed)

### 🔁 Regression
- `cargo fmt --check` (clean)
- `cargo clippy -p kamn-core --tests -- -D warnings` (clean)
- Re-ran both docs tests and both new runtime harnesses after `cargo fmt` (all passing)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh` | |
| Functional   | ✅ | `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh` | |
| Integration  | ✅ | `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh` (validation+policy composition) | |
| Regression   | ✅ | tamper fail-closed checks in both new runtime harnesses | |
| Performance  | ✅ | bounded runtime budget enforcement in contract lane (`KAMN_RUNTIME_OBSERVABILITY_ENDPOINT_CONTRACT_MAX_SECONDS`) | |

## Risks & Rollback
- None.
- Rollback: revert commit `1b76ab4` if policy/lane integration causes unexpected drift.

## Documentation Updates
- `docs/foundation/observability-slo-dashboards.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core --tests`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope for touched files)
- [x] Docs updated (or justified why not)
