### PR TITLE
fix(ci): fail closed on undocumented non-kolme trend script growth

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -333,6 +333,10 @@ fn doc_contains_make_and_demo_scope_contract_rules() {
     assert!(DOC.contains(
         "native parity fast/local command matrix remains synchronized across `README.md` and `docs/planning/kolme-devnet-ops.md`."
     ));
+    assert!(DOC.contains(
+        "baseline script inventory remains authoritative; any new script path must be documented by refreshing the committed baseline fixture in the same change."
+    ));
+    assert!(DOC.contains("reason_codes=unexpected_current_scripts"));
 }
 
 #[test]

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -422,6 +422,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
   - `scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.py`
   - `scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.sh`
   - `scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh`
+  - baseline script inventory remains authoritative; any new script path must be documented by refreshing the committed baseline fixture in the same change.
   - selector outputs:
     - `run_ci_tool_checks=true`
     - `test_scope=ci-doc-contract`
@@ -1167,12 +1168,13 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
       - `fixtures/ci/non_kolme_wave_trend_test_loc_soft_budget_thresholds.json`
     - checker command:
       - `bash scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.sh --output-json /tmp/non-kolme-wave-trend-test-loc-soft-budget-report.json`
-    - fails closed on trend-test LOC growth and stale baseline script inventory drift.
+    - fails closed on trend-test LOC growth, stale baseline script inventory drift, and undocumented current-script growth.
     - deterministic reason-code surface is emitted for automation:
       - `reason_codes=none` (pass)
       - `reason_codes=script_count_delta_threshold_exceeded`
       - `reason_codes=total_shell_loc_delta_threshold_exceeded`
       - `reason_codes=missing_baseline_scripts`
+      - `reason_codes=unexpected_current_scripts`
     - Regression: #2777
   - Non-Kolme governance dispatcher wrapper-matrix guard stays on PR fast gate:
     - `bash scripts/framework/test_non_kolme_contract_lane_dispatch_wrapper_matrix.sh`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -56,6 +56,12 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Policy checker: `scripts/runtime/check_runtime_observability_endpoint_live_policy.sh` and `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`.
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `runtime_observability_stream_contract_status=verified`, `runtime_observability_policy_status=verified`, `runtime_observability_contract_lane_status=verified`, `docs_contract_status=verified`, `performance_budget_status=verified`.
   - Fail-closed validation confirmed for policy tamper drill behavior: `fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch`.
+- Post-roadmap hardening wave 6 shell-surface trend-guard tranche-3 delivered:
+  - CI checker now fails closed on undocumented current-script growth for non-Kolme wave trend-test LOC soft-budget governance (Task #3152, Subtask #3162):
+    - `scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.py`
+    - `scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh`
+  - Deterministic reason-code surface expanded with: `unexpected_current_scripts`.
+  - Trend-policy interpretation guidance updated in `docs/ci/strategy.md` to require baseline refresh for any new script path.
 - Post-roadmap hardening wave 2 runtime decomposition initial tranche delivered:
   - Extracted state-divergence orchestration from `crates/kamn-core/src/runtime.rs` into dedicated module `crates/kamn-core/src/runtime_state_divergence.rs` with unchanged external behavior (Task #3050, Subtask #3051).
   - Module-ownership contract documented in `docs/foundation/runtime-watchdog-attestation.md` and enforced by `crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs`.

--- a/scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.py
+++ b/scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.py
@@ -136,14 +136,20 @@ def main(argv: list[str]) -> int:
     script_count_delta = current_script_count - baseline_script_count
     total_shell_loc_delta = current_total_shell_loc - baseline_total_shell_loc
 
+    baseline_script_set = set(baseline_script_files)
     current_script_set = set(current_script_files)
     missing_baseline_scripts = [
         script for script in baseline_script_files if script not in current_script_set
+    ]
+    unexpected_current_scripts = [
+        script for script in current_script_files if script not in baseline_script_set
     ]
 
     reason_codes: list[str] = []
     if missing_baseline_scripts:
         reason_codes.append("missing_baseline_scripts")
+    if unexpected_current_scripts:
+        reason_codes.append("unexpected_current_scripts")
     if script_count_delta > max_script_count_increase:
         reason_codes.append("script_count_delta_threshold_exceeded")
     if total_shell_loc_delta > max_total_shell_loc_increase:
@@ -164,6 +170,7 @@ def main(argv: list[str]) -> int:
         "max_script_count_increase": max_script_count_increase,
         "max_total_shell_loc_increase": max_total_shell_loc_increase,
         "missing_baseline_scripts": missing_baseline_scripts,
+        "unexpected_current_scripts": unexpected_current_scripts,
         "reason_codes": reason_codes,
         "violation_count": len(reason_codes),
     }

--- a/scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh
+++ b/scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh
@@ -88,4 +88,44 @@ fi
 grep -q '^status=fail$' "$TMP_DIR/fail-stale.out"
 grep -q 'missing_baseline_scripts' "$TMP_DIR/fail-stale.out"
 
+RELAXED_THRESHOLD="$TMP_DIR/relaxed-threshold.json"
+cat >"$RELAXED_THRESHOLD" <<'JSON'
+{
+  "schema_version": "kamn.ci.non-kolme-wave-trend-test-loc-thresholds.v1",
+  "max_script_count_increase": 1,
+  "max_total_shell_loc_increase": 200
+}
+JSON
+
+MUTATED_UNDOCUMENTED_GROWTH_BASELINE="$TMP_DIR/mutated-undocumented-growth-baseline.json"
+cp "$BASELINE_FILE" "$MUTATED_UNDOCUMENTED_GROWTH_BASELINE"
+python3 - "$MUTATED_UNDOCUMENTED_GROWTH_BASELINE" "$ROOT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline_path = Path(sys.argv[1])
+root_dir = Path(sys.argv[2])
+payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+removed_script = payload["script_files"].pop()
+removed_path = root_dir / removed_script
+with removed_path.open("r", encoding="utf-8") as handle:
+    removed_loc = sum(1 for _ in handle)
+
+payload["script_count"] = len(payload["script_files"])
+payload["total_shell_loc"] = int(payload["total_shell_loc"]) - removed_loc
+baseline_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if bash "$CHECKER" \
+  --baseline-file "$MUTATED_UNDOCUMENTED_GROWTH_BASELINE" \
+  --threshold-file "$RELAXED_THRESHOLD" >"$TMP_DIR/fail-undocumented-growth.out" 2>&1; then
+  echo "expected checker to fail on undocumented current-script growth even when threshold deltas are relaxed" >&2
+  exit 1
+fi
+
+grep -q '^status=fail$' "$TMP_DIR/fail-undocumented-growth.out"
+grep -q 'unexpected_current_scripts' "$TMP_DIR/fail-undocumented-growth.out"
+
 echo "non-Kolme wave trend-test LOC soft-budget checker tests passed."


### PR DESCRIPTION
## Summary
Adds a fail-closed guard for undocumented current-script growth in the non-Kolme wave trend-test LOC soft-budget checker, even when numeric delta thresholds are relaxed. This hardens shell-surface trend governance so baseline inventory documentation remains mandatory.

Closes #3162
Closes #3152
Refs #3144
Refs #3136

## Changes
- `scripts/ci/check_non_kolme_wave_trend_test_loc_soft_budget.py`: add `unexpected_current_scripts` detection and reason code emission.
- `scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh`: add red/green contract scenario for undocumented growth under relaxed thresholds.
- `docs/ci/strategy.md`: add threshold interpretation guidance and new deterministic reason-code marker.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: assert docs include the new guidance + reason code.
- `docs/plans/2026-02-08-production-service-roadmap.md`: record wave-6 tranche-3 shell-surface trend guard delivery markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh`
  - failed with: `expected checker to fail on undocumented current-script growth even when threshold deltas are relaxed`

### 🟢 Green Phase
- `bash scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh` (passed)
- `bash scripts/ci/test_ci_strategy_contract.sh` (passed)
- `cargo test -p kamn-core --test ci_strategy_docs` (passed)

### 🔁 Regression
- `cargo test -p kamn-core --test observability_stack_docs --test persistence_live_validation_roadmap_docs --test runtime_module_extraction_roadmap_docs --test block_pipeline_docs --test p2p_transport_docs --test kolme_runtime_commit_client_docs` (passed)
- `cargo fmt --check` (passed)
- `cargo clippy -p kamn-core --tests -- -D warnings` (passed)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | non-Kolme soft-budget checker reason-code path (`unexpected_current_scripts`) | |
| Functional   | ✅ | `scripts/ci/test_check_non_kolme_wave_trend_test_loc_soft_budget.sh` growth-with-relaxed-threshold scenario | |
| Integration  | ✅ | `scripts/ci/test_ci_strategy_contract.sh`, `cargo test -p kamn-core --test ci_strategy_docs` | |
| Regression   | ✅ | roadmap/docs-contract suite: `observability_stack_docs`, `persistence_live_validation_roadmap_docs`, `runtime_module_extraction_roadmap_docs`, `block_pipeline_docs`, `p2p_transport_docs`, `kolme_runtime_commit_client_docs` | |
| Performance  | N/A | | No runtime-path change; checker remains bounded file-scan logic over deterministic fixture set. |

## Risks & Rollback
- None.
- Rollback: revert commit `3c65de4` to restore previous checker behavior.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/plans/2026-02-08-production-service-roadmap.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core --tests` scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
