### PR TITLE
fix(ci): encode local-heavy selector mode declarations

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -294,6 +294,8 @@ fn doc_contains_make_and_demo_scope_contract_rules() {
     assert!(
         DOC.contains("local-only heavy Kolme run-mode commands remain excluded from ci-fast-gate.")
     );
+    assert!(DOC.contains("kolme_local_heavy_lane_mode=local-only|manual-opt-in|not-applicable"));
+    assert!(DOC.contains("manual-hardened mode: manual"));
     assert!(DOC.contains(
         "local-only fork sync/smoke run-mode commands remain excluded from ci-fast-gate."
     ));

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -1373,6 +1373,11 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `python3 scripts/kolme/check_fast_gate_native_api_parity_policy.py --report-file /tmp/kolme-fast-gate-native-api-parity-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-fast-gate-native-api-parity-policy.json`
     - `KAMN_KOLME_FAST_GATE_NATIVE_PARITY_MAX_SECONDS=120`
   - local-only heavy Kolme run-mode commands remain excluded from ci-fast-gate.
+  - selector mode declaration marker:
+    - `kolme_local_heavy_lane_mode=local-only|manual-opt-in|not-applicable`
+    - `ci-fast-gate mode: fast` (local-heavy run-mode lanes excluded)
+    - `local-dev mode: local` (dry-run and local evidence workflows)
+    - `manual-hardened mode: manual` (`CI_ENABLE_KOLME_LOCAL_HEAVY_CONTRACT_TESTS=true` opt-in)
   - workflow heavy-exclusion policy checker fails closed when local-heavy command coverage drifts (`local_heavy_lane_commands_missing`) or leaks into version compatibility lane (`local_heavy_lane_commands_in_version_lane`).
   - workflow/selector parity contract remains enforced with deterministic reason codes:
     - `python3 scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py --workflow-file .github/workflows/ci-fast-gate.yml --selector-file scripts/ci/select_targets.sh`

--- a/scripts/ci/select_targets.sh
+++ b/scripts/ci/select_targets.sh
@@ -38,6 +38,7 @@ append_summary() {
     echo "- Run Kolme snapshot drift contract tests: ${RUN_KOLME_SNAPSHOT_DRIFT_CONTRACT_TESTS}"
     echo "- Run Kolme local-heavy contract tests: ${RUN_KOLME_LOCAL_HEAVY_CONTRACT_TESTS}"
     echo "- Kolme local-heavy selector opt-in: ${KOLME_LOCAL_HEAVY_SELECTOR_OPT_IN}"
+    echo "- Kolme local-heavy lane mode: ${KOLME_LOCAL_HEAVY_LANE_MODE}"
     echo "- Run Kolme version compatibility contract tests: ${RUN_KOLME_VERSION_COMPATIBILITY_CONTRACT_TESTS}"
     echo "- Run Kolme triadic devnet smoke contract tests: ${RUN_KOLME_TRIADIC_DEVNET_SMOKE_CONTRACT_TESTS}"
     echo "- Run federated delegation settlement contract tests: ${RUN_FEDERATED_DELEGATION_SETTLEMENT_CONTRACT_TESTS}"
@@ -680,6 +681,7 @@ CHANGED_MANIFESTS=""
 RUN_INVARIANT_HARNESS=false
 BRIDGE_REPLAY_SUITES=""
 KOLME_LOCAL_HEAVY_SELECTOR_OPT_IN=false
+KOLME_LOCAL_HEAVY_LANE_MODE="not-applicable"
 
 case "${CI_ENABLE_KOLME_LOCAL_HEAVY_CONTRACT_TESTS:-false}" in
   1|true|TRUE|yes|YES|on|ON)
@@ -824,11 +826,15 @@ fi
 if [ "$KOLME_LOCAL_HEAVY_CONTRACT_CHANGED" = true ]; then
   if [ "$KOLME_LOCAL_HEAVY_SELECTOR_OPT_IN" = true ]; then
     RUN_KOLME_LOCAL_HEAVY_CONTRACT_TESTS=true
+    KOLME_LOCAL_HEAVY_LANE_MODE="manual-opt-in"
     if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
       TEST_SCOPE="kolme-local-heavy-contract"
     fi
-  elif [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
-    TEST_SCOPE="kolme-local-heavy-local-only"
+  else
+    KOLME_LOCAL_HEAVY_LANE_MODE="local-only"
+    if [ "$RUN_RUST" != true ] && [ "$TEST_SCOPE" = "none" ]; then
+      TEST_SCOPE="kolme-local-heavy-local-only"
+    fi
   fi
 fi
 
@@ -1057,6 +1063,7 @@ write_output "run_federated_did_handshake_deep_lane" "$RUN_FEDERATED_DID_HANDSHA
 write_output "run_kolme_snapshot_drift_contract_tests" "$RUN_KOLME_SNAPSHOT_DRIFT_CONTRACT_TESTS"
 write_output "run_kolme_local_heavy_contract_tests" "$RUN_KOLME_LOCAL_HEAVY_CONTRACT_TESTS"
 write_output "kolme_local_heavy_selector_opt_in" "$KOLME_LOCAL_HEAVY_SELECTOR_OPT_IN"
+write_output "kolme_local_heavy_lane_mode" "$KOLME_LOCAL_HEAVY_LANE_MODE"
 write_output "run_kolme_version_compatibility_contract_tests" "$RUN_KOLME_VERSION_COMPATIBILITY_CONTRACT_TESTS"
 write_output "run_kolme_triadic_devnet_smoke_contract_tests" "$RUN_KOLME_TRIADIC_DEVNET_SMOKE_CONTRACT_TESTS"
 write_output "run_federated_delegation_settlement_contract_tests" "$RUN_FEDERATED_DELEGATION_SETTLEMENT_CONTRACT_TESTS"

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -255,6 +255,7 @@ required_snippets=(
   "check_local_heavy_validation_matrix_policy.py --report-file /tmp/kolme-local-heavy-validation-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-heavy-validation-policy.json"
   "run_local_heavy_validation_matrix_contract_lane.sh --output-json /tmp/kolme-local-heavy-validation-summary.json --policy-output-json /tmp/kolme-local-heavy-validation-policy.json"
   "KAMN_KOLME_LOCAL_HEAVY=1"
+  "kolme_local_heavy_lane_mode=local-only|manual-opt-in|not-applicable"
   "check_workflow_kolme_heavy_exclusion_policy.py --workflow-file .github/workflows/ci-fast-gate.yml --selector-file scripts/ci/select_targets.sh"
   "selector_local_heavy_commands_missing"
   "selector_output_run_flag_missing"

--- a/scripts/ci/test_select_targets.sh
+++ b/scripts/ci/test_select_targets.sh
@@ -175,6 +175,7 @@ run_selector_with_federated_did_deep() {
 docs_output="$(run_selector $'docs/foundation/ci-caching-parallelism.md')"
 assert_eq "$(extract_output "$docs_output" "docs_only")" "true" "docs_only selection mismatch"
 assert_docs_only_invariants "$docs_output"
+assert_eq "$(extract_output "$docs_output" "kolme_local_heavy_lane_mode")" "not-applicable" "docs_only should keep local-heavy lane mode marker at not-applicable"
 assert_eq "$(extract_output "$docs_output" "test_scope")" "none" "docs_only should keep none scope"
 
 ci_strategy_docs_output="$(run_selector $'docs/ci/strategy.md')"
@@ -362,12 +363,14 @@ assert_deploy_scope_triplet "$deployment_slo_contract_output" "deployment slo/ro
 kolme_local_heavy_default_gate_output="$(run_selector_with_local_heavy_opt_in $'scripts/kolme/run_local_heavy_validation_matrix.sh' 'false')"
 assert_eq "$(extract_output "$kolme_local_heavy_default_gate_output" "run_kolme_local_heavy_contract_tests")" "false" "Kolme local-heavy script changes should remain local-only by default"
 assert_eq "$(extract_output "$kolme_local_heavy_default_gate_output" "kolme_local_heavy_selector_opt_in")" "false" "Kolme local-heavy selector output must expose default non-opt-in state"
+assert_eq "$(extract_output "$kolme_local_heavy_default_gate_output" "kolme_local_heavy_lane_mode")" "local-only" "Kolme local-heavy selector output must declare local-only lane mode when opt-in is disabled"
 assert_eq "$(extract_output "$kolme_local_heavy_default_gate_output" "test_scope")" "kolme-local-heavy-local-only" "Kolme local-heavy script changes should set local-only selector scope by default"
 
 # Regression: #2303
 kolme_local_heavy_opt_in_gate_output="$(run_selector_with_local_heavy_opt_in $'scripts/kolme/run_local_heavy_validation_matrix.sh' 'true')"
 assert_eq "$(extract_output "$kolme_local_heavy_opt_in_gate_output" "run_kolme_local_heavy_contract_tests")" "true" "Kolme local-heavy script changes should run heavy lane only with explicit opt-in"
 assert_eq "$(extract_output "$kolme_local_heavy_opt_in_gate_output" "kolme_local_heavy_selector_opt_in")" "true" "Kolme local-heavy selector output must expose opt-in state when enabled"
+assert_eq "$(extract_output "$kolme_local_heavy_opt_in_gate_output" "kolme_local_heavy_lane_mode")" "manual-opt-in" "Kolme local-heavy selector output must declare manual-opt-in lane mode when opt-in is enabled"
 assert_eq "$(extract_output "$kolme_local_heavy_opt_in_gate_output" "test_scope")" "kolme-local-heavy-contract" "Kolme local-heavy script changes should set local-heavy contract scope when opt-in is enabled"
 
 # Regression: #2330


### PR DESCRIPTION
## Summary
Adds an explicit selector declaration marker for Kolme local-heavy lane mode so CI contracts can enforce local/manual semantics directly from `select_targets.sh` output. This makes local-only heavy lane governance auditable in both selector and strategy docs contracts.

Closes #3163
Closes #3153
Refs #3138
Refs #3136

## Changes
- `scripts/ci/select_targets.sh`: emit `kolme_local_heavy_lane_mode` with deterministic values (`local-only`, `manual-opt-in`, `not-applicable`) and include it in summary output.
- `scripts/ci/test_select_targets.sh`: add regression assertions for default local-only mode, manual opt-in mode, and docs-only not-applicable mode.
- `scripts/ci/test_ci_strategy_contract.sh`: require strategy docs marker `kolme_local_heavy_lane_mode=local-only|manual-opt-in|not-applicable`.
- `docs/ci/strategy.md`: document local/manual declaration marker and mode semantics.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: assert docs include new marker and manual-hardened mode declaration.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/ci/test_select_targets.sh`
  - failed with: `docs_only should keep local-heavy lane mode marker at not-applicable: expected 'not-applicable', got ''`
- `bash scripts/ci/test_ci_strategy_contract.sh`
  - failed with: `CI strategy contract failed: missing snippet 'kolme_local_heavy_lane_mode=local-only|manual-opt-in|not-applicable'.`

### 🟢 Green Phase
- `bash scripts/ci/test_select_targets.sh` (passed)
- `bash scripts/ci/test_ci_strategy_contract.sh` (passed)
- `bash scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh` (passed)
- `cargo test -p kamn-core --test ci_strategy_docs` (passed)

### 🔁 Regression
- `cargo fmt --check` (passed)
- `cargo clippy -p kamn-core --tests -- -D warnings` (passed)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | selector mode output branch coverage via `scripts/ci/test_select_targets.sh` | |
| Functional   | ✅ | local-only vs manual-opt-in selector mode assertions | |
| Integration  | ✅ | `scripts/ci/test_ci_strategy_contract.sh`, `scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`, `cargo test -p kamn-core --test ci_strategy_docs` | |
| Regression   | ✅ | docs-only selector mode assertion + existing heavy-exclusion policy suite | |
| Performance  | N/A | | No runtime-path change; selector adds a constant-time output marker only. |

## Risks & Rollback
- None.
- Rollback: revert commit `19d6ca3` to restore previous selector output surface.

## Documentation Updates
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core --tests` scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
