### PR TITLE
fix(ci): reconcile Kolme wrapper baseline fixture drift (#3177)

### DIFF
--- a/fixtures/kolme_compatibility/wrapper_inventory_baseline.json
+++ b/fixtures/kolme_compatibility/wrapper_inventory_baseline.json
@@ -26,7 +26,7 @@
       "priority": "P2",
       "shell_loc": 1,
       "source_entry": "scripts/kolme/run_local_heavy_validation_matrix_contract_lane.sh",
-      "status": "planned",
+      "status": "migrated",
       "target_runner": "framework_manifest_lane",
       "wrapper_kind": "symlink"
     },


### PR DESCRIPTION
## Summary
Reconcile `fixtures/kolme_compatibility/wrapper_inventory_baseline.json` with the authoritative generated output from the lane migration matrix so CI governance checks fail only on real drift. This removes the pre-existing fast-mode CI blocker `generated baseline fixture drift detected`.

Closes #3177
Closes #3176
Closes #3175
Closes #3174

## Changes
- `fixtures/kolme_compatibility/wrapper_inventory_baseline.json`: corrected stale status metadata for `kolme.local.heavy.validation_matrix` to match generated inventory.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
```
Output:
```text
generated baseline fixture drift detected
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Output:
```text
Kolme wrapper inventory baseline contract tests passed.
Fast-mode CI tool regression tests passed.
```

### 🔁 Regression
Command:
```bash
KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
```
Result:
```text
Passes end-to-end, including Kolme wrapper baseline and budget trend contract gates.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | Fixture synchronization only; no function-level code path changed |
| Functional   | ✅ | `scripts/ci/test_kolme_wrapper_inventory_baseline_contract.sh` | |
| Integration  | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅ | Existing mutated-fixture drift checks within `test_kolme_wrapper_inventory_baseline_contract.sh` remain green | |
| Performance  | N/A | | No runtime-path or throughput change |

## Risks & Rollback
- Risk is low; one baseline metadata field update aligned to generated source-of-truth.
- Rollback: revert commit `90104e1`.

## Documentation Updates
- None required (existing baseline refresh guidance already present).

## Validation Checklist
- [x] Targeted baseline contract lane passed
- [x] Integration fast-mode CI tools lane passed
- [x] TDD Red/Green evidence included above
- [x] Docs updated (or justified why not)
