### PR TITLE
feat(node): support env-only daemon control overrides

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -191,6 +191,12 @@ fn collect_env_override_args() -> Result<Vec<String>, ConfigError> {
     append_env_override(&mut args, "KAMN_NODE_ENABLE_GOSSIP", "enable_gossip")?;
     append_env_override(&mut args, "KAMN_NODE_SYNC_MODE", "sync_mode")?;
     append_env_override(&mut args, "KAMN_NODE_RUNTIME_MODE", "runtime_mode")?;
+    append_env_override(&mut args, "KAMN_NODE_DAEMON_MAX_TICKS", "daemon_max_ticks")?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_DAEMON_TICK_INTERVAL_MS",
+        "daemon_tick_interval_ms",
+    )?;
     append_env_override(
         &mut args,
         "KAMN_NODE_EXPECTED_STATE_VERSION",
@@ -307,8 +313,8 @@ fn build_layered_cli_args(raw_args: Vec<String>) -> Result<Vec<String>, ConfigEr
     let config_file_path = config_file_from_cli.or(config_file_from_env);
     if let Some(path) = config_file_path.as_deref() {
         layered_args.extend(parse_config_file_args(path)?);
-        layered_args.extend(collect_env_override_args()?);
     }
+    layered_args.extend(collect_env_override_args()?);
     layered_args.extend(args_without_config.into_iter().skip(1));
     Ok(layered_args)
 }

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -1081,6 +1081,53 @@ fn integration_config_layering_executes_bootstrap_report_with_expected_precedenc
 }
 
 #[test]
+fn env_only_daemon_controls_parse_without_config_file() {
+    let _env_lock = signer_env_lock()
+        .lock()
+        .expect("env lock should guard process-level overrides");
+    let _max_ticks_guard = EnvVarGuard::set("KAMN_NODE_DAEMON_MAX_TICKS", Some("12"));
+    let _tick_interval_guard = EnvVarGuard::set("KAMN_NODE_DAEMON_TICK_INTERVAL_MS", Some("25"));
+
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("env-only daemon controls should parse");
+    assert_eq!(parsed.daemon_max_ticks, Some(12));
+    assert_eq!(parsed.daemon_tick_interval_ms, Some(25));
+}
+
+#[test]
+fn regression_3202_invalid_daemon_env_override_fails_closed_without_config_file() {
+    let _env_lock = signer_env_lock()
+        .lock()
+        .expect("env lock should guard process-level overrides");
+    let _max_ticks_guard = EnvVarGuard::set("KAMN_NODE_DAEMON_MAX_TICKS", Some("invalid"));
+    let _tick_interval_guard = EnvVarGuard::set("KAMN_NODE_DAEMON_TICK_INTERVAL_MS", Some("25"));
+
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+    ];
+
+    let parse_result = parse_args(args);
+    assert!(
+        matches!(
+            parse_result,
+            Err(ConfigError::InvalidDaemonControlArgument(value)) if value == "invalid"
+        ),
+        "invalid daemon env override must fail closed with typed daemon control error"
+    );
+}
+
+#[test]
 fn functional_json_render_is_deterministic() {
     let report = NodeBootstrapReport {
         runtime_mode: "bootstrap".to_owned(),

--- a/deploy/k8s/kamn-node.yaml
+++ b/deploy/k8s/kamn-node.yaml
@@ -35,15 +35,22 @@ spec:
         - name: kamn-node
           image: kamn-node:local
           imagePullPolicy: IfNotPresent
+          env:
+            - name: KAMN_NODE_DAEMON_MAX_TICKS
+              valueFrom:
+                configMapKeyRef:
+                  name: kamn-node-defaults
+                  key: daemon_max_ticks
+            - name: KAMN_NODE_DAEMON_TICK_INTERVAL_MS
+              valueFrom:
+                configMapKeyRef:
+                  name: kamn-node-defaults
+                  key: daemon_tick_interval_ms
           args:
             - --role
             - processor
             - --runtime-mode
             - daemon
-            - --daemon-max-ticks
-            - "10"
-            - --daemon-tick-interval-ms
-            - "25"
             - --output
             - json
 ---
@@ -68,15 +75,22 @@ spec:
         - name: kamn-node
           image: kamn-node:local
           imagePullPolicy: IfNotPresent
+          env:
+            - name: KAMN_NODE_DAEMON_MAX_TICKS
+              valueFrom:
+                configMapKeyRef:
+                  name: kamn-node-defaults
+                  key: daemon_max_ticks
+            - name: KAMN_NODE_DAEMON_TICK_INTERVAL_MS
+              valueFrom:
+                configMapKeyRef:
+                  name: kamn-node-defaults
+                  key: daemon_tick_interval_ms
           args:
             - --role
             - listener
             - --runtime-mode
             - daemon
-            - --daemon-max-ticks
-            - "10"
-            - --daemon-tick-interval-ms
-            - "25"
             - --output
             - json
 ---
@@ -101,14 +115,21 @@ spec:
         - name: kamn-node
           image: kamn-node:local
           imagePullPolicy: IfNotPresent
+          env:
+            - name: KAMN_NODE_DAEMON_MAX_TICKS
+              valueFrom:
+                configMapKeyRef:
+                  name: kamn-node-defaults
+                  key: daemon_max_ticks
+            - name: KAMN_NODE_DAEMON_TICK_INTERVAL_MS
+              valueFrom:
+                configMapKeyRef:
+                  name: kamn-node-defaults
+                  key: daemon_tick_interval_ms
           args:
             - --role
             - approver
             - --runtime-mode
             - daemon
-            - --daemon-max-ticks
-            - "10"
-            - --daemon-tick-interval-ms
-            - "25"
             - --output
             - json

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -12,15 +12,13 @@ Phase 6.2 implementation adds:
 
 ## Precedence
 
-When `--config-file` or `KAMN_NODE_CONFIG_FILE` is set, `kamn-node` resolves settings in this order (low to high):
+`kamn-node` resolves settings in this order (low to high):
 
 1. Built-in defaults
 2. Profile defaults (`--profile`)
-3. Config-file entries
+3. Config-file entries (when `--config-file` or `KAMN_NODE_CONFIG_FILE` is set)
 4. `KAMN_NODE_*` environment overrides
 5. Explicit CLI flags
-
-If no config file is declared, environment overrides are not applied by this layer.
 
 ## Config File Format
 
@@ -69,12 +67,14 @@ Kolme-live keys:
 
 ## Environment Override Contracts
 
-Environment override names map to the same key contracts when a config file is active.
+Environment override names map to the same key contracts regardless of config-file usage.
 
 Examples:
 
 - `KAMN_NODE_CHAIN_ID` -> `chain_id`
 - `KAMN_NODE_SYNC_MODE` -> `sync_mode`
+- `KAMN_NODE_DAEMON_MAX_TICKS` -> `daemon_max_ticks`
+- `KAMN_NODE_DAEMON_TICK_INTERVAL_MS` -> `daemon_tick_interval_ms`
 - `KAMN_NODE_ENABLE_GOSSIP` -> `enable_gossip`
 - `KAMN_NODE_API_BIND` -> `api_bind`
 - `KAMN_NODE_KOLME_LIVE_BASE_URL` -> `kolme_live_base_url`

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -53,6 +53,7 @@ Includes:
 
 - `Namespace` (`kamn-system`)
 - `ConfigMap` for chain/runtime defaults
+- env-driven daemon controls via `KAMN_NODE_DAEMON_MAX_TICKS` and `KAMN_NODE_DAEMON_TICK_INTERVAL_MS`
 - `Deployment` resources:
   - `kamn-processor`
   - `kamn-listener`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -241,6 +241,7 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Phase 6.2 initial slice delivered:
   - Added deterministic config layering in `kamn-node` with `--config-file` and `KAMN_NODE_CONFIG_FILE`.
   - Added validated `KAMN_NODE_*` override projection over config-file values with precedence `config < env < CLI`.
+  - Extended layering so `KAMN_NODE_*` overrides apply even without a config file and added daemon env contracts for `KAMN_NODE_DAEMON_MAX_TICKS` and `KAMN_NODE_DAEMON_TICK_INTERVAL_MS` (Story #3200, Task #3201, Subtask #3202).
   - Added fail-closed config/override validation with typed `ConfigError` surfaces and regression coverage for invalid env override values (Story #2965, Task #2966, Subtask #2967).
   - Operator contracts documented in `docs/ops/configuration.md`.
 - Phase 6.2 live validation delivered:

--- a/scripts/deploy/test_deployment_assets.sh
+++ b/scripts/deploy/test_deployment_assets.sh
@@ -88,6 +88,14 @@ if ! grep -q 'name: kamn-approver' "$K8S_MANIFEST"; then
   echo "expected kubernetes approver deployment marker" >&2
   exit 1
 fi
+if ! grep -q 'KAMN_NODE_DAEMON_MAX_TICKS' "$K8S_MANIFEST"; then
+  echo "expected kubernetes manifest daemon max-ticks env marker" >&2
+  exit 1
+fi
+if ! grep -q 'KAMN_NODE_DAEMON_TICK_INTERVAL_MS' "$K8S_MANIFEST"; then
+  echo "expected kubernetes manifest daemon tick-interval env marker" >&2
+  exit 1
+fi
 
 if ! grep -q 'docker compose -f deploy/docker-compose.yml up' "$DEPLOY_DOC"; then
   echo "expected deployment doc compose command marker" >&2
@@ -99,6 +107,14 @@ if ! grep -q 'kubectl apply -f deploy/k8s/kamn-node.yaml' "$DEPLOY_DOC"; then
 fi
 if ! grep -q '\.dockerignore' "$DEPLOY_DOC"; then
   echo "expected deployment doc to mention .dockerignore build-context hygiene" >&2
+  exit 1
+fi
+if ! grep -q 'KAMN_NODE_DAEMON_MAX_TICKS' "$DEPLOY_DOC"; then
+  echo "expected deployment doc daemon max-ticks env marker" >&2
+  exit 1
+fi
+if ! grep -q 'KAMN_NODE_DAEMON_TICK_INTERVAL_MS' "$DEPLOY_DOC"; then
+  echo "expected deployment doc daemon tick-interval env marker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Enable `KAMN_NODE_*` overrides without requiring a config file, add daemon tick env mappings, and align deployment artifacts/docs with env-driven daemon controls.

Closes #3202
Closes #3201
Closes #3200
Closes #3199

## Changes
- `crates/kamn-node/src/cli.rs`: always apply env override layer (`config < env < CLI`) and map daemon env keys:
  - `KAMN_NODE_DAEMON_MAX_TICKS`
  - `KAMN_NODE_DAEMON_TICK_INTERVAL_MS`
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: add red/green/regression coverage for env-only daemon parsing and fail-closed invalid daemon env values.
- `deploy/k8s/kamn-node.yaml`: switch daemon tick controls to env-driven config via `ConfigMap`.
- `scripts/deploy/test_deployment_assets.sh`: enforce k8s/doc markers for daemon env controls.
- Docs updates:
  - `docs/ops/configuration.md`
  - `docs/ops/deployment.md`
  - `docs/plans/2026-02-08-production-service-roadmap.md`

## Risks & Compatibility
- Behavior change: `KAMN_NODE_*` overrides now apply even when no config file is supplied.
- Compatibility impact: operators with globally set `KAMN_NODE_*` values may now affect CLI-only runs (intentional by story scope).

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed env-only daemon controls in parser tests and deployment artifact contract/live checks

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node env_only_daemon_controls_parse_without_config_file` |
| Functional  | ✅     | `cargo test -p kamn-node regression_3202_invalid_daemon_env_override_fails_closed_without_config_file` |
| Integration | ✅     | `bash scripts/deploy/test_deployment_assets.sh`; `bash scripts/runtime/test_validate_config_layering_live.sh` |
| Regression  | ✅     | invalid daemon env override fails closed with typed `ConfigError::InvalidDaemonControlArgument` |
