### PR TITLE
refactor(runtime): split snapshot-store tests into dedicated module

### DIFF
--- a/crates/kamn-core/src/runtime_tests.rs
+++ b/crates/kamn-core/src/runtime_tests.rs
@@ -4,23 +4,22 @@ use super::{
     ApproverQuorumError, ApproverQuorumEvaluator, ApproverQuorumInput, AuthenticatedPeerFrame,
     AuthenticatedPeerFrameError, BoundedRuntimeQueue, ConstructLockError, ConstructLockGuard,
     DeterministicBackpressureController, DeterministicNetworkFaultSimulator,
-    DeterministicProposalPlanner, FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore,
-    ListenerAttestation, ListenerQuorumError, ListenerQuorumEvaluator, ListenerQuorumInput,
-    NetworkFaultSimulationError, NetworkFaultSimulationInput, PeerFrameAuthenticator,
-    PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
-    RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
-    RuntimeBackpressureAction, RuntimeBackpressureDecision, RuntimeBackpressureError,
-    RuntimeBackpressureInput, RuntimeBackpressurePolicy, RuntimeLifecycleError, RuntimeQueueError,
-    RuntimeSnapshot, RuntimeSnapshotStore, SnapshotRestoreError, SnapshotRestoreGuard,
-    SnapshotStoreError, StateDivergenceError, StateDivergenceEvaluator, StateDivergenceSeverity,
-    StateDivergenceStatus, StateDivergenceWatchInput, WatchdogAnomalyError,
-    WatchdogAnomalyEvaluator, WatchdogAnomalyKind, WatchdogAnomalySeverity,
-    WatchdogAnomalyWatchInput,
+    DeterministicProposalPlanner, ListenerAttestation, ListenerQuorumError,
+    ListenerQuorumEvaluator, ListenerQuorumInput, NetworkFaultSimulationError,
+    NetworkFaultSimulationInput, PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent,
+    PeerLifecycleState, ProposalCandidate, ProposalPlannerError, RecoveryGuardError,
+    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeBackpressureAction,
+    RuntimeBackpressureDecision, RuntimeBackpressureError, RuntimeBackpressureInput,
+    RuntimeBackpressurePolicy, RuntimeLifecycleError, RuntimeQueueError, StateDivergenceError,
+    StateDivergenceEvaluator, StateDivergenceSeverity, StateDivergenceStatus,
+    StateDivergenceWatchInput, WatchdogAnomalyError, WatchdogAnomalyEvaluator, WatchdogAnomalyKind,
+    WatchdogAnomalySeverity, WatchdogAnomalyWatchInput,
 };
 use crate::config::{NodeConfig, NodeRole, SyncMode};
-use std::fs;
-use std::path::PathBuf;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
+
+#[path = "runtime_tests_snapshot_store.rs"]
+mod runtime_tests_snapshot_store;
 
 fn sample_config(role: NodeRole) -> NodeConfig {
     NodeConfig {
@@ -105,6 +104,44 @@ fn regression_runtime_source_routes_tests_via_dedicated_module_file() {
         !runtime_source.contains(&inline_pattern),
         "expected inline runtime test body to be removed from runtime.rs"
     );
+}
+
+#[test]
+fn regression_runtime_tests_source_routes_snapshot_store_domain_via_dedicated_module_file() {
+    // Regression: #3207
+    let runtime_tests_source = include_str!("runtime_tests.rs");
+    let declaration = [
+        "#[path = \"runtime_tests_snapshot_store.rs\"]",
+        "mod runtime_tests_snapshot_store;",
+    ]
+    .join("\n");
+    assert!(
+        runtime_tests_source.contains(&declaration),
+        "expected runtime tests source to declare dedicated snapshot-store test module"
+    );
+
+    for legacy_marker in [
+        [
+            "fn functional_",
+            "in_memory_snapshot_store_round_trips_snapshots()",
+        ]
+        .concat(),
+        [
+            "fn integration_file_",
+            "snapshot_store_round_trips_snapshots()",
+        ]
+        .concat(),
+        [
+            "fn performance_file_snapshot_store_",
+            "recovery_scan_stays_within_ci_budget()",
+        ]
+        .concat(),
+    ] {
+        assert!(
+            !runtime_tests_source.contains(&legacy_marker),
+            "expected snapshot-store test `{legacy_marker}` to move out of runtime_tests.rs"
+        );
+    }
 }
 
 #[test]
@@ -719,81 +756,6 @@ fn regression_rejoin_state_hash_mismatch_is_rejected() {
         RecoveryGuardError::StateHashMismatch {
             expected: "state-42".to_owned(),
             found: "state-41".to_owned()
-        }
-    );
-}
-
-#[test]
-fn functional_snapshot_restore_guard_accepts_matching_snapshot() {
-    let guard = SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
-    let snapshot = RuntimeSnapshot::new(42, "state-42").expect("snapshot should be valid");
-    assert!(guard.validate(snapshot).is_ok());
-}
-
-#[test]
-fn unit_snapshot_restore_guard_rejects_invalid_state_hash() {
-    let snapshot = RuntimeSnapshot::new(42, "");
-    assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidStateHash));
-}
-
-#[test]
-fn regression_snapshot_restore_version_mismatch_is_rejected() {
-    // Regression: #361
-    let guard = SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
-    let snapshot = RuntimeSnapshot::new(41, "state-42").expect("snapshot should be valid");
-    let error = guard
-        .validate(snapshot)
-        .expect_err("version mismatch should be rejected");
-    assert_eq!(
-        error,
-        SnapshotRestoreError::StateVersionMismatch {
-            expected: 42,
-            found: 41
-        }
-    );
-}
-
-#[test]
-fn regression_snapshot_restore_hash_mismatch_is_rejected() {
-    // Regression: #361
-    let guard = SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
-    let snapshot = RuntimeSnapshot::new(42, "state-41").expect("snapshot should be valid");
-    let error = guard
-        .validate(snapshot)
-        .expect_err("hash mismatch should be rejected");
-    assert_eq!(
-        error,
-        SnapshotRestoreError::StateHashMismatch {
-            expected: "state-42".to_owned(),
-            found: "state-41".to_owned()
-        }
-    );
-}
-
-#[test]
-fn functional_snapshot_restore_guard_with_expected_cursor_accepts_matching_snapshot() {
-    let guard = SnapshotRestoreGuard::with_expected_cursor(42, "state-42", 100)
-        .expect("restore guard should construct");
-    let snapshot =
-        RuntimeSnapshot::with_cursor(42, "state-42", 100).expect("snapshot should be valid");
-    assert!(guard.validate(snapshot).is_ok());
-}
-
-#[test]
-fn regression_snapshot_restore_cursor_mismatch_is_rejected() {
-    // Regression: #617
-    let guard = SnapshotRestoreGuard::with_expected_cursor(42, "state-42", 100)
-        .expect("restore guard should construct");
-    let snapshot =
-        RuntimeSnapshot::with_cursor(42, "state-42", 99).expect("snapshot should be valid");
-    let error = guard
-        .validate(snapshot)
-        .expect_err("cursor mismatch should be rejected");
-    assert_eq!(
-        error,
-        SnapshotRestoreError::CursorMismatch {
-            expected: 100,
-            found: 99
         }
     );
 }
@@ -1542,337 +1504,4 @@ fn performance_network_fault_simulation_chaos_lane_stress() {
         .expect("valid simulation input");
         assert!(simulator.simulate(input).is_ok());
     }
-}
-
-#[test]
-fn functional_in_memory_snapshot_store_round_trips_snapshots() {
-    let mut store = InMemoryRuntimeSnapshotStore::default();
-    assert!(store.list().expect("list should succeed").is_empty());
-
-    let snapshot_1 = RuntimeSnapshot::new(41, "state-41").expect("valid snapshot");
-    let snapshot_2 = RuntimeSnapshot::new(42, "state-42").expect("valid snapshot");
-    assert!(store.write(snapshot_1).is_ok());
-    assert!(store.write(snapshot_2.clone()).is_ok());
-
-    let latest = store.read_latest().expect("read_latest should succeed");
-    assert_eq!(latest, Some(snapshot_2));
-    assert_eq!(store.list().expect("list should succeed").len(), 2);
-}
-
-#[test]
-fn integration_file_snapshot_store_round_trips_snapshots() {
-    let path = temp_snapshot_store_path("roundtrip");
-    let _ = fs::remove_file(&path);
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let snapshot_1 = RuntimeSnapshot::new(41, "state-41").expect("valid snapshot");
-    let snapshot_2 = RuntimeSnapshot::new(42, "state-42").expect("valid snapshot");
-    assert!(store.write(snapshot_1).is_ok());
-    assert!(store.write(snapshot_2.clone()).is_ok());
-
-    let latest = store.read_latest().expect("read_latest should succeed");
-    assert_eq!(latest, Some(snapshot_2));
-    assert_eq!(store.list().expect("list should succeed").len(), 2);
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn regression_file_snapshot_store_rejects_malformed_payload() {
-    // Regression: #387
-    let path = temp_snapshot_store_path("malformed");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "not-a-valid-snapshot-line\n").is_ok());
-
-    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let error = store
-        .list()
-        .expect_err("malformed payload must be rejected");
-    assert_eq!(
-        error,
-        SnapshotStoreError::InvalidPayload("not-a-valid-snapshot-line".to_owned())
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn unit_file_snapshot_store_recovery_handles_missing_snapshot_file() {
-    let path = temp_snapshot_store_path("recover-missing");
-    let _ = fs::remove_file(&path);
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let result = store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    assert!(result.latest.is_none());
-    assert_eq!(result.recovered_entries, 0);
-    assert_eq!(result.dropped_corrupt_entries, 0);
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn functional_file_snapshot_store_recovery_recovers_latest_after_trailing_corruption() {
-    let path = temp_snapshot_store_path("recover-trailing-corruption");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41\n42|state-42\n43|\n").is_ok());
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    assert_eq!(
-        store.list(),
-        Err(SnapshotStoreError::InvalidPayload("43|".to_owned()))
-    );
-
-    let result = store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    assert_eq!(
-        result.latest,
-        Some(RuntimeSnapshot::new(42, "state-42").expect("valid snapshot"))
-    );
-    assert_eq!(result.recovered_entries, 2);
-    assert_eq!(result.dropped_corrupt_entries, 1);
-    assert_eq!(store.list().expect("list should succeed").len(), 2);
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn integration_file_snapshot_store_recovery_allows_append_after_restart() {
-    let path = temp_snapshot_store_path("recover-restart");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41\n42|state-42\n43|\n").is_ok());
-
-    let mut first_store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let first_recovery = first_store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    assert_eq!(first_recovery.recovered_entries, 2);
-
-    let mut restarted_store =
-        FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let next_snapshot = RuntimeSnapshot::new(43, "state-43").expect("valid snapshot");
-    assert!(restarted_store.write(next_snapshot.clone()).is_ok());
-    assert_eq!(
-        restarted_store.read_latest().expect("read should pass"),
-        Some(next_snapshot)
-    );
-    assert_eq!(restarted_store.list().expect("list should pass").len(), 3);
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn regression_file_snapshot_store_recovery_truncates_corrupt_suffix() {
-    // Regression: #617
-    let path = temp_snapshot_store_path("recover-corrupt-suffix");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41\n42|state-42\nbroken\n43|state-43\n").is_ok());
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let result = store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    assert_eq!(
-        result.latest,
-        Some(RuntimeSnapshot::new(42, "state-42").expect("valid snapshot"))
-    );
-    assert_eq!(result.recovered_entries, 2);
-    assert_eq!(result.dropped_corrupt_entries, 2);
-    assert_eq!(
-        fs::read_to_string(&path).expect("snapshot file should be readable"),
-        "41|state-41|41\n42|state-42|42\n"
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn unit_runtime_snapshot_with_cursor_rejects_zero_cursor() {
-    let snapshot = RuntimeSnapshot::with_cursor(42, "state-42", 0);
-    assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidCursor));
-}
-
-#[test]
-fn unit_runtime_snapshot_rejects_hash_with_metadata_delimiter() {
-    let snapshot = RuntimeSnapshot::new(42, "state-42|100");
-    assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidStateHash));
-}
-
-#[test]
-fn unit_in_memory_snapshot_store_rejects_state_version_regression() {
-    let mut store = InMemoryRuntimeSnapshotStore::default();
-    let baseline = RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot");
-    assert!(store.write(baseline).is_ok());
-    let stale = RuntimeSnapshot::with_cursor(40, "state-40", 101).expect("valid snapshot");
-    assert_eq!(
-        store.write(stale),
-        Err(SnapshotStoreError::StateVersionRegression {
-            previous: 41,
-            found: 40
-        })
-    );
-}
-
-#[test]
-fn unit_in_memory_snapshot_store_rejects_cursor_regression() {
-    let mut store = InMemoryRuntimeSnapshotStore::default();
-    let baseline = RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot");
-    assert!(store.write(baseline).is_ok());
-    let stale = RuntimeSnapshot::with_cursor(42, "state-42", 99).expect("valid snapshot");
-    assert_eq!(
-        store.write(stale),
-        Err(SnapshotStoreError::CursorRegression {
-            previous: 100,
-            found: 99
-        })
-    );
-}
-
-#[test]
-fn regression_file_snapshot_store_rejects_version_regression_metadata() {
-    // Regression: #617
-    let path = temp_snapshot_store_path("version-regression");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41|100\n40|state-40|101\n").is_ok());
-
-    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    assert_eq!(
-        store.list(),
-        Err(SnapshotStoreError::StateVersionRegression {
-            previous: 41,
-            found: 40
-        })
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn regression_file_snapshot_store_rejects_cursor_regression_metadata() {
-    // Regression: #617
-    let path = temp_snapshot_store_path("cursor-regression");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41|100\n42|state-42|99\n").is_ok());
-
-    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    assert_eq!(
-        store.list(),
-        Err(SnapshotStoreError::CursorRegression {
-            previous: 100,
-            found: 99
-        })
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn regression_file_snapshot_store_rejects_stale_hash_metadata() {
-    // Regression: #617
-    let path = temp_snapshot_store_path("hash-regression");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41|100\n42|state-41|101\n").is_ok());
-
-    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    assert_eq!(
-        store.list(),
-        Err(SnapshotStoreError::StaleStateHash {
-            state_hash: "state-41".to_owned(),
-            previous_version: 41,
-            found_version: 42
-        })
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn functional_file_snapshot_store_recovery_truncates_stale_metadata_suffix() {
-    let path = temp_snapshot_store_path("recover-stale-metadata");
-    let _ = fs::remove_file(&path);
-    assert!(fs::write(&path, "41|state-41|100\n42|state-42|99\n43|state-43|102\n").is_ok());
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let result = store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    assert_eq!(
-        result.latest,
-        Some(RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot"))
-    );
-    assert_eq!(result.recovered_entries, 1);
-    assert_eq!(result.dropped_corrupt_entries, 2);
-    assert_eq!(
-        fs::read_to_string(&path).expect("snapshot file should be readable"),
-        "41|state-41|100\n"
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-fn performance_file_snapshot_store_recovery_scan_stays_within_ci_budget() {
-    let path = temp_snapshot_store_path("recover-performance");
-    let _ = fs::remove_file(&path);
-    let mut payload = String::new();
-    for state_version in 1..=256 {
-        payload.push_str(&format!("{state_version}|state-{state_version}\n"));
-    }
-    payload.push_str("broken\n");
-    assert!(fs::write(&path, payload).is_ok());
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let start = Instant::now();
-    let result = store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    let elapsed_millis = start.elapsed().as_millis();
-    assert_eq!(result.recovered_entries, 256);
-    assert_eq!(result.dropped_corrupt_entries, 1);
-    assert!(
-        elapsed_millis < 250,
-        "snapshot recovery exceeded CI budget: {elapsed_millis}ms"
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-#[test]
-#[ignore = "scheduled snapshot deep lane"]
-fn performance_file_snapshot_store_recovery_deep_lane_large_payload() {
-    let path = temp_snapshot_store_path("recover-deep-lane");
-    let _ = fs::remove_file(&path);
-    let mut payload = String::new();
-    for state_version in 1..=8192 {
-        payload.push_str(&format!(
-            "{state_version}|state-{state_version}|{state_version}\n"
-        ));
-    }
-    payload.push_str("8193|state-8193|0\n");
-    assert!(fs::write(&path, payload).is_ok());
-
-    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
-    let start = Instant::now();
-    let result = store
-        .recover_latest_and_repair()
-        .expect("recovery should pass");
-    let elapsed_millis = start.elapsed().as_millis();
-    assert_eq!(result.recovered_entries, 8192);
-    assert_eq!(result.dropped_corrupt_entries, 1);
-    assert!(
-        elapsed_millis < 2000,
-        "snapshot deep-lane recovery exceeded budget: {elapsed_millis}ms"
-    );
-
-    let _ = fs::remove_file(path);
-}
-
-fn temp_snapshot_store_path(tag: &str) -> PathBuf {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock should be monotonic")
-        .as_nanos();
-    std::env::temp_dir().join(format!("kamn-runtime-snapshot-{tag}-{nonce}.log"))
 }

--- a/crates/kamn-core/src/runtime_tests_snapshot_store.rs
+++ b/crates/kamn-core/src/runtime_tests_snapshot_store.rs
@@ -1,0 +1,415 @@
+use super::super::{
+    FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore, RuntimeSnapshot, RuntimeSnapshotStore,
+    SnapshotRestoreError, SnapshotRestoreGuard, SnapshotStoreError,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+#[test]
+fn functional_snapshot_restore_guard_accepts_matching_snapshot() {
+    let guard = SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
+    let snapshot = RuntimeSnapshot::new(42, "state-42").expect("snapshot should be valid");
+    assert!(guard.validate(snapshot).is_ok());
+}
+
+#[test]
+fn unit_snapshot_restore_guard_rejects_invalid_state_hash() {
+    let snapshot = RuntimeSnapshot::new(42, "");
+    assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidStateHash));
+}
+
+#[test]
+fn regression_snapshot_restore_version_mismatch_is_rejected() {
+    // Regression: #361
+    let guard = SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
+    let snapshot = RuntimeSnapshot::new(41, "state-42").expect("snapshot should be valid");
+    let error = guard
+        .validate(snapshot)
+        .expect_err("version mismatch should be rejected");
+    assert_eq!(
+        error,
+        SnapshotRestoreError::StateVersionMismatch {
+            expected: 42,
+            found: 41
+        }
+    );
+}
+
+#[test]
+fn regression_snapshot_restore_hash_mismatch_is_rejected() {
+    // Regression: #361
+    let guard = SnapshotRestoreGuard::new(42, "state-42").expect("restore guard should construct");
+    let snapshot = RuntimeSnapshot::new(42, "state-41").expect("snapshot should be valid");
+    let error = guard
+        .validate(snapshot)
+        .expect_err("hash mismatch should be rejected");
+    assert_eq!(
+        error,
+        SnapshotRestoreError::StateHashMismatch {
+            expected: "state-42".to_owned(),
+            found: "state-41".to_owned()
+        }
+    );
+}
+
+#[test]
+fn functional_snapshot_restore_guard_with_expected_cursor_accepts_matching_snapshot() {
+    let guard = SnapshotRestoreGuard::with_expected_cursor(42, "state-42", 100)
+        .expect("restore guard should construct");
+    let snapshot =
+        RuntimeSnapshot::with_cursor(42, "state-42", 100).expect("snapshot should be valid");
+    assert!(guard.validate(snapshot).is_ok());
+}
+
+#[test]
+fn regression_snapshot_restore_cursor_mismatch_is_rejected() {
+    // Regression: #617
+    let guard = SnapshotRestoreGuard::with_expected_cursor(42, "state-42", 100)
+        .expect("restore guard should construct");
+    let snapshot =
+        RuntimeSnapshot::with_cursor(42, "state-42", 99).expect("snapshot should be valid");
+    let error = guard
+        .validate(snapshot)
+        .expect_err("cursor mismatch should be rejected");
+    assert_eq!(
+        error,
+        SnapshotRestoreError::CursorMismatch {
+            expected: 100,
+            found: 99
+        }
+    );
+}
+
+#[test]
+fn functional_in_memory_snapshot_store_round_trips_snapshots() {
+    let mut store = InMemoryRuntimeSnapshotStore::default();
+    assert!(store.list().expect("list should succeed").is_empty());
+
+    let snapshot_1 = RuntimeSnapshot::new(41, "state-41").expect("valid snapshot");
+    let snapshot_2 = RuntimeSnapshot::new(42, "state-42").expect("valid snapshot");
+    assert!(store.write(snapshot_1).is_ok());
+    assert!(store.write(snapshot_2.clone()).is_ok());
+
+    let latest = store.read_latest().expect("read_latest should succeed");
+    assert_eq!(latest, Some(snapshot_2));
+    assert_eq!(store.list().expect("list should succeed").len(), 2);
+}
+
+#[test]
+fn integration_file_snapshot_store_round_trips_snapshots() {
+    let path = temp_snapshot_store_path("roundtrip");
+    let _ = fs::remove_file(&path);
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let snapshot_1 = RuntimeSnapshot::new(41, "state-41").expect("valid snapshot");
+    let snapshot_2 = RuntimeSnapshot::new(42, "state-42").expect("valid snapshot");
+    assert!(store.write(snapshot_1).is_ok());
+    assert!(store.write(snapshot_2.clone()).is_ok());
+
+    let latest = store.read_latest().expect("read_latest should succeed");
+    assert_eq!(latest, Some(snapshot_2));
+    assert_eq!(store.list().expect("list should succeed").len(), 2);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_file_snapshot_store_rejects_malformed_payload() {
+    // Regression: #387
+    let path = temp_snapshot_store_path("malformed");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "not-a-valid-snapshot-line\n").is_ok());
+
+    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let error = store
+        .list()
+        .expect_err("malformed payload must be rejected");
+    assert_eq!(
+        error,
+        SnapshotStoreError::InvalidPayload("not-a-valid-snapshot-line".to_owned())
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn unit_file_snapshot_store_recovery_handles_missing_snapshot_file() {
+    let path = temp_snapshot_store_path("recover-missing");
+    let _ = fs::remove_file(&path);
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let result = store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    assert!(result.latest.is_none());
+    assert_eq!(result.recovered_entries, 0);
+    assert_eq!(result.dropped_corrupt_entries, 0);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn functional_file_snapshot_store_recovery_recovers_latest_after_trailing_corruption() {
+    let path = temp_snapshot_store_path("recover-trailing-corruption");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41\n42|state-42\n43|\n").is_ok());
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    assert_eq!(
+        store.list(),
+        Err(SnapshotStoreError::InvalidPayload("43|".to_owned()))
+    );
+
+    let result = store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    assert_eq!(
+        result.latest,
+        Some(RuntimeSnapshot::new(42, "state-42").expect("valid snapshot"))
+    );
+    assert_eq!(result.recovered_entries, 2);
+    assert_eq!(result.dropped_corrupt_entries, 1);
+    assert_eq!(store.list().expect("list should succeed").len(), 2);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn integration_file_snapshot_store_recovery_allows_append_after_restart() {
+    let path = temp_snapshot_store_path("recover-restart");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41\n42|state-42\n43|\n").is_ok());
+
+    let mut first_store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let first_recovery = first_store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    assert_eq!(first_recovery.recovered_entries, 2);
+
+    let mut restarted_store =
+        FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let next_snapshot = RuntimeSnapshot::new(43, "state-43").expect("valid snapshot");
+    assert!(restarted_store.write(next_snapshot.clone()).is_ok());
+    assert_eq!(
+        restarted_store.read_latest().expect("read should pass"),
+        Some(next_snapshot)
+    );
+    assert_eq!(restarted_store.list().expect("list should pass").len(), 3);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_file_snapshot_store_recovery_truncates_corrupt_suffix() {
+    // Regression: #617
+    let path = temp_snapshot_store_path("recover-corrupt-suffix");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41\n42|state-42\nbroken\n43|state-43\n").is_ok());
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let result = store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    assert_eq!(
+        result.latest,
+        Some(RuntimeSnapshot::new(42, "state-42").expect("valid snapshot"))
+    );
+    assert_eq!(result.recovered_entries, 2);
+    assert_eq!(result.dropped_corrupt_entries, 2);
+    assert_eq!(
+        fs::read_to_string(&path).expect("snapshot file should be readable"),
+        "41|state-41|41\n42|state-42|42\n"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn unit_runtime_snapshot_with_cursor_rejects_zero_cursor() {
+    let snapshot = RuntimeSnapshot::with_cursor(42, "state-42", 0);
+    assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidCursor));
+}
+
+#[test]
+fn unit_runtime_snapshot_rejects_hash_with_metadata_delimiter() {
+    let snapshot = RuntimeSnapshot::new(42, "state-42|100");
+    assert_eq!(snapshot, Err(SnapshotRestoreError::InvalidStateHash));
+}
+
+#[test]
+fn unit_in_memory_snapshot_store_rejects_state_version_regression() {
+    let mut store = InMemoryRuntimeSnapshotStore::default();
+    let baseline = RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot");
+    assert!(store.write(baseline).is_ok());
+    let stale = RuntimeSnapshot::with_cursor(40, "state-40", 101).expect("valid snapshot");
+    assert_eq!(
+        store.write(stale),
+        Err(SnapshotStoreError::StateVersionRegression {
+            previous: 41,
+            found: 40
+        })
+    );
+}
+
+#[test]
+fn unit_in_memory_snapshot_store_rejects_cursor_regression() {
+    let mut store = InMemoryRuntimeSnapshotStore::default();
+    let baseline = RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot");
+    assert!(store.write(baseline).is_ok());
+    let stale = RuntimeSnapshot::with_cursor(42, "state-42", 99).expect("valid snapshot");
+    assert_eq!(
+        store.write(stale),
+        Err(SnapshotStoreError::CursorRegression {
+            previous: 100,
+            found: 99
+        })
+    );
+}
+
+#[test]
+fn regression_file_snapshot_store_rejects_version_regression_metadata() {
+    // Regression: #617
+    let path = temp_snapshot_store_path("version-regression");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41|100\n40|state-40|101\n").is_ok());
+
+    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    assert_eq!(
+        store.list(),
+        Err(SnapshotStoreError::StateVersionRegression {
+            previous: 41,
+            found: 40
+        })
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_file_snapshot_store_rejects_cursor_regression_metadata() {
+    // Regression: #617
+    let path = temp_snapshot_store_path("cursor-regression");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41|100\n42|state-42|99\n").is_ok());
+
+    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    assert_eq!(
+        store.list(),
+        Err(SnapshotStoreError::CursorRegression {
+            previous: 100,
+            found: 99
+        })
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_file_snapshot_store_rejects_stale_hash_metadata() {
+    // Regression: #617
+    let path = temp_snapshot_store_path("hash-regression");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41|100\n42|state-41|101\n").is_ok());
+
+    let store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    assert_eq!(
+        store.list(),
+        Err(SnapshotStoreError::StaleStateHash {
+            state_hash: "state-41".to_owned(),
+            previous_version: 41,
+            found_version: 42
+        })
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn functional_file_snapshot_store_recovery_truncates_stale_metadata_suffix() {
+    let path = temp_snapshot_store_path("recover-stale-metadata");
+    let _ = fs::remove_file(&path);
+    assert!(fs::write(&path, "41|state-41|100\n42|state-42|99\n43|state-43|102\n").is_ok());
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let result = store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    assert_eq!(
+        result.latest,
+        Some(RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot"))
+    );
+    assert_eq!(result.recovered_entries, 1);
+    assert_eq!(result.dropped_corrupt_entries, 2);
+    assert_eq!(
+        fs::read_to_string(&path).expect("snapshot file should be readable"),
+        "41|state-41|100\n"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn performance_file_snapshot_store_recovery_scan_stays_within_ci_budget() {
+    let path = temp_snapshot_store_path("recover-performance");
+    let _ = fs::remove_file(&path);
+    let mut payload = String::new();
+    for state_version in 1..=256 {
+        payload.push_str(&format!("{state_version}|state-{state_version}\n"));
+    }
+    payload.push_str("broken\n");
+    assert!(fs::write(&path, payload).is_ok());
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let start = Instant::now();
+    let result = store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    let elapsed_millis = start.elapsed().as_millis();
+    assert_eq!(result.recovered_entries, 256);
+    assert_eq!(result.dropped_corrupt_entries, 1);
+    assert!(
+        elapsed_millis < 250,
+        "snapshot recovery exceeded CI budget: {elapsed_millis}ms"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+#[ignore = "scheduled snapshot deep lane"]
+fn performance_file_snapshot_store_recovery_deep_lane_large_payload() {
+    let path = temp_snapshot_store_path("recover-deep-lane");
+    let _ = fs::remove_file(&path);
+    let mut payload = String::new();
+    for state_version in 1..=8192 {
+        payload.push_str(&format!(
+            "{state_version}|state-{state_version}|{state_version}\n"
+        ));
+    }
+    payload.push_str("8193|state-8193|0\n");
+    assert!(fs::write(&path, payload).is_ok());
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let start = Instant::now();
+    let result = store
+        .recover_latest_and_repair()
+        .expect("recovery should pass");
+    let elapsed_millis = start.elapsed().as_millis();
+    assert_eq!(result.recovered_entries, 8192);
+    assert_eq!(result.dropped_corrupt_entries, 1);
+    assert!(
+        elapsed_millis < 2000,
+        "snapshot deep-lane recovery exceeded budget: {elapsed_millis}ms"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+fn temp_snapshot_store_path(tag: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-runtime-snapshot-{tag}-{nonce}.log"))
+}

--- a/crates/kamn-core/tests/runtime_module_extraction_contract.rs
+++ b/crates/kamn-core/tests/runtime_module_extraction_contract.rs
@@ -171,13 +171,34 @@ fn runtime_module_extraction_contract_keeps_transport_coordination_impls_in_new_
         "runtime_transport_coordination module should own WatchdogAnomalyWatchInput"
     );
     assert!(
-        runtime_transport_coordination_rs
-            .contains("pub struct DeterministicNetworkFaultSimulator {"),
-        "runtime_transport_coordination module should own DeterministicNetworkFaultSimulator"
+        runtime_transport_coordination_rs.contains("pub struct WatchdogAnomalyEvaluator;"),
+        "runtime_transport_coordination module should own WatchdogAnomalyEvaluator"
     );
     assert!(
-        runtime_transport_coordination_rs.contains("pub enum NetworkFaultSimulationError {"),
-        "runtime_transport_coordination module should own NetworkFaultSimulationError"
+        runtime_transport_coordination_rs.contains("pub enum WatchdogAnomalyError {"),
+        "runtime_transport_coordination module should own WatchdogAnomalyError"
+    );
+}
+
+#[test]
+fn runtime_module_extraction_contract_declares_runtime_network_fault_module() {
+    let runtime_rs = read_repo_file("runtime.rs");
+    assert!(
+        runtime_rs.contains("mod runtime_network_fault;"),
+        "runtime.rs should declare extracted runtime_network_fault module"
+    );
+}
+
+#[test]
+fn runtime_module_extraction_contract_keeps_network_fault_impls_in_new_module() {
+    let runtime_network_fault_rs = read_repo_file("runtime_network_fault.rs");
+    assert!(
+        runtime_network_fault_rs.contains("pub struct DeterministicNetworkFaultSimulator {"),
+        "runtime_network_fault module should own DeterministicNetworkFaultSimulator"
+    );
+    assert!(
+        runtime_network_fault_rs.contains("pub enum NetworkFaultSimulationError {"),
+        "runtime_network_fault module should own NetworkFaultSimulationError"
     );
 }
 
@@ -316,4 +337,60 @@ fn runtime_module_extraction_contract_keeps_peer_coordination_types_in_new_modul
         runtime_peer_coordination_rs.contains("pub struct RuntimeWiring {"),
         "runtime_peer_coordination module should own RuntimeWiring"
     );
+}
+
+#[test]
+fn runtime_module_extraction_contract_declares_runtime_snapshot_test_module_routing() {
+    let runtime_tests_rs = read_repo_file("runtime_tests.rs");
+    let declaration = [
+        "#[path = \"runtime_tests_snapshot_store.rs\"]",
+        "mod runtime_tests_snapshot_store;",
+    ]
+    .join("\n");
+    assert!(
+        runtime_tests_rs.contains(&declaration),
+        "runtime_tests.rs should route snapshot-store tests through dedicated module file"
+    );
+}
+
+#[test]
+fn runtime_module_extraction_contract_moves_snapshot_store_tests_out_of_runtime_tests_rs() {
+    let runtime_tests_rs = read_repo_file("runtime_tests.rs");
+    for legacy_marker in [
+        [
+            "fn functional_",
+            "in_memory_snapshot_store_round_trips_snapshots()",
+        ]
+        .concat(),
+        [
+            "fn integration_file_",
+            "snapshot_store_round_trips_snapshots()",
+        ]
+        .concat(),
+        [
+            "fn performance_file_snapshot_store_",
+            "recovery_scan_stays_within_ci_budget()",
+        ]
+        .concat(),
+    ] {
+        assert!(
+            !runtime_tests_rs.contains(&legacy_marker),
+            "runtime_tests.rs should not keep inline snapshot-store test `{legacy_marker}`"
+        );
+    }
+}
+
+#[test]
+fn runtime_module_extraction_contract_keeps_snapshot_store_tests_in_new_module() {
+    let runtime_tests_snapshot_store_rs = read_repo_file("runtime_tests_snapshot_store.rs");
+    for marker in [
+        "fn functional_in_memory_snapshot_store_round_trips_snapshots()",
+        "fn integration_file_snapshot_store_round_trips_snapshots()",
+        "fn performance_file_snapshot_store_recovery_scan_stays_within_ci_budget()",
+    ] {
+        assert!(
+            runtime_tests_snapshot_store_rs.contains(marker),
+            "runtime_tests_snapshot_store.rs should own snapshot-store test `{marker}`"
+        );
+    }
 }

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -7,12 +7,14 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("crates/kamn-core/src/runtime_phase_coordination.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_transport_coordination.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_snapshot_store.rs"));
+    assert!(DOC.contains("crates/kamn-core/src/runtime_tests_snapshot_store.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_recovery_guard.rs"));
     assert!(DOC.contains("## Node CLI Recovery-Check Mapping"));
     assert!(DOC.contains("## Node CLI Daemon Lifecycle Mapping"));
     assert!(DOC.contains("## Bridge Quorum Runtime Mapping"));
     assert!(DOC.contains("## Snapshot Persistence and Restore Contract Rules"));
     assert!(DOC.contains("## Deterministic Fault Simulation Harness Rules"));
+    assert!(DOC.contains("## Runtime Test Module Ownership Rules"));
     assert!(DOC.contains("## Kolme Notifications Websocket Consumer Contract Rules"));
     assert!(DOC.contains("## Kolme Block Fallback Finality Reconciliation Contract Rules"));
     assert!(DOC.contains("PeerLifecycle"));

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -57,6 +57,9 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `InMemoryRuntimeSnapshotStore`
   - `FileRuntimeSnapshotStore`
   - `SnapshotStoreError`
+- Added dedicated runtime snapshot-store test ownership module:
+  - `crates/kamn-core/src/runtime_tests_snapshot_store.rs`
+  - routed via path-based test module declaration from `crates/kamn-core/src/runtime_tests.rs`
 - Added watchdog anomaly and deterministic fault simulation primitives in `crates/kamn-core/src/runtime_transport_coordination.rs`:
   - `WatchdogAnomalyKind`
   - `WatchdogAnomalySeverity`
@@ -70,6 +73,14 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `DeterministicNetworkFaultSimulator`
   - `simulate_daemon_network_fault(...)`
 - Kept runtime role wiring behavior unchanged and covered by existing tests.
+
+## Runtime Test Module Ownership Rules
+- Snapshot-store test cases are owned by `crates/kamn-core/src/runtime_tests_snapshot_store.rs`.
+- `crates/kamn-core/src/runtime_tests.rs` retains routing via:
+  - `#[path = "runtime_tests_snapshot_store.rs"]`
+  - `mod runtime_tests_snapshot_store;`
+- Regression contract:
+  - snapshot-store test definitions are not re-inlined into `runtime_tests.rs` (`Regression: #3207`).
 
 ## Node CLI Recovery-Check Mapping
 - `kamn-node --runtime-mode recovery-check` maps directly to `RecoveryRejoinGuard` evaluation flow.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -193,6 +193,9 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Runtime decomposition wave 2 delivered:
   - Moved inline runtime tests from `crates/kamn-core/src/runtime.rs` into `crates/kamn-core/src/runtime_tests.rs`, leaving `runtime.rs` focused on runtime module wiring/re-exports (Task #3191, Subtask #3192).
   - Added extraction-routing regression coverage for path-based runtime test module loading (`runtime::tests::regression_runtime_source_routes_tests_via_dedicated_module_file`).
+- Runtime decomposition wave 3 delivered:
+  - Extracted runtime snapshot-store test surface from `crates/kamn-core/src/runtime_tests.rs` into `crates/kamn-core/src/runtime_tests_snapshot_store.rs` with path-based routing through `runtime_tests.rs` (Task #3206, Subtask #3207).
+  - Added extraction-routing regression coverage to fail closed if snapshot-store tests drift back inline (`runtime::tests::regression_runtime_tests_source_routes_snapshot_store_domain_via_dedicated_module_file`).
 - Phase 3.1 initial slice delivered:
   - Added deterministic p2p transport contracts in `kamn-core`: `PeerLifecycleTransport`, `InMemoryPeerLifecycleTransport`, `PeerDiscoveryRecord`, `PeerGossipFrame`, and `PeerLifecycleTransportCoordinator` (Task #2921, Subtask #2922).
   - Added bootstrap/runtime wiring integration so `enable_gossip` toggles explicit `p2p-discovery`/`p2p-gossip-transport` components (or `gossip-transport-disabled` when off).


### PR DESCRIPTION
## Summary
Extract runtime snapshot-store tests from the `runtime_tests.rs` monolith into a dedicated test module and add extraction/doc contracts so the boundary remains enforced.

Closes #3207
Closes #3206
Closes #3205
Closes #3204

## Changes
- `crates/kamn-core/src/runtime_tests.rs`
  - route snapshot-store tests via `#[path = "runtime_tests_snapshot_store.rs"] mod runtime_tests_snapshot_store;`
  - add regression contract `regression_runtime_tests_source_routes_snapshot_store_domain_via_dedicated_module_file`
  - remove inline snapshot-store test implementations from monolith file
- `crates/kamn-core/src/runtime_tests_snapshot_store.rs`
  - new dedicated snapshot-store runtime test module owning restore/store/recovery/perf tests
- `crates/kamn-core/tests/runtime_module_extraction_contract.rs`
  - add module-contract checks for snapshot test routing and ownership
  - align transport-vs-network-fault ownership checks with current runtime module split
- `crates/kamn-core/tests/runtime_network_docs.rs`
  - require snapshot test module ownership docs markers
- `docs/foundation/runtime-network.md`
  - document runtime snapshot test module ownership rules
- `docs/plans/2026-02-08-production-service-roadmap.md`
  - record runtime decomposition wave 3 status

## Risks & Compatibility
- No production runtime behavior changes.
- Test/module ownership structure changes only; risk is limited to test discovery drift, covered by new extraction contracts.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed dedicated snapshot test module ownership and contract/doc parity

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core regression_runtime_tests_source_routes_snapshot_store_domain_via_dedicated_module_file` |
| Functional  | ✅     | `cargo test -p kamn-core snapshot_store` |
| Integration | ✅     | `cargo test -p kamn-core --test runtime_module_extraction_contract`; `cargo test -p kamn-core --test runtime_network_docs` |
| Regression  | ✅     | extraction contracts fail closed on snapshot-test boundary drift |
