### PR TITLE
refactor(runtime): split network-fault tests into dedicated module

### DIFF
--- a/crates/kamn-core/src/runtime_tests.rs
+++ b/crates/kamn-core/src/runtime_tests.rs
@@ -3,21 +3,21 @@ use super::{
     evaluate_daemon_watchdog_anomaly, execute_processor_daemon_tick, ApproverAttestation,
     ApproverQuorumError, ApproverQuorumEvaluator, ApproverQuorumInput, AuthenticatedPeerFrame,
     AuthenticatedPeerFrameError, BoundedRuntimeQueue, ConstructLockError, ConstructLockGuard,
-    DeterministicBackpressureController, DeterministicNetworkFaultSimulator,
-    DeterministicProposalPlanner, ListenerAttestation, ListenerQuorumError,
-    ListenerQuorumEvaluator, ListenerQuorumInput, NetworkFaultSimulationError,
-    NetworkFaultSimulationInput, PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent,
-    PeerLifecycleState, ProposalCandidate, ProposalPlannerError, RecoveryGuardError,
-    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeBackpressureAction,
-    RuntimeBackpressureDecision, RuntimeBackpressureError, RuntimeBackpressureInput,
-    RuntimeBackpressurePolicy, RuntimeLifecycleError, RuntimeQueueError, StateDivergenceError,
-    StateDivergenceEvaluator, StateDivergenceSeverity, StateDivergenceStatus,
+    DeterministicBackpressureController, DeterministicProposalPlanner, ListenerAttestation,
+    ListenerQuorumError, ListenerQuorumEvaluator, ListenerQuorumInput, PeerFrameAuthenticator,
+    PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, ProposalCandidate, ProposalPlannerError,
+    RecoveryGuardError, RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt,
+    RuntimeBackpressureAction, RuntimeBackpressureDecision, RuntimeBackpressureError,
+    RuntimeBackpressureInput, RuntimeBackpressurePolicy, RuntimeLifecycleError, RuntimeQueueError,
+    StateDivergenceError, StateDivergenceEvaluator, StateDivergenceSeverity, StateDivergenceStatus,
     StateDivergenceWatchInput, WatchdogAnomalyError, WatchdogAnomalyEvaluator, WatchdogAnomalyKind,
     WatchdogAnomalySeverity, WatchdogAnomalyWatchInput,
 };
 use crate::config::{NodeConfig, NodeRole, SyncMode};
 use std::time::Instant;
 
+#[path = "runtime_tests_network_fault.rs"]
+mod runtime_tests_network_fault;
 #[path = "runtime_tests_snapshot_store.rs"]
 mod runtime_tests_snapshot_store;
 
@@ -140,6 +140,44 @@ fn regression_runtime_tests_source_routes_snapshot_store_domain_via_dedicated_mo
         assert!(
             !runtime_tests_source.contains(&legacy_marker),
             "expected snapshot-store test `{legacy_marker}` to move out of runtime_tests.rs"
+        );
+    }
+}
+
+#[test]
+fn regression_runtime_tests_source_routes_network_fault_domain_via_dedicated_module_file() {
+    // Regression: #3212
+    let runtime_tests_source = include_str!("runtime_tests.rs");
+    let declaration = [
+        "#[path = \"runtime_tests_network_fault.rs\"]",
+        "mod runtime_tests_network_fault;",
+    ]
+    .join("\n");
+    assert!(
+        runtime_tests_source.contains(&declaration),
+        "expected runtime tests source to declare dedicated network-fault test module"
+    );
+
+    for legacy_marker in [
+        [
+            "fn unit_network_fault_simulation_",
+            "rejects_zero_queue_capacity()",
+        ]
+        .concat(),
+        [
+            "fn integration_daemon_network_fault_simulation_",
+            "reports_overflow_and_degradation()",
+        ]
+        .concat(),
+        [
+            "fn performance_network_fault_simulation_",
+            "pr_lane_stays_within_budget()",
+        ]
+        .concat(),
+    ] {
+        assert!(
+            !runtime_tests_source.contains(&legacy_marker),
+            "expected network-fault test `{legacy_marker}` to move out of runtime_tests.rs"
         );
     }
 }
@@ -1302,206 +1340,4 @@ fn regression_censorship_edge_signal_remains_detected_as_critical() {
         .expect("edge censorship signal should be classified");
     assert_eq!(report.kind, WatchdogAnomalyKind::CensorshipSignal);
     assert_eq!(report.severity, WatchdogAnomalySeverity::Critical);
-}
-
-#[test]
-fn unit_network_fault_simulation_rejects_zero_queue_capacity() {
-    let input = NetworkFaultSimulationInput::new(
-        "fault-sample-invalid",
-        "peer-sim-a",
-        100,
-        99,
-        6,
-        6,
-        30,
-        1,
-        0,
-        2,
-    );
-    assert_eq!(
-        input,
-        Err(NetworkFaultSimulationError::InvalidQueueCapacity { capacity: 0 })
-    );
-}
-
-#[test]
-fn functional_network_fault_simulation_classifies_targeted_packet_loss_as_critical() {
-    let simulator = DeterministicNetworkFaultSimulator::default();
-    let input = NetworkFaultSimulationInput::new(
-        "fault-sample-censorship",
-        "peer-sim-a",
-        100,
-        45,
-        8,
-        8,
-        60,
-        3,
-        8,
-        8,
-    )
-    .expect("valid simulation input");
-    let report = simulator
-        .simulate(input)
-        .expect("simulation should classify targeted packet loss");
-
-    assert_eq!(report.watchdog_kind, WatchdogAnomalyKind::CensorshipSignal);
-    assert_eq!(report.watchdog_severity, WatchdogAnomalySeverity::Critical);
-    assert_eq!(report.final_lifecycle_state, PeerLifecycleState::Active);
-    assert_eq!(report.queue_overflow_attempts, 0);
-    assert_eq!(
-        report.backpressure_last_action,
-        RuntimeBackpressureAction::SlowProducer
-    );
-    assert_eq!(
-        report.backpressure_last_reason_code,
-        "runtime_backpressure_slow_producer"
-    );
-}
-
-#[test]
-fn integration_daemon_network_fault_simulation_reports_overflow_and_degradation() {
-    let simulator = DeterministicNetworkFaultSimulator::default();
-    let input = NetworkFaultSimulationInput::new(
-        "fault-sample-overflow",
-        "peer-sim-b",
-        120,
-        110,
-        6,
-        4,
-        30,
-        1,
-        2,
-        5,
-    )
-    .expect("valid simulation input");
-    let report =
-        super::simulate_daemon_network_fault(&simulator, input).expect("simulation should pass");
-
-    assert_eq!(report.final_lifecycle_state, PeerLifecycleState::Degraded);
-    assert_eq!(report.queue_overflow_attempts, 3);
-    assert_eq!(
-        report.backpressure_last_action,
-        RuntimeBackpressureAction::RejectNewEnqueue
-    );
-    assert_eq!(
-        report.backpressure_last_reason_code,
-        "runtime_backpressure_reject_new_enqueue"
-    );
-    assert_eq!(report.backpressure_rejected_events, 3);
-    assert_eq!(report.backpressure_purged_events, 0);
-    assert_eq!(
-        report.watchdog_kind,
-        WatchdogAnomalyKind::LivenessDegradation
-    );
-}
-
-#[test]
-fn integration_network_fault_simulation_purges_stale_disconnected_peer_queue() {
-    let simulator = DeterministicNetworkFaultSimulator::default();
-    let input = NetworkFaultSimulationInput::new(
-        "fault-sample-stale-peer",
-        "peer-sim-stale",
-        120,
-        118,
-        6,
-        0,
-        30,
-        1,
-        4,
-        4,
-    )
-    .expect("valid simulation input");
-    let report =
-        super::simulate_daemon_network_fault(&simulator, input).expect("simulation should pass");
-
-    assert_eq!(
-        report.final_lifecycle_state,
-        PeerLifecycleState::Disconnected
-    );
-    assert_eq!(
-        report.backpressure_last_action,
-        RuntimeBackpressureAction::PurgeStalePeerQueue
-    );
-    assert_eq!(
-        report.backpressure_last_reason_code,
-        "runtime_backpressure_purge_stale_peer_queue"
-    );
-    assert!(report.backpressure_purged_events > 0);
-}
-
-#[test]
-fn regression_network_fault_simulation_keeps_censorship_critical_boundary() {
-    // Regression: #618
-    let simulator = DeterministicNetworkFaultSimulator::default();
-    let input = NetworkFaultSimulationInput::new(
-        "fault-sample-regression",
-        "peer-sim-c",
-        200,
-        100,
-        12,
-        12,
-        60,
-        2,
-        4,
-        4,
-    )
-    .expect("valid simulation input");
-    let report = simulator
-        .simulate(input)
-        .expect("simulation should classify censorship boundary");
-
-    assert_eq!(report.watchdog_kind, WatchdogAnomalyKind::CensorshipSignal);
-    assert_eq!(report.watchdog_severity, WatchdogAnomalySeverity::Critical);
-}
-
-#[test]
-fn performance_network_fault_simulation_pr_lane_stays_within_budget() {
-    let simulator = DeterministicNetworkFaultSimulator::default();
-    let start = Instant::now();
-    for sample_index in 0..256 {
-        let input = NetworkFaultSimulationInput::new(
-            &format!("fault-sample-perf-{sample_index}"),
-            "peer-sim-perf",
-            100,
-            98,
-            16,
-            16,
-            30,
-            1,
-            8,
-            8,
-        )
-        .expect("valid simulation input");
-        assert!(simulator.simulate(input).is_ok());
-    }
-    let elapsed_millis = start.elapsed().as_millis();
-    assert!(
-        elapsed_millis < 250,
-        "network fault simulation PR lane exceeded budget: {elapsed_millis}ms"
-    );
-}
-
-#[test]
-#[ignore = "scheduled chaos lane"]
-fn performance_network_fault_simulation_chaos_lane_stress() {
-    let simulator = DeterministicNetworkFaultSimulator::default();
-    for sample_index in 0..5000 {
-        let targeted_peer_count = if sample_index % 4 == 0 { 3 } else { 1 };
-        let delivered = if targeted_peer_count == 3 { 45 } else { 99 };
-        let healthy_peers = if sample_index % 3 == 0 { 8 } else { 10 };
-        let input = NetworkFaultSimulationInput::new(
-            &format!("fault-sample-chaos-{sample_index}"),
-            "peer-sim-chaos",
-            100,
-            delivered,
-            10,
-            healthy_peers,
-            30,
-            targeted_peer_count,
-            16,
-            24,
-        )
-        .expect("valid simulation input");
-        assert!(simulator.simulate(input).is_ok());
-    }
 }

--- a/crates/kamn-core/src/runtime_tests_network_fault.rs
+++ b/crates/kamn-core/src/runtime_tests_network_fault.rs
@@ -1,0 +1,206 @@
+use super::super::{
+    simulate_daemon_network_fault, DeterministicNetworkFaultSimulator, NetworkFaultSimulationError,
+    NetworkFaultSimulationInput, PeerLifecycleState, RuntimeBackpressureAction,
+    WatchdogAnomalyKind, WatchdogAnomalySeverity,
+};
+use std::time::Instant;
+
+#[test]
+fn unit_network_fault_simulation_rejects_zero_queue_capacity() {
+    let input = NetworkFaultSimulationInput::new(
+        "fault-sample-invalid",
+        "peer-sim-a",
+        100,
+        99,
+        6,
+        6,
+        30,
+        1,
+        0,
+        2,
+    );
+    assert_eq!(
+        input,
+        Err(NetworkFaultSimulationError::InvalidQueueCapacity { capacity: 0 })
+    );
+}
+
+#[test]
+fn functional_network_fault_simulation_classifies_targeted_packet_loss_as_critical() {
+    let simulator = DeterministicNetworkFaultSimulator::default();
+    let input = NetworkFaultSimulationInput::new(
+        "fault-sample-censorship",
+        "peer-sim-a",
+        100,
+        45,
+        8,
+        8,
+        60,
+        3,
+        8,
+        8,
+    )
+    .expect("valid simulation input");
+    let report = simulator
+        .simulate(input)
+        .expect("simulation should classify targeted packet loss");
+
+    assert_eq!(report.watchdog_kind, WatchdogAnomalyKind::CensorshipSignal);
+    assert_eq!(report.watchdog_severity, WatchdogAnomalySeverity::Critical);
+    assert_eq!(report.final_lifecycle_state, PeerLifecycleState::Active);
+    assert_eq!(report.queue_overflow_attempts, 0);
+    assert_eq!(
+        report.backpressure_last_action,
+        RuntimeBackpressureAction::SlowProducer
+    );
+    assert_eq!(
+        report.backpressure_last_reason_code,
+        "runtime_backpressure_slow_producer"
+    );
+}
+
+#[test]
+fn integration_daemon_network_fault_simulation_reports_overflow_and_degradation() {
+    let simulator = DeterministicNetworkFaultSimulator::default();
+    let input = NetworkFaultSimulationInput::new(
+        "fault-sample-overflow",
+        "peer-sim-b",
+        120,
+        110,
+        6,
+        4,
+        30,
+        1,
+        2,
+        5,
+    )
+    .expect("valid simulation input");
+    let report = simulate_daemon_network_fault(&simulator, input).expect("simulation should pass");
+
+    assert_eq!(report.final_lifecycle_state, PeerLifecycleState::Degraded);
+    assert_eq!(report.queue_overflow_attempts, 3);
+    assert_eq!(
+        report.backpressure_last_action,
+        RuntimeBackpressureAction::RejectNewEnqueue
+    );
+    assert_eq!(
+        report.backpressure_last_reason_code,
+        "runtime_backpressure_reject_new_enqueue"
+    );
+    assert_eq!(report.backpressure_rejected_events, 3);
+    assert_eq!(report.backpressure_purged_events, 0);
+    assert_eq!(
+        report.watchdog_kind,
+        WatchdogAnomalyKind::LivenessDegradation
+    );
+}
+
+#[test]
+fn integration_network_fault_simulation_purges_stale_disconnected_peer_queue() {
+    let simulator = DeterministicNetworkFaultSimulator::default();
+    let input = NetworkFaultSimulationInput::new(
+        "fault-sample-stale-peer",
+        "peer-sim-stale",
+        120,
+        118,
+        6,
+        0,
+        30,
+        1,
+        4,
+        4,
+    )
+    .expect("valid simulation input");
+    let report = simulate_daemon_network_fault(&simulator, input).expect("simulation should pass");
+
+    assert_eq!(
+        report.final_lifecycle_state,
+        PeerLifecycleState::Disconnected
+    );
+    assert_eq!(
+        report.backpressure_last_action,
+        RuntimeBackpressureAction::PurgeStalePeerQueue
+    );
+    assert_eq!(
+        report.backpressure_last_reason_code,
+        "runtime_backpressure_purge_stale_peer_queue"
+    );
+    assert!(report.backpressure_purged_events > 0);
+}
+
+#[test]
+fn regression_network_fault_simulation_keeps_censorship_critical_boundary() {
+    // Regression: #618
+    let simulator = DeterministicNetworkFaultSimulator::default();
+    let input = NetworkFaultSimulationInput::new(
+        "fault-sample-regression",
+        "peer-sim-c",
+        200,
+        100,
+        12,
+        12,
+        60,
+        2,
+        4,
+        4,
+    )
+    .expect("valid simulation input");
+    let report = simulator
+        .simulate(input)
+        .expect("simulation should classify censorship boundary");
+
+    assert_eq!(report.watchdog_kind, WatchdogAnomalyKind::CensorshipSignal);
+    assert_eq!(report.watchdog_severity, WatchdogAnomalySeverity::Critical);
+}
+
+#[test]
+fn performance_network_fault_simulation_pr_lane_stays_within_budget() {
+    let simulator = DeterministicNetworkFaultSimulator::default();
+    let start = Instant::now();
+    for sample_index in 0..256 {
+        let input = NetworkFaultSimulationInput::new(
+            &format!("fault-sample-perf-{sample_index}"),
+            "peer-sim-perf",
+            100,
+            98,
+            16,
+            16,
+            30,
+            1,
+            8,
+            8,
+        )
+        .expect("valid simulation input");
+        assert!(simulator.simulate(input).is_ok());
+    }
+    let elapsed_millis = start.elapsed().as_millis();
+    assert!(
+        elapsed_millis < 250,
+        "network fault simulation PR lane exceeded budget: {elapsed_millis}ms"
+    );
+}
+
+#[test]
+#[ignore = "scheduled chaos lane"]
+fn performance_network_fault_simulation_chaos_lane_stress() {
+    let simulator = DeterministicNetworkFaultSimulator::default();
+    for sample_index in 0..5000 {
+        let targeted_peer_count = if sample_index % 4 == 0 { 3 } else { 1 };
+        let delivered = if targeted_peer_count == 3 { 45 } else { 99 };
+        let healthy_peers = if sample_index % 3 == 0 { 8 } else { 10 };
+        let input = NetworkFaultSimulationInput::new(
+            &format!("fault-sample-chaos-{sample_index}"),
+            "peer-sim-chaos",
+            100,
+            delivered,
+            10,
+            healthy_peers,
+            30,
+            targeted_peer_count,
+            16,
+            24,
+        )
+        .expect("valid simulation input");
+        assert!(simulator.simulate(input).is_ok());
+    }
+}

--- a/crates/kamn-core/tests/runtime_module_extraction_contract.rs
+++ b/crates/kamn-core/tests/runtime_module_extraction_contract.rs
@@ -394,3 +394,59 @@ fn runtime_module_extraction_contract_keeps_snapshot_store_tests_in_new_module()
         );
     }
 }
+
+#[test]
+fn runtime_module_extraction_contract_declares_runtime_network_fault_test_module_routing() {
+    let runtime_tests_rs = read_repo_file("runtime_tests.rs");
+    let declaration = [
+        "#[path = \"runtime_tests_network_fault.rs\"]",
+        "mod runtime_tests_network_fault;",
+    ]
+    .join("\n");
+    assert!(
+        runtime_tests_rs.contains(&declaration),
+        "runtime_tests.rs should route network-fault tests through dedicated module file"
+    );
+}
+
+#[test]
+fn runtime_module_extraction_contract_moves_network_fault_tests_out_of_runtime_tests_rs() {
+    let runtime_tests_rs = read_repo_file("runtime_tests.rs");
+    for legacy_marker in [
+        [
+            "fn unit_network_fault_simulation_",
+            "rejects_zero_queue_capacity()",
+        ]
+        .concat(),
+        [
+            "fn integration_daemon_network_fault_simulation_",
+            "reports_overflow_and_degradation()",
+        ]
+        .concat(),
+        [
+            "fn performance_network_fault_simulation_",
+            "pr_lane_stays_within_budget()",
+        ]
+        .concat(),
+    ] {
+        assert!(
+            !runtime_tests_rs.contains(&legacy_marker),
+            "runtime_tests.rs should not keep inline network-fault test `{legacy_marker}`"
+        );
+    }
+}
+
+#[test]
+fn runtime_module_extraction_contract_keeps_network_fault_tests_in_new_module() {
+    let runtime_tests_network_fault_rs = read_repo_file("runtime_tests_network_fault.rs");
+    for marker in [
+        "fn unit_network_fault_simulation_rejects_zero_queue_capacity()",
+        "fn integration_daemon_network_fault_simulation_reports_overflow_and_degradation()",
+        "fn performance_network_fault_simulation_pr_lane_stays_within_budget()",
+    ] {
+        assert!(
+            runtime_tests_network_fault_rs.contains(marker),
+            "runtime_tests_network_fault.rs should own network-fault test `{marker}`"
+        );
+    }
+}

--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -8,6 +8,7 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("crates/kamn-core/src/runtime_transport_coordination.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_snapshot_store.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_tests_snapshot_store.rs"));
+    assert!(DOC.contains("crates/kamn-core/src/runtime_tests_network_fault.rs"));
     assert!(DOC.contains("crates/kamn-core/src/runtime_recovery_guard.rs"));
     assert!(DOC.contains("## Node CLI Recovery-Check Mapping"));
     assert!(DOC.contains("## Node CLI Daemon Lifecycle Mapping"));

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -60,6 +60,9 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Added dedicated runtime snapshot-store test ownership module:
   - `crates/kamn-core/src/runtime_tests_snapshot_store.rs`
   - routed via path-based test module declaration from `crates/kamn-core/src/runtime_tests.rs`
+- Added dedicated runtime network-fault test ownership module:
+  - `crates/kamn-core/src/runtime_tests_network_fault.rs`
+  - routed via path-based test module declaration from `crates/kamn-core/src/runtime_tests.rs`
 - Added watchdog anomaly and deterministic fault simulation primitives in `crates/kamn-core/src/runtime_transport_coordination.rs`:
   - `WatchdogAnomalyKind`
   - `WatchdogAnomalySeverity`
@@ -76,11 +79,15 @@ This document captures the initial runtime-network foundation slice for peer lif
 
 ## Runtime Test Module Ownership Rules
 - Snapshot-store test cases are owned by `crates/kamn-core/src/runtime_tests_snapshot_store.rs`.
+- Network-fault simulation test cases are owned by `crates/kamn-core/src/runtime_tests_network_fault.rs`.
 - `crates/kamn-core/src/runtime_tests.rs` retains routing via:
   - `#[path = "runtime_tests_snapshot_store.rs"]`
   - `mod runtime_tests_snapshot_store;`
+  - `#[path = "runtime_tests_network_fault.rs"]`
+  - `mod runtime_tests_network_fault;`
 - Regression contract:
   - snapshot-store test definitions are not re-inlined into `runtime_tests.rs` (`Regression: #3207`).
+  - network-fault test definitions are not re-inlined into `runtime_tests.rs` (`Regression: #3212`).
 
 ## Node CLI Recovery-Check Mapping
 - `kamn-node --runtime-mode recovery-check` maps directly to `RecoveryRejoinGuard` evaluation flow.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -196,6 +196,9 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Runtime decomposition wave 3 delivered:
   - Extracted runtime snapshot-store test surface from `crates/kamn-core/src/runtime_tests.rs` into `crates/kamn-core/src/runtime_tests_snapshot_store.rs` with path-based routing through `runtime_tests.rs` (Task #3206, Subtask #3207).
   - Added extraction-routing regression coverage to fail closed if snapshot-store tests drift back inline (`runtime::tests::regression_runtime_tests_source_routes_snapshot_store_domain_via_dedicated_module_file`).
+- Runtime decomposition wave 4 delivered:
+  - Extracted runtime network-fault simulation tests from `crates/kamn-core/src/runtime_tests.rs` into `crates/kamn-core/src/runtime_tests_network_fault.rs` with path-based routing through `runtime_tests.rs` (Task #3211, Subtask #3212).
+  - Added extraction-routing regression coverage to fail closed if network-fault tests drift back inline (`runtime::tests::regression_runtime_tests_source_routes_network_fault_domain_via_dedicated_module_file`).
 - Phase 3.1 initial slice delivered:
   - Added deterministic p2p transport contracts in `kamn-core`: `PeerLifecycleTransport`, `InMemoryPeerLifecycleTransport`, `PeerDiscoveryRecord`, `PeerGossipFrame`, and `PeerLifecycleTransportCoordinator` (Task #2921, Subtask #2922).
   - Added bootstrap/runtime wiring integration so `enable_gossip` toggles explicit `p2p-discovery`/`p2p-gossip-transport` components (or `gossip-transport-disabled` when off).


### PR DESCRIPTION
## Summary
Continue runtime test monolith decomposition by extracting network-fault simulation tests from `runtime_tests.rs` into a dedicated module with fail-closed extraction contracts.

Closes #3212
Closes #3211
Closes #3210
Closes #3209

## Changes
- `crates/kamn-core/src/runtime_tests.rs`
  - add path-based module routing for network-fault tests: `runtime_tests_network_fault.rs`
  - add regression contract: `regression_runtime_tests_source_routes_network_fault_domain_via_dedicated_module_file`
  - remove inline network-fault simulation tests from monolith file
- `crates/kamn-core/src/runtime_tests_network_fault.rs`
  - new dedicated module owning network-fault unit/functional/integration/regression/performance tests
- `crates/kamn-core/tests/runtime_module_extraction_contract.rs`
  - add module-contract assertions for network-fault test routing and ownership
- `crates/kamn-core/tests/runtime_network_docs.rs`
  - require network-fault test module doc marker
- `docs/foundation/runtime-network.md`
  - document network-fault test module ownership and routing rules
- `docs/plans/2026-02-08-production-service-roadmap.md`
  - record runtime decomposition wave 4 status

## Risks & Compatibility
- No production runtime behavior changes.
- Test-only source decomposition; guarded by new extraction contracts.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed test ownership split and contract/doc parity

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core regression_runtime_tests_source_routes_network_fault_domain_via_dedicated_module_file` |
| Functional  | ✅     | `cargo test -p kamn-core network_fault_simulation` |
| Integration | ✅     | `cargo test -p kamn-core --test runtime_module_extraction_contract`; `cargo test -p kamn-core --test runtime_network_docs` |
| Regression  | ✅     | extraction-routing contracts fail closed on inline drift |
