### PR TITLE
feat: add runtime retry-budget and ingress correlation markers

### DIFF
--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -601,8 +601,24 @@ fn functional_kolme_live_retry_emits_structured_retry_markers() {
         Some("unavailable")
     );
     assert_eq!(
+        extract_json_string_field(submit_retry_line, "backoff_ms").as_deref(),
+        Some("10")
+    );
+    assert_eq!(
+        extract_json_string_field(submit_retry_line, "max_attempts").as_deref(),
+        Some("3")
+    );
+    assert_eq!(
         extract_json_string_field(finality_retry_line, "reason").as_deref(),
         Some("unavailable")
+    );
+    assert_eq!(
+        extract_json_string_field(finality_retry_line, "backoff_ms").as_deref(),
+        Some("10")
+    );
+    assert_eq!(
+        extract_json_string_field(finality_retry_line, "max_attempts").as_deref(),
+        Some("3")
     );
 }
 
@@ -1578,6 +1594,10 @@ fn integration_runtime_kolme_live_renders_provider_contract_markers() {
     assert!(rendered.contains("submit_retry_reason=none"));
     assert!(rendered.contains("finality_retry_attempts=1"));
     assert!(rendered.contains("finality_retry_reason=none"));
+    assert!(rendered.contains("submit_retry_max_attempts=3"));
+    assert!(rendered.contains("finality_retry_max_attempts=3"));
+    assert!(rendered.contains("retry_backoff_base_ms=10"));
+    assert!(rendered.contains("retry_backoff_cap_ms=40"));
 
     let recorded_requests = requests.lock().expect("request mutex should lock");
     assert_eq!(
@@ -1723,6 +1743,10 @@ fn functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailab
     assert!(rendered.contains("submit_retry_reason=unavailable"));
     assert!(rendered.contains("finality_retry_attempts=2"));
     assert!(rendered.contains("finality_retry_reason=unavailable"));
+    assert!(rendered.contains("submit_retry_max_attempts=3"));
+    assert!(rendered.contains("finality_retry_max_attempts=3"));
+    assert!(rendered.contains("retry_backoff_base_ms=10"));
+    assert!(rendered.contains("retry_backoff_cap_ms=40"));
     assert!(rendered.contains("resolution=finality-polled"));
 
     let recorded_requests = requests.lock().expect("request mutex should lock");

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
@@ -289,6 +289,94 @@ fn integration_service_api_endpoint_serves_required_http_routes() {
 }
 
 #[test]
+fn functional_service_api_endpoint_emits_structured_ingress_correlation_markers() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34058".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: 1,
+        idle_timeout_ms: 2_000,
+    };
+    let sender_did = "kamn:did:agent:test-client-correlation";
+    let sender_nonce = 41_u64;
+    let message_body = "{\"message\":\"structured-correlation\"}";
+    let state_hash = format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    );
+    let signature =
+        baseline_signature_for_fields(sender_did, sender_nonce, state_hash.as_str(), message_body);
+    let client_bind_addr = bind_addr.clone();
+    let client = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(50));
+        send_http_request_with_headers(
+            client_bind_addr.as_str(),
+            "POST",
+            "/v1/messages/send",
+            message_body,
+            &[
+                ("X-KAMN-Sender-DID", sender_did),
+                ("X-KAMN-Request-Nonce", "41"),
+                ("X-KAMN-Request-Signature", signature.as_str()),
+            ],
+        )
+    });
+
+    let (serve_result, captured_logs) =
+        capture_test_logs(|| serve_service_api_endpoint(&endpoint_config, &snapshot));
+    let response = client.join().expect("client request should complete");
+    assert!(
+        serve_result.is_ok(),
+        "service api endpoint should serve one request"
+    );
+    assert!(response.contains("HTTP/1.1 202 Accepted"));
+
+    let ingress_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"service.api.request.received\""))
+        .expect("service api ingress should emit received marker");
+    let outcome_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"service.api.request.outcome\""))
+        .expect("service api ingress should emit outcome marker");
+    let ingress_correlation = extract_json_string_field(ingress_line, "correlation_id")
+        .expect("ingress marker should include correlation id");
+    let outcome_correlation = extract_json_string_field(outcome_line, "correlation_id")
+        .expect("outcome marker should include correlation id");
+    assert_eq!(ingress_correlation, outcome_correlation);
+    assert_eq!(
+        extract_json_string_field(ingress_line, "method").as_deref(),
+        Some("POST")
+    );
+    assert_eq!(
+        extract_json_string_field(ingress_line, "path").as_deref(),
+        Some("/v1/messages/send")
+    );
+    assert_eq!(
+        extract_json_string_field(outcome_line, "status_code").as_deref(),
+        Some("202")
+    );
+}
+
+#[test]
 fn unit_service_api_endpoint_metrics_use_runtime_observability_when_present() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -94,11 +94,6 @@ fn deterministic_retry_backoff_millis(retry_attempt: u32) -> u64 {
     (KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS * multiplier).min(KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS)
 }
 
-fn maybe_sleep_retry_backoff(retry_attempt: u32) {
-    let backoff = deterministic_retry_backoff_millis(retry_attempt);
-    thread::sleep(Duration::from_millis(backoff));
-}
-
 pub(crate) fn execute_kolme_live_runtime(
     plan: &BootstrapPlan,
     base_url: String,
@@ -153,6 +148,8 @@ pub(crate) fn execute_kolme_live_runtime(
                         submit_retry_reason = reason_code;
                         let attempt_label = submit_attempts.to_string();
                         let max_attempts_label = KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS.to_string();
+                        let backoff_ms = deterministic_retry_backoff_millis(submit_attempts);
+                        let backoff_ms_label = backoff_ms.to_string();
                         log_warn(
                             "kolme.live.submit.retry",
                             &[
@@ -160,9 +157,10 @@ pub(crate) fn execute_kolme_live_runtime(
                                 ("attempt", attempt_label.as_str()),
                                 ("max_attempts", max_attempts_label.as_str()),
                                 ("reason", reason_code),
+                                ("backoff_ms", backoff_ms_label.as_str()),
                             ],
                         )?;
-                        maybe_sleep_retry_backoff(submit_attempts);
+                        thread::sleep(Duration::from_millis(backoff_ms));
                         continue;
                     }
                     return Err(ConfigError::RuntimeKolmeLive(format!(
@@ -223,6 +221,9 @@ pub(crate) fn execute_kolme_live_runtime(
                             let attempt_label = finality_retry_attempts.to_string();
                             let max_attempts_label =
                                 KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS.to_string();
+                            let backoff_ms =
+                                deterministic_retry_backoff_millis(finality_retry_attempts);
+                            let backoff_ms_label = backoff_ms.to_string();
                             log_warn(
                                 "kolme.live.finality.retry",
                                 &[
@@ -231,9 +232,10 @@ pub(crate) fn execute_kolme_live_runtime(
                                     ("attempt", attempt_label.as_str()),
                                     ("max_attempts", max_attempts_label.as_str()),
                                     ("reason", reason_code),
+                                    ("backoff_ms", backoff_ms_label.as_str()),
                                 ],
                             )?;
-                            maybe_sleep_retry_backoff(finality_retry_attempts);
+                            thread::sleep(Duration::from_millis(backoff_ms));
                             continue;
                         }
                         resolution = if reason_code == "timeout" {
@@ -275,8 +277,12 @@ pub(crate) fn execute_kolme_live_runtime(
     }
 
     let finality = kolme_live_finality_label(receipt.finality);
+    let submit_retry_max_attempts = KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS;
+    let finality_retry_max_attempts = KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS;
+    let retry_backoff_base_ms = KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS;
+    let retry_backoff_cap_ms = KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS;
     let execution_status = format!(
-        "{submit_status};commit_id={};finality={finality};resolution={resolution};submit_attempts={submit_attempts};submit_retry_reason={submit_retry_reason};finality_retry_attempts={finality_retry_attempts};finality_retry_reason={finality_retry_reason}",
+        "{submit_status};commit_id={};finality={finality};resolution={resolution};submit_attempts={submit_attempts};submit_retry_reason={submit_retry_reason};submit_retry_max_attempts={submit_retry_max_attempts};finality_retry_attempts={finality_retry_attempts};finality_retry_reason={finality_retry_reason};finality_retry_max_attempts={finality_retry_max_attempts};retry_backoff_base_ms={retry_backoff_base_ms};retry_backoff_cap_ms={retry_backoff_cap_ms}",
         receipt.commit_id
     );
     let observability = build_kolme_live_observability_telemetry(execution_status.as_str())

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -1,4 +1,7 @@
-use crate::NodeBootstrapReport;
+use crate::{
+    logging::{log_info, log_warn},
+    NodeBootstrapReport,
+};
 use kamn_core::{signature_matches_supported_profile_for_fields, AgentDid};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{ErrorKind, Read, Write};
@@ -263,37 +266,63 @@ pub(crate) fn serve_service_api_endpoint(
             Ok((mut stream, _)) => {
                 let response = match read_http_request(&mut stream) {
                     Ok(request) => {
-                        match authorize_service_api_request(snapshot, &request, &mut replay_guard) {
+                        let correlation_id = service_api_request_correlation_id(&request);
+                        log_service_api_event_info(
+                            "service.api.request.received",
+                            &[
+                                ("correlation_id", correlation_id.as_str()),
+                                ("method", request.method.as_str()),
+                                ("path", request.path.as_str()),
+                            ],
+                        )?;
+                        let (response, outcome) = match authorize_service_api_request(
+                            snapshot,
+                            &request,
+                            &mut replay_guard,
+                        ) {
                             Ok(()) => {
                                 if request.method == "GET" && request.path == ROUTE_EVENTS_WS {
                                     match write_websocket_upgrade_event_response(
-                                        &mut stream,
-                                        snapshot,
-                                        &request.headers,
-                                    ) {
-                                        Ok(()) => {
-                                            served_requests = served_requests.saturating_add(1);
-                                            continue;
-                                        }
-                                        Err(error) => ServiceApiEndpointResponse {
-                                            status_code: 400,
-                                            content_type: "application/json",
-                                            body: format!(
-                                                "{{\"error\":\"bad-request\",\"reason\":\"{}\"}}",
-                                                escape_json_string(error.as_str())
+                                            &mut stream,
+                                            snapshot,
+                                            &request.headers,
+                                        ) {
+                                            Ok(()) => {
+                                                emit_service_api_request_outcome(
+                                                    correlation_id.as_str(),
+                                                    request.method.as_str(),
+                                                    request.path.as_str(),
+                                                    101,
+                                                    "websocket-upgrade",
+                                                )?;
+                                                served_requests = served_requests.saturating_add(1);
+                                                continue;
+                                            }
+                                            Err(error) => (
+                                                ServiceApiEndpointResponse {
+                                                    status_code: 400,
+                                                    content_type: "application/json",
+                                                    body: format!(
+                                                        "{{\"error\":\"bad-request\",\"reason\":\"{}\"}}",
+                                                        escape_json_string(error.as_str())
+                                                    ),
+                                                },
+                                                "websocket-bad-request",
                                             ),
-                                        },
-                                    }
+                                        }
                                 } else {
-                                    render_service_api_endpoint_response(
-                                        snapshot,
-                                        request.method.as_str(),
-                                        request.path.as_str(),
-                                        request.body.as_str(),
+                                    (
+                                        render_service_api_endpoint_response(
+                                            snapshot,
+                                            request.method.as_str(),
+                                            request.path.as_str(),
+                                            request.body.as_str(),
+                                        ),
+                                        "handled",
                                     )
                                 }
                             }
-                            Err(RequestAuthFailure::Unauthorized(reason)) => {
+                            Err(RequestAuthFailure::Unauthorized(reason)) => (
                                 ServiceApiEndpointResponse {
                                     status_code: 401,
                                     content_type: "application/json",
@@ -301,26 +330,51 @@ pub(crate) fn serve_service_api_endpoint(
                                         "{{\"error\":\"unauthorized\",\"reason\":\"{}\"}}",
                                         escape_json_string(reason.as_str())
                                     ),
-                                }
-                            }
-                            Err(RequestAuthFailure::Replay(reason)) => ServiceApiEndpointResponse {
-                                status_code: 409,
-                                content_type: "application/json",
-                                body: format!(
-                                    "{{\"error\":\"replay\",\"reason\":\"{}\"}}",
-                                    escape_json_string(reason.as_str())
-                                ),
-                            },
+                                },
+                                "unauthorized",
+                            ),
+                            Err(RequestAuthFailure::Replay(reason)) => (
+                                ServiceApiEndpointResponse {
+                                    status_code: 409,
+                                    content_type: "application/json",
+                                    body: format!(
+                                        "{{\"error\":\"replay\",\"reason\":\"{}\"}}",
+                                        escape_json_string(reason.as_str())
+                                    ),
+                                },
+                                "replay",
+                            ),
+                        };
+                        emit_service_api_request_outcome(
+                            correlation_id.as_str(),
+                            request.method.as_str(),
+                            request.path.as_str(),
+                            response.status_code,
+                            outcome,
+                        )?;
+                        response
+                    }
+                    Err(error) => {
+                        let correlation_id = format!(
+                            "service-api:parse-error:{:016x}",
+                            deterministic_body_tag(error.as_bytes())
+                        );
+                        emit_service_api_request_outcome(
+                            correlation_id.as_str(),
+                            "unknown",
+                            "unknown",
+                            400,
+                            "bad-request",
+                        )?;
+                        ServiceApiEndpointResponse {
+                            status_code: 400,
+                            content_type: "application/json",
+                            body: format!(
+                                "{{\"error\":\"bad-request\",\"reason\":\"{}\"}}",
+                                escape_json_string(error.as_str())
+                            ),
                         }
                     }
-                    Err(error) => ServiceApiEndpointResponse {
-                        status_code: 400,
-                        content_type: "application/json",
-                        body: format!(
-                            "{{\"error\":\"bad-request\",\"reason\":\"{}\"}}",
-                            escape_json_string(error.as_str())
-                        ),
-                    },
                 };
                 write_http_response(&mut stream, &response)?;
                 served_requests = served_requests.saturating_add(1);
@@ -336,6 +390,48 @@ pub(crate) fn serve_service_api_endpoint(
 
 fn route_requires_auth(method: &str, path: &str) -> bool {
     !(method == "GET" && (path == ROUTE_HEALTHZ || path == ROUTE_METRICS))
+}
+
+fn log_service_api_event_info(event: &str, fields: &[(&str, &str)]) -> Result<(), String> {
+    log_info(event, fields).map_err(|error| format!("service api log emission failed: {error}"))
+}
+
+fn log_service_api_event_warn(event: &str, fields: &[(&str, &str)]) -> Result<(), String> {
+    log_warn(event, fields).map_err(|error| format!("service api log emission failed: {error}"))
+}
+
+fn service_api_request_correlation_id(request: &ParsedRequest) -> String {
+    let method = request.method.to_ascii_lowercase();
+    if let (Some(sender_did), Some(nonce)) = (
+        header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER),
+        header_value(&request.headers, REQUEST_AUTH_NONCE_HEADER),
+    ) {
+        return format!("service-api:{method}:{}:{sender_did}:{nonce}", request.path);
+    }
+    let request_tag = deterministic_body_tag(request.body.as_bytes());
+    format!("service-api:{method}:{}:{request_tag:016x}", request.path)
+}
+
+fn emit_service_api_request_outcome(
+    correlation_id: &str,
+    method: &str,
+    path: &str,
+    status_code: u16,
+    outcome: &str,
+) -> Result<(), String> {
+    let status_code_label = status_code.to_string();
+    let fields = [
+        ("correlation_id", correlation_id),
+        ("method", method),
+        ("path", path),
+        ("status_code", status_code_label.as_str()),
+        ("outcome", outcome),
+    ];
+    if status_code >= 400 {
+        log_service_api_event_warn("service.api.request.outcome", &fields)
+    } else {
+        log_service_api_event_info("service.api.request.outcome", &fields)
+    }
 }
 
 fn service_api_signature_state_hash(snapshot: &ServiceApiSnapshot) -> String {

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -324,6 +324,10 @@ This document captures node-runtime productionization slices for machine-readabl
   - default mode executes one deterministic runtime-commit request
   - continuous mode executes one runtime-commit/finality sequence per `--daemon-max-ticks` cycle
   - pending submit receipts poll finality via `/runtime-commit/status` with max-attempt budget `2`
+  - submit retries are bounded to max-attempt budget `3`
+  - finality retries are bounded to max-attempt budget `3`
+  - retry backoff is deterministic exponential (`10ms`, `20ms`, capped at `40ms`)
+  - structured retry markers include `attempt`, `max_attempts`, `reason`, `backoff_ms`, and `correlation_id`
   - malformed finality responses fail closed
   - finality transport timeout/unavailable keeps execution in pending status without falling back to in-memory adapters
   - managed-external signer mode enforces secure-provider handshake routing before payload signing and maps provider failures to deterministic reason codes such as:
@@ -337,7 +341,7 @@ This document captures node-runtime productionization slices for machine-readabl
     - `kolme_live_signer_profile=ops-primary|ops-secondary`
     - `kolme_live_signer_key_source=env-local|managed-external`
     - `kolme_live_signer_private_key_env=KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX|KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY`
-  - `kolme_live_execution_status=submitted;commit_id=<deterministic-commit-id>;finality=<pending|final|failed>;resolution=<submit-receipt|finality-polled|finality-timeout|finality-unavailable>`
+  - `kolme_live_execution_status=submitted;commit_id=<deterministic-commit-id>;finality=<pending|final|failed>;resolution=<submit-receipt|finality-polled|finality-timeout|finality-unavailable>;submit_attempts=<u32>;submit_retry_reason=<none|timeout|unavailable>;submit_retry_max_attempts=3;finality_retry_attempts=<u32>;finality_retry_reason=<none|timeout|unavailable>;finality_retry_max_attempts=3;retry_backoff_base_ms=10;retry_backoff_cap_ms=40`
   - `kolme_live_observability_latency_p50_ms=<u64>`
   - `kolme_live_observability_latency_p99_ms=<u64>`
   - `kolme_live_observability_throughput_tps=<u64>`
@@ -345,6 +349,20 @@ This document captures node-runtime productionization slices for machine-readabl
   - `kolme_live_observability_availability_bps=<u64>`
   - `kolme_live_observability_health=<healthy|degraded|critical>`
   - `kolme_live_observability_alert_count=<usize>`
+
+## Service API Ingress Logging Contracts
+- Service API ingress emits structured request markers for deterministic correlation and auditability:
+  - `service.api.request.received`
+  - `service.api.request.outcome`
+- Correlation marker is deterministic per request envelope:
+  - authenticated requests: `service-api:<method-lower>:<path>:<sender-did>:<nonce>`
+  - unauthenticated/parse-error paths: deterministic fallback tag
+- Required marker fields:
+  - `correlation_id`
+  - `method`
+  - `path`
+  - `status_code` (for outcome marker)
+  - `outcome` (for outcome marker)
 
 ## Decomposition Guardrails
 - `main.rs` orchestrates only and must not absorb parser/signer/wire/live-runtime implementation details.


### PR DESCRIPTION
## Summary
Adds deterministic retry-budget evidence markers for Kolme live runtime execution and structured ingress correlation logging for the service API path. This closes the remaining contract gaps tracked in #3216 for runtime traceability and bounded retry/backoff observability.

Closes #3216

## Changes
- `crates/kamn-node/src/runtime_kolme_live.rs`: emit `backoff_ms` on submit/finality retry events and append retry/backoff budget markers to `kolme_live_execution_status`.
- `crates/kamn-node/src/service_api_endpoint.rs`: add structured `service.api.request.received` and `service.api.request.outcome` markers with deterministic request `correlation_id`.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: assert retry marker `backoff_ms`/budget fields and execution-status budget markers.
- `crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs`: add functional ingress-correlation log contract test.
- `docs/foundation/node-runtime-cli.md`: document retry budget/backoff markers and service ingress logging contract markers.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (targeted lane)
- [x] Manual verification: inspected emitted structured log lines for retry and service ingress markers in test runs

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Runtime retry marker assertions in `functional_kolme_live_retry_emits_structured_retry_markers` |
| Functional  | ✅ | `functional_service_api_endpoint_emits_structured_ingress_correlation_markers` |
| Integration | ✅ | `integration_runtime_kolme_live_renders_provider_contract_markers`; `functional_runtime_kolme_live_retries_transient_submit_and_finality_unavailable_errors` |
| Regression  | ✅ | Existing runtime/doc contract lanes still passing (`--test node_runtime_cli_docs`) |
