### PR TITLE
feat: add daemon drain markers and signer-secret fail-closed coverage

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -460,6 +460,33 @@ fn build_runtime_execution_id(runtime_mode: RuntimeMode, chain_id: &str, role: &
     format!("node-runtime:{}:{chain_id}:{role}", runtime_mode.as_str())
 }
 
+fn daemon_shutdown_drain_status(completion_reason: &str) -> &'static str {
+    if completion_reason.starts_with("graceful-shutdown:signal@") {
+        "completed"
+    } else if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
+        "timeout"
+    } else {
+        "not-signaled"
+    }
+}
+
+fn daemon_shutdown_signal_tick(completion_reason: &str) -> Option<&str> {
+    completion_reason
+        .strip_prefix("graceful-shutdown:signal@")
+        .or_else(|| completion_reason.strip_prefix("graceful-shutdown-timeout:signal@"))
+        .map(|value| value.split(';').next().unwrap_or(value))
+}
+
+fn daemon_shutdown_reason_field<'a>(completion_reason: &'a str, key: &str) -> Option<&'a str> {
+    completion_reason.split(';').find_map(|segment| {
+        let (field, value) = segment.split_once('=')?;
+        if field == key {
+            return Some(value);
+        }
+        None
+    })
+}
+
 fn run() -> Result<(), ConfigError> {
     let cli = parse_args(env::args())?;
     let runtime_mode = cli.runtime_mode.as_str();
@@ -821,6 +848,26 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 daemon_completion.completion_reason.as_str(),
             )
             .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+            let shutdown_drain_status =
+                daemon_shutdown_drain_status(daemon_completion.completion_reason.as_str());
+            let shutdown_signal_tick =
+                daemon_shutdown_signal_tick(daemon_completion.completion_reason.as_str())
+                    .unwrap_or("none");
+            let shutdown_drain_ticks = daemon_shutdown_reason_field(
+                daemon_completion.completion_reason.as_str(),
+                "drain_ticks",
+            )
+            .unwrap_or("0");
+            let shutdown_timeout_ticks = daemon_shutdown_reason_field(
+                daemon_completion.completion_reason.as_str(),
+                "timeout_ticks",
+            )
+            .unwrap_or("0");
+            let shutdown_ignored_signals = daemon_shutdown_reason_field(
+                daemon_completion.completion_reason.as_str(),
+                "ignored_signals",
+            )
+            .unwrap_or("0");
             let executed_ticks_label = daemon_completion.executed_ticks.to_string();
             log_info(
                 "node.runtime.daemon.execute.complete",
@@ -831,6 +878,11 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                         "completion_reason",
                         daemon_completion.completion_reason.as_str(),
                     ),
+                    ("shutdown_drain_status", shutdown_drain_status),
+                    ("shutdown_signal_tick", shutdown_signal_tick),
+                    ("shutdown_drain_ticks", shutdown_drain_ticks),
+                    ("shutdown_timeout_ticks", shutdown_timeout_ticks),
+                    ("shutdown_ignored_signals", shutdown_ignored_signals),
                     ("execution_id", execution_id.as_str()),
                 ],
             )?;

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -526,6 +526,26 @@ fn functional_runtime_daemon_emits_structured_transition_markers() {
         extract_json_string_field(complete_line, "completion_reason").as_deref(),
         Some("tick-budget-exhausted")
     );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_drain_status").as_deref(),
+        Some("not-signaled")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_signal_tick").as_deref(),
+        Some("none")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_drain_ticks").as_deref(),
+        Some("0")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_timeout_ticks").as_deref(),
+        Some("0")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_ignored_signals").as_deref(),
+        Some("0")
+    );
     let complete_execution_id = extract_json_string_field(complete_line, "execution_id")
         .expect("daemon completion marker should include execution_id");
     assert_eq!(start_execution_id, complete_execution_id);
@@ -657,6 +677,174 @@ fn functional_kolme_live_nonce_retry_emits_structured_retry_marker() {
     assert_eq!(
         extract_json_string_field(nonce_retry_line, "reason").as_deref(),
         Some("unavailable")
+    );
+}
+
+#[test]
+fn functional_runtime_daemon_graceful_shutdown_emits_structured_drain_markers() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "10".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "3".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "4".to_owned(),
+    ])
+    .expect("daemon args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("daemon execution should succeed");
+    assert_eq!(report.runtime_mode, "daemon");
+
+    let complete_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.daemon.execute.complete\""))
+        .expect("daemon execution should emit structured completion marker");
+    assert_eq!(
+        extract_json_string_field(complete_line, "completion_reason").as_deref(),
+        Some("graceful-shutdown:signal@3;drain_ticks=2;timeout_ticks=4;ignored_signals=0")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_drain_status").as_deref(),
+        Some("completed")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_signal_tick").as_deref(),
+        Some("3")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_drain_ticks").as_deref(),
+        Some("2")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_timeout_ticks").as_deref(),
+        Some("4")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_ignored_signals").as_deref(),
+        Some("0")
+    );
+}
+
+#[test]
+fn regression_runtime_daemon_shutdown_timeout_emits_structured_timeout_drain_markers() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "10".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "7".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "4".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "2".to_owned(),
+    ])
+    .expect("daemon timeout args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("daemon timeout execution should succeed");
+    assert_eq!(report.runtime_mode, "daemon");
+
+    let complete_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.daemon.execute.complete\""))
+        .expect("daemon execution should emit structured completion marker");
+    assert_eq!(
+        extract_json_string_field(complete_line, "completion_reason").as_deref(),
+        Some("graceful-shutdown-timeout:signal@7;drain_ticks=4;timeout_ticks=2;ignored_signals=0")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_drain_status").as_deref(),
+        Some("timeout")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_signal_tick").as_deref(),
+        Some("7")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_drain_ticks").as_deref(),
+        Some("4")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_timeout_ticks").as_deref(),
+        Some("2")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_ignored_signals").as_deref(),
+        Some("0")
+    );
+}
+
+#[test]
+fn regression_runtime_kolme_live_rejects_fallback_signer_secret_env_with_reason_code() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _primary_key_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let _fallback_key_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY),
+    );
+    let (base_url, requests) = spawn_kolme_live_mock_server(Vec::new());
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-strict-signer-contracts".to_owned(),
+        "--kolme-live-signer-profile".to_owned(),
+        "ops-primary".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+    let error = execute(parsed).expect_err("fallback signer secret env path must fail closed");
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("fallback_signer_secret_present_violation")),
+        "fallback signer secret env path must emit deterministic fail-closed reason code"
+    );
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        0,
+        "fallback signer secret env path must fail before nonce/finality network dispatch"
     );
 }
 

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -130,6 +130,15 @@ fn doc_contains_runtime_daemon_rules() {
 }
 
 #[test]
+fn doc_contains_daemon_shutdown_drain_marker_fields() {
+    assert!(DOC.contains("shutdown_drain_status"));
+    assert!(DOC.contains("shutdown_signal_tick"));
+    assert!(DOC.contains("shutdown_drain_ticks"));
+    assert!(DOC.contains("shutdown_timeout_ticks"));
+    assert!(DOC.contains("shutdown_ignored_signals"));
+}
+
+#[test]
 fn doc_contains_runtime_kolme_live_rules() {
     assert!(DOC.contains("## Kolme Live Runtime Rules"));
     assert!(DOC.contains("`kolme-live`"));

--- a/docs/foundation/kolme-runtime-commit-client.md
+++ b/docs/foundation/kolme-runtime-commit-client.md
@@ -306,6 +306,8 @@ bash scripts/kolme/run_runtime_commit_contract_lane.sh
       - deterministic backend reason-code classes: `managed_signer_backend_timeout`, `managed_signer_backend_unavailable`, `managed_signer_backend_response_malformed`.
     - malformed signature bytes, invalid recovery id, or recovered-key mismatch are rejected fail-closed before runtime submit dispatch.
     - fallback private key marker contract: `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` must remain unset; policy fails closed with `fallback_signer_secret_present_violation` when present.
+    - managed-external raw private key env path is rejected fail-closed with `managed_signer_raw_private_key_forbidden`.
+    - signer-secret fail-closed violations (`fallback_signer_secret_present_violation`, `managed_signer_raw_private_key_forbidden`) are enforced before nonce/finality network dispatch in runtime execute paths.
     - synthetic fallback signature material (`signature=<idempotency_key>`) is rejected by runtime tests/policies.
   - in-memory fallback markers and non-fork signing profiles are rejected fail-closed by typed node config errors.
 - Runtime live lane (submit + optional finality):

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -248,6 +248,12 @@ This document captures node-runtime productionization slices for machine-readabl
   - graceful completion => `daemon_completion_reason` emits `graceful-shutdown:...`
   - timeout/fail-closed completion => `daemon_completion_reason` emits `graceful-shutdown-timeout:...`
   - repeated/late shutdown signals are counted as `ignored_signals` in completion metadata.
+- Structured daemon completion marker fields:
+  - `shutdown_drain_status=<not-signaled|completed|timeout>`
+  - `shutdown_signal_tick=<u64|none>`
+  - `shutdown_drain_ticks=<u64>`
+  - `shutdown_timeout_ticks=<u64>`
+  - `shutdown_ignored_signals=<u64>`
 - Daemon observability telemetry is emitted in deterministic report fields:
   - `daemon_observability_latency_p50_ms`
   - `daemon_observability_latency_p99_ms`


### PR DESCRIPTION
## Summary
Adds deterministic daemon shutdown drain markers to structured runtime completion logs and extends runtime execute-path coverage for signer-secret fail-closed behavior. Also updates runtime and signer contract docs to keep marker/reason-code expectations aligned.

Closes #3219

## Changes
- `crates/kamn-node/src/main.rs`: added daemon completion marker helpers and emitted `shutdown_drain_status`, `shutdown_signal_tick`, `shutdown_drain_ticks`, `shutdown_timeout_ticks`, and `shutdown_ignored_signals` on `node.runtime.daemon.execute.complete`.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: extended daemon structured marker assertions for no-signal, graceful-drain, and timeout-drain paths; added runtime execute-path regression test for `fallback_signer_secret_present_violation` with zero network dispatch.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: added docs contract assertion for daemon drain marker fields.
- `docs/foundation/kolme-runtime-commit-client.md`: clarified signer-secret fail-closed pre-dispatch enforcement markers.
- `docs/foundation/node-runtime-cli.md`: documented daemon structured drain completion marker fields.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (targeted lane)
- [x] Manual verification: observed structured completion markers in test log output for no-signal, graceful, and timeout shutdown paths

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Daemon completion marker helper paths exercised through deterministic structured marker assertions |
| Functional  | ✅ | `functional_runtime_daemon_graceful_shutdown_emits_structured_drain_markers` |
| Integration | ✅ | `functional_runtime_daemon_emits_structured_transition_markers`; `regression_runtime_daemon_shutdown_timeout_emits_structured_timeout_drain_markers` |
| Regression  | ✅ | `regression_runtime_kolme_live_rejects_fallback_signer_secret_env_with_reason_code`; `doc_contains_daemon_shutdown_drain_marker_fields` |
