### PR TITLE
fix(ci): fail closed heavy-lane leakage and go/no-go evidence completeness (#3240)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -1378,7 +1378,7 @@ Selector routing remains bounded through `scripts/ci/select_targets.sh`:
     - `ci-fast-gate mode: fast` (local-heavy run-mode lanes excluded)
     - `local-dev mode: local` (dry-run and local evidence workflows)
     - `manual-hardened mode: manual` (`CI_ENABLE_KOLME_LOCAL_HEAVY_CONTRACT_TESTS=true` opt-in)
-  - workflow heavy-exclusion policy checker fails closed when local-heavy command coverage drifts (`local_heavy_lane_commands_missing`) or leaks into version compatibility lane (`local_heavy_lane_commands_in_version_lane`).
+  - workflow heavy-exclusion policy checker fails closed when local-heavy command coverage drifts (`local_heavy_lane_commands_missing`), leaks into non-local-heavy steps (`local_heavy_lane_commands_outside_local_heavy_step`), or leaks into version compatibility lane (`local_heavy_lane_commands_in_version_lane`).
   - workflow/selector parity contract remains enforced with deterministic reason codes:
     - `python3 scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py --workflow-file .github/workflows/ci-fast-gate.yml --selector-file scripts/ci/select_targets.sh`
     - selector parity reason codes include:

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -82,6 +82,15 @@ Go/no-go decisions are captured as machine-readable JSON so release policy check
   - `scripts/deploy/gonogo_evidence_contract.py`
 - Scheduled deep lane entrypoint:
   - `bash scripts/deploy/run_gonogo_evidence_deep_lane.sh`
+- Required checklist evidence markers (machine-readable bundle):
+  - `ci_fast_gate`
+  - `ci_deep_lane`
+  - `rollback_precheck`
+  - `rollback_trigger_status`
+  - `approval_quorum`
+  - `runtime_image_digest`
+- Fail-closed policy reason:
+  - missing required checklist evidence markers force `NO-GO` (`Regression: #3240`).
 
 ## Staging Deploy + Rollback Rehearsal Contract (Issue #658)
 Staging rehearsal automation must verify deploy and rollback outcomes before release decisions are accepted.

--- a/scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py
+++ b/scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py
@@ -51,12 +51,22 @@ def parse_args() -> argparse.Namespace:
 
 def extract_step_block(text: str, step_name: str) -> str:
     step_match = re.search(
-        rf"- name:\s*{re.escape(step_name)}(?P<body>(?:\n\s{{6,}}.*)+)",
+        rf"- name:\s*{re.escape(step_name)}(?P<body>(?:\n\s{{8,}}.*)+)",
         text,
     )
     if not step_match:
         return ""
     return step_match.group("body")
+
+
+def extract_step_section(text: str, step_name: str) -> str:
+    step_match = re.search(
+        rf"(?P<section>-\sname:\s*{re.escape(step_name)}(?:\n\s{{8,}}.*)+)",
+        text,
+    )
+    if not step_match:
+        return ""
+    return step_match.group("section")
 
 
 def extract_ci_tools_fast_mode_block(text: str) -> str:
@@ -130,6 +140,15 @@ def main() -> int:
         ]
         if missing_local_heavy_commands:
             failed_checks.append("local_heavy_lane_commands_missing")
+
+    heavy_step_section = extract_step_section(text, "Run Kolme local-heavy contract lane")
+    if heavy_step_section:
+        workflow_without_heavy_step = text.replace(heavy_step_section, "")
+        leaked_outside_local_heavy_step = [
+            command for command in LOCAL_HEAVY_LANE_COMMANDS if command in workflow_without_heavy_step
+        ]
+        if leaked_outside_local_heavy_step:
+            failed_checks.append("local_heavy_lane_commands_outside_local_heavy_step")
 
     version_lane_block = extract_step_block(text, "Run Kolme version compatibility contract lane")
     if version_lane_block:

--- a/scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh
+++ b/scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh
@@ -172,4 +172,31 @@ if ! grep -Fq "reason_codes=local_heavy_lane_commands_in_ci_tools_fast_mode" "$c
 fi
 
 rm -f "$unsafe_ci_tools_file" "$ci_tools_local_heavy_log"
+
+unsafe_workflow_file="$(mktemp)"
+cat "$SAFE_FIXTURE" >"$unsafe_workflow_file"
+cat <<'YAML' >>"$unsafe_workflow_file"
+      - name: Unsafe leaked local-heavy command
+        run: |
+          bash scripts/kolme/test_run_local_heavy_validation_matrix.sh
+YAML
+
+outside_local_heavy_step_log="$(mktemp)"
+if python3 "$CHECKER" --workflow-file "$unsafe_workflow_file" --selector-file "$SELECTOR_FILE" --ci-tools-file "$CI_TOOLS_SCRIPT" >"$outside_local_heavy_step_log" 2>&1; then
+  cat "$outside_local_heavy_step_log" >&2
+  echo "expected workflow fixture leaking local-heavy command outside dedicated step to fail policy checker" >&2
+  exit 1
+fi
+if ! grep -Fq "local_heavy_lane_commands_outside_local_heavy_step" "$outside_local_heavy_step_log"; then
+  cat "$outside_local_heavy_step_log" >&2
+  echo "expected workflow fixture leaking local-heavy command outside dedicated step to report local_heavy_lane_commands_outside_local_heavy_step" >&2
+  exit 1
+fi
+if ! grep -Fq "reason_codes=local_heavy_lane_commands_outside_local_heavy_step" "$outside_local_heavy_step_log"; then
+  cat "$outside_local_heavy_step_log" >&2
+  echo "expected workflow fixture leaking local-heavy command outside dedicated step to emit deterministic reason code marker" >&2
+  exit 1
+fi
+
+rm -f "$unsafe_workflow_file" "$outside_local_heavy_step_log"
 echo "workflow Kolme local-heavy exclusion policy checker tests passed."

--- a/scripts/deploy/gonogo_evidence_contract.py
+++ b/scripts/deploy/gonogo_evidence_contract.py
@@ -24,6 +24,14 @@ from framework.contract_framework import (  # noqa: E402
 SCHEMA_VERSION = "kamn.release.gonogo.v1"
 GO_DECISION = "GO"
 NO_GO_DECISION = "NO-GO"
+REQUIRED_EVIDENCE_MARKERS = (
+    "ci_fast_gate",
+    "ci_deep_lane",
+    "rollback_precheck",
+    "rollback_trigger_status",
+    "approval_quorum",
+    "runtime_image_digest",
+)
 
 
 def generate_bundle(args: argparse.Namespace) -> int:
@@ -82,6 +90,7 @@ def generate_bundle(args: argparse.Namespace) -> int:
         "release_candidate": args.release_candidate,
         "schema_target_version": args.schema_target_version,
         "runtime_image_digest": args.runtime_image_digest,
+        "evidence_markers": list(REQUIRED_EVIDENCE_MARKERS),
         "gates": {
             "ci_fast_gate": ci_fast_gate,
             "ci_deep_lane": ci_deep_lane,
@@ -121,6 +130,7 @@ def check_bundle(args: argparse.Namespace) -> int:
             "release_candidate",
             "schema_target_version",
             "runtime_image_digest",
+            "evidence_markers",
             "gates",
             "rollback_trigger_status",
             "approvals",
@@ -141,6 +151,20 @@ def check_bundle(args: argparse.Namespace) -> int:
     rollback_trigger_status = payload["rollback_trigger_status"]
     if rollback_trigger_status not in {"CLEAR", "TRIGGERED"}:
         fail("rollback_trigger_status must be CLEAR or TRIGGERED")
+
+    evidence_markers = payload["evidence_markers"]
+    if not isinstance(evidence_markers, list):
+        fail("bundle field 'evidence_markers' must be an array")
+    if any(not isinstance(marker, str) or marker == "" for marker in evidence_markers):
+        fail("evidence_markers entries must be non-empty strings")
+    missing_required_markers = [
+        marker for marker in REQUIRED_EVIDENCE_MARKERS if marker not in evidence_markers
+    ]
+    if missing_required_markers:
+        fail(
+            "missing required evidence markers: "
+            + ",".join(sorted(set(missing_required_markers)))
+        )
 
     approvals = payload["approvals"]
     if not isinstance(approvals, dict):

--- a/scripts/deploy/test_generate_gonogo_evidence_bundle.sh
+++ b/scripts/deploy/test_generate_gonogo_evidence_bundle.sh
@@ -51,6 +51,27 @@ go_generate_output="$(
 assert_eq "$(extract_value "$go_generate_output" "status")" "generated" "expected GO bundle generation to succeed"
 assert_eq "$(extract_value "$go_generate_output" "final_decision")" "GO" "expected generator to derive GO decision"
 
+python3 - "$go_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+required_markers = {
+    "ci_fast_gate",
+    "ci_deep_lane",
+    "rollback_precheck",
+    "rollback_trigger_status",
+    "approval_quorum",
+    "runtime_image_digest",
+}
+markers = payload.get("evidence_markers")
+if not isinstance(markers, list):
+    raise SystemExit("expected go/no-go bundle evidence_markers list")
+if set(markers) != required_markers:
+    raise SystemExit("expected go/no-go bundle evidence_markers to match required checklist markers")
+PY
+
 go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
 assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO bundle policy check to pass"
 assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected policy check to keep GO decision"
@@ -107,6 +128,34 @@ fi
 # Regression: #623
 if ! printf '%s\n' "$tampered_output" | grep -q "policy decision mismatch"; then
   echo "expected regression guard to catch policy decision mismatch" >&2
+  exit 1
+fi
+
+tampered_missing_evidence_bundle="$TMP_DIR/gonogo-missing-evidence-marker.json"
+cp "$go_bundle" "$tampered_missing_evidence_bundle"
+python3 - "$tampered_missing_evidence_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["evidence_markers"] = [marker for marker in payload.get("evidence_markers", []) if marker != "rollback_precheck"]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_missing_evidence_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_missing_evidence_bundle" 2>&1)"
+tampered_missing_evidence_code=$?
+set -e
+
+if [ "$tampered_missing_evidence_code" -eq 0 ]; then
+  echo "expected missing-evidence-marker bundle to fail policy validation" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$tampered_missing_evidence_output" | grep -q "missing required evidence markers"; then
+  echo "expected explicit missing-required-evidence-markers error from policy checker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This hardens CI lane governance and release evidence policy for task #3240. It adds fail-closed detection when Kolme local-heavy commands leak outside the dedicated opt-in step, and enforces required go/no-go checklist evidence markers in machine-readable release bundles.

## Changes
- `scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py`: adds `local_heavy_lane_commands_outside_local_heavy_step` detection and tighter step-body parsing.
- `scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`: adds regression fixture for local-heavy command leakage outside the dedicated step.
- `scripts/deploy/gonogo_evidence_contract.py`: adds required `evidence_markers` payload and fail-closed checker validation for missing required markers.
- `scripts/deploy/test_generate_gonogo_evidence_bundle.sh`: adds marker-completeness assertions and tamper test for missing evidence marker rejection.
- `docs/ci/strategy.md`: documents new fail-closed heavy-lane leakage reason code.
- `docs/foundation/release-gonogo-checklist.md`: documents required go/no-go checklist evidence markers and fail-closed marker policy.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`
  - failed with: `expected workflow fixture leaking local-heavy command outside dedicated step to fail policy checker`
- `bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh`
  - failed with: `expected go/no-go bundle evidence_markers list`

### 🟢 Green Phase
- `bash scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh`
- `bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh`

### 🔁 Regression
- `bash scripts/deploy/test_run_gonogo_evidence_contract_lane.sh`
- `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`
- `cargo test -p kamn-core --test release_gonogo_checklist_docs`
- `python3 -m py_compile scripts/ci/check_workflow_kolme_heavy_exclusion_policy.py scripts/deploy/gonogo_evidence_contract.py`
- `bash -n scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh scripts/deploy/test_generate_gonogo_evidence_bundle.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Python contract field/marker validation in `scripts/deploy/test_generate_gonogo_evidence_bundle.sh` | |
| Functional   | ✅ | Workflow governance policy checks in `scripts/ci/test_check_workflow_kolme_heavy_exclusion_policy.sh` | |
| Integration  | ✅ | End-to-end go/no-go lane validation in `scripts/runtime/test_run_go_no_go_gate_lane.sh` | |
| Regression   | ✅ | Existing workflow/deploy/runtime/doc contract lanes rerun with new fail-closed cases | |
| Performance  | ✅ | Fast-gate scope/budget contract still green via `scripts/ci/test_workflow_scope_policy.sh` | |

## Risks & Rollback
- None.
- Rollback plan: revert this PR to restore previous checker behavior.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/foundation/release-gonogo-checklist.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean (N/A: no Rust code changed)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: no Rust code changed)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)

Closes #3240
