### PR TITLE
feat(deploy): add staged rehearsal signoff artifact contract (#3241)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -85,6 +85,15 @@ fn plan_contains_local_live_api_conformance_harness() {
 }
 
 #[test]
+fn plan_contains_staged_rehearsal_signoff_artifact_contract() {
+    assert!(PLAN.contains("## Staged Rehearsal Signoff Artifact Contract (Issue #3241)"));
+    assert!(PLAN.contains("run_staging_rehearsal_contract_lane.sh"));
+    assert!(PLAN.contains("check_staging_rehearsal_policy.sh"));
+    assert!(PLAN.contains("kamn.release.staged-rehearsal-signoff.v1"));
+    assert!(PLAN.contains("staged_rehearsal_signoff_status=verified|fail-closed"));
+}
+
+#[test]
 fn plan_contains_local_fork_bootstrap_readiness_contract_lane() {
     assert!(PLAN.contains("## Local Kolme Fork Bootstrap/Readiness Contract Lane"));
     assert!(PLAN.contains("run_local_kolme_fork_bootstrap_readiness_lane.sh"));

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -76,6 +76,8 @@ fn checklist_contains_staging_rehearsal_contract() {
     assert!(CHECKLIST.contains("check_staging_rehearsal_policy.sh"));
     assert!(CHECKLIST.contains("run_staging_rehearsal_contract_lane.sh"));
     assert!(CHECKLIST.contains("run_staging_rehearsal_deep_lane.sh"));
+    assert!(CHECKLIST.contains("kamn.release.staged-rehearsal-signoff.v1"));
+    assert!(CHECKLIST.contains("staged_rehearsal_signoff_status=verified|fail-closed"));
     assert!(CHECKLIST.contains("--recovery-time-seconds"));
     assert!(CHECKLIST.contains("--max-allowed-recovery-time-seconds"));
     assert!(CHECKLIST.contains("mttr-threshold-exceeded"));

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -153,9 +153,13 @@ Staging rehearsal automation must verify deploy and rollback outcomes before rel
   - `scripts/deploy/staging_rehearsal_contract.py`
 - Scheduled deep lane entrypoint:
   - `bash scripts/deploy/run_staging_rehearsal_deep_lane.sh`
+- Staged signoff artifact schema:
+  - `kamn.release.staged-rehearsal-signoff.v1`
+  - policy output marker: `staged_rehearsal_signoff_status=verified|fail-closed`
 - Regression policy:
   - rollback target hash mismatch and incomplete rehearsal evidence force `NO-GO` (`Regression: #623`).
   - MTTR evidence drift and out-of-bound recovery time force `NO-GO` (`Regression: #2337`).
+  - staged signoff artifact drift fails closed (`staged rehearsal signoff artifact mismatch`) (`Regression: #3241`).
   - bounded MTTR policy emits deterministic markers: `recovery_time_seconds`, `max_allowed_recovery_time_seconds`, `mttr_within_bound`, and reason code `mttr-threshold-exceeded`.
 
 ## Durable Guard Migration + Recovery Matrix Evidence (Issue #691)

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1112,6 +1112,19 @@ Operator checkpoints:
   - `milestone_review_go_no_go_gate_final_decision_mismatch`
   - `milestone review bundle lineage mismatch`
 
+## Staged Rehearsal Signoff Artifact Contract (Issue #3241)
+
+- Rehearsal fast-lane contract command:
+  - `bash scripts/deploy/run_staging_rehearsal_contract_lane.sh`
+- Rehearsal policy checker command:
+  - `bash scripts/deploy/check_staging_rehearsal_policy.sh --bundle-file /tmp/staging-rehearsal-report.json`
+- Signoff schema marker:
+  - `kamn.release.staged-rehearsal-signoff.v1`
+- Policy output marker:
+  - `staged_rehearsal_signoff_status=verified|fail-closed`
+- Fail-closed behavior:
+  - deterministic signoff-schema or contract drift yields `staged rehearsal signoff artifact mismatch`.
+
 ## Localhost Two-Process Signed-Message Demo Contract (Issue #1612)
 
 - Makefile demo command:

--- a/scripts/deploy/run_staging_rehearsal_deep_lane.sh
+++ b/scripts/deploy/run_staging_rehearsal_deep_lane.sh
@@ -40,5 +40,9 @@ if ! printf '%s\n' "$policy_output" | grep -q "^mttr_within_bound=false$"; then
   echo "expected deep-lane policy check to report out-of-bound MTTR evidence" >&2
   exit 1
 fi
+if ! printf '%s\n' "$policy_output" | grep -q "^staged_rehearsal_signoff_status=fail-closed$"; then
+  echo "expected deep-lane policy check to report fail-closed staged rehearsal signoff status" >&2
+  exit 1
+fi
 
 echo "staging rehearsal deep lane tests passed."

--- a/scripts/deploy/staging_rehearsal_contract.py
+++ b/scripts/deploy/staging_rehearsal_contract.py
@@ -21,9 +21,21 @@ from framework.contract_framework import (  # noqa: E402
 )
 
 SCHEMA_VERSION = "kamn.release.staging-rehearsal.v1"
+STAGED_REHEARSAL_SIGNOFF_SCHEMA_VERSION = "kamn.release.staged-rehearsal-signoff.v1"
 GO_DECISION = "GO"
 NO_GO_DECISION = "NO-GO"
 MAX_BPS = 10_000
+SIGNOFF_REQUIRED_ARTIFACTS = (
+    "deploy_status",
+    "rollback_status",
+    "rollback_hash_match",
+    "mttr_within_bound",
+    "runtime_submit_success_rate_within_bound",
+    "runtime_finality_timeouts_within_bound",
+    "signer_profile_drift_within_bound",
+    "evidence_complete",
+    "ci_fast_gate",
+)
 
 
 def _parse_pass_fail(field_name: str, raw_value: str) -> str:
@@ -98,6 +110,51 @@ def _compute_decision_reasons(
     return decision_reasons
 
 
+def _build_staged_rehearsal_signoff_artifact(
+    *,
+    final_decision: str,
+    decision_reasons: list[str],
+    deploy_status: str,
+    rollback_status: str,
+    rollback_hash_match: bool,
+    mttr_within_bound: bool,
+    runtime_submit_success_rate_within_bound: bool,
+    runtime_finality_timeouts_within_bound: bool,
+    signer_profile_drift_within_bound: bool,
+    evidence_complete: bool,
+    ci_fast_gate: str,
+) -> dict[str, Any]:
+    lineage_status = "verified" if final_decision == GO_DECISION else "fail-closed"
+    return {
+        "schema_version": STAGED_REHEARSAL_SIGNOFF_SCHEMA_VERSION,
+        "lineage_status": lineage_status,
+        "final_decision": final_decision,
+        "required_artifacts": list(SIGNOFF_REQUIRED_ARTIFACTS),
+        "observed_artifacts": {
+            "deploy_status": deploy_status,
+            "rollback_status": rollback_status,
+            "rollback_hash_match": rollback_hash_match,
+            "mttr_within_bound": mttr_within_bound,
+            "runtime_submit_success_rate_within_bound": runtime_submit_success_rate_within_bound,
+            "runtime_finality_timeouts_within_bound": runtime_finality_timeouts_within_bound,
+            "signer_profile_drift_within_bound": signer_profile_drift_within_bound,
+            "evidence_complete": evidence_complete,
+            "ci_fast_gate": ci_fast_gate,
+        },
+        "reason_codes": decision_reasons,
+        "contracts": {
+            "go_no_go_readiness_required": True,
+            "rollback_hash_match_required": True,
+            "mttr_within_bound_required": True,
+            "runtime_submit_success_rate_within_bound_required": True,
+            "runtime_finality_timeouts_within_bound_required": True,
+            "signer_profile_drift_within_bound_required": True,
+            "evidence_complete_required": True,
+            "ci_fast_gate_pass_required": True,
+        },
+    }
+
+
 def generate_bundle(args: argparse.Namespace) -> int:
     required_values = (
         args.output_file,
@@ -170,6 +227,20 @@ def generate_bundle(args: argparse.Namespace) -> int:
     if not decision_reasons:
         decision_reasons.append("all rehearsal gates satisfied")
 
+    staged_rehearsal_signoff = _build_staged_rehearsal_signoff_artifact(
+        final_decision=final_decision,
+        decision_reasons=decision_reasons,
+        deploy_status=deploy_status,
+        rollback_status=rollback_status,
+        rollback_hash_match=rollback_hash_match,
+        mttr_within_bound=mttr_within_bound,
+        runtime_submit_success_rate_within_bound=runtime_submit_success_rate_within_bound,
+        runtime_finality_timeouts_within_bound=runtime_finality_timeouts_within_bound,
+        signer_profile_drift_within_bound=signer_profile_drift_within_bound,
+        evidence_complete=evidence_complete,
+        ci_fast_gate=ci_fast_gate,
+    )
+
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -195,6 +266,7 @@ def generate_bundle(args: argparse.Namespace) -> int:
             "evidence_complete": evidence_complete,
             "ci_fast_gate": ci_fast_gate,
         },
+        "staged_rehearsal_signoff": staged_rehearsal_signoff,
         "decision_reasons": decision_reasons,
         "final_decision": final_decision,
     }
@@ -237,6 +309,7 @@ def check_bundle(args: argparse.Namespace) -> int:
             "generated_at",
             "release_candidate",
             "rehearsal",
+            "staged_rehearsal_signoff",
             "decision_reasons",
             "final_decision",
         ),
@@ -446,6 +519,29 @@ def check_bundle(args: argparse.Namespace) -> int:
         decision_reasons if decision_reasons else ["all rehearsal gates satisfied"]
     )
 
+    expected_signoff_artifact = _build_staged_rehearsal_signoff_artifact(
+        final_decision=expected_decision,
+        decision_reasons=expected_decision_reasons,
+        deploy_status=deploy_status,
+        rollback_status=rollback_status,
+        rollback_hash_match=rollback_hash_match,
+        mttr_within_bound=mttr_within_bound,
+        runtime_submit_success_rate_within_bound=runtime_submit_success_rate_within_bound,
+        runtime_finality_timeouts_within_bound=runtime_finality_timeouts_within_bound,
+        signer_profile_drift_within_bound=signer_profile_drift_within_bound,
+        evidence_complete=evidence_complete,
+        ci_fast_gate=ci_fast_gate,
+    )
+
+    staged_rehearsal_signoff = payload.get("staged_rehearsal_signoff")
+    if not isinstance(staged_rehearsal_signoff, dict):
+        fail("bundle field 'staged_rehearsal_signoff' must be an object")
+    if staged_rehearsal_signoff != expected_signoff_artifact:
+        fail(
+            "staged rehearsal signoff artifact mismatch: "
+            "expected deterministic signoff schema, contracts, and decision surface"
+        )
+
     actual_decision_reasons = payload.get("decision_reasons")
     if not isinstance(actual_decision_reasons, list) or not all(
         isinstance(reason, str) for reason in actual_decision_reasons
@@ -497,6 +593,10 @@ def check_bundle(args: argparse.Namespace) -> int:
     print(
         "signer_profile_drift_within_bound="
         f"{str(signer_profile_drift_within_bound).lower()}"
+    )
+    print(
+        "staged_rehearsal_signoff_status="
+        f"{expected_signoff_artifact['lineage_status']}"
     )
     print(f"reason_codes={','.join(expected_decision_reasons)}")
     print(f"evidence_complete={str(evidence_complete).lower()}")

--- a/scripts/deploy/staging_rehearsal_contract_lane_contract.sh
+++ b/scripts/deploy/staging_rehearsal_contract_lane_contract.sh
@@ -37,5 +37,9 @@ if ! printf '%s\n' "$policy_output" | grep -q "^mttr_within_bound=true$"; then
   echo "expected rehearsal contract lane policy check to confirm bounded MTTR evidence" >&2
   exit 1
 fi
+if ! printf '%s\n' "$policy_output" | grep -q "^staged_rehearsal_signoff_status=verified$"; then
+  echo "expected rehearsal contract lane policy check to confirm verified staged rehearsal signoff" >&2
+  exit 1
+fi
 
 echo "staging rehearsal contract lane tests passed."

--- a/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
+++ b/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
@@ -57,10 +57,33 @@ go_generate_output="$(
 assert_eq "$(extract_value "$go_generate_output" "status")" "generated" "expected GO rehearsal bundle generation to succeed"
 assert_eq "$(extract_value "$go_generate_output" "final_decision")" "GO" "expected generator to derive GO rehearsal decision"
 
+python3 - "$go_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+signoff = payload.get("staged_rehearsal_signoff")
+if not isinstance(signoff, dict):
+    raise SystemExit("expected staged_rehearsal_signoff object")
+if signoff.get("schema_version") != "kamn.release.staged-rehearsal-signoff.v1":
+    raise SystemExit("expected staged_rehearsal_signoff schema marker")
+if signoff.get("lineage_status") != "verified":
+    raise SystemExit("expected staged_rehearsal_signoff lineage_status=verified for GO rehearsal")
+if signoff.get("final_decision") != "GO":
+    raise SystemExit("expected staged_rehearsal_signoff final_decision=GO for GO rehearsal")
+required_artifacts = signoff.get("required_artifacts")
+if not isinstance(required_artifacts, list) or "rollback_hash_match" not in required_artifacts:
+    raise SystemExit("expected staged_rehearsal_signoff required_artifacts to include rollback_hash_match")
+if "contracts" not in signoff:
+    raise SystemExit("expected staged_rehearsal_signoff contracts object")
+PY
+
 go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$go_bundle")"
 assert_eq "$(extract_value "$go_policy_output" "status")" "ok" "expected GO rehearsal policy check to pass"
 assert_eq "$(extract_value "$go_policy_output" "final_decision")" "GO" "expected GO rehearsal policy check decision"
 assert_eq "$(extract_value "$go_policy_output" "mttr_within_bound")" "true" "expected GO rehearsal policy check to report bounded MTTR"
+assert_eq "$(extract_value "$go_policy_output" "staged_rehearsal_signoff_status")" "verified" "expected policy checker to report verified staged rehearsal signoff status for GO rehearsal"
 
 no_go_bundle="$TMP_DIR/rehearsal-no-go.json"
 no_go_generate_output="$(
@@ -131,6 +154,7 @@ assert_eq "$(extract_value "$telemetry_no_go_generate_output" "final_decision")"
 telemetry_no_go_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$telemetry_no_go_bundle")"
 assert_eq "$(extract_value "$telemetry_no_go_policy_output" "status")" "ok" "expected telemetry NO-GO rehearsal policy check to pass"
 assert_eq "$(extract_value "$telemetry_no_go_policy_output" "final_decision")" "NO-GO" "expected telemetry NO-GO rehearsal policy check decision"
+assert_eq "$(extract_value "$telemetry_no_go_policy_output" "staged_rehearsal_signoff_status")" "fail-closed" "expected policy checker to report fail-closed staged rehearsal signoff status for NO-GO rehearsal"
 
 telemetry_reason_codes="$(extract_value "$telemetry_no_go_policy_output" "reason_codes")"
 if ! printf '%s\n' "$telemetry_reason_codes" | grep -q "runtime_submit_success_rate_below_threshold"; then

--- a/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
+++ b/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
@@ -72,6 +72,11 @@ if ! grep -Fq -- "--max-allowed-recovery-time-seconds" "$SHARED_CONTRACT"; then
   exit 1
 fi
 
+if ! grep -Fq "staged_rehearsal_signoff_status=verified" "$SHARED_CONTRACT"; then
+  echo "expected staging rehearsal shared contract module to assert verified staged signoff status" >&2
+  exit 1
+fi
+
 if ! grep -Fq -- "--recovery-time-seconds" "$DEEP_SCRIPT"; then
   echo "expected staging rehearsal deep-lane runner to pass deterministic MTTR evidence markers" >&2
   exit 1
@@ -79,6 +84,11 @@ fi
 
 if ! grep -Fq -- "--max-allowed-recovery-time-seconds" "$DEEP_SCRIPT"; then
   echo "expected staging rehearsal deep-lane runner to pass bounded MTTR contract markers" >&2
+  exit 1
+fi
+
+if ! grep -Fq "staged_rehearsal_signoff_status=fail-closed" "$DEEP_SCRIPT"; then
+  echo "expected staging rehearsal deep-lane runner to assert fail-closed staged signoff status" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #3241
Refs #3239

## Summary
This adds a deterministic staged rehearsal signoff artifact contract to the existing staging rehearsal lane so go/no-go readiness has an auditable schema and fail-closed validation path. It also updates contract-lane checks and documentation contracts for the new signoff markers.

## Changes
- `scripts/deploy/staging_rehearsal_contract.py`
  - Adds `staged_rehearsal_signoff` artifact generation (`kamn.release.staged-rehearsal-signoff.v1`) with deterministic required/observed artifact fields and signoff contract markers.
  - Enforces exact signoff artifact validation during `check` and emits `staged_rehearsal_signoff_status=verified|fail-closed`.
- `scripts/deploy/test_generate_staging_rehearsal_bundle.sh`
  - Adds schema/signoff assertions and policy output checks for GO/NO-GO signoff status.
- `scripts/deploy/staging_rehearsal_contract_lane_contract.sh`
  - Requires verified signoff status in fast contract lane.
- `scripts/deploy/run_staging_rehearsal_deep_lane.sh`
  - Requires fail-closed signoff status in deep MTTR-breach scenario.
- `scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`
  - Adds regression guards for signoff status assertions in shared/deep lane modules.
- `docs/foundation/release-gonogo-checklist.md`
  - Documents staged signoff schema and fail-closed marker behavior.
- `docs/planning/kolme-devnet-ops.md`
  - Adds staged rehearsal signoff artifact contract section for operator runbook parity.
- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`
  - Adds checklist docs-contract assertions for staged signoff markers.
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
  - Adds plan docs-contract assertions for staged signoff contract section/markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh`
  - failed with: `expected staged_rehearsal_signoff object`
- `cargo test -p kamn-core --test release_gonogo_checklist_docs checklist_contains_staging_rehearsal_contract -- --exact`
  - failed with missing checklist marker assertion: `kamn.release.staged-rehearsal-signoff.v1`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs plan_contains_staged_rehearsal_signoff_artifact_contract -- --exact`
  - failed with missing plan section assertion: `## Staged Rehearsal Signoff Artifact Contract (Issue #3241)`

### 🟢 Green Phase
- `bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh`
- `bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`
- `cargo test -p kamn-core --test release_gonogo_checklist_docs checklist_contains_staging_rehearsal_contract -- --exact`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs plan_contains_staged_rehearsal_signoff_artifact_contract -- --exact`

### 🔁 Regression
- `python3 -m py_compile scripts/deploy/staging_rehearsal_contract.py`
- `bash -n scripts/deploy/test_generate_staging_rehearsal_bundle.sh scripts/deploy/staging_rehearsal_contract_lane_contract.sh scripts/deploy/run_staging_rehearsal_deep_lane.sh scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`
- `bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh`
- `bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`
- `bash scripts/deploy/test_run_gonogo_evidence_contract_lane.sh`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --test release_gonogo_checklist_docs --test kolme_devnet_ops_docs -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Signoff schema/field validation in `scripts/deploy/test_generate_staging_rehearsal_bundle.sh` | |
| Functional   | ✅ | Lane behavior assertions in `scripts/deploy/staging_rehearsal_contract_lane_contract.sh` and `scripts/deploy/run_staging_rehearsal_deep_lane.sh` | |
| Integration  | ✅ | End-to-end staging rehearsal bundle generation + checker path via `scripts/deploy/test_generate_staging_rehearsal_bundle.sh` | |
| Regression   | ✅ | Contract-lane wrapper regression in `scripts/deploy/test_run_staging_rehearsal_contract_lane.sh` and docs contracts | |
| Performance  | ✅ | Existing bounded staging rehearsal runtime checks retained; no unbounded CI path added | |

## Risks & Rollback
- Risk: stricter checker behavior now fails closed if staged signoff artifact drifts.
- Rollback plan: revert commit `36b06ab`.

## Documentation Updates
- `docs/foundation/release-gonogo-checklist.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (targeted scope)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
