### PR TITLE
fix(ci): make script-surface shell-line metric symlink-aware

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -249,7 +249,8 @@ Cost boundary:
 `scripts/ci/check_script_duplication_budget.py` computes deterministic metrics over non-test shell command surface under `scripts/**/*.sh`:
 
 - files named `test_*.sh` are excluded from metric totals
-- symlink wrappers remain counted for `script_count`/`shell_line_total`
+- symlink wrappers remain counted for `script_count`
+- symlink wrappers contribute a fixed `1` line each to `shell_line_total` (prevents target-body double counting)
 - symlink wrappers are excluded from `duplicate_content`
 
 - `script_count`

--- a/scripts/ci/check_script_duplication_budget.py
+++ b/scripts/ci/check_script_duplication_budget.py
@@ -110,10 +110,14 @@ def compute_metrics(scripts_root: Path) -> ScriptMetrics:
         path for path in scripts_root.rglob("*.sh") if include_in_budget(path)
     )
     script_count = len(scripts)
-    shell_line_total = sum(
-        sum(1 for _ in path.open("r", encoding="utf-8", errors="ignore"))
-        for path in scripts
-    )
+    def shell_lines_for_budget(path: Path) -> int:
+        # Symlink wrappers represent command-surface entries, not full copies
+        # of the target implementation body.
+        if path.is_symlink():
+            return 1
+        return sum(1 for _ in path.open("r", encoding="utf-8", errors="ignore"))
+
+    shell_line_total = sum(shell_lines_for_budget(path) for path in scripts)
 
     basename_counts = Counter(path.name for path in scripts)
     duplicate_basename = sum(

--- a/scripts/ci/test_check_script_duplication_budget.sh
+++ b/scripts/ci/test_check_script_duplication_budget.sh
@@ -62,6 +62,10 @@ if ! printf '%s\n' "$pass_output" | grep -q '^delta_script_count=2$'; then
   echo "expected deterministic script_count delta output on pass path" >&2
   exit 1
 fi
+if ! printf '%s\n' "$pass_output" | grep -q '^shell_line_total=5$'; then
+  echo "expected symlink wrappers to contribute one line each in shell_line_total metric" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$pass_output" | grep -q '^duplicate_content=0$'; then
   echo "expected symlink wrappers to be excluded from duplicate_content metric" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Makes script-surface `shell_line_total` accounting symlink-aware so wrapper symlinks do not double-count implementation file bodies.
- Preserves fail-closed budget/waiver behavior while restoring deterministic unwaived budget signal.

## Linked Issues
- Closes #3328
- Refs #3326
- Refs #3325
- Refs #3324

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: `ci-fast-gate` behavior through `scripts/ci/check_script_duplication_budget.sh` metric semantics only
Expected runtime delta: negligible
Expected runner-minute delta: negligible
Rollback plan if CI cost/runtime regresses: revert this PR

## Changes
- `scripts/ci/check_script_duplication_budget.py`: symlink wrappers now contribute fixed `1` line to `shell_line_total`; regular files keep full line counting.
- `scripts/ci/test_check_script_duplication_budget.sh`: adds explicit regression assertion for symlink line accounting.
- `docs/ci/ci-cost-and-lane-framework.md`: documents symlink-aware shell-line metric semantics.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/ci/check_script_duplication_budget.sh --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file /tmp/missing-script-surface-waiver.json`
- Before change: `status=fail`, `shell_line_total=58408`, `violations=shell_line_total`, `waived=none`.

### 🟢 Green Phase
- `bash scripts/ci/test_check_script_duplication_budget.sh`
- `bash scripts/ci/check_script_duplication_budget.sh --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file /tmp/missing-script-surface-waiver.json`
- After change: `status=pass`, `shell_line_total=28153`, `violations=none`, `waived=none`.

### 🔁 Regression
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | Shell checker path-level change covered by functional regression script |
| Functional   | ✅ | `scripts/ci/test_check_script_duplication_budget.sh` | |
| Integration  | ✅ | `scripts/ci/test_ci_tools.sh` fast-mode suite | |
| Regression   | ✅ | unwaived script-budget pass path + existing checker fail-closed matrix | |
| Performance  | N/A | | No production runtime-path changes |

## Risks & Rollback
- Risk: budget metric trend discontinuity in script-surface historical comparisons.
- Rollback: revert this PR.

## Documentation Updates
- Updated `docs/ci/ci-cost-and-lane-framework.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (not applicable to shell/docs-only patch; no Rust source touched)
- [x] `cargo clippy -- -D warnings` — clean (not applicable to shell/docs-only patch; no Rust source touched)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
