### PR TITLE
chore(ci): retire script-surface waiver artifact

### DIFF
--- a/.ci/script-surface-budget-waiver.json
+++ b/.ci/script-surface-budget-waiver.json
@@ -1,7 +1,0 @@
-{
-  "reason": "Temporary shell line overrun during dispatcher migration tracked by #3323; remove after shell surface reduction lands.",
-  "expires_on": "2026-03-31",
-  "allow_metrics": [
-    "shell_line_total"
-  ]
-}

--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -269,7 +269,6 @@ The checker fails closed when any metric exceeds its configured threshold and em
 
 ## Waiver Rules
 Temporary exceptions are allowed through `.ci/script-surface-budget-waiver.json`.
-The repository currently tracks a temporary waiver for `shell_line_total` with expiry `2026-03-31` (`#3323`); keep this waiver short-lived and remove it once script-surface reductions land.
 Required fields:
 
 - `reason` (non-empty string)

--- a/scripts/ci/test_check_script_duplication_budget.sh
+++ b/scripts/ci/test_check_script_duplication_budget.sh
@@ -75,6 +75,23 @@ if ! printf '%s\n' "$pass_output" | grep -q '^remediation=none$'; then
   exit 1
 fi
 
+missing_waiver_pass_output="$(
+  bash "$SCRIPT" \
+    --scripts-root "$SCRIPTS_ROOT" \
+    --budget-file "$PASS_BUDGET" \
+    --baseline-file "$BASELINE_FILE" \
+    --waiver-file "$TMP_DIR/missing-waiver.json"
+)"
+
+if ! printf '%s\n' "$missing_waiver_pass_output" | grep -q '^status=pass$'; then
+  echo "expected checker pass path to remain green when waiver file is absent" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_waiver_pass_output" | grep -q '^waived=none$'; then
+  echo "expected waived marker to remain none when waiver file is absent and no violations exist" >&2
+  exit 1
+fi
+
 TEST_EXCLUSION_BUDGET="$TMP_DIR/test-exclusion-budget.env"
 cat >"$TEST_EXCLUSION_BUDGET" <<'EOF_BUDGET'
 SCRIPT_COUNT_MAX=3


### PR DESCRIPTION
## Summary
- Retires `.ci/script-surface-budget-waiver.json` now that script-surface budget checks pass unwaived after symlink-aware accounting.
- Adds regression coverage proving pass-path behavior when the waiver file is absent.

## Linked Issues
- Closes #3327
- Refs #3325
- Refs #3324

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: `ci-fast-gate` script-surface checker path and docs contract surfaces
Expected runtime delta: negligible
Expected runner-minute delta: negligible
Rollback plan if CI cost/runtime regresses: revert this PR

## Changes
- `.ci/script-surface-budget-waiver.json`: removed (waiver retired).
- `scripts/ci/test_check_script_duplication_budget.sh`: adds missing-waiver pass-path regression assertions.
- `docs/ci/ci-cost-and-lane-framework.md`: removes active-waiver note; keeps generic waiver policy.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Missing-waiver pass-path behavior was not explicitly regression-tested while waiver artifact was still tracked.

### 🟢 Green Phase
- `bash scripts/ci/test_check_script_duplication_budget.sh`
- `bash scripts/ci/check_script_duplication_budget.sh --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env`

### 🔁 Regression
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | | Shell/docs-only change |
| Functional   | ✅ | `scripts/ci/test_check_script_duplication_budget.sh` | |
| Integration  | ✅ | `scripts/ci/test_ci_tools.sh` fast-mode suite | |
| Regression   | ✅ | missing-waiver pass-path + existing checker matrix | |
| Performance  | N/A | | No runtime hot-path change |

## Risks & Rollback
- Risk: none expected; waiver retirement only.
- Rollback: revert this PR.

## Documentation Updates
- Updated `docs/ci/ci-cost-and-lane-framework.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean (not applicable to shell/docs-only patch)
- [x] `cargo clippy -- -D warnings` — clean (not applicable to shell/docs-only patch)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
