### PR TITLE
feat(node): add runtime-mode full bootstrap readiness contracts (#3358)

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -639,7 +639,10 @@ where
             return Err(ConfigError::MissingArgumentValue("--rejoin-attempt"));
         }
     }
-    if runtime_mode.kind == RuntimeModeKind::Daemon {
+    if matches!(
+        runtime_mode.kind,
+        RuntimeModeKind::Daemon | RuntimeModeKind::Full
+    ) {
         if daemon_max_ticks.is_none() {
             return Err(ConfigError::MissingArgumentValue("--daemon-max-ticks"));
         }
@@ -670,7 +673,11 @@ where
             ));
         }
     }
-    if runtime_mode.kind == RuntimeModeKind::Api && api_bind_addr.is_none() {
+    if matches!(
+        runtime_mode.kind,
+        RuntimeModeKind::Api | RuntimeModeKind::Full
+    ) && api_bind_addr.is_none()
+    {
         return Err(ConfigError::MissingArgumentValue("--api-bind"));
     }
     if runtime_mode.kind == RuntimeModeKind::KolmeLive {

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -142,6 +142,7 @@ enum RuntimeModeKind {
     RecoveryCheck,
     Daemon,
     Api,
+    Full,
     KolmeLive,
 }
 
@@ -176,6 +177,12 @@ impl RuntimeMode {
         }
     }
 
+    fn full() -> Self {
+        Self {
+            kind: RuntimeModeKind::Full,
+        }
+    }
+
     fn kolme_live() -> Self {
         Self {
             kind: RuntimeModeKind::KolmeLive,
@@ -189,6 +196,7 @@ impl RuntimeMode {
             "recovery-check" => Ok(Self::recovery_check()),
             "daemon" => Ok(Self::daemon()),
             "api" => Ok(Self::api()),
+            "full" => Ok(Self::full()),
             "kolme-live" => Ok(Self::kolme_live()),
             other => Err(ConfigError::InvalidRuntimeMode(other.to_owned())),
         }
@@ -201,6 +209,7 @@ impl RuntimeMode {
             RuntimeModeKind::RecoveryCheck => "recovery-check",
             RuntimeModeKind::Daemon => "daemon",
             RuntimeModeKind::Api => "api",
+            RuntimeModeKind::Full => "full",
             RuntimeModeKind::KolmeLive => "kolme-live",
         }
     }
@@ -353,6 +362,18 @@ struct DaemonExecution {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct DaemonRuntimeOptions {
+    daemon_max_ticks: Option<u64>,
+    daemon_tick_interval_ms: Option<u64>,
+    daemon_shutdown_signal_ticks: Vec<u64>,
+    daemon_shutdown_os_signals: bool,
+    daemon_shutdown_drain_ticks: Option<u64>,
+    daemon_shutdown_timeout_ticks: Option<u64>,
+    daemon_peer_id: Option<String>,
+    daemon_lifecycle_events: Vec<PeerLifecycleEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct KolmeLiveExecution {
     provider_client_contract: String,
     base_url: String,
@@ -487,6 +508,132 @@ fn daemon_shutdown_reason_field<'a>(completion_reason: &'a str, key: &str) -> Op
     })
 }
 
+fn execute_daemon_runtime(
+    runtime_mode: RuntimeMode,
+    execution_id: &str,
+    options: DaemonRuntimeOptions,
+) -> Result<DaemonExecution, ConfigError> {
+    let DaemonRuntimeOptions {
+        daemon_max_ticks,
+        daemon_tick_interval_ms,
+        daemon_shutdown_signal_ticks,
+        daemon_shutdown_os_signals,
+        daemon_shutdown_drain_ticks,
+        daemon_shutdown_timeout_ticks,
+        daemon_peer_id,
+        daemon_lifecycle_events,
+    } = options;
+    let max_ticks =
+        daemon_max_ticks.ok_or(ConfigError::MissingArgumentValue("--daemon-max-ticks"))?;
+    let tick_interval_ms = daemon_tick_interval_ms.ok_or(ConfigError::MissingArgumentValue(
+        "--daemon-tick-interval-ms",
+    ))?;
+    let max_ticks_label = max_ticks.to_string();
+    let tick_interval_ms_label = tick_interval_ms.to_string();
+    log_info(
+        "node.runtime.daemon.execute.start",
+        &[
+            ("runtime_mode", runtime_mode.as_str()),
+            ("max_ticks", max_ticks_label.as_str()),
+            ("tick_interval_ms", tick_interval_ms_label.as_str()),
+            ("execution_id", execution_id),
+        ],
+    )?;
+    let (peer_id, peer_lifecycle_final_state, peer_lifecycle_applied_events) = match daemon_peer_id
+    {
+        Some(peer_id) => {
+            let mut lifecycle = PeerLifecycle::new(&peer_id)
+                .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+            let mut applied_events = Vec::with_capacity(daemon_lifecycle_events.len());
+            for event in daemon_lifecycle_events {
+                lifecycle
+                    .transition(event)
+                    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+                applied_events.push(daemon_lifecycle_event_as_str(event).to_owned());
+            }
+            (
+                Some(peer_id),
+                Some(peer_lifecycle_state_as_str(lifecycle.state()).to_owned()),
+                Some(applied_events),
+            )
+        }
+        None => (None, None, None),
+    };
+    let daemon_completion = if daemon_shutdown_os_signals && daemon_shutdown_signal_ticks.is_empty()
+    {
+        evaluate_daemon_completion_with_os_signals(
+            max_ticks,
+            tick_interval_ms,
+            daemon_shutdown_drain_ticks,
+            daemon_shutdown_timeout_ticks,
+        )
+        .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?
+    } else {
+        evaluate_daemon_completion(
+            max_ticks,
+            daemon_shutdown_signal_ticks.as_slice(),
+            daemon_shutdown_drain_ticks,
+            daemon_shutdown_timeout_ticks,
+        )
+    };
+    let daemon_observability = build_daemon_observability_telemetry(
+        tick_interval_ms,
+        daemon_completion.completion_reason.as_str(),
+    )
+    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+    let shutdown_drain_status =
+        daemon_shutdown_drain_status(daemon_completion.completion_reason.as_str());
+    let shutdown_signal_tick =
+        daemon_shutdown_signal_tick(daemon_completion.completion_reason.as_str()).unwrap_or("none");
+    let shutdown_drain_ticks =
+        daemon_shutdown_reason_field(daemon_completion.completion_reason.as_str(), "drain_ticks")
+            .unwrap_or("0");
+    let shutdown_timeout_ticks = daemon_shutdown_reason_field(
+        daemon_completion.completion_reason.as_str(),
+        "timeout_ticks",
+    )
+    .unwrap_or("0");
+    let shutdown_ignored_signals = daemon_shutdown_reason_field(
+        daemon_completion.completion_reason.as_str(),
+        "ignored_signals",
+    )
+    .unwrap_or("0");
+    let executed_ticks_label = daemon_completion.executed_ticks.to_string();
+    log_info(
+        "node.runtime.daemon.execute.complete",
+        &[
+            ("runtime_mode", runtime_mode.as_str()),
+            ("executed_ticks", executed_ticks_label.as_str()),
+            (
+                "completion_reason",
+                daemon_completion.completion_reason.as_str(),
+            ),
+            ("shutdown_drain_status", shutdown_drain_status),
+            ("shutdown_signal_tick", shutdown_signal_tick),
+            ("shutdown_drain_ticks", shutdown_drain_ticks),
+            ("shutdown_timeout_ticks", shutdown_timeout_ticks),
+            ("shutdown_ignored_signals", shutdown_ignored_signals),
+            ("execution_id", execution_id),
+        ],
+    )?;
+    Ok(DaemonExecution {
+        max_ticks,
+        tick_interval_ms,
+        executed_ticks: daemon_completion.executed_ticks,
+        completion_reason: daemon_completion.completion_reason,
+        observability_latency_p50_ms: daemon_observability.latency_p50_ms,
+        observability_latency_p99_ms: daemon_observability.latency_p99_ms,
+        observability_throughput_tps: daemon_observability.throughput_tps,
+        observability_error_rate_bps: daemon_observability.error_rate_bps,
+        observability_availability_bps: daemon_observability.availability_bps,
+        observability_health: daemon_observability.health,
+        observability_alert_count: daemon_observability.alert_count,
+        peer_id,
+        peer_lifecycle_final_state,
+        peer_lifecycle_applied_events,
+    })
+}
+
 fn run() -> Result<(), ConfigError> {
     let cli = parse_args(env::args())?;
     let runtime_mode = cli.runtime_mode.as_str();
@@ -529,9 +676,9 @@ fn run() -> Result<(), ConfigError> {
     )?;
     println!("{}", render_bootstrap_report(&report, output_mode));
     if let Some(endpoint_config) = service_api_endpoint_config {
-        if report.runtime_mode != "api" {
+        if report.runtime_mode != "api" && report.runtime_mode != "full" {
             return Err(ConfigError::RuntimeDaemonLifecycle(
-                "service api endpoint requires runtime-mode api".to_owned(),
+                "service api endpoint requires runtime-mode api or full".to_owned(),
             ));
         }
         let snapshot = build_service_api_snapshot(&report);
@@ -789,120 +936,22 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             }
         }
         RuntimeModeKind::Daemon => {
-            let max_ticks =
-                daemon_max_ticks.ok_or(ConfigError::MissingArgumentValue("--daemon-max-ticks"))?;
-            let tick_interval_ms = daemon_tick_interval_ms.ok_or(
-                ConfigError::MissingArgumentValue("--daemon-tick-interval-ms"),
-            )?;
-            let max_ticks_label = max_ticks.to_string();
-            let tick_interval_ms_label = tick_interval_ms.to_string();
-            log_info(
-                "node.runtime.daemon.execute.start",
-                &[
-                    ("runtime_mode", runtime_mode.as_str()),
-                    ("max_ticks", max_ticks_label.as_str()),
-                    ("tick_interval_ms", tick_interval_ms_label.as_str()),
-                    ("execution_id", execution_id.as_str()),
-                ],
-            )?;
-            let (peer_id, peer_lifecycle_final_state, peer_lifecycle_applied_events) =
-                match daemon_peer_id {
-                    Some(peer_id) => {
-                        let mut lifecycle = PeerLifecycle::new(&peer_id).map_err(|error| {
-                            ConfigError::RuntimeDaemonLifecycle(error.to_string())
-                        })?;
-                        let mut applied_events = Vec::with_capacity(daemon_lifecycle_events.len());
-                        for event in daemon_lifecycle_events {
-                            lifecycle.transition(event).map_err(|error| {
-                                ConfigError::RuntimeDaemonLifecycle(error.to_string())
-                            })?;
-                            applied_events.push(daemon_lifecycle_event_as_str(event).to_owned());
-                        }
-                        (
-                            Some(peer_id),
-                            Some(peer_lifecycle_state_as_str(lifecycle.state()).to_owned()),
-                            Some(applied_events),
-                        )
-                    }
-                    None => (None, None, None),
-                };
-            let daemon_completion =
-                if daemon_shutdown_os_signals && daemon_shutdown_signal_ticks.is_empty() {
-                    evaluate_daemon_completion_with_os_signals(
-                        max_ticks,
-                        tick_interval_ms,
-                        daemon_shutdown_drain_ticks,
-                        daemon_shutdown_timeout_ticks,
-                    )
-                    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?
-                } else {
-                    evaluate_daemon_completion(
-                        max_ticks,
-                        daemon_shutdown_signal_ticks.as_slice(),
-                        daemon_shutdown_drain_ticks,
-                        daemon_shutdown_timeout_ticks,
-                    )
-                };
-            let daemon_observability = build_daemon_observability_telemetry(
-                tick_interval_ms,
-                daemon_completion.completion_reason.as_str(),
-            )
-            .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
-            let shutdown_drain_status =
-                daemon_shutdown_drain_status(daemon_completion.completion_reason.as_str());
-            let shutdown_signal_tick =
-                daemon_shutdown_signal_tick(daemon_completion.completion_reason.as_str())
-                    .unwrap_or("none");
-            let shutdown_drain_ticks = daemon_shutdown_reason_field(
-                daemon_completion.completion_reason.as_str(),
-                "drain_ticks",
-            )
-            .unwrap_or("0");
-            let shutdown_timeout_ticks = daemon_shutdown_reason_field(
-                daemon_completion.completion_reason.as_str(),
-                "timeout_ticks",
-            )
-            .unwrap_or("0");
-            let shutdown_ignored_signals = daemon_shutdown_reason_field(
-                daemon_completion.completion_reason.as_str(),
-                "ignored_signals",
-            )
-            .unwrap_or("0");
-            let executed_ticks_label = daemon_completion.executed_ticks.to_string();
-            log_info(
-                "node.runtime.daemon.execute.complete",
-                &[
-                    ("runtime_mode", runtime_mode.as_str()),
-                    ("executed_ticks", executed_ticks_label.as_str()),
-                    (
-                        "completion_reason",
-                        daemon_completion.completion_reason.as_str(),
-                    ),
-                    ("shutdown_drain_status", shutdown_drain_status),
-                    ("shutdown_signal_tick", shutdown_signal_tick),
-                    ("shutdown_drain_ticks", shutdown_drain_ticks),
-                    ("shutdown_timeout_ticks", shutdown_timeout_ticks),
-                    ("shutdown_ignored_signals", shutdown_ignored_signals),
-                    ("execution_id", execution_id.as_str()),
-                ],
+            let daemon_execution = execute_daemon_runtime(
+                runtime_mode,
+                execution_id.as_str(),
+                DaemonRuntimeOptions {
+                    daemon_max_ticks,
+                    daemon_tick_interval_ms,
+                    daemon_shutdown_signal_ticks,
+                    daemon_shutdown_os_signals,
+                    daemon_shutdown_drain_ticks,
+                    daemon_shutdown_timeout_ticks,
+                    daemon_peer_id,
+                    daemon_lifecycle_events,
+                },
             )?;
             RuntimeExecutionBundle {
-                daemon: Some(DaemonExecution {
-                    max_ticks,
-                    tick_interval_ms,
-                    executed_ticks: daemon_completion.executed_ticks,
-                    completion_reason: daemon_completion.completion_reason,
-                    observability_latency_p50_ms: daemon_observability.latency_p50_ms,
-                    observability_latency_p99_ms: daemon_observability.latency_p99_ms,
-                    observability_throughput_tps: daemon_observability.throughput_tps,
-                    observability_error_rate_bps: daemon_observability.error_rate_bps,
-                    observability_availability_bps: daemon_observability.availability_bps,
-                    observability_health: daemon_observability.health,
-                    observability_alert_count: daemon_observability.alert_count,
-                    peer_id,
-                    peer_lifecycle_final_state,
-                    peer_lifecycle_applied_events,
-                }),
+                daemon: Some(daemon_execution),
                 ..RuntimeExecutionBundle::default()
             }
         }
@@ -915,6 +964,48 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 ],
             )?;
             RuntimeExecutionBundle::default()
+        }
+        RuntimeModeKind::Full => {
+            log_info(
+                "node.runtime.full.bootstrap.start",
+                &[("execution_id", execution_id.as_str())],
+            )?;
+            for (stage_index, component) in ["daemon", "api", "transport", "kolme-commit"]
+                .into_iter()
+                .enumerate()
+            {
+                let stage_index_label = (stage_index + 1).to_string();
+                log_info(
+                    "node.runtime.full.bootstrap.component.ready",
+                    &[
+                        ("component", component),
+                        ("stage_index", stage_index_label.as_str()),
+                        ("execution_id", execution_id.as_str()),
+                    ],
+                )?;
+            }
+            let daemon_execution = execute_daemon_runtime(
+                runtime_mode,
+                execution_id.as_str(),
+                DaemonRuntimeOptions {
+                    daemon_max_ticks,
+                    daemon_tick_interval_ms,
+                    daemon_shutdown_signal_ticks,
+                    daemon_shutdown_os_signals,
+                    daemon_shutdown_drain_ticks,
+                    daemon_shutdown_timeout_ticks,
+                    daemon_peer_id,
+                    daemon_lifecycle_events,
+                },
+            )?;
+            log_info(
+                "node.runtime.full.bootstrap.ready",
+                &[("execution_id", execution_id.as_str())],
+            )?;
+            RuntimeExecutionBundle {
+                daemon: Some(daemon_execution),
+                ..RuntimeExecutionBundle::default()
+            }
         }
         RuntimeModeKind::KolmeLive => {
             let base_url = kolme_live_base_url

--- a/crates/kamn-node/src/main_tests/cli_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/cli_contract_tests.rs
@@ -231,6 +231,44 @@ fn rejects_daemon_without_tick_interval() {
 }
 
 #[test]
+fn rejects_full_without_max_ticks() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:19083".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue("--daemon-max-ticks"))
+    );
+}
+
+#[test]
+fn rejects_full_without_api_bind() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ];
+    assert_eq!(
+        parse_args(args),
+        Err(ConfigError::MissingArgumentValue("--api-bind"))
+    );
+}
+
+#[test]
 fn rejects_daemon_shutdown_signal_without_drain_ticks() {
     let args = vec![
         "kamn-node".to_owned(),

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -988,6 +988,29 @@ fn parses_runtime_mode_daemon_with_bounded_controls() {
 }
 
 #[test]
+fn parses_runtime_mode_full_with_required_controls() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:19081".to_owned(),
+    ];
+
+    let parsed = parse_args(args).expect("full args should parse");
+    assert_eq!(parsed.runtime_mode.as_str(), "full");
+    assert_eq!(parsed.daemon_max_ticks, Some(3));
+    assert_eq!(parsed.daemon_tick_interval_ms, Some(25));
+    assert_eq!(parsed.api_bind_addr, Some("127.0.0.1:19081".to_owned()));
+}
+
+#[test]
 fn parses_runtime_mode_daemon_with_shutdown_controls() {
     let args = vec![
         "kamn-node".to_owned(),
@@ -1012,6 +1035,90 @@ fn parses_runtime_mode_daemon_with_shutdown_controls() {
     assert!(!parsed.daemon_shutdown_os_signals);
     assert_eq!(parsed.daemon_shutdown_drain_ticks, Some(2));
     assert_eq!(parsed.daemon_shutdown_timeout_ticks, Some(4));
+}
+
+#[test]
+fn integration_runtime_full_emits_ordered_bootstrap_readiness_markers() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "10".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:19082".to_owned(),
+    ])
+    .expect("full args should parse");
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("runtime-mode full execution should succeed");
+    assert_eq!(report.runtime_mode, "full");
+    assert_eq!(report.daemon_max_ticks, Some(2));
+    let start_idx = captured_logs
+        .iter()
+        .position(|line| line.contains("\"event\":\"node.runtime.full.bootstrap.start\""))
+        .expect("full bootstrap start marker should be emitted");
+    let daemon_idx = captured_logs
+        .iter()
+        .position(|line| {
+            line.contains("\"event\":\"node.runtime.full.bootstrap.component.ready\"")
+                && line.contains("\"component\":\"daemon\"")
+        })
+        .expect("daemon readiness marker should be emitted");
+    let api_idx = captured_logs
+        .iter()
+        .position(|line| {
+            line.contains("\"event\":\"node.runtime.full.bootstrap.component.ready\"")
+                && line.contains("\"component\":\"api\"")
+        })
+        .expect("api readiness marker should be emitted");
+    let transport_idx = captured_logs
+        .iter()
+        .position(|line| {
+            line.contains("\"event\":\"node.runtime.full.bootstrap.component.ready\"")
+                && line.contains("\"component\":\"transport\"")
+        })
+        .expect("transport readiness marker should be emitted");
+    let commit_idx = captured_logs
+        .iter()
+        .position(|line| {
+            line.contains("\"event\":\"node.runtime.full.bootstrap.component.ready\"")
+                && line.contains("\"component\":\"kolme-commit\"")
+        })
+        .expect("kolme commit readiness marker should be emitted");
+    let ready_idx = captured_logs
+        .iter()
+        .position(|line| line.contains("\"event\":\"node.runtime.full.bootstrap.ready\""))
+        .expect("full bootstrap ready marker should be emitted");
+    assert!(
+        start_idx < daemon_idx
+            && daemon_idx < api_idx
+            && api_idx < transport_idx
+            && transport_idx < commit_idx
+            && commit_idx < ready_idx,
+        "full-mode readiness markers must preserve deterministic ordering"
+    );
+    let dispatch_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.mode.dispatch\""))
+        .expect("runtime dispatch marker should be emitted");
+    let ready_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.full.bootstrap.ready\""))
+        .expect("full runtime ready marker should be emitted");
+    let dispatch_execution_id = extract_json_string_field(dispatch_line, "execution_id")
+        .expect("dispatch marker should include execution id");
+    let ready_execution_id = extract_json_string_field(ready_line, "execution_id")
+        .expect("full ready marker should include execution id");
+    assert_eq!(dispatch_execution_id, ready_execution_id);
 }
 
 #[test]

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -27,6 +27,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--runtime-mode planning`
   - `--runtime-mode recovery-check`
   - `--runtime-mode daemon`
+  - `--runtime-mode full`
   - `--runtime-mode kolme-live`
 - Added runtime planning inputs:
   - `--expected-state-hash <state-hash>`
@@ -217,6 +218,9 @@ This document captures node-runtime productionization slices for machine-readabl
   - `kamn-node --role processor --runtime-mode daemon`
   - `kamn-node --role processor --runtime-mode daemon --daemon-max-ticks 3 --daemon-tick-interval-ms 25`
   - `kamn-node --role processor --runtime-mode daemon --daemon-max-ticks 10 --daemon-tick-interval-ms 25 --daemon-shutdown-signal-tick 3 --daemon-shutdown-drain-ticks 2 --daemon-shutdown-timeout-ticks 4`
+- Full mode:
+  - `kamn-node --role processor --runtime-mode full`
+  - `kamn-node --role processor --runtime-mode full --daemon-max-ticks 3 --daemon-tick-interval-ms 25 --api-bind 127.0.0.1:19081`
 - Kolme-live mode:
   - `kamn-node --role processor --runtime-mode kolme-live`
   - `kamn-node --role processor --runtime-mode kolme-live --kolme-live-base-url http://127.0.0.1:3000 --kolme-live-provider-hint kolme-fork-local --kolme-live-signing-profile kolme-fork-secp256k1-v1`
@@ -263,6 +267,23 @@ This document captures node-runtime productionization slices for machine-readabl
   - `daemon_observability_availability_bps`
   - `daemon_observability_health`
   - `daemon_observability_alert_count`
+
+## Full Runtime Rules
+- Supported runtime modes:
+  - `bootstrap` (default)
+  - `full`
+- Full mode requires:
+  - `--daemon-max-ticks`
+  - `--daemon-tick-interval-ms`
+  - `--api-bind`
+- Full mode emits deterministic readiness markers:
+  - `node.runtime.full.bootstrap.start`
+  - `node.runtime.full.bootstrap.component.ready` for ordered components:
+    - `daemon`
+    - `api`
+    - `transport`
+    - `kolme-commit`
+  - `node.runtime.full.bootstrap.ready`
 
 ## Runtime Observability Endpoint Rules
 - Endpoint export is optional and enabled only when `--observability-endpoint-bind` is set.


### PR DESCRIPTION
Closes #3358

## Summary
Adds the first `runtime-mode full` execution slice with deterministic bootstrap/readiness markers and required CLI controls.
This introduces explicit full-mode parse/validation behavior and keeps daemon execution semantics deterministic via shared execution wiring.

## Changes
- `crates/kamn-node/src/main.rs`: added `RuntimeModeKind::Full`, parser/as_str support, full-mode dispatch branch, deterministic bootstrap/readiness markers, and shared daemon execution helper.
- `crates/kamn-node/src/cli.rs`: enforced full-mode required controls (`--daemon-max-ticks`, `--daemon-tick-interval-ms`, `--api-bind`).
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added full-mode parse and ordered readiness marker integration coverage.
- `crates/kamn-node/src/main_tests/cli_contract_tests.rs`: added fail-closed parse tests for missing full-mode required controls.
- `docs/foundation/node-runtime-cli.md`: documented `runtime-mode full` command surface, examples, and readiness markers.

## Risks & Compatibility
- Runtime behavior change: `--runtime-mode full` is now valid and requires daemon + api bind controls.
- Existing runtime modes remain unchanged and covered by regression suite.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated structured marker ordering for full-mode bootstrap via integration test

## TDD Evidence
- Red basis: `runtime-mode full` was previously rejected as invalid (`ConfigError::InvalidRuntimeMode`) and had no readiness marker coverage.
- Green:
  - `cargo test -p kamn-node full -- --nocapture`
  - `cargo test -p kamn-node`
  - `cargo test -p kamn-node --test node_runtime_cli_docs -- --nocapture`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Full-mode parse/validation and helper behavior |
| Functional  | ✅     | Deterministic full-mode bootstrap readiness marker ordering |
| Integration | ✅     | Full `kamn-node` suite green with existing runtime modes |
| Regression  | ✅     | Existing daemon/api/kolme-live tests remain green |
