### PR TITLE
fix(node): emit full-mode supervisor stop choreography markers (#3359)

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1002,6 +1002,26 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 "node.runtime.full.bootstrap.ready",
                 &[("execution_id", execution_id.as_str())],
             )?;
+            let stop_reason = "daemon-execution-complete";
+            let completion_reason = daemon_execution.completion_reason.as_str();
+            let shutdown_drain_status = daemon_shutdown_drain_status(completion_reason);
+            log_info(
+                "node.runtime.full.supervisor.stop.requested",
+                &[
+                    ("stop_reason", stop_reason),
+                    ("daemon_completion_reason", completion_reason),
+                    ("execution_id", execution_id.as_str()),
+                ],
+            )?;
+            log_info(
+                "node.runtime.full.supervisor.stop.complete",
+                &[
+                    ("stop_reason", stop_reason),
+                    ("daemon_completion_reason", completion_reason),
+                    ("shutdown_drain_status", shutdown_drain_status),
+                    ("execution_id", execution_id.as_str()),
+                ],
+            )?;
             RuntimeExecutionBundle {
                 daemon: Some(daemon_execution),
                 ..RuntimeExecutionBundle::default()

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -1122,6 +1122,58 @@ fn integration_runtime_full_emits_ordered_bootstrap_readiness_markers() {
 }
 
 #[test]
+fn regression_runtime_full_emits_supervisor_stop_markers_with_daemon_reason() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "2".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "10".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:19084".to_owned(),
+    ])
+    .expect("full args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("runtime-mode full execution should succeed");
+    assert_eq!(report.runtime_mode, "full");
+    let stop_requested_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.full.supervisor.stop.requested\""))
+        .expect("full runtime should emit supervisor stop-request marker");
+    let stop_complete_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.full.supervisor.stop.complete\""))
+        .expect("full runtime should emit supervisor stop-complete marker");
+    assert_eq!(
+        extract_json_string_field(stop_requested_line, "stop_reason").as_deref(),
+        Some("daemon-execution-complete")
+    );
+    assert_eq!(
+        extract_json_string_field(stop_complete_line, "stop_reason").as_deref(),
+        Some("daemon-execution-complete")
+    );
+    assert_eq!(
+        extract_json_string_field(stop_complete_line, "daemon_completion_reason").as_deref(),
+        Some("tick-budget-exhausted")
+    );
+    let requested_execution_id = extract_json_string_field(stop_requested_line, "execution_id")
+        .expect("stop-request marker should include execution id");
+    let complete_execution_id = extract_json_string_field(stop_complete_line, "execution_id")
+        .expect("stop-complete marker should include execution id");
+    assert_eq!(requested_execution_id, complete_execution_id);
+}
+
+#[test]
 fn parses_runtime_mode_daemon_with_os_signal_shutdown_controls() {
     let args = vec![
         "kamn-node".to_owned(),

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -284,6 +284,8 @@ This document captures node-runtime productionization slices for machine-readabl
     - `transport`
     - `kolme-commit`
   - `node.runtime.full.bootstrap.ready`
+  - `node.runtime.full.supervisor.stop.requested`
+  - `node.runtime.full.supervisor.stop.complete`
 
 ## Runtime Observability Endpoint Rules
 - Endpoint export is optional and enabled only when `--observability-endpoint-bind` is set.


### PR DESCRIPTION
Closes #3359

## Summary
Adds deterministic full-mode supervisor stop choreography markers so cancellation/drain intent and completion are explicit and reason-coded.
This lands the first stop-propagation slice after #3358 by wiring marker emission to daemon completion outcomes.

## Changes
- `crates/kamn-node/src/main.rs`: emit `node.runtime.full.supervisor.stop.requested` and `node.runtime.full.supervisor.stop.complete` with stop reason, daemon completion reason, and drain status.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added regression test asserting supervisor stop markers and execution-id/reason propagation.
- `docs/foundation/node-runtime-cli.md`: documented full-mode supervisor stop markers.

## Risks & Compatibility
- None; additive structured markers for full mode.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified full-mode marker sequence in structured log output

## TDD Evidence
- 🔴 Red:
  - `cargo test -p kamn-node regression_runtime_full_emits_supervisor_stop_markers_with_daemon_reason -- --nocapture`
  - failed because supervisor stop markers were missing.
- 🟢 Green:
  - `cargo test -p kamn-node full -- --nocapture`
  - `cargo test -p kamn-node --test node_runtime_cli_docs -- --nocapture`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Marker field and reason propagation checks |
| Functional  | ✅     | Full-mode supervisor stop marker behavior |
| Integration | ✅     | Full-mode execution path remains green under existing suite |
| Regression  | ✅     | Explicit red-green test for missing marker drift |
