### PR TITLE
feat(node): enforce full-runtime supervisor invariant contracts

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -96,6 +96,8 @@ const KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_ENV: &str =
 const KOLME_LIVE_MANAGED_SIGNER_TIMEOUT_SECONDS_DEFAULT: u64 = 5;
 const KOLME_LIVE_MANAGED_SIGNER_POLL_INTERVAL_MILLIS: u64 = 10;
 const KOLME_LIVE_NATIVE_CREATED_AT: &str = "2026-02-12T00:00:00Z";
+const FULL_RUNTIME_BOOTSTRAP_COMPONENT_SEQUENCE: [&str; 4] =
+    ["daemon", "api", "transport", "kolme-commit"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct OutputMode {
@@ -506,6 +508,103 @@ fn daemon_shutdown_reason_field<'a>(completion_reason: &'a str, key: &str) -> Op
         }
         None
     })
+}
+
+fn classify_full_bootstrap_component_contract_violation(
+    components: &[&str],
+) -> Option<&'static str> {
+    if components.len() != FULL_RUNTIME_BOOTSTRAP_COMPONENT_SEQUENCE.len() {
+        return Some("full_supervisor_bootstrap_component_count_mismatch");
+    }
+    for (component, expected_component) in components
+        .iter()
+        .zip(FULL_RUNTIME_BOOTSTRAP_COMPONENT_SEQUENCE.iter())
+    {
+        if component != expected_component {
+            return Some("full_supervisor_bootstrap_component_order_mismatch");
+        }
+    }
+    None
+}
+
+fn validate_full_bootstrap_component_contract(components: &[&str]) -> Result<(), ConfigError> {
+    if let Some(reason) = classify_full_bootstrap_component_contract_violation(components) {
+        return Err(ConfigError::RuntimeDaemonLifecycle(format!(
+            "full_supervisor_invariant_violation:{reason}"
+        )));
+    }
+    Ok(())
+}
+
+fn classify_full_supervisor_stop_contract_violation(
+    completion_reason: &str,
+    shutdown_drain_status: &str,
+) -> Option<&'static str> {
+    if !matches!(
+        shutdown_drain_status,
+        "completed" | "timeout" | "not-signaled"
+    ) {
+        return Some("full_supervisor_stop_invalid_shutdown_drain_status");
+    }
+    if completion_reason == "tick-budget-exhausted"
+        || completion_reason.starts_with("tick-budget-exhausted;ignored_signals=")
+    {
+        if shutdown_drain_status != "not-signaled" {
+            return Some("full_supervisor_stop_not_signaled_status_mismatch");
+        }
+        return None;
+    }
+    if completion_reason.starts_with("graceful-shutdown:signal@") {
+        if daemon_shutdown_signal_tick(completion_reason).is_none() {
+            return Some("full_supervisor_stop_missing_signal_tick");
+        }
+        if daemon_shutdown_reason_field(completion_reason, "drain_ticks").is_none() {
+            return Some("full_supervisor_stop_missing_drain_ticks");
+        }
+        if daemon_shutdown_reason_field(completion_reason, "timeout_ticks").is_none() {
+            return Some("full_supervisor_stop_missing_timeout_ticks");
+        }
+        if daemon_shutdown_reason_field(completion_reason, "ignored_signals").is_none() {
+            return Some("full_supervisor_stop_missing_ignored_signals");
+        }
+        if shutdown_drain_status != "completed" {
+            return Some("full_supervisor_stop_graceful_status_mismatch");
+        }
+        return None;
+    }
+    if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
+        if daemon_shutdown_signal_tick(completion_reason).is_none() {
+            return Some("full_supervisor_stop_missing_signal_tick");
+        }
+        if daemon_shutdown_reason_field(completion_reason, "drain_ticks").is_none() {
+            return Some("full_supervisor_stop_missing_drain_ticks");
+        }
+        if daemon_shutdown_reason_field(completion_reason, "timeout_ticks").is_none() {
+            return Some("full_supervisor_stop_missing_timeout_ticks");
+        }
+        if daemon_shutdown_reason_field(completion_reason, "ignored_signals").is_none() {
+            return Some("full_supervisor_stop_missing_ignored_signals");
+        }
+        if shutdown_drain_status != "timeout" {
+            return Some("full_supervisor_stop_graceful_timeout_status_mismatch");
+        }
+        return None;
+    }
+    Some("full_supervisor_stop_unknown_completion_reason")
+}
+
+fn validate_full_supervisor_stop_contract(
+    completion_reason: &str,
+    shutdown_drain_status: &str,
+) -> Result<(), ConfigError> {
+    if let Some(reason) =
+        classify_full_supervisor_stop_contract_violation(completion_reason, shutdown_drain_status)
+    {
+        return Err(ConfigError::RuntimeDaemonLifecycle(format!(
+            "full_supervisor_invariant_violation:{reason}"
+        )));
+    }
+    Ok(())
 }
 
 fn execute_daemon_runtime(
@@ -966,11 +1065,14 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             RuntimeExecutionBundle::default()
         }
         RuntimeModeKind::Full => {
+            validate_full_bootstrap_component_contract(
+                FULL_RUNTIME_BOOTSTRAP_COMPONENT_SEQUENCE.as_slice(),
+            )?;
             log_info(
                 "node.runtime.full.bootstrap.start",
                 &[("execution_id", execution_id.as_str())],
             )?;
-            for (stage_index, component) in ["daemon", "api", "transport", "kolme-commit"]
+            for (stage_index, component) in FULL_RUNTIME_BOOTSTRAP_COMPONENT_SEQUENCE
                 .into_iter()
                 .enumerate()
             {
@@ -1005,6 +1107,7 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             let stop_reason = "daemon-execution-complete";
             let completion_reason = daemon_execution.completion_reason.as_str();
             let shutdown_drain_status = daemon_shutdown_drain_status(completion_reason);
+            validate_full_supervisor_stop_contract(completion_reason, shutdown_drain_status)?;
             log_info(
                 "node.runtime.full.supervisor.stop.requested",
                 &[

--- a/crates/kamn-node/src/main_tests.rs
+++ b/crates/kamn-node/src/main_tests.rs
@@ -3,6 +3,8 @@ use super::{
     build_kolme_live_managed_signing_key, build_kolme_live_request,
     build_kolme_live_signer_adapter, build_runtime_observability_snapshot,
     build_service_api_snapshot, capture_test_logs,
+    classify_full_bootstrap_component_contract_violation,
+    classify_full_supervisor_stop_contract_violation,
     classify_kolme_live_signer_key_source_policy_violation, encode_kolme_hex_lower,
     enforce_kolme_live_signer_contract_policy, enforce_kolme_live_signer_key_source_policy,
     execute, parse_args, render_bootstrap_report, render_kolme_live_native_direct_message,
@@ -11,10 +13,10 @@ use super::{
     resolve_kolme_live_managed_signer_required_marker, resolve_kolme_live_nonce,
     resolve_kolme_live_signer_private_key_env_name, resolve_log_config_from_inputs,
     serve_observability_endpoint, serve_service_api_endpoint,
-    sign_kolme_live_managed_external_message, DiagnosticsMode, KolmeForkSecp256k1SignerAdapter,
-    LocalProfile, NodeBootstrapReport, NodeLogConfig, NodeLogFormat, NodeLogLevel,
-    ObservabilityEndpointConfig, OutputMode, RuntimeExecutionBundle, RuntimeMode,
-    ServiceApiEndpointConfig,
+    sign_kolme_live_managed_external_message, validate_full_supervisor_stop_contract,
+    DiagnosticsMode, KolmeForkSecp256k1SignerAdapter, LocalProfile, NodeBootstrapReport,
+    NodeLogConfig, NodeLogFormat, NodeLogLevel, ObservabilityEndpointConfig, OutputMode,
+    RuntimeExecutionBundle, RuntimeMode, ServiceApiEndpointConfig,
 };
 use kamn_core::{
     bootstrap, ConfigError, KolmeRuntimeCommitHttpTransport, KolmeRuntimeCommitRequest, NodeConfig,

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -1174,6 +1174,89 @@ fn regression_runtime_full_emits_supervisor_stop_markers_with_daemon_reason() {
 }
 
 #[test]
+fn unit_full_supervisor_bootstrap_component_contract_rejects_order_drift() {
+    let reason = classify_full_bootstrap_component_contract_violation(&[
+        "daemon",
+        "transport",
+        "api",
+        "kolme-commit",
+    ]);
+    assert_eq!(
+        reason,
+        Some("full_supervisor_bootstrap_component_order_mismatch")
+    );
+}
+
+#[test]
+fn regression_full_supervisor_stop_contract_rejects_unknown_completion_reason() {
+    // Regression: #3283
+    let error = validate_full_supervisor_stop_contract("legacy-stop-reason", "not-signaled")
+        .expect_err("unknown supervisor stop completion reason must fail closed");
+    assert!(
+        matches!(error, ConfigError::RuntimeDaemonLifecycle(message) if message.contains("full_supervisor_invariant_violation:full_supervisor_stop_unknown_completion_reason")),
+        "unknown supervisor stop completion reason must emit deterministic fail-closed reason code"
+    );
+}
+
+#[test]
+fn unit_full_supervisor_stop_contract_classifier_rejects_status_mismatch() {
+    let reason = classify_full_supervisor_stop_contract_violation(
+        "graceful-shutdown:signal@2;drain_ticks=1;timeout_ticks=3;ignored_signals=0",
+        "not-signaled",
+    );
+    assert_eq!(
+        reason,
+        Some("full_supervisor_stop_graceful_status_mismatch")
+    );
+}
+
+#[test]
+fn integration_runtime_full_emits_timeout_shutdown_supervisor_reason_codes() {
+    let _lock = log_env_lock()
+        .lock()
+        .expect("log env lock should guard test mutation");
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "4".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "10".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "1".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "5".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "1".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:19085".to_owned(),
+    ])
+    .expect("full args with timeout shutdown controls should parse");
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("full runtime with timeout shutdown controls should succeed");
+    assert_eq!(report.runtime_mode, "full");
+    let stop_complete_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"node.runtime.full.supervisor.stop.complete\""))
+        .expect("full runtime should emit supervisor stop-complete marker");
+    assert_eq!(
+        extract_json_string_field(stop_complete_line, "shutdown_drain_status").as_deref(),
+        Some("timeout")
+    );
+    assert!(
+        extract_json_string_field(stop_complete_line, "daemon_completion_reason")
+            .as_deref()
+            .is_some_and(|value| value.starts_with("graceful-shutdown-timeout:signal@")),
+        "timeout shutdown flow must preserve deterministic graceful-shutdown-timeout reason marker"
+    );
+}
+
+#[test]
 fn parses_runtime_mode_daemon_with_os_signal_shutdown_controls() {
     let args = vec![
         "kamn-node".to_owned(),

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -119,6 +119,20 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - deterministic tick-budget simulation with bounded loop-free assertions
   - timeout behavior and observability telemetry validated through direct state transitions instead of wall-clock waits
 
+## Node Runtime Full-Mode Supervisor Invariant Contract Lane
+- For `kamn-node` full runtime supervisor lifecycle contract changes, keep PR validation on bounded deterministic tests:
+  - `cargo test -p kamn-node full_supervisor`
+  - `cargo test -p kamn-node integration_runtime_full_emits_timeout_shutdown_supervisor_reason_codes -- --exact`
+  - `cargo test -p kamn-node integration_runtime_full_emits_ordered_bootstrap_readiness_markers -- --exact`
+  - `cargo test -p kamn-node regression_runtime_full_emits_supervisor_stop_markers_with_daemon_reason -- --exact`
+- This lane is cost-effective:
+  - all tests run in-process with deterministic tick-budget simulation and no external network dependency.
+  - invariant drift uses fail-closed reason-code checks on bootstrap order and supervisor stop contracts.
+  - timeout/cancellation behavior is validated without launching multi-process orchestration.
+- Deterministic fail-closed markers:
+  - `full_supervisor_invariant_violation:full_supervisor_bootstrap_component_order_mismatch`
+  - `full_supervisor_invariant_violation:full_supervisor_stop_unknown_completion_reason`
+
 ## Runtime Observability Endpoint Contract Lane
 - Entry commands:
   - `bash scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh --output-json /tmp/runtime-observability-endpoint-contract-lane-report.json --policy-output-json /tmp/runtime-observability-endpoint-policy-report.json`


### PR DESCRIPTION
## Summary
Adds fail-closed supervisor lifecycle invariant enforcement for `runtime-mode full`, covering bootstrap component order/count contracts and shutdown completion reason/status contracts.
Also extends `kamn-node` tests with explicit drift regression fixtures and timeout-shutdown integration evidence, and documents the bounded CI lane in strategy docs.

Closes #3283
Refs #3282

## Changes
- `crates/kamn-node/src/main.rs`: added full-mode invariant classifiers/validators and runtime enforcement before readiness/stop marker emission.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added unit/regression/integration tests for component-order drift, unknown completion fail-closed behavior, status mismatch classification, and timeout shutdown marker flow.
- `crates/kamn-node/src/main_tests.rs`: exposed new invariant helpers to the test module.
- `docs/ci/strategy.md`: added Node Runtime Full-Mode Supervisor Invariant Contract Lane commands, cost controls, and deterministic reason markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command:
  - `cargo test -p kamn-node full_supervisor -- --nocapture`
- Failing output (expected): unresolved imports for new invariant helper symbols:
  - `classify_full_bootstrap_component_contract_violation`
  - `classify_full_supervisor_stop_contract_violation`
  - `validate_full_supervisor_stop_contract`

### 🟢 Green Phase
- Commands:
  - `cargo test -p kamn-node full_supervisor -- --nocapture`
  - `cargo test -p kamn-node integration_runtime_full_emits_timeout_shutdown_supervisor_reason_codes -- --nocapture`
- Result: pass; full-mode timeout shutdown flow emits deterministic supervisor stop markers and reason/status fields.

### 🔁 Regression
- Commands:
  - `cargo fmt --check`
  - `cargo clippy -p kamn-node -- -D warnings`
  - `cargo test -p kamn-node full -- --nocapture`
  - `cargo test -p kamn-node`
  - `bash scripts/ci/test_ci_strategy_contract.sh`
- Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `unit_full_supervisor_bootstrap_component_contract_rejects_order_drift`, `unit_full_supervisor_stop_contract_classifier_rejects_status_mismatch` | |
| Functional   | ✅ | existing `integration_runtime_full_emits_ordered_bootstrap_readiness_markers` + full supervisor contract checks now enforced at runtime | |
| Integration  | ✅ | `integration_runtime_full_emits_timeout_shutdown_supervisor_reason_codes` | |
| Regression   | ✅ | `regression_full_supervisor_stop_contract_rejects_unknown_completion_reason` (`Regression: #3283`) | |
| Performance  | N/A | | No hot-path throughput/latency surface changed; bounded deterministic lane retained. |

## Risks & Rollback
- Breaking changes: None.
- Operational risk: low; failure mode is explicit fail-closed `RuntimeDaemonLifecycle` error on invariant drift.
- Rollback: revert commit `d9db81f` to remove new invariant checks and tests.

## Documentation Updates
- `docs/ci/strategy.md`: added full-mode supervisor invariant contract lane and reason markers.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-node`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated
