### PR TITLE
feat(deploy): enforce compose healthcheck and restart contracts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN cargo build --release -p kamn-node
 
 FROM debian:bookworm-slim AS runtime
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN useradd --system --create-home --uid 10001 kamn
 
 COPY --from=builder /app/target/release/kamn-node /usr/local/bin/kamn-node

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,14 @@ services:
       - "19081:19081"
     networks:
       - kamn_mesh
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - curl --fail --silent http://127.0.0.1:19081/healthz > /dev/null || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   listener:
@@ -57,9 +65,18 @@ services:
     ports:
       - "19082:19082"
     depends_on:
-      - processor
+      processor:
+        condition: service_healthy
     networks:
       - kamn_mesh
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - curl --fail --silent http://127.0.0.1:19082/healthz > /dev/null || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   approver:
@@ -87,9 +104,18 @@ services:
     ports:
       - "19083:19083"
     depends_on:
-      - processor
+      processor:
+        condition: service_healthy
     networks:
       - kamn_mesh
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - curl --fail --silent http://127.0.0.1:19083/healthz > /dev/null || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
 volumes:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -41,6 +41,16 @@ These are mounted to `/data/<role>` paths in each container so restarts preserve
 
 All services join the named bridge network `kamn_mesh` for deterministic local service discovery.
 
+## Healthcheck And Restart
+
+Each role service includes a compose `healthcheck` probing `/healthz` over its local API bind:
+
+- processor: `curl --fail --silent http://127.0.0.1:19081/healthz`
+- listener: `curl --fail --silent http://127.0.0.1:19082/healthz`
+- approver: `curl --fail --silent http://127.0.0.1:19083/healthz`
+
+`listener` and `approver` dependencies require `service_healthy` on `processor`, and all roles keep `restart: unless-stopped`.
+
 ## Commands
 
 Start topology:

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -41,6 +41,8 @@ Compose file: `deploy/docker-compose.yml`
   - `listener_data`
   - `approver_data`
 - named bridge network: `kamn_mesh`
+- each service defines a compose `healthcheck` probing local `/healthz` endpoints.
+- listener/approver service dependencies require `service_healthy` on processor.
 - each service includes `restart: unless-stopped` for resilient local process restarts.
 
 Run all roles locally:

--- a/scripts/deploy/test_deployment_assets.sh
+++ b/scripts/deploy/test_deployment_assets.sh
@@ -112,6 +112,33 @@ if [ "$restart_marker_count" -lt 3 ]; then
   echo "expected docker-compose triad services to include restart: unless-stopped markers" >&2
   exit 1
 fi
+healthcheck_marker_count="$(grep -c 'healthcheck:' "$COMPOSE_FILE" || true)"
+if [ "$healthcheck_marker_count" -lt 3 ]; then
+  echo "expected docker-compose triad services to include healthcheck blocks" >&2
+  exit 1
+fi
+healthz_probe_marker_count="$(grep -c '/healthz' "$COMPOSE_FILE" || true)"
+if [ "$healthz_probe_marker_count" -lt 3 ]; then
+  echo "expected docker-compose triad services to probe /healthz endpoints" >&2
+  exit 1
+fi
+if ! grep -q 'curl --fail --silent http://127.0.0.1:19081/healthz > /dev/null' "$COMPOSE_FILE"; then
+  echo "expected docker-compose processor healthcheck probe marker" >&2
+  exit 1
+fi
+if ! grep -q 'curl --fail --silent http://127.0.0.1:19082/healthz > /dev/null' "$COMPOSE_FILE"; then
+  echo "expected docker-compose listener healthcheck probe marker" >&2
+  exit 1
+fi
+if ! grep -q 'curl --fail --silent http://127.0.0.1:19083/healthz > /dev/null' "$COMPOSE_FILE"; then
+  echo "expected docker-compose approver healthcheck probe marker" >&2
+  exit 1
+fi
+depends_on_health_marker_count="$(grep -c 'condition: service_healthy' "$COMPOSE_FILE" || true)"
+if [ "$depends_on_health_marker_count" -lt 2 ]; then
+  echo "expected docker-compose listener/approver dependencies to require service_healthy" >&2
+  exit 1
+fi
 
 if ! grep -q 'kind: Deployment' "$K8S_MANIFEST"; then
   echo "expected kubernetes deployment resources" >&2
@@ -144,6 +171,18 @@ if ! grep -q 'docker compose -f deploy/docker-compose.yml up' "$DEPLOY_DOC"; the
 fi
 if ! grep -q 'runtime-mode full' "$DEPLOY_DOC"; then
   echo "expected deployment doc runtime-mode full marker" >&2
+  exit 1
+fi
+if ! grep -q 'healthcheck' "$DEPLOY_DOC"; then
+  echo "expected deployment doc healthcheck marker" >&2
+  exit 1
+fi
+if ! grep -q '/healthz' "$DEPLOY_DOC"; then
+  echo "expected deployment doc /healthz marker" >&2
+  exit 1
+fi
+if ! grep -q 'service_healthy' "$DEPLOY_DOC"; then
+  echo "expected deployment doc service_healthy dependency marker" >&2
   exit 1
 fi
 if ! grep -q '19081:19081' "$DEPLOY_DOC"; then
@@ -179,7 +218,10 @@ for required_marker in \
   'processor_data' \
   'listener_data' \
   'approver_data' \
-  'kamn_mesh'; do
+  'kamn_mesh' \
+  'healthcheck' \
+  '/healthz' \
+  'service_healthy'; do
   if ! grep -q "$required_marker" "$DOCKER_DEPLOY_DOC"; then
     echo "expected docker deployment doc marker ${required_marker}" >&2
     exit 1

--- a/scripts/deploy/validate_deployment_assets_live.sh
+++ b/scripts/deploy/validate_deployment_assets_live.sh
@@ -53,6 +53,26 @@ if ! printf '%s\n' "$negative_output" | grep -q 'expected Dockerfile multi-stage
   exit 1
 fi
 
+bad_compose="$TMP_DIR/docker-compose.healthcheck.bad.yml"
+sed 's|19081/healthz|19081/healthz-drift|g' "$ROOT_DIR/deploy/docker-compose.yml" >"$bad_compose"
+
+set +e
+healthcheck_negative_output="$(
+  COMPOSE_FILE_PATH="$bad_compose" \
+  bash "$ROOT_DIR/scripts/deploy/test_deployment_assets.sh" 2>&1
+)"
+healthcheck_negative_code=$?
+set -e
+if [ "$healthcheck_negative_code" -eq 0 ]; then
+  echo "expected deployment assets checker to fail closed for invalid compose healthcheck marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$healthcheck_negative_output" | grep -q 'expected docker-compose processor healthcheck probe marker'; then
+  printf '%s\n' "$healthcheck_negative_output" >&2
+  echo "expected deterministic fail-closed reason marker for invalid compose healthcheck marker" >&2
+  exit 1
+fi
+
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
 if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
   echo "deployment assets live validation exceeded runtime budget: ${elapsed_seconds}s" >&2


### PR DESCRIPTION
## Summary
Adds deterministic compose healthcheck and restart/dependency contracts for full-mode triad services, including `/healthz` probe markers and `service_healthy` dependency semantics.
Extends deployment live validation to include fail-closed negative drills for healthcheck drift and updates docker/deployment docs accordingly.

Closes #3361
Refs #3286

## Changes
- `deploy/docker-compose.yml`: adds healthcheck blocks for processor/listener/approver (`/healthz` probes), and `service_healthy` dependency conditions for listener/approver.
- `Dockerfile`: installs `curl` and `ca-certificates` in runtime image for healthcheck probe support.
- `scripts/deploy/test_deployment_assets.sh`: adds fail-closed checks for healthcheck blocks, `/healthz` probe markers, and `service_healthy` dependencies, plus docs parity markers.
- `scripts/deploy/validate_deployment_assets_live.sh`: adds deterministic negative drill for tampered compose healthcheck marker.
- `docs/ops/deployment.md`: documents healthcheck + dependency semantics.
- `docs/deployment/docker.md`: documents healthcheck probes and restart/dependency behavior.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command:
  - `bash scripts/deploy/test_deployment_assets.sh`
- Initial failure marker: `expected docker-compose triad services to include healthcheck blocks`.

### 🟢 Green Phase
- Commands:
  - `bash scripts/deploy/test_deployment_assets.sh`
  - `bash scripts/deploy/validate_deployment_assets_live.sh`
  - `bash scripts/deploy/test_validate_deployment_assets_live.sh`
  - `bash scripts/deploy/test_validate_compose_topology_contract_lane.sh`
  - `bash scripts/deploy/test_check_compose_topology_contract_policy.sh`
- Result: all pass.

### 🔁 Regression
- Commands:
  - `bash scripts/deploy/test_deployment_assets.sh`
  - `bash scripts/deploy/validate_deployment_assets_live.sh`
  - `bash scripts/deploy/test_validate_deployment_assets_live.sh`
  - `bash scripts/deploy/test_validate_compose_topology_contract_lane.sh`
  - `bash scripts/deploy/test_check_compose_topology_contract_policy.sh`
  - `bash scripts/ci/test_ci_strategy_contract.sh`
  - `cargo fmt --check`
- Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | health/restart marker assertions in `scripts/deploy/test_deployment_assets.sh` | |
| Functional   | ✅ | deterministic compose contract behavior in `scripts/deploy/test_deployment_assets.sh` | |
| Integration  | ✅ | `scripts/deploy/validate_deployment_assets_live.sh` + test harness include healthcheck tamper drill | |
| Regression   | ✅ | fail-closed marker checks for healthcheck drift in live validation | |
| Performance  | ✅ | bounded live validation runtime via `--max-seconds` remains enforced | |

## Risks & Rollback
- Breaking changes: None.
- Risk: low; compose/docker/docs/deploy-script updates only.
- Rollback: revert commit `51cfe92`.

## Documentation Updates
- `docs/ops/deployment.md`
- `docs/deployment/docker.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source behavior changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated
