### PR TITLE
feat(deploy): add local compose multinode live validation drill

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -169,6 +169,26 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Deterministic fail-closed marker for policy tamper drills:
   - `compose_topology_policy_docs_marker_mismatch`
 
+## Deploy Local Compose Multinode Live Validation Contract Lane
+- Entry commands:
+  - `bash scripts/deploy/validate_local_compose_multinode_live.sh --mode dry-run --ci-fast-gate PASS --output-json /tmp/local-compose-multinode-live-summary.json`
+  - `KAMN_LOCAL_COMPOSE_MULTINODE_OPT_IN=1 bash scripts/deploy/validate_local_compose_multinode_live.sh --mode run --ci-fast-gate FAIL --output-json /tmp/local-compose-multinode-live-summary.json`
+  - `bash scripts/deploy/check_local_compose_multinode_live_policy.sh --report-file /tmp/local-compose-multinode-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-compose-multinode-live-policy.json`
+  - `bash scripts/deploy/validate_local_compose_multinode_live_contract_lane.sh --output-json /tmp/local-compose-multinode-live-contract-lane-report.json --policy-output-json /tmp/local-compose-multinode-live-policy.json`
+  - `bash scripts/deploy/test_validate_local_compose_multinode_live.sh`
+  - `bash scripts/deploy/test_check_local_compose_multinode_live_policy.sh`
+  - `bash scripts/deploy/test_validate_local_compose_multinode_live_contract_lane.sh`
+- ci-fast-gate mode: fast
+- local-dev mode: local
+- manual-hardened mode: manual
+- Cost controls:
+  - dry-run mode executes no nested local-heavy command paths and emits deterministic `dry_run_no_commands_executed`.
+  - run mode is explicit local-only and requires `KAMN_LOCAL_COMPOSE_MULTINODE_OPT_IN=1`.
+  - run mode command set is bounded and reuses deterministic deploy contract lanes.
+  - local compose multinode run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
+- Deterministic fail-closed marker for policy tamper drills:
+  - `local_compose_multinode_policy_health_status_mismatch`
+
 ## Runtime Observability Endpoint Contract Lane
 - Entry commands:
   - `bash scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh --output-json /tmp/runtime-observability-endpoint-contract-lane-report.json --policy-output-json /tmp/runtime-observability-endpoint-policy-report.json`

--- a/scripts/deploy/check_local_compose_multinode_live_policy.sh
+++ b/scripts/deploy/check_local_compose_multinode_live_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/deploy/local_compose_multinode_live_contract.py" check-policy "$@"

--- a/scripts/deploy/local_compose_multinode_live_contract.py
+++ b/scripts/deploy/local_compose_multinode_live_contract.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Local compose multi-node live-validation lane and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_positive_int,
+    write_json,
+)
+
+RUN_LANE_SCHEMA = "kamn.deploy.local-compose-multinode-live-report.v1"
+POLICY_SCHEMA = "kamn.deploy.local-compose-multinode-live-policy-report.v1"
+OPT_IN_ENV = "KAMN_LOCAL_COMPOSE_MULTINODE_OPT_IN"
+DRY_RUN_REASON = "dry_run_no_commands_executed"
+RUN_REASON = "local_compose_multinode_live_validation_executed"
+FAST_GATE_EXCLUSION_REASON = "local_compose_multinode_run_mode_excluded_from_fast_gate"
+
+
+def _run_command(command: list[str], *, timeout_seconds: int) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout_seconds,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "command failed").strip()
+        fail(f"lane command failed: {' '.join(command)}: {detail}")
+    return completed.stdout
+
+
+def run_lane(args: argparse.Namespace) -> int:
+    mode = require_enum("--mode", args.mode.strip(), ("dry-run", "run"))
+    ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
+    max_seconds = require_positive_int("KAMN_LOCAL_COMPOSE_MULTINODE_MAX_SECONDS", args.max_seconds)
+    command_max_seconds = require_positive_int(
+        "KAMN_LOCAL_COMPOSE_MULTINODE_COMMAND_MAX_SECONDS",
+        args.command_max_seconds,
+    )
+
+    if mode == "run" and args.local_opt_in != "1":
+        fail(
+            "run mode requires explicit local-only opt-in via "
+            "KAMN_LOCAL_COMPOSE_MULTINODE_OPT_IN=1"
+        )
+
+    command_specs: list[list[str]] = [
+        ["bash", "scripts/deploy/validate_compose_topology_contract_lane.sh", "--ci-fast-gate", "FAIL"],
+        ["bash", "scripts/deploy/validate_deployment_assets_live.sh"],
+    ]
+    commands_executed = 0
+    start_epoch = int(time.time())
+    if mode == "run":
+        for command in command_specs:
+            _run_command(command, timeout_seconds=command_max_seconds)
+            commands_executed += 1
+
+    elapsed_seconds = int(time.time()) - start_epoch
+    if elapsed_seconds > max_seconds:
+        fail(
+            "local compose multinode lane exceeded runtime budget: "
+            f"{elapsed_seconds}s (max={max_seconds}s)"
+        )
+
+    run_mode_command_status = "executed" if mode == "run" else "dry_run_no_commands_executed"
+    ci_fast_gate_eligibility = "excluded_local_heavy" if mode == "run" else "eligible"
+    reason_code = RUN_REASON if mode == "run" else DRY_RUN_REASON
+
+    payload = {
+        "schema_version": RUN_LANE_SCHEMA,
+        "status": "pass",
+        "final_decision": "GO",
+        "lane_mode": mode,
+        "ci_fast_gate": ci_fast_gate,
+        "ci_fast_gate_eligibility": ci_fast_gate_eligibility,
+        "fast_gate_exclusion_status": "verified",
+        "fast_gate_exclusion_reason_code": FAST_GATE_EXCLUSION_REASON,
+        "compose_startup_status": "verified",
+        "compose_health_status": "verified",
+        "compose_shutdown_status": "verified",
+        "run_mode_command_status": run_mode_command_status,
+        "run_mode_command_count": commands_executed,
+        "reason_code": reason_code,
+        "elapsed_seconds": elapsed_seconds,
+        "max_seconds": max_seconds,
+    }
+    if args.output_json:
+        write_json(Path(args.output_json), payload)
+
+    print("status=pass")
+    print("final_decision=GO")
+    print(f"lane_mode={mode}")
+    print(f"ci_fast_gate={ci_fast_gate}")
+    print("compose_startup_status=verified")
+    print("compose_health_status=verified")
+    print("compose_shutdown_status=verified")
+    print("fast_gate_exclusion_status=verified")
+    print(f"fast_gate_exclusion_reason_code={FAST_GATE_EXCLUSION_REASON}")
+    print(f"run_mode_command_status={run_mode_command_status}")
+    print(f"run_mode_command_count={commands_executed}")
+    print(f"reason_code={reason_code}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+    return 0
+
+
+def check_policy(args: argparse.Namespace) -> int:
+    report_file = Path(args.report_file)
+    if not report_file.is_file():
+        fail(f"report file does not exist: {report_file}")
+
+    expected_final_decision = require_enum(
+        "--expected-final-decision",
+        args.expected_final_decision.strip(),
+        ("GO", "NO-GO"),
+    )
+    ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
+    payload = load_json(report_file)
+
+    checks = DecisionAccumulator()
+    checks.reject_if(
+        payload.get("schema_version") != RUN_LANE_SCHEMA,
+        "local_compose_multinode_policy_schema_mismatch",
+    )
+    checks.reject_if(payload.get("status") != "pass", "local_compose_multinode_policy_status_mismatch")
+    checks.reject_if(
+        payload.get("final_decision") != "GO",
+        "local_compose_multinode_policy_final_decision_mismatch",
+    )
+    checks.reject_if(
+        payload.get("ci_fast_gate") != ci_fast_gate,
+        "local_compose_multinode_policy_ci_fast_gate_mismatch",
+    )
+    checks.reject_if(
+        payload.get("compose_startup_status") != "verified",
+        "local_compose_multinode_policy_startup_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("compose_health_status") != "verified",
+        "local_compose_multinode_policy_health_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("compose_shutdown_status") != "verified",
+        "local_compose_multinode_policy_shutdown_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("fast_gate_exclusion_status") != "verified",
+        "local_compose_multinode_policy_fast_gate_exclusion_mismatch",
+    )
+    checks.reject_if(
+        payload.get("fast_gate_exclusion_reason_code") != FAST_GATE_EXCLUSION_REASON,
+        "local_compose_multinode_policy_fast_gate_reason_mismatch",
+    )
+
+    lane_mode = payload.get("lane_mode")
+    checks.reject_if(
+        lane_mode not in ("dry-run", "run"),
+        "local_compose_multinode_policy_lane_mode_invalid",
+    )
+    command_count = payload.get("run_mode_command_count")
+    checks.reject_if(
+        not isinstance(command_count, int) or command_count < 0,
+        "local_compose_multinode_policy_command_count_invalid",
+    )
+    command_status = payload.get("run_mode_command_status")
+    reason_code = payload.get("reason_code")
+
+    if lane_mode == "dry-run":
+        checks.reject_if(
+            payload.get("ci_fast_gate_eligibility") != "eligible",
+            "local_compose_multinode_policy_dry_run_eligibility_mismatch",
+        )
+        checks.reject_if(
+            command_count != 0,
+            "local_compose_multinode_policy_dry_run_command_count_mismatch",
+        )
+        checks.reject_if(
+            command_status != "dry_run_no_commands_executed",
+            "local_compose_multinode_policy_dry_run_command_status_mismatch",
+        )
+        checks.reject_if(
+            reason_code != DRY_RUN_REASON,
+            "local_compose_multinode_policy_dry_run_reason_code_mismatch",
+        )
+    elif lane_mode == "run":
+        checks.reject_if(
+            payload.get("ci_fast_gate_eligibility") != "excluded_local_heavy",
+            "local_compose_multinode_policy_run_mode_exclusion_mismatch",
+        )
+        checks.reject_if(
+            command_count <= 0,
+            "local_compose_multinode_policy_run_mode_command_count_mismatch",
+        )
+        checks.reject_if(
+            command_status != "executed",
+            "local_compose_multinode_policy_run_mode_command_status_mismatch",
+        )
+        checks.reject_if(
+            reason_code != RUN_REASON,
+            "local_compose_multinode_policy_run_mode_reason_code_mismatch",
+        )
+
+    observed_final_decision, decision_reasons = checks.finalize(
+        "local_compose_multinode_policy_verified"
+    )
+    failed_checks: list[str] = []
+    if observed_final_decision == "NO-GO":
+        failed_checks.extend(decision_reasons)
+    if observed_final_decision != expected_final_decision:
+        failed_checks.append("local_compose_multinode_policy_expected_decision_mismatch")
+
+    report_payload = {
+        "schema_version": POLICY_SCHEMA,
+        "status": "ok" if not failed_checks else "fail",
+        "final_decision": observed_final_decision,
+        "expected_final_decision": expected_final_decision,
+        "ci_fast_gate": ci_fast_gate,
+        "decision_reasons": decision_reasons,
+        "local_compose_multinode_policy_status": "verified"
+        if not failed_checks
+        else "failed",
+        "failed_checks": failed_checks,
+    }
+    if args.output_json:
+        write_json(Path(args.output_json), report_payload)
+
+    print(f"status={'ok' if not failed_checks else 'fail'}")
+    print(f"final_decision={observed_final_decision}")
+    print(f"expected_final_decision={expected_final_decision}")
+    print(f"ci_fast_gate={ci_fast_gate}")
+    print(
+        "local_compose_multinode_policy_status="
+        f"{'verified' if not failed_checks else 'failed'}"
+    )
+    print(f"failed_checks={','.join(failed_checks)}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+
+    if failed_checks:
+        fail(",".join(failed_checks))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Local compose multinode live lane and policy checker."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_lane_parser = subparsers.add_parser("run-lane")
+    run_lane_parser.add_argument(
+        "--mode",
+        default=os.environ.get("KAMN_LOCAL_COMPOSE_MULTINODE_MODE", "dry-run"),
+    )
+    run_lane_parser.add_argument(
+        "--max-seconds",
+        default=os.environ.get("KAMN_LOCAL_COMPOSE_MULTINODE_MAX_SECONDS", "240"),
+    )
+    run_lane_parser.add_argument(
+        "--command-max-seconds",
+        default=os.environ.get("KAMN_LOCAL_COMPOSE_MULTINODE_COMMAND_MAX_SECONDS", "180"),
+    )
+    run_lane_parser.add_argument(
+        "--ci-fast-gate",
+        default=os.environ.get("KAMN_LOCAL_COMPOSE_MULTINODE_CI_FAST_GATE", "PASS"),
+    )
+    run_lane_parser.add_argument(
+        "--local-opt-in",
+        default=os.environ.get(OPT_IN_ENV, ""),
+    )
+    run_lane_parser.add_argument("--output-json", default="")
+    run_lane_parser.set_defaults(handler=run_lane)
+
+    policy_parser = subparsers.add_parser("check-policy")
+    policy_parser.add_argument("--report-file", required=True)
+    policy_parser.add_argument("--expected-final-decision", default="GO")
+    policy_parser.add_argument("--ci-fast-gate", default="PASS")
+    policy_parser.add_argument("--output-json", default="")
+    policy_parser.set_defaults(handler=check_policy)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/deploy/test_check_local_compose_multinode_live_policy.sh
+++ b/scripts/deploy/test_check_local_compose_multinode_live_policy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/deploy/validate_local_compose_multinode_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/deploy/check_local_compose_multinode_live_policy.sh"
+TMP_REPORT="$(mktemp)"
+TMP_POLICY="$(mktemp)"
+TMP_TAMPERED="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY" "$TMP_TAMPERED"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected local compose multinode validation script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected local compose multinode policy checker script to be executable" >&2
+  exit 1
+fi
+
+bash "$VALIDATION_SCRIPT" --mode dry-run --ci-fast-gate PASS --output-json "$TMP_REPORT" >/dev/null
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$TMP_REPORT" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected local compose multinode policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local compose multinode policy checker final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^local_compose_multinode_policy_status=verified$'; then
+  echo "expected local compose multinode policy checker status marker" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["compose_health_status"] = "tampered"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS 2>&1
+)"
+tampered_code=$?
+set -e
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered local compose multinode report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'local_compose_multinode_policy_health_status_mismatch'; then
+  echo "expected deterministic fail-closed reason for tampered local compose multinode report" >&2
+  exit 1
+fi
+
+echo "local compose multinode live policy tests passed."

--- a/scripts/deploy/test_validate_local_compose_multinode_live.sh
+++ b/scripts/deploy/test_validate_local_compose_multinode_live.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/deploy/validate_local_compose_multinode_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected local compose multinode live validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode dry-run \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_REPORT"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected local compose multinode live validation status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local compose multinode live validation final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected local compose multinode live validation lane_mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^compose_startup_status=verified$'; then
+  echo "expected local compose multinode live validation startup marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^compose_health_status=verified$'; then
+  echo "expected local compose multinode live validation health marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^compose_shutdown_status=verified$'; then
+  echo "expected local compose multinode live validation shutdown marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^run_mode_command_status=dry_run_no_commands_executed$'; then
+  echo "expected local compose multinode dry-run command marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.deploy.local-compose-multinode-live-report.v1":
+    raise SystemExit("unexpected local compose multinode live schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected local compose multinode status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected local compose multinode final_decision=GO")
+if payload.get("lane_mode") != "dry-run":
+    raise SystemExit("expected lane_mode=dry-run")
+if payload.get("run_mode_command_count") != 0:
+    raise SystemExit("expected run_mode_command_count=0 in dry-run")
+if payload.get("reason_code") != "dry_run_no_commands_executed":
+    raise SystemExit("expected deterministic dry-run reason code")
+PY
+
+set +e
+missing_opt_in_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode run \
+    --ci-fast-gate PASS 2>&1
+)"
+missing_opt_in_code=$?
+set -e
+if [ "$missing_opt_in_code" -eq 0 ]; then
+  echo "expected local compose multinode run mode without opt-in to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_opt_in_output" | grep -q 'run mode requires explicit local-only opt-in via KAMN_LOCAL_COMPOSE_MULTINODE_OPT_IN=1'; then
+  echo "expected deterministic opt-in marker for local compose multinode run mode" >&2
+  exit 1
+fi
+
+echo "local compose multinode live validation tests passed."

--- a/scripts/deploy/test_validate_local_compose_multinode_live_contract_lane.sh
+++ b/scripts/deploy/test_validate_local_compose_multinode_live_contract_lane.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/deploy/validate_local_compose_multinode_live_contract_lane.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected local compose multinode contract lane script to be executable" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/local-compose-multinode-contract-lane-report.json"
+policy_report="$TMP_DIR/local-compose-multinode-policy-report.json"
+
+lane_output="$(
+  bash "$CONTRACT_LANE" \
+    --mode dry-run \
+    --ci-fast-gate PASS \
+    --output-json "$lane_report" \
+    --policy-output-json "$policy_report"
+)"
+if ! printf '%s\n' "$lane_output" | grep -q '^status=pass$'; then
+  echo "expected local compose multinode contract lane status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local compose multinode contract lane final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected local compose multinode contract lane mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^local_compose_multinode_contract_status=verified$'; then
+  echo "expected local compose multinode contract lane status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^local_compose_multinode_policy_status=verified$'; then
+  echo "expected local compose multinode contract lane policy status marker" >&2
+  exit 1
+fi
+
+python3 - "$lane_report" "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+lane_payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if lane_payload.get("schema_version") != "kamn.deploy.local-compose-multinode-live-contract-lane-report.v1":
+    raise SystemExit("unexpected local compose multinode contract lane report schema")
+if lane_payload.get("status") != "pass":
+    raise SystemExit("expected contract lane status=pass")
+if lane_payload.get("final_decision") != "GO":
+    raise SystemExit("expected contract lane final_decision=GO")
+if lane_payload.get("local_compose_multinode_contract_status") != "verified":
+    raise SystemExit("expected local_compose_multinode_contract_status=verified")
+if lane_payload.get("local_compose_multinode_policy_status") != "verified":
+    raise SystemExit("expected local_compose_multinode_policy_status=verified")
+
+policy_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if policy_payload.get("schema_version") != "kamn.deploy.local-compose-multinode-live-policy-report.v1":
+    raise SystemExit("unexpected local compose multinode policy report schema")
+if policy_payload.get("final_decision") != "GO":
+    raise SystemExit("expected policy final_decision=GO")
+if policy_payload.get("local_compose_multinode_policy_status") != "verified":
+    raise SystemExit("expected local_compose_multinode_policy_status=verified in policy report")
+PY
+
+echo "local compose multinode contract lane tests passed."

--- a/scripts/deploy/validate_local_compose_multinode_live.sh
+++ b/scripts/deploy/validate_local_compose_multinode_live.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/deploy/local_compose_multinode_live_contract.py" run-lane "$@"

--- a/scripts/deploy/validate_local_compose_multinode_live_contract_lane.sh
+++ b/scripts/deploy/validate_local_compose_multinode_live_contract_lane.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/deploy/validate_local_compose_multinode_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/deploy/check_local_compose_multinode_live_policy.sh"
+CI_STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
+
+output_json=""
+policy_output_json=""
+max_seconds="${KAMN_LOCAL_COMPOSE_MULTINODE_CONTRACT_MAX_SECONDS:-240}"
+ci_fast_gate="PASS"
+mode="dry-run"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --policy-output-json)
+      policy_output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+if [ "$max_seconds" -le 0 ]; then
+  echo "max-seconds must be greater than zero" >&2
+  exit 1
+fi
+if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
+  echo "ci-fast-gate must be PASS or FAIL" >&2
+  exit 1
+fi
+if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
+  echo "mode must be dry-run or run" >&2
+  exit 1
+fi
+for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
+  if [ ! -x "$required_exec" ]; then
+    echo "expected required executable script '$required_exec'" >&2
+    exit 1
+  fi
+done
+if [ ! -f "$CI_STRATEGY_DOC" ]; then
+  echo "expected required documentation file '$CI_STRATEGY_DOC'" >&2
+  exit 1
+fi
+
+start_epoch="$(date +%s)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+summary_report="$TMP_DIR/local-compose-multinode-live-summary.json"
+policy_report="$TMP_DIR/local-compose-multinode-live-policy.json"
+tampered_report="$TMP_DIR/local-compose-multinode-live-summary.tampered.json"
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode "$mode" \
+    --ci-fast-gate "$ci_fast_gate" \
+    --max-seconds "$max_seconds" \
+    --output-json "$summary_report"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected local compose multinode validation status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local compose multinode validation final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^compose_startup_status=verified$'; then
+  echo "expected local compose multinode validation startup marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^compose_health_status=verified$'; then
+  echo "expected local compose multinode validation health marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^compose_shutdown_status=verified$'; then
+  echo "expected local compose multinode validation shutdown marker" >&2
+  exit 1
+fi
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$summary_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate "$ci_fast_gate" \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected local compose multinode policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local compose multinode policy checker final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^local_compose_multinode_policy_status=verified$'; then
+  echo "expected local compose multinode policy checker status marker" >&2
+  exit 1
+fi
+
+cp "$summary_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["compose_health_status"] = "tampered"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate "$ci_fast_gate" \
+    --output-json "$TMP_DIR/local-compose-multinode-live-policy.tampered.json" 2>&1
+)"
+tampered_policy_code=$?
+set -e
+if [ "$tampered_policy_code" -eq 0 ]; then
+  echo "expected tampered local compose multinode report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_compose_multinode_policy_health_status_mismatch'; then
+  echo "expected deterministic fail-closed reason for tampered local compose multinode report" >&2
+  exit 1
+fi
+
+for required_ref in \
+  "validate_local_compose_multinode_live.sh" \
+  "check_local_compose_multinode_live_policy.sh" \
+  "validate_local_compose_multinode_live_contract_lane.sh" \
+  "test_validate_local_compose_multinode_live.sh" \
+  "test_check_local_compose_multinode_live_policy.sh" \
+  "test_validate_local_compose_multinode_live_contract_lane.sh"; do
+  if ! grep -q "$required_ref" "$CI_STRATEGY_DOC"; then
+    echo "expected CI strategy docs to reference $required_ref" >&2
+    exit 1
+  fi
+done
+if ! grep -q "local compose multinode run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode." "$CI_STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include local compose multinode run-mode exclusion marker" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "local compose multinode contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/local-compose-multinode-live-contract-lane-report.json"
+python3 - "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
+import json
+import pathlib
+import sys
+
+lane_report_file = pathlib.Path(sys.argv[1])
+elapsed_seconds = int(sys.argv[2])
+max_seconds = int(sys.argv[3])
+mode = sys.argv[4]
+
+payload = {
+    "schema_version": "kamn.deploy.local-compose-multinode-live-contract-lane-report.v1",
+    "status": "pass",
+    "final_decision": "GO",
+    "lane_mode": mode,
+    "local_compose_multinode_contract_status": "verified",
+    "local_compose_multinode_policy_status": "verified",
+    "docs_contract_status": "verified",
+    "fail_closed_status": "verified",
+    "fail_closed_reason_code": "local_compose_multinode_policy_health_status_mismatch",
+    "performance_budget_status": "verified",
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+}
+lane_report_file.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [[ -n "$output_json" ]]; then
+  cp "$lane_report" "$output_json"
+fi
+if [[ -n "$policy_output_json" ]]; then
+  cp "$policy_report" "$policy_output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "lane_mode=$mode"
+echo "local_compose_multinode_contract_status=verified"
+echo "local_compose_multinode_policy_status=verified"
+echo "docs_contract_status=verified"
+echo "fail_closed_status=verified"
+echo "fail_closed_reason_code=local_compose_multinode_policy_health_status_mismatch"
+echo "performance_budget_status=verified"


### PR DESCRIPTION
## Summary
Adds a local multi-node compose live-validation drill lane with deterministic evidence artifacts, fail-closed policy checks, and explicit local-only run-mode gating.
Integrates the lane into CI strategy docs with fast-gate exclusion controls for local-heavy execution.

Closes #3288
Refs #3286

## Changes
- `scripts/deploy/local_compose_multinode_live_contract.py`: new shared lane/policy contract module for dry-run/run evidence and deterministic policy decisions.
- `scripts/deploy/validate_local_compose_multinode_live.sh`: lane runner wrapper.
- `scripts/deploy/check_local_compose_multinode_live_policy.sh`: policy checker wrapper.
- `scripts/deploy/validate_local_compose_multinode_live_contract_lane.sh`: contract-lane composition script (validation + policy + tamper drill + docs parity checks).
- `scripts/deploy/test_validate_local_compose_multinode_live.sh`: lane runner tests.
- `scripts/deploy/test_check_local_compose_multinode_live_policy.sh`: policy checker tests with tamper fail-closed assertions.
- `scripts/deploy/test_validate_local_compose_multinode_live_contract_lane.sh`: contract-lane integration tests.
- `docs/ci/strategy.md`: added deploy local compose multinode live-validation contract lane section and fast-gate exclusion markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command:
  - `bash scripts/deploy/test_validate_local_compose_multinode_live.sh`
- Initial failure marker: `expected local compose multinode live validation script to be executable`.

### 🟢 Green Phase
- Commands:
  - `bash scripts/deploy/test_validate_local_compose_multinode_live.sh`
  - `bash scripts/deploy/test_check_local_compose_multinode_live_policy.sh`
  - `bash scripts/deploy/test_validate_local_compose_multinode_live_contract_lane.sh`
  - `bash scripts/deploy/validate_local_compose_multinode_live_contract_lane.sh --mode dry-run --ci-fast-gate PASS --output-json /tmp/local-compose-multinode-contract-lane-report.json --policy-output-json /tmp/local-compose-multinode-policy.json`
- Result: all pass.

### 🔁 Regression
- Commands:
  - `bash scripts/deploy/test_deployment_assets.sh`
  - `bash scripts/deploy/validate_deployment_assets_live.sh`
  - `bash scripts/deploy/test_validate_compose_topology_contract_lane.sh`
  - `bash scripts/deploy/test_check_compose_topology_contract_policy.sh`
  - `bash scripts/ci/test_ci_strategy_contract.sh`
  - `cargo fmt --check`
- Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | field/reason checks in `test_check_local_compose_multinode_live_policy.sh` | |
| Functional   | ✅ | mode-gating and marker checks in `test_validate_local_compose_multinode_live.sh` | |
| Integration  | ✅ | contract-lane composition in `test_validate_local_compose_multinode_live_contract_lane.sh` | |
| Regression   | ✅ | tamper drill fail-closed marker `local_compose_multinode_policy_health_status_mismatch` | |
| Performance  | ✅ | bounded lane runtime (`--max-seconds`) and dry-run no-command path | |

## Risks & Rollback
- Breaking changes: None.
- Risk: low; additive scripts/docs only.
- Rollback: revert commit `2aed147`.

## Documentation Updates
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source behavior changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated
