### PR TITLE
feat(infra): add reusable process harness primitives

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -153,6 +153,23 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Deterministic fail-closed marker for policy tamper drills:
   - `local_full_runtime_policy_fast_gate_exclusion_mismatch`
 
+## Process Harness Primitive Contract
+- Entry commands:
+  - `python3 scripts/framework/test_process_harness.py`
+  - `bash scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh`
+- Harness invocation contract:
+  - reserve deterministic localhost ports through `scripts/framework/process_harness.py` before process start.
+  - release reserved labels only at start call sites (`release_port_labels`) so lifecycle sequencing remains deterministic.
+  - start/stop process lifecycle is managed through `ProcessHarness.start_process()` and `ProcessHarness.stop_process()`.
+- Evidence artifact layout:
+  - schema version: `kamn.runtime.process-harness-evidence.v1`
+  - top-level machine-checkable fields: `schema_version`, `status`, `final_decision`, `reason_code`, `ports`, `processes`, `artifacts`
+  - current integration report linkage: `process_harness_evidence_file` in `kamn.kolme.local-live-provider-runtime-integration-contract-report.v1`
+- Cost controls:
+  - uses a local mock API process and bounded readiness probe timeout (10 seconds).
+  - no external network or remote process orchestration dependency.
+  - lifecycle teardown is automatic on exception via harness context management.
+
 ## Deploy Compose Topology Contract Lane
 - Entry commands:
   - `bash scripts/deploy/validate_compose_topology_contract_lane.sh --output-json /tmp/compose-topology-contract-summary.json --ci-fast-gate PASS`

--- a/scripts/framework/process_harness.py
+++ b/scripts/framework/process_harness.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Reusable process harness primitives for local integration lanes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, TextIO
+from urllib.error import URLError
+from urllib.request import urlopen
+
+
+class ProcessHarnessError(RuntimeError):
+    """Raised when process harness invariants are violated."""
+
+
+@dataclass
+class PortReservation:
+    """Tracks a reserved localhost TCP port."""
+
+    label: str
+    port: int
+    host: str
+    _socket: socket.socket
+
+    def release(self) -> None:
+        """Release the reservation socket."""
+        if self._socket.fileno() >= 0:
+            self._socket.close()
+
+
+@dataclass
+class ManagedProcess:
+    """Tracks a spawned process and its evidence metadata."""
+
+    name: str
+    command: list[str]
+    log_file: Path
+    process: subprocess.Popen[str]
+    started_at_epoch: int
+    _log_handle: TextIO
+
+    def close_log(self) -> None:
+        """Close the attached log file handle."""
+        if not self._log_handle.closed:
+            self._log_handle.close()
+
+
+class ProcessHarness:
+    """Reusable lifecycle harness for local process orchestration."""
+
+    def __init__(self, *, root_dir: Path) -> None:
+        self.root_dir = root_dir
+        self._reservations: dict[str, PortReservation] = {}
+        self._processes: dict[str, ManagedProcess] = {}
+
+    def __enter__(self) -> ProcessHarness:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
+
+    def reserve_port(
+        self,
+        label: str,
+        *,
+        host: str = "127.0.0.1",
+        start_port: int = 30000,
+        end_port: int = 60000,
+    ) -> int:
+        """Reserve a deterministic local TCP port for later process startup."""
+        if label in self._reservations:
+            raise ProcessHarnessError(f"port label already reserved: {label}")
+        if start_port > end_port:
+            raise ProcessHarnessError("start_port must be <= end_port")
+
+        reserved_ports = {reservation.port for reservation in self._reservations.values()}
+        for port in range(start_port, end_port + 1):
+            if port in reserved_ports:
+                continue
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                sock.bind((host, port))
+                sock.listen(1)
+            except OSError:
+                sock.close()
+                continue
+
+            self._reservations[label] = PortReservation(
+                label=label,
+                port=port,
+                host=host,
+                _socket=sock,
+            )
+            return port
+
+        raise ProcessHarnessError(
+            f"no available port found for label '{label}' in range {start_port}-{end_port}"
+        )
+
+    def release_port(self, label: str) -> None:
+        """Release a previously reserved port label."""
+        reservation = self._reservations.pop(label, None)
+        if reservation is None:
+            raise ProcessHarnessError(f"unknown port reservation label: {label}")
+        reservation.release()
+
+    def start_process(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        log_file: Path,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        release_port_labels: tuple[str, ...] = (),
+    ) -> ManagedProcess:
+        """Start a process, capture stdout/stderr to a log, and track lifecycle."""
+        if name in self._processes:
+            raise ProcessHarnessError(f"process already running for name: {name}")
+        for label in release_port_labels:
+            self.release_port(label)
+
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_handle = log_file.open("w", encoding="utf-8")
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=str(cwd or self.root_dir),
+                env=env,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except OSError as error:
+            log_handle.close()
+            raise ProcessHarnessError(
+                f"failed to start process '{name}': {error}"
+            ) from error
+
+        managed = ManagedProcess(
+            name=name,
+            command=list(command),
+            log_file=log_file,
+            process=process,
+            started_at_epoch=int(time.time()),
+            _log_handle=log_handle,
+        )
+        self._processes[name] = managed
+        return managed
+
+    def wait_for_http_ready(
+        self,
+        url: str,
+        *,
+        timeout_seconds: int,
+        expected_status: int = 200,
+        interval_seconds: float = 0.1,
+    ) -> bool:
+        """Poll an HTTP endpoint until readiness or timeout."""
+        if timeout_seconds <= 0:
+            raise ProcessHarnessError("timeout_seconds must be greater than zero")
+
+        deadline = time.monotonic() + float(timeout_seconds)
+        while time.monotonic() < deadline:
+            try:
+                with urlopen(url, timeout=1) as response:
+                    if int(response.status) == expected_status:
+                        return True
+            except URLError:
+                pass
+            time.sleep(interval_seconds)
+        return False
+
+    def stop_process(self, name: str, *, grace_seconds: int = 3) -> dict[str, Any]:
+        """Stop a tracked process and return machine-checkable stop evidence."""
+        managed = self._processes.pop(name, None)
+        if managed is None:
+            return {
+                "name": name,
+                "status": "not_running",
+                "reason_code": "process_not_running",
+            }
+
+        process = managed.process
+        reason_code = "already_exited"
+        was_forced = False
+        if process.poll() is None:
+            process.terminate()
+            reason_code = "terminated_gracefully"
+            try:
+                process.wait(timeout=max(grace_seconds, 1))
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=max(grace_seconds, 1))
+                reason_code = "terminated_forced"
+                was_forced = True
+
+        managed.close_log()
+        return {
+            "name": name,
+            "status": "stopped",
+            "reason_code": reason_code,
+            "exit_code": process.poll(),
+            "forced": was_forced,
+            "pid": process.pid,
+            "log_file": str(managed.log_file),
+        }
+
+    def stop_all(self, *, grace_seconds: int = 3) -> dict[str, dict[str, Any]]:
+        """Stop all tracked processes in reverse-start order."""
+        results: dict[str, dict[str, Any]] = {}
+        for name in reversed(list(self._processes.keys())):
+            results[name] = self.stop_process(name, grace_seconds=grace_seconds)
+        return results
+
+    def close(self) -> None:
+        """Close all tracked resources."""
+        self.stop_all()
+        for reservation in list(self._reservations.values()):
+            reservation.release()
+        self._reservations.clear()
+
+
+def _validate_evidence_payload(payload: dict[str, Any]) -> None:
+    required_fields = (
+        "schema_version",
+        "status",
+        "final_decision",
+        "reason_code",
+        "ports",
+        "processes",
+        "artifacts",
+    )
+    for field_name in required_fields:
+        if field_name not in payload:
+            raise ProcessHarnessError(f"missing evidence field: {field_name}")
+
+    if not isinstance(payload["schema_version"], str):
+        raise ProcessHarnessError("schema_version must be a string")
+    if payload["status"] not in ("pass", "fail"):
+        raise ProcessHarnessError("status must be pass or fail")
+    if payload["final_decision"] not in ("GO", "NO-GO"):
+        raise ProcessHarnessError("final_decision must be GO or NO-GO")
+    if not isinstance(payload["reason_code"], str):
+        raise ProcessHarnessError("reason_code must be a string")
+
+    ports = payload["ports"]
+    if not isinstance(ports, dict):
+        raise ProcessHarnessError("ports must be an object")
+    for label, port in ports.items():
+        if not isinstance(label, str):
+            raise ProcessHarnessError("ports labels must be strings")
+        if not isinstance(port, int) or port <= 0:
+            raise ProcessHarnessError("ports values must be positive integers")
+
+    processes = payload["processes"]
+    if not isinstance(processes, list):
+        raise ProcessHarnessError("processes must be an array")
+    for entry in processes:
+        if not isinstance(entry, dict):
+            raise ProcessHarnessError("process entries must be objects")
+        if not isinstance(entry.get("name"), str):
+            raise ProcessHarnessError("process entry name must be a string")
+        if not isinstance(entry.get("status"), str):
+            raise ProcessHarnessError("process entry status must be a string")
+
+    artifacts = payload["artifacts"]
+    if not isinstance(artifacts, dict):
+        raise ProcessHarnessError("artifacts must be an object")
+    for key, value in artifacts.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ProcessHarnessError("artifacts entries must map strings to strings")
+
+
+def write_evidence_report(path: Path, payload: dict[str, Any]) -> None:
+    """Write a validated machine-checkable evidence report."""
+    _validate_evidence_payload(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def load_evidence_report(path: Path) -> dict[str, Any]:
+    """Load and validate an evidence report payload."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ProcessHarnessError(f"evidence report is not valid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise ProcessHarnessError("evidence report must be a JSON object")
+
+    _validate_evidence_payload(payload)
+    return payload

--- a/scripts/framework/test_process_harness.py
+++ b/scripts/framework/test_process_harness.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Unit and integration tests for reusable process harness primitives."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import time
+import unittest
+import sys
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR / "scripts"))
+
+from framework.process_harness import (  # noqa: E402
+    ProcessHarness,
+    ProcessHarnessError,
+    load_evidence_report,
+    write_evidence_report,
+)
+
+
+class ProcessHarnessTests(unittest.TestCase):
+    def test_unit_reserve_port_is_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            harness = ProcessHarness(root_dir=pathlib.Path(temp_dir))
+            first = harness.reserve_port("first", start_port=45000, end_port=45010)
+            second = harness.reserve_port("second", start_port=45000, end_port=45010)
+            self.assertEqual(first, 45000)
+            self.assertEqual(second, 45001)
+            harness.close()
+
+    def test_unit_evidence_report_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = pathlib.Path(temp_dir) / "evidence.json"
+            payload = {
+                "schema_version": "kamn.runtime.process-harness-evidence.v1",
+                "status": "pass",
+                "final_decision": "GO",
+                "reason_code": "process_harness_verified",
+                "ports": {"api": 19081},
+                "processes": [{"name": "api", "status": "stopped"}],
+                "artifacts": {"api_log": "/tmp/api.log"},
+            }
+            write_evidence_report(output_path, payload)
+            parsed = load_evidence_report(output_path)
+            self.assertEqual(parsed, payload)
+
+    def test_functional_single_process_lifecycle(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            with ProcessHarness(root_dir=ROOT_DIR) as harness:
+                port = harness.reserve_port("api", start_port=45100, end_port=45120)
+                process = harness.start_process(
+                    "api",
+                    ["python3", "-m", "http.server", str(port), "--bind", "127.0.0.1"],
+                    log_file=temp_path / "api.log",
+                    release_port_labels=("api",),
+                )
+                ready = harness.wait_for_http_ready(f"http://127.0.0.1:{port}/", timeout_seconds=5)
+                self.assertTrue(ready)
+                stop_result = harness.stop_process("api", grace_seconds=2)
+                self.assertEqual(stop_result["status"], "stopped")
+                self.assertIsNotNone(process.process.poll())
+
+    def test_integration_multi_process_orchestration(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            with ProcessHarness(root_dir=ROOT_DIR) as harness:
+                api_port = harness.reserve_port("api", start_port=45200, end_port=45220)
+                ws_port = harness.reserve_port("ws", start_port=45200, end_port=45220)
+
+                harness.start_process(
+                    "api",
+                    ["python3", "-m", "http.server", str(api_port), "--bind", "127.0.0.1"],
+                    log_file=temp_path / "api.log",
+                    release_port_labels=("api",),
+                )
+                harness.start_process(
+                    "ws",
+                    ["python3", "-m", "http.server", str(ws_port), "--bind", "127.0.0.1"],
+                    log_file=temp_path / "ws.log",
+                    release_port_labels=("ws",),
+                )
+
+                self.assertTrue(
+                    harness.wait_for_http_ready(f"http://127.0.0.1:{api_port}/", timeout_seconds=5)
+                )
+                self.assertTrue(
+                    harness.wait_for_http_ready(f"http://127.0.0.1:{ws_port}/", timeout_seconds=5)
+                )
+                stop_results = harness.stop_all(grace_seconds=2)
+                self.assertEqual(stop_results["api"]["status"], "stopped")
+                self.assertEqual(stop_results["ws"]["status"], "stopped")
+
+    def test_regression_context_manager_tears_down_on_exception(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            process_ref = None
+            try:
+                with ProcessHarness(root_dir=ROOT_DIR) as harness:
+                    port = harness.reserve_port("api", start_port=45300, end_port=45320)
+                    process_ref = harness.start_process(
+                        "api",
+                        ["python3", "-m", "http.server", str(port), "--bind", "127.0.0.1"],
+                        log_file=temp_path / "api.log",
+                        release_port_labels=("api",),
+                    )
+                    self.assertTrue(
+                        harness.wait_for_http_ready(
+                            f"http://127.0.0.1:{port}/", timeout_seconds=5
+                        )
+                    )
+                    raise RuntimeError("force teardown")
+            except RuntimeError:
+                pass
+            self.assertIsNotNone(process_ref)
+            assert process_ref is not None
+            self.assertIsNotNone(process_ref.process.poll())
+
+    def test_performance_setup_teardown_within_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            start = time.monotonic()
+            with ProcessHarness(root_dir=ROOT_DIR) as harness:
+                port = harness.reserve_port("api", start_port=45400, end_port=45420)
+                harness.start_process(
+                    "api",
+                    ["python3", "-m", "http.server", str(port), "--bind", "127.0.0.1"],
+                    log_file=temp_path / "api.log",
+                    release_port_labels=("api",),
+                )
+                ready = harness.wait_for_http_ready(f"http://127.0.0.1:{port}/", timeout_seconds=5)
+                self.assertTrue(ready)
+            elapsed = time.monotonic() - start
+            self.assertLess(
+                elapsed,
+                8.0,
+                msg=f"process harness setup/teardown exceeded budget: {elapsed:.2f}s",
+            )
+
+    def test_unit_reject_invalid_evidence_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = pathlib.Path(temp_dir) / "bad-evidence.json"
+            with self.assertRaises(ProcessHarnessError):
+                write_evidence_report(
+                    output_path,
+                    {
+                        "schema_version": "kamn.runtime.process-harness-evidence.v1",
+                        "status": "pass",
+                        "final_decision": "GO",
+                    },
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py
+++ b/scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py
@@ -6,16 +6,21 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import socket
 import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
-from urllib.error import URLError
-from urllib.request import urlopen
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT_DIR / "scripts"))
+
+from framework.process_harness import (  # noqa: E402
+    ProcessHarness,
+    ProcessHarnessError,
+    write_evidence_report,
+)
+
 RUNNER = ROOT_DIR / "scripts/kolme/run_local_runtime_commit_live_lane.sh"
 CHECKER = ROOT_DIR / "scripts/kolme/check_local_runtime_commit_live_evidence_policy.py"
 DOC_FILES = [
@@ -45,25 +50,6 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--max-seconds", default="90")
     return parser.parse_args()
-
-
-def _pick_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def _wait_for_healthz(base_url: str, timeout_seconds: int = 10) -> bool:
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            with urlopen(f"{base_url}/healthz", timeout=1) as response:
-                if response.status == 200:
-                    return True
-        except URLError:
-            pass
-        time.sleep(0.1)
-    return False
 
 
 def _run(command: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -111,23 +97,25 @@ def main() -> int:
 
     start_epoch = time.monotonic()
 
-    with tempfile.TemporaryDirectory(prefix="live-provider-runtime-integration-contract-") as temp_dir:
-        temp_path = Path(temp_dir)
-        mock_server_file = temp_path / "mock_kolme_api.py"
-        mock_server_log = temp_path / "mock_kolme_api.log"
-        go_summary_file = temp_path / "go_summary.json"
-        go_policy_file = temp_path / "go_policy.json"
-        provider_mismatch_summary_file = temp_path / "provider_mismatch_summary.json"
-        provider_mismatch_policy_file = temp_path / "provider_mismatch_policy.json"
-        unavailable_summary_file = temp_path / "unavailable_summary.json"
-        unavailable_policy_file = temp_path / "unavailable_policy.json"
-        go_live_output = temp_path / "go_live_output.txt"
-        go_finality_output = temp_path / "go_finality_output.txt"
-        unavailable_live_output = temp_path / "unavailable_live_output.txt"
-        unavailable_finality_output = temp_path / "unavailable_finality_output.txt"
+    try:
+        with tempfile.TemporaryDirectory(prefix="live-provider-runtime-integration-contract-") as temp_dir:
+            temp_path = Path(temp_dir)
+            mock_server_file = temp_path / "mock_kolme_api.py"
+            mock_server_log = temp_path / "mock_kolme_api.log"
+            go_summary_file = temp_path / "go_summary.json"
+            go_policy_file = temp_path / "go_policy.json"
+            provider_mismatch_summary_file = temp_path / "provider_mismatch_summary.json"
+            provider_mismatch_policy_file = temp_path / "provider_mismatch_policy.json"
+            unavailable_summary_file = temp_path / "unavailable_summary.json"
+            unavailable_policy_file = temp_path / "unavailable_policy.json"
+            go_live_output = temp_path / "go_live_output.txt"
+            go_finality_output = temp_path / "go_finality_output.txt"
+            unavailable_live_output = temp_path / "unavailable_live_output.txt"
+            unavailable_finality_output = temp_path / "unavailable_finality_output.txt"
+            process_harness_evidence_file = temp_path / "process_harness_evidence.json"
 
-        mock_server_file.write_text(
-            """#!/usr/bin/env python3
+            mock_server_file.write_text(
+                """#!/usr/bin/env python3
 from __future__ import annotations
 
 import http.server
@@ -173,225 +161,239 @@ def main() -> int:
 if __name__ == "__main__":
     raise SystemExit(main())
 """,
-            encoding="utf-8",
-        )
-        mock_server_file.chmod(0o755)
-
-        port = _pick_free_port()
-        base_url = f"http://127.0.0.1:{port}"
-        server_process = subprocess.Popen(
-            ["python3", str(mock_server_file), str(port)],
-            cwd=ROOT_DIR,
-            stdout=mock_server_log.open("w", encoding="utf-8"),
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-
-        try:
-            if not _wait_for_healthz(base_url):
-                raise RuntimeError("mock Kolme API server failed readiness probe")
-
-            go_live_command = (
-                "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 "
-                f"curl --silent --show-error --fail {base_url}/healthz >/dev/null && "
-                "printf 'status=submitted\\nintegration_kolme_fork_live_node_submit_reaches_endpoint\\n"
-                "replay_guard=verified\\n{\"pubkey\":\"proof\",\"nonce\":1,\"messages\":[]}\\n'"
-            )
-            go_result = _run(
-                [
-                    "bash",
-                    str(RUNNER),
-                    "--mode",
-                    "run",
-                    "--base-url",
-                    base_url,
-                    "--provider-hint",
-                    "kolme-fork-local",
-                    "--max-seconds",
-                    "30",
-                    "--preflight-max-seconds",
-                    "5",
-                    "--live-command",
-                    go_live_command,
-                    "--finality-command",
-                    f"curl --silent --show-error --fail {base_url}/healthz >/dev/null && printf 'finality=final\\n'",
-                    "--finality-max-seconds",
-                    "5",
-                    "--finality-retry-max-attempts",
-                    "2",
-                    "--finality-retry-backoff-seconds",
-                    "0",
-                    "--output-json",
-                    str(go_summary_file),
-                    "--live-output-file",
-                    str(go_live_output),
-                    "--finality-output-file",
-                    str(go_finality_output),
-                ],
-                env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
-            )
-            if go_result.returncode != 0:
-                raise RuntimeError(
-                    "expected GO live-provider integration run to succeed: "
-                    f"{go_result.stdout}{go_result.stderr}"
-                )
-
-            go_policy_result = _run(
-                [
-                    "python3",
-                    str(CHECKER),
-                    "--report-file",
-                    str(go_summary_file),
-                    "--expected-final-decision",
-                    "GO",
-                    "--ci-fast-gate",
-                    "PASS",
-                    "--expected-provider-client-contract",
-                    "KolmeRuntimeCommitLiveProvider",
-                    "--require-non-synthetic-run-evidence",
-                    "--require-native-payload-evidence",
-                    "--output-json",
-                    str(go_policy_file),
-                ]
-            )
-            if go_policy_result.returncode != 0:
-                raise RuntimeError(
-                    "expected GO live-provider integration policy check to pass: "
-                    f"{go_policy_result.stdout}{go_policy_result.stderr}"
-                )
-
-            go_summary = json.loads(go_summary_file.read_text(encoding="utf-8"))
-            if go_summary.get("provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
-                raise RuntimeError("expected provider_client_contract=KolmeRuntimeCommitLiveProvider in GO summary")
-            if go_summary.get("provider_in_memory_reference_detected") is not False:
-                raise RuntimeError("expected provider_in_memory_reference_detected=false in GO summary")
-
-            provider_mismatch_summary = dict(go_summary)
-            provider_mismatch_summary["provider_client_contract"] = "InMemoryKolmeRuntimeCommitClient"
-            provider_mismatch_summary["provider_in_memory_reference_detected"] = True
-            provider_mismatch_summary["provider_live_contract_marker"] = (
-                "provider_client_contract=InMemoryKolmeRuntimeCommitClient"
-            )
-            provider_mismatch_summary["provider_live_contract_marker_present"] = False
-            provider_mismatch_summary_file.write_text(
-                json.dumps(provider_mismatch_summary, sort_keys=True, indent=2) + "\n",
                 encoding="utf-8",
             )
+            mock_server_file.chmod(0o755)
 
-            provider_mismatch_result = _run(
-                [
-                    "python3",
-                    str(CHECKER),
-                    "--report-file",
-                    str(provider_mismatch_summary_file),
-                    "--expected-final-decision",
-                    "NO-GO",
-                    "--ci-fast-gate",
-                    "PASS",
-                    "--expected-provider-client-contract",
-                    "KolmeRuntimeCommitLiveProvider",
-                    "--output-json",
-                    str(provider_mismatch_policy_file),
-                ]
-            )
-            if provider_mismatch_result.returncode == 0:
-                raise RuntimeError("expected provider mismatch policy check to fail closed")
-            provider_mismatch_policy = json.loads(
-                provider_mismatch_policy_file.read_text(encoding="utf-8")
-            )
-            provider_mismatch_reasons = provider_mismatch_policy.get("reason_codes")
-            if not isinstance(provider_mismatch_reasons, list):
-                raise RuntimeError("expected reason_codes list in provider mismatch policy output")
-            required_provider_reasons = {
-                "provider_client_contract_mismatch",
-                "provider_in_memory_reference_detected",
-            }
-            if not required_provider_reasons.issubset(set(provider_mismatch_reasons)):
-                raise RuntimeError("missing required provider mismatch fail-closed reason markers")
-
-            unavailable_base_url = f"http://127.0.0.1:{port + 17}"
-            unavailable_result = _run(
-                [
-                    "bash",
-                    str(RUNNER),
-                    "--mode",
-                    "run",
-                    "--base-url",
-                    unavailable_base_url,
-                    "--provider-hint",
-                    "kolme-fork-local",
-                    "--max-seconds",
-                    "20",
-                    "--preflight-max-seconds",
-                    "2",
-                    "--live-command",
-                    go_live_command,
-                    "--output-json",
-                    str(unavailable_summary_file),
-                    "--live-output-file",
-                    str(unavailable_live_output),
-                    "--finality-output-file",
-                    str(unavailable_finality_output),
-                ],
-                env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
-            )
-            if unavailable_result.returncode == 0:
-                raise RuntimeError("expected unavailable-node integration run to fail closed")
-            unavailable_summary = json.loads(unavailable_summary_file.read_text(encoding="utf-8"))
-            unavailable_reason_code = unavailable_summary.get("reason_code")
-            if unavailable_reason_code not in {"live_preflight_failed", "live_preflight_timeout"}:
-                raise RuntimeError("expected deterministic preflight failure reason for unavailable-node path")
-
-            unavailable_policy_result = _run(
-                [
-                    "python3",
-                    str(CHECKER),
-                    "--report-file",
-                    str(unavailable_summary_file),
-                    "--expected-final-decision",
-                    "NO-GO",
-                    "--ci-fast-gate",
-                    "PASS",
-                    "--expected-provider-client-contract",
-                    "KolmeRuntimeCommitLiveProvider",
-                    "--require-reason-code",
-                    str(unavailable_reason_code),
-                    "--output-json",
-                    str(unavailable_policy_file),
-                ]
-            )
-            if unavailable_policy_result.returncode != 0:
-                raise RuntimeError(
-                    "expected unavailable-node NO-GO policy check to pass with deterministic reason: "
-                    f"{unavailable_policy_result.stdout}{unavailable_policy_result.stderr}"
+            with ProcessHarness(root_dir=ROOT_DIR) as harness:
+                port = harness.reserve_port("mock_kolme_api", start_port=30000, end_port=45000)
+                base_url = f"http://127.0.0.1:{port}"
+                mock_process = harness.start_process(
+                    "mock_kolme_api",
+                    ["python3", str(mock_server_file), str(port)],
+                    log_file=mock_server_log,
+                    release_port_labels=("mock_kolme_api",),
                 )
 
-            contract_report = {
-                "schema_version": "kamn.kolme.local-live-provider-runtime-integration-contract-report.v1",
-                "go_summary_file": str(go_summary_file),
-                "go_policy_file": str(go_policy_file),
-                "provider_mismatch_summary_file": str(provider_mismatch_summary_file),
-                "provider_mismatch_policy_file": str(provider_mismatch_policy_file),
-                "unavailable_summary_file": str(unavailable_summary_file),
-                "unavailable_policy_file": str(unavailable_policy_file),
-                "final_decision": "GO",
-            }
-            output_path = Path(args.output_json).resolve()
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(
-                json.dumps(contract_report, sort_keys=True, indent=2) + "\n",
-                encoding="utf-8",
-            )
-        except RuntimeError as exc:
-            print(str(exc), file=sys.stderr)
-            return 1
-        finally:
-            server_process.terminate()
-            try:
-                server_process.wait(timeout=3)
-            except subprocess.TimeoutExpired:
-                server_process.kill()
-                server_process.wait(timeout=3)
+                if not harness.wait_for_http_ready(f"{base_url}/healthz", timeout_seconds=10):
+                    raise RuntimeError("mock Kolme API server failed readiness probe")
+
+                go_live_command = (
+                    "KAMN_KOLME_LIVE_SIGNING_PROFILE=kolme-fork-secp256k1-v1 "
+                    f"curl --silent --show-error --fail {base_url}/healthz >/dev/null && "
+                    "printf 'status=submitted\\nintegration_kolme_fork_live_node_submit_reaches_endpoint\\n"
+                    "replay_guard=verified\\n{\"pubkey\":\"proof\",\"nonce\":1,\"messages\":[]}\\n'"
+                )
+                go_result = _run(
+                    [
+                        "bash",
+                        str(RUNNER),
+                        "--mode",
+                        "run",
+                        "--base-url",
+                        base_url,
+                        "--provider-hint",
+                        "kolme-fork-local",
+                        "--max-seconds",
+                        "30",
+                        "--preflight-max-seconds",
+                        "5",
+                        "--live-command",
+                        go_live_command,
+                        "--finality-command",
+                        f"curl --silent --show-error --fail {base_url}/healthz >/dev/null && printf 'finality=final\\n'",
+                        "--finality-max-seconds",
+                        "5",
+                        "--finality-retry-max-attempts",
+                        "2",
+                        "--finality-retry-backoff-seconds",
+                        "0",
+                        "--output-json",
+                        str(go_summary_file),
+                        "--live-output-file",
+                        str(go_live_output),
+                        "--finality-output-file",
+                        str(go_finality_output),
+                    ],
+                    env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
+                )
+                if go_result.returncode != 0:
+                    raise RuntimeError(
+                        "expected GO live-provider integration run to succeed: "
+                        f"{go_result.stdout}{go_result.stderr}"
+                    )
+
+                go_policy_result = _run(
+                    [
+                        "python3",
+                        str(CHECKER),
+                        "--report-file",
+                        str(go_summary_file),
+                        "--expected-final-decision",
+                        "GO",
+                        "--ci-fast-gate",
+                        "PASS",
+                        "--expected-provider-client-contract",
+                        "KolmeRuntimeCommitLiveProvider",
+                        "--require-non-synthetic-run-evidence",
+                        "--require-native-payload-evidence",
+                        "--output-json",
+                        str(go_policy_file),
+                    ]
+                )
+                if go_policy_result.returncode != 0:
+                    raise RuntimeError(
+                        "expected GO live-provider integration policy check to pass: "
+                        f"{go_policy_result.stdout}{go_policy_result.stderr}"
+                    )
+
+                go_summary = json.loads(go_summary_file.read_text(encoding="utf-8"))
+                if go_summary.get("provider_client_contract") != "KolmeRuntimeCommitLiveProvider":
+                    raise RuntimeError("expected provider_client_contract=KolmeRuntimeCommitLiveProvider in GO summary")
+                if go_summary.get("provider_in_memory_reference_detected") is not False:
+                    raise RuntimeError("expected provider_in_memory_reference_detected=false in GO summary")
+
+                provider_mismatch_summary = dict(go_summary)
+                provider_mismatch_summary["provider_client_contract"] = "InMemoryKolmeRuntimeCommitClient"
+                provider_mismatch_summary["provider_in_memory_reference_detected"] = True
+                provider_mismatch_summary["provider_live_contract_marker"] = (
+                    "provider_client_contract=InMemoryKolmeRuntimeCommitClient"
+                )
+                provider_mismatch_summary["provider_live_contract_marker_present"] = False
+                provider_mismatch_summary_file.write_text(
+                    json.dumps(provider_mismatch_summary, sort_keys=True, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+
+                provider_mismatch_result = _run(
+                    [
+                        "python3",
+                        str(CHECKER),
+                        "--report-file",
+                        str(provider_mismatch_summary_file),
+                        "--expected-final-decision",
+                        "NO-GO",
+                        "--ci-fast-gate",
+                        "PASS",
+                        "--expected-provider-client-contract",
+                        "KolmeRuntimeCommitLiveProvider",
+                        "--output-json",
+                        str(provider_mismatch_policy_file),
+                    ]
+                )
+                if provider_mismatch_result.returncode == 0:
+                    raise RuntimeError("expected provider mismatch policy check to fail closed")
+                provider_mismatch_policy = json.loads(
+                    provider_mismatch_policy_file.read_text(encoding="utf-8")
+                )
+                provider_mismatch_reasons = provider_mismatch_policy.get("reason_codes")
+                if not isinstance(provider_mismatch_reasons, list):
+                    raise RuntimeError("expected reason_codes list in provider mismatch policy output")
+                required_provider_reasons = {
+                    "provider_client_contract_mismatch",
+                    "provider_in_memory_reference_detected",
+                }
+                if not required_provider_reasons.issubset(set(provider_mismatch_reasons)):
+                    raise RuntimeError("missing required provider mismatch fail-closed reason markers")
+
+                unavailable_base_url = f"http://127.0.0.1:{port + 17}"
+                unavailable_result = _run(
+                    [
+                        "bash",
+                        str(RUNNER),
+                        "--mode",
+                        "run",
+                        "--base-url",
+                        unavailable_base_url,
+                        "--provider-hint",
+                        "kolme-fork-local",
+                        "--max-seconds",
+                        "20",
+                        "--preflight-max-seconds",
+                        "2",
+                        "--live-command",
+                        go_live_command,
+                        "--output-json",
+                        str(unavailable_summary_file),
+                        "--live-output-file",
+                        str(unavailable_live_output),
+                        "--finality-output-file",
+                        str(unavailable_finality_output),
+                    ],
+                    env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
+                )
+                if unavailable_result.returncode == 0:
+                    raise RuntimeError("expected unavailable-node integration run to fail closed")
+                unavailable_summary = json.loads(unavailable_summary_file.read_text(encoding="utf-8"))
+                unavailable_reason_code = unavailable_summary.get("reason_code")
+                if unavailable_reason_code not in {"live_preflight_failed", "live_preflight_timeout"}:
+                    raise RuntimeError("expected deterministic preflight failure reason for unavailable-node path")
+
+                unavailable_policy_result = _run(
+                    [
+                        "python3",
+                        str(CHECKER),
+                        "--report-file",
+                        str(unavailable_summary_file),
+                        "--expected-final-decision",
+                        "NO-GO",
+                        "--ci-fast-gate",
+                        "PASS",
+                        "--expected-provider-client-contract",
+                        "KolmeRuntimeCommitLiveProvider",
+                        "--require-reason-code",
+                        str(unavailable_reason_code),
+                        "--output-json",
+                        str(unavailable_policy_file),
+                    ]
+                )
+                if unavailable_policy_result.returncode != 0:
+                    raise RuntimeError(
+                        "expected unavailable-node NO-GO policy check to pass with deterministic reason: "
+                        f"{unavailable_policy_result.stdout}{unavailable_policy_result.stderr}"
+                    )
+
+                write_evidence_report(
+                    process_harness_evidence_file,
+                    {
+                        "schema_version": "kamn.runtime.process-harness-evidence.v1",
+                        "status": "pass",
+                        "final_decision": "GO",
+                        "reason_code": "local_live_provider_process_harness_verified",
+                        "ports": {"mock_kolme_api": port},
+                        "processes": [
+                            {
+                                "name": "mock_kolme_api",
+                                "status": "running",
+                                "pid": mock_process.process.pid,
+                            }
+                        ],
+                        "artifacts": {
+                            "mock_kolme_api_log": str(mock_server_log),
+                        },
+                    },
+                )
+
+                contract_report = {
+                    "schema_version": "kamn.kolme.local-live-provider-runtime-integration-contract-report.v1",
+                    "go_summary_file": str(go_summary_file),
+                    "go_policy_file": str(go_policy_file),
+                    "provider_mismatch_summary_file": str(provider_mismatch_summary_file),
+                    "provider_mismatch_policy_file": str(provider_mismatch_policy_file),
+                    "unavailable_summary_file": str(unavailable_summary_file),
+                    "unavailable_policy_file": str(unavailable_policy_file),
+                    "process_harness_evidence_file": str(process_harness_evidence_file),
+                    "final_decision": "GO",
+                }
+                output_path = Path(args.output_json).resolve()
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(
+                    json.dumps(contract_report, sort_keys=True, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+    except (RuntimeError, ProcessHarnessError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     elapsed_seconds = int(time.monotonic() - start_epoch)
     if elapsed_seconds > int(args.max_seconds):


### PR DESCRIPTION
## Summary
Introduce a reusable process harness foundation for local integration lanes with deterministic port reservation, lifecycle-safe process teardown, readiness probing, and machine-checkable evidence payload helpers.

Closes #3362.

## Changes
- scripts/framework/process_harness.py: add ProcessHarness primitives (port reservation, process start/stop, readiness probe, evidence report helpers).
- scripts/framework/test_process_harness.py: add unit/functional/integration/regression/performance tests for harness behavior.
- scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py: migrate ad-hoc port/process handling to ProcessHarness and emit linked process harness evidence artifact.
- docs/ci/strategy.md: document harness invocation contract and evidence artifact layout.

## Risks & Compatibility
- Low risk: contract-lane behavior is preserved while subprocess orchestration internals are centralized.
- Compatibility: added `process_harness_evidence_file` field to the live-provider integration contract report (additive).

## Validation
- [ ] `cargo fmt --check` — clean (not run; no Rust files changed)
- [ ] `cargo clippy -- -D warnings` — clean (not run; no Rust files changed)
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual verification:
  - `python3 scripts/framework/test_process_harness.py`
  - `bash scripts/kolme/test_run_local_live_provider_runtime_integration_contract_lane.sh`
  - `bash scripts/ci/test_ci_strategy_contract.sh`
  - `python3 -m py_compile scripts/framework/process_harness.py scripts/framework/test_process_harness.py scripts/kolme/contracts/local_live_provider_runtime_integration_contract_lane.py`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `scripts/framework/test_process_harness.py` |
| Functional  | ✅ | single-process lifecycle + readiness checks in harness tests |
| Integration | ✅ | multi-process orchestration smoke + live-provider lane wrapper test |
| Regression  | ✅ | context-manager teardown-on-exception test |
