### PR TITLE
feat(runtime): add local full-stack integration contract lane

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -199,6 +199,30 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Deterministic fail-closed marker for policy tamper drills:
   - `full_io_scenario_matrix_policy_multinode_propagation_mismatch`
 
+## Runtime Local Full-Stack Integration Contract Lane
+- Entry commands:
+  - `bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode dry-run --output-json /tmp/local-full-stack-integration-summary.json`
+  - `KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1 bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode run --ci-fast-gate FAIL --output-json /tmp/local-full-stack-integration-summary.json`
+  - `bash scripts/runtime/check_local_full_stack_integration_live_policy.sh --report-file /tmp/local-full-stack-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-full-stack-integration-policy.json`
+  - `bash scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh --output-json /tmp/local-full-stack-integration-contract-lane-report.json --policy-output-json /tmp/local-full-stack-integration-policy.json`
+  - `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
+  - `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
+  - `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
+- ci-fast-gate mode: fast
+- local-dev mode: local
+- manual-hardened mode: manual
+- Integration composition contract:
+  - composes full I/O scenario matrix lane (`validate_full_io_scenario_matrix_live.sh`) in run mode.
+  - composes full-runtime supervisor lane (`validate_local_full_runtime_live.sh`) in run mode.
+  - emits deterministic evidence bundle schema `kamn.runtime.local-full-stack-integration-evidence-bundle.v1`.
+- Cost controls:
+  - dry-run mode executes no nested local-heavy commands and emits deterministic `dry_run_no_commands_executed`.
+  - run mode is explicit local-only and requires `KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1`.
+  - nested run-mode commands propagate local-only opt-in for composed lanes.
+  - local full-stack integration run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
+- Deterministic fail-closed marker for policy tamper drills:
+  - `local_full_stack_integration_policy_evidence_bundle_status_mismatch`
+
 ## Deploy Compose Topology Contract Lane
 - Entry commands:
   - `bash scripts/deploy/validate_compose_topology_contract_lane.sh --output-json /tmp/compose-topology-contract-summary.json --ci-fast-gate PASS`

--- a/scripts/runtime/check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/check_local_full_stack_integration_live_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/local_full_stack_integration_live_contract.py" check-policy "$@"

--- a/scripts/runtime/local_full_stack_integration_live_contract.py
+++ b/scripts/runtime/local_full_stack_integration_live_contract.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Local full-stack integration live-validation lane and policy checker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_positive_int,
+    write_json,
+)
+
+RUN_LANE_SCHEMA = "kamn.runtime.local-full-stack-integration-live-report.v1"
+POLICY_SCHEMA = "kamn.runtime.local-full-stack-integration-live-policy-report.v1"
+EVIDENCE_BUNDLE_SCHEMA = "kamn.runtime.local-full-stack-integration-evidence-bundle.v1"
+OPT_IN_ENV = "KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN"
+DRY_RUN_REASON = "dry_run_no_commands_executed"
+RUN_REASON = "local_full_stack_integration_live_validation_executed"
+FAST_GATE_EXCLUSION_REASON = "local_full_stack_integration_run_mode_excluded_from_fast_gate"
+
+
+def _extract_line_value(output: str, key: str) -> str:
+    prefix = f"{key}="
+    for line in output.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    return ""
+
+
+def _run_command(
+    command: list[str],
+    *,
+    timeout_seconds: int,
+    env: dict[str, str] | None = None,
+) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout_seconds,
+        env=env,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "command failed").strip()
+        fail(f"lane command failed: {' '.join(command)}: {detail}")
+    return completed.stdout
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def run_lane(args: argparse.Namespace) -> int:
+    mode = require_enum("--mode", args.mode.strip(), ("dry-run", "run"))
+    ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
+    max_seconds = require_positive_int("KAMN_LOCAL_FULL_STACK_INTEGRATION_MAX_SECONDS", args.max_seconds)
+    command_max_seconds = require_positive_int(
+        "KAMN_LOCAL_FULL_STACK_INTEGRATION_COMMAND_MAX_SECONDS",
+        args.command_max_seconds,
+    )
+
+    if mode == "run" and args.local_opt_in != "1":
+        fail(
+            "run mode requires explicit local-only opt-in via "
+            "KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1"
+        )
+
+    start_epoch = int(time.time())
+    commands_executed = 0
+    artifact_paths: dict[str, str] = {}
+    if mode == "run":
+        artifact_dir = Path(tempfile.mkdtemp(prefix="local-full-stack-integration-live-"))
+        full_io_report = artifact_dir / "full-io-scenario-matrix-report.json"
+        full_runtime_report = artifact_dir / "local-full-runtime-report.json"
+        evidence_bundle_file = artifact_dir / "local-full-stack-evidence-bundle.json"
+
+        full_io_output = _run_command(
+            [
+                "bash",
+                "scripts/runtime/validate_full_io_scenario_matrix_live.sh",
+                "--mode",
+                "run",
+                "--ci-fast-gate",
+                "FAIL",
+                "--max-seconds",
+                str(command_max_seconds),
+                "--output-json",
+                str(full_io_report),
+            ],
+            timeout_seconds=command_max_seconds,
+            env={**os.environ, "KAMN_LOCAL_FULL_IO_SCENARIO_MATRIX_OPT_IN": "1"},
+        )
+        if _extract_line_value(full_io_output, "status") != "pass":
+            fail("full I/O scenario matrix command did not emit status=pass")
+        if _extract_line_value(full_io_output, "final_decision") != "GO":
+            fail("full I/O scenario matrix command did not emit final_decision=GO")
+        commands_executed += 1
+
+        full_runtime_output = _run_command(
+            [
+                "bash",
+                "scripts/runtime/validate_local_full_runtime_live.sh",
+                "--mode",
+                "run",
+                "--ci-fast-gate",
+                "FAIL",
+                "--max-seconds",
+                str(command_max_seconds),
+                "--command-max-seconds",
+                str(min(command_max_seconds, 180)),
+                "--output-json",
+                str(full_runtime_report),
+            ],
+            timeout_seconds=command_max_seconds,
+            env={**os.environ, "KAMN_LOCAL_FULL_RUNTIME_LIVE_OPT_IN": "1"},
+        )
+        if _extract_line_value(full_runtime_output, "status") != "pass":
+            fail("local full-runtime command did not emit status=pass")
+        if _extract_line_value(full_runtime_output, "final_decision") != "GO":
+            fail("local full-runtime command did not emit final_decision=GO")
+        commands_executed += 1
+
+        full_io_payload = json.loads(full_io_report.read_text(encoding="utf-8"))
+        full_runtime_payload = json.loads(full_runtime_report.read_text(encoding="utf-8"))
+        if full_io_payload.get("final_decision") != "GO":
+            fail("full I/O scenario matrix report missing final_decision=GO")
+        if full_runtime_payload.get("final_decision") != "GO":
+            fail("local full-runtime report missing final_decision=GO")
+
+        evidence_bundle = {
+            "schema_version": EVIDENCE_BUNDLE_SCHEMA,
+            "status": "pass",
+            "final_decision": "GO",
+            "lane_mode": mode,
+            "full_io_matrix_report_file": str(full_io_report),
+            "full_runtime_report_file": str(full_runtime_report),
+            "commands_executed": commands_executed,
+            "ci_fast_gate_eligibility": "excluded_local_heavy",
+        }
+        _write_json(evidence_bundle_file, evidence_bundle)
+
+        artifact_paths = {
+            "full_io_matrix_report": str(full_io_report),
+            "full_runtime_report": str(full_runtime_report),
+            "evidence_bundle_file": str(evidence_bundle_file),
+        }
+
+    elapsed_seconds = int(time.time()) - start_epoch
+    if elapsed_seconds > max_seconds:
+        fail(
+            "local full-stack integration lane exceeded runtime budget: "
+            f"{elapsed_seconds}s (max={max_seconds}s)"
+        )
+
+    run_mode_command_status = "executed" if mode == "run" else "dry_run_no_commands_executed"
+    ci_fast_gate_eligibility = "excluded_local_heavy" if mode == "run" else "eligible"
+    reason_code = RUN_REASON if mode == "run" else DRY_RUN_REASON
+
+    payload = {
+        "schema_version": RUN_LANE_SCHEMA,
+        "status": "pass",
+        "final_decision": "GO",
+        "lane_mode": mode,
+        "ci_fast_gate": ci_fast_gate,
+        "ci_fast_gate_eligibility": ci_fast_gate_eligibility,
+        "fast_gate_exclusion_status": "verified",
+        "fast_gate_exclusion_reason_code": FAST_GATE_EXCLUSION_REASON,
+        "scenario_matrix_status": "verified",
+        "full_runtime_status": "verified",
+        "evidence_bundle_status": "verified",
+        "run_mode_command_status": run_mode_command_status,
+        "run_mode_command_count": commands_executed,
+        "reason_code": reason_code,
+        "elapsed_seconds": elapsed_seconds,
+        "max_seconds": max_seconds,
+        "command_max_seconds": command_max_seconds,
+        "artifact_paths": artifact_paths,
+    }
+    if args.output_json:
+        write_json(Path(args.output_json), payload)
+
+    print("status=pass")
+    print("final_decision=GO")
+    print(f"lane_mode={mode}")
+    print(f"ci_fast_gate={ci_fast_gate}")
+    print(f"ci_fast_gate_eligibility={ci_fast_gate_eligibility}")
+    print("fast_gate_exclusion_status=verified")
+    print(f"fast_gate_exclusion_reason_code={FAST_GATE_EXCLUSION_REASON}")
+    print("scenario_matrix_status=verified")
+    print("full_runtime_status=verified")
+    print("evidence_bundle_status=verified")
+    print(f"run_mode_command_status={run_mode_command_status}")
+    print(f"run_mode_command_count={commands_executed}")
+    print(f"reason_code={reason_code}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+    return 0
+
+
+def check_policy(args: argparse.Namespace) -> int:
+    report_file = Path(args.report_file)
+    if not report_file.is_file():
+        fail(f"report file does not exist: {report_file}")
+
+    expected_final_decision = require_enum(
+        "--expected-final-decision",
+        args.expected_final_decision.strip(),
+        ("GO", "NO-GO"),
+    )
+    ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
+    payload = load_json(report_file)
+
+    checks = DecisionAccumulator()
+    checks.reject_if(
+        payload.get("schema_version") != RUN_LANE_SCHEMA,
+        "local_full_stack_integration_policy_schema_mismatch",
+    )
+    checks.reject_if(payload.get("status") != "pass", "local_full_stack_integration_policy_status_mismatch")
+    checks.reject_if(
+        payload.get("final_decision") != "GO",
+        "local_full_stack_integration_policy_final_decision_mismatch",
+    )
+    checks.reject_if(
+        payload.get("ci_fast_gate") != ci_fast_gate,
+        "local_full_stack_integration_policy_ci_fast_gate_mismatch",
+    )
+    checks.reject_if(
+        payload.get("fast_gate_exclusion_status") != "verified",
+        "local_full_stack_integration_policy_fast_gate_exclusion_mismatch",
+    )
+    checks.reject_if(
+        payload.get("fast_gate_exclusion_reason_code") != FAST_GATE_EXCLUSION_REASON,
+        "local_full_stack_integration_policy_fast_gate_reason_mismatch",
+    )
+    checks.reject_if(
+        payload.get("scenario_matrix_status") != "verified",
+        "local_full_stack_integration_policy_scenario_matrix_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("full_runtime_status") != "verified",
+        "local_full_stack_integration_policy_full_runtime_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("evidence_bundle_status") != "verified",
+        "local_full_stack_integration_policy_evidence_bundle_status_mismatch",
+    )
+
+    lane_mode = payload.get("lane_mode")
+    checks.reject_if(
+        lane_mode not in ("dry-run", "run"),
+        "local_full_stack_integration_policy_lane_mode_invalid",
+    )
+    command_count = payload.get("run_mode_command_count")
+    checks.reject_if(
+        not isinstance(command_count, int) or command_count < 0,
+        "local_full_stack_integration_policy_command_count_invalid",
+    )
+    command_status = payload.get("run_mode_command_status")
+    reason_code = payload.get("reason_code")
+    artifact_paths = payload.get("artifact_paths")
+    checks.reject_if(
+        not isinstance(artifact_paths, dict),
+        "local_full_stack_integration_policy_artifact_paths_invalid",
+    )
+
+    if lane_mode == "dry-run":
+        checks.reject_if(
+            payload.get("ci_fast_gate_eligibility") != "eligible",
+            "local_full_stack_integration_policy_dry_run_eligibility_mismatch",
+        )
+        checks.reject_if(
+            command_count != 0,
+            "local_full_stack_integration_policy_dry_run_command_count_mismatch",
+        )
+        checks.reject_if(
+            command_status != "dry_run_no_commands_executed",
+            "local_full_stack_integration_policy_dry_run_command_status_mismatch",
+        )
+        checks.reject_if(
+            reason_code != DRY_RUN_REASON,
+            "local_full_stack_integration_policy_dry_run_reason_code_mismatch",
+        )
+    elif lane_mode == "run":
+        checks.reject_if(
+            payload.get("ci_fast_gate_eligibility") != "excluded_local_heavy",
+            "local_full_stack_integration_policy_run_mode_exclusion_mismatch",
+        )
+        checks.reject_if(
+            command_count < 2,
+            "local_full_stack_integration_policy_run_mode_command_count_mismatch",
+        )
+        checks.reject_if(
+            command_status != "executed",
+            "local_full_stack_integration_policy_run_mode_command_status_mismatch",
+        )
+        checks.reject_if(
+            reason_code != RUN_REASON,
+            "local_full_stack_integration_policy_run_mode_reason_code_mismatch",
+        )
+        required_artifacts = (
+            "full_io_matrix_report",
+            "full_runtime_report",
+            "evidence_bundle_file",
+        )
+        if isinstance(artifact_paths, dict):
+            for artifact_key in required_artifacts:
+                artifact_value = artifact_paths.get(artifact_key)
+                checks.reject_if(
+                    not isinstance(artifact_value, str) or not Path(artifact_value).is_file(),
+                    f"local_full_stack_integration_policy_artifact_missing:{artifact_key}",
+                )
+
+    observed_final_decision, decision_reasons = checks.finalize(
+        "local_full_stack_integration_policy_verified"
+    )
+    failed_checks: list[str] = []
+    if observed_final_decision == "NO-GO":
+        failed_checks.extend(decision_reasons)
+    if observed_final_decision != expected_final_decision:
+        failed_checks.append("local_full_stack_integration_policy_expected_decision_mismatch")
+
+    report_payload = {
+        "schema_version": POLICY_SCHEMA,
+        "status": "ok" if not failed_checks else "fail",
+        "final_decision": observed_final_decision,
+        "expected_final_decision": expected_final_decision,
+        "ci_fast_gate": ci_fast_gate,
+        "decision_reasons": decision_reasons,
+        "local_full_stack_integration_policy_status": "verified" if not failed_checks else "failed",
+        "failed_checks": failed_checks,
+    }
+    if args.output_json:
+        write_json(Path(args.output_json), report_payload)
+
+    print(f"status={'ok' if not failed_checks else 'fail'}")
+    print(f"final_decision={observed_final_decision}")
+    print(f"expected_final_decision={expected_final_decision}")
+    print(f"ci_fast_gate={ci_fast_gate}")
+    print(
+        "local_full_stack_integration_policy_status="
+        f"{'verified' if not failed_checks else 'failed'}"
+    )
+    print(f"failed_checks={','.join(failed_checks)}")
+    if args.output_json:
+        print(f"report_file={Path(args.output_json).resolve()}")
+
+    if failed_checks:
+        fail(",".join(failed_checks))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Local full-stack integration lane contracts.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_lane_parser = subparsers.add_parser("run-lane", help="Run local full-stack integration lane.")
+    run_lane_parser.add_argument("--mode", default=os.environ.get("KAMN_LOCAL_FULL_STACK_INTEGRATION_MODE", "dry-run"))
+    run_lane_parser.add_argument(
+        "--max-seconds",
+        default=os.environ.get("KAMN_LOCAL_FULL_STACK_INTEGRATION_MAX_SECONDS", "360"),
+    )
+    run_lane_parser.add_argument(
+        "--command-max-seconds",
+        default=os.environ.get("KAMN_LOCAL_FULL_STACK_INTEGRATION_COMMAND_MAX_SECONDS", "300"),
+    )
+    run_lane_parser.add_argument("--ci-fast-gate", default=os.environ.get("KAMN_CI_FAST_GATE", "PASS"))
+    run_lane_parser.add_argument("--local-opt-in", default=os.environ.get(OPT_IN_ENV, "0"))
+    run_lane_parser.add_argument("--output-json", default="")
+    run_lane_parser.set_defaults(handler=run_lane)
+
+    policy_parser = subparsers.add_parser("check-policy", help="Check local full-stack integration policy.")
+    policy_parser.add_argument("--report-file", required=True)
+    policy_parser.add_argument("--expected-final-decision", default="GO")
+    policy_parser.add_argument("--ci-fast-gate", default="PASS")
+    policy_parser.add_argument("--output-json", default="")
+    policy_parser.set_defaults(handler=check_policy)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POLICY_SCRIPT="$ROOT_DIR/scripts/runtime/check_local_full_stack_integration_live_policy.sh"
+TMP_REPORT="$(mktemp)"
+TMP_POLICY="$(mktemp)"
+TMP_TAMPERED="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY" "$TMP_TAMPERED"' EXIT
+
+if [ ! -x "$POLICY_SCRIPT" ]; then
+  echo "expected local full-stack integration policy script to be executable" >&2
+  exit 1
+fi
+
+cat >"$TMP_REPORT" <<'JSON'
+{
+  "schema_version": "kamn.runtime.local-full-stack-integration-live-report.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "lane_mode": "dry-run",
+  "ci_fast_gate": "PASS",
+  "ci_fast_gate_eligibility": "eligible",
+  "fast_gate_exclusion_status": "verified",
+  "fast_gate_exclusion_reason_code": "local_full_stack_integration_run_mode_excluded_from_fast_gate",
+  "scenario_matrix_status": "verified",
+  "full_runtime_status": "verified",
+  "evidence_bundle_status": "verified",
+  "run_mode_command_status": "dry_run_no_commands_executed",
+  "run_mode_command_count": 0,
+  "reason_code": "dry_run_no_commands_executed",
+  "elapsed_seconds": 1,
+  "max_seconds": 120,
+  "command_max_seconds": 60,
+  "artifact_paths": {}
+}
+JSON
+
+policy_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_REPORT" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected local full-stack integration policy status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local full-stack integration policy final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^local_full_stack_integration_policy_status=verified$'; then
+  echo "expected local full-stack integration policy status marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_POLICY" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-policy-report.v1":
+    raise SystemExit("unexpected local full-stack integration policy schema")
+if payload.get("status") != "ok":
+    raise SystemExit("expected local full-stack integration policy status=ok")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected local full-stack integration policy final_decision=GO")
+if payload.get("local_full_stack_integration_policy_status") != "verified":
+    raise SystemExit("expected local_full_stack_integration_policy_status=verified")
+PY
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["scenario_matrix_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_code=$?
+set -e
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered local full-stack integration report to fail policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'local_full_stack_integration_policy_scenario_matrix_status_mismatch'; then
+  echo "expected deterministic reason marker for tampered scenario matrix status" >&2
+  exit 1
+fi
+
+echo "local full-stack integration policy checker tests passed."

--- a/scripts/runtime/test_validate_local_full_stack_integration_live.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected local full-stack integration validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode dry-run \
+    --max-seconds 120 \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_REPORT"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected local full-stack integration validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local full-stack integration validation GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected local full-stack integration validation dry-run mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^scenario_matrix_status=verified$'; then
+  echo "expected local full-stack integration scenario matrix marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^full_runtime_status=verified$'; then
+  echo "expected local full-stack integration full runtime marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^evidence_bundle_status=verified$'; then
+  echo "expected local full-stack integration evidence bundle marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^run_mode_command_status=dry_run_no_commands_executed$'; then
+  echo "expected local full-stack integration dry-run command marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-report.v1":
+    raise SystemExit("unexpected local full-stack integration validation schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected local full-stack integration validation status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected local full-stack integration validation final_decision=GO")
+if payload.get("lane_mode") != "dry-run":
+    raise SystemExit("expected lane_mode=dry-run")
+if payload.get("ci_fast_gate_eligibility") != "eligible":
+    raise SystemExit("expected ci_fast_gate_eligibility=eligible")
+if payload.get("run_mode_command_count") != 0:
+    raise SystemExit("expected run_mode_command_count=0 for dry-run")
+if payload.get("reason_code") != "dry_run_no_commands_executed":
+    raise SystemExit("expected deterministic dry-run reason code")
+if not isinstance(payload.get("artifact_paths"), dict):
+    raise SystemExit("expected artifact_paths dictionary")
+PY
+
+set +e
+run_without_opt_in_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode run \
+    --max-seconds 120 \
+    --ci-fast-gate PASS 2>&1
+)"
+run_without_opt_in_code=$?
+set -e
+if [ "$run_without_opt_in_code" -eq 0 ]; then
+  echo "expected run mode without opt-in to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_without_opt_in_output" | grep -q 'run mode requires explicit local-only opt-in via KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1'; then
+  echo "expected deterministic opt-in marker for local full-stack integration run mode" >&2
+  exit 1
+fi
+
+set +e
+invalid_budget_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --max-seconds nope 2>&1
+)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected local full-stack integration validation script to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q 'KAMN_LOCAL_FULL_STACK_INTEGRATION_MAX_SECONDS must be an integer'; then
+  echo "expected deterministic invalid max-seconds marker for local full-stack integration validation script" >&2
+  exit 1
+fi
+
+echo "local full-stack integration live validation tests passed."

--- a/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_local_full_stack_integration_live_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CONTRACT_LANE" ]; then
+  echo "expected local full-stack integration contract lane script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected local full-stack integration validation script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected local full-stack integration policy checker script to be executable" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/local-full-stack-integration-contract-lane-report.json"
+policy_report="$TMP_DIR/local-full-stack-integration-policy-report.json"
+
+lane_output="$(
+  bash "$CONTRACT_LANE" \
+    --mode dry-run \
+    --max-seconds 120 \
+    --output-json "$lane_report" \
+    --policy-output-json "$policy_report"
+)"
+if ! printf '%s\n' "$lane_output" | grep -q '^status=pass$'; then
+  echo "expected local full-stack integration contract lane status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local full-stack integration contract lane final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected local full-stack integration contract lane mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^local_full_stack_integration_policy_status=verified$'; then
+  echo "expected local full-stack integration contract lane policy status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^local_full_stack_integration_contract_status=verified$'; then
+  echo "expected local full-stack integration contract lane status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_full_stack_integration_policy_evidence_bundle_status_mismatch$'; then
+  echo "expected local full-stack integration contract lane fail-closed reason marker" >&2
+  exit 1
+fi
+
+python3 - "$lane_report" "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+lane_payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if lane_payload.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-contract-lane-report.v1":
+    raise SystemExit("unexpected local full-stack integration contract lane report schema")
+if lane_payload.get("status") != "pass":
+    raise SystemExit("expected contract lane status=pass")
+if lane_payload.get("final_decision") != "GO":
+    raise SystemExit("expected contract lane final_decision=GO")
+if lane_payload.get("local_full_stack_integration_policy_status") != "verified":
+    raise SystemExit("expected local_full_stack_integration_policy_status=verified")
+if lane_payload.get("local_full_stack_integration_contract_status") != "verified":
+    raise SystemExit("expected local_full_stack_integration_contract_status=verified")
+if lane_payload.get("docs_contract_status") != "verified":
+    raise SystemExit("expected docs_contract_status=verified")
+if lane_payload.get("performance_budget_status") != "verified":
+    raise SystemExit("expected performance_budget_status=verified")
+
+policy_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if policy_payload.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-policy-report.v1":
+    raise SystemExit("unexpected local full-stack integration policy report schema")
+if policy_payload.get("final_decision") != "GO":
+    raise SystemExit("expected policy final_decision=GO")
+if policy_payload.get("local_full_stack_integration_policy_status") != "verified":
+    raise SystemExit("expected local_full_stack_integration_policy_status=verified in policy report")
+PY
+
+if ! grep -q "check_local_full_stack_integration_live_policy.sh" "$CONTRACT_LANE"; then
+  echo "expected local full-stack integration contract lane to compose policy checker" >&2
+  exit 1
+fi
+if ! grep -q "validate_local_full_stack_integration_live.sh" "$CONTRACT_LANE"; then
+  echo "expected local full-stack integration contract lane to compose validation lane" >&2
+  exit 1
+fi
+
+set +e
+invalid_ci_fast_gate_output="$(
+  bash "$CONTRACT_LANE" \
+    --mode dry-run \
+    --ci-fast-gate MAYBE 2>&1
+)"
+invalid_ci_fast_gate_code=$?
+set -e
+if [ "$invalid_ci_fast_gate_code" -eq 0 ]; then
+  echo "expected local full-stack integration contract lane to reject invalid ci-fast-gate value" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_ci_fast_gate_output" | grep -q 'ci-fast-gate must be PASS or FAIL'; then
+  echo "expected deterministic invalid ci-fast-gate marker for local full-stack integration contract lane" >&2
+  exit 1
+fi
+
+echo "local full-stack integration contract lane tests passed."

--- a/scripts/runtime/validate_local_full_stack_integration_live.sh
+++ b/scripts/runtime/validate_local_full_stack_integration_live.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/local_full_stack_integration_live_contract.py" run-lane "$@"

--- a/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_local_full_stack_integration_live_policy.sh"
+STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
+
+output_json=""
+policy_output_json=""
+max_seconds="${KAMN_LOCAL_FULL_STACK_INTEGRATION_CONTRACT_MAX_SECONDS:-180}"
+ci_fast_gate="PASS"
+mode="dry-run"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --policy-output-json)
+      policy_output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --ci-fast-gate)
+      ci_fast_gate="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+if [ "$max_seconds" -le 0 ]; then
+  echo "max-seconds must be greater than zero" >&2
+  exit 1
+fi
+if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
+  echo "ci-fast-gate must be PASS or FAIL" >&2
+  exit 1
+fi
+if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
+  echo "mode must be dry-run or run" >&2
+  exit 1
+fi
+
+for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
+  if [ ! -x "$required_exec" ]; then
+    echo "expected required executable script '$required_exec'" >&2
+    exit 1
+  fi
+done
+if [ ! -f "$STRATEGY_DOC" ]; then
+  echo "expected required documentation file '$STRATEGY_DOC'" >&2
+  exit 1
+fi
+
+start_epoch="$(date +%s)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+summary_report="$TMP_DIR/local-full-stack-integration-summary.json"
+policy_report="$TMP_DIR/local-full-stack-integration-policy.json"
+tampered_report="$TMP_DIR/local-full-stack-integration-summary.tampered.json"
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode "$mode" \
+    --max-seconds "$max_seconds" \
+    --output-json "$summary_report"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected local full-stack integration validation status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local full-stack integration validation final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^scenario_matrix_status=verified$'; then
+  echo "expected local full-stack integration scenario matrix marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^full_runtime_status=verified$'; then
+  echo "expected local full-stack integration runtime marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^evidence_bundle_status=verified$'; then
+  echo "expected local full-stack integration evidence bundle marker" >&2
+  exit 1
+fi
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$summary_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate "$ci_fast_gate" \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected local full-stack integration policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local full-stack integration policy checker final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^local_full_stack_integration_policy_status=verified$'; then
+  echo "expected local full-stack integration policy checker status marker" >&2
+  exit 1
+fi
+
+cp "$summary_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["evidence_bundle_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate "$ci_fast_gate" \
+    --output-json "$TMP_DIR/local-full-stack-integration-policy.tampered.json" 2>&1
+)"
+tampered_policy_code=$?
+set -e
+if [ "$tampered_policy_code" -eq 0 ]; then
+  echo "expected tampered local full-stack integration report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_full_stack_integration_policy_evidence_bundle_status_mismatch'; then
+  echo "expected deterministic fail-closed reason for tampered local full-stack integration report" >&2
+  exit 1
+fi
+
+for required_ref in \
+  "validate_local_full_stack_integration_live.sh" \
+  "check_local_full_stack_integration_live_policy.sh" \
+  "validate_local_full_stack_integration_live_contract_lane.sh" \
+  "test_validate_local_full_stack_integration_live.sh" \
+  "test_check_local_full_stack_integration_live_policy.sh" \
+  "test_validate_local_full_stack_integration_live_contract_lane.sh"; do
+  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
+    echo "expected CI strategy docs to reference $required_ref" >&2
+    exit 1
+  fi
+done
+if ! grep -q "local full-stack integration run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include local full-stack integration run-mode exclusion marker" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "local full-stack integration contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/local-full-stack-integration-contract-lane-report.json"
+python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
+import json
+import pathlib
+import sys
+
+summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+lane_report_file = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
+mode = sys.argv[6]
+
+if summary_report.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-report.v1":
+    raise SystemExit("unexpected local full-stack integration summary schema")
+if policy_report.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-policy-report.v1":
+    raise SystemExit("unexpected local full-stack integration policy schema")
+if summary_report.get("final_decision") != "GO":
+    raise SystemExit("expected local full-stack integration summary final_decision=GO")
+if policy_report.get("final_decision") != "GO":
+    raise SystemExit("expected local full-stack integration policy final_decision=GO")
+
+lane_report = {
+    "schema_version": "kamn.runtime.local-full-stack-integration-live-contract-lane-report.v1",
+    "status": "pass",
+    "final_decision": "GO",
+    "lane_mode": mode,
+    "local_full_stack_integration_contract_status": "verified",
+    "local_full_stack_integration_policy_status": policy_report.get(
+        "local_full_stack_integration_policy_status", "unknown"
+    ),
+    "docs_contract_status": "verified",
+    "performance_budget_status": "verified",
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "summary_report_file": str(pathlib.Path(sys.argv[1]).resolve()),
+    "policy_report_file": str(pathlib.Path(sys.argv[2]).resolve()),
+    "fail_closed_reason_code": "local_full_stack_integration_policy_evidence_bundle_status_mismatch",
+}
+lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [[ -n "$output_json" ]]; then
+  cp "$lane_report" "$output_json"
+fi
+if [[ -n "$policy_output_json" ]]; then
+  cp "$policy_report" "$policy_output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "lane_mode=${mode}"
+echo "local_full_stack_integration_contract_status=verified"
+echo "local_full_stack_integration_policy_status=verified"
+echo "docs_contract_status=verified"
+echo "performance_budget_status=verified"
+echo "fail_closed_reason_code=local_full_stack_integration_policy_evidence_bundle_status_mismatch"
+if [[ -n "$output_json" ]]; then
+  echo "report_file=$(realpath "$output_json")"
+fi


### PR DESCRIPTION
## Summary
Add a local-heavy full-stack integration live-validation lane that composes the full I/O scenario matrix and full-runtime supervisor validations into deterministic evidence artifacts, with fail-closed policy checks and explicit fast-gate exclusion enforcement.

Closes #3292.

## Changes
- docs/ci/strategy.md: add Runtime Local Full-Stack Integration Contract Lane section, artifact schemas, and local-heavy cost controls.
- scripts/runtime/local_full_stack_integration_live_contract.py: add run-lane and check-policy contracts.
- scripts/runtime/validate_local_full_stack_integration_live.sh: run-lane wrapper.
- scripts/runtime/check_local_full_stack_integration_live_policy.sh: policy wrapper.
- scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh: compose validation + policy + tamper drill + docs parity checks.
- scripts/runtime/test_validate_local_full_stack_integration_live.sh: validation contract tests.
- scripts/runtime/test_check_local_full_stack_integration_live_policy.sh: policy checker tests.
- scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh: contract-lane tests.

## Risks & Compatibility
- Low risk: additive scripts/docs only.
- Run mode remains local-only and opt-in (`KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1`) to keep CI runtime/cost low.

## Validation
- [ ] `cargo fmt --check` — clean (not run; no Rust files changed)
- [ ] `cargo clippy -- -D warnings` — clean (not run; no Rust files changed)
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual verification:
  - `python3 -m py_compile scripts/runtime/local_full_stack_integration_live_contract.py`
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
  - `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
  - `bash scripts/ci/test_ci_strategy_contract.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | policy schema/assertion coverage in `test_check_local_full_stack_integration_live_policy.sh` |
| Functional  | ✅ | validation script option/mode behavior and deterministic marker checks |
| Integration | ✅ | contract lane composes validation + policy + docs parity checks end-to-end |
| Regression  | ✅ | tampered evidence bundle status fails closed with deterministic reason markers |
