### PR TITLE
feat(sdk): align rust/python error envelope reason code decoding

### DIFF
--- a/crates/kamn-sdk/src/error.rs
+++ b/crates/kamn-sdk/src/error.rs
@@ -14,6 +14,17 @@ pub enum SdkError {
     },
     /// Underlying transport operation failed.
     TransportFailure(&'static str),
+    /// Service API returned structured error envelope.
+    ServiceApiError {
+        /// HTTP status code returned by service route.
+        status: u16,
+        /// Service error class marker.
+        error: String,
+        /// Deterministic machine-readable reason code.
+        reason_code: String,
+        /// Human-readable failure detail.
+        message: String,
+    },
     /// The caller expected one transport mode but the client uses another.
     TransportModeMismatch {
         /// Expected transport mode identifier.
@@ -47,6 +58,15 @@ impl fmt::Display for SdkError {
                 write!(f, "invalid input for {field}: {reason}")
             }
             Self::TransportFailure(reason) => write!(f, "transport failure: {reason}"),
+            Self::ServiceApiError {
+                status,
+                error,
+                reason_code,
+                message,
+            } => write!(
+                f,
+                "service api rejected request: status={status} error={error} reason_code={reason_code} message={message}"
+            ),
             Self::TransportModeMismatch { expected, found } => {
                 write!(
                     f,

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -8,6 +8,22 @@ const REQUEST_AUTH_SENDER_DID_HEADER: &str = "x-kamn-sender-did";
 const REQUEST_AUTH_NONCE_HEADER: &str = "x-kamn-request-nonce";
 const REQUEST_AUTH_SIGNATURE_HEADER: &str = "x-kamn-request-signature";
 const SERVICE_WS_ROUTE: &str = "/v1/events/ws";
+const REASON_CODE_WEBSOCKET_UPGRADE_REQUIRED: &str = "service_api_websocket_upgrade_required";
+const REASON_CODE_METHOD_NOT_ALLOWED: &str = "service_api_method_not_allowed";
+const REASON_CODE_ROUTE_NOT_FOUND: &str = "service_api_route_not_found";
+const REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING: &str =
+    "service_api_auth_sender_did_header_missing";
+const REASON_CODE_AUTH_NONCE_HEADER_MISSING: &str = "service_api_auth_nonce_header_missing";
+const REASON_CODE_AUTH_NONCE_INVALID: &str = "service_api_auth_nonce_invalid";
+const REASON_CODE_AUTH_NONCE_NON_POSITIVE: &str = "service_api_auth_nonce_non_positive";
+const REASON_CODE_AUTH_SIGNATURE_HEADER_MISSING: &str = "service_api_auth_signature_header_missing";
+const REASON_CODE_AUTH_SIGNATURE_VERIFICATION_FAILED: &str =
+    "service_api_auth_signature_verification_failed";
+const REASON_CODE_AUTH_REPLAY_NONCE_DETECTED: &str = "service_api_auth_replay_nonce_detected";
+const REASON_CODE_LEGACY_UNAUTHORIZED: &str = "service_api_legacy_unauthorized";
+const REASON_CODE_LEGACY_CONFLICT: &str = "service_api_legacy_conflict";
+const REASON_CODE_LEGACY_BAD_REQUEST: &str = "service_api_legacy_bad_request";
+const REASON_CODE_LEGACY_UNKNOWN: &str = "service_api_legacy_error_unknown";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ServiceScheme {
@@ -594,7 +610,19 @@ fn status_from_header(header: &str) -> Option<u16> {
     raw_code.parse::<u16>().ok()
 }
 
-fn map_non_success_response<T>(status: Option<u16>, _body: &str) -> Result<T, SdkError> {
+fn map_non_success_response<T>(status: Option<u16>, body: &str) -> Result<T, SdkError> {
+    if let Some(status_code) = status {
+        if let Some((error, reason_code, message)) = parse_service_api_error_envelope(body)
+            .or_else(|| parse_service_api_legacy_error_envelope(status_code, body))
+        {
+            return Err(SdkError::ServiceApiError {
+                status: status_code,
+                error,
+                reason_code,
+                message,
+            });
+        }
+    }
     match status {
         Some(409) => Err(SdkError::Conflict("request rejected by service api")),
         Some(401) => Err(SdkError::TransportFailure(
@@ -610,6 +638,60 @@ fn map_non_success_response<T>(status: Option<u16>, _body: &str) -> Result<T, Sd
         _ => Err(SdkError::TransportFailure(
             "request rejected by service api",
         )),
+    }
+}
+
+fn parse_service_api_error_envelope(body: &str) -> Option<(String, String, String)> {
+    let error = json_optional_string_field(body, "error")?;
+    let reason_code = json_optional_string_field(body, "reason_code")?;
+    let message = json_optional_string_field(body, "message")?;
+    Some((error, reason_code, message))
+}
+
+fn parse_service_api_legacy_error_envelope(
+    status: u16,
+    body: &str,
+) -> Option<(String, String, String)> {
+    let error = json_optional_string_field(body, "error")?;
+    let reason = json_optional_string_field(body, "reason")?;
+    let reason_code =
+        classify_legacy_service_api_reason_code(status, error.as_str(), reason.as_str()).to_owned();
+    Some((error, reason_code, reason))
+}
+
+fn classify_legacy_service_api_reason_code(status: u16, error: &str, reason: &str) -> &'static str {
+    if reason.contains(REQUEST_AUTH_SENDER_DID_HEADER) {
+        return REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING;
+    }
+    if reason.contains(REQUEST_AUTH_NONCE_HEADER) && reason.contains("missing required header") {
+        return REASON_CODE_AUTH_NONCE_HEADER_MISSING;
+    }
+    if reason.contains("invalid request nonce header") {
+        return REASON_CODE_AUTH_NONCE_INVALID;
+    }
+    if reason.contains("request nonce must be positive") {
+        return REASON_CODE_AUTH_NONCE_NON_POSITIVE;
+    }
+    if reason.contains(REQUEST_AUTH_SIGNATURE_HEADER) && reason.contains("missing required header")
+    {
+        return REASON_CODE_AUTH_SIGNATURE_HEADER_MISSING;
+    }
+    if reason.contains("signature verification failed") {
+        return REASON_CODE_AUTH_SIGNATURE_VERIFICATION_FAILED;
+    }
+    if reason.contains("replay") {
+        return REASON_CODE_AUTH_REPLAY_NONCE_DETECTED;
+    }
+    if reason.contains("websocket upgrade required") {
+        return REASON_CODE_WEBSOCKET_UPGRADE_REQUIRED;
+    }
+    match status {
+        404 => REASON_CODE_ROUTE_NOT_FOUND,
+        405 => REASON_CODE_METHOD_NOT_ALLOWED,
+        401 if error == "unauthorized" => REASON_CODE_LEGACY_UNAUTHORIZED,
+        409 => REASON_CODE_LEGACY_CONFLICT,
+        400 => REASON_CODE_LEGACY_BAD_REQUEST,
+        _ => REASON_CODE_LEGACY_UNKNOWN,
     }
 }
 
@@ -660,4 +742,12 @@ fn json_u64_field(payload: &str, key: &str) -> Result<u64, SdkError> {
     rest[..value_end]
         .parse::<u64>()
         .map_err(|_| SdkError::TransportFailure("service response numeric field was malformed"))
+}
+
+fn json_optional_string_field(payload: &str, key: &str) -> Option<String> {
+    let marker = format!("\"{key}\":\"");
+    let start = payload.find(marker.as_str())? + marker.len();
+    let rest = &payload[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_owned())
 }

--- a/crates/kamn-sdk/tests/service_api_client.rs
+++ b/crates/kamn-sdk/tests/service_api_client.rs
@@ -155,35 +155,84 @@ fn validate_auth(
     body: &str,
     headers: &BTreeMap<String, String>,
     replay_guard: &mut BTreeSet<(String, u64)>,
-) -> Result<(), (u16, &'static str)> {
+) -> Result<(), (u16, &'static str, &'static str, &'static str)> {
     let did = headers
         .get("x-kamn-sender-did")
-        .ok_or((401, "missing required header: x-kamn-sender-did"))?
+        .ok_or((
+            401,
+            "unauthorized",
+            "service_api_auth_sender_did_header_missing",
+            "missing required header: x-kamn-sender-did",
+        ))?
         .to_owned();
-    AgentDid::parse(did.clone()).map_err(|_| (401, "invalid sender did"))?;
+    AgentDid::parse(did.clone()).map_err(|_| {
+        (
+            401,
+            "unauthorized",
+            "service_api_auth_sender_did_invalid",
+            "invalid sender did",
+        )
+    })?;
     let nonce = headers
         .get("x-kamn-request-nonce")
-        .ok_or((401, "missing required header: x-kamn-request-nonce"))?
+        .ok_or((
+            401,
+            "unauthorized",
+            "service_api_auth_nonce_header_missing",
+            "missing required header: x-kamn-request-nonce",
+        ))?
         .parse::<u64>()
-        .map_err(|_| (401, "invalid request nonce header: x-kamn-request-nonce"))?;
+        .map_err(|_| {
+            (
+                401,
+                "unauthorized",
+                "service_api_auth_nonce_invalid",
+                "invalid request nonce header: x-kamn-request-nonce",
+            )
+        })?;
     if nonce == 0 {
-        return Err((401, "request nonce must be positive: x-kamn-request-nonce"));
+        return Err((
+            401,
+            "unauthorized",
+            "service_api_auth_nonce_non_positive",
+            "request nonce must be positive: x-kamn-request-nonce",
+        ));
     }
-    let signature = headers
-        .get("x-kamn-request-signature")
-        .ok_or((401, "missing required header: x-kamn-request-signature"))?;
+    let signature = headers.get("x-kamn-request-signature").ok_or((
+        401,
+        "unauthorized",
+        "service_api_auth_signature_header_missing",
+        "missing required header: x-kamn-request-signature",
+    ))?;
     let expected = service_signature_for_fields(
-        &AgentDid::parse(did.clone()).map_err(|_| (401, "invalid sender did"))?,
+        &AgentDid::parse(did.clone()).map_err(|_| {
+            (
+                401,
+                "unauthorized",
+                "service_api_auth_sender_did_invalid",
+                "invalid sender did",
+            )
+        })?,
         nonce,
         CHAIN_ID,
         CHAIN_VERSION,
         body,
     );
     if &expected != signature {
-        return Err((401, "signature verification failed for request envelope"));
+        return Err((
+            401,
+            "unauthorized",
+            "service_api_auth_signature_verification_failed",
+            "signature verification failed for request envelope",
+        ));
     }
     if !replay_guard.insert((did, nonce)) {
-        return Err((409, "request nonce replay detected for sender"));
+        return Err((
+            409,
+            "replay",
+            "service_api_auth_replay_nonce_detected",
+            "request nonce replay detected for sender",
+        ));
     }
     Ok(())
 }
@@ -228,15 +277,11 @@ fn run_service_contract_server(bind_addr: String, max_requests: u64) -> Result<(
                     continue;
                 }
 
-                if let Err((status, reason)) = validate_auth(&body, &headers, &mut replay_guard) {
+                if let Err((status, error, reason_code, message)) =
+                    validate_auth(&body, &headers, &mut replay_guard)
+                {
                     let payload = format!(
-                        "{{\"error\":\"{}\",\"reason\":\"{}\"}}",
-                        if status == 409 {
-                            "replay"
-                        } else {
-                            "unauthorized"
-                        },
-                        reason
+                        "{{\"error\":\"{error}\",\"reason_code\":\"{reason_code}\",\"message\":\"{message}\"}}",
                     );
                     write_http_response(&mut stream, status, payload.as_str())?;
                     served = served.saturating_add(1);
@@ -262,7 +307,7 @@ fn run_service_contract_server(bind_addr: String, max_requests: u64) -> Result<(
                         write_http_response(
                             &mut stream,
                             400,
-                            r#"{"error":"bad-request","reason":"websocket upgrade required"}"#,
+                            r#"{"error":"bad-request","reason_code":"service_api_websocket_upgrade_required","message":"websocket upgrade required"}"#,
                         )?;
                     } else {
                         write_websocket_upgrade_response(&mut stream)?;
@@ -309,7 +354,11 @@ fn run_service_contract_server(bind_addr: String, max_requests: u64) -> Result<(
                     let payload = format!("{{\"did\":\"{}\",\"reputation_score\":500}}", did);
                     write_http_response(&mut stream, 200, payload.as_str())?;
                 } else {
-                    write_http_response(&mut stream, 404, "not found")?;
+                    write_http_response(
+                        &mut stream,
+                        404,
+                        r#"{"error":"not-found","reason_code":"service_api_route_not_found","message":"not found"}"#,
+                    )?;
                 }
 
                 served = served.saturating_add(1);
@@ -443,7 +492,7 @@ fn regression_service_api_client_rejects_replayed_nonce() {
     // Regression: #2946
     let bind_addr = reserve_loopback_addr();
     let server_addr = bind_addr.clone();
-    let server = thread::spawn(move || run_service_contract_server(server_addr, 2));
+    let server = thread::spawn(move || run_service_contract_server(server_addr, 3));
     wait_for_server_ready(bind_addr.as_str());
 
     let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str())
@@ -455,11 +504,25 @@ fn regression_service_api_client_rejects_replayed_nonce() {
     client
         .send_message(payload, &replay_auth)
         .expect("first send should pass");
-    assert_eq!(
-        client
-            .send_message(payload, &replay_auth)
-            .expect_err("replayed nonce should fail closed"),
-        SdkError::Conflict("request rejected by service api")
+    let replay_error = client
+        .send_message(payload, &replay_auth)
+        .expect_err("replayed nonce should fail closed");
+    assert!(
+        replay_error
+            .to_string()
+            .contains("reason_code=service_api_auth_replay_nonce_detected"),
+        "replay failure should expose deterministic reason code: {replay_error}"
+    );
+
+    let invalid_auth = auth(&sender, 12, r#"{"message":"mismatch-signature"}"#);
+    let unauthorized_error = client
+        .send_message(payload, &invalid_auth)
+        .expect_err("signature mismatch should fail closed");
+    assert!(
+        unauthorized_error
+            .to_string()
+            .contains("reason_code=service_api_auth_signature_verification_failed"),
+        "unauthorized failure should expose deterministic reason code: {unauthorized_error}"
     );
 
     let server_result = server.join().expect("server thread should join");

--- a/docs/sdk/python-sdk.md
+++ b/docs/sdk/python-sdk.md
@@ -10,6 +10,16 @@ The Python SDK surface is provided by module `kamn_sdk.py` and includes:
 - live transport client (`LiveKAMNClient`)
 - transport error taxonomy and parity contracts
 
+Live transport backend adapter errors use a normalized envelope contract:
+
+- preferred adapter error shape: `{ "status": "error", "reason_code": "...", "message": "..." }`
+- legacy adapter error shape `{ "status": "error", "reason": "..." }` remains supported
+- raised exception: `LiveTransportBackendAdapterError` exposes:
+  - `operation`
+  - `reason_code`
+  - `message`
+  - backward-compatible alias `reason` (mapped to `reason_code`)
+
 Packaging metadata is published through repository-root `pyproject.toml`.
 
 ## Packaging Metadata

--- a/docs/sdk/rust-sdk.md
+++ b/docs/sdk/rust-sdk.md
@@ -23,6 +23,23 @@ The client targets deterministic service routes exposed by `kamn-node` runtime m
 - `GET /metrics`
 - `GET /v1/events/ws` (upgrade + single event frame)
 
+## Error Envelope Decoding
+
+Service route failures are decoded from the standardized node error envelope:
+
+- `error`
+- `reason_code`
+- `message`
+
+Non-2xx service responses are surfaced through:
+
+- `SdkError::ServiceApiError { status, error, reason_code, message }`
+
+Compatibility fallback remains fail-closed for legacy payloads:
+
+- legacy shape `{ "error": "...", "reason": "..." }` is still parsed
+- deterministic legacy `reason` mapping is applied to produce a stable `reason_code`
+
 ## Usage
 
 ```rust

--- a/kamn_sdk.py
+++ b/kamn_sdk.py
@@ -71,9 +71,11 @@ class LiveTransportBackendResponseOk(TypedDict):
     value: object
 
 
-class LiveTransportBackendResponseError(TypedDict):
+class LiveTransportBackendResponseError(TypedDict, total=False):
     status: Literal["error"]
     reason: str
+    reason_code: str
+    message: str
 
 
 LiveTransportBackendResponse = (
@@ -88,10 +90,18 @@ class LiveTransportBackendAdapter(Protocol):
 
 
 class LiveTransportBackendAdapterError(SDKError):
-    def __init__(self, operation: LiveTransportOperation, reason: str) -> None:
+    def __init__(
+        self, operation: LiveTransportOperation, reason_code: str, message: str
+    ) -> None:
         self.operation = operation
-        self.reason = reason
-        super().__init__(f"backend adapter operation {operation} failed: {reason}")
+        self.reason_code = reason_code
+        self.message = message
+        # Backward-compat alias retained for existing reason-only call sites.
+        self.reason = reason_code
+        super().__init__(
+            f"backend adapter operation {operation} failed: "
+            f"reason_code={reason_code}; message={message}"
+        )
 
 
 @dataclass
@@ -441,17 +451,48 @@ class LiveKAMNClient:
 
         status = response.get("status")
         if status == "error":
-            reason_raw = response.get("reason")
-            reason = (
-                reason_raw.strip()
-                if isinstance(reason_raw, str) and reason_raw.strip()
-                else "backend adapter returned unknown error"
-            )
-            raise LiveTransportBackendAdapterError(operation, reason)
+            reason_code, message = self._decode_backend_error_envelope(response)
+            raise LiveTransportBackendAdapterError(operation, reason_code, message)
 
         if status != "ok":
             self._raise_invalid_adapter_response(operation, "expected status ok|error")
         return normalize(response.get("value"))
+
+    def _decode_backend_error_envelope(
+        self, response: Dict[str, object]
+    ) -> tuple[str, str]:
+        reason_code_raw = response.get("reason_code")
+        message_raw = response.get("message")
+        if (
+            isinstance(reason_code_raw, str)
+            and reason_code_raw.strip()
+            and isinstance(message_raw, str)
+            and message_raw.strip()
+        ):
+            return reason_code_raw.strip(), message_raw.strip()
+
+        reason_raw = response.get("reason")
+        if isinstance(reason_raw, str) and reason_raw.strip():
+            reason = reason_raw.strip()
+            return self._normalize_legacy_backend_reason_code(reason), reason
+
+        return (
+            "backend_adapter_error_unknown",
+            "backend adapter returned unknown error",
+        )
+
+    def _normalize_legacy_backend_reason_code(self, reason: str) -> str:
+        normalized = reason.strip().lower().replace("-", "_").replace(" ", "_")
+        sanitized = "".join(
+            character if (character.isalnum() or character == "_") else "_"
+            for character in normalized
+        )
+        collapsed = "_".join(
+            segment for segment in sanitized.split("_") if segment
+        ).strip()
+        if collapsed:
+            return collapsed
+        return "backend_adapter_error_legacy_unknown"
 
     def _raise_invalid_adapter_response(
         self, operation: LiveTransportOperation, reason: str

--- a/tests/python/test_sdk.py
+++ b/tests/python/test_sdk.py
@@ -220,7 +220,11 @@ class PythonLiveTransportSDKTests(unittest.TestCase):
                 if operation == "register":
                     return {"status": "ok", "value": 42}
                 if operation == "send":
-                    return {"status": "error", "reason": "backend_timeout"}
+                    return {
+                        "status": "error",
+                        "reason_code": "backend_timeout",
+                        "message": "secure signer backend timed out",
+                    }
                 return {"status": "error", "reason": "policy_denied"}
 
         LiveKAMNClient.register_backend_adapter(endpoint, Adapter())
@@ -237,11 +241,17 @@ class PythonLiveTransportSDKTests(unittest.TestCase):
                 client.send("kamn:did:agent:x", "kamn:did:agent:y", "hello")
             self.assertEqual(timeout_error.exception.operation, "send")
             self.assertEqual(timeout_error.exception.reason, "backend_timeout")
+            self.assertEqual(timeout_error.exception.reason_code, "backend_timeout")
+            self.assertEqual(
+                timeout_error.exception.message, "secure signer backend timed out"
+            )
 
             with self.assertRaises(LiveTransportBackendAdapterError) as policy_error:
                 client.receive("kamn:did:agent:y")
             self.assertEqual(policy_error.exception.operation, "receive")
             self.assertEqual(policy_error.exception.reason, "policy_denied")
+            self.assertEqual(policy_error.exception.reason_code, "policy_denied")
+            self.assertEqual(policy_error.exception.message, "policy_denied")
         finally:
             LiveKAMNClient.clear_backend_adapters()
 


### PR DESCRIPTION
## Summary
This aligns Rust and Python SDK error decoding with the unified service error envelope (`error`, `reason_code`, `message`) and preserves deterministic compatibility for legacy `reason`-only payloads. It ensures reason codes are surfaced consistently in SDK-facing errors and validated across both SDK suites.

Closes #3365

## Changes
- `crates/kamn-sdk/src/error.rs`: added `SdkError::ServiceApiError { status, error, reason_code, message }` and display rendering with deterministic reason-code markers.
- `crates/kamn-sdk/src/service.rs`: non-2xx service responses now decode structured envelopes; added legacy envelope fallback with deterministic reason-code normalization.
- `crates/kamn-sdk/tests/service_api_client.rs`: service test harness emits structured error envelopes; regression test now asserts replay + unauthorized reason-code surfacing.
- `kamn_sdk.py`: backend adapter error path now decodes structured `{reason_code,message}` envelopes and supports legacy `{reason}` fallback with deterministic normalization.
- `tests/python/test_sdk.py`: regression assertions updated to require `reason_code` and `message` parity fields.
- `docs/sdk/rust-sdk.md`: documented Rust SDK structured error envelope decoding and legacy fallback behavior.
- `docs/sdk/python-sdk.md`: documented Python adapter error envelope contract and backward-compatible reason alias.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `cargo test -p kamn-sdk --test service_api_client regression_service_api_client_rejects_replayed_nonce -- --exact`
  - failed: replay error surfaced as generic conflict without deterministic reason code marker.
- `python3 -m unittest tests.python.test_sdk.PythonLiveTransportSDKTests.test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed`
  - failed: Python adapter path did not decode `reason_code` + `message` and returned unknown-error fallback.

### 🟢 Green Phase
- `cargo test -p kamn-sdk --test service_api_client regression_service_api_client_rejects_replayed_nonce -- --exact`
- `python3 -m unittest tests.python.test_sdk.PythonLiveTransportSDKTests.test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed`
- `cargo test -p kamn-sdk --test service_api_client`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-sdk -- -D warnings`
- `cargo test -p kamn-sdk`
- `python3 -m unittest tests/python/test_sdk.py`
- `bash scripts/sdk/run_rust_sdk_service_client_contract.sh`
- `bash scripts/sdk/validate_rust_sdk_service_client_live.sh --max-seconds 240`
- `bash scripts/sdk/run_python_sdk_packaging_contract.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Rust unit route remains covered (`unit_service_api_client_rejects_invalid_endpoint_scheme`) with decoder helpers exercised through service-client parsing | |
| Functional   | ✅ | Rust functional signed route contract (`functional_service_api_client_executes_signed_http_route_contracts`) now validates structured error responses in harness | |
| Integration  | ✅ | Rust websocket integration (`integration_service_api_client_reads_websocket_event_frame`) + full `cargo test -p kamn-sdk` suite | |
| Regression   | ✅ | Rust replay/unauthorized reason-code regression + Python backend adapter regression envelope checks | |
| Performance  | ✅ | `scripts/sdk/run_rust_sdk_service_client_contract.sh` and `scripts/sdk/validate_rust_sdk_service_client_live.sh --max-seconds 240` budget gates | |

## Risks & Rollback
- Risk: callers that string-match old generic Rust SDK conflict/transport messages may see richer service-api error strings.
- Rollback: revert this PR to restore previous generic error mapping and legacy Python reason-only behavior.

## Documentation Updates
- Updated `docs/sdk/rust-sdk.md`
- Updated `docs/sdk/python-sdk.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-sdk -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
