### PR TITLE
test(ci): enforce service api envelope parity lane markers

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -415,12 +415,14 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - local-dev mode: local
 - manual-hardened mode: manual
 - Cost controls:
-  - bounded to four targeted `kamn-node` reason-code compatibility tests.
+  - bounded to seven targeted local-only checks (five `kamn-node` contract tests + one Rust SDK regression + one Python SDK regression).
   - source-marker checks run locally and avoid external network dependencies.
+  - includes SDK parity marker checks for structured envelope decoding in `crates/kamn-sdk/src/service.rs` and `kamn_sdk.py`.
   - runtime budget is bounded via `KAMN_SERVICE_API_REASON_CODE_CONTRACT_MAX_SECONDS`.
   - service api reason-code compatibility contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:
   - `service_api_reason_code_policy_marker_missing:route_error_mapping_status`
+  - `service_api_reason_code_policy_marker_missing:error_envelope_field_status`
 
 ## Runtime Service API Validation Negative-Matrix Contract Lane
 - Entry commands:

--- a/scripts/runtime/service_api_reason_code_compatibility_live_contract.py
+++ b/scripts/runtime/service_api_reason_code_compatibility_live_contract.py
@@ -31,6 +31,9 @@ REQUIRED_REPORT_FIELDS = [
     "status",
     "final_decision",
     "reason_registry_status",
+    "error_envelope_field_status",
+    "rust_sdk_reason_code_status",
+    "python_sdk_reason_code_status",
     "route_error_mapping_status",
     "replay_error_mapping_status",
     "websocket_error_mapping_status",
@@ -42,6 +45,9 @@ REQUIRED_REPORT_FIELDS = [
 
 REQUIRED_VERIFIED_FIELDS = [
     "reason_registry_status",
+    "error_envelope_field_status",
+    "rust_sdk_reason_code_status",
+    "python_sdk_reason_code_status",
     "route_error_mapping_status",
     "replay_error_mapping_status",
     "websocket_error_mapping_status",

--- a/scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh
+++ b/scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh
@@ -18,6 +18,9 @@ cat >"$report_file" <<'JSON'
   "status": "pass",
   "final_decision": "GO",
   "reason_registry_status": "verified",
+  "error_envelope_field_status": "verified",
+  "rust_sdk_reason_code_status": "verified",
+  "python_sdk_reason_code_status": "verified",
   "route_error_mapping_status": "verified",
   "replay_error_mapping_status": "verified",
   "websocket_error_mapping_status": "verified",
@@ -97,6 +100,39 @@ if [ "$tampered_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_output" | grep -q 'service_api_reason_code_policy_marker_missing:route_error_mapping_status'; then
   echo "expected deterministic mismatch reason code for tampered reason-code policy validation" >&2
+  exit 1
+fi
+
+tampered_envelope_report="$TMP_DIR/service-api-reason-code-compatibility-live-summary.envelope.tampered.json"
+cp "$report_file" "$tampered_envelope_report"
+python3 - "$tampered_envelope_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["error_envelope_field_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_envelope_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_envelope_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/service-api-reason-code-compatibility-live-policy.envelope.tampered.json" 2>&1
+)"
+tampered_envelope_code=$?
+set -e
+
+if [ "$tampered_envelope_code" -eq 0 ]; then
+  echo "expected tampered envelope field status to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_envelope_output" | grep -q 'service_api_reason_code_policy_marker_missing:error_envelope_field_status'; then
+  echo "expected deterministic mismatch reason code for tampered envelope field parity marker" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
@@ -45,6 +45,18 @@ if ! printf '%s\n' "$lane_output" | grep -q '^service_api_reason_code_policy_sta
   echo "expected service api reason-code compatibility contract lane policy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^error_envelope_field_status=verified$'; then
+  echo "expected service api reason-code compatibility contract lane envelope marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^rust_sdk_reason_code_status=verified$'; then
+  echo "expected service api reason-code compatibility contract lane rust sdk marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^python_sdk_reason_code_status=verified$'; then
+  echo "expected service api reason-code compatibility contract lane python sdk marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=service_api_reason_code_policy_marker_missing:route_error_mapping_status$'; then
   echo "expected service api reason-code compatibility contract lane fail-closed reason marker" >&2
   exit 1
@@ -66,6 +78,12 @@ if lane_payload.get("service_api_reason_code_contract_status") != "verified":
     raise SystemExit("expected service_api_reason_code_contract_status=verified")
 if lane_payload.get("service_api_reason_code_policy_status") != "verified":
     raise SystemExit("expected service_api_reason_code_policy_status=verified")
+if lane_payload.get("error_envelope_field_status") != "verified":
+    raise SystemExit("expected error_envelope_field_status=verified")
+if lane_payload.get("rust_sdk_reason_code_status") != "verified":
+    raise SystemExit("expected rust_sdk_reason_code_status=verified")
+if lane_payload.get("python_sdk_reason_code_status") != "verified":
+    raise SystemExit("expected python_sdk_reason_code_status=verified")
 if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":

--- a/scripts/runtime/validate_service_api_reason_code_compatibility_live.sh
+++ b/scripts/runtime/validate_service_api_reason_code_compatibility_live.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SOURCE_FILE="$ROOT_DIR/crates/kamn-node/src/service_api_endpoint.rs"
 TEST_FILE="$ROOT_DIR/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs"
+RUST_SDK_SOURCE="$ROOT_DIR/crates/kamn-sdk/src/service.rs"
+RUST_SDK_TEST_FILE="$ROOT_DIR/crates/kamn-sdk/tests/service_api_client.rs"
+PYTHON_SDK_SOURCE="$ROOT_DIR/kamn_sdk.py"
+PYTHON_SDK_TEST_FILE="$ROOT_DIR/tests/python/test_sdk.py"
 
 output_json=""
 max_seconds=240
@@ -42,6 +46,22 @@ if [ ! -f "$TEST_FILE" ]; then
   echo "expected service api endpoint test file: $TEST_FILE" >&2
   exit 1
 fi
+if [ ! -f "$RUST_SDK_SOURCE" ]; then
+  echo "expected rust sdk source file: $RUST_SDK_SOURCE" >&2
+  exit 1
+fi
+if [ ! -f "$RUST_SDK_TEST_FILE" ]; then
+  echo "expected rust sdk test file: $RUST_SDK_TEST_FILE" >&2
+  exit 1
+fi
+if [ ! -f "$PYTHON_SDK_SOURCE" ]; then
+  echo "expected python sdk source file: $PYTHON_SDK_SOURCE" >&2
+  exit 1
+fi
+if [ ! -f "$PYTHON_SDK_TEST_FILE" ]; then
+  echo "expected python sdk test file: $PYTHON_SDK_TEST_FILE" >&2
+  exit 1
+fi
 
 start_epoch="$(date +%s)"
 TMP_DIR="$(mktemp -d)"
@@ -70,6 +90,26 @@ for envelope_marker in \
   fi
 done
 
+for rust_sdk_marker in \
+  "SdkError::ServiceApiError" \
+  "parse_service_api_error_envelope" \
+  "parse_service_api_legacy_error_envelope"; do
+  if ! grep -Fq "$rust_sdk_marker" "$RUST_SDK_SOURCE"; then
+    echo "missing required rust sdk reason-code parity marker: $rust_sdk_marker" >&2
+    exit 1
+  fi
+done
+
+for python_sdk_marker in \
+  "def _decode_backend_error_envelope" \
+  "def _normalize_legacy_backend_reason_code" \
+  "reason_code"; do
+  if ! grep -Fq "$python_sdk_marker" "$PYTHON_SDK_SOURCE"; then
+    echo "missing required python sdk reason-code parity marker: $python_sdk_marker" >&2
+    exit 1
+  fi
+done
+
 for mapping_marker in \
   "RequestAuthFailure::Unauthorized(reasoned_error)" \
   "RequestAuthFailure::Replay(reasoned_error)" \
@@ -83,6 +123,7 @@ for mapping_marker in \
 done
 
 for test_marker in \
+  "unit_service_api_endpoint_error_envelopes_use_reason_code_and_message_contracts" \
   "regression_service_api_payload_parse_reason_codes_fail_closed" \
   "integration_service_api_endpoint_rejects_missing_request_auth_headers" \
   "regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender" \
@@ -93,7 +134,25 @@ for test_marker in \
   fi
 done
 
+for rust_sdk_test_marker in \
+  "regression_service_api_client_rejects_replayed_nonce"; do
+  if ! grep -Fq "$rust_sdk_test_marker" "$RUST_SDK_TEST_FILE"; then
+    echo "missing required rust sdk parity test marker: $rust_sdk_test_marker" >&2
+    exit 1
+  fi
+done
+
+for python_sdk_test_marker in \
+  "test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed"; do
+  if ! grep -Fq "$python_sdk_test_marker" "$PYTHON_SDK_TEST_FILE"; then
+    echo "missing required python sdk parity test marker: $python_sdk_test_marker" >&2
+    exit 1
+  fi
+done
+
 pushd "$ROOT_DIR" >/dev/null
+cargo test -p kamn-node main_tests::unit_service_api_endpoint_error_envelopes_use_reason_code_and_message_contracts -- --exact \
+  >"$TMP_DIR/service-api-envelope-unit.log" 2>&1
 cargo test -p kamn-node main_tests::regression_service_api_payload_parse_reason_codes_fail_closed -- --exact \
   >"$TMP_DIR/service-api-reason-code-regression.log" 2>&1
 cargo test -p kamn-node main_tests::integration_service_api_endpoint_rejects_missing_request_auth_headers -- --exact \
@@ -102,6 +161,10 @@ cargo test -p kamn-node main_tests::regression_service_api_endpoint_rejects_repl
   >"$TMP_DIR/service-api-reason-code-replay.log" 2>&1
 cargo test -p kamn-node main_tests::regression_service_api_endpoint_websocket_rejects_invalid_version_header -- --exact \
   >"$TMP_DIR/service-api-reason-code-websocket.log" 2>&1
+cargo test -p kamn-sdk --test service_api_client regression_service_api_client_rejects_replayed_nonce -- --exact \
+  >"$TMP_DIR/service-api-reason-code-rust-sdk.log" 2>&1
+python3 -m unittest tests.python.test_sdk.PythonLiveTransportSDKTests.test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed \
+  >"$TMP_DIR/service-api-reason-code-python-sdk.log" 2>&1
 popd >/dev/null
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
@@ -125,6 +188,9 @@ payload = {
     "status": "pass",
     "final_decision": "GO",
     "reason_registry_status": "verified",
+    "error_envelope_field_status": "verified",
+    "rust_sdk_reason_code_status": "verified",
+    "python_sdk_reason_code_status": "verified",
     "route_error_mapping_status": "verified",
     "replay_error_mapping_status": "verified",
     "websocket_error_mapping_status": "verified",
@@ -144,6 +210,9 @@ fi
 echo "status=pass"
 echo "final_decision=GO"
 echo "reason_registry_status=verified"
+echo "error_envelope_field_status=verified"
+echo "rust_sdk_reason_code_status=verified"
+echo "python_sdk_reason_code_status=verified"
 echo "route_error_mapping_status=verified"
 echo "replay_error_mapping_status=verified"
 echo "websocket_error_mapping_status=verified"

--- a/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh
@@ -88,6 +88,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^reason_registry_status=verif
   echo "expected service api reason-code compatibility reason registry marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^error_envelope_field_status=verified$'; then
+  echo "expected service api reason-code compatibility envelope field marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^rust_sdk_reason_code_status=verified$'; then
+  echo "expected service api reason-code compatibility rust sdk marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^python_sdk_reason_code_status=verified$'; then
+  echo "expected service api reason-code compatibility python sdk marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^route_error_mapping_status=verified$'; then
   echo "expected service api reason-code compatibility route mapping marker" >&2
   exit 1
@@ -218,6 +230,9 @@ lane_report = {
     "status": "pass",
     "final_decision": "GO",
     "service_api_reason_code_contract_status": "verified",
+    "error_envelope_field_status": summary_report.get("error_envelope_field_status"),
+    "rust_sdk_reason_code_status": summary_report.get("rust_sdk_reason_code_status"),
+    "python_sdk_reason_code_status": summary_report.get("python_sdk_reason_code_status"),
     "service_api_reason_code_policy_status": policy_report.get(
         "service_api_reason_code_policy_status"
     ),
@@ -241,6 +256,9 @@ fi
 echo "status=pass"
 echo "final_decision=GO"
 echo "service_api_reason_code_contract_status=verified"
+echo "error_envelope_field_status=verified"
+echo "rust_sdk_reason_code_status=verified"
+echo "python_sdk_reason_code_status=verified"
 echo "service_api_reason_code_policy_status=verified"
 echo "docs_contract_status=verified"
 echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
This hardens the existing service-api reason-code compatibility contract lane to explicitly enforce structured error-envelope parity and cross-SDK reason-code marker coverage. Policy checks now fail closed when critical envelope parity markers drift.

Closes #3296

## Changes
- `scripts/runtime/validate_service_api_reason_code_compatibility_live.sh`:
  - added critical marker checks for `error_envelope_field_status`, Rust SDK decoder parity, and Python SDK decoder parity.
  - added targeted local tests for Rust/Python SDK regression paths.
  - expanded summary report + output markers with envelope and SDK parity statuses.
- `scripts/runtime/service_api_reason_code_compatibility_live_contract.py`:
  - policy checker now requires/validates `error_envelope_field_status`, `rust_sdk_reason_code_status`, `python_sdk_reason_code_status`.
- `scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh`:
  - propagates new envelope/SDK parity markers into lane output + lane report JSON.
- `scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh`:
  - added fail-closed tamper drill for `error_envelope_field_status`.
- `scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh`:
  - added assertions for new envelope/SDK parity markers in lane output and lane report.
- `docs/ci/strategy.md`:
  - documented expanded local cost profile and new deterministic fail-closed policy marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh`
  - failed pre-change: `expected tampered envelope field status to fail policy checker`
- `bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh`
  - failed pre-change: `expected service api reason-code compatibility contract lane envelope marker`

### 🟢 Green Phase
- `bash scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh`
- `bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh`

### 🔁 Regression
- `bash scripts/runtime/validate_service_api_reason_code_compatibility_live.sh --max-seconds 240`
- `bash scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh --max-seconds 240`
- `bash scripts/ci/test_service_api_reason_code_compatibility_ci_exclusion_policy.sh`
- `bash scripts/ci/test_ci_strategy_contract.sh`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Policy required-field validation in `service_api_reason_code_compatibility_live_contract.py` | |
| Functional   | ✅ | Contract-lane command output/report marker checks in `test_validate_service_api_reason_code_compatibility_live_contract_lane.sh` | |
| Integration  | ✅ | Live summary -> policy -> contract lane flow via `validate_service_api_reason_code_compatibility_live_contract_lane.sh` | |
| Regression   | ✅ | Added fail-closed tamper drill for envelope parity marker drift (`error_envelope_field_status`) | |
| Performance  | ✅ | Runtime budget remains bounded via `--max-seconds` and documented local-only checks | |

## Risks & Rollback
- Risk: none beyond stricter policy enforcement; this change only increases fail-closed detection sensitivity.
- Rollback: revert this PR to restore previous marker set and policy strictness.

## Documentation Updates
- Updated `docs/ci/strategy.md` with envelope/SDK parity cost scope and fail-closed marker details.

## Validation Checklist
- [x] TDD Red/Green evidence included above
