### PR TITLE
test(runtime): add structured-error regression corpus lane checks (#3297)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -418,6 +418,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - bounded to seven targeted local-only checks (five `kamn-node` contract tests + one Rust SDK regression + one Python SDK regression).
   - source-marker checks run locally and avoid external network dependencies.
   - includes SDK parity marker checks for structured envelope decoding in `crates/kamn-sdk/src/service.rs` and `kamn_sdk.py`.
+  - structured-error regression corpus is sourced from `fixtures/runtime/service_api_structured_error_regression_corpus.json` and must preserve representative classes: `auth`, `validation`, `replay`, and `transport`.
   - runtime budget is bounded via `KAMN_SERVICE_API_REASON_CODE_CONTRACT_MAX_SECONDS`.
   - service api reason-code compatibility contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:

--- a/fixtures/runtime/service_api_structured_error_regression_corpus.json
+++ b/fixtures/runtime/service_api_structured_error_regression_corpus.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "kamn.runtime.service-api-structured-error-regression-corpus.v1",
+  "scenarios": [
+    {
+      "id": "auth_missing_sender_did_header",
+      "class": "auth",
+      "reason_code": "service_api_auth_sender_did_header_missing",
+      "test_selector": "main_tests::service_api_endpoint_tests::integration_service_api_endpoint_rejects_missing_request_auth_headers",
+      "regression_issue": "3297"
+    },
+    {
+      "id": "validation_invalid_websocket_version_header",
+      "class": "validation",
+      "reason_code": "service_api_ws_version_header_invalid",
+      "test_selector": "main_tests::service_api_endpoint_tests::regression_service_api_endpoint_websocket_rejects_invalid_version_header",
+      "regression_issue": "3297"
+    },
+    {
+      "id": "replay_nonce_rejected",
+      "class": "replay",
+      "reason_code": "service_api_auth_replay_nonce_detected",
+      "test_selector": "main_tests::service_api_endpoint_tests::regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender",
+      "regression_issue": "3297"
+    },
+    {
+      "id": "transport_payload_json_syntax_invalid",
+      "class": "transport",
+      "reason_code": "service_api_payload_json_syntax_invalid",
+      "test_selector": "main_tests::service_api_endpoint_tests::regression_service_api_payload_parse_reason_codes_fail_closed",
+      "regression_issue": "3297"
+    }
+  ]
+}

--- a/scripts/runtime/service_api_reason_code_compatibility_live_contract.py
+++ b/scripts/runtime/service_api_reason_code_compatibility_live_contract.py
@@ -34,6 +34,9 @@ REQUIRED_REPORT_FIELDS = [
     "error_envelope_field_status",
     "rust_sdk_reason_code_status",
     "python_sdk_reason_code_status",
+    "regression_corpus_status",
+    "regression_drift_diagnostics_status",
+    "regression_corpus_scenario_count",
     "route_error_mapping_status",
     "replay_error_mapping_status",
     "websocket_error_mapping_status",
@@ -48,6 +51,8 @@ REQUIRED_VERIFIED_FIELDS = [
     "error_envelope_field_status",
     "rust_sdk_reason_code_status",
     "python_sdk_reason_code_status",
+    "regression_corpus_status",
+    "regression_drift_diagnostics_status",
     "route_error_mapping_status",
     "replay_error_mapping_status",
     "websocket_error_mapping_status",
@@ -58,6 +63,10 @@ REQUIRED_VERIFIED_FIELDS = [
 
 def _is_non_negative_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
 def _check_policy(args: argparse.Namespace) -> int:
@@ -111,6 +120,10 @@ def _check_policy(args: argparse.Namespace) -> int:
     decision.reject_if(
         not _is_non_negative_int(report.get("elapsed_seconds")),
         "service_api_reason_code_policy_elapsed_seconds_invalid",
+    )
+    decision.reject_if(
+        not _is_positive_int(report.get("regression_corpus_scenario_count")),
+        "service_api_reason_code_policy_regression_corpus_scenario_count_invalid",
     )
     decision.reject_if(ci_fast_gate != "PASS", "ci_fast_gate_failed")
 

--- a/scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh
+++ b/scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh
@@ -21,6 +21,9 @@ cat >"$report_file" <<'JSON'
   "error_envelope_field_status": "verified",
   "rust_sdk_reason_code_status": "verified",
   "python_sdk_reason_code_status": "verified",
+  "regression_corpus_status": "verified",
+  "regression_drift_diagnostics_status": "verified",
+  "regression_corpus_scenario_count": 4,
   "route_error_mapping_status": "verified",
   "replay_error_mapping_status": "verified",
   "websocket_error_mapping_status": "verified",
@@ -133,6 +136,39 @@ if [ "$tampered_envelope_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_envelope_output" | grep -q 'service_api_reason_code_policy_marker_missing:error_envelope_field_status'; then
   echo "expected deterministic mismatch reason code for tampered envelope field parity marker" >&2
+  exit 1
+fi
+
+tampered_corpus_report="$TMP_DIR/service-api-reason-code-compatibility-live-summary.corpus.tampered.json"
+cp "$report_file" "$tampered_corpus_report"
+python3 - "$tampered_corpus_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["regression_corpus_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_corpus_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_corpus_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/service-api-reason-code-compatibility-live-policy.corpus.tampered.json" 2>&1
+)"
+tampered_corpus_code=$?
+set -e
+
+if [ "$tampered_corpus_code" -eq 0 ]; then
+  echo "expected tampered regression corpus status to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_corpus_output" | grep -q 'service_api_reason_code_policy_marker_missing:regression_corpus_status'; then
+  echo "expected deterministic mismatch reason code for tampered regression corpus marker" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
@@ -57,6 +57,18 @@ if ! printf '%s\n' "$lane_output" | grep -q '^python_sdk_reason_code_status=veri
   echo "expected service api reason-code compatibility contract lane python sdk marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^regression_corpus_status=verified$'; then
+  echo "expected service api reason-code compatibility contract lane regression corpus marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^regression_drift_diagnostics_status=verified$'; then
+  echo "expected service api reason-code compatibility contract lane regression drift marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -Eq '^regression_corpus_scenario_count=[1-9][0-9]*$'; then
+  echo "expected service api reason-code compatibility contract lane regression corpus count marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=service_api_reason_code_policy_marker_missing:route_error_mapping_status$'; then
   echo "expected service api reason-code compatibility contract lane fail-closed reason marker" >&2
   exit 1
@@ -84,6 +96,13 @@ if lane_payload.get("rust_sdk_reason_code_status") != "verified":
     raise SystemExit("expected rust_sdk_reason_code_status=verified")
 if lane_payload.get("python_sdk_reason_code_status") != "verified":
     raise SystemExit("expected python_sdk_reason_code_status=verified")
+if lane_payload.get("regression_corpus_status") != "verified":
+    raise SystemExit("expected regression_corpus_status=verified")
+if lane_payload.get("regression_drift_diagnostics_status") != "verified":
+    raise SystemExit("expected regression_drift_diagnostics_status=verified")
+scenario_count = lane_payload.get("regression_corpus_scenario_count")
+if not isinstance(scenario_count, int) or scenario_count <= 0:
+    raise SystemExit("expected regression_corpus_scenario_count to be positive integer")
 if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":

--- a/scripts/runtime/validate_service_api_reason_code_compatibility_live.sh
+++ b/scripts/runtime/validate_service_api_reason_code_compatibility_live.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SOURCE_FILE="$ROOT_DIR/crates/kamn-node/src/service_api_endpoint.rs"
 TEST_FILE="$ROOT_DIR/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs"
+CORPUS_FILE="$ROOT_DIR/fixtures/runtime/service_api_structured_error_regression_corpus.json"
 RUST_SDK_SOURCE="$ROOT_DIR/crates/kamn-sdk/src/service.rs"
 RUST_SDK_TEST_FILE="$ROOT_DIR/crates/kamn-sdk/tests/service_api_client.rs"
 PYTHON_SDK_SOURCE="$ROOT_DIR/kamn_sdk.py"
@@ -44,6 +45,10 @@ if [ ! -f "$SOURCE_FILE" ]; then
 fi
 if [ ! -f "$TEST_FILE" ]; then
   echo "expected service api endpoint test file: $TEST_FILE" >&2
+  exit 1
+fi
+if [ ! -f "$CORPUS_FILE" ]; then
+  echo "expected structured error regression corpus file: $CORPUS_FILE" >&2
   exit 1
 fi
 if [ ! -f "$RUST_SDK_SOURCE" ]; then
@@ -150,17 +155,135 @@ for python_sdk_test_marker in \
   fi
 done
 
+corpus_selectors_file="$TMP_DIR/service-api-structured-error-regression-selectors.txt"
+corpus_metadata_file="$TMP_DIR/service-api-structured-error-regression-metadata.json"
+python3 - "$CORPUS_FILE" "$SOURCE_FILE" "$TEST_FILE" "$corpus_selectors_file" "$corpus_metadata_file" <<'PY'
+import json
+import pathlib
+import sys
+
+corpus_file = pathlib.Path(sys.argv[1])
+source_file = pathlib.Path(sys.argv[2])
+test_file = pathlib.Path(sys.argv[3])
+selectors_file = pathlib.Path(sys.argv[4])
+metadata_file = pathlib.Path(sys.argv[5])
+
+payload = json.loads(corpus_file.read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.service-api-structured-error-regression-corpus.v1":
+    raise SystemExit("unexpected structured error regression corpus schema_version")
+
+scenarios = payload.get("scenarios")
+if not isinstance(scenarios, list) or not scenarios:
+    raise SystemExit("structured error regression corpus must include non-empty scenarios list")
+
+required_classes = {"auth", "validation", "replay", "transport"}
+seen_classes = set()
+seen_ids = set()
+selectors = []
+
+source_text = source_file.read_text(encoding="utf-8")
+test_text = test_file.read_text(encoding="utf-8")
+
+for scenario in scenarios:
+    if not isinstance(scenario, dict):
+        raise SystemExit("structured error regression corpus scenarios must be objects")
+    scenario_id = scenario.get("id")
+    scenario_class = scenario.get("class")
+    reason_code = scenario.get("reason_code")
+    test_selector = scenario.get("test_selector")
+    if not isinstance(scenario_id, str) or not scenario_id.strip():
+        raise SystemExit("structured error regression scenario id must be non-empty string")
+    if scenario_id in seen_ids:
+        raise SystemExit(f"structured error regression scenario id duplicated: {scenario_id}")
+    seen_ids.add(scenario_id)
+    if not isinstance(scenario_class, str) or scenario_class not in required_classes:
+        raise SystemExit(f"structured error regression scenario class invalid: {scenario_class}")
+    seen_classes.add(scenario_class)
+    if not isinstance(reason_code, str) or not reason_code.strip():
+        raise SystemExit(f"structured error regression scenario reason_code missing: {scenario_id}")
+    if reason_code not in source_text:
+        raise SystemExit(
+            "structured error regression corpus reason_code missing from source: "
+            f"{reason_code}"
+        )
+    if not isinstance(test_selector, str) or not test_selector.strip():
+        raise SystemExit(f"structured error regression scenario test_selector missing: {scenario_id}")
+    if not test_selector.startswith("main_tests::service_api_endpoint_tests::"):
+        raise SystemExit(
+            "structured error regression scenario test_selector must target service_api_endpoint_tests: "
+            f"{test_selector}"
+        )
+    selector_parts = test_selector.split("::")
+    if len(selector_parts) < 2:
+        raise SystemExit(
+            "structured error regression scenario test_selector must include module path: "
+            f"{test_selector}"
+        )
+    test_fn_name = selector_parts[-1]
+    if not test_fn_name:
+        raise SystemExit(
+            "structured error regression scenario test_selector function marker missing: "
+            f"{test_selector}"
+        )
+    if test_fn_name not in test_text:
+        raise SystemExit(
+            "structured error regression corpus test selector missing from tests: "
+            f"{test_selector}"
+        )
+    selectors.append(test_selector)
+
+missing_classes = sorted(required_classes - seen_classes)
+if missing_classes:
+    raise SystemExit(
+        "structured error regression corpus missing required classes: "
+        + ",".join(missing_classes)
+    )
+
+selectors_file.write_text("\n".join(selectors) + "\n", encoding="utf-8")
+metadata_file.write_text(
+    json.dumps(
+        {
+            "schema_version": "kamn.runtime.service-api-structured-error-regression-corpus-metadata.v1",
+            "scenario_count": len(scenarios),
+            "classes": sorted(seen_classes),
+        },
+        sort_keys=True,
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+PY
+
+regression_corpus_scenario_count="$(python3 - "$corpus_metadata_file" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+scenario_count = payload.get("scenario_count")
+if not isinstance(scenario_count, int) or scenario_count <= 0:
+    raise SystemExit("structured error regression corpus scenario_count must be positive integer")
+print(scenario_count)
+PY
+)"
+
 pushd "$ROOT_DIR" >/dev/null
 cargo test -p kamn-node main_tests::unit_service_api_endpoint_error_envelopes_use_reason_code_and_message_contracts -- --exact \
   >"$TMP_DIR/service-api-envelope-unit.log" 2>&1
-cargo test -p kamn-node main_tests::regression_service_api_payload_parse_reason_codes_fail_closed -- --exact \
-  >"$TMP_DIR/service-api-reason-code-regression.log" 2>&1
-cargo test -p kamn-node main_tests::integration_service_api_endpoint_rejects_missing_request_auth_headers -- --exact \
-  >"$TMP_DIR/service-api-reason-code-auth.log" 2>&1
-cargo test -p kamn-node main_tests::regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender -- --exact \
-  >"$TMP_DIR/service-api-reason-code-replay.log" 2>&1
-cargo test -p kamn-node main_tests::regression_service_api_endpoint_websocket_rejects_invalid_version_header -- --exact \
-  >"$TMP_DIR/service-api-reason-code-websocket.log" 2>&1
+selector_index=0
+while IFS= read -r selector; do
+  if [[ -z "$selector" ]]; then
+    continue
+  fi
+  selector_index=$((selector_index + 1))
+  cargo test -p kamn-node "$selector" -- --exact \
+    >"$TMP_DIR/service-api-reason-code-corpus-${selector_index}.log" 2>&1
+done < "$corpus_selectors_file"
+if [ "$selector_index" -le 0 ]; then
+  echo "structured error regression corpus selector list was empty after parsing" >&2
+  exit 1
+fi
 cargo test -p kamn-sdk --test service_api_client regression_service_api_client_rejects_replayed_nonce -- --exact \
   >"$TMP_DIR/service-api-reason-code-rust-sdk.log" 2>&1
 python3 -m unittest tests.python.test_sdk.PythonLiveTransportSDKTests.test_regression_backend_adapter_errors_and_invalid_payloads_fail_closed \
@@ -174,7 +297,7 @@ if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
 fi
 
 summary_report="$TMP_DIR/service-api-reason-code-compatibility-live-summary.json"
-python3 - "$summary_report" "$elapsed_seconds" "$max_seconds" <<'PY'
+python3 - "$summary_report" "$elapsed_seconds" "$max_seconds" "$regression_corpus_scenario_count" <<'PY'
 import json
 import pathlib
 import sys
@@ -182,6 +305,7 @@ import sys
 summary_report = pathlib.Path(sys.argv[1])
 elapsed_seconds = int(sys.argv[2])
 max_seconds = int(sys.argv[3])
+regression_corpus_scenario_count = int(sys.argv[4])
 
 payload = {
     "schema_version": "kamn.runtime.service-api-reason-code-compatibility-live-validation.v1",
@@ -191,6 +315,9 @@ payload = {
     "error_envelope_field_status": "verified",
     "rust_sdk_reason_code_status": "verified",
     "python_sdk_reason_code_status": "verified",
+    "regression_corpus_status": "verified",
+    "regression_drift_diagnostics_status": "verified",
+    "regression_corpus_scenario_count": regression_corpus_scenario_count,
     "route_error_mapping_status": "verified",
     "replay_error_mapping_status": "verified",
     "websocket_error_mapping_status": "verified",
@@ -213,6 +340,9 @@ echo "reason_registry_status=verified"
 echo "error_envelope_field_status=verified"
 echo "rust_sdk_reason_code_status=verified"
 echo "python_sdk_reason_code_status=verified"
+echo "regression_corpus_status=verified"
+echo "regression_drift_diagnostics_status=verified"
+echo "regression_corpus_scenario_count=${regression_corpus_scenario_count}"
 echo "route_error_mapping_status=verified"
 echo "replay_error_mapping_status=verified"
 echo "websocket_error_mapping_status=verified"

--- a/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh
@@ -100,6 +100,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^python_sdk_reason_code_statu
   echo "expected service api reason-code compatibility python sdk marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^regression_corpus_status=verified$'; then
+  echo "expected service api reason-code compatibility regression corpus marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^regression_drift_diagnostics_status=verified$'; then
+  echo "expected service api reason-code compatibility regression drift diagnostics marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -Eq '^regression_corpus_scenario_count=[1-9][0-9]*$'; then
+  echo "expected service api reason-code compatibility regression corpus scenario count marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^route_error_mapping_status=verified$'; then
   echo "expected service api reason-code compatibility route mapping marker" >&2
   exit 1
@@ -233,6 +245,13 @@ lane_report = {
     "error_envelope_field_status": summary_report.get("error_envelope_field_status"),
     "rust_sdk_reason_code_status": summary_report.get("rust_sdk_reason_code_status"),
     "python_sdk_reason_code_status": summary_report.get("python_sdk_reason_code_status"),
+    "regression_corpus_status": summary_report.get("regression_corpus_status"),
+    "regression_drift_diagnostics_status": summary_report.get(
+        "regression_drift_diagnostics_status"
+    ),
+    "regression_corpus_scenario_count": summary_report.get(
+        "regression_corpus_scenario_count"
+    ),
     "service_api_reason_code_policy_status": policy_report.get(
         "service_api_reason_code_policy_status"
     ),
@@ -259,6 +278,17 @@ echo "service_api_reason_code_contract_status=verified"
 echo "error_envelope_field_status=verified"
 echo "rust_sdk_reason_code_status=verified"
 echo "python_sdk_reason_code_status=verified"
+echo "regression_corpus_status=verified"
+echo "regression_drift_diagnostics_status=verified"
+echo "regression_corpus_scenario_count=$(python3 - "$summary_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("regression_corpus_scenario_count", 0))
+PY
+)"
 echo "service_api_reason_code_policy_status=verified"
 echo "docs_contract_status=verified"
 echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
Adds a versioned structured-error regression corpus for service-api reason-code compatibility and wires it into the runtime validation contract lane. This prevents drift between reason-code mappings, regression selectors, and lane policy outputs.

## Changes
- `fixtures/runtime/service_api_structured_error_regression_corpus.json`: adds canonical auth/validation/replay/transport regression scenarios.
- `scripts/runtime/validate_service_api_reason_code_compatibility_live.sh`: validates corpus schema/classes/selectors, runs selector-driven replay tests, and emits regression corpus diagnostics markers.
- `scripts/runtime/service_api_reason_code_compatibility_live_contract.py`: enforces regression-corpus fields and positive scenario count.
- `scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh`: validates and forwards regression corpus markers.
- `scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh`: adds fail-closed tamper drill for regression corpus status marker.
- `scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh`: asserts regression corpus lane markers and scenario count.
- `docs/ci/strategy.md`: documents corpus source and required representative classes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
```
Output excerpt:
```text
structured error regression corpus test selector missing from tests: main_tests::service_api_endpoint_tests::integration_service_api_endpoint_rejects_missing_request_auth_headers
```

### 🟢 Green Phase
Command:
```bash
bash scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh
bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
```
Output excerpt:
```text
service api reason-code compatibility live policy checker tests passed.
service api reason-code compatibility contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh && \
bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh && \
bash scripts/runtime/validate_service_api_reason_code_compatibility_live.sh --max-seconds 240 >/tmp/kamn-3297-live.out && \
bash scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh --max-seconds 240 >/tmp/kamn-3297-lane.out && \
bash scripts/ci/test_service_api_reason_code_compatibility_ci_exclusion_policy.sh && \
bash scripts/ci/test_ci_strategy_contract.sh
```
Output excerpt:
```text
service api reason-code compatibility live policy checker tests passed.
service api reason-code compatibility contract lane tests passed.
service api reason-code compatibility CI exclusion policy tests passed.
CI strategy contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Lane/policy scripts only; no Rust unit scope changed in this issue. |
| Functional   | ✅     | `scripts/runtime/test_check_service_api_reason_code_compatibility_live_policy.sh`; `scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh` | |
| Integration  | ✅     | `scripts/runtime/validate_service_api_reason_code_compatibility_live.sh --max-seconds 240`; `scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh --max-seconds 240` | |
| Regression   | ✅     | selector-driven replay via `fixtures/runtime/service_api_structured_error_regression_corpus.json` | |
| Performance  | N/A    | Existing lane budget retained | No throughput/load path changed; command duration budget already enforced by lane policy. |

## Risks & Rollback
- None expected; this change is additive to validation/test harness behavior.
- Rollback plan: revert this PR to restore previous fixed-selector lane behavior.

## Documentation Updates
- Updated `docs/ci/strategy.md` with structured-error regression corpus policy details.

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #3297
