### PR TITLE
test(runtime): enforce ingress limit config/docs parity contract lane (#3301)

### DIFF
--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -12,6 +12,7 @@ Runtime mode: `api`
 - `--api-bind <host:port>`
 - `--api-max-requests <n>` (default: `1`)
 - `--api-idle-timeout-ms <ms>` (default: `5000`)
+- request payload body read limit: `65536` bytes (64 KiB)
 
 Fail-closed behavior:
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -381,10 +381,12 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Cost controls:
   - uses only localhost process-level probes against `runtime-mode api`.
   - no external Kolme node, remote service, or internet dependency.
+  - ingress limit config matrix defaults remain parity-checked against source constants and API docs (`api_max_requests_default=1`, `api_idle_timeout_default_ms=5000`, `body_size_limit_bytes=65536`).
   - runtime budget is bounded via `KAMN_SERVICE_API_AXUM_INGRESS_CONTRACT_MAX_SECONDS`.
   - service api axum ingress run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:
   - `service_api_axum_policy_marker_missing:concurrency_status`
+  - `service_api_axum_policy_body_size_limit_mismatch`
 
 ## Runtime Service API Serde Payload Parity Contract Lane
 - Entry commands:

--- a/scripts/runtime/service_api_axum_ingress_live_contract.py
+++ b/scripts/runtime/service_api_axum_ingress_live_contract.py
@@ -25,6 +25,9 @@ from framework.contract_framework import (  # noqa: E402
 REPORT_SCHEMA = "kamn.runtime.service-api-axum-ingress-live-validation.v1"
 POLICY_SCHEMA = "kamn.runtime.service-api-axum-ingress-live-policy-report.v1"
 EXPECTED_FAIL_CLOSED_REASON_CODE = "service_api_axum_oversized_body_rejected"
+EXPECTED_BODY_SIZE_LIMIT_BYTES = 64 * 1024
+EXPECTED_API_MAX_REQUESTS_DEFAULT = 1
+EXPECTED_API_IDLE_TIMEOUT_DEFAULT_MS = 5_000
 
 REQUIRED_REPORT_FIELDS = [
     "schema_version",
@@ -34,6 +37,11 @@ REQUIRED_REPORT_FIELDS = [
     "body_size_guard_status",
     "concurrency_status",
     "websocket_status",
+    "ingress_limit_config_status",
+    "docs_ingress_limit_matrix_status",
+    "api_max_requests_default",
+    "api_idle_timeout_default_ms",
+    "body_size_limit_bytes",
     "fail_closed_status",
     "ci_fast_gate_exclusion_status",
     "performance_budget_status",
@@ -46,6 +54,8 @@ REQUIRED_VERIFIED_FIELDS = [
     "body_size_guard_status",
     "concurrency_status",
     "websocket_status",
+    "ingress_limit_config_status",
+    "docs_ingress_limit_matrix_status",
     "fail_closed_status",
     "ci_fast_gate_exclusion_status",
     "performance_budget_status",
@@ -54,6 +64,10 @@ REQUIRED_VERIFIED_FIELDS = [
 
 def _is_non_negative_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
 def _check_policy(args: argparse.Namespace) -> int:
@@ -103,6 +117,30 @@ def _check_policy(args: argparse.Namespace) -> int:
     decision.reject_if(
         report.get("fail_closed_reason_code") != EXPECTED_FAIL_CLOSED_REASON_CODE,
         "service_api_axum_policy_fail_closed_reason_code_mismatch",
+    )
+    decision.reject_if(
+        not _is_positive_int(report.get("body_size_limit_bytes")),
+        "service_api_axum_policy_body_size_limit_invalid",
+    )
+    decision.reject_if(
+        report.get("body_size_limit_bytes") != EXPECTED_BODY_SIZE_LIMIT_BYTES,
+        "service_api_axum_policy_body_size_limit_mismatch",
+    )
+    decision.reject_if(
+        not _is_positive_int(report.get("api_max_requests_default")),
+        "service_api_axum_policy_api_max_requests_default_invalid",
+    )
+    decision.reject_if(
+        report.get("api_max_requests_default") != EXPECTED_API_MAX_REQUESTS_DEFAULT,
+        "service_api_axum_policy_api_max_requests_default_mismatch",
+    )
+    decision.reject_if(
+        not _is_positive_int(report.get("api_idle_timeout_default_ms")),
+        "service_api_axum_policy_api_idle_timeout_default_invalid",
+    )
+    decision.reject_if(
+        report.get("api_idle_timeout_default_ms") != EXPECTED_API_IDLE_TIMEOUT_DEFAULT_MS,
+        "service_api_axum_policy_api_idle_timeout_default_mismatch",
     )
     decision.reject_if(
         not _is_non_negative_int(report.get("elapsed_seconds")),

--- a/scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
+++ b/scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
@@ -21,6 +21,11 @@ cat >"$report_file" <<'JSON'
   "body_size_guard_status": "verified",
   "concurrency_status": "verified",
   "websocket_status": "verified",
+  "ingress_limit_config_status": "verified",
+  "docs_ingress_limit_matrix_status": "verified",
+  "api_max_requests_default": 1,
+  "api_idle_timeout_default_ms": 5000,
+  "body_size_limit_bytes": 65536,
   "fail_closed_status": "verified",
   "ci_fast_gate_exclusion_status": "verified",
   "performance_budget_status": "verified",
@@ -98,6 +103,39 @@ if [ "$tampered_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_output" | grep -q 'service_api_axum_policy_marker_missing:concurrency_status'; then
   echo "expected deterministic mismatch reason code for tampered policy validation" >&2
+  exit 1
+fi
+
+tampered_threshold_report="$TMP_DIR/service-api-axum-ingress-live-summary.threshold.tampered.json"
+cp "$report_file" "$tampered_threshold_report"
+python3 - "$tampered_threshold_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["body_size_limit_bytes"] = 65535
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_threshold_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_threshold_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/service-api-axum-ingress-live-policy.threshold.tampered.json" 2>&1
+)"
+tampered_threshold_code=$?
+set -e
+
+if [ "$tampered_threshold_code" -eq 0 ]; then
+  echo "expected tampered service api body-size threshold to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_threshold_output" | grep -q 'service_api_axum_policy_body_size_limit_mismatch'; then
+  echo "expected deterministic mismatch reason code for tampered body-size threshold" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
@@ -45,6 +45,26 @@ if ! printf '%s\n' "$lane_output" | grep -q '^service_api_axum_ingress_policy_st
   echo "expected service api axum ingress contract lane policy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^ingress_limit_config_status=verified$'; then
+  echo "expected service api axum ingress contract lane config matrix marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^docs_ingress_limit_matrix_status=verified$'; then
+  echo "expected service api axum ingress contract lane docs parity marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -Eq '^api_max_requests_default=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress contract lane max-requests default marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -Eq '^api_idle_timeout_default_ms=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress contract lane idle-timeout default marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -Eq '^body_size_limit_bytes=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress contract lane body-size limit marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=service_api_axum_policy_marker_missing:concurrency_status$'; then
   echo "expected service api axum ingress contract lane fail-closed reason marker" >&2
   exit 1
@@ -66,6 +86,16 @@ if lane_payload.get("service_api_axum_ingress_contract_status") != "verified":
     raise SystemExit("expected service_api_axum_ingress_contract_status=verified")
 if lane_payload.get("service_api_axum_ingress_policy_status") != "verified":
     raise SystemExit("expected service_api_axum_ingress_policy_status=verified")
+if lane_payload.get("ingress_limit_config_status") != "verified":
+    raise SystemExit("expected ingress_limit_config_status=verified")
+if lane_payload.get("docs_ingress_limit_matrix_status") != "verified":
+    raise SystemExit("expected docs_ingress_limit_matrix_status=verified")
+if lane_payload.get("api_max_requests_default") != 1:
+    raise SystemExit("expected api_max_requests_default=1")
+if lane_payload.get("api_idle_timeout_default_ms") != 5000:
+    raise SystemExit("expected api_idle_timeout_default_ms=5000")
+if lane_payload.get("body_size_limit_bytes") != 65536:
+    raise SystemExit("expected body_size_limit_bytes=65536")
 if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":

--- a/scripts/runtime/validate_service_api_axum_ingress_live.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_FILE="$ROOT_DIR/crates/kamn-node/src/service_api_endpoint.rs"
+API_DOC="$ROOT_DIR/docs/api/service-http-api.md"
 
 output_json=""
 max_seconds=180
@@ -31,6 +33,14 @@ if [ "$max_seconds" -le 0 ]; then
   echo "max-seconds must be greater than zero" >&2
   exit 1
 fi
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "expected service api source file: $SOURCE_FILE" >&2
+  exit 1
+fi
+if [ ! -f "$API_DOC" ]; then
+  echo "expected service api docs file: $API_DOC" >&2
+  exit 1
+fi
 
 TMP_DIR="$(mktemp -d)"
 node_pid=""
@@ -44,6 +54,68 @@ cleanup() {
 trap cleanup EXIT
 
 start_epoch="$(date +%s)"
+
+config_matrix_report="$TMP_DIR/service-api-axum-ingress-config-matrix.json"
+python3 - "$SOURCE_FILE" "$API_DOC" "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+source_file = pathlib.Path(sys.argv[1])
+api_doc_file = pathlib.Path(sys.argv[2])
+report_file = pathlib.Path(sys.argv[3])
+
+source_text = source_file.read_text(encoding="utf-8")
+api_doc_text = api_doc_file.read_text(encoding="utf-8")
+
+def parse_u64_const(name: str) -> int:
+    match = re.search(rf"pub\(crate\)\s+const\s+{name}:\s*u64\s*=\s*([0-9_]+);", source_text)
+    if match is None:
+        raise SystemExit(f"missing source constant: {name}")
+    return int(match.group(1).replace("_", ""))
+
+max_requests_default = parse_u64_const("DEFAULT_SERVICE_API_MAX_REQUESTS")
+idle_timeout_default_ms = parse_u64_const("DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS")
+
+body_limit_match = re.search(r"let\s+body_limit\s*=\s*([0-9_]+)\s*\*\s*([0-9_]+);", source_text)
+if body_limit_match is None:
+    raise SystemExit("missing service api request body limit marker")
+body_size_limit_bytes = int(body_limit_match.group(1).replace("_", "")) * int(
+    body_limit_match.group(2).replace("_", "")
+)
+
+if max_requests_default <= 0:
+    raise SystemExit("service api max-requests default must be positive")
+if idle_timeout_default_ms <= 0:
+    raise SystemExit("service api idle-timeout default must be positive")
+if body_size_limit_bytes <= 0:
+    raise SystemExit("service api body-size limit must be positive")
+
+required_doc_markers = [
+    f"--api-max-requests <n>` (default: `{max_requests_default}`)",
+    f"--api-idle-timeout-ms <ms>` (default: `{idle_timeout_default_ms}`)",
+    f"request payload body read limit: `{body_size_limit_bytes}` bytes",
+]
+missing_doc_markers = [
+    marker for marker in required_doc_markers if marker not in api_doc_text
+]
+if missing_doc_markers:
+    raise SystemExit(
+        "service api docs missing ingress-limit config markers: "
+        + ",".join(missing_doc_markers)
+    )
+
+report = {
+    "schema_version": "kamn.runtime.service-api-axum-ingress-config-matrix.v1",
+    "ingress_limit_config_status": "verified",
+    "docs_ingress_limit_matrix_status": "verified",
+    "api_max_requests_default": max_requests_default,
+    "api_idle_timeout_default_ms": idle_timeout_default_ms,
+    "body_size_limit_bytes": body_size_limit_bytes,
+}
+report_file.write_text(json.dumps(report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
 
 pushd "$ROOT_DIR" >/dev/null
 cargo build --quiet -p kamn-node
@@ -372,6 +444,51 @@ payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 print(payload["fail_closed_status"])
 PY
 )"
+ingress_limit_config_status="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["ingress_limit_config_status"])
+PY
+)"
+docs_ingress_limit_matrix_status="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["docs_ingress_limit_matrix_status"])
+PY
+)"
+api_max_requests_default="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["api_max_requests_default"])
+PY
+)"
+api_idle_timeout_default_ms="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["api_idle_timeout_default_ms"])
+PY
+)"
+body_size_limit_bytes="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["body_size_limit_bytes"])
+PY
+)"
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
 if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
@@ -389,6 +506,11 @@ cat >"$report_json" <<JSON
   "body_size_guard_status": "${body_size_guard_status}",
   "concurrency_status": "${concurrency_status}",
   "websocket_status": "${websocket_status}",
+  "ingress_limit_config_status": "${ingress_limit_config_status}",
+  "docs_ingress_limit_matrix_status": "${docs_ingress_limit_matrix_status}",
+  "api_max_requests_default": ${api_max_requests_default},
+  "api_idle_timeout_default_ms": ${api_idle_timeout_default_ms},
+  "body_size_limit_bytes": ${body_size_limit_bytes},
   "fail_closed_status": "${fail_closed_status}",
   "ci_fast_gate_exclusion_status": "${ci_fast_gate_exclusion_status}",
   "performance_budget_status": "verified",
@@ -407,6 +529,11 @@ echo "keep_alive_status=${keep_alive_status}"
 echo "body_size_guard_status=${body_size_guard_status}"
 echo "concurrency_status=${concurrency_status}"
 echo "websocket_status=${websocket_status}"
+echo "ingress_limit_config_status=${ingress_limit_config_status}"
+echo "docs_ingress_limit_matrix_status=${docs_ingress_limit_matrix_status}"
+echo "api_max_requests_default=${api_max_requests_default}"
+echo "api_idle_timeout_default_ms=${api_idle_timeout_default_ms}"
+echo "body_size_limit_bytes=${body_size_limit_bytes}"
 echo "fail_closed_status=${fail_closed_status}"
 echo "ci_fast_gate_exclusion_status=${ci_fast_gate_exclusion_status}"
 echo "performance_budget_status=verified"

--- a/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
@@ -100,6 +100,26 @@ if ! printf '%s\n' "$validation_output" | grep -q '^websocket_status=verified$';
   echo "expected service api axum ingress websocket marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^ingress_limit_config_status=verified$'; then
+  echo "expected service api axum ingress config-matrix marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^docs_ingress_limit_matrix_status=verified$'; then
+  echo "expected service api axum ingress docs parity marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -Eq '^api_max_requests_default=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress max-requests default marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -Eq '^api_idle_timeout_default_ms=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress idle-timeout default marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -Eq '^body_size_limit_bytes=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress body-size limit marker" >&2
+  exit 1
+fi
 
 policy_output="$(
   bash "$POLICY_CHECKER" \
@@ -168,6 +188,10 @@ if ! grep -q "service api axum ingress run-mode commands remain excluded from ci
   echo "expected CI strategy docs to include service api axum ingress run-mode exclusion marker" >&2
   exit 1
 fi
+if ! grep -q "ingress limit config matrix defaults remain parity-checked against source constants and API docs" "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include ingress-limit config matrix parity marker" >&2
+  exit 1
+fi
 
 if ! grep -q "Task #3308" "$ROADMAP_DOC"; then
   echo "expected roadmap marker for Task #3308" >&2
@@ -217,6 +241,13 @@ lane_report = {
     "service_api_axum_ingress_policy_status": policy_report.get(
         "service_api_axum_ingress_policy_status"
     ),
+    "ingress_limit_config_status": summary_report.get("ingress_limit_config_status"),
+    "docs_ingress_limit_matrix_status": summary_report.get(
+        "docs_ingress_limit_matrix_status"
+    ),
+    "api_max_requests_default": summary_report.get("api_max_requests_default"),
+    "api_idle_timeout_default_ms": summary_report.get("api_idle_timeout_default_ms"),
+    "body_size_limit_bytes": summary_report.get("body_size_limit_bytes"),
     "docs_contract_status": "verified",
     "fail_closed_status": "verified",
     "fail_closed_reason_code": "service_api_axum_policy_marker_missing:concurrency_status",
@@ -238,6 +269,35 @@ echo "status=pass"
 echo "final_decision=GO"
 echo "service_api_axum_ingress_contract_status=verified"
 echo "service_api_axum_ingress_policy_status=verified"
+echo "ingress_limit_config_status=verified"
+echo "docs_ingress_limit_matrix_status=verified"
+echo "api_max_requests_default=$(python3 - "$summary_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("api_max_requests_default", 0))
+PY
+)"
+echo "api_idle_timeout_default_ms=$(python3 - "$summary_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("api_idle_timeout_default_ms", 0))
+PY
+)"
+echo "body_size_limit_bytes=$(python3 - "$summary_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("body_size_limit_bytes", 0))
+PY
+)"
 echo "docs_contract_status=verified"
 echo "fail_closed_status=verified"
 echo "fail_closed_reason_code=service_api_axum_policy_marker_missing:concurrency_status"


### PR DESCRIPTION
## Summary
Adds fail-closed ingress-limit config/docs parity contracts to the axum service-api live validation lane. The lane now enforces deterministic threshold defaults and docs parity for max requests, idle timeout, and request body size.

## Changes
- `scripts/runtime/validate_service_api_axum_ingress_live.sh`: adds source+docs config matrix extraction/validation and emits new markers (`ingress_limit_config_status`, `docs_ingress_limit_matrix_status`, threshold fields).
- `scripts/runtime/service_api_axum_ingress_live_contract.py`: enforces new required report fields and fail-closed mismatch diagnostics for threshold drift.
- `scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh`: validates new markers, propagates threshold fields to lane report, and checks new docs parity marker.
- `scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`: adds report fixture fields and body-size-threshold tamper failure assertion.
- `scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`: adds output/report assertions for new config parity fields.
- `docs/api/service-http-api.md`: documents deterministic request body read limit.
- `docs/ci/strategy.md`: documents ingress config-matrix parity contract and deterministic mismatch reason marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
TMP_DIR=$(mktemp -d)
cat >"$TMP_DIR/red-report.json" <<'JSON'
{
  "schema_version": "kamn.runtime.service-api-axum-ingress-live-validation.v1",
  "status": "pass",
  "final_decision": "GO",
  "keep_alive_status": "verified",
  "body_size_guard_status": "verified",
  "concurrency_status": "verified",
  "websocket_status": "verified",
  "fail_closed_status": "verified",
  "ci_fast_gate_exclusion_status": "verified",
  "performance_budget_status": "verified",
  "fail_closed_reason_code": "service_api_axum_oversized_body_rejected",
  "elapsed_seconds": 1
}
JSON
bash scripts/runtime/check_service_api_axum_ingress_live_policy.sh \
  --report-file "$TMP_DIR/red-report.json" \
  --expected-final-decision GO \
  --ci-fast-gate PASS
```
Output excerpt:
```text
missing required report fields: ingress_limit_config_status,docs_ingress_limit_matrix_status,api_max_requests_default,api_idle_timeout_default_ms,body_size_limit_bytes
```

### 🟢 Green Phase
Command:
```bash
bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
```
Output excerpt:
```text
service api axum ingress live policy checker tests passed.
service api axum ingress contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh && \
bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh && \
bash scripts/runtime/validate_service_api_axum_ingress_live.sh --max-seconds 180 >/tmp/kamn-3301-live.out && \
bash scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh --max-seconds 180 >/tmp/kamn-3301-lane.out && \
bash scripts/ci/test_ci_strategy_contract.sh
```
Output excerpt:
```text
service api axum ingress live policy checker tests passed.
service api axum ingress contract lane tests passed.
CI strategy contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Contract lane/policy harness scope; no Rust unit module changed in this issue. |
| Functional   | ✅     | `scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`; `scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh` | |
| Integration  | ✅     | `scripts/runtime/validate_service_api_axum_ingress_live.sh --max-seconds 180`; `scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh --max-seconds 180` | |
| Regression   | ✅     | policy tamper drill for threshold drift (`service_api_axum_policy_body_size_limit_mismatch`) | |
| Performance  | N/A    | Existing runtime budget checks retained | No throughput/load path changed beyond existing bounded local probes. |

## Risks & Rollback
- Risk: docs/source threshold drift now fails closed in contract lane until parity is restored.
- Rollback plan: revert this PR to restore prior axum ingress lane marker contract.

## Documentation Updates
- Updated `docs/api/service-http-api.md` and `docs/ci/strategy.md`.

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #3301
