### PR TITLE
feat(runtime): wire ingress limiter config and rejection contracts (#3366)

### DIFF
--- a/crates/kamn-node/src/cli.rs
+++ b/crates/kamn-node/src/cli.rs
@@ -4,8 +4,10 @@ use super::{
     ProposalCandidate, RejoinAttempt, RuntimeMode, RuntimeModeKind, SyncMode,
     DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH, DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS,
     DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS, DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH,
+    DEFAULT_SERVICE_API_BODY_LIMIT_BYTES, DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
     DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS, DEFAULT_SERVICE_API_MAX_REQUESTS,
-    KOLME_IN_MEMORY_PROVIDER_MARKER, KOLME_LIVE_SIGNING_PROFILE,
+    DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND, KOLME_IN_MEMORY_PROVIDER_MARKER,
+    KOLME_LIVE_SIGNING_PROFILE,
 };
 use std::{env, fs};
 
@@ -113,6 +115,13 @@ fn map_config_entry_to_args(
         "api_bind" => push_key_value_flag(&mut mapped, value, "--api-bind"),
         "api_max_requests" => push_key_value_flag(&mut mapped, value, "--api-max-requests"),
         "api_idle_timeout_ms" => push_key_value_flag(&mut mapped, value, "--api-idle-timeout-ms"),
+        "api_body_limit_bytes" => push_key_value_flag(&mut mapped, value, "--api-body-limit-bytes"),
+        "api_concurrency_limit" => {
+            push_key_value_flag(&mut mapped, value, "--api-concurrency-limit")
+        }
+        "api_rate_limit_per_second" => {
+            push_key_value_flag(&mut mapped, value, "--api-rate-limit-per-second")
+        }
         "observability_endpoint_bind" => {
             push_key_value_flag(&mut mapped, value, "--observability-endpoint-bind")
         }
@@ -213,6 +222,21 @@ fn collect_env_override_args() -> Result<Vec<String>, ConfigError> {
         &mut args,
         "KAMN_NODE_API_IDLE_TIMEOUT_MS",
         "api_idle_timeout_ms",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_API_BODY_LIMIT_BYTES",
+        "api_body_limit_bytes",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_API_CONCURRENCY_LIMIT",
+        "api_concurrency_limit",
+    )?;
+    append_env_override(
+        &mut args,
+        "KAMN_NODE_API_RATE_LIMIT_PER_SECOND",
+        "api_rate_limit_per_second",
     )?;
     append_env_override(
         &mut args,
@@ -353,6 +377,9 @@ where
     let mut api_bind_addr: Option<String> = None;
     let mut api_max_requests = DEFAULT_SERVICE_API_MAX_REQUESTS;
     let mut api_idle_timeout_ms = DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS;
+    let mut api_body_limit_bytes = DEFAULT_SERVICE_API_BODY_LIMIT_BYTES;
+    let mut api_concurrency_limit = DEFAULT_SERVICE_API_CONCURRENCY_LIMIT;
+    let mut api_rate_limit_per_second = DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND;
     let mut observability_endpoint_bind_addr: Option<String> = None;
     let mut observability_endpoint_metrics_path =
         DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH.to_owned();
@@ -368,6 +395,9 @@ where
     let mut observability_endpoint_idle_timeout_ms_overridden = false;
     let mut api_max_requests_overridden = false;
     let mut api_idle_timeout_ms_overridden = false;
+    let mut api_body_limit_bytes_overridden = false;
+    let mut api_concurrency_limit_overridden = false;
+    let mut api_rate_limit_per_second_overridden = false;
     let mut role_overridden = false;
     let mut chain_id_overridden = false;
     let mut chain_version_overridden = false;
@@ -545,6 +575,27 @@ where
                     .ok_or(ConfigError::MissingArgumentValue("--api-idle-timeout-ms"))?;
                 api_idle_timeout_ms = parse_daemon_control_arg(&value)?;
                 api_idle_timeout_ms_overridden = true;
+            }
+            "--api-body-limit-bytes" => {
+                let value = iter
+                    .next()
+                    .ok_or(ConfigError::MissingArgumentValue("--api-body-limit-bytes"))?;
+                api_body_limit_bytes = parse_daemon_control_arg(&value)?;
+                api_body_limit_bytes_overridden = true;
+            }
+            "--api-concurrency-limit" => {
+                let value = iter
+                    .next()
+                    .ok_or(ConfigError::MissingArgumentValue("--api-concurrency-limit"))?;
+                api_concurrency_limit = parse_daemon_control_arg(&value)?;
+                api_concurrency_limit_overridden = true;
+            }
+            "--api-rate-limit-per-second" => {
+                let value = iter.next().ok_or(ConfigError::MissingArgumentValue(
+                    "--api-rate-limit-per-second",
+                ))?;
+                api_rate_limit_per_second = parse_daemon_control_arg(&value)?;
+                api_rate_limit_per_second_overridden = true;
             }
             "--observability-endpoint-bind" => {
                 observability_endpoint_bind_addr = Some(iter.next().ok_or(
@@ -741,7 +792,13 @@ where
             normalize_kolme_live_signer_profile_selector(signer_profile)?;
         }
     }
-    if api_bind_addr.is_none() && (api_max_requests_overridden || api_idle_timeout_ms_overridden) {
+    if api_bind_addr.is_none()
+        && (api_max_requests_overridden
+            || api_idle_timeout_ms_overridden
+            || api_body_limit_bytes_overridden
+            || api_concurrency_limit_overridden
+            || api_rate_limit_per_second_overridden)
+    {
         return Err(ConfigError::MissingArgumentValue("--api-bind"));
     }
     if observability_endpoint_bind_addr.is_none()
@@ -797,6 +854,9 @@ where
         api_bind_addr,
         api_max_requests,
         api_idle_timeout_ms,
+        api_body_limit_bytes,
+        api_concurrency_limit,
+        api_rate_limit_per_second,
         observability_endpoint_bind_addr,
         observability_endpoint_metrics_path,
         observability_endpoint_health_path,

--- a/crates/kamn-node/src/cli_tests.rs
+++ b/crates/kamn-node/src/cli_tests.rs
@@ -24,6 +24,9 @@ fn cli_module_parses_required_role_and_defaults() {
     assert_eq!(parsed.api_bind_addr, None);
     assert_eq!(parsed.api_max_requests, 1);
     assert_eq!(parsed.api_idle_timeout_ms, 5_000);
+    assert_eq!(parsed.api_body_limit_bytes, 64 * 1024);
+    assert_eq!(parsed.api_concurrency_limit, 32);
+    assert_eq!(parsed.api_rate_limit_per_second, 120);
     assert_eq!(parsed.observability_endpoint_bind_addr, None);
     assert_eq!(parsed.observability_endpoint_metrics_path, "/metrics");
     assert_eq!(parsed.observability_endpoint_health_path, "/healthz");
@@ -51,6 +54,23 @@ fn cli_module_runtime_mode_api_requires_bind_address() {
 }
 
 #[test]
+fn regression_cli_module_api_limiter_overrides_require_bind_address() {
+    let args = vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--api-body-limit-bytes".to_owned(),
+        "1024".to_owned(),
+    ];
+
+    let err = cli::parse_args(args).expect_err("api limiter override without bind should fail");
+    assert_eq!(
+        err,
+        kamn_core::ConfigError::MissingArgumentValue("--api-bind")
+    );
+}
+
+#[test]
 fn cli_module_parses_api_runtime_endpoint_controls() {
     let args = vec![
         "kamn-node".to_owned(),
@@ -64,6 +84,12 @@ fn cli_module_parses_api_runtime_endpoint_controls() {
         "4".to_owned(),
         "--api-idle-timeout-ms".to_owned(),
         "2000".to_owned(),
+        "--api-body-limit-bytes".to_owned(),
+        "131072".to_owned(),
+        "--api-concurrency-limit".to_owned(),
+        "16".to_owned(),
+        "--api-rate-limit-per-second".to_owned(),
+        "240".to_owned(),
     ];
 
     let parsed = cli::parse_args(args).expect("api args should parse");
@@ -74,6 +100,9 @@ fn cli_module_parses_api_runtime_endpoint_controls() {
     assert_eq!(parsed.api_bind_addr.as_deref(), Some("127.0.0.1:34051"));
     assert_eq!(parsed.api_max_requests, 4);
     assert_eq!(parsed.api_idle_timeout_ms, 2_000);
+    assert_eq!(parsed.api_body_limit_bytes, 131_072);
+    assert_eq!(parsed.api_concurrency_limit, 16);
+    assert_eq!(parsed.api_rate_limit_per_second, 240);
 }
 
 #[test]

--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -47,7 +47,9 @@ use runtime_kolme_live::{
 pub(crate) use service_api_endpoint::render_service_api_endpoint_response;
 pub(crate) use service_api_endpoint::{
     build_service_api_snapshot, serve_service_api_endpoint, ServiceApiEndpointConfig,
+    DEFAULT_SERVICE_API_BODY_LIMIT_BYTES, DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
     DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS, DEFAULT_SERVICE_API_MAX_REQUESTS,
+    DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
 };
 #[cfg(test)]
 use signer::{
@@ -321,6 +323,9 @@ struct NodeCli {
     api_bind_addr: Option<String>,
     api_max_requests: u64,
     api_idle_timeout_ms: u64,
+    api_body_limit_bytes: u64,
+    api_concurrency_limit: u64,
+    api_rate_limit_per_second: u64,
     observability_endpoint_bind_addr: Option<String>,
     observability_endpoint_metrics_path: String,
     observability_endpoint_health_path: String,
@@ -753,6 +758,9 @@ fn run() -> Result<(), ConfigError> {
                 bind_addr: bind_addr.clone(),
                 max_requests: cli.api_max_requests,
                 idle_timeout_ms: cli.api_idle_timeout_ms,
+                body_limit_bytes: cli.api_body_limit_bytes,
+                concurrency_limit: cli.api_concurrency_limit,
+                rate_limit_per_second: cli.api_rate_limit_per_second,
             });
     let observability_endpoint_config =
         cli.observability_endpoint_bind_addr
@@ -783,12 +791,21 @@ fn run() -> Result<(), ConfigError> {
         let snapshot = build_service_api_snapshot(&report);
         let max_requests_label = endpoint_config.max_requests.to_string();
         let idle_timeout_ms_label = endpoint_config.idle_timeout_ms.to_string();
+        let body_limit_bytes_label = endpoint_config.body_limit_bytes.to_string();
+        let concurrency_limit_label = endpoint_config.concurrency_limit.to_string();
+        let rate_limit_per_second_label = endpoint_config.rate_limit_per_second.to_string();
         log_info(
             "node.runtime.service_api.endpoint.start",
             &[
                 ("bind_addr", endpoint_config.bind_addr.as_str()),
                 ("max_requests", max_requests_label.as_str()),
                 ("idle_timeout_ms", idle_timeout_ms_label.as_str()),
+                ("body_limit_bytes", body_limit_bytes_label.as_str()),
+                ("concurrency_limit", concurrency_limit_label.as_str()),
+                (
+                    "rate_limit_per_second",
+                    rate_limit_per_second_label.as_str(),
+                ),
                 ("execution_id", execution_id.as_str()),
             ],
         )?;
@@ -945,6 +962,9 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
         api_bind_addr: _,
         api_max_requests: _,
         api_idle_timeout_ms: _,
+        api_body_limit_bytes: _,
+        api_concurrency_limit: _,
+        api_rate_limit_per_second: _,
         observability_endpoint_bind_addr: _,
         observability_endpoint_metrics_path: _,
         observability_endpoint_health_path: _,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
@@ -2,11 +2,14 @@ use super::*;
 use crate::service_api_endpoint::{
     parse_service_api_payload, ServiceApiAgentGetBody, ServiceApiChannelCreateBody,
     ServiceApiHealthBody, ServiceApiMessageCreateBody, ServiceApiTaskCreateBody,
+    DEFAULT_SERVICE_API_BODY_LIMIT_BYTES, DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+    DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
 };
 use kamn_core::baseline_signature_for_fields;
 use serde::Deserialize;
 use std::io::{ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -458,6 +461,9 @@ fn integration_service_api_endpoint_serves_required_http_routes() {
         bind_addr: bind_addr.clone(),
         max_requests: 3,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
 
     let server_snapshot = snapshot.clone();
@@ -524,6 +530,9 @@ fn integration_service_api_endpoint_http_response_bodies_match_serde_contracts()
         bind_addr: bind_addr.clone(),
         max_requests: 2,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
 
     let server_snapshot = snapshot.clone();
@@ -595,6 +604,9 @@ fn integration_service_api_endpoint_supports_keep_alive_requests_on_single_conne
         bind_addr: bind_addr.clone(),
         max_requests: 2,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let server_snapshot = snapshot.clone();
     let server =
@@ -658,6 +670,9 @@ fn functional_service_api_endpoint_emits_structured_ingress_correlation_markers(
         bind_addr: bind_addr.clone(),
         max_requests: 1,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let sender_did = "kamn:did:agent:test-client-correlation";
     let sender_nonce = 41_u64;
@@ -770,6 +785,9 @@ fn integration_service_api_endpoint_rejects_missing_request_auth_headers() {
         bind_addr: bind_addr.clone(),
         max_requests: 1,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let server_snapshot = snapshot.clone();
     let server =
@@ -799,6 +817,255 @@ fn integration_service_api_endpoint_rejects_missing_request_auth_headers() {
 }
 
 #[test]
+fn functional_service_api_endpoint_rejects_when_rate_limit_is_exceeded() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34062".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: 2,
+        idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: 1,
+    };
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let message_body = "{\"message\":\"rate-limit-check\"}";
+    let sender_did = "kamn:did:agent:test-client-rate-limit";
+    let state_hash = format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    );
+    let first_signature =
+        baseline_signature_for_fields(sender_did, 101, state_hash.as_str(), message_body);
+    let second_signature =
+        baseline_signature_for_fields(sender_did, 102, state_hash.as_str(), message_body);
+
+    let first_response = send_http_request_with_headers(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        message_body,
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", "101"),
+            ("X-KAMN-Request-Signature", first_signature.as_str()),
+        ],
+    );
+    let second_response = send_http_request_with_headers(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        message_body,
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", "102"),
+            ("X-KAMN-Request-Signature", second_signature.as_str()),
+        ],
+    );
+
+    assert!(first_response.contains("HTTP/1.1 202 Accepted"));
+    assert!(second_response.contains("HTTP/1.1 429 Too Many Requests"));
+    let second_payload = parse_error_envelope_from_http_response(second_response.as_str());
+    assert_eq!(second_payload.error, "too-many-requests");
+    assert_eq!(
+        second_payload.reason_code,
+        "service_api_ingress_rate_limit_exceeded"
+    );
+    assert!(second_payload
+        .message
+        .contains("ingress rate limit exceeded"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn integration_service_api_endpoint_rejects_when_concurrency_limit_is_exceeded() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34063".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let worker_count = 6_usize;
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: worker_count as u64,
+        idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: 1,
+        rate_limit_per_second: 1_000,
+    };
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let sender_did = "kamn:did:agent:test-client-concurrency-limit";
+    let message_body = "{\"message\":\"concurrency-limit-check\"}";
+    let state_hash = format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    );
+
+    let barrier = Arc::new(Barrier::new(worker_count));
+    let mut clients = Vec::with_capacity(worker_count);
+    for request_index in 0..worker_count {
+        let client_bind_addr = bind_addr.clone();
+        let barrier = barrier.clone();
+        let state_hash = state_hash.clone();
+        clients.push(thread::spawn(move || {
+            let nonce = 200 + request_index as u64;
+            let signature =
+                baseline_signature_for_fields(sender_did, nonce, state_hash.as_str(), message_body);
+            let nonce_text = nonce.to_string();
+            barrier.wait();
+            send_http_request_with_headers(
+                client_bind_addr.as_str(),
+                "POST",
+                "/v1/messages/send",
+                message_body,
+                &[
+                    ("X-KAMN-Sender-DID", sender_did),
+                    ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+                    ("X-KAMN-Request-Signature", signature.as_str()),
+                ],
+            )
+        }));
+    }
+
+    let responses = clients
+        .into_iter()
+        .map(|client| client.join().expect("client request should complete"))
+        .collect::<Vec<String>>();
+
+    assert!(
+        responses
+            .iter()
+            .any(|response| response.contains("HTTP/1.1 202 Accepted")),
+        "expected at least one accepted request under constrained concurrency"
+    );
+    let concurrency_rejection = responses
+        .iter()
+        .find(|response| response.contains("HTTP/1.1 429 Too Many Requests"))
+        .expect("expected at least one request to fail closed on concurrency limit");
+    let rejection_payload = parse_error_envelope_from_http_response(concurrency_rejection);
+    assert_eq!(rejection_payload.error, "too-many-requests");
+    assert_eq!(
+        rejection_payload.reason_code,
+        "service_api_ingress_concurrency_limit_exceeded"
+    );
+    assert!(rejection_payload
+        .message
+        .contains("ingress concurrency limit exceeded"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn regression_service_api_endpoint_oversized_payload_maps_body_limit_reason_code() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34064".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: 1,
+        idle_timeout_ms: 2_000,
+        body_limit_bytes: 256,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: 1_000,
+    };
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let oversized_body = format!("{{\"message\":\"{}\"}}", "x".repeat(700));
+    let sender_did = "kamn:did:agent:test-client-oversized";
+    let nonce = 303_u64;
+    let state_hash = format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    );
+    let signature = baseline_signature_for_fields(
+        sender_did,
+        nonce,
+        state_hash.as_str(),
+        oversized_body.as_str(),
+    );
+    let response = send_http_request_with_headers(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        oversized_body.as_str(),
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", "303"),
+            ("X-KAMN-Request-Signature", signature.as_str()),
+        ],
+    );
+    assert!(response.contains("HTTP/1.1 400 Bad Request"));
+    let payload = parse_error_envelope_from_http_response(response.as_str());
+    assert_eq!(payload.error, "bad-request");
+    assert_eq!(
+        payload.reason_code,
+        "service_api_ingress_body_size_limit_exceeded"
+    );
+    assert!(payload.message.contains("request body size limit exceeded"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
 fn regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
@@ -818,6 +1085,9 @@ fn regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender() {
         bind_addr: bind_addr.clone(),
         max_requests: 2,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let server_snapshot = snapshot.clone();
     let server =
@@ -893,6 +1163,9 @@ fn integration_service_api_endpoint_websocket_upgrade_streams_state_transition_e
         bind_addr: bind_addr.clone(),
         max_requests: 1,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let server_snapshot = snapshot.clone();
     let server =
@@ -952,6 +1225,9 @@ fn regression_service_api_endpoint_websocket_route_rejects_missing_upgrade_heade
         bind_addr: bind_addr.clone(),
         max_requests: 1,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let server_snapshot = snapshot.clone();
     let server =
@@ -1012,6 +1288,9 @@ fn regression_service_api_endpoint_websocket_rejects_invalid_version_header() {
         bind_addr: bind_addr.clone(),
         max_requests: 1,
         idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     };
     let server_snapshot = snapshot.clone();
     let server =

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -25,10 +25,13 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 use tokio::runtime::Builder;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{Mutex, Notify, Semaphore};
 
 pub(crate) const DEFAULT_SERVICE_API_MAX_REQUESTS: u64 = 1;
 pub(crate) const DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS: u64 = 5_000;
+pub(crate) const DEFAULT_SERVICE_API_BODY_LIMIT_BYTES: u64 = 64 * 1024;
+pub(crate) const DEFAULT_SERVICE_API_CONCURRENCY_LIMIT: u64 = 32;
+pub(crate) const DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND: u64 = 120;
 
 const ROUTE_MESSAGES_SEND: &str = "/v1/messages/send";
 const ROUTE_CHANNELS_CREATE: &str = "/v1/channels/create";
@@ -48,6 +51,11 @@ const REASON_CODE_WEBSOCKET_UPGRADE_REQUIRED: &str = "service_api_websocket_upgr
 const REASON_CODE_METHOD_NOT_ALLOWED: &str = "service_api_method_not_allowed";
 const REASON_CODE_ROUTE_NOT_FOUND: &str = "service_api_route_not_found";
 const REASON_CODE_REQUEST_READ_FAILED: &str = "service_api_request_read_failed";
+const REASON_CODE_INGRESS_BODY_SIZE_LIMIT_EXCEEDED: &str =
+    "service_api_ingress_body_size_limit_exceeded";
+const REASON_CODE_INGRESS_CONCURRENCY_LIMIT_EXCEEDED: &str =
+    "service_api_ingress_concurrency_limit_exceeded";
+const REASON_CODE_INGRESS_RATE_LIMIT_EXCEEDED: &str = "service_api_ingress_rate_limit_exceeded";
 const REASON_CODE_REQUEST_HEADER_UTF8_INVALID: &str = "service_api_request_header_utf8_invalid";
 const REASON_CODE_REQUEST_BODY_UTF8_INVALID: &str = "service_api_request_body_utf8_invalid";
 const REASON_CODE_REQUEST_LOG_EMISSION_FAILED: &str = "service_api_request_log_emission_failed";
@@ -75,6 +83,9 @@ pub(crate) struct ServiceApiEndpointConfig {
     pub(crate) bind_addr: String,
     pub(crate) max_requests: u64,
     pub(crate) idle_timeout_ms: u64,
+    pub(crate) body_limit_bytes: u64,
+    pub(crate) concurrency_limit: u64,
+    pub(crate) rate_limit_per_second: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -229,11 +240,43 @@ impl ServiceApiRequestBudget {
     }
 }
 
+impl ServiceApiIngressRateWindow {
+    fn new(max_requests_per_second: u64) -> Self {
+        Self {
+            window_start: Instant::now(),
+            accepted_requests: 0,
+            max_requests_per_second,
+        }
+    }
+
+    fn try_record_request(&mut self, now: Instant) -> bool {
+        if now.duration_since(self.window_start) >= Duration::from_secs(1) {
+            self.window_start = now;
+            self.accepted_requests = 0;
+        }
+        if self.accepted_requests >= self.max_requests_per_second {
+            return false;
+        }
+        self.accepted_requests += 1;
+        true
+    }
+}
+
 #[derive(Debug)]
 struct ServiceApiRuntimeState {
     snapshot: ServiceApiSnapshot,
     replay_guard: Arc<Mutex<BTreeSet<(String, u64)>>>,
     request_budget: Arc<ServiceApiRequestBudget>,
+    body_limit_bytes: usize,
+    concurrency_limiter: Arc<Semaphore>,
+    ingress_rate_window: Arc<Mutex<ServiceApiIngressRateWindow>>,
+}
+
+#[derive(Debug)]
+struct ServiceApiIngressRateWindow {
+    window_start: Instant,
+    accepted_requests: u64,
+    max_requests_per_second: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -441,6 +484,21 @@ pub(crate) fn serve_service_api_endpoint(
     if config.idle_timeout_ms == 0 {
         return Err("service api idle timeout must be greater than zero".to_owned());
     }
+    if config.body_limit_bytes == 0 {
+        return Err("service api body limit bytes must be greater than zero".to_owned());
+    }
+    if config.concurrency_limit == 0 {
+        return Err("service api concurrency limit must be greater than zero".to_owned());
+    }
+    if config.rate_limit_per_second == 0 {
+        return Err("service api rate limit per second must be greater than zero".to_owned());
+    }
+    if config.body_limit_bytes > usize::MAX as u64 {
+        return Err("service api body limit bytes exceed platform usize range".to_owned());
+    }
+    if config.concurrency_limit > usize::MAX as u64 {
+        return Err("service api concurrency limit exceeds platform usize range".to_owned());
+    }
 
     let runtime = Builder::new_current_thread()
         .enable_io()
@@ -465,6 +523,11 @@ async fn serve_service_api_endpoint_async(
         snapshot,
         replay_guard: Arc::new(Mutex::new(BTreeSet::new())),
         request_budget: Arc::new(ServiceApiRequestBudget::new(config.max_requests)),
+        body_limit_bytes: config.body_limit_bytes as usize,
+        concurrency_limiter: Arc::new(Semaphore::new(config.concurrency_limit as usize)),
+        ingress_rate_window: Arc::new(Mutex::new(ServiceApiIngressRateWindow::new(
+            config.rate_limit_per_second,
+        ))),
     });
     let timeout_reached = Arc::new(AtomicBool::new(false));
     let request_budget = runtime_state.request_budget.clone();
@@ -519,30 +582,61 @@ async fn service_api_auth_middleware(
     let method_label = request.method().to_string();
     let path = request.uri().path().to_owned();
     let is_websocket_route = method_label == "GET" && path == ROUTE_EVENTS_WS;
+    let concurrency_permit = match state.concurrency_limiter.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            let correlation_id = format!(
+                "service-api:{}:{}:concurrency-limit",
+                method_label.to_ascii_lowercase(),
+                path
+            );
+            return service_api_middleware_error_response(
+                &state,
+                ServiceApiMiddlewareError {
+                    correlation_id: correlation_id.as_str(),
+                    method: method_label.as_str(),
+                    path: path.as_str(),
+                    status_code: StatusCode::TOO_MANY_REQUESTS,
+                    error_label: "too-many-requests",
+                    reason_code: REASON_CODE_INGRESS_CONCURRENCY_LIMIT_EXCEEDED,
+                    message: "ingress concurrency limit exceeded",
+                    outcome: "concurrency-limit",
+                },
+            );
+        }
+    };
+    // Yield once so queued requests observe bounded in-flight concurrency on the
+    // single-thread runtime and deterministically fail closed when over budget.
+    tokio::task::yield_now().await;
 
-    let (mut request, parsed_request) =
-        match parse_service_api_request(request, is_websocket_route).await {
-            Ok(parsed_request) => parsed_request,
-            Err(error) => {
-                let correlation_id = format!(
-                    "service-api:parse-error:{:016x}",
-                    deterministic_body_tag(error.message.as_bytes())
-                );
-                return service_api_middleware_error_response(
-                    &state,
-                    ServiceApiMiddlewareError {
-                        correlation_id: correlation_id.as_str(),
-                        method: "unknown",
-                        path: "unknown",
-                        status_code: StatusCode::BAD_REQUEST,
-                        error_label: "bad-request",
-                        reason_code: error.reason_code,
-                        message: error.message.as_str(),
-                        outcome: "bad-request",
-                    },
-                );
-            }
-        };
+    let (mut request, parsed_request) = match parse_service_api_request(
+        request,
+        is_websocket_route,
+        state.body_limit_bytes,
+    )
+    .await
+    {
+        Ok(parsed_request) => parsed_request,
+        Err(error) => {
+            let correlation_id = format!(
+                "service-api:parse-error:{:016x}",
+                deterministic_body_tag(error.message.as_bytes())
+            );
+            return service_api_middleware_error_response(
+                &state,
+                ServiceApiMiddlewareError {
+                    correlation_id: correlation_id.as_str(),
+                    method: "unknown",
+                    path: "unknown",
+                    status_code: StatusCode::BAD_REQUEST,
+                    error_label: "bad-request",
+                    reason_code: error.reason_code,
+                    message: error.message.as_str(),
+                    outcome: "bad-request",
+                },
+            );
+        }
+    };
 
     let correlation_id = service_api_request_correlation_id(&parsed_request);
     if let Err(reason) = log_service_api_event_info(
@@ -600,6 +694,25 @@ async fn service_api_auth_middleware(
         }
     }
 
+    if route_requires_auth(parsed_request.method.as_str(), parsed_request.path.as_str()) {
+        let mut ingress_rate_window = state.ingress_rate_window.lock().await;
+        if !ingress_rate_window.try_record_request(Instant::now()) {
+            return service_api_middleware_error_response(
+                &state,
+                ServiceApiMiddlewareError {
+                    correlation_id: correlation_id.as_str(),
+                    method: parsed_request.method.as_str(),
+                    path: parsed_request.path.as_str(),
+                    status_code: StatusCode::TOO_MANY_REQUESTS,
+                    error_label: "too-many-requests",
+                    reason_code: REASON_CODE_INGRESS_RATE_LIMIT_EXCEEDED,
+                    message: "ingress rate limit exceeded",
+                    outcome: "rate-limit",
+                },
+            );
+        }
+    }
+
     if let Err(error) =
         validate_websocket_route_requirements(is_websocket_route, &parsed_request.headers)
     {
@@ -645,12 +758,14 @@ async fn service_api_auth_middleware(
         outcome,
     );
     state.request_budget.record_request();
+    drop(concurrency_permit);
     response
 }
 
 async fn parse_service_api_request(
     request: Request,
     is_websocket_route: bool,
+    body_limit_bytes: usize,
 ) -> Result<(Request, ParsedRequest), ServiceApiReasonedError> {
     let method_label = request.method().to_string();
     let path = request.uri().path().to_owned();
@@ -663,12 +778,20 @@ async fn parse_service_api_request(
     }
 
     let (parts, body) = request.into_parts();
-    let body_limit = 64 * 1024;
+    let body_limit = body_limit_bytes;
     let body = to_bytes(body, body_limit).await.map_err(|error| {
-        ServiceApiReasonedError::new(
-            REASON_CODE_REQUEST_READ_FAILED,
-            format!("request read failed: {error}"),
-        )
+        let message = error.to_string();
+        if message.contains("length limit exceeded") {
+            ServiceApiReasonedError::new(
+                REASON_CODE_INGRESS_BODY_SIZE_LIMIT_EXCEEDED,
+                format!("request body size limit exceeded: {body_limit} bytes"),
+            )
+        } else {
+            ServiceApiReasonedError::new(
+                REASON_CODE_REQUEST_READ_FAILED,
+                format!("request read failed: {error}"),
+            )
+        }
     })?;
     let parsed_request =
         build_parsed_request(method_label.as_str(), path.as_str(), &headers, body.clone())?;

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -169,6 +169,16 @@ fn doc_contains_runtime_kolme_live_rules() {
 }
 
 #[test]
+fn doc_contains_service_api_ingress_limiter_matrix_rules() {
+    assert!(DOC.contains("--api-body-limit-bytes"));
+    assert!(DOC.contains("--api-concurrency-limit"));
+    assert!(DOC.contains("--api-rate-limit-per-second"));
+    assert!(DOC.contains("service_api_ingress_body_size_limit_exceeded"));
+    assert!(DOC.contains("service_api_ingress_concurrency_limit_exceeded"));
+    assert!(DOC.contains("service_api_ingress_rate_limit_exceeded"));
+}
+
+#[test]
 fn doc_contains_decomposition_guardrails() {
     assert!(DOC.contains("## Decomposition Guardrails"));
     assert!(DOC.contains("main.rs` orchestrates only"));

--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -12,12 +12,19 @@ Runtime mode: `api`
 - `--api-bind <host:port>`
 - `--api-max-requests <n>` (default: `1`)
 - `--api-idle-timeout-ms <ms>` (default: `5000`)
+- `--api-body-limit-bytes <bytes>` (default: `65536`)
+- `--api-concurrency-limit <n>` (default: `32`)
+- `--api-rate-limit-per-second <n>` (default: `120`)
 - request payload body read limit: `65536` bytes (64 KiB)
 
 Fail-closed behavior:
 
 - `runtime-mode api` without `--api-bind` is rejected.
-- `--api-max-requests` and `--api-idle-timeout-ms` must be positive integers.
+- all API limiter controls must be positive integers.
+- limiter violations return deterministic structured reason codes:
+  - `service_api_ingress_body_size_limit_exceeded`
+  - `service_api_ingress_concurrency_limit_exceeded`
+  - `service_api_ingress_rate_limit_exceeded`
 
 ## Endpoints
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -381,7 +381,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Cost controls:
   - uses only localhost process-level probes against `runtime-mode api`.
   - no external Kolme node, remote service, or internet dependency.
-  - ingress limit config matrix defaults remain parity-checked against source constants and API docs (`api_max_requests_default=1`, `api_idle_timeout_default_ms=5000`, `body_size_limit_bytes=65536`).
+  - ingress limit config matrix defaults remain parity-checked against source constants and API docs (`api_max_requests_default=1`, `api_idle_timeout_default_ms=5000`, `body_size_limit_bytes=65536`, `api_concurrency_limit_default=32`, `api_rate_limit_per_second_default=120`).
   - runtime budget is bounded via `KAMN_SERVICE_API_AXUM_INGRESS_CONTRACT_MAX_SECONDS`.
   - service api axum ingress run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -413,6 +413,15 @@ This document captures node-runtime productionization slices for machine-readabl
   - auth middleware: `service_api_auth_sender_did_header_missing`, `service_api_auth_signature_verification_failed`, `service_api_auth_replay_nonce_detected`
   - websocket middleware: `service_api_ws_upgrade_header_missing`, `service_api_ws_version_header_invalid`
   - request parse/logging guards: `service_api_request_read_failed`, `service_api_request_header_utf8_invalid`, `service_api_request_log_emission_failed`
+- Service API ingress limiter matrix (runtime-mode `api`):
+  - `--api-body-limit-bytes <bytes>` default `65536`
+  - `--api-concurrency-limit <n>` default `32`
+  - `--api-rate-limit-per-second <n>` default `120`
+  - all limiter controls are fail-closed positive-integer guards and require `--api-bind` when overridden
+  - deterministic limiter rejection reason codes:
+    - `service_api_ingress_body_size_limit_exceeded`
+    - `service_api_ingress_concurrency_limit_exceeded`
+    - `service_api_ingress_rate_limit_exceeded`
 - Payload decode failures map to deterministic reason-code prefixes:
   - `service_api_payload_json_syntax_invalid`
   - `service_api_payload_structure_invalid`

--- a/scripts/runtime/service_api_axum_ingress_live_contract.py
+++ b/scripts/runtime/service_api_axum_ingress_live_contract.py
@@ -28,6 +28,8 @@ EXPECTED_FAIL_CLOSED_REASON_CODE = "service_api_axum_oversized_body_rejected"
 EXPECTED_BODY_SIZE_LIMIT_BYTES = 64 * 1024
 EXPECTED_API_MAX_REQUESTS_DEFAULT = 1
 EXPECTED_API_IDLE_TIMEOUT_DEFAULT_MS = 5_000
+EXPECTED_API_CONCURRENCY_LIMIT_DEFAULT = 32
+EXPECTED_API_RATE_LIMIT_PER_SECOND_DEFAULT = 120
 
 REQUIRED_REPORT_FIELDS = [
     "schema_version",
@@ -42,6 +44,8 @@ REQUIRED_REPORT_FIELDS = [
     "api_max_requests_default",
     "api_idle_timeout_default_ms",
     "body_size_limit_bytes",
+    "api_concurrency_limit_default",
+    "api_rate_limit_per_second_default",
     "fail_closed_status",
     "ci_fast_gate_exclusion_status",
     "performance_budget_status",
@@ -141,6 +145,23 @@ def _check_policy(args: argparse.Namespace) -> int:
     decision.reject_if(
         report.get("api_idle_timeout_default_ms") != EXPECTED_API_IDLE_TIMEOUT_DEFAULT_MS,
         "service_api_axum_policy_api_idle_timeout_default_mismatch",
+    )
+    decision.reject_if(
+        not _is_positive_int(report.get("api_concurrency_limit_default")),
+        "service_api_axum_policy_api_concurrency_limit_default_invalid",
+    )
+    decision.reject_if(
+        report.get("api_concurrency_limit_default") != EXPECTED_API_CONCURRENCY_LIMIT_DEFAULT,
+        "service_api_axum_policy_api_concurrency_limit_default_mismatch",
+    )
+    decision.reject_if(
+        not _is_positive_int(report.get("api_rate_limit_per_second_default")),
+        "service_api_axum_policy_api_rate_limit_per_second_default_invalid",
+    )
+    decision.reject_if(
+        report.get("api_rate_limit_per_second_default")
+        != EXPECTED_API_RATE_LIMIT_PER_SECOND_DEFAULT,
+        "service_api_axum_policy_api_rate_limit_per_second_default_mismatch",
     )
     decision.reject_if(
         not _is_non_negative_int(report.get("elapsed_seconds")),

--- a/scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
+++ b/scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
@@ -26,6 +26,8 @@ cat >"$report_file" <<'JSON'
   "api_max_requests_default": 1,
   "api_idle_timeout_default_ms": 5000,
   "body_size_limit_bytes": 65536,
+  "api_concurrency_limit_default": 32,
+  "api_rate_limit_per_second_default": 120,
   "fail_closed_status": "verified",
   "ci_fast_gate_exclusion_status": "verified",
   "performance_budget_status": "verified",

--- a/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
@@ -65,6 +65,14 @@ if ! printf '%s\n' "$lane_output" | grep -Eq '^body_size_limit_bytes=[1-9][0-9]*
   echo "expected service api axum ingress contract lane body-size limit marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -Eq '^api_concurrency_limit_default=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress contract lane concurrency-limit default marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -Eq '^api_rate_limit_per_second_default=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress contract lane rate-limit default marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=service_api_axum_policy_marker_missing:concurrency_status$'; then
   echo "expected service api axum ingress contract lane fail-closed reason marker" >&2
   exit 1
@@ -96,6 +104,10 @@ if lane_payload.get("api_idle_timeout_default_ms") != 5000:
     raise SystemExit("expected api_idle_timeout_default_ms=5000")
 if lane_payload.get("body_size_limit_bytes") != 65536:
     raise SystemExit("expected body_size_limit_bytes=65536")
+if lane_payload.get("api_concurrency_limit_default") != 32:
+    raise SystemExit("expected api_concurrency_limit_default=32")
+if lane_payload.get("api_rate_limit_per_second_default") != 120:
+    raise SystemExit("expected api_rate_limit_per_second_default=120")
 if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":

--- a/scripts/runtime/validate_service_api_axum_ingress_live.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live.sh
@@ -70,20 +70,24 @@ source_text = source_file.read_text(encoding="utf-8")
 api_doc_text = api_doc_file.read_text(encoding="utf-8")
 
 def parse_u64_const(name: str) -> int:
-    match = re.search(rf"pub\(crate\)\s+const\s+{name}:\s*u64\s*=\s*([0-9_]+);", source_text)
+    match = re.search(rf"pub\(crate\)\s+const\s+{name}:\s*u64\s*=\s*([^;]+);", source_text)
     if match is None:
         raise SystemExit(f"missing source constant: {name}")
-    return int(match.group(1).replace("_", ""))
+    expr = match.group(1).strip()
+    if re.fullmatch(r"[0-9_]+", expr):
+        return int(expr.replace("_", ""))
+    if re.fullmatch(r"[0-9_]+\s*\*\s*[0-9_]+", expr):
+        left_raw, right_raw = re.split(r"\*", expr, maxsplit=1)
+        left = int(left_raw.strip().replace("_", ""))
+        right = int(right_raw.strip().replace("_", ""))
+        return left * right
+    raise SystemExit(f"unsupported const expression for {name}: {expr}")
 
 max_requests_default = parse_u64_const("DEFAULT_SERVICE_API_MAX_REQUESTS")
 idle_timeout_default_ms = parse_u64_const("DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS")
-
-body_limit_match = re.search(r"let\s+body_limit\s*=\s*([0-9_]+)\s*\*\s*([0-9_]+);", source_text)
-if body_limit_match is None:
-    raise SystemExit("missing service api request body limit marker")
-body_size_limit_bytes = int(body_limit_match.group(1).replace("_", "")) * int(
-    body_limit_match.group(2).replace("_", "")
-)
+body_size_limit_bytes = parse_u64_const("DEFAULT_SERVICE_API_BODY_LIMIT_BYTES")
+concurrency_limit_default = parse_u64_const("DEFAULT_SERVICE_API_CONCURRENCY_LIMIT")
+rate_limit_per_second_default = parse_u64_const("DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND")
 
 if max_requests_default <= 0:
     raise SystemExit("service api max-requests default must be positive")
@@ -91,10 +95,16 @@ if idle_timeout_default_ms <= 0:
     raise SystemExit("service api idle-timeout default must be positive")
 if body_size_limit_bytes <= 0:
     raise SystemExit("service api body-size limit must be positive")
+if concurrency_limit_default <= 0:
+    raise SystemExit("service api concurrency-limit default must be positive")
+if rate_limit_per_second_default <= 0:
+    raise SystemExit("service api rate-limit default must be positive")
 
 required_doc_markers = [
     f"--api-max-requests <n>` (default: `{max_requests_default}`)",
     f"--api-idle-timeout-ms <ms>` (default: `{idle_timeout_default_ms}`)",
+    f"--api-concurrency-limit <n>` (default: `{concurrency_limit_default}`)",
+    f"--api-rate-limit-per-second <n>` (default: `{rate_limit_per_second_default}`)",
     f"request payload body read limit: `{body_size_limit_bytes}` bytes",
 ]
 missing_doc_markers = [
@@ -113,6 +123,8 @@ report = {
     "api_max_requests_default": max_requests_default,
     "api_idle_timeout_default_ms": idle_timeout_default_ms,
     "body_size_limit_bytes": body_size_limit_bytes,
+    "api_concurrency_limit_default": concurrency_limit_default,
+    "api_rate_limit_per_second_default": rate_limit_per_second_default,
 }
 report_file.write_text(json.dumps(report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
@@ -386,9 +398,14 @@ if ! grep -q '"error":"bad-request"' "$oversized_response_file"; then
   echo "expected oversized service api response bad-request marker" >&2
   exit 1
 fi
-if ! grep -q 'length limit exceeded' "$oversized_response_file"; then
+if ! grep -q '"reason_code":"service_api_ingress_body_size_limit_exceeded"' "$oversized_response_file"; then
   cat "$oversized_response_file" >&2
-  echo "expected oversized service api response reason marker" >&2
+  echo "expected oversized service api response reason-code marker" >&2
+  exit 1
+fi
+if ! grep -q 'request body size limit exceeded' "$oversized_response_file"; then
+  cat "$oversized_response_file" >&2
+  echo "expected oversized service api response message marker" >&2
   exit 1
 fi
 body_size_guard_status="verified"
@@ -489,6 +506,24 @@ payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 print(payload["body_size_limit_bytes"])
 PY
 )"
+api_concurrency_limit_default="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["api_concurrency_limit_default"])
+PY
+)"
+api_rate_limit_per_second_default="$(python3 - "$config_matrix_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["api_rate_limit_per_second_default"])
+PY
+)"
 
 elapsed_seconds="$(( $(date +%s) - start_epoch ))"
 if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
@@ -511,6 +546,8 @@ cat >"$report_json" <<JSON
   "api_max_requests_default": ${api_max_requests_default},
   "api_idle_timeout_default_ms": ${api_idle_timeout_default_ms},
   "body_size_limit_bytes": ${body_size_limit_bytes},
+  "api_concurrency_limit_default": ${api_concurrency_limit_default},
+  "api_rate_limit_per_second_default": ${api_rate_limit_per_second_default},
   "fail_closed_status": "${fail_closed_status}",
   "ci_fast_gate_exclusion_status": "${ci_fast_gate_exclusion_status}",
   "performance_budget_status": "verified",
@@ -534,6 +571,8 @@ echo "docs_ingress_limit_matrix_status=${docs_ingress_limit_matrix_status}"
 echo "api_max_requests_default=${api_max_requests_default}"
 echo "api_idle_timeout_default_ms=${api_idle_timeout_default_ms}"
 echo "body_size_limit_bytes=${body_size_limit_bytes}"
+echo "api_concurrency_limit_default=${api_concurrency_limit_default}"
+echo "api_rate_limit_per_second_default=${api_rate_limit_per_second_default}"
 echo "fail_closed_status=${fail_closed_status}"
 echo "ci_fast_gate_exclusion_status=${ci_fast_gate_exclusion_status}"
 echo "performance_budget_status=verified"

--- a/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
@@ -120,6 +120,14 @@ if ! printf '%s\n' "$validation_output" | grep -Eq '^body_size_limit_bytes=[1-9]
   echo "expected service api axum ingress body-size limit marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -Eq '^api_concurrency_limit_default=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress concurrency-limit default marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -Eq '^api_rate_limit_per_second_default=[1-9][0-9]*$'; then
+  echo "expected service api axum ingress rate-limit default marker" >&2
+  exit 1
+fi
 
 policy_output="$(
   bash "$POLICY_CHECKER" \
@@ -248,6 +256,10 @@ lane_report = {
     "api_max_requests_default": summary_report.get("api_max_requests_default"),
     "api_idle_timeout_default_ms": summary_report.get("api_idle_timeout_default_ms"),
     "body_size_limit_bytes": summary_report.get("body_size_limit_bytes"),
+    "api_concurrency_limit_default": summary_report.get("api_concurrency_limit_default"),
+    "api_rate_limit_per_second_default": summary_report.get(
+        "api_rate_limit_per_second_default"
+    ),
     "docs_contract_status": "verified",
     "fail_closed_status": "verified",
     "fail_closed_reason_code": "service_api_axum_policy_marker_missing:concurrency_status",
@@ -296,6 +308,24 @@ import sys
 
 payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 print(payload.get("body_size_limit_bytes", 0))
+PY
+)"
+echo "api_concurrency_limit_default=$(python3 - "$summary_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("api_concurrency_limit_default", 0))
+PY
+)"
+echo "api_rate_limit_per_second_default=$(python3 - "$summary_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("api_rate_limit_per_second_default", 0))
 PY
 )"
 echo "docs_contract_status=verified"


### PR DESCRIPTION
## Summary
- Wire service API ingress limiter controls into runtime config and endpoint enforcement so body-size, concurrency, and rate limits are deterministic and fail closed.
- Add deterministic rejection reason-code mapping for ingress limit failures and enforce config/docs parity in the live contract lane.
- Extend tests and policy checks so limiter defaults and rejection behavior are covered by unit, functional, integration, and regression paths.

## Linked Issues
- Closes #3366

## Changes
- `crates/kamn-node/src/cli.rs`: add limiter flags/env parsing (`--api-body-limit-bytes`, `--api-concurrency-limit`, `--api-rate-limit-per-second`) and fail-closed bind override validation.
- `crates/kamn-node/src/service_api_endpoint.rs`: add limiter config fields, deterministic rejection codes, body/concurrency/rate limit enforcement, and validation guards.
- `crates/kamn-node/src/main.rs`: wire limiter config fields into service API runtime startup.
- `crates/kamn-node/src/cli_tests.rs`, `crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs`, `crates/kamn-node/tests/node_runtime_cli_docs.rs`: add/extend coverage for limiter parsing and rejection behavior.
- `scripts/runtime/*.sh`, `scripts/runtime/service_api_axum_ingress_live_contract.py`: extend live ingress contract lane and policy checker for limiter defaults and mismatch reasons.
- `docs/api/service-http-api.md`, `docs/foundation/node-runtime-cli.md`, `docs/ci/strategy.md`: document limiter defaults, reason codes, and lane parity requirements.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
tmp_report=$(mktemp) && cat > "$tmp_report" <<'JSON'
{
  "schema_version": "kamn.runtime.service-api-axum-ingress-live-validation.v1",
  "status": "pass",
  "final_decision": "GO",
  "keep_alive_status": "verified",
  "body_size_guard_status": "verified",
  "concurrency_status": "verified",
  "websocket_status": "verified",
  "ingress_limit_config_status": "verified",
  "docs_ingress_limit_matrix_status": "verified",
  "api_max_requests_default": 1,
  "api_idle_timeout_default_ms": 5000,
  "body_size_limit_bytes": 65536,
  "api_concurrency_limit_default": 32,
  "fail_closed_status": "verified",
  "ci_fast_gate_exclusion_status": "verified",
  "performance_budget_status": "verified",
  "fail_closed_reason_code": "service_api_axum_oversized_body_rejected",
  "elapsed_seconds": 3
}
JSON
bash scripts/runtime/check_service_api_axum_ingress_live_policy.sh \
  --report-file "$tmp_report" \
  --expected-final-decision GO \
  --ci-fast-gate PASS \
  --output-json "$tmp_report.out"
```
Output:
```text
missing required report fields: api_rate_limit_per_second_default
```

### 🟢 Green Phase
```bash
cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_service_api_ingress_limiter_matrix_rules -- --exact
cargo test -p kamn-node cli_tests::regression_cli_module_api_limiter_overrides_require_bind_address -- --exact
cargo test -p kamn-node cli_tests::cli_module_parses_api_runtime_endpoint_controls -- --exact
cargo test -p kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_rejects_when_rate_limit_is_exceeded -- --exact
cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_rejects_when_concurrency_limit_is_exceeded -- --exact
cargo test -p kamn-node main_tests::service_api_endpoint_tests::regression_service_api_endpoint_oversized_payload_maps_body_limit_reason_code -- --exact
bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
bash scripts/runtime/validate_service_api_axum_ingress_live.sh --max-seconds 180
bash scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh --max-seconds 180
```
Result:
```text
All listed commands exited 0.
```

### 🔁 Regression
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
bash scripts/ci/test_ci_strategy_contract.sh
```
Result:
```text
All listed commands exited 0.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | `cli_tests::{cli_module_parses_api_runtime_endpoint_controls, regression_cli_module_api_limiter_overrides_require_bind_address}` |                      |
| Functional   | ✅     | `main_tests::service_api_endpoint_tests::functional_service_api_endpoint_rejects_when_rate_limit_is_exceeded` |                      |
| Integration  | ✅     | `main_tests::service_api_endpoint_tests::integration_service_api_endpoint_rejects_when_concurrency_limit_is_exceeded` |                      |
| Regression   | ✅     | `main_tests::service_api_endpoint_tests::regression_service_api_endpoint_oversized_payload_maps_body_limit_reason_code` + ingress live contract lane scripts |                      |
| Performance  | N/A    |                                                                                       | No throughput model changes; contract lane keeps max-seconds budget unchanged. |

## Risks & Rollback
- No API path removals; runtime behavior becomes stricter when limiter overrides are misconfigured.
- Rollback: revert commit `24da338` to restore previous ingress default behavior and lane expectations.

## Documentation Updates
- Updated `docs/api/service-http-api.md`.
- Updated `docs/foundation/node-runtime-cli.md`.
- Updated `docs/ci/strategy.md`.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: contract-lane shell validation for runtime ingress (no new workflow file).
- Expected runtime delta: negligible; existing lane has same timeout budget and no added external dependencies.
- Expected runner-minute delta: negligible for fast-gate, low for contract lanes.
- Rollback plan if CI cost/runtime regresses: revert `24da338` or temporarily disable new lane assertions while retaining code-level limiter checks.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated (or justified why not)
