### PR TITLE
feat(runtime): enforce sender anti-spam ingress policies (#3367)

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
@@ -900,6 +900,96 @@ fn functional_service_api_endpoint_rejects_when_rate_limit_is_exceeded() {
 }
 
 #[test]
+fn functional_service_api_endpoint_applies_sender_anti_spam_throttle_and_suspension() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34065".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: 6,
+        idle_timeout_ms: 3_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: 1_000,
+    };
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let message_body = "{\"message\":\"anti-spam-check\"}";
+    let sender_did = "kamn:did:agent:test-client-anti-spam";
+    let state_hash = format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    );
+
+    let mut responses = Vec::new();
+    for nonce in 610_u64..616_u64 {
+        let signature =
+            baseline_signature_for_fields(sender_did, nonce, state_hash.as_str(), message_body);
+        let nonce_text = nonce.to_string();
+        responses.push(send_http_request_with_headers(
+            bind_addr.as_str(),
+            "POST",
+            "/v1/messages/send",
+            message_body,
+            &[
+                ("X-KAMN-Sender-DID", sender_did),
+                ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+                ("X-KAMN-Request-Signature", signature.as_str()),
+            ],
+        ));
+    }
+
+    assert!(responses[0].contains("HTTP/1.1 202 Accepted"));
+    assert!(responses[1].contains("HTTP/1.1 202 Accepted"));
+    assert!(responses[2].contains("HTTP/1.1 202 Accepted"));
+
+    assert!(responses[3].contains("HTTP/1.1 429 Too Many Requests"));
+    let fourth_payload = parse_error_envelope_from_http_response(responses[3].as_str());
+    assert_eq!(fourth_payload.error, "too-many-requests");
+    assert_eq!(
+        fourth_payload.reason_code,
+        "service_api_ingress_sender_rate_limit_exceeded"
+    );
+
+    assert!(responses[4].contains("HTTP/1.1 429 Too Many Requests"));
+    let fifth_payload = parse_error_envelope_from_http_response(responses[4].as_str());
+    assert_eq!(fifth_payload.error, "too-many-requests");
+    assert_eq!(
+        fifth_payload.reason_code,
+        "service_api_ingress_sender_rate_limit_exceeded"
+    );
+
+    assert!(responses[5].contains("HTTP/1.1 429 Too Many Requests"));
+    let sixth_payload = parse_error_envelope_from_http_response(responses[5].as_str());
+    assert_eq!(sixth_payload.error, "too-many-requests");
+    assert_eq!(
+        sixth_payload.reason_code,
+        "service_api_ingress_sender_suspended"
+    );
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
 fn integration_service_api_endpoint_rejects_when_concurrency_limit_is_exceeded() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
@@ -1135,6 +1225,102 @@ fn regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender() {
     assert!(replay_payload
         .message
         .contains("request nonce replay detected"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn integration_service_api_endpoint_replay_rejection_remains_stable_with_anti_spam_enforcement() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34066".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: 3,
+        idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: 1_000,
+    };
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let message_body = "{\"message\":\"replay-anti-spam-matrix\"}";
+    let sender_did = "kamn:did:agent:test-client-replay-anti-spam";
+    let state_hash = format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    );
+    let signature_nonce_one =
+        baseline_signature_for_fields(sender_did, 701, state_hash.as_str(), message_body);
+    let signature_nonce_two =
+        baseline_signature_for_fields(sender_did, 702, state_hash.as_str(), message_body);
+
+    let first_response = send_http_request_with_headers(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        message_body,
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", "701"),
+            ("X-KAMN-Request-Signature", signature_nonce_one.as_str()),
+        ],
+    );
+    let replay_response = send_http_request_with_headers(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        message_body,
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", "701"),
+            ("X-KAMN-Request-Signature", signature_nonce_one.as_str()),
+        ],
+    );
+    let fresh_nonce_response = send_http_request_with_headers(
+        bind_addr.as_str(),
+        "POST",
+        "/v1/messages/send",
+        message_body,
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", "702"),
+            ("X-KAMN-Request-Signature", signature_nonce_two.as_str()),
+        ],
+    );
+
+    assert!(first_response.contains("HTTP/1.1 202 Accepted"));
+    assert!(replay_response.contains("HTTP/1.1 409 Conflict"));
+    let replay_payload = parse_error_envelope_from_http_response(replay_response.as_str());
+    assert_eq!(replay_payload.error, "replay");
+    assert_eq!(
+        replay_payload.reason_code,
+        "service_api_auth_replay_nonce_detected"
+    );
+
+    assert!(
+        fresh_nonce_response.contains("HTTP/1.1 202 Accepted"),
+        "replay rejection should not force anti-spam limiter rejection for the next valid nonce"
+    );
 
     let server_result = server.join().expect("endpoint thread should complete");
     assert!(

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -14,7 +14,10 @@ use axum::{
     routing::{any, get},
     Extension, Router,
 };
-use kamn_core::{signature_matches_supported_profile_for_fields, AgentDid};
+use kamn_core::{
+    signature_matches_supported_profile_for_fields, AgentDid, AntiSpamConfig, AntiSpamDecision,
+    AntiSpamEngine, AntiSpamRejection,
+};
 #[cfg(test)]
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -23,7 +26,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
 };
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Builder;
 use tokio::sync::{Mutex, Notify, Semaphore};
 
@@ -56,6 +59,15 @@ const REASON_CODE_INGRESS_BODY_SIZE_LIMIT_EXCEEDED: &str =
 const REASON_CODE_INGRESS_CONCURRENCY_LIMIT_EXCEEDED: &str =
     "service_api_ingress_concurrency_limit_exceeded";
 const REASON_CODE_INGRESS_RATE_LIMIT_EXCEEDED: &str = "service_api_ingress_rate_limit_exceeded";
+const REASON_CODE_INGRESS_SENDER_RATE_LIMIT_EXCEEDED: &str =
+    "service_api_ingress_sender_rate_limit_exceeded";
+const REASON_CODE_INGRESS_SENDER_SUSPENDED: &str = "service_api_ingress_sender_suspended";
+const REASON_CODE_INGRESS_SENDER_DUPLICATE_MESSAGE_ID: &str =
+    "service_api_ingress_sender_duplicate_message_id";
+const REASON_CODE_INGRESS_SENDER_INSUFFICIENT_DEPOSIT: &str =
+    "service_api_ingress_sender_insufficient_deposit";
+const REASON_CODE_INGRESS_ANTI_SPAM_ENGINE_INVALID: &str =
+    "service_api_ingress_anti_spam_engine_invalid";
 const REASON_CODE_REQUEST_HEADER_UTF8_INVALID: &str = "service_api_request_header_utf8_invalid";
 const REASON_CODE_REQUEST_BODY_UTF8_INVALID: &str = "service_api_request_body_utf8_invalid";
 const REASON_CODE_REQUEST_LOG_EMISSION_FAILED: &str = "service_api_request_log_emission_failed";
@@ -270,6 +282,7 @@ struct ServiceApiRuntimeState {
     body_limit_bytes: usize,
     concurrency_limiter: Arc<Semaphore>,
     ingress_rate_window: Arc<Mutex<ServiceApiIngressRateWindow>>,
+    sender_anti_spam: Arc<Mutex<AntiSpamEngine>>,
 }
 
 #[derive(Debug)]
@@ -518,6 +531,8 @@ async fn serve_service_api_endpoint_async(
     let listener = tokio::net::TcpListener::bind(config.bind_addr.as_str())
         .await
         .map_err(|error| format!("service api bind failed: {error}"))?;
+    let sender_anti_spam = build_service_api_sender_anti_spam_engine()
+        .map_err(|error| format!("service api anti-spam init failed: {error}"))?;
 
     let runtime_state = Arc::new(ServiceApiRuntimeState {
         snapshot,
@@ -528,6 +543,7 @@ async fn serve_service_api_endpoint_async(
         ingress_rate_window: Arc::new(Mutex::new(ServiceApiIngressRateWindow::new(
             config.rate_limit_per_second,
         ))),
+        sender_anti_spam: Arc::new(Mutex::new(sender_anti_spam)),
     });
     let timeout_reached = Arc::new(AtomicBool::new(false));
     let request_budget = runtime_state.request_budget.clone();
@@ -560,6 +576,14 @@ async fn serve_service_api_endpoint_async(
     }
 
     Ok(())
+}
+
+fn build_service_api_sender_anti_spam_engine() -> Result<AntiSpamEngine, String> {
+    let config = AntiSpamConfig {
+        minimum_sybil_deposit: 0,
+        ..AntiSpamConfig::default()
+    };
+    AntiSpamEngine::new(config).map_err(|error| error.to_string())
 }
 
 fn build_service_api_router(state: Arc<ServiceApiRuntimeState>) -> Router {
@@ -692,6 +716,36 @@ async fn service_api_auth_middleware(
                 },
             );
         }
+    }
+
+    if let Err(error) = enforce_sender_anti_spam(&state, &parsed_request).await {
+        let (status_code, error_label, outcome) =
+            if error.reason_code == REASON_CODE_INGRESS_ANTI_SPAM_ENGINE_INVALID {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal",
+                    "anti-spam-error",
+                )
+            } else {
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "too-many-requests",
+                    "anti-spam",
+                )
+            };
+        return service_api_middleware_error_response(
+            &state,
+            ServiceApiMiddlewareError {
+                correlation_id: correlation_id.as_str(),
+                method: parsed_request.method.as_str(),
+                path: parsed_request.path.as_str(),
+                status_code,
+                error_label,
+                reason_code: error.reason_code,
+                message: error.message.as_str(),
+                outcome,
+            },
+        );
     }
 
     if route_requires_auth(parsed_request.method.as_str(), parsed_request.path.as_str()) {
@@ -1061,6 +1115,94 @@ fn authorize_service_api_request(
     Ok(())
 }
 
+async fn enforce_sender_anti_spam(
+    state: &ServiceApiRuntimeState,
+    request: &ParsedRequest,
+) -> Result<(), ServiceApiReasonedError> {
+    if !route_requires_auth(request.method.as_str(), request.path.as_str()) {
+        return Ok(());
+    }
+
+    let sender_did =
+        header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER).ok_or_else(|| {
+            ServiceApiReasonedError::new(
+                REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING,
+                format!("missing required header: {REQUEST_AUTH_SENDER_DID_HEADER}"),
+            )
+        })?;
+    let nonce_raw = header_value(&request.headers, REQUEST_AUTH_NONCE_HEADER).ok_or_else(|| {
+        ServiceApiReasonedError::new(
+            REASON_CODE_AUTH_NONCE_HEADER_MISSING,
+            format!("missing required header: {REQUEST_AUTH_NONCE_HEADER}"),
+        )
+    })?;
+    let nonce = nonce_raw.parse::<u64>().map_err(|_| {
+        ServiceApiReasonedError::new(
+            REASON_CODE_AUTH_NONCE_INVALID,
+            format!("invalid request nonce header: {REQUEST_AUTH_NONCE_HEADER}"),
+        )
+    })?;
+    let now_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            ServiceApiReasonedError::new(
+                REASON_CODE_INGRESS_ANTI_SPAM_ENGINE_INVALID,
+                format!("anti-spam clock evaluation failed: {error}"),
+            )
+        })?
+        .as_secs();
+    let message_id = format!("{sender_did}:{nonce}:{}", request.path);
+    let decision = {
+        let mut anti_spam = state.sender_anti_spam.lock().await;
+        anti_spam
+            .evaluate(sender_did, message_id.as_str(), now_unix)
+            .map_err(|error| {
+                ServiceApiReasonedError::new(
+                    REASON_CODE_INGRESS_ANTI_SPAM_ENGINE_INVALID,
+                    format!("anti-spam decision evaluation failed: {error}"),
+                )
+            })?
+    };
+
+    match decision {
+        AntiSpamDecision::Accepted => Ok(()),
+        AntiSpamDecision::Rejected(rejection) => {
+            Err(map_anti_spam_rejection_to_reasoned_error(rejection))
+        }
+    }
+}
+
+fn map_anti_spam_rejection_to_reasoned_error(
+    rejection: AntiSpamRejection,
+) -> ServiceApiReasonedError {
+    match rejection {
+        AntiSpamRejection::InsufficientDeposit { required, provided } => ServiceApiReasonedError::new(
+            REASON_CODE_INGRESS_SENDER_INSUFFICIENT_DEPOSIT,
+            format!(
+                "sender deposit below anti-spam minimum: required={required}, provided={provided}"
+            ),
+        ),
+        AntiSpamRejection::RateLimitExceeded {
+            limit,
+            observed,
+            window_seconds,
+        } => ServiceApiReasonedError::new(
+            REASON_CODE_INGRESS_SENDER_RATE_LIMIT_EXCEEDED,
+            format!(
+                "sender anti-spam rate limit exceeded: observed={observed}, limit={limit}, window_seconds={window_seconds}"
+            ),
+        ),
+        AntiSpamRejection::SenderSuspended { until_unix } => ServiceApiReasonedError::new(
+            REASON_CODE_INGRESS_SENDER_SUSPENDED,
+            format!("sender suspended by anti-spam policy until unix={until_unix}"),
+        ),
+        AntiSpamRejection::DuplicateMessageId(message_id) => ServiceApiReasonedError::new(
+            REASON_CODE_INGRESS_SENDER_DUPLICATE_MESSAGE_ID,
+            format!("sender anti-spam duplicate message id rejected: {message_id}"),
+        ),
+    }
+}
+
 fn route_exists_for_other_method(path: &str) -> bool {
     path == ROUTE_MESSAGES_SEND
         || path == ROUTE_CHANNELS_CREATE
@@ -1294,6 +1436,67 @@ pub(crate) fn service_api_payload_decode_reason_code(error: &serde_json::Error) 
         Category::Io => "service_api_payload_io_error",
         Category::Syntax | Category::Eof => "service_api_payload_json_syntax_invalid",
         Category::Data => "service_api_payload_structure_invalid",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        map_anti_spam_rejection_to_reasoned_error, AntiSpamRejection,
+        REASON_CODE_INGRESS_SENDER_DUPLICATE_MESSAGE_ID,
+        REASON_CODE_INGRESS_SENDER_INSUFFICIENT_DEPOSIT,
+        REASON_CODE_INGRESS_SENDER_RATE_LIMIT_EXCEEDED, REASON_CODE_INGRESS_SENDER_SUSPENDED,
+    };
+
+    #[test]
+    fn anti_spam_rate_limit_rejection_maps_to_sender_rate_limit_reason_code() {
+        let error =
+            map_anti_spam_rejection_to_reasoned_error(AntiSpamRejection::RateLimitExceeded {
+                limit: 3,
+                observed: 3,
+                window_seconds: 5,
+            });
+        assert_eq!(
+            error.reason_code,
+            REASON_CODE_INGRESS_SENDER_RATE_LIMIT_EXCEEDED
+        );
+        assert!(error.message.contains("observed=3"));
+    }
+
+    #[test]
+    fn anti_spam_sender_suspension_maps_to_sender_suspended_reason_code() {
+        let error = map_anti_spam_rejection_to_reasoned_error(AntiSpamRejection::SenderSuspended {
+            until_unix: 123_456,
+        });
+        assert_eq!(error.reason_code, REASON_CODE_INGRESS_SENDER_SUSPENDED);
+        assert!(error.message.contains("123456"));
+    }
+
+    #[test]
+    fn anti_spam_insufficient_deposit_maps_to_sender_deposit_reason_code() {
+        let error =
+            map_anti_spam_rejection_to_reasoned_error(AntiSpamRejection::InsufficientDeposit {
+                required: 9,
+                provided: 4,
+            });
+        assert_eq!(
+            error.reason_code,
+            REASON_CODE_INGRESS_SENDER_INSUFFICIENT_DEPOSIT
+        );
+        assert!(error.message.contains("required=9"));
+        assert!(error.message.contains("provided=4"));
+    }
+
+    #[test]
+    fn anti_spam_duplicate_message_maps_to_sender_duplicate_reason_code() {
+        let error = map_anti_spam_rejection_to_reasoned_error(
+            AntiSpamRejection::DuplicateMessageId("message-1".to_owned()),
+        );
+        assert_eq!(
+            error.reason_code,
+            REASON_CODE_INGRESS_SENDER_DUPLICATE_MESSAGE_ID
+        );
+        assert!(error.message.contains("message-1"));
     }
 }
 

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -173,9 +173,14 @@ fn doc_contains_service_api_ingress_limiter_matrix_rules() {
     assert!(DOC.contains("--api-body-limit-bytes"));
     assert!(DOC.contains("--api-concurrency-limit"));
     assert!(DOC.contains("--api-rate-limit-per-second"));
+    assert!(DOC.contains("sender window limit: `3` messages over `5` seconds"));
+    assert!(DOC.contains("suspension trigger: `2` consecutive sender rate-limit violations"));
+    assert!(DOC.contains("suspension duration: `60` seconds"));
     assert!(DOC.contains("service_api_ingress_body_size_limit_exceeded"));
     assert!(DOC.contains("service_api_ingress_concurrency_limit_exceeded"));
     assert!(DOC.contains("service_api_ingress_rate_limit_exceeded"));
+    assert!(DOC.contains("service_api_ingress_sender_rate_limit_exceeded"));
+    assert!(DOC.contains("service_api_ingress_sender_suspended"));
 }
 
 #[test]

--- a/docs/api/service-http-api.md
+++ b/docs/api/service-http-api.md
@@ -25,6 +25,12 @@ Fail-closed behavior:
   - `service_api_ingress_body_size_limit_exceeded`
   - `service_api_ingress_concurrency_limit_exceeded`
   - `service_api_ingress_rate_limit_exceeded`
+  - `service_api_ingress_sender_rate_limit_exceeded`
+  - `service_api_ingress_sender_suspended`
+- authenticated sender traffic is additionally enforced through `kamn-core` anti-spam decisions:
+  - sender window: `3` messages / `5` seconds (default anti-spam profile)
+  - suspension threshold: `2` consecutive sender rate-limit violations
+  - suspension duration: `60` seconds
 
 ## Endpoints
 
@@ -69,6 +75,8 @@ Auth policy:
 - `GET /healthz` and `GET /metrics` are intentionally unauthenticated for probes/scrapes.
 - Other routes fail closed with `401 Unauthorized` when required headers are missing or signature verification fails.
 - Nonce replay per sender fails closed with `409 Conflict`.
+- After auth + replay validation, sender-scoped anti-spam decisions are enforced before request dispatch.
+- Sender anti-spam throttling and suspension failures return `429 Too Many Requests` with deterministic reason codes.
 
 Signature profile:
 

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -418,10 +418,16 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--api-concurrency-limit <n>` default `32`
   - `--api-rate-limit-per-second <n>` default `120`
   - all limiter controls are fail-closed positive-integer guards and require `--api-bind` when overridden
+  - authenticated sender traffic is additionally subject to anti-spam decision enforcement:
+    - sender window limit: `3` messages over `5` seconds
+    - suspension trigger: `2` consecutive sender rate-limit violations
+    - suspension duration: `60` seconds
   - deterministic limiter rejection reason codes:
     - `service_api_ingress_body_size_limit_exceeded`
     - `service_api_ingress_concurrency_limit_exceeded`
     - `service_api_ingress_rate_limit_exceeded`
+    - `service_api_ingress_sender_rate_limit_exceeded`
+    - `service_api_ingress_sender_suspended`
 - Payload decode failures map to deterministic reason-code prefixes:
   - `service_api_payload_json_syntax_invalid`
   - `service_api_payload_structure_invalid`

--- a/scripts/runtime/validate_service_api_axum_ingress_live.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live.sh
@@ -328,15 +328,18 @@ def run_concurrency_probe() -> None:
     def post_message(index: int) -> None:
         payload = json.dumps({"message": f"concurrency-{index}"}, separators=(",", ":"))
         nonce = 600 + index
+        sender = f"kamn:did:agent:axum-ingress-validator-concurrency-{index}"
         status, body = request(
             "POST",
             "/v1/messages/send",
             payload,
             {
                 "content-type": "application/json",
-                "X-KAMN-Sender-DID": sender_did,
+                "X-KAMN-Sender-DID": sender,
                 "X-KAMN-Request-Nonce": str(nonce),
-                "X-KAMN-Request-Signature": signature(nonce, payload),
+                "X-KAMN-Request-Signature": (
+                    f"sig:ed25519:baseline-v1:{sender}:{nonce}:{state_hash}:{len(payload)}"
+                ),
             },
         )
         if status != 202:


### PR DESCRIPTION
## Summary
- Integrate `kamn-core` anti-spam decisions into service API ingress enforcement so authenticated sender traffic is throttled/suspended deterministically before route dispatch.
- Add deterministic anti-spam rejection reason-code mapping for sender rate-limit and suspension failures.
- Keep existing global ingress limiter behavior intact while adding sender-scoped protection and replay compatibility checks.

## Linked Issues
- Closes #3367

## Changes
- `crates/kamn-node/src/service_api_endpoint.rs`: add sender anti-spam engine state, enforce anti-spam decisions in middleware after auth/replay checks, add deterministic rejection mapping helpers and unit tests.
- `crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs`: add functional test for sender throttle/suspension and integration test proving replay rejection remains stable with anti-spam enabled.
- `scripts/runtime/validate_service_api_axum_ingress_live.sh`: isolate concurrency probe from sender anti-spam throttling by using probe-unique sender IDs/signatures.
- `docs/foundation/node-runtime-cli.md`, `docs/api/service-http-api.md`: document sender anti-spam ingress semantics and deterministic reason codes.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: extend docs contract assertions for sender anti-spam limiter markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
cargo test -p kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_applies_sender_anti_spam_throttle_and_suspension -- --exact
```
Output:
```text
thread '...functional_service_api_endpoint_applies_sender_anti_spam_throttle_and_suspension' panicked:
assertion failed: responses[3].contains("HTTP/1.1 429 Too Many Requests")
```

### 🟢 Green Phase
```bash
cargo test -p kamn-node service_api_endpoint::tests::anti_spam_ -- --nocapture
cargo test -p kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_applies_sender_anti_spam_throttle_and_suspension -- --exact
cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_replay_rejection_remains_stable_with_anti_spam_enforcement -- --exact
cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_service_api_ingress_limiter_matrix_rules -- --exact
bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
bash scripts/runtime/validate_service_api_axum_ingress_live.sh --max-seconds 180
bash scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh --max-seconds 180
```
Result:
```text
All listed commands exited 0.
```

### 🔁 Regression
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
cargo test -p kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_rejects_when_rate_limit_is_exceeded -- --exact
cargo test -p kamn-node main_tests::service_api_endpoint_tests::regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender -- --exact
bash scripts/ci/test_ci_strategy_contract.sh
```
Result:
```text
All listed commands exited 0.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `service_api_endpoint::tests::anti_spam_*` mapping tests | |
| Functional   | ✅     | `functional_service_api_endpoint_applies_sender_anti_spam_throttle_and_suspension` | |
| Integration  | ✅     | `integration_service_api_endpoint_replay_rejection_remains_stable_with_anti_spam_enforcement` | |
| Regression   | ✅     | Existing global rate-limit and replay tests re-run; ingress live contract lane scripts updated and revalidated | |
| Performance  | N/A    | | No throughput model change; sender anti-spam uses existing in-memory deterministic engine path. |

## Risks & Rollback
- Added sender anti-spam rejection path may increase `429` frequency for abusive authenticated senders.
- Rollback: revert commit `7af4483` to restore pre-anti-spam ingress enforcement behavior.

## Documentation Updates
- Updated `docs/foundation/node-runtime-cli.md`.
- Updated `docs/api/service-http-api.md`.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: runtime ingress live validation lane behavior (script-level probe adjustment only).
- Expected runtime delta: negligible.
- Expected runner-minute delta: negligible.
- Rollback plan if CI cost/runtime regresses: revert `7af4483` or temporarily relax probe sender-collision assumptions in the updated lane script.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated (or justified why not)
