### PR TITLE
feat(ci): add release evidence manifest registry contracts (#3368)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2537,6 +2537,23 @@ Fast-mode CI tooling regression coverage includes:
 - Makefile execution contract checker (`test_makefile_execution_contract.sh`)
 - Local fork portability preflight lane/policy/contract checks (`test_run_local_kolme_fork_portability_preflight_lane.sh`, `test_check_local_kolme_fork_portability_preflight_policy.sh`, `test_run_local_kolme_fork_portability_preflight_contract_lane.sh`)
 
+## Release Evidence Manifest Schema
+The runtime go/no-go gate lane enforces a versioned release evidence manifest:
+- manifest file: `scripts/runtime/release_evidence_manifest.json`
+- schema version: `kamn.runtime.release-evidence-manifest.v1`
+- required artifact IDs:
+  - `go_no_go_evidence`
+  - `rollback_readiness`
+  - `dr_readiness`
+- contract lane command:
+  - `bash scripts/runtime/run_go_no_go_gate_lane.sh --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`
+- deterministic fail-closed reason-code surface:
+  - `release_manifest_file_missing`
+  - `release_manifest_json_invalid`
+  - `release_manifest_schema_version_invalid`
+  - `release_manifest_missing_required_artifact:<artifact_id>`
+  - `release_manifest_required_marker_missing:<artifact_id>`
+
 ## Reporting and Burn-down
 - Weekly workflow `ci-flaky-registry` validates the quarantine registry and publishes a report artifact.
 - Weekly workflow `ci-flaky-report-comment` posts an automated report comment to issue `#70`.

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -19,6 +19,36 @@ sys.path.insert(0, str(SCRIPT_DIR.parent))
 from framework.contract_framework import ContractError, fail, require_non_negative_int, write_json  # noqa: E402
 
 GATE_DECISION_FAULT_REASON = "gate_decision_fault_injection_triggered"
+RELEASE_MANIFEST_SCHEMA = "kamn.runtime.release-evidence-manifest.v1"
+DEFAULT_RELEASE_MANIFEST_PATH = ROOT_DIR / "scripts/runtime/release_evidence_manifest.json"
+REQUIRED_ARTIFACT_IDS = (
+    "go_no_go_evidence",
+    "rollback_readiness",
+    "dr_readiness",
+)
+ARTIFACT_LANE_REGISTRY: dict[str, dict[str, object]] = {
+    "go_no_go_evidence": {
+        "expected_lane": "deploy.run_gonogo_evidence_deep_lane",
+        "command": ["bash", str(ROOT_DIR / "scripts/deploy/run_gonogo_evidence_deep_lane.sh")],
+        "success_marker": "go/no-go evidence deep lane tests passed.",
+        "failure_label": "go/no-go evidence lane failed unexpectedly",
+    },
+    "rollback_readiness": {
+        "expected_lane": "deploy.run_deployment_slo_rollback_contract_lane",
+        "command": [
+            "bash",
+            str(ROOT_DIR / "scripts/deploy/run_deployment_slo_rollback_contract_lane.sh"),
+        ],
+        "success_marker": "final_decision=GO",
+        "failure_label": "rollback readiness lane failed unexpectedly",
+    },
+    "dr_readiness": {
+        "expected_lane": "deploy.run_dr_evidence_contract_lane",
+        "command": ["bash", str(ROOT_DIR / "scripts/deploy/run_dr_evidence_contract_lane.sh")],
+        "success_marker": "dr evidence contract lane tests passed.",
+        "failure_label": "dr readiness lane failed unexpectedly",
+    },
+}
 
 
 def _ensure_executable(path: Path, label: str) -> None:
@@ -36,6 +66,91 @@ def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _resolve_manifest_path(raw: str) -> Path:
+    value = raw.strip()
+    if not value:
+        return DEFAULT_RELEASE_MANIFEST_PATH
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return (ROOT_DIR / path).resolve()
+
+
+def _load_release_manifest(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        fail("release_manifest_file_missing")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        fail("release_manifest_json_invalid")
+    if not isinstance(payload, dict):
+        fail("release_manifest_root_invalid")
+    return payload
+
+
+def _require_non_empty_string(payload: dict[str, object], key: str, reason_code: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        fail(reason_code)
+    return value.strip()
+
+
+def _validate_release_manifest(payload: dict[str, object]) -> list[dict[str, str]]:
+    schema_version = payload.get("schema_version")
+    if schema_version != RELEASE_MANIFEST_SCHEMA:
+        fail("release_manifest_schema_version_invalid")
+
+    required_artifacts = payload.get("required_artifacts")
+    if not isinstance(required_artifacts, list):
+        fail("release_manifest_required_artifacts_missing")
+
+    seen_artifact_ids: set[str] = set()
+    validated_artifacts: list[dict[str, str]] = []
+    for entry in required_artifacts:
+        if not isinstance(entry, dict):
+            fail("release_manifest_required_artifact_entry_invalid")
+        artifact_id = _require_non_empty_string(
+            entry,
+            "artifact_id",
+            "release_manifest_required_artifact_id_invalid",
+        )
+        if artifact_id in seen_artifact_ids:
+            fail(f"release_manifest_duplicate_artifact_id:{artifact_id}")
+        if artifact_id not in ARTIFACT_LANE_REGISTRY:
+            fail(f"release_manifest_unknown_artifact_id:{artifact_id}")
+
+        expected_lane = _require_non_empty_string(
+            entry,
+            "expected_lane",
+            f"release_manifest_expected_lane_missing:{artifact_id}",
+        )
+        expected_success_marker = _require_non_empty_string(
+            entry,
+            "expected_success_marker",
+            f"release_manifest_expected_success_marker_missing:{artifact_id}",
+        )
+        registry_entry = ARTIFACT_LANE_REGISTRY[artifact_id]
+        if expected_lane != registry_entry["expected_lane"]:
+            fail(f"release_manifest_lane_mismatch:{artifact_id}")
+        if expected_success_marker != registry_entry["success_marker"]:
+            fail(f"release_manifest_success_marker_mismatch:{artifact_id}")
+
+        seen_artifact_ids.add(artifact_id)
+        validated_artifacts.append(
+            {
+                "artifact_id": artifact_id,
+                "expected_lane": expected_lane,
+                "expected_success_marker": expected_success_marker,
+            }
+        )
+
+    for required_artifact in REQUIRED_ARTIFACT_IDS:
+        if required_artifact not in seen_artifact_ids:
+            fail(f"release_manifest_missing_required_artifact:{required_artifact}")
+
+    return validated_artifacts
+
+
 def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     fault_profile = args.fault_profile.strip()
     if fault_profile not in {"none", "gate_decision"}:
@@ -43,41 +158,46 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
 
     max_seconds = require_non_negative_int("KAMN_GONOGO_GATE_MAX_SECONDS", args.max_seconds)
     start_epoch = int(time.time())
+    manifest_path = _resolve_manifest_path(args.manifest_file)
+    manifest_payload = _load_release_manifest(manifest_path)
+    required_artifacts = _validate_release_manifest(manifest_payload)
 
-    gonogo_deep_lane = ROOT_DIR / "scripts/deploy/run_gonogo_evidence_deep_lane.sh"
-    rollback_lane = ROOT_DIR / "scripts/deploy/run_deployment_slo_rollback_contract_lane.sh"
-    dr_lane = ROOT_DIR / "scripts/deploy/run_dr_evidence_contract_lane.sh"
     gonogo_generator = ROOT_DIR / "scripts/deploy/generate_gonogo_evidence_bundle.sh"
     gonogo_checker = ROOT_DIR / "scripts/deploy/check_gonogo_evidence_policy.sh"
 
-    _ensure_executable(gonogo_deep_lane, "go/no-go evidence deep lane")
-    _ensure_executable(rollback_lane, "deployment slo rollback contract lane")
-    _ensure_executable(dr_lane, "dr evidence contract lane")
     _ensure_executable(gonogo_generator, "go/no-go evidence bundle generator")
     _ensure_executable(gonogo_checker, "go/no-go evidence policy checker")
 
     reason_codes: list[str] = []
+    artifact_inventory: list[dict[str, str]] = []
 
-    gonogo_run = _run_command(["bash", str(gonogo_deep_lane)])
-    if gonogo_run.returncode != 0:
-        detail = (gonogo_run.stderr or gonogo_run.stdout or "go/no-go deep lane failed").strip()
-        fail(f"go/no-go evidence lane failed unexpectedly: {detail}")
-    if "go/no-go evidence deep lane tests passed." not in gonogo_run.stdout:
-        fail("go/no-go evidence lane did not emit success marker")
-
-    rollback_run = _run_command(["bash", str(rollback_lane)])
-    if rollback_run.returncode != 0:
-        detail = (rollback_run.stderr or rollback_run.stdout or "rollback lane failed").strip()
-        fail(f"rollback readiness lane failed unexpectedly: {detail}")
-    if "final_decision=GO" not in rollback_run.stdout:
-        fail("rollback readiness lane did not emit final_decision=GO")
-
-    dr_run = _run_command(["bash", str(dr_lane)])
-    if dr_run.returncode != 0:
-        detail = (dr_run.stderr or dr_run.stdout or "dr lane failed").strip()
-        fail(f"dr readiness lane failed unexpectedly: {detail}")
-    if "dr evidence contract lane tests passed." not in dr_run.stdout:
-        fail("dr readiness lane did not emit success marker")
+    for artifact in required_artifacts:
+        artifact_id = artifact["artifact_id"]
+        registry_entry = ARTIFACT_LANE_REGISTRY[artifact_id]
+        lane_command = registry_entry["command"]
+        if not isinstance(lane_command, list) or len(lane_command) < 2:
+            fail(f"release_manifest_command_invalid:{artifact_id}")
+        lane_path = Path(str(lane_command[1]))
+        _ensure_executable(lane_path, f"{artifact_id} lane command")
+        run_result = _run_command([str(part) for part in lane_command])
+        if run_result.returncode != 0:
+            detail = (
+                run_result.stderr
+                or run_result.stdout
+                or f"{registry_entry['failure_label']}: unknown failure"
+            ).strip()
+            fail(f"release_manifest_artifact_execution_failed:{artifact_id}:{detail}")
+        expected_marker = artifact["expected_success_marker"]
+        if expected_marker not in run_result.stdout:
+            fail(f"release_manifest_required_marker_missing:{artifact_id}")
+        artifact_inventory.append(
+            {
+                "artifact_id": artifact_id,
+                "expected_lane": artifact["expected_lane"],
+                "expected_success_marker": expected_marker,
+                "status": "verified",
+            }
+        )
 
     if fault_profile == "gate_decision":
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -150,6 +270,10 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "go_no_go_evidence_status": "verified",
         "rollback_readiness_status": "verified",
         "dr_readiness_status": "verified",
+        "manifest_schema_version": manifest_payload["schema_version"],
+        "manifest_registry_status": "verified",
+        "required_artifact_ids": [artifact["artifact_id"] for artifact in required_artifacts],
+        "artifact_inventory": artifact_inventory,
         "reason_codes": reason_codes,
         "elapsed_seconds": elapsed_seconds,
         "max_seconds": max_seconds,
@@ -164,6 +288,9 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     print("go_no_go_evidence_status=verified")
     print("rollback_readiness_status=verified")
     print("dr_readiness_status=verified")
+    print(f"manifest_schema_version={manifest_payload['schema_version']}")
+    print("manifest_registry_status=verified")
+    print(f"required_artifact_count={len(required_artifacts)}")
     print(f"reason_codes={reason_codes_csv}")
     if args.output_json:
         print(f"report_file={Path(args.output_json).resolve()}")
@@ -185,6 +312,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--max-seconds",
         default=os.environ.get("KAMN_GONOGO_GATE_MAX_SECONDS", "180"),
+    )
+    parser.add_argument(
+        "--manifest-file",
+        default=os.environ.get(
+            "KAMN_GONOGO_GATE_MANIFEST_FILE",
+            str(DEFAULT_RELEASE_MANIFEST_PATH),
+        ),
     )
     parser.set_defaults(handler=run_go_no_go_gate_lane)
     return parser

--- a/scripts/runtime/release_evidence_manifest.json
+++ b/scripts/runtime/release_evidence_manifest.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "kamn.runtime.release-evidence-manifest.v1",
+  "manifest_id": "runtime_go_no_go_release_evidence_registry",
+  "required_artifacts": [
+    {
+      "artifact_id": "go_no_go_evidence",
+      "expected_lane": "deploy.run_gonogo_evidence_deep_lane",
+      "expected_success_marker": "go/no-go evidence deep lane tests passed."
+    },
+    {
+      "artifact_id": "rollback_readiness",
+      "expected_lane": "deploy.run_deployment_slo_rollback_contract_lane",
+      "expected_success_marker": "final_decision=GO"
+    },
+    {
+      "artifact_id": "dr_readiness",
+      "expected_lane": "deploy.run_dr_evidence_contract_lane",
+      "expected_success_marker": "dr evidence contract lane tests passed."
+    }
+  ]
+}

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -6,9 +6,11 @@ LANE_SCRIPT="$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh"
 LANE_IMPL_SCRIPT="$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane_impl.sh"
 DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
 MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/runtime_go_no_go_gate_lane.json"
+RELEASE_MANIFEST_FILE="$ROOT_DIR/scripts/runtime/release_evidence_manifest.json"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT="$TMP_DIR/go-no-go-gate-report.json"
 TMP_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fault-report.json"
+TMP_MANIFEST_FAIL_REPORT="$TMP_DIR/go-no-go-gate-manifest-fail-report.json"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$LANE_SCRIPT" ]; then
@@ -44,6 +46,10 @@ if ! grep -q 'run_go_no_go_gate_lane_impl.sh' "$MANIFEST_FILE"; then
 fi
 if ! grep -q 'go_no_go_gate_lane_contract.py' "$LANE_IMPL_SCRIPT"; then
   echo "expected go/no-go gate lane implementation to delegate to contract module" >&2
+  exit 1
+fi
+if [ ! -f "$RELEASE_MANIFEST_FILE" ]; then
+  echo "expected release evidence manifest file for go/no-go gate lane" >&2
   exit 1
 fi
 
@@ -93,6 +99,18 @@ if payload.get("rollback_readiness_status") != "verified":
     raise SystemExit("expected rollback_readiness_status=verified")
 if payload.get("dr_readiness_status") != "verified":
     raise SystemExit("expected dr_readiness_status=verified")
+if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-manifest.v1":
+    raise SystemExit("expected manifest_schema_version marker in go/no-go gate report")
+if payload.get("manifest_registry_status") != "verified":
+    raise SystemExit("expected manifest_registry_status=verified")
+inventory = payload.get("artifact_inventory")
+if not isinstance(inventory, list) or len(inventory) != 3:
+    raise SystemExit("expected deterministic artifact inventory list with three required entries")
+for entry in inventory:
+    if not isinstance(entry, dict):
+        raise SystemExit("artifact inventory entry must be an object")
+    if entry.get("status") != "verified":
+        raise SystemExit("expected every artifact inventory entry status=verified")
 if payload.get("reason_codes") != []:
     raise SystemExit("expected empty reason_codes for baseline go/no-go gate run")
 PY
@@ -112,6 +130,41 @@ if [ "$fault_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$fault_output" | grep -q 'gate_decision_fault_injection_triggered'; then
   echo "expected go/no-go gate lane gate_decision fault reason marker" >&2
+  exit 1
+fi
+
+tampered_manifest="$TMP_DIR/release-evidence-manifest.missing-dr.json"
+python3 - "$RELEASE_MANIFEST_FILE" "$tampered_manifest" <<'PY'
+import json
+import pathlib
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+target_path = pathlib.Path(sys.argv[2])
+payload = json.loads(source_path.read_text(encoding="utf-8"))
+payload["required_artifacts"] = [
+    artifact
+    for artifact in payload.get("required_artifacts", [])
+    if artifact.get("artifact_id") != "dr_readiness"
+]
+target_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+manifest_fail_output="$(
+  bash "$LANE_SCRIPT" \
+    --manifest-file "$tampered_manifest" \
+    --max-seconds 120 \
+    --output-json "$TMP_MANIFEST_FAIL_REPORT" 2>&1
+)"
+manifest_fail_code=$?
+set -e
+if [ "$manifest_fail_code" -eq 0 ]; then
+  echo "expected go/no-go gate lane to fail closed on tampered release evidence manifest" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$manifest_fail_output" | grep -q 'release_manifest_missing_required_artifact:dr_readiness'; then
+  echo "expected deterministic missing-artifact reason marker for tampered release evidence manifest" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add a versioned runtime release-evidence manifest contract for the go/no-go gate lane.
- Enforce fail-closed validation of required artifact registry entries before aggregation and emit deterministic artifact inventory in the lane report.
- Extend go/no-go lane tests and CI strategy docs to cover manifest schema and missing-artifact failure behavior.

## Linked Issues
- Closes #3368

## Changes
- `scripts/runtime/release_evidence_manifest.json`: new required release-evidence manifest (`kamn.runtime.release-evidence-manifest.v1`) listing required artifacts and expected success markers.
- `scripts/runtime/go_no_go_gate_lane_contract.py`: add manifest loading/validation (`--manifest-file`), required artifact registry checks, deterministic fail-closed reason-code paths, and artifact inventory report output.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`: add manifest existence/report-field assertions and tampered-manifest fail-closed coverage (`release_manifest_missing_required_artifact:dr_readiness`).
- `docs/ci/strategy.md`: document release evidence manifest schema, required artifact IDs, and deterministic manifest validation reason codes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/runtime/test_run_go_no_go_gate_lane.sh
```
Output:
```text
expected release evidence manifest file for go/no-go gate lane
```

### 🟢 Green Phase
```bash
bash scripts/runtime/test_run_go_no_go_gate_lane.sh
bash scripts/runtime/test_validate_go_no_go_gate_live.sh
bash scripts/runtime/validate_go_no_go_gate_live.sh --max-seconds 180
```
Result:
```text
All listed commands exited 0.
```

### 🔁 Regression
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
bash scripts/ci/test_ci_strategy_contract.sh
```
Result:
```text
All listed commands exited 0.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Manifest field/schema and required-artifact validation paths exercised in `test_run_go_no_go_gate_lane.sh` (including tampered manifest case) | |
| Functional   | ✅     | Baseline go/no-go lane run emits verified manifest registry markers in `test_run_go_no_go_gate_lane.sh` | |
| Integration  | ✅     | `test_validate_go_no_go_gate_live.sh` + `validate_go_no_go_gate_live.sh` verify end-to-end lane behavior with manifest enforcement | |
| Regression   | ✅     | Existing gate decision fault-injection checks preserved and rerun in `test_run_go_no_go_gate_lane.sh` | |
| Performance  | N/A    | | No new heavy lane category; existing bounded `--max-seconds` enforcement retained. |

## Risks & Rollback
- Manifest validation is now fail-closed; malformed/missing required artifact entries will block go/no-go lane success.
- Rollback: revert commit `8e64f10` to restore prior non-manifest gate behavior.

## Documentation Updates
- Updated `docs/ci/strategy.md` with release manifest schema and reason-code contract surface.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: runtime go/no-go lane contract behavior and CI strategy contract docs.
- Expected runtime delta: negligible (single manifest parse/validation step before existing lane commands).
- Expected runner-minute delta: negligible.
- Rollback plan if CI cost/runtime regresses: revert `8e64f10` or temporarily bypass manifest-file override in lane wrapper while preserving baseline gate checks.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated (or justified why not)
