### PR TITLE
feat(ci): add deterministic go-no-go policy taxonomy (#3369)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2541,6 +2541,11 @@ Fast-mode CI tooling regression coverage includes:
 The runtime go/no-go gate lane enforces a versioned release evidence manifest:
 - manifest file: `scripts/runtime/release_evidence_manifest.json`
 - schema version: `kamn.runtime.release-evidence-manifest.v1`
+- reason taxonomy version: `kamn.runtime.go-no-go-gate-reason-taxonomy.v1`
+- deterministic policy outcomes:
+  - `PASS` => `status=pass`, `final_decision=GO`
+  - `WARN` => `status=warn`, `final_decision=GO`
+  - `FAIL` => `status=fail`, `final_decision=NO-GO`
 - required artifact IDs:
   - `go_no_go_evidence`
   - `rollback_readiness`
@@ -2553,6 +2558,8 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `release_manifest_schema_version_invalid`
   - `release_manifest_missing_required_artifact:<artifact_id>`
   - `release_manifest_required_marker_missing:<artifact_id>`
+  - `runtime_budget_exceeded` (warning reason)
+  - `gate_decision_fault_injection_triggered` (fail reason)
 
 ## Reporting and Burn-down
 - Weekly workflow `ci-flaky-registry` validates the quarantine registry and publishes a report artifact.

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -19,6 +19,8 @@ sys.path.insert(0, str(SCRIPT_DIR.parent))
 from framework.contract_framework import ContractError, fail, require_non_negative_int, write_json  # noqa: E402
 
 GATE_DECISION_FAULT_REASON = "gate_decision_fault_injection_triggered"
+RUNTIME_BUDGET_EXCEEDED_REASON = "runtime_budget_exceeded"
+GO_NO_GO_REASON_TAXONOMY_VERSION = "kamn.runtime.go-no-go-gate-reason-taxonomy.v1"
 RELEASE_MANIFEST_SCHEMA = "kamn.runtime.release-evidence-manifest.v1"
 DEFAULT_RELEASE_MANIFEST_PATH = ROOT_DIR / "scripts/runtime/release_evidence_manifest.json"
 REQUIRED_ARTIFACT_IDS = (
@@ -151,10 +153,42 @@ def _validate_release_manifest(payload: dict[str, object]) -> list[dict[str, str
     return validated_artifacts
 
 
+def _evaluate_go_no_go_policy(
+    artifact_inventory: list[dict[str, str]],
+    observed_reason_codes: list[str],
+) -> tuple[str, str, str, list[str]]:
+    fail_reasons: list[str] = []
+    warn_reasons: list[str] = []
+
+    for artifact in artifact_inventory:
+        if artifact.get("status") != "verified":
+            artifact_id = artifact.get("artifact_id", "unknown")
+            fail_reasons.append(f"gate_required_artifact_unverified:{artifact_id}")
+
+    for reason_code in observed_reason_codes:
+        if reason_code == GATE_DECISION_FAULT_REASON:
+            fail_reasons.append(reason_code)
+            continue
+        if reason_code == RUNTIME_BUDGET_EXCEEDED_REASON:
+            warn_reasons.append(reason_code)
+            continue
+        fail_reasons.append(f"gate_policy_unknown_reason_code:{reason_code}")
+
+    fail_reasons = sorted(set(fail_reasons))
+    warn_reasons = sorted(set(warn_reasons))
+
+    if fail_reasons:
+        combined = sorted(set(fail_reasons + warn_reasons))
+        return "FAIL", "NO-GO", "fail", combined
+    if warn_reasons:
+        return "WARN", "GO", "warn", warn_reasons
+    return "PASS", "GO", "pass", []
+
+
 def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     fault_profile = args.fault_profile.strip()
-    if fault_profile not in {"none", "gate_decision"}:
-        fail("--fault-profile must be one of: none, gate_decision")
+    if fault_profile not in {"none", "gate_decision", "runtime_budget_warn"}:
+        fail("--fault-profile must be one of: none, gate_decision, runtime_budget_warn")
 
     max_seconds = require_non_negative_int("KAMN_GONOGO_GATE_MAX_SECONDS", args.max_seconds)
     start_epoch = int(time.time())
@@ -250,52 +284,62 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
             if drift_run.returncode == 0:
                 fail("gate_decision fault profile expected policy checker fail-closed behavior")
             reason_codes.append(GATE_DECISION_FAULT_REASON)
+    elif fault_profile == "runtime_budget_warn":
+        reason_codes.append(RUNTIME_BUDGET_EXCEEDED_REASON)
 
     elapsed_seconds = int(time.time()) - start_epoch
     if elapsed_seconds > max_seconds:
-        reason_codes.append("runtime_budget_exceeded")
+        reason_codes.append(RUNTIME_BUDGET_EXCEEDED_REASON)
 
     reason_codes = sorted(set(reason_codes))
-    status = "pass"
-    final_decision = "GO"
-    if reason_codes:
-        status = "fail"
-        final_decision = "NO-GO"
+    policy_outcome, final_decision, status, evaluator_reason_codes = _evaluate_go_no_go_policy(
+        artifact_inventory,
+        reason_codes,
+    )
 
     report_payload = {
         "schema_version": "kamn.runtime.go-no-go-gate-report.v1",
+        "reason_taxonomy_version": GO_NO_GO_REASON_TAXONOMY_VERSION,
         "status": status,
+        "policy_outcome": policy_outcome,
         "final_decision": final_decision,
         "fault_profile": fault_profile,
         "go_no_go_evidence_status": "verified",
         "rollback_readiness_status": "verified",
         "dr_readiness_status": "verified",
+        "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
         "required_artifact_ids": [artifact["artifact_id"] for artifact in required_artifacts],
         "artifact_inventory": artifact_inventory,
-        "reason_codes": reason_codes,
+        "reason_codes": evaluator_reason_codes,
+        "observed_reason_codes": reason_codes,
         "elapsed_seconds": elapsed_seconds,
         "max_seconds": max_seconds,
     }
     if args.output_json:
         write_json(Path(args.output_json), report_payload)
 
-    reason_codes_csv = "none" if not reason_codes else ",".join(reason_codes)
+    reason_codes_csv = "none" if not evaluator_reason_codes else ",".join(evaluator_reason_codes)
+    observed_reason_codes_csv = "none" if not reason_codes else ",".join(reason_codes)
     print(f"status={status}")
+    print(f"policy_outcome={policy_outcome}")
     print(f"final_decision={final_decision}")
     print(f"fault_profile={fault_profile}")
     print("go_no_go_evidence_status=verified")
     print("rollback_readiness_status=verified")
     print("dr_readiness_status=verified")
+    print("policy_evaluator_status=verified")
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
+    print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")
     print("manifest_registry_status=verified")
     print(f"required_artifact_count={len(required_artifacts)}")
     print(f"reason_codes={reason_codes_csv}")
+    print(f"observed_reason_codes={observed_reason_codes_csv}")
     if args.output_json:
         print(f"report_file={Path(args.output_json).resolve()}")
 
-    if status != "pass":
+    if final_decision != "GO":
         fail(f"go/no-go gate lane failed closed: {reason_codes_csv}")
 
     print("go/no-go gate lane tests passed.")

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -10,6 +10,7 @@ RELEASE_MANIFEST_FILE="$ROOT_DIR/scripts/runtime/release_evidence_manifest.json"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT="$TMP_DIR/go-no-go-gate-report.json"
 TMP_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fault-report.json"
+TMP_WARN_REPORT="$TMP_DIR/go-no-go-gate-warn-report.json"
 TMP_MANIFEST_FAIL_REPORT="$TMP_DIR/go-no-go-gate-manifest-fail-report.json"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -62,6 +63,10 @@ if ! printf '%s\n' "$lane_output" | grep -q '^status=pass$'; then
   echo "expected go/no-go gate lane pass status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^policy_outcome=PASS$'; then
+  echo "expected go/no-go gate lane PASS policy-outcome marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
   echo "expected go/no-go gate lane GO decision marker" >&2
   exit 1
@@ -78,6 +83,14 @@ if ! printf '%s\n' "$lane_output" | grep -q '^dr_readiness_status=verified$'; th
   echo "expected go/no-go gate lane dr status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^policy_evaluator_status=verified$'; then
+  echo "expected go/no-go gate lane policy evaluator status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^reason_taxonomy_version=kamn.runtime.go-no-go-gate-reason-taxonomy.v1$'; then
+  echo "expected go/no-go gate lane reason taxonomy marker" >&2
+  exit 1
+fi
 
 python3 - "$TMP_REPORT" <<'PY'
 import json
@@ -89,16 +102,22 @@ if payload.get("schema_version") != "kamn.runtime.go-no-go-gate-report.v1":
     raise SystemExit("unexpected go/no-go gate report schema")
 if payload.get("status") != "pass":
     raise SystemExit("expected go/no-go gate report status=pass")
+if payload.get("policy_outcome") != "PASS":
+    raise SystemExit("expected go/no-go gate report policy_outcome=PASS")
 if payload.get("final_decision") != "GO":
     raise SystemExit("expected go/no-go gate report final_decision=GO")
 if payload.get("fault_profile") != "none":
     raise SystemExit("expected go/no-go gate report fault_profile=none")
+if payload.get("reason_taxonomy_version") != "kamn.runtime.go-no-go-gate-reason-taxonomy.v1":
+    raise SystemExit("expected go/no-go gate report reason taxonomy version marker")
 if payload.get("go_no_go_evidence_status") != "verified":
     raise SystemExit("expected go_no_go_evidence_status=verified")
 if payload.get("rollback_readiness_status") != "verified":
     raise SystemExit("expected rollback_readiness_status=verified")
 if payload.get("dr_readiness_status") != "verified":
     raise SystemExit("expected dr_readiness_status=verified")
+if payload.get("policy_evaluator_status") != "verified":
+    raise SystemExit("expected policy_evaluator_status=verified")
 if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-manifest.v1":
     raise SystemExit("expected manifest_schema_version marker in go/no-go gate report")
 if payload.get("manifest_registry_status") != "verified":
@@ -113,6 +132,8 @@ for entry in inventory:
         raise SystemExit("expected every artifact inventory entry status=verified")
 if payload.get("reason_codes") != []:
     raise SystemExit("expected empty reason_codes for baseline go/no-go gate run")
+if payload.get("observed_reason_codes") != []:
+    raise SystemExit("expected empty observed_reason_codes for baseline go/no-go gate run")
 PY
 
 set +e
@@ -183,6 +204,55 @@ if payload.get("fault_profile") != "gate_decision":
 reason_codes = payload.get("reason_codes", [])
 if "gate_decision_fault_injection_triggered" not in reason_codes:
     raise SystemExit("expected gate decision fault reason code in report")
+if payload.get("policy_outcome") != "FAIL":
+    raise SystemExit("expected gate decision fault report policy_outcome=FAIL")
+if payload.get("policy_evaluator_status") != "verified":
+    raise SystemExit("expected gate decision fault report policy_evaluator_status=verified")
+if payload.get("observed_reason_codes") != ["gate_decision_fault_injection_triggered"]:
+    raise SystemExit("expected observed_reason_codes to include deterministic gate-decision marker")
+PY
+
+warn_output="$(
+  bash "$LANE_SCRIPT" \
+    --fault-profile runtime_budget_warn \
+    --max-seconds 120 \
+    --output-json "$TMP_WARN_REPORT"
+)"
+if ! printf '%s\n' "$warn_output" | grep -q '^status=warn$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to emit status=warn" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$warn_output" | grep -q '^policy_outcome=WARN$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to emit policy_outcome=WARN" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$warn_output" | grep -q '^final_decision=GO$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to keep final_decision=GO" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$warn_output" | grep -q '^reason_codes=runtime_budget_exceeded$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to emit warning reason code" >&2
+  exit 1
+fi
+
+python3 - "$TMP_WARN_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("status") != "warn":
+    raise SystemExit("expected runtime_budget_warn report status=warn")
+if payload.get("policy_outcome") != "WARN":
+    raise SystemExit("expected runtime_budget_warn report policy_outcome=WARN")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected runtime_budget_warn report final_decision=GO")
+if payload.get("policy_evaluator_status") != "verified":
+    raise SystemExit("expected runtime_budget_warn report policy_evaluator_status=verified")
+if payload.get("reason_codes") != ["runtime_budget_exceeded"]:
+    raise SystemExit("expected runtime_budget_warn report reason_codes=['runtime_budget_exceeded']")
+if payload.get("observed_reason_codes") != ["runtime_budget_exceeded"]:
+    raise SystemExit("expected runtime_budget_warn report observed_reason_codes=['runtime_budget_exceeded']")
 PY
 
 set +e


### PR DESCRIPTION
## Summary
- Add deterministic go/no-go policy evaluation semantics (`PASS|WARN|FAIL`) to the runtime gate lane over manifest-validated artifact inventory.
- Introduce stable reason-taxonomy metadata and machine-readable evaluator fields (`policy_outcome`, `policy_evaluator_status`, `observed_reason_codes`).
- Extend lane tests and CI strategy docs to contract-test deterministic policy outcomes and warning/fail reason behavior.

## Linked Issues
- Closes #3369

## Changes
- `scripts/runtime/go_no_go_gate_lane_contract.py`:
  - add policy evaluator helper (`_evaluate_go_no_go_policy`) for deterministic `PASS|WARN|FAIL` outcomes.
  - keep `GO|NO-GO` final decisions deterministic (`WARN` still `GO`, `FAIL` => `NO-GO`).
  - add reason taxonomy marker `kamn.runtime.go-no-go-gate-reason-taxonomy.v1`.
  - emit `policy_outcome`, `policy_evaluator_status`, `observed_reason_codes` in report/console output.
  - add `runtime_budget_warn` fault profile to deterministically exercise warning policy path.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`:
  - assert policy evaluator marker/report fields.
  - assert deterministic FAIL path for gate-decision fault profile.
  - add deterministic WARN-path coverage (`runtime_budget_warn`).
- `docs/ci/strategy.md`:
  - document policy outcome semantics and taxonomy version alongside go/no-go manifest contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/runtime/test_run_go_no_go_gate_lane.sh
```
Output:
```text
expected go/no-go gate lane policy evaluator status marker
```

### 🟢 Green Phase
```bash
bash scripts/runtime/test_run_go_no_go_gate_lane.sh
bash scripts/runtime/test_validate_go_no_go_gate_live.sh
bash scripts/runtime/validate_go_no_go_gate_live.sh --max-seconds 180
```
Result:
```text
All listed commands exited 0.
```

### 🔁 Regression
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
bash scripts/ci/test_ci_strategy_contract.sh
```
Result:
```text
All listed commands exited 0.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Policy evaluator output/marker assertions in `test_run_go_no_go_gate_lane.sh` | |
| Functional   | ✅     | Baseline PASS and runtime_budget_warn WARN scenario coverage in `test_run_go_no_go_gate_lane.sh` | |
| Integration  | ✅     | `test_validate_go_no_go_gate_live.sh` + `validate_go_no_go_gate_live.sh` with policy-enabled lane output | |
| Regression   | ✅     | Gate-decision fault FAIL path and invalid budget fail-closed behavior retained in `test_run_go_no_go_gate_lane.sh` | |
| Performance  | N/A    | | Runtime remains bounded by existing max-seconds budget controls; no new deep-lane category added. |

## Risks & Rollback
- Consumers parsing go/no-go report fields must tolerate new policy metadata fields.
- Rollback: revert commit `19459f7` to restore prior binary pass/fail-only report semantics.

## Documentation Updates
- Updated `docs/ci/strategy.md` with policy outcome and reason taxonomy semantics.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: runtime go/no-go contract lane behavior and CI strategy policy documentation.
- Expected runtime delta: negligible.
- Expected runner-minute delta: negligible.
- Rollback plan if CI cost/runtime regresses: revert `19459f7` or temporarily pin lane policy output to previous fields while retaining manifest validation from #3368.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated (or justified why not)
