### PR TITLE
feat(runtime): add deterministic go/no-go dry-run and run mode contracts

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2551,7 +2551,12 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `rollback_readiness`
   - `dr_readiness`
 - contract lane command:
-  - `bash scripts/runtime/run_go_no_go_gate_lane.sh --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`
+  - CI-safe dry-run policy path:
+    - `bash scripts/runtime/run_go_no_go_gate_lane.sh --mode dry-run --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`
+  - Local release-candidate aggregation path (explicit opt-in required):
+    - `KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash scripts/runtime/run_go_no_go_gate_lane.sh --mode run --max-seconds 120 --output-json /tmp/go-no-go-gate-run-report.json`
+  - run-mode commands remain excluded from ci-fast-gate:
+    - summary/report markers must emit `ci_fast_gate_eligible=false`, `ci_fast_gate_scope=local-only`, and `fast_gate_exclusion_reason_code=go_no_go_gate_run_mode_excluded_from_fast_gate`.
 - deterministic fail-closed reason-code surface:
   - `release_manifest_file_missing`
   - `release_manifest_json_invalid`

--- a/docs/validation/go-no-go.md
+++ b/docs/validation/go-no-go.md
@@ -29,10 +29,16 @@ Run core harness:
 bash scripts/runtime/test_run_go_no_go_gate_lane.sh
 ```
 
-Run baseline gate:
+Run baseline dry-run gate (CI-safe schema + policy validation only):
 
 ```bash
-bash scripts/runtime/run_go_no_go_gate_lane.sh --output-json /tmp/go-no-go-gate.json
+bash scripts/runtime/run_go_no_go_gate_lane.sh --mode dry-run --output-json /tmp/go-no-go-gate-dry-run.json
+```
+
+Run local release-candidate aggregation gate (executes artifact lanes, local-only):
+
+```bash
+KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash scripts/runtime/run_go_no_go_gate_lane.sh --mode run --output-json /tmp/go-no-go-gate-run.json
 ```
 
 Run injected decision-fault profile (expected fail-closed):
@@ -47,6 +53,22 @@ Baseline GO markers:
 
 - `status=pass`
 - `final_decision=GO`
+- `lane_mode=dry-run`
+- `run_mode_command_status=dry_run_no_commands_executed`
+- `ci_fast_gate_eligible=true`
+- `ci_fast_gate_scope=ci-fast-gate`
+- `fast_gate_exclusion_status=verified`
+- `fast_gate_exclusion_reason_code=go_no_go_gate_run_mode_excluded_from_fast_gate`
+- `go_no_go_evidence_status=dry_run_pending`
+- `rollback_readiness_status=dry_run_pending`
+- `dr_readiness_status=dry_run_pending`
+
+Run-mode GO markers:
+
+- `lane_mode=run`
+- `run_mode_command_status=executed`
+- `ci_fast_gate_eligible=false`
+- `ci_fast_gate_scope=local-only`
 - `go_no_go_evidence_status=verified`
 - `rollback_readiness_status=verified`
 - `dr_readiness_status=verified`

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -17,12 +17,17 @@ ROOT_DIR = SCRIPT_DIR.parent.parent
 sys.path.insert(0, str(SCRIPT_DIR.parent))
 
 from framework.contract_framework import ContractError, fail, require_non_negative_int, write_json  # noqa: E402
+from framework.contract_framework import require_enum  # noqa: E402
 
 GATE_DECISION_FAULT_REASON = "gate_decision_fault_injection_triggered"
 RUNTIME_BUDGET_EXCEEDED_REASON = "runtime_budget_exceeded"
 GO_NO_GO_REASON_TAXONOMY_VERSION = "kamn.runtime.go-no-go-gate-reason-taxonomy.v1"
 RELEASE_MANIFEST_SCHEMA = "kamn.runtime.release-evidence-manifest.v1"
 DEFAULT_RELEASE_MANIFEST_PATH = ROOT_DIR / "scripts/runtime/release_evidence_manifest.json"
+RUN_MODE_FAST_GATE_EXCLUSION_REASON = "go_no_go_gate_run_mode_excluded_from_fast_gate"
+DRY_RUN_REASON = "dry_run_no_commands_executed"
+RUN_REASON = "release_candidate_artifact_aggregation_executed"
+RUN_MODE_OPT_IN_ENV = "KAMN_GONOGO_GATE_LOCAL_OPT_IN"
 REQUIRED_ARTIFACT_IDS = (
     "go_no_go_evidence",
     "rollback_readiness",
@@ -156,14 +161,16 @@ def _validate_release_manifest(payload: dict[str, object]) -> list[dict[str, str
 def _evaluate_go_no_go_policy(
     artifact_inventory: list[dict[str, str]],
     observed_reason_codes: list[str],
+    lane_mode: str,
 ) -> tuple[str, str, str, list[str]]:
     fail_reasons: list[str] = []
     warn_reasons: list[str] = []
+    expected_artifact_status = "verified" if lane_mode == "run" else "dry_run_pending"
 
     for artifact in artifact_inventory:
-        if artifact.get("status") != "verified":
+        if artifact.get("status") != expected_artifact_status:
             artifact_id = artifact.get("artifact_id", "unknown")
-            fail_reasons.append(f"gate_required_artifact_unverified:{artifact_id}")
+            fail_reasons.append(f"gate_required_artifact_status_mismatch:{artifact_id}")
 
     for reason_code in observed_reason_codes:
         if reason_code == GATE_DECISION_FAULT_REASON:
@@ -186,9 +193,13 @@ def _evaluate_go_no_go_policy(
 
 
 def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
+    lane_mode = require_enum("--mode", args.mode.strip(), ("dry-run", "run"))
+    ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
     fault_profile = args.fault_profile.strip()
     if fault_profile not in {"none", "gate_decision", "runtime_budget_warn"}:
         fail("--fault-profile must be one of: none, gate_decision, runtime_budget_warn")
+    if lane_mode == "run" and args.local_opt_in.strip() != "1":
+        fail(f"run mode requires {RUN_MODE_OPT_IN_ENV}=1")
 
     max_seconds = require_non_negative_int("KAMN_GONOGO_GATE_MAX_SECONDS", args.max_seconds)
     start_epoch = int(time.time())
@@ -204,34 +215,38 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
 
     reason_codes: list[str] = []
     artifact_inventory: list[dict[str, str]] = []
+    run_mode_command_count = 0
 
     for artifact in required_artifacts:
         artifact_id = artifact["artifact_id"]
-        registry_entry = ARTIFACT_LANE_REGISTRY[artifact_id]
-        lane_command = registry_entry["command"]
-        if not isinstance(lane_command, list) or len(lane_command) < 2:
-            fail(f"release_manifest_command_invalid:{artifact_id}")
-        lane_path = Path(str(lane_command[1]))
-        _ensure_executable(lane_path, f"{artifact_id} lane command")
-        run_result = _run_command([str(part) for part in lane_command])
-        if run_result.returncode != 0:
-            detail = (
-                run_result.stderr
-                or run_result.stdout
-                or f"{registry_entry['failure_label']}: unknown failure"
-            ).strip()
-            fail(f"release_manifest_artifact_execution_failed:{artifact_id}:{detail}")
         expected_marker = artifact["expected_success_marker"]
-        if expected_marker not in run_result.stdout:
-            fail(f"release_manifest_required_marker_missing:{artifact_id}")
-        artifact_inventory.append(
-            {
-                "artifact_id": artifact_id,
-                "expected_lane": artifact["expected_lane"],
-                "expected_success_marker": expected_marker,
-                "status": "verified",
-            }
-        )
+        artifact_entry = {
+            "artifact_id": artifact_id,
+            "expected_lane": artifact["expected_lane"],
+            "expected_success_marker": expected_marker,
+        }
+        if lane_mode == "run":
+            registry_entry = ARTIFACT_LANE_REGISTRY[artifact_id]
+            lane_command = registry_entry["command"]
+            if not isinstance(lane_command, list) or len(lane_command) < 2:
+                fail(f"release_manifest_command_invalid:{artifact_id}")
+            lane_path = Path(str(lane_command[1]))
+            _ensure_executable(lane_path, f"{artifact_id} lane command")
+            run_result = _run_command([str(part) for part in lane_command])
+            if run_result.returncode != 0:
+                detail = (
+                    run_result.stderr
+                    or run_result.stdout
+                    or f"{registry_entry['failure_label']}: unknown failure"
+                ).strip()
+                fail(f"release_manifest_artifact_execution_failed:{artifact_id}:{detail}")
+            if expected_marker not in run_result.stdout:
+                fail(f"release_manifest_required_marker_missing:{artifact_id}")
+            artifact_entry["status"] = "verified"
+            run_mode_command_count += 1
+        else:
+            artifact_entry["status"] = "dry_run_pending"
+        artifact_inventory.append(artifact_entry)
 
     if fault_profile == "gate_decision":
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -292,9 +307,14 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         reason_codes.append(RUNTIME_BUDGET_EXCEEDED_REASON)
 
     reason_codes = sorted(set(reason_codes))
+    ci_fast_gate_eligible = lane_mode == "dry-run"
+    ci_fast_gate_scope = "ci-fast-gate" if ci_fast_gate_eligible else "local-only"
+    run_mode_command_status = "executed" if lane_mode == "run" else "dry_run_no_commands_executed"
+    mode_reason_code = RUN_REASON if lane_mode == "run" else DRY_RUN_REASON
     policy_outcome, final_decision, status, evaluator_reason_codes = _evaluate_go_no_go_policy(
         artifact_inventory,
         reason_codes,
+        lane_mode,
     )
 
     report_payload = {
@@ -303,10 +323,19 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "status": status,
         "policy_outcome": policy_outcome,
         "final_decision": final_decision,
+        "lane_mode": lane_mode,
+        "ci_fast_gate": ci_fast_gate,
+        "ci_fast_gate_eligible": ci_fast_gate_eligible,
+        "ci_fast_gate_scope": ci_fast_gate_scope,
+        "fast_gate_exclusion_status": "verified",
+        "fast_gate_exclusion_reason_code": RUN_MODE_FAST_GATE_EXCLUSION_REASON,
+        "run_mode_command_status": run_mode_command_status,
+        "run_mode_command_count": run_mode_command_count,
+        "mode_reason_code": mode_reason_code,
         "fault_profile": fault_profile,
-        "go_no_go_evidence_status": "verified",
-        "rollback_readiness_status": "verified",
-        "dr_readiness_status": "verified",
+        "go_no_go_evidence_status": "verified" if lane_mode == "run" else "dry_run_pending",
+        "rollback_readiness_status": "verified" if lane_mode == "run" else "dry_run_pending",
+        "dr_readiness_status": "verified" if lane_mode == "run" else "dry_run_pending",
         "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
@@ -325,10 +354,24 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     print(f"status={status}")
     print(f"policy_outcome={policy_outcome}")
     print(f"final_decision={final_decision}")
+    print(f"lane_mode={lane_mode}")
+    print(f"ci_fast_gate={ci_fast_gate}")
+    print(f"ci_fast_gate_eligible={'true' if ci_fast_gate_eligible else 'false'}")
+    print(f"ci_fast_gate_scope={ci_fast_gate_scope}")
+    print("fast_gate_exclusion_status=verified")
+    print(f"fast_gate_exclusion_reason_code={RUN_MODE_FAST_GATE_EXCLUSION_REASON}")
+    print(f"run_mode_command_status={run_mode_command_status}")
+    print(f"run_mode_command_count={run_mode_command_count}")
+    print(f"mode_reason_code={mode_reason_code}")
     print(f"fault_profile={fault_profile}")
-    print("go_no_go_evidence_status=verified")
-    print("rollback_readiness_status=verified")
-    print("dr_readiness_status=verified")
+    if lane_mode == "run":
+        print("go_no_go_evidence_status=verified")
+        print("rollback_readiness_status=verified")
+        print("dr_readiness_status=verified")
+    else:
+        print("go_no_go_evidence_status=dry_run_pending")
+        print("rollback_readiness_status=dry_run_pending")
+        print("dr_readiness_status=dry_run_pending")
     print("policy_evaluator_status=verified")
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
     print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")
@@ -349,6 +392,14 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run production go/no-go gate lane.")
     parser.add_argument(
+        "--mode",
+        default=os.environ.get("KAMN_GONOGO_GATE_MODE", "dry-run"),
+    )
+    parser.add_argument(
+        "--ci-fast-gate",
+        default=os.environ.get("KAMN_GONOGO_GATE_CI_FAST_GATE", "PASS"),
+    )
+    parser.add_argument(
         "--fault-profile",
         default=os.environ.get("KAMN_GONOGO_GATE_FAULT_PROFILE", "none"),
     )
@@ -363,6 +414,10 @@ def build_parser() -> argparse.ArgumentParser:
             "KAMN_GONOGO_GATE_MANIFEST_FILE",
             str(DEFAULT_RELEASE_MANIFEST_PATH),
         ),
+    )
+    parser.add_argument(
+        "--local-opt-in",
+        default=os.environ.get(RUN_MODE_OPT_IN_ENV, ""),
     )
     parser.set_defaults(handler=run_go_no_go_gate_lane)
     return parser

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -11,6 +11,7 @@ TMP_DIR="$(mktemp -d)"
 TMP_REPORT="$TMP_DIR/go-no-go-gate-report.json"
 TMP_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fault-report.json"
 TMP_WARN_REPORT="$TMP_DIR/go-no-go-gate-warn-report.json"
+TMP_RUN_REPORT="$TMP_DIR/go-no-go-gate-run-mode-report.json"
 TMP_MANIFEST_FAIL_REPORT="$TMP_DIR/go-no-go-gate-manifest-fail-report.json"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -56,6 +57,7 @@ fi
 
 lane_output="$(
   bash "$LANE_SCRIPT" \
+    --mode dry-run \
     --max-seconds 120 \
     --output-json "$TMP_REPORT"
 )"
@@ -71,16 +73,16 @@ if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
   echo "expected go/no-go gate lane GO decision marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^go_no_go_evidence_status=verified$'; then
-  echo "expected go/no-go gate lane evidence status marker" >&2
+if ! printf '%s\n' "$lane_output" | grep -q '^go_no_go_evidence_status=dry_run_pending$'; then
+  echo "expected go/no-go gate lane dry-run evidence status marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^rollback_readiness_status=verified$'; then
-  echo "expected go/no-go gate lane rollback status marker" >&2
+if ! printf '%s\n' "$lane_output" | grep -q '^rollback_readiness_status=dry_run_pending$'; then
+  echo "expected go/no-go gate lane dry-run rollback status marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^dr_readiness_status=verified$'; then
-  echo "expected go/no-go gate lane dr status marker" >&2
+if ! printf '%s\n' "$lane_output" | grep -q '^dr_readiness_status=dry_run_pending$'; then
+  echo "expected go/no-go gate lane dry-run dr status marker" >&2
   exit 1
 fi
 if ! printf '%s\n' "$lane_output" | grep -q '^policy_evaluator_status=verified$'; then
@@ -89,6 +91,34 @@ if ! printf '%s\n' "$lane_output" | grep -q '^policy_evaluator_status=verified$'
 fi
 if ! printf '%s\n' "$lane_output" | grep -q '^reason_taxonomy_version=kamn.runtime.go-no-go-gate-reason-taxonomy.v1$'; then
   echo "expected go/no-go gate lane reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected go/no-go gate lane dry-run mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^run_mode_command_status=dry_run_no_commands_executed$'; then
+  echo "expected go/no-go gate lane dry-run command status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^run_mode_command_count=0$'; then
+  echo "expected go/no-go gate lane dry-run command count marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^ci_fast_gate_eligible=true$'; then
+  echo "expected go/no-go gate lane dry-run fast-gate eligibility marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^ci_fast_gate_scope=ci-fast-gate$'; then
+  echo "expected go/no-go gate lane dry-run fast-gate scope marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fast_gate_exclusion_status=verified$'; then
+  echo "expected go/no-go gate lane fast-gate exclusion status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fast_gate_exclusion_reason_code=go_no_go_gate_run_mode_excluded_from_fast_gate$'; then
+  echo "expected go/no-go gate lane fast-gate exclusion reason marker" >&2
   exit 1
 fi
 
@@ -110,12 +140,12 @@ if payload.get("fault_profile") != "none":
     raise SystemExit("expected go/no-go gate report fault_profile=none")
 if payload.get("reason_taxonomy_version") != "kamn.runtime.go-no-go-gate-reason-taxonomy.v1":
     raise SystemExit("expected go/no-go gate report reason taxonomy version marker")
-if payload.get("go_no_go_evidence_status") != "verified":
-    raise SystemExit("expected go_no_go_evidence_status=verified")
-if payload.get("rollback_readiness_status") != "verified":
-    raise SystemExit("expected rollback_readiness_status=verified")
-if payload.get("dr_readiness_status") != "verified":
-    raise SystemExit("expected dr_readiness_status=verified")
+if payload.get("go_no_go_evidence_status") != "dry_run_pending":
+    raise SystemExit("expected go_no_go_evidence_status=dry_run_pending")
+if payload.get("rollback_readiness_status") != "dry_run_pending":
+    raise SystemExit("expected rollback_readiness_status=dry_run_pending")
+if payload.get("dr_readiness_status") != "dry_run_pending":
+    raise SystemExit("expected dr_readiness_status=dry_run_pending")
 if payload.get("policy_evaluator_status") != "verified":
     raise SystemExit("expected policy_evaluator_status=verified")
 if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-manifest.v1":
@@ -128,13 +158,117 @@ if not isinstance(inventory, list) or len(inventory) != 3:
 for entry in inventory:
     if not isinstance(entry, dict):
         raise SystemExit("artifact inventory entry must be an object")
-    if entry.get("status") != "verified":
-        raise SystemExit("expected every artifact inventory entry status=verified")
+    if entry.get("status") != "dry_run_pending":
+        raise SystemExit("expected every baseline artifact inventory entry status=dry_run_pending")
 if payload.get("reason_codes") != []:
     raise SystemExit("expected empty reason_codes for baseline go/no-go gate run")
 if payload.get("observed_reason_codes") != []:
     raise SystemExit("expected empty observed_reason_codes for baseline go/no-go gate run")
+if payload.get("lane_mode") != "dry-run":
+    raise SystemExit("expected lane_mode=dry-run in baseline go/no-go gate run")
+if payload.get("run_mode_command_status") != "dry_run_no_commands_executed":
+    raise SystemExit("expected run_mode_command_status=dry_run_no_commands_executed for baseline go/no-go gate run")
+if payload.get("run_mode_command_count") != 0:
+    raise SystemExit("expected run_mode_command_count=0 for baseline go/no-go gate run")
+if payload.get("ci_fast_gate_eligible") is not True:
+    raise SystemExit("expected ci_fast_gate_eligible=true for baseline go/no-go gate run")
+if payload.get("ci_fast_gate_scope") != "ci-fast-gate":
+    raise SystemExit("expected ci_fast_gate_scope=ci-fast-gate for baseline go/no-go gate run")
+if payload.get("fast_gate_exclusion_status") != "verified":
+    raise SystemExit("expected fast_gate_exclusion_status=verified for baseline go/no-go gate run")
+if payload.get("fast_gate_exclusion_reason_code") != "go_no_go_gate_run_mode_excluded_from_fast_gate":
+    raise SystemExit("expected deterministic fast-gate exclusion reason marker for baseline go/no-go gate run")
 PY
+
+run_mode_output="$(
+  KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash "$LANE_SCRIPT" \
+    --mode run \
+    --max-seconds 120 \
+    --output-json "$TMP_RUN_REPORT"
+)"
+if ! printf '%s\n' "$run_mode_output" | grep -q '^lane_mode=run$'; then
+  echo "expected go/no-go gate lane run-mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^run_mode_command_status=executed$'; then
+  echo "expected go/no-go gate lane run-mode command status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^go_no_go_evidence_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode evidence status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^rollback_readiness_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode rollback status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^dr_readiness_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode dr status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^ci_fast_gate_eligible=false$'; then
+  echo "expected go/no-go gate lane run-mode fast-gate exclusion marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^ci_fast_gate_scope=local-only$'; then
+  echo "expected go/no-go gate lane run-mode local-only scope marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^fast_gate_exclusion_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode fast-gate exclusion status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^reason_codes=none$'; then
+  echo "expected go/no-go gate lane run-mode reason codes marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_RUN_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("lane_mode") != "run":
+    raise SystemExit("expected lane_mode=run in run-mode go/no-go gate report")
+if payload.get("run_mode_command_status") != "executed":
+    raise SystemExit("expected run_mode_command_status=executed in run-mode go/no-go gate report")
+if not isinstance(payload.get("run_mode_command_count"), int) or payload.get("run_mode_command_count") <= 0:
+    raise SystemExit("expected positive run_mode_command_count in run-mode go/no-go gate report")
+if payload.get("ci_fast_gate_eligible") is not False:
+    raise SystemExit("expected ci_fast_gate_eligible=false in run-mode go/no-go gate report")
+if payload.get("ci_fast_gate_scope") != "local-only":
+    raise SystemExit("expected ci_fast_gate_scope=local-only in run-mode go/no-go gate report")
+if payload.get("fast_gate_exclusion_status") != "verified":
+    raise SystemExit("expected fast_gate_exclusion_status=verified in run-mode go/no-go gate report")
+if payload.get("fast_gate_exclusion_reason_code") != "go_no_go_gate_run_mode_excluded_from_fast_gate":
+    raise SystemExit("expected deterministic fast-gate exclusion reason marker in run-mode go/no-go gate report")
+if payload.get("reason_codes") != []:
+    raise SystemExit("expected empty reason_codes list for run-mode go/no-go gate report")
+if payload.get("go_no_go_evidence_status") != "verified":
+    raise SystemExit("expected go_no_go_evidence_status=verified in run-mode go/no-go gate report")
+if payload.get("rollback_readiness_status") != "verified":
+    raise SystemExit("expected rollback_readiness_status=verified in run-mode go/no-go gate report")
+if payload.get("dr_readiness_status") != "verified":
+    raise SystemExit("expected dr_readiness_status=verified in run-mode go/no-go gate report")
+PY
+
+set +e
+missing_opt_in_output="$(
+  bash "$LANE_SCRIPT" \
+    --mode run \
+    --max-seconds 120 2>&1
+)"
+missing_opt_in_code=$?
+set -e
+if [ "$missing_opt_in_code" -eq 0 ]; then
+  echo "expected go/no-go gate lane run mode to require explicit local opt-in" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_opt_in_output" | grep -q 'run mode requires KAMN_GONOGO_GATE_LOCAL_OPT_IN=1'; then
+  echo "expected deterministic run-mode local opt-in marker for go/no-go gate lane" >&2
+  exit 1
+fi
 
 set +e
 fault_output="$(

--- a/scripts/runtime/test_validate_go_no_go_gate_live.sh
+++ b/scripts/runtime/test_validate_go_no_go_gate_live.sh
@@ -20,6 +20,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
   echo "expected go/no-go gate live validation GO decision marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^lane_mode=run$'; then
+  echo "expected go/no-go gate live validation run-mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^run_mode_command_status=executed$'; then
+  echo "expected go/no-go gate live validation run command status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^ci_fast_gate_scope=local-only$'; then
+  echo "expected go/no-go gate live validation local-only scope marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^baseline_contract_status=verified$'; then
   echo "expected go/no-go gate live validation baseline marker" >&2
   exit 1
@@ -45,6 +57,12 @@ if payload.get("status") != "pass":
     raise SystemExit("expected go/no-go gate live validation status=pass")
 if payload.get("final_decision") != "GO":
     raise SystemExit("expected go/no-go gate live validation final_decision=GO")
+if payload.get("lane_mode") != "run":
+    raise SystemExit("expected go/no-go gate live validation lane_mode=run")
+if payload.get("run_mode_command_status") != "executed":
+    raise SystemExit("expected go/no-go gate live validation run_mode_command_status=executed")
+if payload.get("ci_fast_gate_scope") != "local-only":
+    raise SystemExit("expected go/no-go gate live validation ci_fast_gate_scope=local-only")
 if payload.get("baseline_contract_status") != "verified":
     raise SystemExit("expected baseline_contract_status=verified")
 if payload.get("fault_injection_status") != "verified":

--- a/scripts/runtime/validate_go_no_go_gate_live.sh
+++ b/scripts/runtime/validate_go_no_go_gate_live.sh
@@ -34,7 +34,8 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 start_epoch="$(date +%s)"
 baseline_report="$TMP_DIR/go-no-go-gate-baseline.json"
 baseline_output="$(
-  bash "$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh" \
+  KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash "$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh" \
+    --mode run \
     --max-seconds 120 \
     --output-json "$baseline_report"
 )"
@@ -45,6 +46,22 @@ if ! printf '%s\n' "$baseline_output" | grep -q '^status=pass$'; then
 fi
 if ! printf '%s\n' "$baseline_output" | grep -q '^final_decision=GO$'; then
   echo "expected go/no-go gate baseline GO decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^lane_mode=run$'; then
+  echo "expected go/no-go gate baseline run mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^run_mode_command_status=executed$'; then
+  echo "expected go/no-go gate baseline run command status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^ci_fast_gate_eligible=false$'; then
+  echo "expected go/no-go gate baseline fast-gate exclusion marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$baseline_output" | grep -q '^ci_fast_gate_scope=local-only$'; then
+  echo "expected go/no-go gate baseline local-only scope marker" >&2
   exit 1
 fi
 if ! printf '%s\n' "$baseline_output" | grep -q '^go_no_go_evidence_status=verified$'; then
@@ -63,7 +80,8 @@ fi
 fault_report="$TMP_DIR/go-no-go-gate-fault.json"
 set +e
 fault_output="$(
-  bash "$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh" \
+  KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash "$ROOT_DIR/scripts/runtime/run_go_no_go_gate_lane.sh" \
+    --mode run \
     --fault-profile gate_decision \
     --max-seconds 120 \
     --output-json "$fault_report" 2>&1
@@ -91,6 +109,9 @@ cat >"$report_json" <<JSON
   "schema_version": "kamn.runtime.go-no-go-gate-live-validation.v1",
   "status": "pass",
   "final_decision": "GO",
+  "lane_mode": "run",
+  "run_mode_command_status": "executed",
+  "ci_fast_gate_scope": "local-only",
   "baseline_contract_status": "verified",
   "fault_injection_status": "verified",
   "fail_closed_status": "verified",
@@ -104,6 +125,9 @@ fi
 
 echo "status=pass"
 echo "final_decision=GO"
+echo "lane_mode=run"
+echo "run_mode_command_status=executed"
+echo "ci_fast_gate_scope=local-only"
 echo "baseline_contract_status=verified"
 echo "fault_injection_status=verified"
 echo "fail_closed_status=verified"


### PR DESCRIPTION
## Summary
Implemented the remaining `#3304` acceptance criteria for the runtime go/no-go release-candidate lane by adding explicit `dry-run|run` mode semantics, deterministic fast-gate exclusion assertions, and local run-mode opt-in enforcement. This keeps CI-safe dry-run behavior deterministic while preserving a local run-mode path for real artifact aggregation.

## Changes
- `scripts/runtime/go_no_go_gate_lane_contract.py`: add `--mode`, `--ci-fast-gate`, and `--local-opt-in`; enforce `KAMN_GONOGO_GATE_LOCAL_OPT_IN=1` for run mode; emit deterministic lane-mode and fast-gate exclusion markers in stdout + JSON report.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`: add red/green coverage for dry-run vs run mode, run-mode opt-in fail-closed behavior, and mode-specific report contract assertions.
- `scripts/runtime/validate_go_no_go_gate_live.sh`: run live validation in explicit local run mode; emit deterministic run/exclusion markers in validation outputs.
- `scripts/runtime/test_validate_go_no_go_gate_live.sh`: add contract checks for run-mode validation markers.
- `docs/validation/go-no-go.md`: document dry-run command vs local run command and deterministic mode markers.
- `docs/ci/strategy.md`: document CI-safe dry-run invocation, local run-mode invocation, and run-mode ci-fast-gate exclusion contract markers.

## Risks & Compatibility
- Existing no-arg lane invocation now defaults to `--mode dry-run` for CI-safe behavior.
- Run-mode execution requires explicit opt-in (`KAMN_GONOGO_GATE_LOCAL_OPT_IN=1`).

## Validation
- [x] `cargo fmt --check` — clean (no Rust source changes in this PR)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source changes)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: go/no-go lane run/dry-run contracts, live validation lane, dependent milestone bundle path, and CI strategy contract updated + verified.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` |
| Functional  | ✅     | `bash scripts/runtime/validate_go_no_go_gate_live.sh --max-seconds 180` |
| Integration | ✅     | `bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh` |
| Regression  | ✅     | `bash scripts/runtime/test_validate_go_no_go_gate_live.sh`, `bash scripts/ci/test_ci_strategy_contract.sh` |

Closes #3304
