### PR TITLE
feat(runtime): add deterministic waiver contracts for go/no-go lane

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2557,12 +2557,29 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
     - `KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash scripts/runtime/run_go_no_go_gate_lane.sh --mode run --max-seconds 120 --output-json /tmp/go-no-go-gate-run-report.json`
   - run-mode commands remain excluded from ci-fast-gate:
     - summary/report markers must emit `ci_fast_gate_eligible=false`, `ci_fast_gate_scope=local-only`, and `fast_gate_exclusion_reason_code=go_no_go_gate_run_mode_excluded_from_fast_gate`.
+  - optional waiver path for missing required artifact evidence:
+    - `bash scripts/runtime/run_go_no_go_gate_lane.sh --manifest-file /tmp/release-manifest-missing-dr.json --waiver-file /tmp/go-no-go-waiver.json --max-seconds 120 --output-json /tmp/go-no-go-gate-waiver-report.json`
+    - waiver schema version: `kamn.runtime.go-no-go-gate-waiver.v1`
+    - waiver scope: `runtime_go_no_go_gate_required_artifacts`
+    - required waiver fields: `schema_version`, `scope`, `expires_on`, `allowed_reason_codes`
+    - deterministic waiver outcome markers:
+      - `waiver_status=applied`
+      - `waived_reason_codes=release_manifest_missing_required_artifact:<artifact_id>`
+      - `reason_codes=release_manifest_required_artifact_waiver_applied`
+      - `status=warn` with `final_decision=GO`
 - deterministic fail-closed reason-code surface:
   - `release_manifest_file_missing`
   - `release_manifest_json_invalid`
   - `release_manifest_schema_version_invalid`
   - `release_manifest_missing_required_artifact:<artifact_id>`
   - `release_manifest_required_marker_missing:<artifact_id>`
+  - `waiver_file_not_found`
+  - `waiver_file_json_invalid`
+  - `waiver_file_schema_mismatch`
+  - `waiver_scope_mismatch`
+  - `waiver_expiry_invalid`
+  - `waiver_expired`
+  - `waiver_allowed_reason_codes_invalid`
   - `runtime_budget_exceeded` (warning reason)
   - `gate_decision_fault_injection_triggered` (fail reason)
 

--- a/docs/validation/go-no-go.md
+++ b/docs/validation/go-no-go.md
@@ -47,6 +47,12 @@ Run injected decision-fault profile (expected fail-closed):
 bash scripts/runtime/run_go_no_go_gate_lane.sh --fault-profile gate_decision --output-json /tmp/go-no-go-gate-fault.json
 ```
 
+Run waiver path for a missing required manifest artifact (warn/GO with explicit waiver metadata):
+
+```bash
+bash scripts/runtime/run_go_no_go_gate_lane.sh --manifest-file /tmp/release-manifest-missing-dr.json --waiver-file /tmp/go-no-go-waiver.json --output-json /tmp/go-no-go-gate-waiver.json
+```
+
 ## Deterministic Markers
 
 Baseline GO markers:
@@ -76,6 +82,15 @@ Run-mode GO markers:
 Injected fail-closed marker:
 
 - decision fault profile emits `gate_decision_fault_injection_triggered` and returns non-zero.
+- missing required manifest artifact without waiver emits `release_manifest_missing_required_artifact:<artifact_id>` and returns non-zero.
+
+Waiver markers:
+
+- `waiver_status=applied`
+- `waived_reason_codes=release_manifest_missing_required_artifact:<artifact_id>`
+- `reason_codes=release_manifest_required_artifact_waiver_applied`
+- `status=warn`
+- `policy_outcome=WARN`
 
 ## Evidence Schema
 
@@ -87,6 +102,7 @@ Includes:
 - selected fault profile
 - evidence and readiness contract markers
 - reason codes
+- waiver status and waived reason-code lineage
 - runtime budget and elapsed duration
 
 ## Live Validation (Task #2988 / Subtask #2989)

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import os
 from pathlib import Path
@@ -28,6 +29,9 @@ RUN_MODE_FAST_GATE_EXCLUSION_REASON = "go_no_go_gate_run_mode_excluded_from_fast
 DRY_RUN_REASON = "dry_run_no_commands_executed"
 RUN_REASON = "release_candidate_artifact_aggregation_executed"
 RUN_MODE_OPT_IN_ENV = "KAMN_GONOGO_GATE_LOCAL_OPT_IN"
+WAIVER_SCHEMA = "kamn.runtime.go-no-go-gate-waiver.v1"
+WAIVER_SCOPE = "runtime_go_no_go_gate_required_artifacts"
+WAIVER_APPLIED_REASON = "release_manifest_required_artifact_waiver_applied"
 REQUIRED_ARTIFACT_IDS = (
     "go_no_go_evidence",
     "rollback_readiness",
@@ -83,6 +87,16 @@ def _resolve_manifest_path(raw: str) -> Path:
     return (ROOT_DIR / path).resolve()
 
 
+def _resolve_optional_path(raw: str) -> Path | None:
+    value = raw.strip()
+    if not value:
+        return None
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return (ROOT_DIR / path).resolve()
+
+
 def _load_release_manifest(path: Path) -> dict[str, object]:
     if not path.is_file():
         fail("release_manifest_file_missing")
@@ -102,7 +116,71 @@ def _require_non_empty_string(payload: dict[str, object], key: str, reason_code:
     return value.strip()
 
 
-def _validate_release_manifest(payload: dict[str, object]) -> list[dict[str, str]]:
+def _parse_waiver(
+    waiver_file: Path | None,
+    triggered_reason_codes: list[str],
+) -> tuple[str, list[str], list[str], str]:
+    if waiver_file is None:
+        return "none", [], triggered_reason_codes, ""
+    if not waiver_file.is_file():
+        return "none", [], triggered_reason_codes, "waiver_file_not_found"
+
+    try:
+        waiver_payload = json.loads(waiver_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return "none", [], triggered_reason_codes, "waiver_file_json_invalid"
+    if not isinstance(waiver_payload, dict):
+        return "none", [], triggered_reason_codes, "waiver_file_root_invalid"
+
+    if waiver_payload.get("schema_version") != WAIVER_SCHEMA:
+        return "none", [], triggered_reason_codes, "waiver_file_schema_mismatch"
+    if waiver_payload.get("scope") != WAIVER_SCOPE:
+        return "none", [], triggered_reason_codes, "waiver_scope_mismatch"
+
+    expires_on = waiver_payload.get("expires_on")
+    if not isinstance(expires_on, str):
+        return "none", [], triggered_reason_codes, "waiver_expiry_invalid"
+    try:
+        expiry_date = dt.date.fromisoformat(expires_on)
+    except ValueError:
+        return "none", [], triggered_reason_codes, "waiver_expiry_invalid"
+    if expiry_date < dt.date.today():
+        return "none", [], triggered_reason_codes, "waiver_expired"
+
+    allowed_reason_codes = waiver_payload.get("allowed_reason_codes", [])
+    if not isinstance(allowed_reason_codes, list) or not all(
+        isinstance(value, str) and value for value in allowed_reason_codes
+    ):
+        return "none", [], triggered_reason_codes, "waiver_allowed_reason_codes_invalid"
+
+    allowed_set = set(allowed_reason_codes)
+    waived_reason_codes = sorted(
+        reason_code for reason_code in triggered_reason_codes if reason_code in allowed_set
+    )
+    unwaived_reason_codes = sorted(
+        reason_code for reason_code in triggered_reason_codes if reason_code not in allowed_set
+    )
+    if unwaived_reason_codes:
+        return "none", waived_reason_codes, unwaived_reason_codes, ""
+    return "applied", waived_reason_codes, [], ""
+
+
+def _extract_missing_manifest_artifact_id(reason_code: str) -> str | None:
+    prefix = "release_manifest_missing_required_artifact:"
+    if not reason_code.startswith(prefix):
+        return None
+    artifact_id = reason_code[len(prefix) :]
+    if artifact_id not in REQUIRED_ARTIFACT_IDS:
+        return None
+    return artifact_id
+
+
+def _validate_release_manifest(
+    payload: dict[str, object],
+    *,
+    waived_artifact_ids: set[str] | None = None,
+) -> list[dict[str, str]]:
+    waived_artifact_ids = waived_artifact_ids or set()
     schema_version = payload.get("schema_version")
     if schema_version != RELEASE_MANIFEST_SCHEMA:
         fail("release_manifest_schema_version_invalid")
@@ -152,6 +230,8 @@ def _validate_release_manifest(payload: dict[str, object]) -> list[dict[str, str
         )
 
     for required_artifact in REQUIRED_ARTIFACT_IDS:
+        if required_artifact in waived_artifact_ids:
+            continue
         if required_artifact not in seen_artifact_ids:
             fail(f"release_manifest_missing_required_artifact:{required_artifact}")
 
@@ -179,6 +259,9 @@ def _evaluate_go_no_go_policy(
         if reason_code == RUNTIME_BUDGET_EXCEEDED_REASON:
             warn_reasons.append(reason_code)
             continue
+        if reason_code == WAIVER_APPLIED_REASON:
+            warn_reasons.append(reason_code)
+            continue
         fail_reasons.append(f"gate_policy_unknown_reason_code:{reason_code}")
 
     fail_reasons = sorted(set(fail_reasons))
@@ -204,8 +287,36 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     max_seconds = require_non_negative_int("KAMN_GONOGO_GATE_MAX_SECONDS", args.max_seconds)
     start_epoch = int(time.time())
     manifest_path = _resolve_manifest_path(args.manifest_file)
+    waiver_file = _resolve_optional_path(args.waiver_file)
     manifest_payload = _load_release_manifest(manifest_path)
-    required_artifacts = _validate_release_manifest(manifest_payload)
+    waiver_status = "none"
+    waived_reason_codes: list[str] = []
+    waived_artifact_ids: set[str] = set()
+    while True:
+        try:
+            required_artifacts = _validate_release_manifest(
+                manifest_payload,
+                waived_artifact_ids=waived_artifact_ids,
+            )
+            break
+        except ContractError as error:
+            manifest_reason_code = str(error)
+            missing_artifact_id = _extract_missing_manifest_artifact_id(manifest_reason_code)
+            if missing_artifact_id is None or missing_artifact_id in waived_artifact_ids:
+                fail(manifest_reason_code)
+            parsed_waiver = _parse_waiver(waiver_file, [manifest_reason_code])
+            parsed_waiver_status, waiver_hit_reason_codes, unwaived_reason_codes, waiver_error = (
+                parsed_waiver
+            )
+            if waiver_error:
+                fail(waiver_error)
+            if unwaived_reason_codes:
+                fail(unwaived_reason_codes[0])
+            if parsed_waiver_status != "applied":
+                fail(manifest_reason_code)
+            waiver_status = "applied"
+            waived_reason_codes = sorted(set(waived_reason_codes + waiver_hit_reason_codes))
+            waived_artifact_ids.add(missing_artifact_id)
 
     gonogo_generator = ROOT_DIR / "scripts/deploy/generate_gonogo_evidence_bundle.sh"
     gonogo_checker = ROOT_DIR / "scripts/deploy/check_gonogo_evidence_policy.sh"
@@ -214,6 +325,8 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     _ensure_executable(gonogo_checker, "go/no-go evidence policy checker")
 
     reason_codes: list[str] = []
+    if waiver_status == "applied":
+        reason_codes.append(WAIVER_APPLIED_REASON)
     artifact_inventory: list[dict[str, str]] = []
     run_mode_command_count = 0
 
@@ -339,6 +452,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
+        "waiver_status": waiver_status,
+        "waived_reason_codes": waived_reason_codes,
+        "waiver_review_required": waiver_status == "applied",
+        "waiver_schema_version": WAIVER_SCHEMA if waiver_status == "applied" else "",
+        "waiver_scope": WAIVER_SCOPE if waiver_status == "applied" else "",
+        "waiver_file": str(waiver_file) if waiver_file else "",
         "required_artifact_ids": [artifact["artifact_id"] for artifact in required_artifacts],
         "artifact_inventory": artifact_inventory,
         "reason_codes": evaluator_reason_codes,
@@ -376,6 +495,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
     print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")
     print("manifest_registry_status=verified")
+    print(f"waiver_status={waiver_status}")
+    print(
+        "waived_reason_codes="
+        + ("none" if not waived_reason_codes else ",".join(waived_reason_codes))
+    )
+    print(f"waiver_review_required={'true' if waiver_status == 'applied' else 'false'}")
     print(f"required_artifact_count={len(required_artifacts)}")
     print(f"reason_codes={reason_codes_csv}")
     print(f"observed_reason_codes={observed_reason_codes_csv}")
@@ -414,6 +539,10 @@ def build_parser() -> argparse.ArgumentParser:
             "KAMN_GONOGO_GATE_MANIFEST_FILE",
             str(DEFAULT_RELEASE_MANIFEST_PATH),
         ),
+    )
+    parser.add_argument(
+        "--waiver-file",
+        default=os.environ.get("KAMN_GONOGO_GATE_WAIVER_FILE", ""),
     )
     parser.add_argument(
         "--local-opt-in",

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -12,6 +12,7 @@ TMP_REPORT="$TMP_DIR/go-no-go-gate-report.json"
 TMP_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fault-report.json"
 TMP_WARN_REPORT="$TMP_DIR/go-no-go-gate-warn-report.json"
 TMP_RUN_REPORT="$TMP_DIR/go-no-go-gate-run-mode-report.json"
+TMP_WAIVER_REPORT="$TMP_DIR/go-no-go-gate-waiver-report.json"
 TMP_MANIFEST_FAIL_REPORT="$TMP_DIR/go-no-go-gate-manifest-fail-report.json"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -121,6 +122,14 @@ if ! printf '%s\n' "$lane_output" | grep -q '^fast_gate_exclusion_reason_code=go
   echo "expected go/no-go gate lane fast-gate exclusion reason marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^waiver_status=none$'; then
+  echo "expected go/no-go gate lane baseline waiver status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^waived_reason_codes=none$'; then
+  echo "expected go/no-go gate lane baseline waived reason marker" >&2
+  exit 1
+fi
 
 python3 - "$TMP_REPORT" <<'PY'
 import json
@@ -178,6 +187,10 @@ if payload.get("fast_gate_exclusion_status") != "verified":
     raise SystemExit("expected fast_gate_exclusion_status=verified for baseline go/no-go gate run")
 if payload.get("fast_gate_exclusion_reason_code") != "go_no_go_gate_run_mode_excluded_from_fast_gate":
     raise SystemExit("expected deterministic fast-gate exclusion reason marker for baseline go/no-go gate run")
+if payload.get("waiver_status") != "none":
+    raise SystemExit("expected waiver_status=none for baseline go/no-go gate run")
+if payload.get("waived_reason_codes") != []:
+    raise SystemExit("expected empty waived_reason_codes for baseline go/no-go gate run")
 PY
 
 run_mode_output="$(
@@ -320,6 +333,133 @@ if [ "$manifest_fail_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$manifest_fail_output" | grep -q 'release_manifest_missing_required_artifact:dr_readiness'; then
   echo "expected deterministic missing-artifact reason marker for tampered release evidence manifest" >&2
+  exit 1
+fi
+
+valid_waiver="$TMP_DIR/go-no-go-waiver.valid.json"
+cat >"$valid_waiver" <<'JSON'
+{
+  "schema_version": "kamn.runtime.go-no-go-gate-waiver.v1",
+  "scope": "runtime_go_no_go_gate_required_artifacts",
+  "expires_on": "2099-12-31",
+  "allowed_reason_codes": [
+    "release_manifest_missing_required_artifact:dr_readiness"
+  ]
+}
+JSON
+
+waiver_output="$(
+  bash "$LANE_SCRIPT" \
+    --manifest-file "$tampered_manifest" \
+    --waiver-file "$valid_waiver" \
+    --max-seconds 120 \
+    --output-json "$TMP_WAIVER_REPORT"
+)"
+if ! printf '%s\n' "$waiver_output" | grep -q '^status=warn$'; then
+  echo "expected go/no-go gate waiver path status marker to be warn" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$waiver_output" | grep -q '^policy_outcome=WARN$'; then
+  echo "expected go/no-go gate waiver path policy_outcome marker to be WARN" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$waiver_output" | grep -q '^final_decision=GO$'; then
+  echo "expected go/no-go gate waiver path final decision marker to stay GO" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$waiver_output" | grep -q '^waiver_status=applied$'; then
+  echo "expected go/no-go gate waiver path waiver_status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$waiver_output" | grep -q '^reason_codes=release_manifest_required_artifact_waiver_applied$'; then
+  echo "expected go/no-go gate waiver path reason code marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$waiver_output" | grep -q '^waived_reason_codes=release_manifest_missing_required_artifact:dr_readiness$'; then
+  echo "expected go/no-go gate waiver path waived reason marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_WAIVER_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("status") != "warn":
+    raise SystemExit("expected waiver report status=warn")
+if payload.get("policy_outcome") != "WARN":
+    raise SystemExit("expected waiver report policy_outcome=WARN")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected waiver report final_decision=GO")
+if payload.get("waiver_status") != "applied":
+    raise SystemExit("expected waiver_status=applied in waiver report")
+if payload.get("reason_codes") != ["release_manifest_required_artifact_waiver_applied"]:
+    raise SystemExit("expected waiver-applied reason code in waiver report")
+if payload.get("waived_reason_codes") != ["release_manifest_missing_required_artifact:dr_readiness"]:
+    raise SystemExit("expected waived reason code list in waiver report")
+required_ids = payload.get("required_artifact_ids")
+if not isinstance(required_ids, list) or "dr_readiness" in required_ids:
+    raise SystemExit("expected waived missing artifact id to be absent from required_artifact_ids")
+PY
+
+expired_waiver="$TMP_DIR/go-no-go-waiver.expired.json"
+cat >"$expired_waiver" <<'JSON'
+{
+  "schema_version": "kamn.runtime.go-no-go-gate-waiver.v1",
+  "scope": "runtime_go_no_go_gate_required_artifacts",
+  "expires_on": "2000-01-01",
+  "allowed_reason_codes": [
+    "release_manifest_missing_required_artifact:dr_readiness"
+  ]
+}
+JSON
+
+set +e
+expired_waiver_output="$(
+  bash "$LANE_SCRIPT" \
+    --manifest-file "$tampered_manifest" \
+    --waiver-file "$expired_waiver" \
+    --max-seconds 120 2>&1
+)"
+expired_waiver_code=$?
+set -e
+if [ "$expired_waiver_code" -eq 0 ]; then
+  echo "expected go/no-go gate lane to fail closed for expired waiver metadata" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$expired_waiver_output" | grep -q 'waiver_expired'; then
+  echo "expected deterministic waiver_expired marker for go/no-go gate lane waiver validation" >&2
+  exit 1
+fi
+
+scope_mismatch_waiver="$TMP_DIR/go-no-go-waiver.scope-mismatch.json"
+cat >"$scope_mismatch_waiver" <<'JSON'
+{
+  "schema_version": "kamn.runtime.go-no-go-gate-waiver.v1",
+  "scope": "runtime_go_no_go_gate_wrong_scope",
+  "expires_on": "2099-12-31",
+  "allowed_reason_codes": [
+    "release_manifest_missing_required_artifact:dr_readiness"
+  ]
+}
+JSON
+
+set +e
+scope_mismatch_waiver_output="$(
+  bash "$LANE_SCRIPT" \
+    --manifest-file "$tampered_manifest" \
+    --waiver-file "$scope_mismatch_waiver" \
+    --max-seconds 120 2>&1
+)"
+scope_mismatch_waiver_code=$?
+set -e
+if [ "$scope_mismatch_waiver_code" -eq 0 ]; then
+  echo "expected go/no-go gate lane to fail closed for waiver scope mismatch" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$scope_mismatch_waiver_output" | grep -q 'waiver_scope_mismatch'; then
+  echo "expected deterministic waiver_scope_mismatch marker for go/no-go gate lane waiver validation" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Implemented deterministic waiver metadata support for the runtime go/no-go release-gate lane. Missing required manifest artifact evidence now supports explicit, scoped, unexpired waiver handling with deterministic `WARN/GO` markers, while invalid waiver metadata remains fail-closed.

## Changes
- `scripts/runtime/go_no_go_gate_lane_contract.py`: add `--waiver-file` support; implement waiver schema/scope/expiry/allowed-reason validation; apply waivers to missing required artifact manifest checks; emit deterministic waiver markers in stdout/JSON; add waiver-aware policy outcome handling.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`: add waiver contract coverage for valid waiver, expired waiver, and scope mismatch fail-closed behavior.
- `docs/ci/strategy.md`: document release go/no-go waiver schema, command surface, and deterministic reason-code outcomes.
- `docs/validation/go-no-go.md`: document waiver command path and deterministic waiver markers.

## Risks & Compatibility
- `--waiver-file` is optional and defaults to disabled, preserving existing fail-closed behavior when absent.
- Waiver semantics only apply to required-manifest-artifact-missing reasons and remain deterministic/auditable.

## Validation
- [x] `cargo fmt --check` — clean (N/A: no Rust source changes)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source changes)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: waiver and non-waiver go/no-go lane paths validated with deterministic markers/reason codes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` |
| Functional  | ✅     | `bash scripts/runtime/test_validate_go_no_go_gate_live.sh`; `bash scripts/runtime/validate_go_no_go_gate_live.sh --max-seconds 180` |
| Integration | ✅     | `bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh` |
| Regression  | ✅     | `bash scripts/ci/test_ci_strategy_contract.sh` |

Closes #3392
