### PR TITLE
feat(core): add sqlite backend bootstrap/version contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +92,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -221,6 +239,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +374,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +507,7 @@ version = "0.1.0"
 dependencies = [
  "k256",
  "kamn-kolme",
+ "rusqlite",
  "rustls",
  "rustls-pemfile",
  "webpki-roots",
@@ -491,6 +540,17 @@ name = "libc"
 version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -560,6 +620,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "ppv-lite86"
@@ -654,6 +720,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1035,6 +1115,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -13,6 +13,7 @@ live-https = ["dep:rustls", "dep:rustls-pemfile", "dep:webpki-roots"]
 
 [dependencies]
 kamn-kolme = { path = "../kamn-kolme" }
+rusqlite = { version = "0.31.0", features = ["bundled"] }
 # Live HTTPS runtime-commit transport uses rustls directly (no subprocess curl path).
 rustls = { version = "0.23.36", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -106,6 +106,8 @@ pub mod signature_profile;
 pub mod signer_backend;
 /// Deterministic triadic runtime smoke simulation contracts.
 pub mod smoke;
+/// Sqlite backend bootstrap/versioning and namespace-key-value persistence contracts.
+pub mod sqlite_store_backend;
 pub mod state;
 /// Task artifact registration, integrity checks, and lookup contracts.
 pub mod task_artifacts;
@@ -382,6 +384,9 @@ pub use signer_backend::{
     SignerProviderHandshakeStatus, SigningRequest,
 };
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
+pub use sqlite_store_backend::{
+    SqliteStoreBackend, SqliteStoreBackendError, SQLITE_STORE_SCHEMA_VERSION,
+};
 pub use state::{
     canonical_state_key, AppStateSchema, StateKeyError, StateVersion, APP_STATE_VERSION,
 };

--- a/crates/kamn-core/src/sqlite_store_backend.rs
+++ b/crates/kamn-core/src/sqlite_store_backend.rs
@@ -1,0 +1,271 @@
+//! Sqlite-backed key/value storage foundation for runtime persistence adapters.
+//!
+//! This module provides deterministic sqlite bootstrap/version checks and a
+//! minimal namespace/key/value API that higher-level store adapters can use.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use std::fmt;
+use std::path::Path;
+
+const META_SCHEMA_KEY: &str = "schema_version";
+const CREATE_META_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS kamn_store_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+)
+"#;
+const CREATE_ENTRIES_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS kamn_store_entries (
+  namespace TEXT NOT NULL,
+  entry_key TEXT NOT NULL,
+  entry_value BLOB NOT NULL,
+  PRIMARY KEY(namespace, entry_key)
+)
+"#;
+
+/// Current sqlite schema version expected by `SqliteStoreBackend`.
+pub const SQLITE_STORE_SCHEMA_VERSION: u32 = 1;
+
+/// Sqlite backend error taxonomy for open/bootstrap/query operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SqliteStoreBackendError {
+    /// Backend path cannot be empty.
+    InvalidPath,
+    /// Required field is empty.
+    EmptyField(&'static str),
+    /// Connection open failed.
+    Open(String),
+    /// SQLite pragma setup failed.
+    Pragma(String),
+    /// Schema bootstrap DDL failed.
+    Migration(String),
+    /// Schema version row is missing.
+    SchemaVersionMissing,
+    /// Schema version row is present but invalid.
+    SchemaVersionInvalid(String),
+    /// Schema version does not match expected backend version.
+    SchemaVersionMismatch {
+        /// Expected schema version.
+        expected: u32,
+        /// Found schema version.
+        found: u32,
+    },
+    /// Query execution failed.
+    Query(String),
+}
+
+impl fmt::Display for SqliteStoreBackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPath => write!(f, "sqlite backend path cannot be empty"),
+            Self::EmptyField(field) => write!(f, "sqlite backend field cannot be empty: {field}"),
+            Self::Open(message) => write!(f, "sqlite backend open failed: {message}"),
+            Self::Pragma(message) => write!(f, "sqlite backend pragma setup failed: {message}"),
+            Self::Migration(message) => {
+                write!(f, "sqlite backend schema bootstrap failed: {message}")
+            }
+            Self::SchemaVersionMissing => write!(f, "sqlite backend schema version row missing"),
+            Self::SchemaVersionInvalid(value) => {
+                write!(f, "sqlite backend schema version invalid: {value}")
+            }
+            Self::SchemaVersionMismatch { expected, found } => write!(
+                f,
+                "sqlite backend schema version mismatch: expected {expected}, found {found}"
+            ),
+            Self::Query(message) => write!(f, "sqlite backend query failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for SqliteStoreBackendError {}
+
+/// Minimal sqlite namespace/key/value backend used by higher-level stores.
+#[derive(Debug)]
+pub struct SqliteStoreBackend {
+    connection: Connection,
+    schema_version: u32,
+}
+
+impl SqliteStoreBackend {
+    /// Opens backend at `path`, bootstrapping schema and validating version.
+    pub fn open(path: &Path) -> Result<Self, SqliteStoreBackendError> {
+        if path.as_os_str().is_empty() {
+            return Err(SqliteStoreBackendError::InvalidPath);
+        }
+        let connection = Connection::open(path)
+            .map_err(|error| SqliteStoreBackendError::Open(error.to_string()))?;
+        Self::from_connection(connection)
+    }
+
+    /// Opens backend in-memory for tests and deterministic local probes.
+    pub fn open_in_memory() -> Result<Self, SqliteStoreBackendError> {
+        let connection = Connection::open_in_memory()
+            .map_err(|error| SqliteStoreBackendError::Open(error.to_string()))?;
+        Self::from_connection(connection)
+    }
+
+    /// Returns active schema version validated at backend initialization.
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Inserts or updates `value` for namespace/key.
+    pub fn put(
+        &mut self,
+        namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<(), SqliteStoreBackendError> {
+        validate_namespace_and_key(namespace, key)?;
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO kamn_store_entries (namespace, entry_key, entry_value)
+                VALUES (?1, ?2, ?3)
+                ON CONFLICT(namespace, entry_key)
+                DO UPDATE SET entry_value = excluded.entry_value
+                "#,
+                params![namespace, key, value],
+            )
+            .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?;
+        Ok(())
+    }
+
+    /// Loads value for namespace/key if present.
+    pub fn get(
+        &self,
+        namespace: &str,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, SqliteStoreBackendError> {
+        validate_namespace_and_key(namespace, key)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT entry_value
+                FROM kamn_store_entries
+                WHERE namespace = ?1 AND entry_key = ?2
+                "#,
+                params![namespace, key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))
+    }
+
+    /// Lists keys for namespace in deterministic lexical order.
+    pub fn list_keys(&self, namespace: &str) -> Result<Vec<String>, SqliteStoreBackendError> {
+        if namespace.trim().is_empty() {
+            return Err(SqliteStoreBackendError::EmptyField("namespace"));
+        }
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT entry_key
+                FROM kamn_store_entries
+                WHERE namespace = ?1
+                ORDER BY entry_key ASC
+                "#,
+            )
+            .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?;
+        let rows = statement
+            .query_map(params![namespace], |row| row.get::<_, String>(0))
+            .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?;
+        let mut keys = Vec::new();
+        for row in rows {
+            keys.push(row.map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?);
+        }
+        Ok(keys)
+    }
+
+    /// Deletes namespace/key row and returns `true` when a row was removed.
+    pub fn delete(&mut self, namespace: &str, key: &str) -> Result<bool, SqliteStoreBackendError> {
+        validate_namespace_and_key(namespace, key)?;
+        let deleted = self
+            .connection
+            .execute(
+                r#"
+                DELETE FROM kamn_store_entries
+                WHERE namespace = ?1 AND entry_key = ?2
+                "#,
+                params![namespace, key],
+            )
+            .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?;
+        Ok(deleted > 0)
+    }
+
+    fn from_connection(connection: Connection) -> Result<Self, SqliteStoreBackendError> {
+        connection
+            .execute_batch(
+                r#"
+                PRAGMA foreign_keys = ON;
+                PRAGMA busy_timeout = 5000;
+                "#,
+            )
+            .map_err(|error| SqliteStoreBackendError::Pragma(error.to_string()))?;
+        connection
+            .execute_batch(CREATE_META_TABLE_SQL)
+            .map_err(|error| SqliteStoreBackendError::Migration(error.to_string()))?;
+        connection
+            .execute_batch(CREATE_ENTRIES_TABLE_SQL)
+            .map_err(|error| SqliteStoreBackendError::Migration(error.to_string()))?;
+        let schema_version = bootstrap_and_validate_schema_version(&connection)?;
+        Ok(Self {
+            connection,
+            schema_version,
+        })
+    }
+}
+
+fn validate_namespace_and_key(namespace: &str, key: &str) -> Result<(), SqliteStoreBackendError> {
+    if namespace.trim().is_empty() {
+        return Err(SqliteStoreBackendError::EmptyField("namespace"));
+    }
+    if key.trim().is_empty() {
+        return Err(SqliteStoreBackendError::EmptyField("key"));
+    }
+    Ok(())
+}
+
+fn bootstrap_and_validate_schema_version(
+    connection: &Connection,
+) -> Result<u32, SqliteStoreBackendError> {
+    let maybe_schema_version: Option<String> = connection
+        .query_row(
+            "SELECT value FROM kamn_store_meta WHERE key = ?1",
+            params![META_SCHEMA_KEY],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?;
+
+    if maybe_schema_version.is_none() {
+        connection
+            .execute(
+                "INSERT INTO kamn_store_meta (key, value) VALUES (?1, ?2)",
+                params![META_SCHEMA_KEY, SQLITE_STORE_SCHEMA_VERSION.to_string()],
+            )
+            .map_err(|error| SqliteStoreBackendError::Migration(error.to_string()))?;
+    }
+
+    let current = connection
+        .query_row(
+            "SELECT value FROM kamn_store_meta WHERE key = ?1",
+            params![META_SCHEMA_KEY],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| SqliteStoreBackendError::Query(error.to_string()))?
+        .ok_or(SqliteStoreBackendError::SchemaVersionMissing)?;
+
+    let parsed = current
+        .parse::<u32>()
+        .map_err(|_| SqliteStoreBackendError::SchemaVersionInvalid(current.clone()))?;
+    if parsed != SQLITE_STORE_SCHEMA_VERSION {
+        return Err(SqliteStoreBackendError::SchemaVersionMismatch {
+            expected: SQLITE_STORE_SCHEMA_VERSION,
+            found: parsed,
+        });
+    }
+    Ok(parsed)
+}

--- a/crates/kamn-core/tests/sqlite_store_backend.rs
+++ b/crates/kamn-core/tests/sqlite_store_backend.rs
@@ -1,0 +1,82 @@
+use kamn_core::{SqliteStoreBackend, SqliteStoreBackendError, SQLITE_STORE_SCHEMA_VERSION};
+use rusqlite::Connection;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_sqlite_path(name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-{name}-{unique}.db"))
+}
+
+#[test]
+fn functional_sqlite_store_bootstraps_and_round_trips_entries() {
+    let sqlite_path = temp_sqlite_path("sqlite-store-roundtrip");
+    let mut backend =
+        SqliteStoreBackend::open(&sqlite_path).expect("sqlite backend should initialize");
+
+    assert_eq!(backend.schema_version(), SQLITE_STORE_SCHEMA_VERSION);
+
+    backend
+        .put("runtime_snapshot", "snapshot:1", b"payload-v1")
+        .expect("put should succeed");
+    backend
+        .put("runtime_snapshot", "snapshot:2", b"payload-v2")
+        .expect("second put should succeed");
+
+    let first = backend
+        .get("runtime_snapshot", "snapshot:1")
+        .expect("get should succeed");
+    assert_eq!(first, Some(b"payload-v1".to_vec()));
+
+    let keys = backend
+        .list_keys("runtime_snapshot")
+        .expect("list should succeed");
+    assert_eq!(keys, vec!["snapshot:1".to_owned(), "snapshot:2".to_owned()]);
+
+    let deleted = backend
+        .delete("runtime_snapshot", "snapshot:1")
+        .expect("delete should succeed");
+    assert!(deleted, "delete should report removed row");
+    assert_eq!(
+        backend
+            .get("runtime_snapshot", "snapshot:1")
+            .expect("get after delete should succeed"),
+        None
+    );
+
+    let _ = fs::remove_file(sqlite_path);
+}
+
+#[test]
+fn regression_sqlite_store_fails_closed_on_schema_version_mismatch() {
+    let sqlite_path = temp_sqlite_path("sqlite-store-schema-mismatch");
+    let backend = SqliteStoreBackend::open(&sqlite_path).expect("sqlite backend should initialize");
+    drop(backend);
+    let connection = Connection::open(&sqlite_path).expect("must open sqlite database");
+    connection
+        .execute(
+            "UPDATE kamn_store_meta SET value = ?1 WHERE key = 'schema_version'",
+            [format!("{}", SQLITE_STORE_SCHEMA_VERSION + 1)],
+        )
+        .expect("must tamper schema version row");
+    drop(connection);
+
+    let error = SqliteStoreBackend::open(&sqlite_path)
+        .expect_err("schema mismatch must fail closed on open");
+    assert!(
+        matches!(
+            error,
+            SqliteStoreBackendError::SchemaVersionMismatch {
+                expected: SQLITE_STORE_SCHEMA_VERSION,
+                found
+            } if found == SQLITE_STORE_SCHEMA_VERSION + 1
+        ),
+        "schema mismatch should return deterministic typed error"
+    );
+
+    let _ = fs::remove_file(sqlite_path);
+}

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -158,6 +158,28 @@ This document captures node-runtime productionization slices for machine-readabl
 - Invalid config lines, unknown keys, duplicate `--config-file` declarations, and invalid env marker values are rejected with typed `ConfigError::InvalidNodeConfig` or existing typed parse errors (for example `InvalidSyncMode`).
 - Full operator reference: `docs/ops/configuration.md`.
 
+## SQLite Backend Bootstrap Contracts
+- `SqliteStoreBackend` bootstraps deterministic sqlite metadata for runtime-adjacent stores.
+- Bootstrap creates:
+  - `kamn_store_meta` (schema metadata)
+  - `kamn_store_entries` (namespace/key/value rows)
+- Schema-version contract:
+  - expected version constant: `SQLITE_STORE_SCHEMA_VERSION`
+  - metadata key: `schema_version`
+  - missing version row is bootstrapped to expected value on first open
+  - mismatched version fails closed with typed `SchemaVersionMismatch`
+- Connection setup contracts:
+  - `PRAGMA foreign_keys = ON`
+  - `PRAGMA busy_timeout = 5000`
+- Typed fail-closed error surface:
+  - `Open`
+  - `Pragma`
+  - `Migration`
+  - `SchemaVersionMissing`
+  - `SchemaVersionInvalid`
+  - `SchemaVersionMismatch`
+  - `Query`
+
 ## Diagnostics Snapshot Rules
 - Supported diagnostics modes:
   - `basic` (default)


### PR DESCRIPTION
## Summary
Implemented sqlite backend core foundation for `kamn-core` with deterministic schema bootstrap/version checks, typed error mapping, and namespace/key/value CRUD helpers. This establishes the prerequisite persistence primitive for adapter fan-out work (`#3355`).

## Changes
- `crates/kamn-core/src/sqlite_store_backend.rs`: add `SqliteStoreBackend`, schema bootstrap contracts, version validation, typed error taxonomy, and CRUD helpers (`put/get/list_keys/delete`).
- `crates/kamn-core/src/lib.rs`: export `sqlite_store_backend` module and public sqlite backend types/constants.
- `crates/kamn-core/tests/sqlite_store_backend.rs`: add functional round-trip and schema-mismatch fail-closed tests.
- `crates/kamn-core/Cargo.toml`: add `rusqlite` dependency with `bundled` feature.
- `Cargo.lock`: lock sqlite dependency graph.
- `docs/foundation/node-runtime-cli.md`: document sqlite bootstrap/version and typed error contracts.

## Risks & Compatibility
- Introduces new dependency surface (`rusqlite` + bundled sqlite) for `kamn-core`.
- Backend is additive and not yet wired into runtime adapter selection (tracked by `#3355`).

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core -- -D warnings`)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: sqlite backend bootstrap/version + CRUD contracts and docs updates.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test sqlite_store_backend` |
| Functional  | ✅     | `cargo test -p kamn-core --lib` |
| Integration | ✅     | `cargo test -p kamn-node --test node_runtime_cli_docs` |
| Regression  | ✅     | `cargo test -p kamn-core --test missing_docs_policy` |

Closes #3354
