### PR TITLE
feat(core): wire sqlite snapshot adapters into bootstrap (#3355)

### DIFF
--- a/crates/kamn-core/src/bootstrap.rs
+++ b/crates/kamn-core/src/bootstrap.rs
@@ -1,28 +1,31 @@
 //! Bootstrap planning for validated config, schema migrations, and runtime wiring.
 
 use crate::channel_models::{
-    ChannelSnapshotError, ChannelSnapshotStore, ChannelSnapshotStoreError, FileChannelSnapshotStore,
+    ChannelSnapshotError, ChannelSnapshotStore, ChannelSnapshotStoreError,
+    FileChannelSnapshotStore, SqliteChannelSnapshotStore,
 };
 use crate::config::{ConfigError, NodeConfig};
 use crate::content_storage::{ContentStorageError, FileContentAdapter};
 use crate::did_registry::{DidRegistryError, FileDidRegistrationChainAdapter};
 use crate::durable_guard_store::{
     DurableGuardBundleSnapshotStore, DurableGuardSnapshotStoreError, FileDurableGuardSnapshotStore,
+    SqliteDurableGuardSnapshotStore,
 };
 use crate::message_lifecycle::{
     FileMessageLifecycleSnapshotStore, MessageLifecycleSnapshotError,
     MessageLifecycleSnapshotStore, MessageLifecycleSnapshotStoreError,
+    SqliteMessageLifecycleSnapshotStore,
 };
 use crate::migrations::{MigrationPlan, MigrationRegistry};
 use crate::namespaces::StateNamespaces;
 use crate::runtime::{
     build_runtime_wiring, FileRuntimeSnapshotStore, RuntimeSnapshotStore, RuntimeWiring,
-    SnapshotStoreError,
+    SnapshotStoreError, SqliteRuntimeSnapshotStore,
 };
 use crate::state::{AppStateSchema, StateVersion, APP_STATE_VERSION};
 use crate::task_operations::{
-    FileTaskOperationSnapshotStore, TaskOperationError, TaskOperationSnapshotStore,
-    TaskOperationSnapshotStoreError,
+    FileTaskOperationSnapshotStore, SqliteTaskOperationSnapshotStore, TaskOperationError,
+    TaskOperationSnapshotStore, TaskOperationSnapshotStoreError,
 };
 use crate::token::{default_token_config, TokenConfig};
 use std::fs;
@@ -35,16 +38,29 @@ const DURABLE_GUARD_STORE_FILE_NAME: &str = "durable-guard.snapshot";
 const CHANNEL_SNAPSHOT_STORE_FILE_NAME: &str = "channel.snapshot";
 const MESSAGE_LIFECYCLE_SNAPSHOT_STORE_FILE_NAME: &str = "message-lifecycle.snapshot";
 const RUNTIME_SNAPSHOT_STORE_FILE_NAME: &str = "runtime.snapshot";
+const SQLITE_STORAGE_SELECTOR_PREFIX: &str = "sqlite://";
 
 const CONTENT_STORE_COMPONENT: &str = "content-storage:file-default";
 const DID_REGISTRY_STORE_COMPONENT: &str = "did-registry:file-default";
-const TASK_OPERATION_STORE_COMPONENT: &str = "task-operation-snapshot-store:file-default";
-const DURABLE_GUARD_STORE_COMPONENT: &str = "durable-guard-snapshot-store:file-default";
-const CHANNEL_SNAPSHOT_STORE_COMPONENT: &str = "channel-snapshot-store:file-default";
-const MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT: &str =
+const TASK_OPERATION_STORE_COMPONENT_FILE: &str = "task-operation-snapshot-store:file-default";
+const DURABLE_GUARD_STORE_COMPONENT_FILE: &str = "durable-guard-snapshot-store:file-default";
+const CHANNEL_SNAPSHOT_STORE_COMPONENT_FILE: &str = "channel-snapshot-store:file-default";
+const MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT_FILE: &str =
     "message-lifecycle-snapshot-store:file-default";
-const RUNTIME_SNAPSHOT_STORE_COMPONENT: &str = "runtime-snapshot-store:file-default";
+const RUNTIME_SNAPSHOT_STORE_COMPONENT_FILE: &str = "runtime-snapshot-store:file-default";
+const TASK_OPERATION_STORE_COMPONENT_SQLITE: &str = "task-operation-snapshot-store:sqlite-default";
+const DURABLE_GUARD_STORE_COMPONENT_SQLITE: &str = "durable-guard-snapshot-store:sqlite-default";
+const CHANNEL_SNAPSHOT_STORE_COMPONENT_SQLITE: &str = "channel-snapshot-store:sqlite-default";
+const MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT_SQLITE: &str =
+    "message-lifecycle-snapshot-store:sqlite-default";
+const RUNTIME_SNAPSHOT_STORE_COMPONENT_SQLITE: &str = "runtime-snapshot-store:sqlite-default";
 const DID_REGISTRY_BOOTSTRAP_PROVIDER: &str = "bootstrap-runtime-compatibility";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuntimeStoreAdapter {
+    File,
+    Sqlite { database_path: PathBuf },
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimePersistenceLayout {
@@ -56,6 +72,7 @@ struct RuntimePersistenceLayout {
     channel_snapshot_store_path: PathBuf,
     message_lifecycle_snapshot_store_path: PathBuf,
     runtime_snapshot_store_path: PathBuf,
+    runtime_store_adapter: RuntimeStoreAdapter,
 }
 
 /// Deterministic bootstrap artifact bundling validated config, schema, and wiring.
@@ -100,11 +117,12 @@ pub fn bootstrap_from_state_version(
     token_config
         .validate()
         .map_err(|error| ConfigError::TokenModel(error.to_string()))?;
-    let persistence_layout = resolve_runtime_persistence_layout(config.storage_dir.as_str());
+    let persistence_layout = resolve_runtime_persistence_layout(config.storage_dir.as_str())?;
     validate_runtime_persistence_layout(&persistence_layout)?;
 
     let mut wiring = build_runtime_wiring(&config);
-    for component in prioritized_runtime_store_components() {
+    for component in prioritized_runtime_store_components(&persistence_layout.runtime_store_adapter)
+    {
         if !wiring.common_components.contains(&component) {
             wiring.common_components.push(component);
         }
@@ -120,9 +138,38 @@ pub fn bootstrap_from_state_version(
     })
 }
 
-fn resolve_runtime_persistence_layout(storage_dir: &str) -> RuntimePersistenceLayout {
+fn resolve_runtime_persistence_layout(
+    storage_dir: &str,
+) -> Result<RuntimePersistenceLayout, ConfigError> {
+    if let Some(database_path_raw) = storage_dir.strip_prefix(SQLITE_STORAGE_SELECTOR_PREFIX) {
+        let trimmed = database_path_raw.trim();
+        if trimmed.is_empty() {
+            return Err(ConfigError::RuntimeStoreCompatibility {
+                store: "runtime-storage-root",
+                reason_code: "runtime_storage_root_invalid_sqlite_selector",
+                detail: "sqlite storage_dir selector must include a database path".to_owned(),
+            });
+        }
+        let database_path = PathBuf::from(trimmed);
+        let storage_root = database_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        return Ok(RuntimePersistenceLayout {
+            content_store_path: storage_root.join(CONTENT_STORE_FILE_NAME),
+            did_registry_store_path: storage_root.join(DID_REGISTRY_STORE_FILE_NAME),
+            task_operation_store_path: database_path.clone(),
+            durable_guard_store_path: database_path.clone(),
+            channel_snapshot_store_path: database_path.clone(),
+            message_lifecycle_snapshot_store_path: database_path.clone(),
+            runtime_snapshot_store_path: database_path.clone(),
+            storage_root,
+            runtime_store_adapter: RuntimeStoreAdapter::Sqlite { database_path },
+        });
+    }
+
     let storage_root = PathBuf::from(storage_dir);
-    RuntimePersistenceLayout {
+    Ok(RuntimePersistenceLayout {
         content_store_path: storage_root.join(CONTENT_STORE_FILE_NAME),
         did_registry_store_path: storage_root.join(DID_REGISTRY_STORE_FILE_NAME),
         task_operation_store_path: storage_root.join(TASK_OPERATION_STORE_FILE_NAME),
@@ -132,19 +179,31 @@ fn resolve_runtime_persistence_layout(storage_dir: &str) -> RuntimePersistenceLa
             .join(MESSAGE_LIFECYCLE_SNAPSHOT_STORE_FILE_NAME),
         runtime_snapshot_store_path: storage_root.join(RUNTIME_SNAPSHOT_STORE_FILE_NAME),
         storage_root,
-    }
+        runtime_store_adapter: RuntimeStoreAdapter::File,
+    })
 }
 
-fn prioritized_runtime_store_components() -> [&'static str; 7] {
-    [
-        CONTENT_STORE_COMPONENT,
-        DID_REGISTRY_STORE_COMPONENT,
-        TASK_OPERATION_STORE_COMPONENT,
-        DURABLE_GUARD_STORE_COMPONENT,
-        CHANNEL_SNAPSHOT_STORE_COMPONENT,
-        MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT,
-        RUNTIME_SNAPSHOT_STORE_COMPONENT,
-    ]
+fn prioritized_runtime_store_components(store_adapter: &RuntimeStoreAdapter) -> [&'static str; 7] {
+    match store_adapter {
+        RuntimeStoreAdapter::File => [
+            CONTENT_STORE_COMPONENT,
+            DID_REGISTRY_STORE_COMPONENT,
+            TASK_OPERATION_STORE_COMPONENT_FILE,
+            DURABLE_GUARD_STORE_COMPONENT_FILE,
+            CHANNEL_SNAPSHOT_STORE_COMPONENT_FILE,
+            MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT_FILE,
+            RUNTIME_SNAPSHOT_STORE_COMPONENT_FILE,
+        ],
+        RuntimeStoreAdapter::Sqlite { .. } => [
+            CONTENT_STORE_COMPONENT,
+            DID_REGISTRY_STORE_COMPONENT,
+            TASK_OPERATION_STORE_COMPONENT_SQLITE,
+            DURABLE_GUARD_STORE_COMPONENT_SQLITE,
+            CHANNEL_SNAPSHOT_STORE_COMPONENT_SQLITE,
+            MESSAGE_LIFECYCLE_SNAPSHOT_STORE_COMPONENT_SQLITE,
+            RUNTIME_SNAPSHOT_STORE_COMPONENT_SQLITE,
+        ],
+    }
 }
 
 fn validate_runtime_persistence_layout(
@@ -159,11 +218,24 @@ fn validate_runtime_persistence_layout(
     })?;
     validate_content_store_path(&layout.content_store_path)?;
     validate_did_registry_store_path(&layout.did_registry_store_path)?;
-    validate_task_operation_store_path(&layout.task_operation_store_path)?;
-    validate_durable_guard_store_path(&layout.durable_guard_store_path)?;
-    validate_channel_snapshot_store_path(&layout.channel_snapshot_store_path)?;
-    validate_message_lifecycle_snapshot_store_path(&layout.message_lifecycle_snapshot_store_path)?;
-    validate_runtime_snapshot_store_path(&layout.runtime_snapshot_store_path)?;
+    match &layout.runtime_store_adapter {
+        RuntimeStoreAdapter::File => {
+            validate_task_operation_store_path(&layout.task_operation_store_path)?;
+            validate_durable_guard_store_path(&layout.durable_guard_store_path)?;
+            validate_channel_snapshot_store_path(&layout.channel_snapshot_store_path)?;
+            validate_message_lifecycle_snapshot_store_path(
+                &layout.message_lifecycle_snapshot_store_path,
+            )?;
+            validate_runtime_snapshot_store_path(&layout.runtime_snapshot_store_path)?;
+        }
+        RuntimeStoreAdapter::Sqlite { database_path } => {
+            validate_task_operation_store_sqlite_path(database_path)?;
+            validate_durable_guard_store_sqlite_path(database_path)?;
+            validate_channel_snapshot_store_sqlite_path(database_path)?;
+            validate_message_lifecycle_snapshot_store_sqlite_path(database_path)?;
+            validate_runtime_snapshot_store_sqlite_path(database_path)?;
+        }
+    }
     Ok(())
 }
 
@@ -217,6 +289,51 @@ fn validate_message_lifecycle_snapshot_store_path(path: &Path) -> Result<(), Con
 
 fn validate_runtime_snapshot_store_path(path: &Path) -> Result<(), ConfigError> {
     let store = FileRuntimeSnapshotStore::new(path.to_path_buf())
+        .map_err(map_runtime_snapshot_store_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_runtime_snapshot_store_error)
+}
+
+fn validate_task_operation_store_sqlite_path(path: &Path) -> Result<(), ConfigError> {
+    let store = SqliteTaskOperationSnapshotStore::new(path.to_path_buf())
+        .map_err(map_task_operation_store_validation_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_task_operation_store_validation_error)
+}
+
+fn validate_durable_guard_store_sqlite_path(path: &Path) -> Result<(), ConfigError> {
+    let store = SqliteDurableGuardSnapshotStore::new(path.to_path_buf())
+        .map_err(map_durable_guard_store_validation_error)?;
+    store
+        .load_bundle()
+        .map(|_| ())
+        .map_err(map_durable_guard_store_validation_error)
+}
+
+fn validate_channel_snapshot_store_sqlite_path(path: &Path) -> Result<(), ConfigError> {
+    let store = SqliteChannelSnapshotStore::new(path.to_path_buf())
+        .map_err(map_channel_store_validation_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_channel_store_validation_error)
+}
+
+fn validate_message_lifecycle_snapshot_store_sqlite_path(path: &Path) -> Result<(), ConfigError> {
+    let store = SqliteMessageLifecycleSnapshotStore::new(path.to_path_buf())
+        .map_err(map_message_lifecycle_store_validation_error)?;
+    store
+        .read_latest()
+        .map(|_| ())
+        .map_err(map_message_lifecycle_store_validation_error)
+}
+
+fn validate_runtime_snapshot_store_sqlite_path(path: &Path) -> Result<(), ConfigError> {
+    let store = SqliteRuntimeSnapshotStore::new(path.to_path_buf())
         .map_err(map_runtime_snapshot_store_error)?;
     store
         .read_latest()

--- a/crates/kamn-core/src/channel_models.rs
+++ b/crates/kamn-core/src/channel_models.rs
@@ -1,6 +1,6 @@
 //! Channel model contracts covering membership, admin policy, and snapshot recovery.
 
-use crate::AgentDid;
+use crate::{AgentDid, SqliteStoreBackend, SqliteStoreBackendError};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -861,6 +861,80 @@ impl ChannelSnapshotStore for FileChannelSnapshotStore {
         let snapshot_payload = read_channel_snapshot_file(&self.path)?;
         let journal_snapshot = replay_channel_snapshot_journal(&self.journal_path)?;
         Ok(journal_snapshot.or(snapshot_payload))
+    }
+}
+
+/// Sqlite-backed snapshot store for durable channel-state persistence.
+#[derive(Debug)]
+pub struct SqliteChannelSnapshotStore {
+    backend: SqliteStoreBackend,
+}
+
+impl SqliteChannelSnapshotStore {
+    /// Creates a sqlite-backed channel snapshot store rooted at `path`.
+    pub fn new(path: PathBuf) -> Result<Self, ChannelSnapshotStoreError> {
+        let backend = SqliteStoreBackend::open(path.as_path()).map_err(map_sqlite_store_error)?;
+        Ok(Self { backend })
+    }
+}
+
+impl ChannelSnapshotStore for SqliteChannelSnapshotStore {
+    fn write(&mut self, snapshot: ChannelSnapshot) -> Result<(), ChannelSnapshotStoreError> {
+        let mut verifier = ChannelStore::new();
+        verifier
+            .restore_snapshot(snapshot.clone())
+            .map_err(ChannelSnapshotStoreError::Snapshot)?;
+        let payload = serialize_channel_snapshot(&snapshot)?;
+        self.backend
+            .put("channel_snapshot_store", "latest", payload.as_bytes())
+            .map_err(map_sqlite_store_error)?;
+        Ok(())
+    }
+
+    fn read_latest(&self) -> Result<Option<ChannelSnapshot>, ChannelSnapshotStoreError> {
+        let Some(payload_bytes) = self
+            .backend
+            .get("channel_snapshot_store", "latest")
+            .map_err(map_sqlite_store_error)?
+        else {
+            return Ok(None);
+        };
+        let payload = String::from_utf8(payload_bytes).map_err(|_| {
+            ChannelSnapshotStoreError::InvalidPayload(
+                "channel snapshot sqlite payload is not utf-8".to_owned(),
+            )
+        })?;
+        if payload.trim().is_empty() {
+            return Ok(None);
+        }
+        let snapshot = parse_channel_snapshot_payload(&payload)?;
+        let mut verifier = ChannelStore::new();
+        verifier
+            .restore_snapshot(snapshot.clone())
+            .map_err(ChannelSnapshotStoreError::Snapshot)?;
+        Ok(Some(snapshot))
+    }
+}
+
+fn map_sqlite_store_error(error: SqliteStoreBackendError) -> ChannelSnapshotStoreError {
+    match error {
+        SqliteStoreBackendError::SchemaVersionMissing => ChannelSnapshotStoreError::InvalidPayload(
+            "channel snapshot sqlite schema missing".to_owned(),
+        ),
+        SqliteStoreBackendError::SchemaVersionInvalid(value) => {
+            ChannelSnapshotStoreError::InvalidPayload(format!(
+                "channel snapshot sqlite schema invalid: {value}"
+            ))
+        }
+        SqliteStoreBackendError::SchemaVersionMismatch { expected, found } => {
+            ChannelSnapshotStoreError::InvalidPayload(format!(
+                "channel snapshot sqlite schema mismatch: expected {expected}, found {found}"
+            ))
+        }
+        SqliteStoreBackendError::InvalidPath => ChannelSnapshotStoreError::InvalidPayload(
+            "snapshot file path cannot be empty".to_owned(),
+        ),
+        other => ChannelSnapshotStoreError::Io(other.to_string()),
     }
 }
 

--- a/crates/kamn-core/src/durable_guard_store.rs
+++ b/crates/kamn-core/src/durable_guard_store.rs
@@ -4,6 +4,7 @@ use crate::{
     ChannelPermissionEngine, ChannelPermissions, ChannelPolicySnapshot,
     ChannelPolicySnapshotChannel, ChannelPolicySnapshotError, DeliveryGuardSnapshot,
     DeliveryGuardSnapshotError, MessageDeliveryGuards, PermissionRule, RetentionPolicy,
+    SqliteStoreBackend, SqliteStoreBackendError,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -304,6 +305,120 @@ impl ChannelPolicySnapshotStore for FileDurableGuardSnapshotStore {
         &self,
     ) -> Result<Option<ChannelPolicySnapshot>, DurableGuardSnapshotStoreError> {
         Ok(self.load_bundle()?.map(|bundle| bundle.channel_policy))
+    }
+}
+
+#[derive(Debug)]
+/// Sqlite-backed durable snapshot store implementation.
+pub struct SqliteDurableGuardSnapshotStore {
+    backend: SqliteStoreBackend,
+}
+
+impl SqliteDurableGuardSnapshotStore {
+    /// Creates a sqlite-backed durable snapshot store rooted at `path`.
+    pub fn new(path: PathBuf) -> Result<Self, DurableGuardSnapshotStoreError> {
+        let backend = SqliteStoreBackend::open(path.as_path()).map_err(map_sqlite_store_error)?;
+        Ok(Self { backend })
+    }
+
+    fn load_or_default_bundle(
+        &self,
+    ) -> Result<DurableGuardSnapshotBundle, DurableGuardSnapshotStoreError> {
+        Ok(self.load_bundle()?.unwrap_or_else(default_bundle))
+    }
+}
+
+impl DurableGuardBundleSnapshotStore for SqliteDurableGuardSnapshotStore {
+    fn save_bundle(
+        &mut self,
+        bundle: DurableGuardSnapshotBundle,
+    ) -> Result<(), DurableGuardSnapshotStoreError> {
+        validate_bundle(&bundle)?;
+        let payload = serialize_bundle(&bundle);
+        self.backend
+            .put("durable_guard_snapshot_store", "latest", payload.as_bytes())
+            .map_err(map_sqlite_store_error)?;
+        Ok(())
+    }
+
+    fn load_bundle(
+        &self,
+    ) -> Result<Option<DurableGuardSnapshotBundle>, DurableGuardSnapshotStoreError> {
+        let Some(payload_bytes) = self
+            .backend
+            .get("durable_guard_snapshot_store", "latest")
+            .map_err(map_sqlite_store_error)?
+        else {
+            return Ok(None);
+        };
+        let payload = String::from_utf8(payload_bytes).map_err(|_| {
+            DurableGuardSnapshotStoreError::InvalidPayload(
+                "durable guard sqlite payload is not utf-8".to_owned(),
+            )
+        })?;
+        if payload.trim().is_empty() {
+            return Ok(None);
+        }
+        let bundle = deserialize_bundle(payload.as_str())?;
+        Ok(Some(bundle))
+    }
+}
+
+impl DeliveryGuardSnapshotStore for SqliteDurableGuardSnapshotStore {
+    fn save_delivery_guard(
+        &mut self,
+        snapshot: DeliveryGuardSnapshot,
+    ) -> Result<(), DurableGuardSnapshotStoreError> {
+        let mut bundle = self.load_or_default_bundle()?;
+        bundle.delivery_guard = snapshot;
+        self.save_bundle(bundle)
+    }
+
+    fn load_delivery_guard(
+        &self,
+    ) -> Result<Option<DeliveryGuardSnapshot>, DurableGuardSnapshotStoreError> {
+        Ok(self.load_bundle()?.map(|bundle| bundle.delivery_guard))
+    }
+}
+
+impl ChannelPolicySnapshotStore for SqliteDurableGuardSnapshotStore {
+    fn save_channel_policy(
+        &mut self,
+        snapshot: ChannelPolicySnapshot,
+    ) -> Result<(), DurableGuardSnapshotStoreError> {
+        let mut bundle = self.load_or_default_bundle()?;
+        bundle.channel_policy = snapshot;
+        self.save_bundle(bundle)
+    }
+
+    fn load_channel_policy(
+        &self,
+    ) -> Result<Option<ChannelPolicySnapshot>, DurableGuardSnapshotStoreError> {
+        Ok(self.load_bundle()?.map(|bundle| bundle.channel_policy))
+    }
+}
+
+fn map_sqlite_store_error(error: SqliteStoreBackendError) -> DurableGuardSnapshotStoreError {
+    match error {
+        SqliteStoreBackendError::SchemaVersionMissing => {
+            DurableGuardSnapshotStoreError::InvalidPayload(
+                "durable guard sqlite schema missing".to_owned(),
+            )
+        }
+        SqliteStoreBackendError::SchemaVersionInvalid(value) => {
+            DurableGuardSnapshotStoreError::InvalidPayload(format!(
+                "durable guard sqlite schema invalid: {value}"
+            ))
+        }
+        SqliteStoreBackendError::SchemaVersionMismatch { expected, found } => {
+            DurableGuardSnapshotStoreError::InvalidPayload(format!(
+                "durable guard sqlite schema mismatch: expected {expected}, found {found}"
+            ))
+        }
+        SqliteStoreBackendError::InvalidPath => DurableGuardSnapshotStoreError::InvalidPayload(
+            "snapshot file path cannot be empty".to_owned(),
+        ),
+        other => DurableGuardSnapshotStoreError::Io(other.to_string()),
     }
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -162,7 +162,7 @@ pub use channel_models::{
     ChannelMetadata, ChannelModelError, ChannelRecordSnapshot, ChannelRecoveryResult,
     ChannelSnapshot, ChannelSnapshotError, ChannelSnapshotStore, ChannelSnapshotStoreError,
     ChannelStore, ChannelType, FileChannelSnapshotStore, InMemoryChannelSnapshotStore,
-    CHANNEL_SNAPSHOT_SCHEMA_VERSION,
+    SqliteChannelSnapshotStore, CHANNEL_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use channel_policies::{
     ChannelAction, ChannelPermissionEngine, ChannelPermissions, ChannelPolicyError,
@@ -232,7 +232,8 @@ pub use discord_bridge::{
 pub use durable_guard_store::{
     ChannelPolicySnapshotStore, DeliveryGuardSnapshotStore, DurableGuardBundleSnapshotStore,
     DurableGuardSnapshotBundle, DurableGuardSnapshotStoreError, FileDurableGuardSnapshotStore,
-    InMemoryDurableGuardSnapshotStore, DURABLE_GUARD_BUNDLE_SCHEMA_VERSION,
+    InMemoryDurableGuardSnapshotStore, SqliteDurableGuardSnapshotStore,
+    DURABLE_GUARD_BUNDLE_SCHEMA_VERSION,
 };
 pub use escrow::{
     EscrowLifecycle, EscrowLifecycleError, EscrowReceiptFinality, EscrowSettlementAction,
@@ -294,7 +295,8 @@ pub use message_lifecycle::{
     MessageLifecycleError, MessageLifecycleRecoveryResult, MessageLifecycleSnapshot,
     MessageLifecycleSnapshotError, MessageLifecycleSnapshotStore,
     MessageLifecycleSnapshotStoreError, MessageLifecycleStore, MessageProofAdmissionError,
-    MessageRecordSnapshot, MessageStatus, MESSAGE_LIFECYCLE_SNAPSHOT_SCHEMA_VERSION,
+    MessageRecordSnapshot, MessageStatus, SqliteMessageLifecycleSnapshotStore,
+    MESSAGE_LIFECYCLE_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use message_proof_anchoring::{
     InMemoryMessageProofChainAdapter, KolmeMessageProofChainAdapter,
@@ -358,12 +360,15 @@ pub use retention_engine::{
 pub use runtime::{
     simulate_daemon_network_fault, AuthenticatedPeerFrame, AuthenticatedPeerFrameError,
     BoundedRuntimeQueue, DeterministicBackpressureController, DeterministicNetworkFaultSimulator,
-    DeterministicProposalPlanner, NetworkFaultSimulationError, NetworkFaultSimulationInput,
-    NetworkFaultSimulationReport, PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent,
-    PeerLifecycleState, ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError,
-    RecoveryRejoinGuard, RecoveryStatus, RejoinAttempt, RuntimeBackpressureAction,
-    RuntimeBackpressureDecision, RuntimeBackpressureError, RuntimeBackpressureInput,
-    RuntimeBackpressurePolicy, RuntimeLifecycleError, RuntimeQueueError, RuntimeWiring,
+    DeterministicProposalPlanner, FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore,
+    NetworkFaultSimulationError, NetworkFaultSimulationInput, NetworkFaultSimulationReport,
+    PeerFrameAuthenticator, PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState,
+    ProposalCandidate, ProposalPlan, ProposalPlannerError, RecoveryGuardError, RecoveryRejoinGuard,
+    RecoveryStatus, RejoinAttempt, RuntimeBackpressureAction, RuntimeBackpressureDecision,
+    RuntimeBackpressureError, RuntimeBackpressureInput, RuntimeBackpressurePolicy,
+    RuntimeLifecycleError, RuntimeQueueError, RuntimeSnapshot, RuntimeSnapshotStore, RuntimeWiring,
+    SnapshotRecoveryResult, SnapshotRestoreError, SnapshotRestoreGuard, SnapshotStoreError,
+    SqliteRuntimeSnapshotStore,
 };
 pub use service_marketplace::{
     MarketplaceSearchFilter, NegotiationThreadHook, ServiceListing, ServiceMarketplaceEngine,
@@ -397,11 +402,11 @@ pub use task_lifecycle::{
     TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition, TaskTransitionEvidence,
 };
 pub use task_operations::{
-    FileTaskOperationSnapshotStore, InMemoryTaskOperationSnapshotStore, SwarmTaskDraft,
-    TaskOperationEngine, TaskOperationError, TaskOperationNoticeKind, TaskOperationRecord,
-    TaskOperationRecordSnapshot, TaskOperationRecoveryResult, TaskOperationSnapshot,
-    TaskOperationSnapshotStore, TaskOperationSnapshotStoreError,
-    TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION,
+    FileTaskOperationSnapshotStore, InMemoryTaskOperationSnapshotStore,
+    SqliteTaskOperationSnapshotStore, SwarmTaskDraft, TaskOperationEngine, TaskOperationError,
+    TaskOperationNoticeKind, TaskOperationRecord, TaskOperationRecordSnapshot,
+    TaskOperationRecoveryResult, TaskOperationSnapshot, TaskOperationSnapshotStore,
+    TaskOperationSnapshotStoreError, TASK_OPERATION_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use task_payment::{PaymentConfirm, PaymentOffer, TaskPaymentError, TaskPaymentWorkflow};
 pub use telegram_bridge::{

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::{
     AgentDid, ProcessorProofAdmissionEvaluator, ProcessorProofAdmissionInput,
-    ProcessorProofArtifact, ZkDesignError,
+    ProcessorProofArtifact, SqliteStoreBackend, SqliteStoreBackendError, ZkDesignError,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -757,6 +757,91 @@ impl MessageLifecycleSnapshotStore for FileMessageLifecycleSnapshotStore {
         let snapshot_payload = read_message_lifecycle_snapshot_file(&self.path)?;
         let journal_snapshot = replay_message_lifecycle_snapshot_journal(&self.journal_path)?;
         Ok(journal_snapshot.or(snapshot_payload))
+    }
+}
+
+/// Sqlite-backed snapshot store for lifecycle state recovery.
+#[derive(Debug)]
+pub struct SqliteMessageLifecycleSnapshotStore {
+    backend: SqliteStoreBackend,
+}
+
+impl SqliteMessageLifecycleSnapshotStore {
+    /// Creates a sqlite-backed snapshot store at `path`.
+    pub fn new(path: PathBuf) -> Result<Self, MessageLifecycleSnapshotStoreError> {
+        let backend = SqliteStoreBackend::open(path.as_path()).map_err(map_sqlite_store_error)?;
+        Ok(Self { backend })
+    }
+}
+
+impl MessageLifecycleSnapshotStore for SqliteMessageLifecycleSnapshotStore {
+    fn write(
+        &mut self,
+        snapshot: MessageLifecycleSnapshot,
+    ) -> Result<(), MessageLifecycleSnapshotStoreError> {
+        let mut verifier = MessageLifecycleStore::new();
+        verifier
+            .restore_snapshot(snapshot.clone())
+            .map_err(MessageLifecycleSnapshotStoreError::Snapshot)?;
+        let payload = serialize_message_lifecycle_snapshot(&snapshot)?;
+        self.backend
+            .put(
+                "message_lifecycle_snapshot_store",
+                "latest",
+                payload.as_bytes(),
+            )
+            .map_err(map_sqlite_store_error)?;
+        Ok(())
+    }
+
+    fn read_latest(
+        &self,
+    ) -> Result<Option<MessageLifecycleSnapshot>, MessageLifecycleSnapshotStoreError> {
+        let Some(payload_bytes) = self
+            .backend
+            .get("message_lifecycle_snapshot_store", "latest")
+            .map_err(map_sqlite_store_error)?
+        else {
+            return Ok(None);
+        };
+        let payload = String::from_utf8(payload_bytes).map_err(|_| {
+            MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "message lifecycle sqlite payload is not utf-8".to_owned(),
+            )
+        })?;
+        if payload.trim().is_empty() {
+            return Ok(None);
+        }
+        let snapshot = parse_message_lifecycle_snapshot_payload(&payload)?;
+        let mut verifier = MessageLifecycleStore::new();
+        verifier
+            .restore_snapshot(snapshot.clone())
+            .map_err(MessageLifecycleSnapshotStoreError::Snapshot)?;
+        Ok(Some(snapshot))
+    }
+}
+
+fn map_sqlite_store_error(error: SqliteStoreBackendError) -> MessageLifecycleSnapshotStoreError {
+    match error {
+        SqliteStoreBackendError::SchemaVersionMissing => {
+            MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "message lifecycle sqlite schema missing".to_owned(),
+            )
+        }
+        SqliteStoreBackendError::SchemaVersionInvalid(value) => {
+            MessageLifecycleSnapshotStoreError::InvalidPayload(format!(
+                "message lifecycle sqlite schema invalid: {value}"
+            ))
+        }
+        SqliteStoreBackendError::SchemaVersionMismatch { expected, found } => {
+            MessageLifecycleSnapshotStoreError::InvalidPayload(format!(
+                "message lifecycle sqlite schema mismatch: expected {expected}, found {found}"
+            ))
+        }
+        SqliteStoreBackendError::InvalidPath => MessageLifecycleSnapshotStoreError::InvalidPayload(
+            "snapshot file path cannot be empty".to_owned(),
+        ),
+        other => MessageLifecycleSnapshotStoreError::Io(other.to_string()),
     }
 }
 

--- a/crates/kamn-core/src/runtime.rs
+++ b/crates/kamn-core/src/runtime.rs
@@ -44,6 +44,7 @@ pub use runtime_recovery_guard::{
 pub use runtime_snapshot_store::{
     FileRuntimeSnapshotStore, InMemoryRuntimeSnapshotStore, RuntimeSnapshot, RuntimeSnapshotStore,
     SnapshotRecoveryResult, SnapshotRestoreError, SnapshotRestoreGuard, SnapshotStoreError,
+    SqliteRuntimeSnapshotStore,
 };
 pub use runtime_state_divergence::{
     evaluate_daemon_state_divergence, StateDivergenceError, StateDivergenceEvaluator,

--- a/crates/kamn-core/src/runtime_snapshot_store.rs
+++ b/crates/kamn-core/src/runtime_snapshot_store.rs
@@ -1,3 +1,4 @@
+use crate::{SqliteStoreBackend, SqliteStoreBackendError};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::fs::{self, OpenOptions};
@@ -437,6 +438,96 @@ impl RuntimeSnapshotStore for FileRuntimeSnapshotStore {
         }
 
         Ok(snapshots)
+    }
+}
+
+#[derive(Debug)]
+/// Sqlite runtime snapshot store.
+pub struct SqliteRuntimeSnapshotStore {
+    backend: SqliteStoreBackend,
+}
+
+impl SqliteRuntimeSnapshotStore {
+    /// Handles new.
+    pub fn new(path: PathBuf) -> Result<Self, SnapshotStoreError> {
+        let backend = SqliteStoreBackend::open(path.as_path()).map_err(map_sqlite_store_error)?;
+        Ok(Self { backend })
+    }
+}
+
+impl RuntimeSnapshotStore for SqliteRuntimeSnapshotStore {
+    fn write(&mut self, snapshot: RuntimeSnapshot) -> Result<(), SnapshotStoreError> {
+        if let Some(previous) = self.read_latest()? {
+            validate_snapshot_continuity(Some(&previous), &snapshot)?;
+        }
+        let key = format!("{:020}", snapshot.state_version());
+        let serialized = format!(
+            "{}|{}|{}",
+            snapshot.state_version(),
+            snapshot.state_hash(),
+            snapshot.cursor()
+        );
+        self.backend
+            .put(
+                "runtime_snapshot_store",
+                key.as_str(),
+                serialized.as_bytes(),
+            )
+            .map_err(map_sqlite_store_error)?;
+        Ok(())
+    }
+
+    fn read_latest(&self) -> Result<Option<RuntimeSnapshot>, SnapshotStoreError> {
+        Ok(self.list()?.pop())
+    }
+
+    fn list(&self) -> Result<Vec<RuntimeSnapshot>, SnapshotStoreError> {
+        let keys = self
+            .backend
+            .list_keys("runtime_snapshot_store")
+            .map_err(map_sqlite_store_error)?;
+        let mut snapshots = Vec::new();
+        for key in keys {
+            let Some(payload_bytes) = self
+                .backend
+                .get("runtime_snapshot_store", key.as_str())
+                .map_err(map_sqlite_store_error)?
+            else {
+                continue;
+            };
+            let payload = String::from_utf8(payload_bytes).map_err(|_| {
+                SnapshotStoreError::InvalidPayload(
+                    "runtime snapshot sqlite payload is not utf-8".to_owned(),
+                )
+            })?;
+            if payload.trim().is_empty() {
+                continue;
+            }
+            let snapshot = parse_snapshot_line(payload.as_str())?;
+            validate_snapshot_continuity(snapshots.last(), &snapshot)?;
+            snapshots.push(snapshot);
+        }
+        Ok(snapshots)
+    }
+}
+
+fn map_sqlite_store_error(error: SqliteStoreBackendError) -> SnapshotStoreError {
+    match error {
+        SqliteStoreBackendError::SchemaVersionMissing => {
+            SnapshotStoreError::InvalidPayload("runtime snapshot sqlite schema missing".to_owned())
+        }
+        SqliteStoreBackendError::SchemaVersionInvalid(value) => SnapshotStoreError::InvalidPayload(
+            format!("runtime snapshot sqlite schema invalid: {value}"),
+        ),
+        SqliteStoreBackendError::SchemaVersionMismatch { expected, found } => {
+            SnapshotStoreError::InvalidPayload(format!(
+                "runtime snapshot sqlite schema mismatch: expected {expected}, found {found}"
+            ))
+        }
+        SqliteStoreBackendError::InvalidPath => {
+            SnapshotStoreError::InvalidPayload("snapshot file path cannot be empty".to_owned())
+        }
+        other => SnapshotStoreError::Io(other.to_string()),
     }
 }
 

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -1,6 +1,9 @@
 //! Task operation workflow contracts, dependency orchestration, and snapshot persistence.
 
-use crate::{AgentDid, TaskLifecycle, TaskLifecycleError, TaskState, TaskTransition};
+use crate::{
+    AgentDid, SqliteStoreBackend, SqliteStoreBackendError, TaskLifecycle, TaskLifecycleError,
+    TaskState, TaskTransition,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -868,6 +871,91 @@ impl TaskOperationSnapshotStore for FileTaskOperationSnapshotStore {
         let snapshot_payload = read_task_operation_snapshot_file(&self.path)?;
         let journal_snapshot = replay_task_operation_snapshot_journal(&self.journal_path)?;
         Ok(journal_snapshot.or(snapshot_payload))
+    }
+}
+
+/// Sqlite-backed snapshot store implementation.
+#[derive(Debug)]
+pub struct SqliteTaskOperationSnapshotStore {
+    backend: SqliteStoreBackend,
+}
+
+impl SqliteTaskOperationSnapshotStore {
+    /// Construct sqlite snapshot store with target database path.
+    pub fn new(path: PathBuf) -> Result<Self, TaskOperationSnapshotStoreError> {
+        let backend = SqliteStoreBackend::open(path.as_path()).map_err(map_sqlite_store_error)?;
+        Ok(Self { backend })
+    }
+}
+
+impl TaskOperationSnapshotStore for SqliteTaskOperationSnapshotStore {
+    fn write(
+        &mut self,
+        snapshot: TaskOperationSnapshot,
+    ) -> Result<(), TaskOperationSnapshotStoreError> {
+        let mut verifier = TaskOperationEngine::new();
+        verifier
+            .restore_snapshot(snapshot.clone())
+            .map_err(TaskOperationSnapshotStoreError::Snapshot)?;
+        let payload = serialize_task_operation_snapshot(&snapshot)?;
+        self.backend
+            .put(
+                "task_operation_snapshot_store",
+                "latest",
+                payload.as_bytes(),
+            )
+            .map_err(map_sqlite_store_error)?;
+        Ok(())
+    }
+
+    fn read_latest(
+        &self,
+    ) -> Result<Option<TaskOperationSnapshot>, TaskOperationSnapshotStoreError> {
+        let Some(payload_bytes) = self
+            .backend
+            .get("task_operation_snapshot_store", "latest")
+            .map_err(map_sqlite_store_error)?
+        else {
+            return Ok(None);
+        };
+        let payload = String::from_utf8(payload_bytes).map_err(|_| {
+            TaskOperationSnapshotStoreError::InvalidPayload(
+                "task operation sqlite payload is not utf-8".to_owned(),
+            )
+        })?;
+        if payload.trim().is_empty() {
+            return Ok(None);
+        }
+        let snapshot = parse_task_operation_snapshot_payload(&payload)?;
+        let mut verifier = TaskOperationEngine::new();
+        verifier
+            .restore_snapshot(snapshot.clone())
+            .map_err(TaskOperationSnapshotStoreError::Snapshot)?;
+        Ok(Some(snapshot))
+    }
+}
+
+fn map_sqlite_store_error(error: SqliteStoreBackendError) -> TaskOperationSnapshotStoreError {
+    match error {
+        SqliteStoreBackendError::SchemaVersionMissing => {
+            TaskOperationSnapshotStoreError::InvalidPayload(
+                "task operation sqlite schema missing".to_owned(),
+            )
+        }
+        SqliteStoreBackendError::SchemaVersionInvalid(value) => {
+            TaskOperationSnapshotStoreError::InvalidPayload(format!(
+                "task operation sqlite schema invalid: {value}"
+            ))
+        }
+        SqliteStoreBackendError::SchemaVersionMismatch { expected, found } => {
+            TaskOperationSnapshotStoreError::InvalidPayload(format!(
+                "task operation sqlite schema mismatch: expected {expected}, found {found}"
+            ))
+        }
+        SqliteStoreBackendError::InvalidPath => TaskOperationSnapshotStoreError::InvalidPayload(
+            "snapshot file path cannot be empty".to_owned(),
+        ),
+        other => TaskOperationSnapshotStoreError::Io(other.to_string()),
     }
 }
 

--- a/crates/kamn-core/tests/sqlite_snapshot_store_adapters.rs
+++ b/crates/kamn-core/tests/sqlite_snapshot_store_adapters.rs
@@ -1,0 +1,140 @@
+use kamn_core::{
+    bootstrap, ChannelPermissionEngine, ChannelSnapshotStore, ChannelStore,
+    DurableGuardBundleSnapshotStore, DurableGuardSnapshotBundle, MessageDeliveryGuards,
+    MessageLifecycleSnapshotStore, MessageLifecycleStore, NodeConfig, NodeRole, RuntimeSnapshot,
+    RuntimeSnapshotStore, SqliteChannelSnapshotStore, SqliteDurableGuardSnapshotStore,
+    SqliteMessageLifecycleSnapshotStore, SqliteRuntimeSnapshotStore,
+    SqliteTaskOperationSnapshotStore, SyncMode, TaskOperationEngine, TaskOperationSnapshotStore,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-{tag}-{unique}"))
+}
+
+#[test]
+fn functional_sqlite_snapshot_adapters_roundtrip_all_store_types() {
+    let root = temp_dir("sqlite-snapshot-adapters");
+    fs::create_dir_all(&root).expect("fixture directory should build");
+    let sqlite_path = root.join("runtime-snapshot-stores.sqlite");
+
+    let mut channel_store = SqliteChannelSnapshotStore::new(sqlite_path.clone())
+        .expect("sqlite channel snapshot store should initialize");
+    let channel_snapshot = ChannelStore::new().export_snapshot();
+    channel_store
+        .write(channel_snapshot.clone())
+        .expect("sqlite channel snapshot write should succeed");
+    assert_eq!(
+        channel_store
+            .read_latest()
+            .expect("sqlite channel snapshot read should succeed"),
+        Some(channel_snapshot)
+    );
+
+    let mut message_store = SqliteMessageLifecycleSnapshotStore::new(sqlite_path.clone())
+        .expect("sqlite message lifecycle snapshot store should initialize");
+    let message_snapshot = MessageLifecycleStore::new().export_snapshot();
+    message_store
+        .write(message_snapshot.clone())
+        .expect("sqlite message lifecycle snapshot write should succeed");
+    assert_eq!(
+        message_store
+            .read_latest()
+            .expect("sqlite message lifecycle snapshot read should succeed"),
+        Some(message_snapshot)
+    );
+
+    let mut task_store = SqliteTaskOperationSnapshotStore::new(sqlite_path.clone())
+        .expect("sqlite task-operation snapshot store should initialize");
+    let task_snapshot = TaskOperationEngine::new().export_snapshot();
+    task_store
+        .write(task_snapshot.clone())
+        .expect("sqlite task-operation snapshot write should succeed");
+    assert_eq!(
+        task_store
+            .read_latest()
+            .expect("sqlite task-operation snapshot read should succeed"),
+        Some(task_snapshot)
+    );
+
+    let mut durable_store = SqliteDurableGuardSnapshotStore::new(sqlite_path.clone())
+        .expect("sqlite durable-guard snapshot store should initialize");
+    let durable_bundle = DurableGuardSnapshotBundle::capture(
+        &MessageDeliveryGuards::new(),
+        &ChannelPermissionEngine::new(),
+    );
+    durable_store
+        .save_bundle(durable_bundle.clone())
+        .expect("sqlite durable-guard bundle write should succeed");
+    assert_eq!(
+        durable_store
+            .load_bundle()
+            .expect("sqlite durable-guard bundle read should succeed"),
+        Some(durable_bundle)
+    );
+
+    let mut runtime_store = SqliteRuntimeSnapshotStore::new(sqlite_path.clone())
+        .expect("sqlite runtime snapshot store should initialize");
+    let first = RuntimeSnapshot::new(1, "state-hash-v1").expect("first snapshot should build");
+    let second =
+        RuntimeSnapshot::with_cursor(2, "state-hash-v2", 2).expect("second snapshot should build");
+    runtime_store
+        .write(first.clone())
+        .expect("sqlite runtime snapshot first write should succeed");
+    runtime_store
+        .write(second.clone())
+        .expect("sqlite runtime snapshot second write should succeed");
+    assert_eq!(
+        runtime_store
+            .read_latest()
+            .expect("sqlite runtime snapshot read_latest should succeed"),
+        Some(second)
+    );
+    assert_eq!(
+        runtime_store
+            .list()
+            .expect("sqlite runtime snapshot list should succeed"),
+        vec![
+            first,
+            RuntimeSnapshot::with_cursor(2, "state-hash-v2", 2).expect("snapshot")
+        ]
+    );
+
+    let _ = fs::remove_file(sqlite_path);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn integration_bootstrap_selects_sqlite_snapshot_components() {
+    let root = temp_dir("bootstrap-sqlite-components");
+    fs::create_dir_all(&root).expect("fixture directory should build");
+    let sqlite_path = root.join("runtime-stores.sqlite");
+    let storage_dir = format!("sqlite://{}", sqlite_path.to_string_lossy());
+
+    let config = NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role: NodeRole::Processor,
+        storage_dir,
+        enable_gossip: true,
+        sync_mode: SyncMode::Fast,
+    };
+    let plan = bootstrap(config).expect("bootstrap should support sqlite storage dir");
+    let components = plan.wiring.all_components();
+    assert!(components.contains(&"content-storage:file-default"));
+    assert!(components.contains(&"did-registry:file-default"));
+    assert!(components.contains(&"task-operation-snapshot-store:sqlite-default"));
+    assert!(components.contains(&"durable-guard-snapshot-store:sqlite-default"));
+    assert!(components.contains(&"channel-snapshot-store:sqlite-default"));
+    assert!(components.contains(&"message-lifecycle-snapshot-store:sqlite-default"));
+    assert!(components.contains(&"runtime-snapshot-store:sqlite-default"));
+
+    let _ = fs::remove_file(sqlite_path);
+    let _ = fs::remove_dir_all(root);
+}

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -160,6 +160,9 @@ This document captures node-runtime productionization slices for machine-readabl
 
 ## SQLite Backend Bootstrap Contracts
 - `SqliteStoreBackend` bootstraps deterministic sqlite metadata for runtime-adjacent stores.
+- `storage_dir` selector controls runtime snapshot adapter mode:
+  - file mode: `storage_dir=<directory>` keeps all stores on file snapshots (`*:file-default`)
+  - sqlite mode: `storage_dir=sqlite://<db-path>` keeps content/DID stores file-backed and routes runtime snapshot stores through sqlite adapters (`*:sqlite-default`)
 - Bootstrap creates:
   - `kamn_store_meta` (schema metadata)
   - `kamn_store_entries` (namespace/key/value rows)


### PR DESCRIPTION
## Summary
This change completes sqlite adapter wiring for runtime snapshot stores so bootstrap can select sqlite-backed stores via `storage_dir=sqlite://...` while preserving file-backed content and DID stores. It also exposes sqlite/runtime snapshot types through root exports to keep integration call sites stable.

Closes #3355

## Changes
- `crates/kamn-core/src/durable_guard_store.rs`: added `SqliteDurableGuardSnapshotStore` with bundle/delivery/channel lane support.
- `crates/kamn-core/src/bootstrap.rs`: added sqlite storage selector parsing, sqlite adapter validation paths, and sqlite component markers.
- `crates/kamn-core/src/lib.rs`, `crates/kamn-core/src/runtime.rs`: exported sqlite snapshot adapters and runtime snapshot traits/types from root/runtime surfaces.
- `crates/kamn-core/tests/sqlite_snapshot_store_adapters.rs`: added functional + bootstrap integration tests for sqlite adapter parity.
- `docs/foundation/node-runtime-cli.md`: documented `storage_dir=sqlite://<db-path>` runtime adapter selector contract.

## Risks & Compatibility
- No breaking API removal; this extends public exports and bootstrap selector support.
- File-backed bootstrap behavior remains unchanged for non-sqlite `storage_dir` values.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated sqlite adapter bootstrap/component selection and roundtrip paths through targeted tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core --lib` |
| Functional  | ✅ | `cargo test -p kamn-core --test sqlite_snapshot_store_adapters` |
| Integration | ✅ | sqlite bootstrap selector assertions in `sqlite_snapshot_store_adapters` |
| Regression  | ✅ | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-node --test node_runtime_cli_docs` |
