### PR TITLE
feat(core): add file-to-sqlite migration parity contracts (#3311)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -106,6 +106,8 @@ pub mod signature_profile;
 pub mod signer_backend;
 /// Deterministic triadic runtime smoke simulation contracts.
 pub mod smoke;
+/// Legacy file snapshot to sqlite migration parity-check contracts.
+pub mod snapshot_migration;
 /// Sqlite backend bootstrap/versioning and namespace-key-value persistence contracts.
 pub mod sqlite_store_backend;
 pub mod state;
@@ -389,6 +391,9 @@ pub use signer_backend::{
     SignerProviderHandshakeStatus, SigningRequest,
 };
 pub use smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
+pub use snapshot_migration::{
+    migrate_file_snapshots_to_sqlite_parity, SnapshotMigrationError, SnapshotMigrationParityReport,
+};
 pub use sqlite_store_backend::{
     SqliteStoreBackend, SqliteStoreBackendError, SQLITE_STORE_SCHEMA_VERSION,
 };

--- a/crates/kamn-core/src/snapshot_migration.rs
+++ b/crates/kamn-core/src/snapshot_migration.rs
@@ -1,0 +1,447 @@
+//! File-to-sqlite snapshot migration and parity-check contracts.
+
+use crate::{
+    ChannelSnapshotStore, DurableGuardBundleSnapshotStore, FileChannelSnapshotStore,
+    FileDurableGuardSnapshotStore, FileMessageLifecycleSnapshotStore, FileRuntimeSnapshotStore,
+    FileTaskOperationSnapshotStore, MessageLifecycleSnapshotStore, RuntimeSnapshotStore,
+    SqliteChannelSnapshotStore, SqliteDurableGuardSnapshotStore,
+    SqliteMessageLifecycleSnapshotStore, SqliteRuntimeSnapshotStore,
+    SqliteTaskOperationSnapshotStore, TaskOperationSnapshotStore,
+};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::path::Path;
+
+const CHANNEL_STORE_FILE_NAME: &str = "channel.snapshot";
+const MESSAGE_LIFECYCLE_STORE_FILE_NAME: &str = "message-lifecycle.snapshot";
+const TASK_OPERATION_STORE_FILE_NAME: &str = "task-operation.snapshot";
+const DURABLE_GUARD_STORE_FILE_NAME: &str = "durable-guard.snapshot";
+const RUNTIME_STORE_FILE_NAME: &str = "runtime.snapshot";
+
+const CHANNEL_STORE_DOMAIN: &str = "channel-snapshot-store";
+const MESSAGE_LIFECYCLE_STORE_DOMAIN: &str = "message-lifecycle-snapshot-store";
+const TASK_OPERATION_STORE_DOMAIN: &str = "task-operation-snapshot-store";
+const DURABLE_GUARD_STORE_DOMAIN: &str = "durable-guard-snapshot-store";
+const RUNTIME_STORE_DOMAIN: &str = "runtime-snapshot-store";
+
+const REASON_STORAGE_ROOT_INVALID: &str = "snapshot_migration_storage_root_invalid";
+const REASON_SQLITE_PATH_INVALID: &str = "snapshot_migration_sqlite_path_invalid";
+const REASON_LEGACY_STORE_LOAD_FAILED: &str = "snapshot_migration_legacy_store_load_failed";
+const REASON_SQLITE_STORE_WRITE_FAILED: &str = "snapshot_migration_sqlite_store_write_failed";
+const REASON_SQLITE_STORE_READ_FAILED: &str = "snapshot_migration_sqlite_store_read_failed";
+const REASON_PARITY_MISMATCH: &str = "snapshot_migration_parity_mismatch";
+const REASON_PARITY_PASS: &str = "snapshot_migration_parity_pass";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// File-to-sqlite migration parity report.
+pub struct SnapshotMigrationParityReport {
+    /// Deterministic terminal reason code.
+    pub reason_code: &'static str,
+    /// Ordered domain identifiers migrated during this run.
+    pub migrated_domains: Vec<&'static str>,
+    /// Number of migrated snapshot records across all domains.
+    pub migrated_snapshot_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// File-to-sqlite migration error taxonomy.
+pub enum SnapshotMigrationError {
+    /// Source storage root is missing, invalid, or not directory-backed.
+    InvalidStorageRoot {
+        /// Deterministic fail-closed reason code.
+        reason_code: &'static str,
+        /// Error detail for audit/debug traces.
+        detail: String,
+    },
+    /// Sqlite path selector is invalid.
+    InvalidSqlitePath {
+        /// Deterministic fail-closed reason code.
+        reason_code: &'static str,
+        /// Error detail for audit/debug traces.
+        detail: String,
+    },
+    /// Legacy file-backed store failed to load or parse.
+    LegacyStoreLoad {
+        /// Logical store domain.
+        domain: &'static str,
+        /// Deterministic fail-closed reason code.
+        reason_code: &'static str,
+        /// Error detail for audit/debug traces.
+        detail: String,
+    },
+    /// Sqlite store failed while writing migrated records.
+    SqliteStoreWrite {
+        /// Logical store domain.
+        domain: &'static str,
+        /// Deterministic fail-closed reason code.
+        reason_code: &'static str,
+        /// Error detail for audit/debug traces.
+        detail: String,
+    },
+    /// Sqlite store failed while reading parity records.
+    SqliteStoreRead {
+        /// Logical store domain.
+        domain: &'static str,
+        /// Deterministic fail-closed reason code.
+        reason_code: &'static str,
+        /// Error detail for audit/debug traces.
+        detail: String,
+    },
+    /// Roundtrip parity mismatch between legacy snapshot payload and sqlite result.
+    ParityMismatch {
+        /// Logical store domain.
+        domain: &'static str,
+        /// Deterministic fail-closed reason code.
+        reason_code: &'static str,
+        /// Error detail for audit/debug traces.
+        detail: String,
+    },
+}
+
+impl SnapshotMigrationError {
+    /// Returns deterministic reason code for fail-closed lane contracts.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::InvalidStorageRoot { reason_code, .. }
+            | Self::InvalidSqlitePath { reason_code, .. }
+            | Self::LegacyStoreLoad { reason_code, .. }
+            | Self::SqliteStoreWrite { reason_code, .. }
+            | Self::SqliteStoreRead { reason_code, .. }
+            | Self::ParityMismatch { reason_code, .. } => reason_code,
+        }
+    }
+}
+
+impl Display for SnapshotMigrationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidStorageRoot { detail, .. } => write!(f, "invalid storage root: {detail}"),
+            Self::InvalidSqlitePath { detail, .. } => write!(f, "invalid sqlite path: {detail}"),
+            Self::LegacyStoreLoad { domain, detail, .. } => {
+                write!(f, "failed to load legacy store {domain}: {detail}")
+            }
+            Self::SqliteStoreWrite { domain, detail, .. } => {
+                write!(f, "failed to write sqlite store {domain}: {detail}")
+            }
+            Self::SqliteStoreRead { domain, detail, .. } => {
+                write!(f, "failed to read sqlite store {domain}: {detail}")
+            }
+            Self::ParityMismatch { domain, detail, .. } => {
+                write!(f, "parity mismatch in {domain}: {detail}")
+            }
+        }
+    }
+}
+
+impl Error for SnapshotMigrationError {}
+
+/// Migrates legacy file snapshots into sqlite and enforces roundtrip parity.
+pub fn migrate_file_snapshots_to_sqlite_parity(
+    storage_root: &Path,
+    sqlite_path: &Path,
+) -> Result<SnapshotMigrationParityReport, SnapshotMigrationError> {
+    if !storage_root.exists() || !storage_root.is_dir() {
+        return Err(SnapshotMigrationError::InvalidStorageRoot {
+            reason_code: REASON_STORAGE_ROOT_INVALID,
+            detail: format!("storage root must exist and be a directory: {storage_root:?}"),
+        });
+    }
+    if sqlite_path.as_os_str().is_empty() {
+        return Err(SnapshotMigrationError::InvalidSqlitePath {
+            reason_code: REASON_SQLITE_PATH_INVALID,
+            detail: "sqlite path must not be empty".to_owned(),
+        });
+    }
+
+    let mut migrated_domains = Vec::new();
+    let mut migrated_snapshot_count = 0_usize;
+
+    let channel_file_store = FileChannelSnapshotStore::new(
+        storage_root.join(CHANNEL_STORE_FILE_NAME),
+    )
+    .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+        domain: CHANNEL_STORE_DOMAIN,
+        reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+        detail: error.to_string(),
+    })?;
+    let channel_snapshot = channel_file_store.read_latest().map_err(|error| {
+        SnapshotMigrationError::LegacyStoreLoad {
+            domain: CHANNEL_STORE_DOMAIN,
+            reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+            detail: error.to_string(),
+        }
+    })?;
+    if let Some(snapshot) = channel_snapshot {
+        let mut sqlite_store =
+            SqliteChannelSnapshotStore::new(sqlite_path.to_path_buf()).map_err(|error| {
+                SnapshotMigrationError::SqliteStoreWrite {
+                    domain: CHANNEL_STORE_DOMAIN,
+                    reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                    detail: error.to_string(),
+                }
+            })?;
+        sqlite_store.write(snapshot.clone()).map_err(|error| {
+            SnapshotMigrationError::SqliteStoreWrite {
+                domain: CHANNEL_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        let sqlite_snapshot = sqlite_store.read_latest().map_err(|error| {
+            SnapshotMigrationError::SqliteStoreRead {
+                domain: CHANNEL_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_READ_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        if sqlite_snapshot != Some(snapshot) {
+            return Err(SnapshotMigrationError::ParityMismatch {
+                domain: CHANNEL_STORE_DOMAIN,
+                reason_code: REASON_PARITY_MISMATCH,
+                detail: "sqlite channel snapshot does not match legacy payload".to_owned(),
+            });
+        }
+        migrated_domains.push(CHANNEL_STORE_DOMAIN);
+        migrated_snapshot_count += 1;
+    }
+
+    let message_file_store = FileMessageLifecycleSnapshotStore::new(
+        storage_root.join(MESSAGE_LIFECYCLE_STORE_FILE_NAME),
+    )
+    .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+        domain: MESSAGE_LIFECYCLE_STORE_DOMAIN,
+        reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+        detail: error.to_string(),
+    })?;
+    let message_snapshot = message_file_store.read_latest().map_err(|error| {
+        SnapshotMigrationError::LegacyStoreLoad {
+            domain: MESSAGE_LIFECYCLE_STORE_DOMAIN,
+            reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+            detail: error.to_string(),
+        }
+    })?;
+    if let Some(snapshot) = message_snapshot {
+        let mut sqlite_store = SqliteMessageLifecycleSnapshotStore::new(sqlite_path.to_path_buf())
+            .map_err(|error| SnapshotMigrationError::SqliteStoreWrite {
+                domain: MESSAGE_LIFECYCLE_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            })?;
+        sqlite_store.write(snapshot.clone()).map_err(|error| {
+            SnapshotMigrationError::SqliteStoreWrite {
+                domain: MESSAGE_LIFECYCLE_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        let sqlite_snapshot = sqlite_store.read_latest().map_err(|error| {
+            SnapshotMigrationError::SqliteStoreRead {
+                domain: MESSAGE_LIFECYCLE_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_READ_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        if sqlite_snapshot != Some(snapshot) {
+            return Err(SnapshotMigrationError::ParityMismatch {
+                domain: MESSAGE_LIFECYCLE_STORE_DOMAIN,
+                reason_code: REASON_PARITY_MISMATCH,
+                detail: "sqlite message lifecycle snapshot does not match legacy payload"
+                    .to_owned(),
+            });
+        }
+        migrated_domains.push(MESSAGE_LIFECYCLE_STORE_DOMAIN);
+        migrated_snapshot_count += 1;
+    }
+
+    let task_file_store =
+        FileTaskOperationSnapshotStore::new(storage_root.join(TASK_OPERATION_STORE_FILE_NAME))
+            .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+                domain: TASK_OPERATION_STORE_DOMAIN,
+                reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+                detail: error.to_string(),
+            })?;
+    let task_snapshot =
+        task_file_store
+            .read_latest()
+            .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+                domain: TASK_OPERATION_STORE_DOMAIN,
+                reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+                detail: error.to_string(),
+            })?;
+    if let Some(snapshot) = task_snapshot {
+        let mut sqlite_store = SqliteTaskOperationSnapshotStore::new(sqlite_path.to_path_buf())
+            .map_err(|error| SnapshotMigrationError::SqliteStoreWrite {
+                domain: TASK_OPERATION_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            })?;
+        sqlite_store.write(snapshot.clone()).map_err(|error| {
+            SnapshotMigrationError::SqliteStoreWrite {
+                domain: TASK_OPERATION_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        let sqlite_snapshot = sqlite_store.read_latest().map_err(|error| {
+            SnapshotMigrationError::SqliteStoreRead {
+                domain: TASK_OPERATION_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_READ_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        if sqlite_snapshot != Some(snapshot) {
+            return Err(SnapshotMigrationError::ParityMismatch {
+                domain: TASK_OPERATION_STORE_DOMAIN,
+                reason_code: REASON_PARITY_MISMATCH,
+                detail: "sqlite task operation snapshot does not match legacy payload".to_owned(),
+            });
+        }
+        migrated_domains.push(TASK_OPERATION_STORE_DOMAIN);
+        migrated_snapshot_count += 1;
+    }
+
+    let durable_file_store =
+        FileDurableGuardSnapshotStore::new(storage_root.join(DURABLE_GUARD_STORE_FILE_NAME))
+            .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+                domain: DURABLE_GUARD_STORE_DOMAIN,
+                reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+                detail: error.to_string(),
+            })?;
+    let durable_bundle = durable_file_store.load_bundle().map_err(|error| {
+        SnapshotMigrationError::LegacyStoreLoad {
+            domain: DURABLE_GUARD_STORE_DOMAIN,
+            reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+            detail: error.to_string(),
+        }
+    })?;
+    if let Some(bundle) = durable_bundle {
+        let mut sqlite_store = SqliteDurableGuardSnapshotStore::new(sqlite_path.to_path_buf())
+            .map_err(|error| SnapshotMigrationError::SqliteStoreWrite {
+                domain: DURABLE_GUARD_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            })?;
+        sqlite_store.save_bundle(bundle.clone()).map_err(|error| {
+            SnapshotMigrationError::SqliteStoreWrite {
+                domain: DURABLE_GUARD_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        let sqlite_bundle = sqlite_store.load_bundle().map_err(|error| {
+            SnapshotMigrationError::SqliteStoreRead {
+                domain: DURABLE_GUARD_STORE_DOMAIN,
+                reason_code: REASON_SQLITE_STORE_READ_FAILED,
+                detail: error.to_string(),
+            }
+        })?;
+        if sqlite_bundle != Some(bundle) {
+            return Err(SnapshotMigrationError::ParityMismatch {
+                domain: DURABLE_GUARD_STORE_DOMAIN,
+                reason_code: REASON_PARITY_MISMATCH,
+                detail: "sqlite durable guard bundle does not match legacy payload".to_owned(),
+            });
+        }
+        migrated_domains.push(DURABLE_GUARD_STORE_DOMAIN);
+        migrated_snapshot_count += 1;
+    }
+
+    let runtime_file_store = FileRuntimeSnapshotStore::new(
+        storage_root.join(RUNTIME_STORE_FILE_NAME),
+    )
+    .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+        domain: RUNTIME_STORE_DOMAIN,
+        reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+        detail: error.to_string(),
+    })?;
+    let runtime_snapshots =
+        runtime_file_store
+            .list()
+            .map_err(|error| SnapshotMigrationError::LegacyStoreLoad {
+                domain: RUNTIME_STORE_DOMAIN,
+                reason_code: REASON_LEGACY_STORE_LOAD_FAILED,
+                detail: error.to_string(),
+            })?;
+    if !runtime_snapshots.is_empty() {
+        let mut sqlite_store =
+            SqliteRuntimeSnapshotStore::new(sqlite_path.to_path_buf()).map_err(|error| {
+                SnapshotMigrationError::SqliteStoreWrite {
+                    domain: RUNTIME_STORE_DOMAIN,
+                    reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                    detail: error.to_string(),
+                }
+            })?;
+        for snapshot in &runtime_snapshots {
+            sqlite_store.write(snapshot.clone()).map_err(|error| {
+                SnapshotMigrationError::SqliteStoreWrite {
+                    domain: RUNTIME_STORE_DOMAIN,
+                    reason_code: REASON_SQLITE_STORE_WRITE_FAILED,
+                    detail: error.to_string(),
+                }
+            })?;
+        }
+        let sqlite_snapshots =
+            sqlite_store
+                .list()
+                .map_err(|error| SnapshotMigrationError::SqliteStoreRead {
+                    domain: RUNTIME_STORE_DOMAIN,
+                    reason_code: REASON_SQLITE_STORE_READ_FAILED,
+                    detail: error.to_string(),
+                })?;
+        if sqlite_snapshots != runtime_snapshots {
+            return Err(SnapshotMigrationError::ParityMismatch {
+                domain: RUNTIME_STORE_DOMAIN,
+                reason_code: REASON_PARITY_MISMATCH,
+                detail: "sqlite runtime snapshots do not match legacy payload".to_owned(),
+            });
+        }
+        migrated_domains.push(RUNTIME_STORE_DOMAIN);
+        migrated_snapshot_count += runtime_snapshots.len();
+    }
+
+    Ok(SnapshotMigrationParityReport {
+        reason_code: REASON_PARITY_PASS,
+        migrated_domains,
+        migrated_snapshot_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        migrate_file_snapshots_to_sqlite_parity, SnapshotMigrationError,
+        REASON_SQLITE_PATH_INVALID, REASON_STORAGE_ROOT_INVALID,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn unit_migration_rejects_missing_storage_root() {
+        let missing_root = PathBuf::from("/tmp/kamn-nonexistent-migration-root");
+        let sqlite_path = PathBuf::from("/tmp/kamn-migration.sqlite");
+        let result =
+            migrate_file_snapshots_to_sqlite_parity(missing_root.as_path(), sqlite_path.as_path());
+        assert!(
+            matches!(
+                result,
+                Err(SnapshotMigrationError::InvalidStorageRoot { reason_code, .. })
+                    if reason_code == REASON_STORAGE_ROOT_INVALID
+            ),
+            "missing source storage root must fail closed"
+        );
+    }
+
+    #[test]
+    fn unit_migration_rejects_empty_sqlite_path() {
+        let root = std::env::temp_dir();
+        let result =
+            migrate_file_snapshots_to_sqlite_parity(root.as_path(), PathBuf::new().as_path());
+        assert!(
+            matches!(
+                result,
+                Err(SnapshotMigrationError::InvalidSqlitePath { reason_code, .. })
+                    if reason_code == REASON_SQLITE_PATH_INVALID
+            ),
+            "empty sqlite path must fail closed"
+        );
+    }
+}

--- a/crates/kamn-core/tests/file_to_sqlite_migration_parity.rs
+++ b/crates/kamn-core/tests/file_to_sqlite_migration_parity.rs
@@ -1,0 +1,188 @@
+use kamn_core::{
+    migrate_file_snapshots_to_sqlite_parity, ChannelPermissionEngine, ChannelSnapshotStore,
+    ChannelStore, DurableGuardBundleSnapshotStore, DurableGuardSnapshotBundle,
+    FileChannelSnapshotStore, FileDurableGuardSnapshotStore, FileMessageLifecycleSnapshotStore,
+    FileRuntimeSnapshotStore, FileTaskOperationSnapshotStore, MessageDeliveryGuards,
+    MessageLifecycleSnapshotStore, MessageLifecycleStore, RuntimeSnapshot, RuntimeSnapshotStore,
+    SnapshotMigrationError, SnapshotMigrationParityReport, SqliteChannelSnapshotStore,
+    SqliteDurableGuardSnapshotStore, SqliteMessageLifecycleSnapshotStore,
+    SqliteRuntimeSnapshotStore, SqliteTaskOperationSnapshotStore, TaskOperationEngine,
+    TaskOperationSnapshotStore,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be monotonic")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-{tag}-{unique}"))
+}
+
+#[test]
+fn functional_migration_corpus_replays_file_snapshots_into_sqlite() {
+    let root = temp_dir("file-sqlite-migration-corpus");
+    fs::create_dir_all(&root).expect("fixture directory should build");
+    let sqlite_path = root.join("migration-parity.sqlite");
+
+    let mut channel_file_store =
+        FileChannelSnapshotStore::new(root.join("channel.snapshot")).expect("channel file store");
+    let channel_snapshot = ChannelStore::new().export_snapshot();
+    channel_file_store
+        .write(channel_snapshot.clone())
+        .expect("channel snapshot should persist");
+
+    let mut message_file_store =
+        FileMessageLifecycleSnapshotStore::new(root.join("message-lifecycle.snapshot"))
+            .expect("message file store");
+    let message_snapshot = MessageLifecycleStore::new().export_snapshot();
+    message_file_store
+        .write(message_snapshot.clone())
+        .expect("message snapshot should persist");
+
+    let mut task_file_store =
+        FileTaskOperationSnapshotStore::new(root.join("task-operation.snapshot"))
+            .expect("task file store");
+    let task_snapshot = TaskOperationEngine::new().export_snapshot();
+    task_file_store
+        .write(task_snapshot.clone())
+        .expect("task snapshot should persist");
+
+    let mut durable_file_store =
+        FileDurableGuardSnapshotStore::new(root.join("durable-guard.snapshot"))
+            .expect("durable file store");
+    let durable_bundle = DurableGuardSnapshotBundle::capture(
+        &MessageDeliveryGuards::new(),
+        &ChannelPermissionEngine::new(),
+    );
+    durable_file_store
+        .save_bundle(durable_bundle.clone())
+        .expect("durable bundle should persist");
+
+    let mut runtime_file_store = FileRuntimeSnapshotStore::new(root.join("runtime.snapshot"))
+        .expect("runtime file store should initialize");
+    let runtime_first = RuntimeSnapshot::new(1, "runtime-state-v1").expect("runtime snapshot");
+    let runtime_second =
+        RuntimeSnapshot::with_cursor(2, "runtime-state-v2", 2).expect("runtime snapshot");
+    runtime_file_store
+        .write(runtime_first.clone())
+        .expect("runtime first snapshot should persist");
+    runtime_file_store
+        .write(runtime_second.clone())
+        .expect("runtime second snapshot should persist");
+
+    let report = migrate_file_snapshots_to_sqlite_parity(root.as_path(), sqlite_path.as_path())
+        .expect("migration parity should pass");
+    assert_eq!(
+        report,
+        SnapshotMigrationParityReport {
+            reason_code: "snapshot_migration_parity_pass",
+            migrated_domains: vec![
+                "channel-snapshot-store",
+                "message-lifecycle-snapshot-store",
+                "task-operation-snapshot-store",
+                "durable-guard-snapshot-store",
+                "runtime-snapshot-store",
+            ],
+            migrated_snapshot_count: 6,
+        }
+    );
+
+    let channel_sqlite_store =
+        SqliteChannelSnapshotStore::new(sqlite_path.clone()).expect("sqlite channel");
+    assert_eq!(
+        channel_sqlite_store
+            .read_latest()
+            .expect("sqlite channel read should pass"),
+        Some(channel_snapshot)
+    );
+
+    let message_sqlite_store =
+        SqliteMessageLifecycleSnapshotStore::new(sqlite_path.clone()).expect("sqlite message");
+    assert_eq!(
+        message_sqlite_store
+            .read_latest()
+            .expect("sqlite message read should pass"),
+        Some(message_snapshot)
+    );
+
+    let task_sqlite_store =
+        SqliteTaskOperationSnapshotStore::new(sqlite_path.clone()).expect("sqlite task");
+    assert_eq!(
+        task_sqlite_store
+            .read_latest()
+            .expect("sqlite task read should pass"),
+        Some(task_snapshot)
+    );
+
+    let durable_sqlite_store =
+        SqliteDurableGuardSnapshotStore::new(sqlite_path.clone()).expect("sqlite durable");
+    assert_eq!(
+        durable_sqlite_store
+            .load_bundle()
+            .expect("sqlite durable read should pass"),
+        Some(durable_bundle)
+    );
+
+    let runtime_sqlite_store =
+        SqliteRuntimeSnapshotStore::new(sqlite_path.clone()).expect("sqlite runtime");
+    assert_eq!(
+        runtime_sqlite_store
+            .list()
+            .expect("sqlite runtime list should pass"),
+        vec![runtime_first, runtime_second]
+    );
+}
+
+#[test]
+fn integration_migration_checker_fails_closed_on_corrupt_legacy_payload() {
+    let root = temp_dir("file-sqlite-migration-corrupt");
+    fs::create_dir_all(&root).expect("fixture directory should build");
+    fs::write(root.join("channel.snapshot"), "schema|1\nbroken\n")
+        .expect("corrupt fixture should persist");
+    let sqlite_path = root.join("migration-corrupt.sqlite");
+
+    let error = migrate_file_snapshots_to_sqlite_parity(root.as_path(), sqlite_path.as_path())
+        .expect_err("corrupt fixture must fail closed");
+    match error {
+        SnapshotMigrationError::LegacyStoreLoad {
+            domain,
+            reason_code,
+            ..
+        } => {
+            assert_eq!(domain, "channel-snapshot-store");
+            assert_eq!(reason_code, "snapshot_migration_legacy_store_load_failed");
+        }
+        other => panic!("unexpected migration error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn performance_migration_corpus_replay_stays_within_local_budget() {
+    let root = temp_dir("file-sqlite-migration-budget");
+    fs::create_dir_all(&root).expect("fixture directory should build");
+    let sqlite_path = root.join("migration-budget.sqlite");
+
+    let mut runtime_file_store = FileRuntimeSnapshotStore::new(root.join("runtime.snapshot"))
+        .expect("runtime file store should initialize");
+    for version in 1..=64_u64 {
+        let state_hash = format!("runtime-state-{version}");
+        let snapshot =
+            RuntimeSnapshot::with_cursor(version, state_hash.as_str(), version).expect("snapshot");
+        runtime_file_store
+            .write(snapshot)
+            .expect("runtime snapshot should persist");
+    }
+
+    let started = Instant::now();
+    let report = migrate_file_snapshots_to_sqlite_parity(root.as_path(), sqlite_path.as_path())
+        .expect("migration parity should pass");
+    let elapsed = started.elapsed();
+    assert_eq!(report.reason_code, "snapshot_migration_parity_pass");
+    assert!(
+        elapsed <= Duration::from_secs(2),
+        "migration corpus replay should remain bounded (elapsed={elapsed:?})"
+    );
+}

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -64,6 +64,20 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - `task_operation_snapshot_journal_corrupt_tail:<line>`
 - Regression: #2690
 
+## File-to-Sqlite Migration Parity Contract
+- Snapshot migration parity policy is tracked in `docs/plans/2026-02-14-production-service-next-steps.md`.
+- Migration parity corpus commands:
+  - `cargo test -p kamn-core --lib snapshot_migration::tests::`
+  - `cargo test -p kamn-core --test file_to_sqlite_migration_parity`
+- Deterministic migration contracts:
+  - replay compares legacy file snapshots against sqlite roundtrip payloads across channel/message/task/durable/runtime domains.
+  - corrupt legacy fixtures fail closed with typed migration errors and stable reason codes.
+  - successful migration reports `snapshot_migration_parity_pass`.
+- Cost controls:
+  - corpus remains bounded to local synthetic fixtures with deterministic payload size.
+  - performance lane enforces a bounded local replay budget in under 2 seconds for a 64-snapshot runtime corpus.
+- Regression: #3311
+
 ## Runtime Backpressure Enforcement Contract
 - Runtime backpressure enforcement policy is tracked in `docs/planning/runtime_backpressure_policy.md`.
 - Fast-gate backpressure contract command:


### PR DESCRIPTION
## Summary
This adds a deterministic file-to-sqlite migration parity checker for runtime-adjacent snapshot stores and a corpus-driven test lane that validates replay parity and fail-closed corruption handling. It also documents the new migration lane in CI strategy guidance.

Closes #3311

## Changes
- `crates/kamn-core/src/snapshot_migration.rs`: added migration checker, parity report/error taxonomy, and unit tests.
- `crates/kamn-core/src/lib.rs`: exported migration API surface.
- `crates/kamn-core/tests/file_to_sqlite_migration_parity.rs`: added functional/integration/performance migration corpus tests.
- `docs/ci/strategy.md`: documented file-to-sqlite migration parity contract lane and bounded budget.

## Risks & Compatibility
- No breaking API removals; this adds new API and tests.
- Migration checker is fail-closed and does not alter existing runtime bootstrap path behavior.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated parity across channel/message/task/durable/runtime snapshot domains and corruption failure contract.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core --lib snapshot_migration::tests::` |
| Functional  | ✅ | `cargo test -p kamn-core --test file_to_sqlite_migration_parity functional_migration_corpus_replays_file_snapshots_into_sqlite -- --exact` |
| Integration | ✅ | `cargo test -p kamn-core --test file_to_sqlite_migration_parity integration_migration_checker_fails_closed_on_corrupt_legacy_payload -- --exact` |
| Regression  | ✅ | `cargo test -p kamn-core --test missing_docs_policy`; `cargo test -p kamn-core --lib` |
