### PR TITLE
feat(core): wire transport-fed block pipeline commit path (#3357)

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -1,5 +1,6 @@
 //! Mempool block production and consensus validation pipeline contracts.
 
+use crate::config::NodeRole;
 use crate::runtime::{
     ApproverAttestation, ApproverQuorumDecision, ApproverQuorumError, ApproverQuorumEvaluator,
     ApproverQuorumInput, ListenerAttestation, ListenerQuorumDecision, ListenerQuorumError,
@@ -56,6 +57,15 @@ pub enum BlockPipelineError {
         /// Found override digest.
         found: String,
     },
+    /// Transport feed returned an error while draining mempool candidates.
+    TransportFeed(String),
+    /// Canonical commit store returned an error while persisting/listing records.
+    CommitStore(String),
+    /// Fork-choice hook rejected canonical candidate block.
+    ForkChoiceRejected {
+        /// Deterministic reason code supplied by fork-choice hook.
+        reason_code: String,
+    },
 }
 
 impl From<ListenerQuorumError> for BlockPipelineError {
@@ -92,11 +102,150 @@ impl Display for BlockPipelineError {
                     "block pipeline payload digest mismatch: expected {expected}, found {found}"
                 )
             }
+            Self::TransportFeed(detail) => {
+                write!(f, "block pipeline transport feed error: {detail}")
+            }
+            Self::CommitStore(detail) => write!(f, "block pipeline commit store error: {detail}"),
+            Self::ForkChoiceRejected { reason_code } => {
+                write!(
+                    f,
+                    "block pipeline fork-choice rejected candidate: {reason_code}"
+                )
+            }
         }
     }
 }
 
 impl Error for BlockPipelineError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Canonical commit record persisted after fork-choice acceptance.
+pub struct CanonicalCommitRecord {
+    /// Committed block height.
+    pub block_height: u64,
+    /// Producer role for the committed block.
+    pub producer_role: NodeRole,
+    /// Deterministic block payload digest.
+    pub payload_digest: String,
+    /// Ordered committed transaction identifiers.
+    pub transaction_ids: Vec<String>,
+}
+
+impl CanonicalCommitRecord {
+    fn from_commit_report(report: &BlockPipelineCommitReport) -> Self {
+        Self {
+            block_height: report.block.height,
+            producer_role: report.block.producer.clone(),
+            payload_digest: report.payload_digest.clone(),
+            transaction_ids: report
+                .block
+                .transactions
+                .iter()
+                .map(|tx| tx.id.clone())
+                .collect(),
+        }
+    }
+}
+
+/// Transport feed abstraction for draining pending mempool candidates.
+pub trait TransportMempoolFeed {
+    /// Drains pending transport candidates in implementation-defined order.
+    fn drain_pending_transactions(
+        &mut self,
+    ) -> Result<Vec<BaselineTransaction>, BlockPipelineError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// In-memory transport feed used for deterministic tests and local contract lanes.
+pub struct InMemoryTransportMempoolFeed {
+    pending: Vec<BaselineTransaction>,
+}
+
+impl InMemoryTransportMempoolFeed {
+    /// Creates in-memory transport feed with deterministic pending queue.
+    pub fn new(pending: Vec<BaselineTransaction>) -> Self {
+        Self { pending }
+    }
+
+    /// Pushes candidate transaction into pending queue.
+    pub fn push(&mut self, tx: BaselineTransaction) {
+        self.pending.push(tx);
+    }
+}
+
+impl TransportMempoolFeed for InMemoryTransportMempoolFeed {
+    fn drain_pending_transactions(
+        &mut self,
+    ) -> Result<Vec<BaselineTransaction>, BlockPipelineError> {
+        Ok(std::mem::take(&mut self.pending))
+    }
+}
+
+/// Canonical commit persistence interface used by transport-fed block pipeline.
+pub trait CanonicalCommitStore {
+    /// Persists canonical commit record after fork-choice acceptance.
+    fn persist_canonical_commit(
+        &mut self,
+        record: CanonicalCommitRecord,
+    ) -> Result<(), BlockPipelineError>;
+
+    /// Lists canonical commit records in persistence order.
+    fn list_canonical_commits(&self) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// In-memory canonical commit store for deterministic tests and local runtime probes.
+pub struct InMemoryCanonicalCommitStore {
+    records: Vec<CanonicalCommitRecord>,
+}
+
+impl CanonicalCommitStore for InMemoryCanonicalCommitStore {
+    fn persist_canonical_commit(
+        &mut self,
+        record: CanonicalCommitRecord,
+    ) -> Result<(), BlockPipelineError> {
+        self.records.push(record);
+        Ok(())
+    }
+
+    fn list_canonical_commits(&self) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
+        Ok(self.records.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Fork-choice decision for canonical candidate commit.
+pub enum ForkChoiceDecision {
+    /// Candidate is accepted as canonical.
+    Accept,
+    /// Candidate is rejected with deterministic reason code.
+    Reject {
+        /// Deterministic rejection reason code.
+        reason_code: String,
+    },
+}
+
+/// Fork-choice evaluation hook for candidate canonical commit records.
+pub trait ForkChoiceHook {
+    /// Evaluates candidate canonical commit and returns deterministic decision.
+    fn evaluate_candidate(
+        &mut self,
+        record: &CanonicalCommitRecord,
+    ) -> Result<ForkChoiceDecision, BlockPipelineError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// Fork-choice hook that accepts every candidate.
+pub struct AcceptAllForkChoiceHook;
+
+impl ForkChoiceHook for AcceptAllForkChoiceHook {
+    fn evaluate_candidate(
+        &mut self,
+        _record: &CanonicalCommitRecord,
+    ) -> Result<ForkChoiceDecision, BlockPipelineError> {
+        Ok(ForkChoiceDecision::Accept)
+    }
+}
 
 /// Deterministic mempool->consensus->commit pipeline for processor runtime flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -104,6 +253,83 @@ pub struct MempoolBlockPipeline {
     network: RoleSmokeNetwork,
     listener_evaluator: ListenerQuorumEvaluator,
     approver_required_approvals: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Transport-fed block pipeline that persists canonical commit records.
+pub struct TransportFedBlockPipeline<TFeed, TStore, THook> {
+    pipeline: MempoolBlockPipeline,
+    transport_feed: TFeed,
+    commit_store: TStore,
+    fork_choice_hook: THook,
+}
+
+impl<TFeed, TStore, THook> TransportFedBlockPipeline<TFeed, TStore, THook>
+where
+    TFeed: TransportMempoolFeed,
+    TStore: CanonicalCommitStore,
+    THook: ForkChoiceHook,
+{
+    /// Builds transport-fed block pipeline with supplied transport, persistence, and fork-choice hook.
+    pub fn new(
+        gossip_enabled: bool,
+        listener_required_confirmations: usize,
+        approver_required_approvals: usize,
+        transport_feed: TFeed,
+        commit_store: TStore,
+        fork_choice_hook: THook,
+    ) -> Result<Self, BlockPipelineError> {
+        Ok(Self {
+            pipeline: MempoolBlockPipeline::new(
+                gossip_enabled,
+                listener_required_confirmations,
+                approver_required_approvals,
+            )?,
+            transport_feed,
+            commit_store,
+            fork_choice_hook,
+        })
+    }
+
+    /// Runs one transport-fed consensus round and persists canonical commit record.
+    pub fn run_transport_consensus_round(
+        &mut self,
+        input: BlockConsensusRoundInput,
+    ) -> Result<BlockPipelineCommitReport, BlockPipelineError> {
+        let mut candidates = self.transport_feed.drain_pending_transactions()?;
+        if candidates.is_empty() {
+            return Err(BlockPipelineError::EmptyMempool);
+        }
+        sort_candidates_for_ingress(&mut candidates);
+        for candidate in candidates {
+            self.pipeline.submit_transaction(candidate)?;
+        }
+
+        let report = self.pipeline.run_consensus_round(input)?;
+        let commit_record = CanonicalCommitRecord::from_commit_report(&report);
+        match self.fork_choice_hook.evaluate_candidate(&commit_record)? {
+            ForkChoiceDecision::Accept => {}
+            ForkChoiceDecision::Reject { reason_code } => {
+                return Err(BlockPipelineError::ForkChoiceRejected { reason_code });
+            }
+        }
+        self.commit_store.persist_canonical_commit(commit_record)?;
+        Ok(report)
+    }
+
+    /// Lists canonical commit records from configured persistence backend.
+    pub fn list_canonical_commits(&self) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
+        self.commit_store.list_canonical_commits()
+    }
+}
+
+fn sort_candidates_for_ingress(candidates: &mut [BaselineTransaction]) {
+    candidates.sort_by(|left, right| {
+        left.nonce
+            .cmp(&right.nonce)
+            .then_with(|| left.id.cmp(&right.id))
+            .then_with(|| left.sender.cmp(&right.sender))
+    });
 }
 
 impl MempoolBlockPipeline {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -152,7 +152,10 @@ pub use audit_exports::{
     AuditExportFilter, AuditExportFormat, AuditExportManifest, AuditExportRequest,
 };
 pub use block_pipeline::{
-    BlockConsensusRoundInput, BlockPipelineCommitReport, BlockPipelineError, MempoolBlockPipeline,
+    AcceptAllForkChoiceHook, BlockConsensusRoundInput, BlockPipelineCommitReport,
+    BlockPipelineError, CanonicalCommitRecord, CanonicalCommitStore, ForkChoiceDecision,
+    ForkChoiceHook, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
+    MempoolBlockPipeline, TransportFedBlockPipeline, TransportMempoolFeed,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/block_pipeline_transport_fed.rs
+++ b/crates/kamn-core/tests/block_pipeline_transport_fed.rs
@@ -1,0 +1,124 @@
+use kamn_core::{
+    BaselineTransaction, BlockConsensusRoundInput, BlockPipelineError, ForkChoiceDecision,
+    ForkChoiceHook, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
+    MempoolBlockPipeline, TransportFedBlockPipeline,
+};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Default)]
+struct RejectAllForkChoiceHook;
+
+impl ForkChoiceHook for RejectAllForkChoiceHook {
+    fn evaluate_candidate(
+        &mut self,
+        _record: &kamn_core::CanonicalCommitRecord,
+    ) -> Result<ForkChoiceDecision, BlockPipelineError> {
+        Ok(ForkChoiceDecision::Reject {
+            reason_code: "fork_choice_rejected_for_test".to_owned(),
+        })
+    }
+}
+
+fn sample_consensus_input() -> BlockConsensusRoundInput {
+    BlockConsensusRoundInput {
+        listener_event_id: "event-1".to_owned(),
+        listener_event_sequence: 1,
+        outbound_action_id: "outbound-1".to_owned(),
+        listener_votes: vec![("kamn:did:listener:alpha".to_owned(), "att-1".to_owned())],
+        approver_votes: vec![(
+            "kamn:did:agent:approver-alpha".to_owned(),
+            "att-1".to_owned(),
+            None,
+        )],
+    }
+}
+
+fn build_valid_chain_transactions() -> Vec<BaselineTransaction> {
+    let mut planner = MempoolBlockPipeline::new(true, 1, 1).expect("planner pipeline should build");
+    let state_hash_one = planner.expected_state_hash().to_owned();
+    let tx_one = BaselineTransaction::signed("tx-1", "agent-a", 1, "payload-1", &state_hash_one);
+    planner
+        .submit_transaction(tx_one.clone())
+        .expect("first tx should be accepted");
+    let state_hash_two = planner.expected_state_hash().to_owned();
+    let tx_two = BaselineTransaction::signed("tx-2", "agent-a", 2, "payload-2", &state_hash_two);
+    vec![tx_two, tx_one]
+}
+
+#[test]
+fn functional_transport_fed_pipeline_orders_candidates_and_persists_commit() {
+    let feed = InMemoryTransportMempoolFeed::new(build_valid_chain_transactions());
+    let store = InMemoryCanonicalCommitStore::default();
+    let mut pipeline =
+        TransportFedBlockPipeline::new(true, 1, 1, feed, store, kamn_core::AcceptAllForkChoiceHook)
+            .expect("transport-fed pipeline should build");
+
+    let report = pipeline
+        .run_transport_consensus_round(sample_consensus_input())
+        .expect("transport-fed round should commit");
+    let committed_ids = report
+        .block
+        .transactions
+        .iter()
+        .map(|tx| tx.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(committed_ids, vec!["tx-1", "tx-2"]);
+
+    let commit_records = pipeline
+        .list_canonical_commits()
+        .expect("canonical commit list should load");
+    assert_eq!(commit_records.len(), 1);
+    assert_eq!(commit_records[0].payload_digest, report.payload_digest);
+    assert_eq!(commit_records[0].transaction_ids, vec!["tx-1", "tx-2"]);
+}
+
+#[test]
+fn integration_transport_fed_pipeline_respects_fork_choice_rejects() {
+    let feed = InMemoryTransportMempoolFeed::new(build_valid_chain_transactions());
+    let store = InMemoryCanonicalCommitStore::default();
+    let mut pipeline =
+        TransportFedBlockPipeline::new(true, 1, 1, feed, store, RejectAllForkChoiceHook)
+            .expect("transport-fed pipeline should build");
+
+    let result = pipeline.run_transport_consensus_round(sample_consensus_input());
+    assert_eq!(
+        result,
+        Err(BlockPipelineError::ForkChoiceRejected {
+            reason_code: "fork_choice_rejected_for_test".to_owned(),
+        })
+    );
+    assert!(pipeline
+        .list_canonical_commits()
+        .expect("canonical commit list should load")
+        .is_empty());
+}
+
+#[test]
+fn regression_transport_fed_pipeline_rejects_empty_transport_feed() {
+    let feed = InMemoryTransportMempoolFeed::new(Vec::new());
+    let store = InMemoryCanonicalCommitStore::default();
+    let mut pipeline =
+        TransportFedBlockPipeline::new(true, 1, 1, feed, store, kamn_core::AcceptAllForkChoiceHook)
+            .expect("transport-fed pipeline should build");
+
+    let result = pipeline.run_transport_consensus_round(sample_consensus_input());
+    assert_eq!(result, Err(BlockPipelineError::EmptyMempool));
+}
+
+#[test]
+fn performance_transport_fed_pipeline_commit_path_stays_within_local_budget() {
+    let feed = InMemoryTransportMempoolFeed::new(build_valid_chain_transactions());
+    let store = InMemoryCanonicalCommitStore::default();
+    let mut pipeline =
+        TransportFedBlockPipeline::new(true, 1, 1, feed, store, kamn_core::AcceptAllForkChoiceHook)
+            .expect("transport-fed pipeline should build");
+
+    let started = Instant::now();
+    let _ = pipeline
+        .run_transport_consensus_round(sample_consensus_input())
+        .expect("transport-fed round should commit");
+    assert!(
+        started.elapsed() <= Duration::from_secs(2),
+        "transport-fed commit path should remain bounded"
+    );
+}

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -183,6 +183,17 @@ This document captures node-runtime productionization slices for machine-readabl
   - `SchemaVersionMismatch`
   - `Query`
 
+## Transport-Fed Block Pipeline Contracts
+- `TransportFedBlockPipeline` consumes transaction candidates from `TransportMempoolFeed` rather than synthetic-only mempool input.
+- Canonical commits persist through `CanonicalCommitStore` after fork-choice acceptance.
+- Fork-choice integration points are deterministic:
+  - `ForkChoiceHook::evaluate_candidate(...)` drives `Accept` vs `Reject` decisions
+  - reject path fails closed via `BlockPipelineError::ForkChoiceRejected`
+- Canonical commit payload includes:
+  - block height and producer role
+  - deterministic payload digest
+  - ordered committed transaction IDs
+
 ## Diagnostics Snapshot Rules
 - Supported diagnostics modes:
   - `basic` (default)


### PR DESCRIPTION
## Summary
This introduces transport-fed block production contracts and canonical commit persistence for the block pipeline. The new path ingests candidates from a transport feed, applies deterministic ordering, runs consensus/commit, evaluates fork-choice hooks, and persists canonical commit records via a configured store.

Closes #3357

## Changes
- `crates/kamn-core/src/block_pipeline.rs`: added transport feed/store traits, canonical commit record model, fork-choice hook surface, in-memory implementations, and `TransportFedBlockPipeline`.
- `crates/kamn-core/src/lib.rs`: exported new block pipeline transport/persistence/fork-choice contracts.
- `crates/kamn-core/tests/block_pipeline_transport_fed.rs`: added functional/integration/regression/performance tests for transport-fed pipeline behavior.
- `docs/foundation/node-runtime-cli.md`: documented transport-fed block pipeline integration contracts.

## Risks & Compatibility
- Existing `MempoolBlockPipeline` behavior remains unchanged.
- New transport-fed pipeline path is additive and fail-closed on empty feed and fork-choice rejection.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated ordering, persistence, and fork-choice rejection behavior through dedicated transport-fed tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | `cargo test -p kamn-core --lib block_pipeline::tests::` |
| Functional  | ✅ | `cargo test -p kamn-core --test block_pipeline_transport_fed functional_transport_fed_pipeline_orders_candidates_and_persists_commit -- --exact` |
| Integration | ✅ | `cargo test -p kamn-core --test block_pipeline_transport_fed integration_transport_fed_pipeline_respects_fork_choice_rejects -- --exact` |
| Regression  | ✅ | `cargo test -p kamn-core --test block_pipeline_transport_fed regression_transport_fed_pipeline_rejects_empty_transport_feed -- --exact`; `cargo test -p kamn-node --test node_runtime_cli_docs` |
