### PR TITLE
test(core): add deterministic competing-branch fork-choice regression corpus (#3317)

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -247,6 +247,73 @@ impl ForkChoiceHook for AcceptAllForkChoiceHook {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Deterministic fork-choice hook for competing branch candidates.
+///
+/// Selection rules:
+/// - Higher `block_height` always wins.
+/// - At equal `block_height`, lexicographically lower `payload_digest` wins.
+/// - Identical height+digest is treated as duplicate candidate and rejected.
+pub struct DeterministicCompetingBranchForkChoiceHook {
+    canonical_head: Option<CanonicalCommitRecord>,
+}
+
+impl DeterministicCompetingBranchForkChoiceHook {
+    /// Creates deterministic competing-branch hook with empty head.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates deterministic competing-branch hook seeded with existing canonical head.
+    pub fn with_canonical_head(canonical_head: CanonicalCommitRecord) -> Self {
+        Self {
+            canonical_head: Some(canonical_head),
+        }
+    }
+
+    /// Returns currently selected canonical head, if any.
+    pub fn canonical_head(&self) -> Option<&CanonicalCommitRecord> {
+        self.canonical_head.as_ref()
+    }
+}
+
+impl ForkChoiceHook for DeterministicCompetingBranchForkChoiceHook {
+    fn evaluate_candidate(
+        &mut self,
+        record: &CanonicalCommitRecord,
+    ) -> Result<ForkChoiceDecision, BlockPipelineError> {
+        let Some(head) = self.canonical_head.as_ref() else {
+            self.canonical_head = Some(record.clone());
+            return Ok(ForkChoiceDecision::Accept);
+        };
+
+        if record.block_height > head.block_height {
+            self.canonical_head = Some(record.clone());
+            return Ok(ForkChoiceDecision::Accept);
+        }
+        if record.block_height < head.block_height {
+            return Ok(ForkChoiceDecision::Reject {
+                reason_code: "fork_choice_stale_block_height".to_owned(),
+            });
+        }
+
+        if record.payload_digest == head.payload_digest {
+            return Ok(ForkChoiceDecision::Reject {
+                reason_code: "fork_choice_duplicate_candidate".to_owned(),
+            });
+        }
+
+        if record.payload_digest < head.payload_digest {
+            self.canonical_head = Some(record.clone());
+            return Ok(ForkChoiceDecision::Accept);
+        }
+
+        Ok(ForkChoiceDecision::Reject {
+            reason_code: "fork_choice_tie_break_loser".to_owned(),
+        })
+    }
+}
+
 /// Deterministic mempool->consensus->commit pipeline for processor runtime flows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MempoolBlockPipeline {
@@ -457,7 +524,12 @@ fn payload_digest_for_transactions(transactions: &[BaselineTransaction]) -> Stri
 
 #[cfg(test)]
 mod tests {
-    use super::{payload_digest_for_transactions, BlockPipelineError, MempoolBlockPipeline};
+    use super::{
+        payload_digest_for_transactions, BlockPipelineError, CanonicalCommitRecord,
+        DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
+        MempoolBlockPipeline,
+    };
+    use crate::config::NodeRole;
     use crate::transaction::BaselineTransaction;
 
     #[test]
@@ -497,5 +569,97 @@ mod tests {
         let digest_a = payload_digest_for_transactions(&[tx1.clone(), tx2.clone()]);
         let digest_b = payload_digest_for_transactions(&[tx2, tx1]);
         assert_eq!(digest_a, digest_b);
+    }
+
+    #[test]
+    fn deterministic_competing_branch_hook_rejects_stale_candidate_height() {
+        let seeded_head = CanonicalCommitRecord {
+            block_height: 8,
+            producer_role: NodeRole::Processor,
+            payload_digest: "digest-z".to_owned(),
+            transaction_ids: vec!["tx-z".to_owned()],
+        };
+        let mut hook = DeterministicCompetingBranchForkChoiceHook::with_canonical_head(seeded_head);
+        let stale_candidate = CanonicalCommitRecord {
+            block_height: 7,
+            producer_role: NodeRole::Processor,
+            payload_digest: "digest-a".to_owned(),
+            transaction_ids: vec!["tx-a".to_owned()],
+        };
+
+        let decision = hook
+            .evaluate_candidate(&stale_candidate)
+            .expect("hook should evaluate stale candidate");
+        assert_eq!(
+            decision,
+            ForkChoiceDecision::Reject {
+                reason_code: "fork_choice_stale_block_height".to_owned(),
+            }
+        );
+        assert_eq!(
+            hook.canonical_head()
+                .expect("seeded canonical head should remain set")
+                .payload_digest,
+            "digest-z"
+        );
+    }
+
+    #[test]
+    fn deterministic_competing_branch_hook_prefers_lexicographically_lower_digest_on_tie() {
+        let mut hook = DeterministicCompetingBranchForkChoiceHook::new();
+        let branch_high = CanonicalCommitRecord {
+            block_height: 5,
+            producer_role: NodeRole::Processor,
+            payload_digest: "digest-b".to_owned(),
+            transaction_ids: vec!["tx-b".to_owned()],
+        };
+        let branch_low = CanonicalCommitRecord {
+            block_height: 5,
+            producer_role: NodeRole::Processor,
+            payload_digest: "digest-a".to_owned(),
+            transaction_ids: vec!["tx-a".to_owned()],
+        };
+
+        let first = hook
+            .evaluate_candidate(&branch_high)
+            .expect("first branch should evaluate");
+        let second = hook
+            .evaluate_candidate(&branch_low)
+            .expect("second branch should evaluate");
+
+        assert_eq!(first, ForkChoiceDecision::Accept);
+        assert_eq!(second, ForkChoiceDecision::Accept);
+        assert_eq!(
+            hook.canonical_head()
+                .expect("head should be selected after tie break")
+                .payload_digest,
+            "digest-a"
+        );
+    }
+
+    #[test]
+    fn deterministic_competing_branch_hook_rejects_duplicate_candidate() {
+        let mut hook = DeterministicCompetingBranchForkChoiceHook::new();
+        let candidate = CanonicalCommitRecord {
+            block_height: 11,
+            producer_role: NodeRole::Processor,
+            payload_digest: "digest-11".to_owned(),
+            transaction_ids: vec!["tx-11".to_owned()],
+        };
+
+        let first = hook
+            .evaluate_candidate(&candidate)
+            .expect("first candidate should evaluate");
+        let second = hook
+            .evaluate_candidate(&candidate)
+            .expect("duplicate candidate should evaluate");
+
+        assert_eq!(first, ForkChoiceDecision::Accept);
+        assert_eq!(
+            second,
+            ForkChoiceDecision::Reject {
+                reason_code: "fork_choice_duplicate_candidate".to_owned(),
+            }
+        );
     }
 }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -153,9 +153,10 @@ pub use audit_exports::{
 };
 pub use block_pipeline::{
     AcceptAllForkChoiceHook, BlockConsensusRoundInput, BlockPipelineCommitReport,
-    BlockPipelineError, CanonicalCommitRecord, CanonicalCommitStore, ForkChoiceDecision,
-    ForkChoiceHook, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
-    MempoolBlockPipeline, TransportFedBlockPipeline, TransportMempoolFeed,
+    BlockPipelineError, CanonicalCommitRecord, CanonicalCommitStore,
+    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
+    InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed, MempoolBlockPipeline,
+    TransportFedBlockPipeline, TransportMempoolFeed,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/block_pipeline_transport_fed.rs
+++ b/crates/kamn-core/tests/block_pipeline_transport_fed.rs
@@ -1,7 +1,8 @@
 use kamn_core::{
-    BaselineTransaction, BlockConsensusRoundInput, BlockPipelineError, ForkChoiceDecision,
-    ForkChoiceHook, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
-    MempoolBlockPipeline, TransportFedBlockPipeline,
+    BaselineTransaction, BlockConsensusRoundInput, BlockPipelineError, CanonicalCommitRecord,
+    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
+    InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed, MempoolBlockPipeline,
+    TransportFedBlockPipeline,
 };
 use std::time::{Duration, Instant};
 
@@ -121,4 +122,75 @@ fn performance_transport_fed_pipeline_commit_path_stays_within_local_budget() {
         started.elapsed() <= Duration::from_secs(2),
         "transport-fed commit path should remain bounded"
     );
+}
+
+#[test]
+fn regression_competing_branch_fork_choice_prefers_stable_head_independent_of_candidate_order() {
+    let mut hook_a = DeterministicCompetingBranchForkChoiceHook::default();
+    let mut hook_b = DeterministicCompetingBranchForkChoiceHook::default();
+
+    let branch_a = CanonicalCommitRecord {
+        block_height: 9,
+        producer_role: kamn_core::NodeRole::Processor,
+        payload_digest: "digest-b".to_owned(),
+        transaction_ids: vec!["tx-b".to_owned()],
+    };
+    let branch_b = CanonicalCommitRecord {
+        block_height: 9,
+        producer_role: kamn_core::NodeRole::Processor,
+        payload_digest: "digest-a".to_owned(),
+        transaction_ids: vec!["tx-a".to_owned()],
+    };
+
+    hook_a
+        .evaluate_candidate(&branch_a)
+        .expect("first branch should evaluate");
+    hook_a
+        .evaluate_candidate(&branch_b)
+        .expect("second branch should evaluate");
+
+    hook_b
+        .evaluate_candidate(&branch_b)
+        .expect("first branch should evaluate");
+    hook_b
+        .evaluate_candidate(&branch_a)
+        .expect("second branch should evaluate");
+
+    let head_a = hook_a
+        .canonical_head()
+        .expect("head should be assigned after competing candidates");
+    let head_b = hook_b
+        .canonical_head()
+        .expect("head should be assigned after competing candidates");
+
+    assert_eq!(head_a.payload_digest, "digest-a");
+    assert_eq!(head_b.payload_digest, "digest-a");
+}
+
+#[test]
+fn regression_transport_fed_pipeline_rejects_stale_candidate_against_seeded_head() {
+    let feed = InMemoryTransportMempoolFeed::new(build_valid_chain_transactions());
+    let store = InMemoryCanonicalCommitStore::default();
+    let seeded_head = CanonicalCommitRecord {
+        block_height: 50,
+        producer_role: kamn_core::NodeRole::Processor,
+        payload_digest: "head-50".to_owned(),
+        transaction_ids: vec!["head-tx".to_owned()],
+    };
+
+    let hook = DeterministicCompetingBranchForkChoiceHook::with_canonical_head(seeded_head);
+    let mut pipeline = TransportFedBlockPipeline::new(true, 1, 1, feed, store, hook)
+        .expect("transport-fed pipeline should build");
+
+    let result = pipeline.run_transport_consensus_round(sample_consensus_input());
+    assert_eq!(
+        result,
+        Err(BlockPipelineError::ForkChoiceRejected {
+            reason_code: "fork_choice_stale_block_height".to_owned(),
+        })
+    );
+    assert!(pipeline
+        .list_canonical_commits()
+        .expect("canonical commit list should load")
+        .is_empty());
 }


### PR DESCRIPTION
## Summary
Adds deterministic competing-branch fork-choice behavior for transport-fed canonical commit candidates and introduces regression coverage for stale-branch rejection and same-height tie-break determinism.

Closes #3317.

## Changes
- `crates/kamn-core/src/block_pipeline.rs`: added `DeterministicCompetingBranchForkChoiceHook` with seeded-head support and deterministic rules for stale/duplicate/tie-break branch handling.
- `crates/kamn-core/src/lib.rs`: exported the new deterministic fork-choice hook.
- `crates/kamn-core/tests/block_pipeline_transport_fed.rs`: added regression tests for competing-branch order independence and stale candidate rejection against seeded canonical head.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `cargo test -p kamn-core --test block_pipeline_transport_fed`

Failing output excerpt:
- `unresolved import kamn_core::DeterministicCompetingBranchForkChoiceHook`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test block_pipeline_transport_fed`
- `cargo test -p kamn-core --lib block_pipeline::tests::`

Passing result:
- transport-fed lane: `6 passed; 0 failed`
- block_pipeline unit lane: `7 passed; 0 failed`

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core --lib block_pipeline::tests::`
- `cargo test -p kamn-core --test block_pipeline_transport_fed`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Added deterministic fork-choice unit tests in `block_pipeline.rs` |                      |
| Functional   | ✅     | Extended transport-fed pipeline behavior checks with deterministic branch decisions |                      |
| Integration  | ✅     | Regression test verifies seeded-head stale candidate rejection through `TransportFedBlockPipeline` |                      |
| Regression   | ✅     | Added competing-branch order-independence regression and stale branch rejection regression |                      |
| Performance  | ✅     | Existing bounded transport-fed path performance test retained and passing |                      |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore previous accept/reject-only hook behavior.

## Documentation Updates
- None required (internal hook/test behavior only; no runtime CLI/config surface changes).

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped relevant suites)
- [x] Docs updated (or justified why not)
