### PR TITLE
refactor(kolme): extract api probe/smoke lane helpers (#3407)

### DIFF
--- a/scripts/kolme/contracts/local_fork_smoke_evidence_summary.py
+++ b/scripts/kolme/contracts/local_fork_smoke_evidence_summary.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1]).resolve()
+mode = sys.argv[2]
+status = sys.argv[3]
+reason_code = sys.argv[4]
+local_only_enforced = sys.argv[5] == "true"
+elapsed_seconds = int(sys.argv[6])
+max_seconds = int(sys.argv[7])
+budget_status = sys.argv[8]
+checkout_path = sys.argv[9]
+expected_remote_url = sys.argv[10]
+expected_ref = sys.argv[11]
+smoke_command = sys.argv[12]
+metadata_report = sys.argv[13]
+smoke_output_file = sys.argv[14]
+checks_path = pathlib.Path(sys.argv[15])
+
+checkpoints = []
+for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.strip():
+        continue
+    parts = raw_line.split("\t")
+    if len(parts) != 3:
+        continue
+    check_id, command, check_status = parts
+    checkpoints.append(
+        {
+            "id": check_id,
+            "command": command,
+            "status": check_status,
+        }
+    )
+
+summary = {
+    "schema_version": "kamn.kolme.local-fork-smoke-evidence-summary.v1",
+    "mode": mode,
+    "status": status,
+    "reason_code": reason_code,
+    "local_only_enforced": local_only_enforced,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "budget_status": budget_status,
+    "checkout_path": checkout_path,
+    "expected_remote_url": expected_remote_url,
+    "expected_ref": expected_ref,
+    "smoke_command": smoke_command,
+    "metadata_report": metadata_report,
+    "smoke_output_file": smoke_output_file,
+    "checkpoints": checkpoints,
+    "artifact_paths": [
+        metadata_report,
+        smoke_output_file,
+    ],
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")

--- a/scripts/kolme/contracts/local_kolme_api_probe_fork_info_parse.py
+++ b/scripts/kolme/contracts/local_kolme_api_probe_fork_info_parse.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+body_path = pathlib.Path(sys.argv[1])
+out_path = pathlib.Path(sys.argv[2])
+
+try:
+    payload = json.loads(body_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as error:
+    raise SystemExit(f"invalid json: {error.msg}") from error
+
+if not isinstance(payload, dict):
+    raise SystemExit("fork-info payload must be a JSON object")
+
+first_block = payload.get("first_block")
+last_block = payload.get("last_block")
+if not isinstance(first_block, int) or not isinstance(last_block, int):
+    raise SystemExit("fork-info payload must include integer first_block and last_block")
+
+out_path.write_text(
+    f"first_block={first_block}\nlast_block={last_block}\n",
+    encoding="utf-8",
+)

--- a/scripts/kolme/contracts/local_kolme_api_probe_summary.py
+++ b/scripts/kolme/contracts/local_kolme_api_probe_summary.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1]).resolve()
+mode = sys.argv[2]
+status = sys.argv[3]
+reason_code = sys.argv[4]
+base_url = sys.argv[5]
+healthz_path = sys.argv[6]
+fork_info_path = sys.argv[7]
+fork_chain_version = sys.argv[8]
+expected_healthz = sys.argv[9]
+elapsed_seconds = int(sys.argv[10])
+max_seconds = int(sys.argv[11])
+budget_status = sys.argv[12]
+fork_first_block_raw = sys.argv[13]
+fork_last_block_raw = sys.argv[14]
+checks_path = pathlib.Path(sys.argv[15])
+
+checks = []
+for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.strip():
+        continue
+    parts = raw_line.split("\t")
+    if len(parts) != 3:
+        continue
+    check_id, command, check_status = parts
+    checks.append({"id": check_id, "command": command, "status": check_status})
+
+fork_info = {
+    "first_block": int(fork_first_block_raw) if fork_first_block_raw else None,
+    "last_block": int(fork_last_block_raw) if fork_last_block_raw else None,
+}
+
+summary = {
+    "schema_version": "kamn.kolme.local-api-probe-summary.v1",
+    "mode": mode,
+    "status": status,
+    "reason_code": reason_code,
+    "local_only_enforced": True,
+    "base_url": base_url,
+    "healthz_path": healthz_path,
+    "fork_info_path": fork_info_path,
+    "fork_chain_version": fork_chain_version,
+    "expected_healthz": expected_healthz,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "budget_status": budget_status,
+    "fork_info": fork_info,
+    "checks": checks,
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")

--- a/scripts/kolme/contracts/local_kolme_api_smoke_summary.py
+++ b/scripts/kolme/contracts/local_kolme_api_smoke_summary.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1]).resolve()
+mode = sys.argv[2]
+status = sys.argv[3]
+reason_code = sys.argv[4]
+local_only_enforced = sys.argv[5] == "true"
+elapsed_seconds = int(sys.argv[6])
+max_seconds = int(sys.argv[7])
+budget_status = sys.argv[8]
+base_url = sys.argv[9]
+smoke_command = sys.argv[10]
+fork_chain_version = sys.argv[11]
+probe_report = sys.argv[12]
+smoke_output_file = sys.argv[13]
+checks_path = pathlib.Path(sys.argv[14])
+
+checks = []
+for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
+    if not raw_line.strip():
+        continue
+    parts = raw_line.split("\t")
+    if len(parts) != 3:
+        continue
+    check_id, command, check_status = parts
+    checks.append(
+        {
+            "id": check_id,
+            "command": command,
+            "status": check_status,
+        }
+    )
+
+summary = {
+    "schema_version": "kamn.kolme.local-api-smoke-summary.v1",
+    "mode": mode,
+    "status": status,
+    "reason_code": reason_code,
+    "local_only_enforced": local_only_enforced,
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+    "budget_status": budget_status,
+    "base_url": base_url,
+    "smoke_command": smoke_command,
+    "fork_chain_version": fork_chain_version,
+    "probe_report": probe_report,
+    "smoke_output_file": smoke_output_file,
+    "checks": checks,
+    "artifact_paths": [
+        probe_report,
+        smoke_output_file,
+    ],
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")

--- a/scripts/kolme/run_local_fork_smoke_evidence_lane_impl.sh
+++ b/scripts/kolme/run_local_fork_smoke_evidence_lane_impl.sh
@@ -209,70 +209,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$SMOKE_COMMAND" "$METADATA_REPORT" "$SMOKE_OUTPUT_FILE" "$CHECK_FILE" <<'PY'
-from __future__ import annotations
-
-import json
-import pathlib
-import sys
-
-output_path = pathlib.Path(sys.argv[1]).resolve()
-mode = sys.argv[2]
-status = sys.argv[3]
-reason_code = sys.argv[4]
-local_only_enforced = sys.argv[5] == "true"
-elapsed_seconds = int(sys.argv[6])
-max_seconds = int(sys.argv[7])
-budget_status = sys.argv[8]
-checkout_path = sys.argv[9]
-expected_remote_url = sys.argv[10]
-expected_ref = sys.argv[11]
-smoke_command = sys.argv[12]
-metadata_report = sys.argv[13]
-smoke_output_file = sys.argv[14]
-checks_path = pathlib.Path(sys.argv[15])
-
-checkpoints = []
-for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
-    if not raw_line.strip():
-        continue
-    parts = raw_line.split("\t")
-    if len(parts) != 3:
-        continue
-    check_id, command, check_status = parts
-    checkpoints.append(
-        {
-            "id": check_id,
-            "command": command,
-            "status": check_status,
-        }
-    )
-
-summary = {
-    "schema_version": "kamn.kolme.local-fork-smoke-evidence-summary.v1",
-    "mode": mode,
-    "status": status,
-    "reason_code": reason_code,
-    "local_only_enforced": local_only_enforced,
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-    "budget_status": budget_status,
-    "checkout_path": checkout_path,
-    "expected_remote_url": expected_remote_url,
-    "expected_ref": expected_ref,
-    "smoke_command": smoke_command,
-    "metadata_report": metadata_report,
-    "smoke_output_file": smoke_output_file,
-    "checkpoints": checkpoints,
-    "artifact_paths": [
-        metadata_report,
-        smoke_output_file,
-    ],
-}
-
-output_path.parent.mkdir(parents=True, exist_ok=True)
-output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
+python3 "$ROOT_DIR/scripts/kolme/contracts/local_fork_smoke_evidence_summary.py" "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$CHECKOUT_PATH" "$EXPECTED_REMOTE_URL" "$EXPECTED_REF" "$SMOKE_COMMAND" "$METADATA_REPORT" "$SMOKE_OUTPUT_FILE" "$CHECK_FILE"
 
 echo "status=$overall_status"
 echo "smoke_mode=$MODE"

--- a/scripts/kolme/run_local_kolme_api_probe_lane_impl.sh
+++ b/scripts/kolme/run_local_kolme_api_probe_lane_impl.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 MODE="dry-run"
 OUTPUT_JSON="/tmp/kolme-local-api-probe-summary.json"
 BASE_URL="http://127.0.0.1:3000"
@@ -183,34 +185,7 @@ if [ "$MODE" = "run" ]; then
 
     if [ "$overall_status" = "ok" ]; then
       if curl --silent --show-error --max-time "$MAX_SECONDS" "$fork_info_url" >"$FORK_INFO_BODY_FILE" 2>/dev/null; then
-        if python3 - "$FORK_INFO_BODY_FILE" "$FORK_INFO_VALUES_FILE" <<'PY'
-from __future__ import annotations
-
-import json
-import pathlib
-import sys
-
-body_path = pathlib.Path(sys.argv[1])
-out_path = pathlib.Path(sys.argv[2])
-
-try:
-    payload = json.loads(body_path.read_text(encoding="utf-8"))
-except json.JSONDecodeError as error:
-    raise SystemExit(f"invalid json: {error.msg}") from error
-
-if not isinstance(payload, dict):
-    raise SystemExit("fork-info payload must be a JSON object")
-
-first_block = payload.get("first_block")
-last_block = payload.get("last_block")
-if not isinstance(first_block, int) or not isinstance(last_block, int):
-    raise SystemExit("fork-info payload must include integer first_block and last_block")
-
-out_path.write_text(
-    f"first_block={first_block}\nlast_block={last_block}\n",
-    encoding="utf-8",
-)
-PY
+        if python3 "$ROOT_DIR/scripts/kolme/contracts/local_kolme_api_probe_fork_info_parse.py" "$FORK_INFO_BODY_FILE" "$FORK_INFO_VALUES_FILE"
         then
           # shellcheck disable=SC1090
           . "$FORK_INFO_VALUES_FILE"
@@ -244,65 +219,7 @@ PY
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$BASE_URL" "$HEALTHZ_PATH" "$FORK_INFO_PATH" "$FORK_CHAIN_VERSION" "$EXPECTED_HEALTHZ" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$fork_first_block" "$fork_last_block" "$CHECK_FILE" <<'PY'
-from __future__ import annotations
-
-import json
-import pathlib
-import sys
-
-output_path = pathlib.Path(sys.argv[1]).resolve()
-mode = sys.argv[2]
-status = sys.argv[3]
-reason_code = sys.argv[4]
-base_url = sys.argv[5]
-healthz_path = sys.argv[6]
-fork_info_path = sys.argv[7]
-fork_chain_version = sys.argv[8]
-expected_healthz = sys.argv[9]
-elapsed_seconds = int(sys.argv[10])
-max_seconds = int(sys.argv[11])
-budget_status = sys.argv[12]
-fork_first_block_raw = sys.argv[13]
-fork_last_block_raw = sys.argv[14]
-checks_path = pathlib.Path(sys.argv[15])
-
-checks = []
-for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
-    if not raw_line.strip():
-        continue
-    parts = raw_line.split("\t")
-    if len(parts) != 3:
-        continue
-    check_id, command, check_status = parts
-    checks.append({"id": check_id, "command": command, "status": check_status})
-
-fork_info = {
-    "first_block": int(fork_first_block_raw) if fork_first_block_raw else None,
-    "last_block": int(fork_last_block_raw) if fork_last_block_raw else None,
-}
-
-summary = {
-    "schema_version": "kamn.kolme.local-api-probe-summary.v1",
-    "mode": mode,
-    "status": status,
-    "reason_code": reason_code,
-    "local_only_enforced": True,
-    "base_url": base_url,
-    "healthz_path": healthz_path,
-    "fork_info_path": fork_info_path,
-    "fork_chain_version": fork_chain_version,
-    "expected_healthz": expected_healthz,
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-    "budget_status": budget_status,
-    "fork_info": fork_info,
-    "checks": checks,
-}
-
-output_path.parent.mkdir(parents=True, exist_ok=True)
-output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
+python3 "$ROOT_DIR/scripts/kolme/contracts/local_kolme_api_probe_summary.py" "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$BASE_URL" "$HEALTHZ_PATH" "$FORK_INFO_PATH" "$FORK_CHAIN_VERSION" "$EXPECTED_HEALTHZ" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$fork_first_block" "$fork_last_block" "$CHECK_FILE"
 
 echo "status=$overall_status"
 echo "probe_mode=$MODE"

--- a/scripts/kolme/run_local_kolme_api_smoke_lane_impl.sh
+++ b/scripts/kolme/run_local_kolme_api_smoke_lane_impl.sh
@@ -225,68 +225,7 @@ if [ "$MODE" = "run" ]; then
   fi
 fi
 
-python3 - "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$BASE_URL" "$SMOKE_COMMAND" "$FORK_CHAIN_VERSION" "$PROBE_REPORT" "$SMOKE_OUTPUT_FILE" "$CHECK_FILE" <<'PY'
-from __future__ import annotations
-
-import json
-import pathlib
-import sys
-
-output_path = pathlib.Path(sys.argv[1]).resolve()
-mode = sys.argv[2]
-status = sys.argv[3]
-reason_code = sys.argv[4]
-local_only_enforced = sys.argv[5] == "true"
-elapsed_seconds = int(sys.argv[6])
-max_seconds = int(sys.argv[7])
-budget_status = sys.argv[8]
-base_url = sys.argv[9]
-smoke_command = sys.argv[10]
-fork_chain_version = sys.argv[11]
-probe_report = sys.argv[12]
-smoke_output_file = sys.argv[13]
-checks_path = pathlib.Path(sys.argv[14])
-
-checks = []
-for raw_line in checks_path.read_text(encoding="utf-8").splitlines():
-    if not raw_line.strip():
-        continue
-    parts = raw_line.split("\t")
-    if len(parts) != 3:
-        continue
-    check_id, command, check_status = parts
-    checks.append(
-        {
-            "id": check_id,
-            "command": command,
-            "status": check_status,
-        }
-    )
-
-summary = {
-    "schema_version": "kamn.kolme.local-api-smoke-summary.v1",
-    "mode": mode,
-    "status": status,
-    "reason_code": reason_code,
-    "local_only_enforced": local_only_enforced,
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-    "budget_status": budget_status,
-    "base_url": base_url,
-    "smoke_command": smoke_command,
-    "fork_chain_version": fork_chain_version,
-    "probe_report": probe_report,
-    "smoke_output_file": smoke_output_file,
-    "checks": checks,
-    "artifact_paths": [
-        probe_report,
-        smoke_output_file,
-    ],
-}
-
-output_path.parent.mkdir(parents=True, exist_ok=True)
-output_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
+python3 "$ROOT_DIR/scripts/kolme/contracts/local_kolme_api_smoke_summary.py" "$OUTPUT_JSON" "$MODE" "$overall_status" "$reason_code" "$local_only_enforced" "$elapsed_seconds" "$MAX_SECONDS" "$budget_status" "$BASE_URL" "$SMOKE_COMMAND" "$FORK_CHAIN_VERSION" "$PROBE_REPORT" "$SMOKE_OUTPUT_FILE" "$CHECK_FILE"
 
 echo "status=$overall_status"
 echo "smoke_mode=$MODE"


### PR DESCRIPTION
## Summary
Extracted remaining inline Python parser/summary blocks from three mid-size Kolme lane implementation scripts into reusable helper scripts under `scripts/kolme/contracts/`. This keeps lane behavior deterministic while reducing shell LOC and duplication.

Closes #3407

## Changes
- `scripts/kolme/run_local_kolme_api_probe_lane_impl.sh`: replaced inline fork-info parser + summary heredocs with helper invocations.
- `scripts/kolme/run_local_kolme_api_smoke_lane_impl.sh`: replaced inline summary heredoc with helper invocation.
- `scripts/kolme/run_local_fork_smoke_evidence_lane_impl.sh`: replaced inline summary heredoc with helper invocation.
- `scripts/kolme/contracts/local_kolme_api_probe_fork_info_parse.py`: new fork-info payload parser helper.
- `scripts/kolme/contracts/local_kolme_api_probe_summary.py`: new API probe summary helper.
- `scripts/kolme/contracts/local_kolme_api_smoke_summary.py`: new API smoke summary helper.
- `scripts/kolme/contracts/local_fork_smoke_evidence_summary.py`: new fork smoke evidence summary helper.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
N/A for this extraction tranche; existing lane tests provide regression safety while behavior remains unchanged.

### 🟢 Green Phase
- `bash scripts/kolme/test_run_local_kolme_api_probe_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_api_smoke_lane.sh`
- `bash scripts/kolme/test_run_local_fork_smoke_evidence_lane.sh`
- `bash scripts/kolme/test_run_local_kolme_live_api_conformance_contract_lane.sh`

### 🔁 Regression
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`
- `python3 scripts/ci/check_script_duplication_budget.py --scripts-root scripts --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --output-json /tmp/script-surface-budget-report-3407.json`
- `python3 scripts/ci/check_script_duplication_budget.py --scripts-root scripts/kolme --budget-file .ci/kolme-command-surface-soft-budget.env --baseline-file .ci/kolme-command-surface-baseline.env --output-json /tmp/kolme-command-surface-budget-report-3407.json`
  - Result: global `shell_line_total=31754`, Kolme `shell_line_total=8521`; remaining violation is `script_count` only.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `python3 -m py_compile` for added helper scripts | N/A |
| Functional   | ✅     | Targeted lane tests listed above | N/A |
| Integration  | ✅     | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | N/A |
| Regression   | ✅     | script-surface budget checks + conformance contract lane test | N/A |
| Performance  | N/A    | None                 | No runtime algorithm changes |

## Risks & Rollback
- Low risk; extraction only, behavior guarded by existing tests.
- Rollback: revert commit `b4a8654`.

## Documentation Updates
- None required for this internal extraction tranche.

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A: no Rust changes)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust changes)
- [x] TDD Red/Green evidence included above
- [x] Relevant tests pass
