### PR TITLE
fix(ci): exclude symlink wrappers from script-surface script_count metric (#3411)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2380,6 +2380,7 @@ Regression policy:
 - script-surface budget waiver schema/scope/expiry validation remains fail-closed when waiver files are present (`Regression: #1497`).
 - script-surface duplicate-content policy excludes symlink dispatch wrappers and remains fail-closed for duplicated regular files (`Regression: #2090`).
 - script-surface script-count/LOC metrics exclude `test_*.sh` harness scripts and remain fail-closed for non-test shell surfaces (`Regression: #2093`).
+- script-surface script-count/LOC metrics exclude symlink dispatch wrappers and defer wrapper-growth governance to wrapper-family trend budgets (`Regression: #3411`).
 - Kolme command-surface missing-both coverage drift remains fail-closed (`Regression: #1561`).
 - Kolme command-surface asymmetry split drift remains fail-closed (`Regression: #1565`).
 - Kolme command-surface asymmetry policy-file schema drift remains fail-closed (`Regression: #1569`).

--- a/scripts/ci/check_script_duplication_budget.py
+++ b/scripts/ci/check_script_duplication_budget.py
@@ -104,17 +104,15 @@ def load_baseline_metrics(path: Path) -> ScriptMetrics:
 
 def compute_metrics(scripts_root: Path) -> ScriptMetrics:
     def include_in_budget(path: Path) -> bool:
-        return path.is_file() and not path.name.startswith("test_")
+        # Symlink wrappers are tracked by dedicated wrapper-family trend
+        # budgets; this checker focuses on concrete implementation scripts.
+        return path.is_file() and not path.is_symlink() and not path.name.startswith("test_")
 
     scripts = sorted(
         path for path in scripts_root.rglob("*.sh") if include_in_budget(path)
     )
     script_count = len(scripts)
     def shell_lines_for_budget(path: Path) -> int:
-        # Symlink wrappers represent command-surface entries, not full copies
-        # of the target implementation body.
-        if path.is_symlink():
-            return 1
         return sum(1 for _ in path.open("r", encoding="utf-8", errors="ignore"))
 
     shell_line_total = sum(shell_lines_for_budget(path) for path in scripts)
@@ -124,12 +122,11 @@ def compute_metrics(scripts_root: Path) -> ScriptMetrics:
         count for count in basename_counts.values() if count > 1
     )
 
-    # Treat symlink wrappers as intentional command-surface entries and only
-    # enforce duplicate-content policy across regular files.
+    # Only regular files are in-budget; duplicate-content policy applies
+    # across the same regular-file set.
     content_counts = Counter(
         hashlib.sha256(path.read_bytes()).hexdigest()
         for path in scripts
-        if not path.is_symlink()
     )
     duplicate_content = sum(
         count for count in content_counts.values() if count > 1

--- a/scripts/ci/test_check_script_duplication_budget.sh
+++ b/scripts/ci/test_check_script_duplication_budget.sh
@@ -58,12 +58,12 @@ if ! printf '%s\n' "$pass_output" | grep -q '^violations=none$'; then
   echo "expected no violations on pass path" >&2
   exit 1
 fi
-if ! printf '%s\n' "$pass_output" | grep -q '^delta_script_count=2$'; then
+if ! printf '%s\n' "$pass_output" | grep -q '^delta_script_count=1$'; then
   echo "expected deterministic script_count delta output on pass path" >&2
   exit 1
 fi
-if ! printf '%s\n' "$pass_output" | grep -q '^shell_line_total=5$'; then
-  echo "expected symlink wrappers to contribute one line each in shell_line_total metric" >&2
+if ! printf '%s\n' "$pass_output" | grep -q '^shell_line_total=4$'; then
+  echo "expected symlink wrappers to be excluded from shell_line_total metric" >&2
   exit 1
 fi
 if ! printf '%s\n' "$pass_output" | grep -q '^duplicate_content=0$'; then
@@ -111,7 +111,7 @@ if ! printf '%s\n' "$test_exclusion_output" | grep -q '^status=pass$'; then
   echo "expected test harness files (test_*.sh) to be excluded from script_count budget" >&2
   exit 1
 fi
-if ! printf '%s\n' "$test_exclusion_output" | grep -q '^script_count=3$'; then
+if ! printf '%s\n' "$test_exclusion_output" | grep -q '^script_count=2$'; then
   echo "expected script_count to ignore test_*.sh harness files" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
Adjusted script-surface budget metric semantics so symlink dispatch wrappers are excluded from `script_count` and `shell_line_total` in `check_script_duplication_budget.py`. Wrapper growth remains governed by wrapper-family trend checks, while this checker now focuses on concrete implementation scripts.

Closes #3411

## Changes
- `scripts/ci/check_script_duplication_budget.py`
  - Exclude symlink wrappers from in-budget script set.
  - Simplify shell-line and duplicate-content counting to regular files only.
  - Keep fail-closed behavior for non-test regular shell scripts.
- `scripts/ci/test_check_script_duplication_budget.sh`
  - Updated assertions to reflect symlink exclusion from script-count/LOC metrics.
- `docs/ci/strategy.md`
  - Added policy note documenting symlink wrapper exclusion and wrapper-family governance split.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
N/A for checker semantic refinement in an existing policy harness.

### 🟢 Green Phase
- `bash scripts/ci/test_check_script_duplication_budget.sh`
- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`

### 🔁 Regression
- `python3 scripts/ci/check_script_duplication_budget.py --scripts-root scripts --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --output-json /tmp/script-surface-budget-report-3411.json`
  - `status=pass`, `script_count=380`, `shell_line_total=31383`
- `python3 scripts/ci/check_script_duplication_budget.py --scripts-root scripts/kolme --budget-file .ci/kolme-command-surface-soft-budget.env --baseline-file .ci/kolme-command-surface-baseline.env --output-json /tmp/kolme-command-surface-budget-report-3411.json`
  - `status=pass`, `script_count=29`, `shell_line_total=8256`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Python checker behavior validated through existing contract test script |
| Functional   | ✅     | `scripts/ci/test_check_script_duplication_budget.sh` | N/A |
| Integration  | ✅     | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | N/A |
| Regression   | ✅     | Global + Kolme checker runs with JSON outputs | N/A |
| Performance  | N/A    | None                 | No workload path changes |

## Risks & Rollback
- Risk: metric redefinition could mask wrapper-growth if wrapper-family checks regress.
- Mitigation: wrapper-family baseline/trend tests are still enforced in fast CI.
- Rollback: revert commit `f9e4064`.

## Documentation Updates
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A: no Rust changes)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust changes)
- [x] TDD Red/Green evidence included above
- [x] Relevant tests pass
