### PR TITLE
feat(core): persist deterministic transport candidate reconciliation outcomes (#3416)

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -235,6 +235,7 @@ impl GossipIngressAdapter {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GossipFrameTransportMempoolFeed {
     pending_frames: Vec<PeerGossipFrame>,
+    pending_transactions: Vec<BaselineTransaction>,
     canonical_candidates: Vec<CanonicalCommitRecord>,
 }
 
@@ -243,6 +244,7 @@ impl GossipFrameTransportMempoolFeed {
     pub fn new(pending_frames: Vec<PeerGossipFrame>) -> Self {
         Self {
             pending_frames,
+            pending_transactions: Vec::new(),
             canonical_candidates: Vec::new(),
         }
     }
@@ -251,20 +253,38 @@ impl GossipFrameTransportMempoolFeed {
     pub fn drain_canonical_candidates(&mut self) -> Vec<CanonicalCommitRecord> {
         std::mem::take(&mut self.canonical_candidates)
     }
+
+    fn decode_pending_frames_if_needed(&mut self) -> Result<(), BlockPipelineError> {
+        if self.pending_frames.is_empty() {
+            return Ok(());
+        }
+        let decoded =
+            GossipIngressAdapter::decode_frames(&self.pending_frames).map_err(|error| {
+                BlockPipelineError::TransportFeed(format!("{}:{}", error.reason_code(), error))
+            })?;
+        self.pending_frames.clear();
+        self.pending_transactions.extend(decoded.transactions);
+        self.canonical_candidates
+            .extend(decoded.canonical_candidates);
+        Ok(())
+    }
 }
 
 impl TransportMempoolFeed for GossipFrameTransportMempoolFeed {
     fn drain_pending_transactions(
         &mut self,
     ) -> Result<Vec<BaselineTransaction>, BlockPipelineError> {
-        let decoded =
-            GossipIngressAdapter::decode_frames(&self.pending_frames).map_err(|error| {
-                BlockPipelineError::TransportFeed(format!("{}:{}", error.reason_code(), error))
-            })?;
-        self.pending_frames.clear();
-        self.canonical_candidates
-            .extend(decoded.canonical_candidates);
-        Ok(decoded.transactions)
+        self.decode_pending_frames_if_needed()?;
+        Ok(std::mem::take(&mut self.pending_transactions))
+    }
+}
+
+impl TransportCanonicalCandidateFeed for GossipFrameTransportMempoolFeed {
+    fn drain_canonical_candidates(
+        &mut self,
+    ) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
+        self.decode_pending_frames_if_needed()?;
+        Ok(std::mem::take(&mut self.canonical_candidates))
     }
 }
 
@@ -297,12 +317,43 @@ impl CanonicalCommitRecord {
     }
 }
 
+/// Deterministic decision outcome for one transport candidate reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalCandidateDecision {
+    /// Candidate was selected as canonical and persisted.
+    Accepted,
+    /// Candidate was rejected by fork-choice with deterministic reason code.
+    Rejected {
+        /// Deterministic fork-choice rejection reason code.
+        reason_code: String,
+    },
+}
+
+/// Reconciliation report for one transport-provided canonical candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalCandidateOutcome {
+    /// Candidate block height.
+    pub block_height: u64,
+    /// Candidate payload digest.
+    pub payload_digest: String,
+    /// Deterministic reconciliation decision.
+    pub decision: CanonicalCandidateDecision,
+}
+
 /// Transport feed abstraction for draining pending mempool candidates.
 pub trait TransportMempoolFeed {
     /// Drains pending transport candidates in implementation-defined order.
     fn drain_pending_transactions(
         &mut self,
     ) -> Result<Vec<BaselineTransaction>, BlockPipelineError>;
+}
+
+/// Transport feed abstraction for draining received canonical block candidates.
+pub trait TransportCanonicalCandidateFeed {
+    /// Drains canonical block candidates discovered via transport gossip.
+    fn drain_canonical_candidates(
+        &mut self,
+    ) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -328,6 +379,14 @@ impl TransportMempoolFeed for InMemoryTransportMempoolFeed {
         &mut self,
     ) -> Result<Vec<BaselineTransaction>, BlockPipelineError> {
         Ok(std::mem::take(&mut self.pending))
+    }
+}
+
+impl TransportCanonicalCandidateFeed for InMemoryTransportMempoolFeed {
+    fn drain_canonical_candidates(
+        &mut self,
+    ) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
+        Ok(Vec::new())
     }
 }
 
@@ -483,7 +542,7 @@ pub struct TransportFedBlockPipeline<TFeed, TStore, THook> {
 
 impl<TFeed, TStore, THook> TransportFedBlockPipeline<TFeed, TStore, THook>
 where
-    TFeed: TransportMempoolFeed,
+    TFeed: TransportMempoolFeed + TransportCanonicalCandidateFeed,
     TStore: CanonicalCommitStore,
     THook: ForkChoiceHook,
 {
@@ -508,11 +567,44 @@ where
         })
     }
 
+    /// Reconciles transport-received canonical block candidates through fork-choice.
+    pub fn reconcile_transport_candidates(
+        &mut self,
+    ) -> Result<Vec<CanonicalCandidateOutcome>, BlockPipelineError> {
+        let mut candidates = self.transport_feed.drain_canonical_candidates()?;
+        sort_canonical_candidates_for_reconciliation(&mut candidates);
+
+        let mut outcomes = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let block_height = candidate.block_height;
+            let payload_digest = candidate.payload_digest.clone();
+            match self.fork_choice_hook.evaluate_candidate(&candidate)? {
+                ForkChoiceDecision::Accept => {
+                    self.commit_store.persist_canonical_commit(candidate)?;
+                    outcomes.push(CanonicalCandidateOutcome {
+                        block_height,
+                        payload_digest,
+                        decision: CanonicalCandidateDecision::Accepted,
+                    });
+                }
+                ForkChoiceDecision::Reject { reason_code } => {
+                    outcomes.push(CanonicalCandidateOutcome {
+                        block_height,
+                        payload_digest,
+                        decision: CanonicalCandidateDecision::Rejected { reason_code },
+                    });
+                }
+            }
+        }
+        Ok(outcomes)
+    }
+
     /// Runs one transport-fed consensus round and persists canonical commit record.
     pub fn run_transport_consensus_round(
         &mut self,
         input: BlockConsensusRoundInput,
     ) -> Result<BlockPipelineCommitReport, BlockPipelineError> {
+        let _candidate_outcomes = self.reconcile_transport_candidates()?;
         let mut candidates = self.transport_feed.drain_pending_transactions()?;
         if candidates.is_empty() {
             return Err(BlockPipelineError::EmptyMempool);
@@ -546,6 +638,20 @@ fn sort_candidates_for_ingress(candidates: &mut [BaselineTransaction]) {
             .cmp(&right.nonce)
             .then_with(|| left.id.cmp(&right.id))
             .then_with(|| left.sender.cmp(&right.sender))
+    });
+}
+
+fn sort_canonical_candidates_for_reconciliation(candidates: &mut [CanonicalCommitRecord]) {
+    candidates.sort_by(|left, right| {
+        left.block_height
+            .cmp(&right.block_height)
+            .then_with(|| left.payload_digest.cmp(&right.payload_digest))
+            .then_with(|| {
+                left.producer_role
+                    .as_str()
+                    .cmp(right.producer_role.as_str())
+            })
+            .then_with(|| left.transaction_ids.cmp(&right.transaction_ids))
     });
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -153,11 +153,12 @@ pub use audit_exports::{
 };
 pub use block_pipeline::{
     AcceptAllForkChoiceHook, BlockConsensusRoundInput, BlockPipelineCommitReport,
-    BlockPipelineError, CanonicalCommitRecord, CanonicalCommitStore,
-    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
-    GossipFrameTransportMempoolFeed, GossipIngressAdapter, GossipIngressBatch, GossipIngressError,
-    GossipIngressRecord, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
-    MempoolBlockPipeline, TransportFedBlockPipeline, TransportMempoolFeed,
+    BlockPipelineError, CanonicalCandidateDecision, CanonicalCandidateOutcome,
+    CanonicalCommitRecord, CanonicalCommitStore, DeterministicCompetingBranchForkChoiceHook,
+    ForkChoiceDecision, ForkChoiceHook, GossipFrameTransportMempoolFeed, GossipIngressAdapter,
+    GossipIngressBatch, GossipIngressError, GossipIngressRecord, InMemoryCanonicalCommitStore,
+    InMemoryTransportMempoolFeed, MempoolBlockPipeline, TransportCanonicalCandidateFeed,
+    TransportFedBlockPipeline, TransportMempoolFeed,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/block_pipeline_canonical_reconciliation.rs
+++ b/crates/kamn-core/tests/block_pipeline_canonical_reconciliation.rs
@@ -1,0 +1,184 @@
+use kamn_core::{
+    BlockPipelineError, CanonicalCandidateDecision, CanonicalCommitRecord,
+    DeterministicCompetingBranchForkChoiceHook, GossipFrameTransportMempoolFeed,
+    InMemoryCanonicalCommitStore, TransportFedBlockPipeline,
+};
+
+fn block_frame_payload(
+    block_height: u64,
+    producer_role: &str,
+    payload_digest: &str,
+    transaction_ids: &str,
+) -> String {
+    format!(
+        "block_height={block_height}\nproducer_role={producer_role}\npayload_digest={payload_digest}\ntransaction_ids={transaction_ids}"
+    )
+}
+
+#[test]
+fn functional_transport_candidate_reconciliation_persists_accepted_candidates() {
+    let frames = vec![kamn_core::PeerGossipFrame::new(
+        "kamn/blocks/v1",
+        "peer-a",
+        "peer-b",
+        &block_frame_payload(41, "processor", "digest-41", "tx-41"),
+    )
+    .expect("frame should build")];
+    let feed = GossipFrameTransportMempoolFeed::new(frames);
+    let store = InMemoryCanonicalCommitStore::default();
+    let hook = DeterministicCompetingBranchForkChoiceHook::new();
+    let mut pipeline = TransportFedBlockPipeline::new(true, 1, 1, feed, store, hook)
+        .expect("pipeline should build");
+
+    let outcomes = pipeline
+        .reconcile_transport_candidates()
+        .expect("candidate reconciliation should pass");
+    assert_eq!(outcomes.len(), 1);
+    assert!(matches!(
+        outcomes[0].decision,
+        CanonicalCandidateDecision::Accepted
+    ));
+
+    let persisted = pipeline
+        .list_canonical_commits()
+        .expect("commit store should load");
+    assert_eq!(
+        persisted,
+        vec![CanonicalCommitRecord {
+            block_height: 41,
+            producer_role: kamn_core::NodeRole::Processor,
+            payload_digest: "digest-41".to_owned(),
+            transaction_ids: vec!["tx-41".to_owned()],
+        }]
+    );
+}
+
+#[test]
+fn integration_transport_candidate_reconciliation_emits_reject_reason_code_without_persisting() {
+    let frames = vec![
+        kamn_core::PeerGossipFrame::new(
+            "kamn/blocks/v1",
+            "peer-a",
+            "peer-b",
+            &block_frame_payload(50, "processor", "digest-z", "tx-z"),
+        )
+        .expect("seed frame should build"),
+        kamn_core::PeerGossipFrame::new(
+            "kamn/blocks/v1",
+            "peer-a",
+            "peer-b",
+            &block_frame_payload(50, "processor", "digest-zz", "tx-zz"),
+        )
+        .expect("tie-break loser frame should build"),
+    ];
+    let feed = GossipFrameTransportMempoolFeed::new(frames);
+    let store = InMemoryCanonicalCommitStore::default();
+    let hook = DeterministicCompetingBranchForkChoiceHook::new();
+    let mut pipeline = TransportFedBlockPipeline::new(true, 1, 1, feed, store, hook)
+        .expect("pipeline should build");
+
+    let outcomes = pipeline
+        .reconcile_transport_candidates()
+        .expect("candidate reconciliation should pass");
+    assert_eq!(outcomes.len(), 2);
+    assert!(matches!(
+        outcomes[0].decision,
+        CanonicalCandidateDecision::Accepted
+    ));
+    assert!(
+        matches!(
+            &outcomes[1].decision,
+            CanonicalCandidateDecision::Rejected { reason_code }
+            if reason_code == "fork_choice_tie_break_loser"
+        ),
+        "reject decision should carry deterministic fork-choice reason code"
+    );
+
+    let persisted = pipeline
+        .list_canonical_commits()
+        .expect("commit store should load");
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0].payload_digest, "digest-z");
+}
+
+#[test]
+fn regression_transport_candidate_reconciliation_sorts_candidates_before_fork_choice() {
+    // Regression: #3416
+    let frames = vec![
+        kamn_core::PeerGossipFrame::new(
+            "kamn/blocks/v1",
+            "peer-a",
+            "peer-b",
+            &block_frame_payload(60, "processor", "digest-b", "tx-b"),
+        )
+        .expect("higher lexical digest frame should build"),
+        kamn_core::PeerGossipFrame::new(
+            "kamn/blocks/v1",
+            "peer-a",
+            "peer-b",
+            &block_frame_payload(60, "processor", "digest-a", "tx-a"),
+        )
+        .expect("lower lexical digest frame should build"),
+    ];
+    let feed = GossipFrameTransportMempoolFeed::new(frames);
+    let store = InMemoryCanonicalCommitStore::default();
+    let hook = DeterministicCompetingBranchForkChoiceHook::new();
+    let mut pipeline = TransportFedBlockPipeline::new(true, 1, 1, feed, store, hook)
+        .expect("pipeline should build");
+
+    let outcomes = pipeline
+        .reconcile_transport_candidates()
+        .expect("candidate reconciliation should pass");
+    assert_eq!(outcomes.len(), 2);
+    assert!(matches!(
+        &outcomes[0].decision,
+        CanonicalCandidateDecision::Accepted
+    ));
+    assert!(matches!(
+        &outcomes[1].decision,
+        CanonicalCandidateDecision::Rejected { reason_code }
+        if reason_code == "fork_choice_tie_break_loser"
+    ));
+
+    let persisted = pipeline
+        .list_canonical_commits()
+        .expect("commit store should load");
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0].payload_digest, "digest-a");
+}
+
+#[test]
+fn integration_transport_candidate_reconciliation_preserves_empty_mempool_error_for_consensus_round(
+) {
+    let frames = vec![kamn_core::PeerGossipFrame::new(
+        "kamn/blocks/v1",
+        "peer-a",
+        "peer-b",
+        &block_frame_payload(72, "processor", "digest-72", "tx-72"),
+    )
+    .expect("frame should build")];
+    let feed = GossipFrameTransportMempoolFeed::new(frames);
+    let store = InMemoryCanonicalCommitStore::default();
+    let hook = DeterministicCompetingBranchForkChoiceHook::new();
+    let mut pipeline = TransportFedBlockPipeline::new(true, 1, 1, feed, store, hook)
+        .expect("pipeline should build");
+
+    let result = pipeline.run_transport_consensus_round(kamn_core::BlockConsensusRoundInput {
+        listener_event_id: "event-1".to_owned(),
+        listener_event_sequence: 1,
+        outbound_action_id: "outbound-1".to_owned(),
+        listener_votes: vec![("kamn:did:listener:alpha".to_owned(), "att-1".to_owned())],
+        approver_votes: vec![(
+            "kamn:did:agent:approver-alpha".to_owned(),
+            "att-1".to_owned(),
+            None,
+        )],
+    });
+    assert_eq!(result, Err(BlockPipelineError::EmptyMempool));
+
+    let persisted = pipeline
+        .list_canonical_commits()
+        .expect("commit store should load");
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0].payload_digest, "digest-72");
+}

--- a/docs/architecture/block-pipeline.md
+++ b/docs/architecture/block-pipeline.md
@@ -22,6 +22,9 @@ production and consensus validation (Task #2926, Subtask #2927).
 - `GossipFrameTransportMempoolFeed`
   - bridges `PeerGossipFrame` ingress payloads into transport-fed mempool
     candidates while retaining decoded canonical block candidates.
+- `TransportFedBlockPipeline::reconcile_transport_candidates(...)`
+  - applies deterministic fork-choice over transport-provided canonical
+    candidates and persists accepted records before transaction consensus.
 - `BlockConsensusRoundInput`
   - listener and approver attestation input envelope for a round.
 - `BlockPipelineCommitReport`
@@ -62,16 +65,22 @@ Processor role runtime wiring now includes:
   `p2p_ingress_payload_line_malformed`.
 - Invalid transaction signatures fail closed with:
   `p2p_ingress_tx_signature_invalid`.
+- Reconciled canonical candidates surface deterministic reject reasons:
+  `fork_choice_stale_block_height`, `fork_choice_duplicate_candidate`,
+  `fork_choice_tie_break_loser`.
 
 Regression marker:
 - `Regression: #2927` keeps digest mismatch fail-closed before commit.
 - `Regression: #3415` keeps gossip ingress decode/reason-code taxonomy stable.
+- `Regression: #3416` keeps canonical candidate reconciliation ordering and
+  reorg reason-code outcomes deterministic.
 
 ## Validation Commands
 
 ```bash
 cargo test -p kamn-core --test block_pipeline
 cargo test -p kamn-core --test block_pipeline_gossip_ingest
+cargo test -p kamn-core --test block_pipeline_canonical_reconciliation
 cargo test -p kamn-core block_pipeline
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -185,10 +185,18 @@ This document captures node-runtime productionization slices for machine-readabl
 
 ## Transport-Fed Block Pipeline Contracts
 - `TransportFedBlockPipeline` consumes transaction candidates from `TransportMempoolFeed` rather than synthetic-only mempool input.
+- `TransportFedBlockPipeline::reconcile_transport_candidates(...)` drains transport-provided canonical block candidates before each consensus round.
 - Canonical commits persist through `CanonicalCommitStore` after fork-choice acceptance.
 - Fork-choice integration points are deterministic:
   - `ForkChoiceHook::evaluate_candidate(...)` drives `Accept` vs `Reject` decisions
   - reject path fails closed via `BlockPipelineError::ForkChoiceRejected`
+- Reconciled transport candidates emit explicit deterministic outcome categories:
+  - `CanonicalCandidateDecision::Accepted`
+  - `CanonicalCandidateDecision::Rejected { reason_code }`
+- Reconciled reject reason-code examples:
+  - `fork_choice_stale_block_height`
+  - `fork_choice_duplicate_candidate`
+  - `fork_choice_tie_break_loser`
 - Canonical commit payload includes:
   - block height and producer role
   - deterministic payload digest


### PR DESCRIPTION
## Summary
This adds deterministic transport-candidate reconciliation to the block pipeline so received canonical candidates are evaluated and persisted before transaction consensus rounds. It also exposes explicit reconciliation outcomes with deterministic reject reason codes.

## Changes
- `crates/kamn-core/src/block_pipeline.rs`: add `CanonicalCandidateDecision`/`CanonicalCandidateOutcome`, `TransportCanonicalCandidateFeed`, deterministic candidate sorting, and `TransportFedBlockPipeline::reconcile_transport_candidates(...)`.
- `crates/kamn-core/src/block_pipeline.rs`: update `GossipFrameTransportMempoolFeed` to decode frames once and buffer both transaction and canonical candidate queues so either drain path works deterministically.
- `crates/kamn-core/src/lib.rs`: re-export new reconciliation types/traits.
- `crates/kamn-core/tests/block_pipeline_canonical_reconciliation.rs`: add functional/integration/regression coverage for accepted persistence, deterministic reject reason codes, and ordering behavior.
- `docs/architecture/block-pipeline.md`: document reconciliation flow and new regression marker.
- `docs/foundation/node-runtime-cli.md`: document runtime contract behavior for candidate reconciliation outcomes and reorg reason codes.

## Risks & Compatibility
- Low risk: added trait bound (`TransportCanonicalCandidateFeed`) to `TransportFedBlockPipeline` feed type parameter; in-tree feeds are updated.
- Behavior change: `run_transport_consensus_round(...)` now reconciles transport canonical candidates before mempool candidate drain.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: deterministic reconciliation outcomes and persistence via transport-fed path

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core block_pipeline` (includes `src/lib.rs` block_pipeline unit tests) |
| Functional  | ✅     | `cargo test -p kamn-core --test block_pipeline_canonical_reconciliation` |
| Integration | ✅     | `cargo test -p kamn-core --test block_pipeline_transport_fed`; `cargo test -p kamn-core --test block_pipeline_gossip_ingest` |
| Regression  | ✅     | `Regression: #3416` assertions in `block_pipeline_canonical_reconciliation.rs` |

Closes #3416
