### PR TITLE
feat(runtime): enforce transport-fed partition/rejoin reconciliation taxonomy (#3418)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -223,6 +223,9 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - lane emits deterministic partition marker (`block_reconciliation_partition_status=verified`).
   - lane emits deterministic rejoin marker (`block_reconciliation_rejoin_status=verified`).
   - lane emits deterministic canonical convergence marker (`canonical_convergence_status=verified`).
+  - lane emits deterministic transport-mode marker (`runtime_transport_mode=libp2p_transport_fed`).
+  - lane emits deterministic reconciliation taxonomy marker (`reconciliation_reason_taxonomy_status=verified`).
+  - lane emits deterministic reconciliation reason-code matrix marker (`reconciliation_reason_codes=none|...`).
   - policy checker fails closed on schema/marker drift and decision mismatches.
 - Cost controls:
   - dry-run mode executes no nested lane commands and emits deterministic `dry_run_no_commands_executed`.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1539,6 +1539,23 @@ Operator checkpoints:
   - matrix execution remains local-only and is excluded from PR fast-gate workflow routing.
   - shared opt-in enforcement helper: `scripts/framework/assert_local_heavy_opt_in.sh`.
 
+## Runtime Block Reconciliation Partition/Rejoin (Issue #3418)
+
+- Bounded dry-run contract lane:
+  - `bash scripts/runtime/validate_block_reconciliation_partition_rejoin_live_contract_lane.sh --mode dry-run --ci-fast-gate PASS --output-json /tmp/block-reconciliation-partition-rejoin-contract-lane-report.json --policy-output-json /tmp/block-reconciliation-partition-rejoin-policy-report.json`
+- Explicit local-heavy run mode:
+  - `KAMN_BLOCK_RECONCILIATION_PARTITION_REJOIN_LIVE_OPT_IN=1 bash scripts/runtime/validate_block_reconciliation_partition_rejoin_live.sh --mode run --ci-fast-gate FAIL --output-json /tmp/block-reconciliation-partition-rejoin-live-summary.json`
+- Required reconciliation evidence markers:
+  - `runtime_transport_mode=libp2p_transport_fed`
+  - `transport_state_transition_status=verified`
+  - `reconciliation_reason_taxonomy_status=verified`
+  - `reconciliation_reason_taxonomy_version=kamn.runtime.block-reconciliation-partition-rejoin-reason-taxonomy.v1`
+  - `reconciliation_reason_codes=none|...`
+- Deterministic fail-closed policy reason markers:
+  - `block_reconciliation_partition_rejoin_policy_transport_mode_mismatch`
+  - `block_reconciliation_partition_rejoin_policy_reconciliation_taxonomy_version_mismatch`
+  - `block_reconciliation_partition_rejoin_policy_reconciliation_reason_codes_invalid`
+
 ## Failover + Sync Drill Lane Policy (Issues #787, #788)
 
 - Selector policy:

--- a/scripts/runtime/block_reconciliation_partition_rejoin_live_contract.py
+++ b/scripts/runtime/block_reconciliation_partition_rejoin_live_contract.py
@@ -32,7 +32,11 @@ RUN_MODE_FAST_GATE_EXCLUSION_REASON = (
 )
 DRY_RUN_REASON = "dry_run_no_commands_executed"
 RUN_REASON = "block_reconciliation_partition_rejoin_live_validation_executed"
-PARTITION_RECONNECT_SCHEMA = "kamn.runtime.live-network-partition-reconnect-contract-report.v1"
+PARTITION_RECONNECT_SCHEMA = "kamn.runtime.live-network-partition-reconnect-matrix-report.v1"
+TRANSPORT_RUNTIME_MODE = "libp2p_transport_fed"
+RECONCILIATION_REASON_TAXONOMY_VERSION = (
+    "kamn.runtime.block-reconciliation-partition-rejoin-reason-taxonomy.v1"
+)
 
 
 def _run_command(command: list[str], *, timeout_seconds: int) -> str:
@@ -48,6 +52,69 @@ def _run_command(command: list[str], *, timeout_seconds: int) -> str:
         detail = (completed.stderr or completed.stdout or "command failed").strip()
         fail(f"lane command failed: {' '.join(command)}: {detail}")
     return completed.stdout
+
+
+def _scenario_reconciliation_reason_code(scenario_name: str) -> str:
+    scenario = scenario_name.lower()
+    if "primary_loss" in scenario or "failover" in scenario or "partition" in scenario:
+        return "reconciliation_partition_transition_failed"
+    if "reconnect" in scenario or "rejoin" in scenario or "catchup" in scenario:
+        return "reconciliation_rejoin_transition_failed"
+    if "fixture" in scenario:
+        return "reconciliation_fixture_contract_failed"
+    return "reconciliation_unclassified_scenario_failed"
+
+
+def _derive_reconciliation_reason_codes(
+    partition_payload: dict[str, object] | None, *, lane_mode: str
+) -> list[str]:
+    if lane_mode == "dry-run" or partition_payload is None:
+        return ["none"]
+
+    reason_codes: list[str] = []
+    scenario_results = partition_payload.get("scenario_results")
+    if isinstance(scenario_results, list):
+        for scenario_result in scenario_results:
+            if not isinstance(scenario_result, dict):
+                continue
+            if scenario_result.get("status") != "fail":
+                continue
+            scenario_name = scenario_result.get("scenario")
+            if isinstance(scenario_name, str) and scenario_name:
+                reason_codes.append(_scenario_reconciliation_reason_code(scenario_name))
+            else:
+                reason_codes.append("reconciliation_unclassified_scenario_failed")
+
+    upstream_reason_codes = partition_payload.get("reason_codes")
+    if isinstance(upstream_reason_codes, list):
+        if "runtime_budget_exceeded" in upstream_reason_codes:
+            reason_codes.append("reconciliation_runtime_budget_exceeded")
+        if "ci_fast_gate_failed" in upstream_reason_codes:
+            reason_codes.append("reconciliation_ci_fast_gate_failed")
+
+    deduplicated = sorted(set(reason_codes))
+    if not deduplicated:
+        return ["none"]
+    return deduplicated
+
+
+def _validate_partition_reconnect_report_payload(partition_payload: dict[str, object]) -> None:
+    if partition_payload.get("schema_version") != PARTITION_RECONNECT_SCHEMA:
+        fail("partition/rejoin contract lane report schema mismatch")
+    if partition_payload.get("status") != "pass":
+        fail("partition/rejoin contract lane status mismatch")
+    if partition_payload.get("final_decision") != "GO":
+        fail("partition/rejoin contract lane final_decision mismatch")
+    if not isinstance(partition_payload.get("lane"), str):
+        fail("partition/rejoin contract lane missing lane marker")
+    reason_codes = partition_payload.get("reason_codes")
+    if not isinstance(reason_codes, list) or not all(
+        isinstance(code, str) and code for code in reason_codes
+    ):
+        fail("partition/rejoin contract lane reason_codes must be a string list")
+    scenario_results = partition_payload.get("scenario_results")
+    if not isinstance(scenario_results, list):
+        fail("partition/rejoin contract lane scenario_results must be an array")
 
 
 def run_lane(args: argparse.Namespace) -> int:
@@ -89,19 +156,16 @@ def run_lane(args: argparse.Namespace) -> int:
 
     start_epoch = int(time.time())
     commands_executed = 0
+    partition_payload: dict[str, object] | None = None
     if mode == "run":
         partition_report_file.parent.mkdir(parents=True, exist_ok=True)
         for command in command_specs:
             _run_command(command, timeout_seconds=command_max_seconds)
             commands_executed += 1
 
-        partition_payload = load_json(partition_report_file)
-        if partition_payload.get("schema_version") != PARTITION_RECONNECT_SCHEMA:
-            fail("partition/rejoin contract lane report schema mismatch")
-        if partition_payload.get("status") != "pass":
-            fail("partition/rejoin contract lane status mismatch")
-        if partition_payload.get("final_decision") != "GO":
-            fail("partition/rejoin contract lane final_decision mismatch")
+        loaded_partition_payload = load_json(partition_report_file)
+        _validate_partition_reconnect_report_payload(loaded_partition_payload)
+        partition_payload = loaded_partition_payload
 
     elapsed_seconds = int(time.time()) - start_epoch
     if elapsed_seconds > max_seconds:
@@ -113,6 +177,9 @@ def run_lane(args: argparse.Namespace) -> int:
     run_mode_command_status = "executed" if mode == "run" else "dry_run_no_commands_executed"
     ci_fast_gate_eligibility = "excluded_local_heavy" if mode == "run" else "eligible"
     reason_code = RUN_REASON if mode == "run" else DRY_RUN_REASON
+    reconciliation_reason_codes = _derive_reconciliation_reason_codes(
+        partition_payload, lane_mode=mode
+    )
 
     payload = {
         "schema_version": RUN_LANE_SCHEMA,
@@ -126,6 +193,11 @@ def run_lane(args: argparse.Namespace) -> int:
         "block_reconciliation_partition_status": "verified",
         "block_reconciliation_rejoin_status": "verified",
         "canonical_convergence_status": "verified",
+        "runtime_transport_mode": TRANSPORT_RUNTIME_MODE,
+        "transport_state_transition_status": "verified",
+        "reconciliation_reason_taxonomy_version": RECONCILIATION_REASON_TAXONOMY_VERSION,
+        "reconciliation_reason_taxonomy_status": "verified",
+        "reconciliation_reason_codes": reconciliation_reason_codes,
         "run_mode_command_status": run_mode_command_status,
         "run_mode_command_count": commands_executed,
         "reason_code": reason_code,
@@ -154,6 +226,12 @@ def run_lane(args: argparse.Namespace) -> int:
     print("block_reconciliation_partition_status=verified")
     print("block_reconciliation_rejoin_status=verified")
     print("canonical_convergence_status=verified")
+    print(f"runtime_transport_mode={TRANSPORT_RUNTIME_MODE}")
+    print("reconciliation_reason_taxonomy_status=verified")
+    print(
+        "reconciliation_reason_codes="
+        + ("none" if reconciliation_reason_codes == ["none"] else ",".join(reconciliation_reason_codes))
+    )
     print(f"run_mode_command_status={run_mode_command_status}")
     print(f"run_mode_command_count={commands_executed}")
     print(f"reason_code={reason_code}")
@@ -212,6 +290,39 @@ def check_policy(args: argparse.Namespace) -> int:
         payload.get("canonical_convergence_status") != "verified",
         "block_reconciliation_partition_rejoin_policy_canonical_convergence_status_mismatch",
     )
+    checks.reject_if(
+        payload.get("runtime_transport_mode") != TRANSPORT_RUNTIME_MODE,
+        "block_reconciliation_partition_rejoin_policy_transport_mode_mismatch",
+    )
+    checks.reject_if(
+        payload.get("transport_state_transition_status") != "verified",
+        "block_reconciliation_partition_rejoin_policy_transport_transition_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("reconciliation_reason_taxonomy_version")
+        != RECONCILIATION_REASON_TAXONOMY_VERSION,
+        "block_reconciliation_partition_rejoin_policy_reconciliation_taxonomy_version_mismatch",
+    )
+    checks.reject_if(
+        payload.get("reconciliation_reason_taxonomy_status") != "verified",
+        "block_reconciliation_partition_rejoin_policy_reconciliation_taxonomy_status_mismatch",
+    )
+
+    reconciliation_reason_codes = payload.get("reconciliation_reason_codes")
+    reconciliation_reason_codes_are_valid = isinstance(reconciliation_reason_codes, list) and bool(
+        reconciliation_reason_codes
+    ) and all(
+        isinstance(code, str) and code for code in reconciliation_reason_codes
+    )
+    checks.reject_if(
+        not reconciliation_reason_codes_are_valid,
+        "block_reconciliation_partition_rejoin_policy_reconciliation_reason_codes_invalid",
+    )
+    if reconciliation_reason_codes_are_valid:
+        checks.reject_if(
+            reconciliation_reason_codes != sorted(set(reconciliation_reason_codes)),
+            "block_reconciliation_partition_rejoin_policy_reconciliation_reason_codes_invalid",
+        )
 
     lane_mode = payload.get("lane_mode")
     checks.reject_if(
@@ -244,6 +355,10 @@ def check_policy(args: argparse.Namespace) -> int:
             reason_code != DRY_RUN_REASON,
             "block_reconciliation_partition_rejoin_policy_dry_run_reason_code_mismatch",
         )
+        checks.reject_if(
+            reconciliation_reason_codes != ["none"],
+            "block_reconciliation_partition_rejoin_policy_dry_run_reconciliation_reason_codes_mismatch",
+        )
     elif lane_mode == "run":
         checks.reject_if(
             payload.get("ci_fast_gate_eligibility") != "excluded_local_heavy",
@@ -260,6 +375,10 @@ def check_policy(args: argparse.Namespace) -> int:
         checks.reject_if(
             reason_code != RUN_REASON,
             "block_reconciliation_partition_rejoin_policy_run_mode_reason_code_mismatch",
+        )
+        checks.reject_if(
+            reconciliation_reason_codes != ["none"],
+            "block_reconciliation_partition_rejoin_policy_run_mode_reconciliation_reason_codes_mismatch",
         )
 
     observed_final_decision, decision_reasons = checks.finalize(

--- a/scripts/runtime/test_check_block_reconciliation_partition_rejoin_live_policy.sh
+++ b/scripts/runtime/test_check_block_reconciliation_partition_rejoin_live_policy.sh
@@ -7,7 +7,8 @@ POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_block_reconciliation_partition_r
 TMP_REPORT="$(mktemp)"
 TMP_POLICY="$(mktemp)"
 TMP_TAMPERED="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY" "$TMP_TAMPERED"' EXIT
+TMP_TAMPERED_TRANSPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY" "$TMP_TAMPERED" "$TMP_TAMPERED_TRANSPORT"' EXIT
 
 if [ ! -x "$VALIDATION_SCRIPT" ]; then
   echo "expected block reconciliation partition/rejoin validation script to be executable" >&2
@@ -97,5 +98,35 @@ reason_codes = [entry for entry in failed_checks.split(",") if entry]
 if "block_reconciliation_partition_rejoin_policy_fast_gate_exclusion_mismatch" not in reason_codes:
     raise SystemExit("expected parser to recover deterministic block reconciliation partition/rejoin reason code")
 PY
+
+cp "$TMP_REPORT" "$TMP_TAMPERED_TRANSPORT"
+python3 - "$TMP_TAMPERED_TRANSPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["runtime_transport_mode"] = "in_memory_simulation"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_transport_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$TMP_TAMPERED_TRANSPORT" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS 2>&1
+)"
+tampered_transport_code=$?
+set -e
+if [ "$tampered_transport_code" -eq 0 ]; then
+  echo "expected transport-mode tampered block reconciliation partition/rejoin report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_transport_output" | grep -q 'block_reconciliation_partition_rejoin_policy_transport_mode_mismatch'; then
+  echo "expected deterministic transport-mode mismatch reason for block reconciliation partition/rejoin report" >&2
+  exit 1
+fi
 
 echo "block reconciliation partition/rejoin live policy tests passed."

--- a/scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live.sh
+++ b/scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_block_reconciliation_partition_rejoin_live.sh"
 TMP_REPORT="$(mktemp)"
-trap 'rm -f "$TMP_REPORT"' EXIT
+TMP_RUN_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_RUN_REPORT"' EXIT
 
 if [ ! -x "$VALIDATION_SCRIPT" ]; then
   echo "expected block reconciliation partition/rejoin live validation script to be executable" >&2
@@ -46,6 +47,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^canonical_convergence_status
   echo "expected canonical convergence marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^runtime_transport_mode=libp2p_transport_fed$'; then
+  echo "expected runtime transport mode marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^reconciliation_reason_taxonomy_status=verified$'; then
+  echo "expected reconciliation reason taxonomy status marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^reconciliation_reason_codes=none$'; then
+  echo "expected deterministic reconciliation reason-code matrix marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^run_mode_command_status=dry_run_no_commands_executed$'; then
   echo "expected block reconciliation partition/rejoin dry-run command marker" >&2
   exit 1
@@ -71,6 +84,97 @@ if payload.get("run_mode_command_count") != 0:
     raise SystemExit("expected run_mode_command_count=0 for dry-run")
 if payload.get("reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected deterministic dry-run reason code")
+if payload.get("runtime_transport_mode") != "libp2p_transport_fed":
+    raise SystemExit("expected runtime_transport_mode=libp2p_transport_fed")
+if payload.get("transport_state_transition_status") != "verified":
+    raise SystemExit("expected transport_state_transition_status=verified")
+if payload.get("reconciliation_reason_taxonomy_status") != "verified":
+    raise SystemExit("expected reconciliation_reason_taxonomy_status=verified")
+if payload.get("reconciliation_reason_taxonomy_version") != "kamn.runtime.block-reconciliation-partition-rejoin-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic reconciliation reason taxonomy version")
+if payload.get("reconciliation_reason_codes") != ["none"]:
+    raise SystemExit("expected deterministic reconciliation_reason_codes=['none'] for dry-run")
+PY
+
+python3 - "$ROOT_DIR" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+sys.path.insert(0, str(root / "scripts" / "runtime"))
+import block_reconciliation_partition_rejoin_live_contract as contract
+
+synthetic_report = {
+    "scenario_results": [
+        {"scenario": "primary_loss_reconnect_catchup", "status": "fail"},
+        {"scenario": "reconnect_drift_regression", "status": "fail"},
+    ],
+    "reason_codes": ["runtime_budget_exceeded", "ci_fast_gate_failed"],
+}
+codes = contract._derive_reconciliation_reason_codes(synthetic_report, lane_mode="run")
+expected = [
+    "reconciliation_ci_fast_gate_failed",
+    "reconciliation_partition_transition_failed",
+    "reconciliation_rejoin_transition_failed",
+    "reconciliation_runtime_budget_exceeded",
+]
+if codes != expected:
+    raise SystemExit(f"unexpected reconciliation taxonomy codes: expected={expected}, found={codes}")
+if contract._derive_reconciliation_reason_codes(None, lane_mode="dry-run") != ["none"]:
+    raise SystemExit("expected dry-run taxonomy derivation to return ['none']")
+PY
+
+run_output="$(
+  KAMN_BLOCK_RECONCILIATION_PARTITION_REJOIN_LIVE_OPT_IN=1 \
+    bash "$VALIDATION_SCRIPT" \
+      --mode run \
+      --max-seconds 120 \
+      --ci-fast-gate PASS \
+      --output-json "$TMP_RUN_REPORT"
+)"
+if ! printf '%s\n' "$run_output" | grep -q '^status=pass$'; then
+  echo "expected block reconciliation partition/rejoin run-mode validation pass status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^lane_mode=run$'; then
+  echo "expected block reconciliation partition/rejoin run-mode lane marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^runtime_transport_mode=libp2p_transport_fed$'; then
+  echo "expected run-mode runtime transport mode marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^reconciliation_reason_codes=none$'; then
+  echo "expected run-mode deterministic reconciliation reason-code matrix marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^run_mode_command_status=executed$'; then
+  echo "expected block reconciliation partition/rejoin run-mode command execution marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_output" | grep -q '^reason_code=block_reconciliation_partition_rejoin_live_validation_executed$'; then
+  echo "expected deterministic run-mode reason code marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+
+python3 - "$TMP_RUN_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("lane_mode") != "run":
+    raise SystemExit("expected lane_mode=run")
+if payload.get("ci_fast_gate_eligibility") != "excluded_local_heavy":
+    raise SystemExit("expected ci_fast_gate_eligibility=excluded_local_heavy")
+if payload.get("run_mode_command_status") != "executed":
+    raise SystemExit("expected run_mode_command_status=executed")
+if payload.get("run_mode_command_count", 0) <= 0:
+    raise SystemExit("expected run_mode_command_count>0 for run mode")
+if payload.get("runtime_transport_mode") != "libp2p_transport_fed":
+    raise SystemExit("expected runtime_transport_mode=libp2p_transport_fed")
+if payload.get("reconciliation_reason_codes") != ["none"]:
+    raise SystemExit("expected deterministic reconciliation_reason_codes=['none'] for run mode")
 PY
 
 set +e

--- a/scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live_contract_lane.sh
@@ -52,6 +52,14 @@ if ! printf '%s\n' "$lane_output" | grep -q '^block_reconciliation_partition_rej
   echo "expected block reconciliation partition/rejoin contract lane status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^runtime_transport_mode_status=verified$'; then
+  echo "expected block reconciliation partition/rejoin contract lane runtime transport mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^reconciliation_reason_taxonomy_status=verified$'; then
+  echo "expected block reconciliation partition/rejoin contract lane reconciliation taxonomy marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=block_reconciliation_partition_rejoin_policy_fast_gate_exclusion_mismatch$'; then
   echo "expected block reconciliation partition/rejoin contract lane fail-closed reason marker" >&2
   exit 1
@@ -75,6 +83,10 @@ if lane_payload.get("block_reconciliation_partition_rejoin_contract_status") != 
     raise SystemExit("expected block_reconciliation_partition_rejoin_contract_status=verified")
 if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
+if lane_payload.get("runtime_transport_mode_status") != "verified":
+    raise SystemExit("expected runtime_transport_mode_status=verified")
+if lane_payload.get("reconciliation_reason_taxonomy_status") != "verified":
+    raise SystemExit("expected reconciliation_reason_taxonomy_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":
     raise SystemExit("expected performance_budget_status=verified")
 

--- a/scripts/runtime/validate_block_reconciliation_partition_rejoin_live_contract_lane.sh
+++ b/scripts/runtime/validate_block_reconciliation_partition_rejoin_live_contract_lane.sh
@@ -107,6 +107,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^canonical_convergence_status
   echo "expected canonical convergence marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^runtime_transport_mode=libp2p_transport_fed$'; then
+  echo "expected runtime transport mode marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^reconciliation_reason_taxonomy_status=verified$'; then
+  echo "expected reconciliation reason taxonomy status marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^reconciliation_reason_codes=none$'; then
+  echo "expected deterministic reconciliation reason-code matrix marker for block reconciliation partition/rejoin validation" >&2
+  exit 1
+fi
 
 policy_output="$(
   bash "$POLICY_CHECKER" \
@@ -203,6 +215,14 @@ if summary_report.get("final_decision") != "GO":
     raise SystemExit("expected block reconciliation partition/rejoin summary final_decision=GO")
 if policy_report.get("final_decision") != "GO":
     raise SystemExit("expected block reconciliation partition/rejoin policy final_decision=GO")
+if summary_report.get("runtime_transport_mode") != "libp2p_transport_fed":
+    raise SystemExit("expected summary runtime_transport_mode=libp2p_transport_fed")
+if summary_report.get("transport_state_transition_status") != "verified":
+    raise SystemExit("expected summary transport_state_transition_status=verified")
+if summary_report.get("reconciliation_reason_taxonomy_status") != "verified":
+    raise SystemExit("expected summary reconciliation_reason_taxonomy_status=verified")
+if summary_report.get("reconciliation_reason_codes") != ["none"]:
+    raise SystemExit("expected summary reconciliation_reason_codes=['none']")
 
 lane_report = {
     "schema_version": "kamn.runtime.block-reconciliation-partition-rejoin-live-contract-lane-report.v1",
@@ -214,6 +234,8 @@ lane_report = {
         "block_reconciliation_partition_rejoin_policy_status"
     ),
     "docs_contract_status": "verified",
+    "runtime_transport_mode_status": "verified",
+    "reconciliation_reason_taxonomy_status": "verified",
     "fail_closed_status": "verified",
     "fail_closed_reason_code": "block_reconciliation_partition_rejoin_policy_fast_gate_exclusion_mismatch",
     "performance_budget_status": "verified",
@@ -236,6 +258,8 @@ echo "lane_mode=$mode"
 echo "block_reconciliation_partition_rejoin_contract_status=verified"
 echo "block_reconciliation_partition_rejoin_policy_status=verified"
 echo "docs_contract_status=verified"
+echo "runtime_transport_mode_status=verified"
+echo "reconciliation_reason_taxonomy_status=verified"
 echo "fail_closed_status=verified"
 echo "fail_closed_reason_code=block_reconciliation_partition_rejoin_policy_fast_gate_exclusion_mismatch"
 echo "performance_budget_status=verified"


### PR DESCRIPTION
## Summary
This enforces partition/rejoin reconciliation taxonomy contracts on the transport-fed live lane by adding deterministic transport-mode markers, taxonomy version markers, and reconciliation reason-code matrix checks. It also tightens policy fail-closed behavior for transport-mode and taxonomy drift.

## Changes
- `scripts/runtime/block_reconciliation_partition_rejoin_live_contract.py`: add deterministic transport/taxonomy markers, reconciliation reason-code derivation, run-mode partition report validation, and stricter policy checks.
- `scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live.sh`: add red/green assertions for transport/taxonomy markers, add unit-style taxonomy derivation checks, and add explicit run-mode opt-in validation path.
- `scripts/runtime/test_check_block_reconciliation_partition_rejoin_live_policy.sh`: add tamper regression for transport-mode mismatch reason code.
- `scripts/runtime/validate_block_reconciliation_partition_rejoin_live_contract_lane.sh`: enforce transport/taxonomy markers from summary in contract-lane composition.
- `scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live_contract_lane.sh`: assert new contract-lane transport/taxonomy markers.
- `docs/ci/strategy.md`: document transport-mode + reconciliation taxonomy evidence markers for this lane.
- `docs/planning/kolme-devnet-ops.md`: add runbook section and deterministic fail-closed marker list for this lane.

## Risks & Compatibility
- Low risk: changes are isolated to runtime lane contract scripts/docs.
- Compatibility: policy checker now fails closed on additional marker drift (`runtime_transport_mode`, taxonomy version/status, reconciliation reason-code matrix).

## Validation
- [x] `cargo fmt --check` — clean (from stacked base branch validation)
- [x] `cargo clippy -- -D warnings` — clean (from stacked base branch validation)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: dry-run and explicit local run-mode paths emit deterministic transport/taxonomy markers and reason-code matrix

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | taxonomy derivation assertions in `scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live.sh` |
| Functional  | ✅     | `bash scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live.sh`; `bash scripts/runtime/test_check_block_reconciliation_partition_rejoin_live_policy.sh` |
| Integration | ✅     | run-mode opt-in path validated in `scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live.sh`; `bash scripts/runtime/test_validate_block_reconciliation_partition_rejoin_live_contract_lane.sh` |
| Regression  | ✅     | transport-mode tamper fail-closed check in `scripts/runtime/test_check_block_reconciliation_partition_rejoin_live_policy.sh`; existing fast-gate tamper regression retained |

Closes #3418
