### PR TITLE
feat(runtime): require composed e2e artifact in go/no-go gate (#3432)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2633,6 +2633,7 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `go_no_go_evidence`
   - `rollback_readiness`
   - `dr_readiness`
+  - `local_full_stack_integration`
 - contract lane command:
   - CI-safe dry-run policy path:
     - `bash scripts/runtime/run_go_no_go_gate_lane.sh --mode dry-run --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -34,6 +34,9 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - provider contract marker `KolmeRuntimeCommitLiveProvider`
 - Deterministic tamper reason:
   - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
+- Release go/no-go linkage:
+  - `scripts/runtime/release_evidence_manifest.json` includes required artifact id `local_full_stack_integration`.
+  - release gate runner consumes `validate_local_full_stack_integration_live_contract_lane.sh` and fails closed on missing/tampered evidence linkage.
 
 ## Lane Migration Matrix (Issue #1721)
 

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -36,6 +36,7 @@ REQUIRED_ARTIFACT_IDS = (
     "go_no_go_evidence",
     "rollback_readiness",
     "dr_readiness",
+    "local_full_stack_integration",
 )
 ARTIFACT_LANE_REGISTRY: dict[str, dict[str, object]] = {
     "go_no_go_evidence": {
@@ -58,6 +59,17 @@ ARTIFACT_LANE_REGISTRY: dict[str, dict[str, object]] = {
         "command": ["bash", str(ROOT_DIR / "scripts/deploy/run_dr_evidence_contract_lane.sh")],
         "success_marker": "dr evidence contract lane tests passed.",
         "failure_label": "dr readiness lane failed unexpectedly",
+    },
+    "local_full_stack_integration": {
+        "expected_lane": "runtime.validate_local_full_stack_integration_live_contract_lane",
+        "command": [
+            "bash",
+            str(ROOT_DIR / "scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh"),
+            "--mode",
+            "dry-run",
+        ],
+        "success_marker": "local_full_stack_integration_policy_status=verified",
+        "failure_label": "local full-stack integration lane failed unexpectedly",
     },
 }
 
@@ -449,6 +461,9 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "go_no_go_evidence_status": "verified" if lane_mode == "run" else "dry_run_pending",
         "rollback_readiness_status": "verified" if lane_mode == "run" else "dry_run_pending",
         "dr_readiness_status": "verified" if lane_mode == "run" else "dry_run_pending",
+        "local_full_stack_integration_status": "verified"
+        if lane_mode == "run"
+        else "dry_run_pending",
         "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
@@ -487,10 +502,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         print("go_no_go_evidence_status=verified")
         print("rollback_readiness_status=verified")
         print("dr_readiness_status=verified")
+        print("local_full_stack_integration_status=verified")
     else:
         print("go_no_go_evidence_status=dry_run_pending")
         print("rollback_readiness_status=dry_run_pending")
         print("dr_readiness_status=dry_run_pending")
+        print("local_full_stack_integration_status=dry_run_pending")
     print("policy_evaluator_status=verified")
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
     print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")

--- a/scripts/runtime/release_evidence_manifest.json
+++ b/scripts/runtime/release_evidence_manifest.json
@@ -16,6 +16,11 @@
       "artifact_id": "dr_readiness",
       "expected_lane": "deploy.run_dr_evidence_contract_lane",
       "expected_success_marker": "dr evidence contract lane tests passed."
+    },
+    {
+      "artifact_id": "local_full_stack_integration",
+      "expected_lane": "runtime.validate_local_full_stack_integration_live_contract_lane",
+      "expected_success_marker": "local_full_stack_integration_policy_status=verified"
     }
   ]
 }

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -86,6 +86,10 @@ if ! printf '%s\n' "$lane_output" | grep -q '^dr_readiness_status=dry_run_pendin
   echo "expected go/no-go gate lane dry-run dr status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^local_full_stack_integration_status=dry_run_pending$'; then
+  echo "expected go/no-go gate lane dry-run local full-stack integration status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^policy_evaluator_status=verified$'; then
   echo "expected go/no-go gate lane policy evaluator status marker" >&2
   exit 1
@@ -155,6 +159,8 @@ if payload.get("rollback_readiness_status") != "dry_run_pending":
     raise SystemExit("expected rollback_readiness_status=dry_run_pending")
 if payload.get("dr_readiness_status") != "dry_run_pending":
     raise SystemExit("expected dr_readiness_status=dry_run_pending")
+if payload.get("local_full_stack_integration_status") != "dry_run_pending":
+    raise SystemExit("expected local_full_stack_integration_status=dry_run_pending")
 if payload.get("policy_evaluator_status") != "verified":
     raise SystemExit("expected policy_evaluator_status=verified")
 if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-manifest.v1":
@@ -162,8 +168,13 @@ if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-mani
 if payload.get("manifest_registry_status") != "verified":
     raise SystemExit("expected manifest_registry_status=verified")
 inventory = payload.get("artifact_inventory")
-if not isinstance(inventory, list) or len(inventory) != 3:
-    raise SystemExit("expected deterministic artifact inventory list with three required entries")
+if not isinstance(inventory, list) or len(inventory) != 4:
+    raise SystemExit("expected deterministic artifact inventory list with four required entries")
+required_ids = payload.get("required_artifact_ids")
+if not isinstance(required_ids, list) or sorted(required_ids) != sorted(
+    ["go_no_go_evidence", "rollback_readiness", "dr_readiness", "local_full_stack_integration"]
+):
+    raise SystemExit("expected required_artifact_ids to include local_full_stack_integration")
 for entry in inventory:
     if not isinstance(entry, dict):
         raise SystemExit("artifact inventory entry must be an object")
@@ -219,6 +230,10 @@ if ! printf '%s\n' "$run_mode_output" | grep -q '^dr_readiness_status=verified$'
   echo "expected go/no-go gate lane run-mode dr status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^local_full_stack_integration_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode local full-stack integration status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$run_mode_output" | grep -q '^ci_fast_gate_eligible=false$'; then
   echo "expected go/no-go gate lane run-mode fast-gate exclusion marker" >&2
   exit 1
@@ -264,6 +279,13 @@ if payload.get("rollback_readiness_status") != "verified":
     raise SystemExit("expected rollback_readiness_status=verified in run-mode go/no-go gate report")
 if payload.get("dr_readiness_status") != "verified":
     raise SystemExit("expected dr_readiness_status=verified in run-mode go/no-go gate report")
+if payload.get("local_full_stack_integration_status") != "verified":
+    raise SystemExit("expected local_full_stack_integration_status=verified in run-mode go/no-go gate report")
+required_ids = payload.get("required_artifact_ids")
+if not isinstance(required_ids, list) or sorted(required_ids) != sorted(
+    ["go_no_go_evidence", "rollback_readiness", "dr_readiness", "local_full_stack_integration"]
+):
+    raise SystemExit("expected run-mode required_artifact_ids to include local_full_stack_integration")
 PY
 
 set +e


### PR DESCRIPTION
## Summary
Extended the runtime go/no-go gate to require composed local full-stack E2E evidence as a first-class release artifact. The gate now enforces `local_full_stack_integration` in manifest validation, execution, and report/status markers.

Closes #3432

## Changes
- `scripts/runtime/go_no_go_gate_lane_contract.py`
  - added required artifact id `local_full_stack_integration`.
  - added lane registry entry for `scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh --mode dry-run`.
  - added `local_full_stack_integration_status` to report payload + stdout markers.
- `scripts/runtime/release_evidence_manifest.json`
  - added required artifact entry for `local_full_stack_integration` with deterministic lane/success marker contract.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`
  - expanded dry-run/run-mode assertions and inventory size to include the new artifact.
  - validated `required_artifact_ids` includes `local_full_stack_integration`.
- `docs/ci/strategy.md`
  - updated required artifact inventory under release manifest schema section.
- `docs/planning/kolme-devnet-ops.md`
  - documented release go/no-go linkage for composed full-stack evidence.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/runtime/run_go_no_go_gate_lane.sh --mode dry-run --max-seconds 120 --output-json /tmp/go-no-go-red.json`
  - failed with: `release_manifest_unknown_artifact_id:local_full_stack_integration`

### 🟢 Green Phase
- `python3 -m py_compile scripts/runtime/go_no_go_gate_lane_contract.py`
- `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
  - passed: `go/no-go gate lane script tests passed.`

### 🔁 Regression
- `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` (includes dry-run, run-mode, waiver, tamper, and fault-profile checks)

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | reason/registry and required-artifact assertions via updated script checks | |
| Functional   | ✅ | go/no-go dry-run/run-mode marker assertions for new artifact | |
| Integration  | ✅ | manifest + lane execution path now includes composed local full-stack contract lane artifact | |
| Regression   | ✅ | missing-artifact/waiver/tamper/fault checks preserved with new artifact inventory | |
| Performance  | ✅ | existing bounded runtime budget semantics retained; no new unbounded command paths | |

## Risks & Rollback
- Risk: release gate now depends on composed full-stack contract-lane script availability.
- Rollback: revert commit `c0e8d36` to restore prior three-artifact manifest/gate behavior.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A, scripts/docs-only change)
- [x] `cargo clippy -- -D warnings` — clean (N/A, scripts/docs-only change)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-scoped go/no-go regression suite)
- [x] Docs updated
