### PR TITLE
feat(runtime): add true local-heavy composed kolm run-mode path (#3434)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -291,7 +291,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 ## Runtime Local Full-Stack Integration Contract Lane
 - Entry commands:
   - `bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode dry-run --output-json /tmp/local-full-stack-integration-summary.json`
-  - `KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1 bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode run --ci-fast-gate FAIL --output-json /tmp/local-full-stack-integration-summary.json`
+- `KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1 bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode run --ci-fast-gate FAIL --kolme-checkout-path /tmp/kolme_fork --kolme-expected-remote-url https://github.com/njfio/kolme_fork.git --kolme-expected-ref refs/heads/main --kolme-base-url http://127.0.0.1:3000 --kolme-fork-chain-version v0.15.2 --output-json /tmp/local-full-stack-integration-summary.json`
   - `bash scripts/runtime/check_local_full_stack_integration_live_policy.sh --report-file /tmp/local-full-stack-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-full-stack-integration-policy.json`
   - `bash scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh --output-json /tmp/local-full-stack-integration-contract-lane-report.json --policy-output-json /tmp/local-full-stack-integration-policy.json`
   - `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
@@ -303,13 +303,15 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Integration composition contract:
   - composes full I/O scenario matrix lane (`validate_full_io_scenario_matrix_live.sh`) in run mode.
   - composes full-runtime supervisor lane (`validate_local_full_runtime_live.sh`) in run mode.
-  - composes Kolme runtime integration contract lane (`run_local_kamn_live_runtime_integration_contract_lane.sh`) in run mode.
+  - composes Kolme runtime integration lane (`run_local_kamn_live_runtime_integration_lane.sh`) in run mode.
   - enforces top-level marker domains for:
     - transport convergence
     - signer provenance
     - runtime commit submission
     - runtime commit finality
     - runtime provider contract (`KolmeRuntimeCommitLiveProvider`)
+    - local-only Kolme checkout/remote/ref/base-url/fork-chain prerequisites
+    - nested Kolme local-only enforcement and run-mode policy markers
   - architecture boundary reference: `docs/architecture/kolme-live-integration.md`
   - emits deterministic evidence bundle schema `kamn.runtime.local-full-stack-integration-evidence-bundle.v1`.
 - Cost controls:

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -17,7 +17,7 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Composed runtime lane command:
   - `bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode dry-run --output-json /tmp/local-full-stack-integration-summary.json`
 - Local-only composed run-mode command:
-  - `KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1 bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode run --ci-fast-gate FAIL --output-json /tmp/local-full-stack-integration-summary.json`
+  - `KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1 bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode run --ci-fast-gate FAIL --kolme-checkout-path /tmp/kolme_fork --kolme-expected-remote-url https://github.com/njfio/kolme_fork.git --kolme-expected-ref refs/heads/main --kolme-base-url http://127.0.0.1:3000 --kolme-fork-chain-version v0.15.2 --output-json /tmp/local-full-stack-integration-summary.json`
 - Policy checker command:
   - `bash scripts/runtime/check_local_full_stack_integration_live_policy.sh --report-file /tmp/local-full-stack-integration-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-full-stack-integration-policy.json`
 - Contract lane command:
@@ -26,12 +26,14 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
   - run-mode composes:
     - `scripts/runtime/validate_full_io_scenario_matrix_live.sh`
     - `scripts/runtime/validate_local_full_runtime_live.sh`
-    - `scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh`
+    - `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
   - nested Kolme summary/policy evidence is fail-closed for:
     - signer provenance markers
     - runtime commit submission markers
     - runtime commit finality markers
     - provider contract marker `KolmeRuntimeCommitLiveProvider`
+    - local checkout/remote/ref/base-url/fork-chain prerequisite markers
+    - local-only enforcement and nested run-mode policy reason-code marker `live_runtime_integration_passed`
 - Deterministic tamper reason:
   - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
 - Release go/no-go linkage:

--- a/scripts/runtime/local_full_stack_integration_live_contract.py
+++ b/scripts/runtime/local_full_stack_integration_live_contract.py
@@ -34,6 +34,12 @@ KOLME_INTEGRATION_POLICY_SCHEMA = "kamn.kolme.local-kamn-live-runtime-integratio
 KOLME_PROVIDER_CLIENT_CONTRACT = "KolmeRuntimeCommitLiveProvider"
 KOLME_RUNTIME_SIGNING_PROFILE = "kolme-fork-secp256k1-v1"
 KOLME_SIGNER_ATTESTATION_SCHEMA = "kamn.kolme.runtime-signer-attestation.v1"
+KOLME_RUNTIME_INTEGRATION_RUN_REASON = "live_runtime_integration_passed"
+KOLME_DEFAULT_CHECKOUT_PATH = "/tmp/kolme_fork"
+KOLME_DEFAULT_EXPECTED_REMOTE_URL = "https://github.com/njfio/kolme_fork.git"
+KOLME_DEFAULT_EXPECTED_REF = "refs/heads/main"
+KOLME_DEFAULT_BASE_URL = "http://127.0.0.1:3000"
+KOLME_DEFAULT_FORK_CHAIN_VERSION = "v0.15.2"
 OPT_IN_ENV = "KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN"
 DRY_RUN_REASON = "dry_run_no_commands_executed"
 RUN_REASON = "local_full_stack_integration_live_validation_executed"
@@ -84,6 +90,52 @@ def _read_json_dict(path: Path, *, failure_reason: str) -> dict[str, object]:
     return payload
 
 
+def _require_local_kolme_checkout(
+    *,
+    checkout_path: Path,
+    expected_remote_url: str,
+    expected_ref: str,
+) -> None:
+    if not checkout_path.is_dir():
+        fail("local_kolme_checkout_missing")
+
+    inside_work_tree = subprocess.run(
+        ["git", "-C", str(checkout_path), "rev-parse", "--is-inside-work-tree"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if inside_work_tree.returncode != 0:
+        fail("local_kolme_checkout_not_git_repo")
+
+    origin_remote = subprocess.run(
+        ["git", "-C", str(checkout_path), "remote", "get-url", "origin"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if origin_remote.returncode != 0:
+        fail("local_kolme_checkout_origin_missing")
+    observed_remote = origin_remote.stdout.strip()
+    if observed_remote != expected_remote_url:
+        fail("local_kolme_checkout_remote_mismatch")
+
+    symbolic_ref = subprocess.run(
+        ["git", "-C", str(checkout_path), "symbolic-ref", "-q", "HEAD"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if symbolic_ref.returncode != 0:
+        fail("local_kolme_checkout_ref_missing")
+    observed_ref = symbolic_ref.stdout.strip()
+    if observed_ref != expected_ref:
+        fail("local_kolme_checkout_ref_mismatch")
+
+
 def run_lane(args: argparse.Namespace) -> int:
     mode = require_enum("--mode", args.mode.strip(), ("dry-run", "run"))
     ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
@@ -92,11 +144,30 @@ def run_lane(args: argparse.Namespace) -> int:
         "KAMN_LOCAL_FULL_STACK_INTEGRATION_COMMAND_MAX_SECONDS",
         args.command_max_seconds,
     )
+    kolme_checkout_path = Path(args.kolme_checkout_path).expanduser().resolve()
+    kolme_expected_remote_url = args.kolme_expected_remote_url.strip()
+    kolme_expected_ref = args.kolme_expected_ref.strip()
+    kolme_base_url = args.kolme_base_url.strip()
+    kolme_fork_chain_version = args.kolme_fork_chain_version.strip()
 
     if mode == "run" and args.local_opt_in != "1":
         fail(
             "run mode requires explicit local-only opt-in via "
             "KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1"
+        )
+    if mode == "run" and not kolme_expected_remote_url:
+        fail("local_kolme_expected_remote_url_missing")
+    if mode == "run" and not kolme_expected_ref:
+        fail("local_kolme_expected_ref_missing")
+    if mode == "run" and not kolme_base_url:
+        fail("local_kolme_base_url_missing")
+    if mode == "run" and not kolme_fork_chain_version:
+        fail("local_kolme_fork_chain_version_missing")
+    if mode == "run":
+        _require_local_kolme_checkout(
+            checkout_path=kolme_checkout_path,
+            expected_remote_url=kolme_expected_remote_url,
+            expected_ref=kolme_expected_ref,
         )
 
     start_epoch = int(time.time())
@@ -107,6 +178,10 @@ def run_lane(args: argparse.Namespace) -> int:
     runtime_commit_submission_status = "planned" if mode == "dry-run" else "verified"
     runtime_commit_finality_status = "planned" if mode == "dry-run" else "verified"
     runtime_provider_contract_status = "planned" if mode == "dry-run" else "verified"
+    kolme_local_prerequisite_status = "planned" if mode == "dry-run" else "verified"
+    kolme_local_only_enforced_status = "planned" if mode == "dry-run" else "verified"
+    kolme_integration_mode_status = "planned" if mode == "dry-run" else "verified"
+    kolme_integration_policy_status = "planned" if mode == "dry-run" else "verified"
 
     if mode == "run":
         artifact_dir = Path(tempfile.mkdtemp(prefix="local-full-stack-integration-live-"))
@@ -165,18 +240,54 @@ def run_lane(args: argparse.Namespace) -> int:
         kolme_output = _run_command(
             [
                 "bash",
-                "scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh",
+                "scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh",
+                "--mode",
+                "run",
+                "--checkout-path",
+                str(kolme_checkout_path),
+                "--expected-remote-url",
+                kolme_expected_remote_url,
+                "--expected-ref",
+                kolme_expected_ref,
+                "--base-url",
+                kolme_base_url,
+                "--fork-chain-version",
+                kolme_fork_chain_version,
                 "--output-json",
                 str(kolme_integration_report),
-                "--policy-output-json",
-                str(kolme_integration_policy_report),
                 "--max-seconds",
                 str(min(command_max_seconds, 210)),
             ],
             timeout_seconds=command_max_seconds,
+            env={**os.environ, "KAMN_KOLME_LOCAL_HEAVY": "1"},
         )
-        if not any(line.strip() == "status=ok" for line in kolme_output.splitlines()):
-            fail("kolme runtime integration contract lane did not emit status=ok")
+        if _extract_line_value(kolme_output, "status") != "ok":
+            fail("kolme runtime integration lane did not emit status=ok")
+        if _extract_line_value(kolme_output, "lane_mode") != "run":
+            fail("kolme runtime integration lane did not emit lane_mode=run")
+        commands_executed += 1
+
+        kolme_policy_output = _run_command(
+            [
+                "python3",
+                "scripts/kolme/check_local_kamn_live_runtime_integration_policy.py",
+                "--report-file",
+                str(kolme_integration_report),
+                "--expected-final-decision",
+                "GO",
+                "--ci-fast-gate",
+                "PASS",
+                "--require-reason-code",
+                KOLME_RUNTIME_INTEGRATION_RUN_REASON,
+                "--output-json",
+                str(kolme_integration_policy_report),
+            ],
+            timeout_seconds=command_max_seconds,
+        )
+        if _extract_line_value(kolme_policy_output, "status") != "ok":
+            fail("kolme runtime integration policy checker did not emit status=ok")
+        if _extract_line_value(kolme_policy_output, "final_decision") != "GO":
+            fail("kolme runtime integration policy checker did not emit final_decision=GO")
         commands_executed += 1
 
         full_io_payload = _read_json_dict(
@@ -204,6 +315,24 @@ def run_lane(args: argparse.Namespace) -> int:
             fail("kolme runtime integration report schema mismatch")
         if kolme_integration_payload.get("status") != "ok":
             fail("kolme runtime integration report status mismatch")
+        if kolme_integration_payload.get("mode") != "run":
+            fail("kolme runtime integration report mode mismatch")
+        if kolme_integration_payload.get("reason_code") != KOLME_RUNTIME_INTEGRATION_RUN_REASON:
+            fail("kolme runtime integration report reason code mismatch")
+        if kolme_integration_payload.get("local_only_enforced") is not True:
+            fail("kolme runtime integration report local_only_enforced mismatch")
+        if kolme_integration_payload.get("ci_fast_gate_eligible") is not False:
+            fail("kolme runtime integration report ci_fast_gate_eligible mismatch")
+        if kolme_integration_payload.get("checkout_path") != str(kolme_checkout_path):
+            fail("kolme runtime integration report checkout_path mismatch")
+        if kolme_integration_payload.get("expected_remote_url") != kolme_expected_remote_url:
+            fail("kolme runtime integration report expected_remote_url mismatch")
+        if kolme_integration_payload.get("expected_ref") != kolme_expected_ref:
+            fail("kolme runtime integration report expected_ref mismatch")
+        if kolme_integration_payload.get("base_url") != kolme_base_url:
+            fail("kolme runtime integration report base_url mismatch")
+        if kolme_integration_payload.get("fork_chain_version") != kolme_fork_chain_version:
+            fail("kolme runtime integration report fork_chain_version mismatch")
         if kolme_integration_payload.get("runtime_profile") != "real-node":
             fail("kolme runtime integration report runtime_profile mismatch")
         if (
@@ -232,6 +361,8 @@ def run_lane(args: argparse.Namespace) -> int:
             fail("kolme runtime integration policy schema mismatch")
         if kolme_policy_payload.get("final_decision") != "GO":
             fail("kolme runtime integration policy missing final_decision=GO")
+        if kolme_policy_payload.get("observed_reason_code") != KOLME_RUNTIME_INTEGRATION_RUN_REASON:
+            fail("kolme runtime integration policy observed reason code mismatch")
 
         evidence_bundle = {
             "schema_version": EVIDENCE_BUNDLE_SCHEMA,
@@ -250,6 +381,15 @@ def run_lane(args: argparse.Namespace) -> int:
             "runtime_provider_client_contract": KOLME_PROVIDER_CLIENT_CONTRACT,
             "runtime_signing_profile": KOLME_RUNTIME_SIGNING_PROFILE,
             "runtime_signer_attestation_schema_version": KOLME_SIGNER_ATTESTATION_SCHEMA,
+            "kolme_local_prerequisite_status": kolme_local_prerequisite_status,
+            "kolme_local_only_enforced_status": kolme_local_only_enforced_status,
+            "kolme_integration_mode_status": kolme_integration_mode_status,
+            "kolme_integration_policy_status": kolme_integration_policy_status,
+            "kolme_checkout_path": str(kolme_checkout_path),
+            "kolme_expected_remote_url": kolme_expected_remote_url,
+            "kolme_expected_ref": kolme_expected_ref,
+            "kolme_base_url": kolme_base_url,
+            "kolme_fork_chain_version": kolme_fork_chain_version,
             "commands_executed": commands_executed,
             "ci_fast_gate_eligibility": "excluded_local_heavy",
         }
@@ -294,6 +434,15 @@ def run_lane(args: argparse.Namespace) -> int:
         "runtime_provider_client_contract": KOLME_PROVIDER_CLIENT_CONTRACT,
         "runtime_signing_profile": KOLME_RUNTIME_SIGNING_PROFILE,
         "runtime_signer_attestation_schema_version": KOLME_SIGNER_ATTESTATION_SCHEMA,
+        "kolme_local_prerequisite_status": kolme_local_prerequisite_status,
+        "kolme_local_only_enforced_status": kolme_local_only_enforced_status,
+        "kolme_integration_mode_status": kolme_integration_mode_status,
+        "kolme_integration_policy_status": kolme_integration_policy_status,
+        "kolme_checkout_path": str(kolme_checkout_path),
+        "kolme_expected_remote_url": kolme_expected_remote_url,
+        "kolme_expected_ref": kolme_expected_ref,
+        "kolme_base_url": kolme_base_url,
+        "kolme_fork_chain_version": kolme_fork_chain_version,
         "kolme_integration_report_schema_version": KOLME_INTEGRATION_REPORT_SCHEMA,
         "kolme_integration_policy_schema_version": KOLME_INTEGRATION_POLICY_SCHEMA,
         "run_mode_command_status": run_mode_command_status,
@@ -325,6 +474,15 @@ def run_lane(args: argparse.Namespace) -> int:
     print(f"runtime_provider_client_contract={KOLME_PROVIDER_CLIENT_CONTRACT}")
     print(f"runtime_signing_profile={KOLME_RUNTIME_SIGNING_PROFILE}")
     print(f"runtime_signer_attestation_schema_version={KOLME_SIGNER_ATTESTATION_SCHEMA}")
+    print(f"kolme_local_prerequisite_status={kolme_local_prerequisite_status}")
+    print(f"kolme_local_only_enforced_status={kolme_local_only_enforced_status}")
+    print(f"kolme_integration_mode_status={kolme_integration_mode_status}")
+    print(f"kolme_integration_policy_status={kolme_integration_policy_status}")
+    print(f"kolme_checkout_path={kolme_checkout_path}")
+    print(f"kolme_expected_remote_url={kolme_expected_remote_url}")
+    print(f"kolme_expected_ref={kolme_expected_ref}")
+    print(f"kolme_base_url={kolme_base_url}")
+    print(f"kolme_fork_chain_version={kolme_fork_chain_version}")
     print(f"kolme_integration_report_schema_version={KOLME_INTEGRATION_REPORT_SCHEMA}")
     print(f"kolme_integration_policy_schema_version={KOLME_INTEGRATION_POLICY_SCHEMA}")
     print(f"run_mode_command_status={run_mode_command_status}")
@@ -441,6 +599,49 @@ def check_policy(args: argparse.Namespace) -> int:
         payload.get("runtime_provider_contract_status") != expected_domain_status,
         "local_full_stack_integration_policy_runtime_provider_contract_status_mismatch",
     )
+    checks.reject_if(
+        payload.get("kolme_local_prerequisite_status") != expected_domain_status,
+        "local_full_stack_integration_policy_kolme_local_prerequisite_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_local_only_enforced_status") != expected_domain_status,
+        "local_full_stack_integration_policy_kolme_local_only_enforced_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_integration_mode_status") != expected_domain_status,
+        "local_full_stack_integration_policy_kolme_integration_mode_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_integration_policy_status") != expected_domain_status,
+        "local_full_stack_integration_policy_kolme_integration_policy_status_mismatch",
+    )
+
+    kolme_checkout_path = payload.get("kolme_checkout_path")
+    kolme_expected_remote_url = payload.get("kolme_expected_remote_url")
+    kolme_expected_ref = payload.get("kolme_expected_ref")
+    kolme_base_url = payload.get("kolme_base_url")
+    kolme_fork_chain_version = payload.get("kolme_fork_chain_version")
+
+    checks.reject_if(
+        not isinstance(kolme_checkout_path, str) or not kolme_checkout_path.strip(),
+        "local_full_stack_integration_policy_kolme_checkout_path_missing",
+    )
+    checks.reject_if(
+        not isinstance(kolme_expected_remote_url, str) or not kolme_expected_remote_url.strip(),
+        "local_full_stack_integration_policy_kolme_expected_remote_url_missing",
+    )
+    checks.reject_if(
+        not isinstance(kolme_expected_ref, str) or not kolme_expected_ref.strip(),
+        "local_full_stack_integration_policy_kolme_expected_ref_missing",
+    )
+    checks.reject_if(
+        not isinstance(kolme_base_url, str) or not kolme_base_url.strip(),
+        "local_full_stack_integration_policy_kolme_base_url_missing",
+    )
+    checks.reject_if(
+        not isinstance(kolme_fork_chain_version, str) or not kolme_fork_chain_version.strip(),
+        "local_full_stack_integration_policy_kolme_fork_chain_version_missing",
+    )
 
     if lane_mode == "dry-run":
         checks.reject_if(
@@ -465,7 +666,7 @@ def check_policy(args: argparse.Namespace) -> int:
             "local_full_stack_integration_policy_run_mode_exclusion_mismatch",
         )
         checks.reject_if(
-            command_count < 3,
+            command_count < 4,
             "local_full_stack_integration_policy_run_mode_command_count_mismatch",
         )
         checks.reject_if(
@@ -525,6 +726,47 @@ def check_policy(args: argparse.Namespace) -> int:
                 "local_full_stack_integration_policy_kolme_summary_status_mismatch",
             )
             checks.reject_if(
+                kolme_summary_payload.get("mode") != "run",
+                "local_full_stack_integration_policy_kolme_summary_mode_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("reason_code") != KOLME_RUNTIME_INTEGRATION_RUN_REASON,
+                "local_full_stack_integration_policy_kolme_summary_reason_code_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("local_only_enforced") is not True,
+                "local_full_stack_integration_policy_kolme_summary_local_only_enforced_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("ci_fast_gate_eligible") is not False,
+                "local_full_stack_integration_policy_kolme_summary_ci_fast_gate_eligibility_mismatch",
+            )
+            checks.reject_if(
+                isinstance(kolme_checkout_path, str)
+                and kolme_summary_payload.get("checkout_path") != kolme_checkout_path,
+                "local_full_stack_integration_policy_kolme_summary_checkout_path_mismatch",
+            )
+            checks.reject_if(
+                isinstance(kolme_expected_remote_url, str)
+                and kolme_summary_payload.get("expected_remote_url") != kolme_expected_remote_url,
+                "local_full_stack_integration_policy_kolme_summary_expected_remote_url_mismatch",
+            )
+            checks.reject_if(
+                isinstance(kolme_expected_ref, str)
+                and kolme_summary_payload.get("expected_ref") != kolme_expected_ref,
+                "local_full_stack_integration_policy_kolme_summary_expected_ref_mismatch",
+            )
+            checks.reject_if(
+                isinstance(kolme_base_url, str)
+                and kolme_summary_payload.get("base_url") != kolme_base_url,
+                "local_full_stack_integration_policy_kolme_summary_base_url_mismatch",
+            )
+            checks.reject_if(
+                isinstance(kolme_fork_chain_version, str)
+                and kolme_summary_payload.get("fork_chain_version") != kolme_fork_chain_version,
+                "local_full_stack_integration_policy_kolme_summary_fork_chain_version_mismatch",
+            )
+            checks.reject_if(
                 kolme_summary_payload.get("runtime_profile") != "real-node",
                 "local_full_stack_integration_policy_kolme_summary_runtime_profile_mismatch",
             )
@@ -579,6 +821,10 @@ def check_policy(args: argparse.Namespace) -> int:
             checks.reject_if(
                 kolme_policy_payload.get("final_decision") != "GO",
                 "local_full_stack_integration_policy_kolme_policy_final_decision_mismatch",
+            )
+            checks.reject_if(
+                kolme_policy_payload.get("observed_reason_code") != KOLME_RUNTIME_INTEGRATION_RUN_REASON,
+                "local_full_stack_integration_policy_kolme_policy_observed_reason_code_mismatch",
             )
 
     observed_final_decision, decision_reasons = checks.finalize(
@@ -636,6 +882,41 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_lane_parser.add_argument("--ci-fast-gate", default=os.environ.get("KAMN_CI_FAST_GATE", "PASS"))
     run_lane_parser.add_argument("--local-opt-in", default=os.environ.get(OPT_IN_ENV, "0"))
+    run_lane_parser.add_argument(
+        "--kolme-checkout-path",
+        default=os.environ.get(
+            "KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_CHECKOUT_PATH",
+            KOLME_DEFAULT_CHECKOUT_PATH,
+        ),
+    )
+    run_lane_parser.add_argument(
+        "--kolme-expected-remote-url",
+        default=os.environ.get(
+            "KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_EXPECTED_REMOTE_URL",
+            KOLME_DEFAULT_EXPECTED_REMOTE_URL,
+        ),
+    )
+    run_lane_parser.add_argument(
+        "--kolme-expected-ref",
+        default=os.environ.get(
+            "KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_EXPECTED_REF",
+            KOLME_DEFAULT_EXPECTED_REF,
+        ),
+    )
+    run_lane_parser.add_argument(
+        "--kolme-base-url",
+        default=os.environ.get(
+            "KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_BASE_URL",
+            KOLME_DEFAULT_BASE_URL,
+        ),
+    )
+    run_lane_parser.add_argument(
+        "--kolme-fork-chain-version",
+        default=os.environ.get(
+            "KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_FORK_CHAIN_VERSION",
+            KOLME_DEFAULT_FORK_CHAIN_VERSION,
+        ),
+    )
     run_lane_parser.add_argument("--output-json", default="")
     run_lane_parser.set_defaults(handler=run_lane)
 

--- a/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
@@ -34,6 +34,15 @@ cat >"$TMP_REPORT" <<'JSON'
   "runtime_provider_client_contract": "KolmeRuntimeCommitLiveProvider",
   "runtime_signing_profile": "kolme-fork-secp256k1-v1",
   "runtime_signer_attestation_schema_version": "kamn.kolme.runtime-signer-attestation.v1",
+  "kolme_local_prerequisite_status": "planned",
+  "kolme_local_only_enforced_status": "planned",
+  "kolme_integration_mode_status": "planned",
+  "kolme_integration_policy_status": "planned",
+  "kolme_checkout_path": "/tmp/kolme_fork",
+  "kolme_expected_remote_url": "https://github.com/njfio/kolme_fork.git",
+  "kolme_expected_ref": "refs/heads/main",
+  "kolme_base_url": "http://127.0.0.1:3000",
+  "kolme_fork_chain_version": "v0.15.2",
   "kolme_integration_report_schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
   "kolme_integration_policy_schema_version": "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1",
   "run_mode_command_status": "dry_run_no_commands_executed",
@@ -110,6 +119,37 @@ if [ "$tampered_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_output" | grep -q 'local_full_stack_integration_policy_runtime_commit_finality_status_mismatch'; then
   echo "expected deterministic reason marker for tampered runtime commit finality status" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["kolme_local_prerequisite_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_kolme_marker_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_kolme_marker_code=$?
+set -e
+if [ "$tampered_kolme_marker_code" -eq 0 ]; then
+  echo "expected tampered Kolme local prerequisite marker to fail policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_kolme_marker_output" | grep -q 'local_full_stack_integration_policy_kolme_local_prerequisite_status_mismatch'; then
+  echo "expected deterministic reason marker for tampered Kolme local prerequisite status" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_full_stack_integration_live.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live.sh"
 TMP_REPORT="$(mktemp)"
-trap 'rm -f "$TMP_REPORT"' EXIT
+TMP_DIR="$(mktemp -d)"
+trap 'rm -f "$TMP_REPORT"; rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -x "$VALIDATION_SCRIPT" ]; then
   echo "expected local full-stack integration validation script to be executable" >&2
@@ -74,6 +75,22 @@ if ! printf '%s\n' "$validation_output" | grep -q '^runtime_signer_attestation_s
   echo "expected local full-stack integration runtime signer attestation schema marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_local_prerequisite_status=planned$'; then
+  echo "expected local full-stack integration Kolme local prerequisite marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_local_only_enforced_status=planned$'; then
+  echo "expected local full-stack integration Kolme local-only marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_integration_mode_status=planned$'; then
+  echo "expected local full-stack integration Kolme integration mode marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_integration_policy_status=planned$'; then
+  echo "expected local full-stack integration Kolme integration policy marker in dry-run" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^run_mode_command_status=dry_run_no_commands_executed$'; then
   echo "expected local full-stack integration dry-run command marker" >&2
   exit 1
@@ -119,6 +136,24 @@ if payload.get("kolme_integration_report_schema_version") != "kamn.kolme.local-k
     raise SystemExit("expected kolme_integration_report_schema_version marker")
 if payload.get("kolme_integration_policy_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("expected kolme_integration_policy_schema_version marker")
+if payload.get("kolme_local_prerequisite_status") != "planned":
+    raise SystemExit("expected kolme_local_prerequisite_status=planned")
+if payload.get("kolme_local_only_enforced_status") != "planned":
+    raise SystemExit("expected kolme_local_only_enforced_status=planned")
+if payload.get("kolme_integration_mode_status") != "planned":
+    raise SystemExit("expected kolme_integration_mode_status=planned")
+if payload.get("kolme_integration_policy_status") != "planned":
+    raise SystemExit("expected kolme_integration_policy_status=planned")
+if payload.get("kolme_checkout_path") != "/tmp/kolme_fork":
+    raise SystemExit("expected default kolme_checkout_path marker")
+if payload.get("kolme_expected_remote_url") != "https://github.com/njfio/kolme_fork.git":
+    raise SystemExit("expected default kolme_expected_remote_url marker")
+if payload.get("kolme_expected_ref") != "refs/heads/main":
+    raise SystemExit("expected default kolme_expected_ref marker")
+if payload.get("kolme_base_url") != "http://127.0.0.1:3000":
+    raise SystemExit("expected default kolme_base_url marker")
+if payload.get("kolme_fork_chain_version") != "v0.15.2":
+    raise SystemExit("expected default kolme_fork_chain_version marker")
 if not isinstance(payload.get("artifact_paths"), dict):
     raise SystemExit("expected artifact_paths dictionary")
 PY
@@ -138,6 +173,29 @@ if [ "$run_without_opt_in_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$run_without_opt_in_output" | grep -q 'run mode requires explicit local-only opt-in via KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1'; then
   echo "expected deterministic opt-in marker for local full-stack integration run mode" >&2
+  exit 1
+fi
+
+set +e
+run_missing_checkout_output="$(
+  KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN=1 bash "$VALIDATION_SCRIPT" \
+    --mode run \
+    --max-seconds 120 \
+    --ci-fast-gate PASS \
+    --kolme-checkout-path "$TMP_DIR/missing-checkout" \
+    --kolme-expected-remote-url "https://github.com/njfio/kolme_fork.git" \
+    --kolme-expected-ref "refs/heads/main" \
+    --kolme-base-url "http://127.0.0.1:3000" \
+    --kolme-fork-chain-version "v0.15.2" 2>&1
+)"
+run_missing_checkout_code=$?
+set -e
+if [ "$run_missing_checkout_code" -eq 0 ]; then
+  echo "expected run mode without local checkout prerequisite to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_missing_checkout_output" | grep -q 'local_kolme_checkout_missing'; then
+  echo "expected deterministic local checkout missing reason for run mode prerequisites" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
@@ -71,6 +71,22 @@ if ! printf '%s\n' "$lane_output" | grep -q '^runtime_provider_contract_status=p
   echo "expected local full-stack integration contract lane provider marker in dry-run" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_local_prerequisite_status=planned$'; then
+  echo "expected local full-stack integration contract lane Kolme local prerequisite marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_local_only_enforced_status=planned$'; then
+  echo "expected local full-stack integration contract lane Kolme local-only marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_integration_mode_status=planned$'; then
+  echo "expected local full-stack integration contract lane Kolme integration mode marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_integration_policy_status=planned$'; then
+  echo "expected local full-stack integration contract lane Kolme integration policy marker in dry-run" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_full_stack_integration_policy_runtime_commit_finality_status_mismatch$'; then
   echo "expected local full-stack integration contract lane fail-closed reason marker" >&2
   exit 1
@@ -112,6 +128,24 @@ if lane_payload.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
     raise SystemExit("expected runtime_signing_profile marker")
 if lane_payload.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
     raise SystemExit("expected runtime_signer_attestation_schema_version marker")
+if lane_payload.get("kolme_local_prerequisite_status") != "planned":
+    raise SystemExit("expected kolme_local_prerequisite_status=planned in dry-run")
+if lane_payload.get("kolme_local_only_enforced_status") != "planned":
+    raise SystemExit("expected kolme_local_only_enforced_status=planned in dry-run")
+if lane_payload.get("kolme_integration_mode_status") != "planned":
+    raise SystemExit("expected kolme_integration_mode_status=planned in dry-run")
+if lane_payload.get("kolme_integration_policy_status") != "planned":
+    raise SystemExit("expected kolme_integration_policy_status=planned in dry-run")
+if lane_payload.get("kolme_checkout_path") != "/tmp/kolme_fork":
+    raise SystemExit("expected default kolme_checkout_path marker")
+if lane_payload.get("kolme_expected_remote_url") != "https://github.com/njfio/kolme_fork.git":
+    raise SystemExit("expected default kolme_expected_remote_url marker")
+if lane_payload.get("kolme_expected_ref") != "refs/heads/main":
+    raise SystemExit("expected default kolme_expected_ref marker")
+if lane_payload.get("kolme_base_url") != "http://127.0.0.1:3000":
+    raise SystemExit("expected default kolme_base_url marker")
+if lane_payload.get("kolme_fork_chain_version") != "v0.15.2":
+    raise SystemExit("expected default kolme_fork_chain_version marker")
 if lane_payload.get("kolme_integration_report_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-summary.v1":
     raise SystemExit("expected kolme integration report schema marker")
 if lane_payload.get("kolme_integration_policy_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":

--- a/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
@@ -11,6 +11,11 @@ policy_output_json=""
 max_seconds="${KAMN_LOCAL_FULL_STACK_INTEGRATION_CONTRACT_MAX_SECONDS:-180}"
 ci_fast_gate="PASS"
 mode="dry-run"
+kolme_checkout_path="${KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_CHECKOUT_PATH:-/tmp/kolme_fork}"
+kolme_expected_remote_url="${KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_EXPECTED_REMOTE_URL:-https://github.com/njfio/kolme_fork.git}"
+kolme_expected_ref="${KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_EXPECTED_REF:-refs/heads/main}"
+kolme_base_url="${KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_BASE_URL:-http://127.0.0.1:3000}"
+kolme_fork_chain_version="${KAMN_LOCAL_FULL_STACK_INTEGRATION_KOLME_FORK_CHAIN_VERSION:-v0.15.2}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -32,6 +37,26 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mode)
       mode="${2:-}"
+      shift 2
+      ;;
+    --kolme-checkout-path)
+      kolme_checkout_path="${2:-}"
+      shift 2
+      ;;
+    --kolme-expected-remote-url)
+      kolme_expected_remote_url="${2:-}"
+      shift 2
+      ;;
+    --kolme-expected-ref)
+      kolme_expected_ref="${2:-}"
+      shift 2
+      ;;
+    --kolme-base-url)
+      kolme_base_url="${2:-}"
+      shift 2
+      ;;
+    --kolme-fork-chain-version)
+      kolme_fork_chain_version="${2:-}"
       shift 2
       ;;
     *)
@@ -81,6 +106,11 @@ validation_output="$(
   bash "$VALIDATION_SCRIPT" \
     --mode "$mode" \
     --max-seconds "$max_seconds" \
+    --kolme-checkout-path "$kolme_checkout_path" \
+    --kolme-expected-remote-url "$kolme_expected_remote_url" \
+    --kolme-expected-ref "$kolme_expected_ref" \
+    --kolme-base-url "$kolme_base_url" \
+    --kolme-fork-chain-version "$kolme_fork_chain_version" \
     --output-json "$summary_report"
 )"
 domain_expected_status="planned"
@@ -137,6 +167,22 @@ if ! printf '%s\n' "$validation_output" | grep -q '^runtime_signing_profile=kolm
 fi
 if ! printf '%s\n' "$validation_output" | grep -q '^runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1$'; then
   echo "expected local full-stack integration runtime signer attestation schema marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^kolme_local_prerequisite_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration Kolme local prerequisite marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^kolme_local_only_enforced_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration Kolme local-only enforcement marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^kolme_integration_mode_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration Kolme integration mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^kolme_integration_policy_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration Kolme integration policy marker" >&2
   exit 1
 fi
 
@@ -215,7 +261,7 @@ if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
 fi
 
 lane_report="$TMP_DIR/local-full-stack-integration-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
+python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" "$kolme_checkout_path" "$kolme_expected_remote_url" "$kolme_expected_ref" "$kolme_base_url" "$kolme_fork_chain_version" <<'PY'
 import json
 import pathlib
 import sys
@@ -245,6 +291,16 @@ if summary_report.get("kolme_integration_report_schema_version") != "kamn.kolme.
     raise SystemExit("expected kolme integration report schema marker in summary report")
 if summary_report.get("kolme_integration_policy_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("expected kolme integration policy schema marker in summary report")
+if summary_report.get("kolme_checkout_path") != sys.argv[7]:
+    raise SystemExit("expected kolme checkout path marker in summary report")
+if summary_report.get("kolme_expected_remote_url") != sys.argv[8]:
+    raise SystemExit("expected kolme expected remote url marker in summary report")
+if summary_report.get("kolme_expected_ref") != sys.argv[9]:
+    raise SystemExit("expected kolme expected ref marker in summary report")
+if summary_report.get("kolme_base_url") != sys.argv[10]:
+    raise SystemExit("expected kolme base url marker in summary report")
+if summary_report.get("kolme_fork_chain_version") != sys.argv[11]:
+    raise SystemExit("expected kolme fork chain version marker in summary report")
 
 expected_domain_status = "planned" if mode == "dry-run" else "verified"
 for marker in (
@@ -253,6 +309,10 @@ for marker in (
     "runtime_commit_submission_status",
     "runtime_commit_finality_status",
     "runtime_provider_contract_status",
+    "kolme_local_prerequisite_status",
+    "kolme_local_only_enforced_status",
+    "kolme_integration_mode_status",
+    "kolme_integration_policy_status",
 ):
     if summary_report.get(marker) != expected_domain_status:
         raise SystemExit(f"expected {marker}={expected_domain_status} in summary report")
@@ -277,6 +337,15 @@ lane_report = {
         "runtime_signer_attestation_schema_version",
         "",
     ),
+    "kolme_local_prerequisite_status": summary_report.get("kolme_local_prerequisite_status", "unknown"),
+    "kolme_local_only_enforced_status": summary_report.get("kolme_local_only_enforced_status", "unknown"),
+    "kolme_integration_mode_status": summary_report.get("kolme_integration_mode_status", "unknown"),
+    "kolme_integration_policy_status": summary_report.get("kolme_integration_policy_status", "unknown"),
+    "kolme_checkout_path": summary_report.get("kolme_checkout_path", ""),
+    "kolme_expected_remote_url": summary_report.get("kolme_expected_remote_url", ""),
+    "kolme_expected_ref": summary_report.get("kolme_expected_ref", ""),
+    "kolme_base_url": summary_report.get("kolme_base_url", ""),
+    "kolme_fork_chain_version": summary_report.get("kolme_fork_chain_version", ""),
     "kolme_integration_report_schema_version": summary_report.get(
         "kolme_integration_report_schema_version",
         "",
@@ -316,6 +385,15 @@ echo "runtime_provider_contract_status=${domain_expected_status}"
 echo "runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider"
 echo "runtime_signing_profile=kolme-fork-secp256k1-v1"
 echo "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
+echo "kolme_local_prerequisite_status=${domain_expected_status}"
+echo "kolme_local_only_enforced_status=${domain_expected_status}"
+echo "kolme_integration_mode_status=${domain_expected_status}"
+echo "kolme_integration_policy_status=${domain_expected_status}"
+echo "kolme_checkout_path=${kolme_checkout_path}"
+echo "kolme_expected_remote_url=${kolme_expected_remote_url}"
+echo "kolme_expected_ref=${kolme_expected_ref}"
+echo "kolme_base_url=${kolme_base_url}"
+echo "kolme_fork_chain_version=${kolme_fork_chain_version}"
 echo "kolme_integration_report_schema_version=kamn.kolme.local-kamn-live-runtime-integration-summary.v1"
 echo "kolme_integration_policy_schema_version=kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1"
 echo "docs_contract_status=verified"


### PR DESCRIPTION
## Summary
Adds explicit local-heavy run-mode composition for the full-stack E2E lane so nested Kolme integration executes real run mode against local `kolme_fork` prerequisites rather than contract-lane dry-run defaults.

## Changes
- `scripts/runtime/local_full_stack_integration_live_contract.py`
  - Added local `kolme_fork` prerequisite enforcement (checkout/remote/ref validation) with deterministic fail-closed reasons.
  - Added run-mode arguments for `kolme-checkout-path`, `kolme-expected-remote-url`, `kolme-expected-ref`, `kolme-base-url`, and `kolme-fork-chain-version`.
  - Switched nested run composition from contract lane to `run_local_kamn_live_runtime_integration_lane.sh --mode run` and added explicit nested policy checker invocation.
  - Propagated new top-level marker domains for Kolme local prerequisites, local-only enforcement, integration mode, and integration policy status.
  - Enforced these markers and nested payload linkage in top-level policy checks.
- `scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh`
  - Added pass-through args for Kolme local-heavy controls and contract assertions for new marker domains.
- `scripts/runtime/test_validate_local_full_stack_integration_live.sh`
  - Added dry-run marker assertions and deterministic run-mode missing-checkout fail-closed regression.
- `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
  - Added new Kolme marker fields and tamper drill for local prerequisite status.
- `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
  - Added contract-lane assertions for new marker domains.
- Docs updated:
  - `docs/ci/strategy.md`
  - `docs/planning/kolme-devnet-ops.md`

## Risks & Compatibility
- No breaking interface change for existing dry-run usage.
- Run-mode now enforces stricter local prerequisites and will fail closed earlier when checkout/remote/ref drift is present.

## Validation
- [x] `python3 -m py_compile scripts/runtime/local_full_stack_integration_live_contract.py`
- [x] `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
- [x] `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
- [x] `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
- [x] `bash scripts/ci/test_local_full_stack_integration_ci_exclusion_policy.sh`
- [x] `bash scripts/ci/test_ci_strategy_contract.sh`
- [x] `bash scripts/ci/test_kolme_live_integration_architecture_contract.sh`
- [x] `bash scripts/ci/test_ci_tools_command_surface_contract.sh`

Closes #3434
