### PR TITLE
feat(core): add transport canonical-candidate egress codec helpers (#3444)

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -171,6 +171,81 @@ pub fn decode_transport_candidate_payload(
     }
 }
 
+/// Encodes canonical commit candidate into deterministic transport block payload.
+pub fn encode_transport_canonical_candidate_payload(
+    record: &CanonicalCommitRecord,
+) -> Result<String, BlockPipelineError> {
+    if record.block_height == 0 {
+        return Err(BlockPipelineError::TransportFeed(
+            "transport canonical candidate block_height must be positive (transport_candidate_block_height_invalid)"
+                .to_owned(),
+        ));
+    }
+    validate_transport_payload_field_value("payload_digest", record.payload_digest.as_str())?;
+    if record.transaction_ids.is_empty() {
+        return Err(BlockPipelineError::TransportFeed(
+            "transport canonical candidate transaction_ids must not be empty (transport_candidate_transaction_ids_invalid)"
+                .to_owned(),
+        ));
+    }
+    let mut seen_ids = BTreeSet::new();
+    for tx_id in &record.transaction_ids {
+        validate_transport_payload_field_value("transaction_id", tx_id.as_str())?;
+        if tx_id.contains(',') {
+            return Err(BlockPipelineError::TransportFeed(
+                "transport canonical candidate transaction_id contains reserved separator ',' (transport_candidate_transaction_id_invalid)"
+                    .to_owned(),
+            ));
+        }
+        if !seen_ids.insert(tx_id) {
+            return Err(BlockPipelineError::TransportFeed(
+                "transport canonical candidate transaction_id is duplicated (transport_candidate_transaction_id_invalid)"
+                    .to_owned(),
+            ));
+        }
+    }
+    let transaction_ids = record.transaction_ids.join(",");
+    Ok(format!(
+        "block_height={}\nproducer_role={}\npayload_digest={}\ntransaction_ids={}",
+        record.block_height,
+        record.producer_role.as_str(),
+        record.payload_digest,
+        transaction_ids
+    ))
+}
+
+/// Decodes deterministic transport canonical-candidate payload into canonical commit record.
+pub fn decode_transport_canonical_candidate_payload(
+    payload: &str,
+) -> Result<CanonicalCommitRecord, BlockPipelineError> {
+    let frame = PeerGossipFrame {
+        topic: TOPIC_BLOCKS_V1.to_owned(),
+        sender_peer_id: "transport-candidate-decode-source".to_owned(),
+        recipient_peer_id: "transport-candidate-decode-target".to_owned(),
+        payload: payload.to_owned(),
+    };
+    match GossipIngressAdapter::decode_frame(&frame) {
+        Ok(GossipIngressRecord::BlockCandidate(record)) => Ok(record),
+        Ok(GossipIngressRecord::Transaction(_)) => Err(BlockPipelineError::TransportFeed(
+            "transport canonical candidate decode yielded transaction payload (transport_candidate_payload_kind_invalid)"
+                .to_owned(),
+        )),
+        Err(error) => Err(BlockPipelineError::TransportFeed(format!(
+            "{}:{}",
+            error.reason_code(),
+            error
+        ))),
+    }
+}
+
+/// Encodes committed consensus round report into deterministic transport canonical-candidate payload.
+pub fn encode_transport_commit_report_payload(
+    report: &BlockPipelineCommitReport,
+) -> Result<String, BlockPipelineError> {
+    let canonical_record = CanonicalCommitRecord::from_commit_report(report);
+    encode_transport_canonical_candidate_payload(&canonical_record)
+}
+
 fn validate_transport_payload_field_value(
     field: &str,
     value: &str,

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -152,14 +152,16 @@ pub use audit_exports::{
     AuditExportFilter, AuditExportFormat, AuditExportManifest, AuditExportRequest,
 };
 pub use block_pipeline::{
-    decode_transport_candidate_payload, encode_transport_candidate_payload,
-    AcceptAllForkChoiceHook, BlockConsensusRoundInput, BlockPipelineCommitReport,
-    BlockPipelineError, CanonicalCandidateDecision, CanonicalCandidateOutcome,
-    CanonicalCommitRecord, CanonicalCommitStore, DeterministicCompetingBranchForkChoiceHook,
-    ForkChoiceDecision, ForkChoiceHook, GossipFrameTransportMempoolFeed, GossipIngressAdapter,
-    GossipIngressBatch, GossipIngressError, GossipIngressRecord, InMemoryCanonicalCommitStore,
-    InMemoryTransportMempoolFeed, MempoolBlockPipeline, TransportCanonicalCandidateFeed,
-    TransportEventMempoolFeed, TransportFedBlockPipeline, TransportMempoolFeed,
+    decode_transport_candidate_payload, decode_transport_canonical_candidate_payload,
+    encode_transport_candidate_payload, encode_transport_canonical_candidate_payload,
+    encode_transport_commit_report_payload, AcceptAllForkChoiceHook, BlockConsensusRoundInput,
+    BlockPipelineCommitReport, BlockPipelineError, CanonicalCandidateDecision,
+    CanonicalCandidateOutcome, CanonicalCommitRecord, CanonicalCommitStore,
+    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
+    GossipFrameTransportMempoolFeed, GossipIngressAdapter, GossipIngressBatch, GossipIngressError,
+    GossipIngressRecord, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
+    MempoolBlockPipeline, TransportCanonicalCandidateFeed, TransportEventMempoolFeed,
+    TransportFedBlockPipeline, TransportMempoolFeed,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/block_pipeline_transport_fed.rs
+++ b/crates/kamn-core/tests/block_pipeline_transport_fed.rs
@@ -1,10 +1,12 @@
 use kamn_core::{
-    encode_transport_candidate_payload, BaselineTransaction, BlockConsensusRoundInput,
-    BlockPipelineError, CanonicalCommitRecord, DeterministicCompetingBranchForkChoiceHook,
-    ForkChoiceDecision, ForkChoiceHook, InMemoryCanonicalCommitStore,
-    InMemoryPeerLifecycleTransport, InMemoryTransportMempoolFeed, MempoolBlockPipeline, NodeRole,
-    PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleTransport, TransportEventMempoolFeed,
-    TransportFedBlockPipeline, TransportMempoolFeed,
+    decode_transport_canonical_candidate_payload, encode_transport_candidate_payload,
+    encode_transport_canonical_candidate_payload, encode_transport_commit_report_payload,
+    BaselineTransaction, BlockConsensusRoundInput, BlockPipelineError, CanonicalCommitRecord,
+    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
+    InMemoryCanonicalCommitStore, InMemoryPeerLifecycleTransport, InMemoryTransportMempoolFeed,
+    MempoolBlockPipeline, NodeRole, PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleTransport,
+    TransportCanonicalCandidateFeed, TransportEventMempoolFeed, TransportFedBlockPipeline,
+    TransportMempoolFeed,
 };
 use std::time::{Duration, Instant};
 
@@ -326,4 +328,87 @@ fn regression_transport_event_feed_rejects_topic_mismatch() {
             if detail.contains("transport_candidate_topic_mismatch")),
         "topic mismatch should fail with deterministic marker"
     );
+}
+
+#[test]
+fn functional_transport_canonical_candidate_payload_round_trip_from_commit_report() {
+    let feed = InMemoryTransportMempoolFeed::new(build_valid_chain_transactions());
+    let store = InMemoryCanonicalCommitStore::default();
+    let mut pipeline =
+        TransportFedBlockPipeline::new(true, 1, 1, feed, store, kamn_core::AcceptAllForkChoiceHook)
+            .expect("transport-fed pipeline should build");
+    let report = pipeline
+        .run_transport_consensus_round(sample_consensus_input())
+        .expect("transport-fed round should commit");
+
+    let payload = encode_transport_commit_report_payload(&report)
+        .expect("commit report payload should encode");
+    let decoded = decode_transport_canonical_candidate_payload(payload.as_str())
+        .expect("canonical candidate payload should decode");
+
+    assert_eq!(decoded.block_height, report.block.height);
+    assert_eq!(decoded.payload_digest, report.payload_digest);
+    assert_eq!(decoded.transaction_ids, vec!["tx-1", "tx-2"]);
+}
+
+#[test]
+fn regression_transport_canonical_candidate_payload_rejects_invalid_transaction_id() {
+    let record = CanonicalCommitRecord {
+        block_height: 9,
+        producer_role: NodeRole::Processor,
+        payload_digest: "digest-9".to_owned(),
+        transaction_ids: vec!["tx-1".to_owned(), "tx,2".to_owned()],
+    };
+
+    let error = encode_transport_canonical_candidate_payload(&record)
+        .expect_err("comma in transaction id must fail closed");
+    assert!(
+        matches!(error, BlockPipelineError::TransportFeed(detail)
+            if detail.contains("transport_candidate_transaction_id_invalid")),
+        "invalid transaction id should carry deterministic reason-code marker"
+    );
+}
+
+#[test]
+fn functional_transport_event_feed_drains_canonical_candidates_from_block_topic_frames() {
+    let transport = InMemoryPeerLifecycleTransport::default();
+    let topic = "kamn/blocks/v1";
+    let sender = "peer-block-sender";
+    let recipient = "peer-block-recipient";
+
+    transport
+        .advertise(
+            PeerDiscoveryRecord::new(sender, NodeRole::Approver, vec![topic.to_owned()])
+                .expect("sender discovery record should build"),
+        )
+        .expect("sender should advertise");
+    transport
+        .advertise(
+            PeerDiscoveryRecord::new(recipient, NodeRole::Processor, vec![topic.to_owned()])
+                .expect("recipient discovery record should build"),
+        )
+        .expect("recipient should advertise");
+
+    let record = CanonicalCommitRecord {
+        block_height: 17,
+        producer_role: NodeRole::Processor,
+        payload_digest: "digest-17".to_owned(),
+        transaction_ids: vec!["tx-17".to_owned()],
+    };
+    let payload = encode_transport_canonical_candidate_payload(&record)
+        .expect("canonical candidate payload should encode");
+    transport
+        .send(
+            PeerGossipFrame::new(topic, sender, recipient, payload.as_str())
+                .expect("gossip frame should build"),
+        )
+        .expect("gossip frame should send");
+
+    let mut feed =
+        TransportEventMempoolFeed::new(transport, recipient, Some(vec![topic.to_owned()]))
+            .expect("feed should build");
+    let candidates = feed
+        .drain_canonical_candidates()
+        .expect("candidate drain should decode block frame");
+    assert_eq!(candidates, vec![record]);
 }


### PR DESCRIPTION
## Summary
Adds deterministic transport egress codec helpers for canonical block candidates and commit reports, enabling runtime-full transport-backed publish paths to emit payloads that are guaranteed to round-trip through existing gossip ingress decoding.

Part of #3444.

## Changes
- `crates/kamn-core/src/block_pipeline.rs`:
  - Added `encode_transport_canonical_candidate_payload`.
  - Added `decode_transport_canonical_candidate_payload`.
  - Added `encode_transport_commit_report_payload`.
  - Kept fail-closed deterministic reason-code markers for invalid payloads/transaction ids.
- `crates/kamn-core/src/lib.rs`:
  - Exported new canonical candidate and commit report transport codec helpers.
- `crates/kamn-core/tests/block_pipeline_transport_fed.rs`:
  - Added round-trip commit-report-to-canonical-payload test.
  - Added regression for invalid canonical candidate transaction IDs.
  - Added canonical-candidate drain validation via `TransportEventMempoolFeed` on block topic frames.

## Risks & Compatibility
- Additive API only; no breaking removals.
- Runtime egress wiring to live transport remains a follow-up implementation step.

## Validation
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p kamn-core --tests -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated canonical payload helpers round-trip through existing gossip decode contracts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-core --test block_pipeline_transport_fed` includes new codec unit/regression assertions |
| Functional  | ✅     | canonical candidate payload round-trip from committed report |
| Integration | ✅     | canonical-candidate drain through `TransportEventMempoolFeed` with real gossip frame topic contracts |
| Regression  | ✅     | deterministic failure marker for invalid transaction id in canonical-candidate payload |
